### PR TITLE
[DOC] Restore bibliography

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -23,8 +23,9 @@
 
    users/api
    users/faq
-   users/release_notes
    users/news
+   users/release_notes
+   users/references
 
 .. toctree::
    :caption: Developer Guide

--- a/doc/users/faq.rst
+++ b/doc/users/faq.rst
@@ -59,7 +59,7 @@ The code I downloaded does not match the documentation. What gives?
 Make sure you are reading the right version of the documentation:
 
 *  If you installed pulse2percept :ref:`with pip <install-release>`, you are
-   using the latest stable release, for which you can find documentation at
+   using the stable release, for which you can find documentation at
    `pulse2percept.readthedocs.io/en/stable`_.
 
 *  If you installed pulse2percept from source, you are using the

--- a/doc/users/news.rst
+++ b/doc/users/news.rst
@@ -27,5 +27,3 @@ Scholarly articles referencing pulse2percept
 * J Steffen, J Napp, S Pollmann, K Tönnies (2018). Perception Enhancement for Bionic Vision - Preliminary Study on Object Classification with Subretinal Implants. *Proceedings of the 7th International Conference on Pattern Recognition Applications and Methods, 169-177*. doi:`10.5220/0006648901690177 <https://doi.org/10.5220/0006648901690177>`_.
 
 *   JR Golden, C Erickson-Davis, NP Cottaris, N Parthasarathy, F Rieke, DH Brainard, BA Wandell, EJ Chichilnisky (2018): Simulation of visual perception and learning with a retinal prosthesis. *bioRxiv 206409*, doi:`10.1101/206409 <https://doi.org/10.1101/206409>`_.
-
-.. include:: references.rst

--- a/doc/users/references.rst
+++ b/doc/users/references.rst
@@ -1,0 +1,50 @@
+.. _users-references:
+
+References
+==========
+
+Studies describing pulse2percept:
+
+.. [Beyeler2017] M Beyeler, GM Boynton, I Fine, A Rokem (2017). pulse2percept:
+                 A Python-based simulation framework for bionic vision.
+                 *Proceedings of the 16th Python in Science Conference*
+                 *(SciPy)*, p.81-88, doi:`10.25080/shinma-7f4c6e7-00c
+                 <https://doi.org/10.25080/shinma-7f4c6e7-00c>`_.
+
+Studies referenced throughout the Documentation:
+
+.. [Beyeler2019] M Beyeler, D Nanduri, JD Weiland, A Rokem, GM Boynton, I Fine
+                 (2019). A model of ganglion axon pathways accounts for
+                 percepts elicited by retinal implants. *Scientific Reports*
+                 9(1):9199, doi:`10.1038/s41598-019-45416-4
+                 <https://doi.org/10.1038/s41598-019-45416-4>`_.
+.. [Hayes2003] JS Hayes et al. (2003). Visually guided performance of
+               simple tasks using simulated prosthetic vision.
+               *Artificial Organs* 27, 1016-1028.
+.. [Jansonius2009] NM Jansonius, J Nevalainen, B Selig, LM Zangwill, PA Sample,
+                   WM Budde, JB Jonas, WA Lagreze, PJ Airaksinen, R Vonthein,
+                   LA Levin, J Paetzold, U Schiefer (2009). A mathematical
+                   description of nerve fiber bundle trajectories and their
+                   variability in the human retina. *Vision Research* 49(17),
+                   2157-63, doi:`10.1016/j.visres.2009.04.029
+                   <https://doi.org/10.1016/j.visres.2009.04.029>`_.
+.. [Layton2014] LN Ayton, PJ Blamey, RH Guymer, CD Luu, DAX Nayagam,
+                NC Sinclair, MN Shivdasani, J Yeoh, MF McCombe, RJ Briggs,
+                NL Opie, J Villalobos, PN Dimitrov, M Varsamidis, MA Petoe,
+                CD McCarthy, JG Walker, N Barnes, AN Burkitt, CE Williams,
+                RK Shepherd, PJ Allen, for the Bionic Vision Australia
+                Research Consortium (2014). First-in-human trial of a novel
+                suprachoroidal retinal prosthesis. *PLoS ONE*  9(12): e115239.
+.. [Thompson2003] RW Thompson Jr, GD Barnett, MS Humayun, G Dagnelie
+                  (2003). Facial recognition using simulated prosthetic
+                  pixelized vision.
+                  *Investigative Ophthalmolology & Visual Science* 44,
+                  5035-5042.
+.. [Watson2014] A.B. Watson (2014). A formula for human retinal ganglion cell
+                receptive field density as a function of visual field
+                location. *Journal of Vision* 14(7):1-17,
+                doi:`10.1167/14.7.15 <https://doi.org/10.1167/14.7.15>`_.
+.. [WileyWebster1982] JD Wiley, JG Webster (1982). Analysis and control of the
+                      current distribution under circular dispersive 
+                      electrodes. *IEEE Transactions on Biomedical Engineering*
+                      5, 381-385.

--- a/pulse2percept/implants/base.py
+++ b/pulse2percept/implants/base.py
@@ -1,4 +1,5 @@
-"""`Electrode`, `ElectrodeArray`, `ElectrodeGrid`, `ProsthesisSystem`"""
+"""`Electrode`, `PointSource`, `DiskElectrode`, `ElectrodeArray`,
+   `ElectrodeGrid`, `ProsthesisSystem`"""
 import numpy as np
 from abc import ABCMeta, abstractmethod
 import collections as coll


### PR DESCRIPTION
PR #140 factored out the bibliography from `doc/users/news.rst`, but accidentally forgot to git add the new file, `doc/users/references.rst`. This PR brings it back and adds some missing references.