### PR TITLE
[REF] Pretty print class attributes

### DIFF
--- a/pulse2percept/implants/alpha.py
+++ b/pulse2percept/implants/alpha.py
@@ -94,8 +94,9 @@ class AlphaIMS(ProsthesisSystem):
             # Assign the new ordered dict to earray:
             self.earray.electrodes = electrodes
 
-    def get_params(self):
-        params = super().get_params()
+    def _pprint_params(self):
+        """Return dict of class attributes to pretty-print"""
+        params = super()._pprint_params()
         params.update({'shape': self.shape})
         return params
 
@@ -191,7 +192,8 @@ class AlphaAMS(ProsthesisSystem):
             # Assign the new ordered dict to earray:
             self.earray.electrodes = electrodes
 
-    def get_params(self):
-        params = super().get_params()
+    def _pprint_params(self):
+        """Return dict of class attributes to pretty-print"""
+        params = super()._pprint_params()
         params.update({'shape': self.shape})
         return params

--- a/pulse2percept/implants/argus.py
+++ b/pulse2percept/implants/argus.py
@@ -121,8 +121,9 @@ class ArgusI(ProsthesisSystem):
             # Assign the new ordered dict to earray:
             self.earray.electrodes = electrodes
 
-    def get_params(self):
-        params = super().get_params()
+    def _pprint_params(self):
+        """Return dict of class attributes to pretty-print"""
+        params = super()._pprint_params()
         params.update({'shape': self.shape})
         return params
 
@@ -233,7 +234,8 @@ class ArgusII(ProsthesisSystem):
             # Assign the new ordered dict to earray:
             self.earray.electrodes = electrodes
 
-    def get_params(self):
-        params = super().get_params()
+    def _pprint_params(self):
+        """Return dict of class attributes to pretty-print"""
+        params = super()._pprint_params()
         params.update({'shape': self.shape})
         return params

--- a/pulse2percept/implants/base.py
+++ b/pulse2percept/implants/base.py
@@ -26,8 +26,8 @@ class Electrode(PrettyPrint, metaclass=ABCMeta):
         self.y = y
         self.z = z
 
-    def get_params(self):
-        """Return a dictionary of class attributes"""
+    def _pprint_params(self):
+        """Return dict of class attributes to pretty-print"""
         return {'x': self.x, 'y': self.y, 'z': self.z}
 
     @abstractmethod
@@ -93,9 +93,9 @@ class DiskElectrode(Electrode):
             raise ValueError("Electrode radius must be > 0, not %f." % r)
         self.r = r
 
-    def get_params(self):
-        """Return a dictionary of class attributes"""
-        params = super().get_params()
+    def _pprint_params(self):
+        """Return dict of class attributes to pretty-print"""
+        params = super()._pprint_params()
         params.update({'r': self.r})
         return params
 
@@ -209,8 +209,8 @@ class ElectrodeArray(PrettyPrint):
     def n_electrodes(self):
         return len(self.electrodes)
 
-    def get_params(self):
-        """Return a dictionary of class attributes"""
+    def _pprint_params(self):
+        """Return dict of class attributes to pretty-print"""
         return {'electrodes': self.electrodes,
                 'n_electrodes': self.n_electrodes}
 
@@ -421,8 +421,8 @@ class ElectrodeGrid(ElectrodeArray):
         self.electrodes = coll.OrderedDict()
         self._make_grid()
 
-    def get_params(self):
-        """Return a dictionary of class attributes"""
+    def _pprint_params(self):
+        """Return dict of class attributes to pretty-print"""
         params = {'shape': self.shape, 'spacing': self.spacing,
                   'x': self.x, 'y': self.y, 'z': self.z,
                   'rot': self.rot, 'etype': self.etype,
@@ -625,7 +625,8 @@ class ProsthesisSystem(PrettyPrint):
         self.stim = stim
         self.eye = eye
 
-    def get_params(self):
+    def _pprint_params(self):
+        """Return dict of class attributes to pretty-print"""
         return {'earray': self.earray, 'stim': self.stim, 'eye': self.eye}
 
     def check_stim(self, stim):

--- a/pulse2percept/implants/bva.py
+++ b/pulse2percept/implants/bva.py
@@ -3,31 +3,32 @@ import numpy as np
 from pulse2percept.implants.base import (ProsthesisSystem, ElectrodeArray,
                                          DiskElectrode)
 
+
 class BVA24(ProsthesisSystem):
     """24-channel suprachoroidal retinal prosthesis
-    
+
     This class creates a 24-channel suprachoroidal retinal prosthesis as
     described in [Layton2014]_, where the center of the array is located
     at (x,y,z), given in microns, and the array is rotated by rotation
     angle ``rot``, given in radians.
-    
+
     The array consists of:
-    
-    -   33 platinum stimulating electrodes: 
+
+    -   33 platinum stimulating electrodes:
         -   30 electrodes with 600um diameter (Electrodes 1-20 (except
-            9, 17, 19) and Electrodes 21a-m), 
+            9, 17, 19) and Electrodes 21a-m),
         -   3 electrodes with 400um diameter (Electrodes 9, 17, 19)
     -   2 return electrodes with 2000um diameter (Electrodes 22, 23)
-    
+
     Electrodes 21a-m are typically being ganged to provide an external
     ring for common ground. The center of the array is assumed to lie
     between Electrodes 7, 8, 9, and 13.
-    
+
     .. note::
-    
+
         Column order for electrode numbering is reversed in a left-eye
         implant.
-    
+
     Parameters
     ----------
     x : float
@@ -43,8 +44,9 @@ class BVA24(ProsthesisSystem):
         system.
     eye : {'LE', 'RE'}, optional, default: 'RE'
         Eye in which array is implanted.
-    
+
     """
+
     def __init__(self, x=0, y=0, z=0, rot=0, eye='RE', stim=None):
         self.earray = ElectrodeArray([])
         self.stim = stim
@@ -56,7 +58,7 @@ class BVA24(ProsthesisSystem):
         if eye != 'LE' and eye != 'RE':
             raise ValueError("'eye' must be either 'LE' or 'RE'.")
         self.eye = eye
-        
+
         # the positions of the electrodes 1-20, 21a-21m, R1-R2
         x_arr = [-1275.0, -850.0, -1275.0, -850.0, -1275.0,
                  -425.0, 0, -425.0, 0, -425.0,
@@ -85,7 +87,7 @@ class BVA24(ProsthesisSystem):
         # the position of the electrodes 1-20, 21a-21m, R1-R2 for left eye
         if eye == 'LE':
             x_arr = np.negative(x_arr)
-        
+
         # the radius of all the electrodes in the implants
         r_arr = [300.0] * n_elecs
         # the radius of electrodes 9, 17, 19 is 200.0 um
@@ -98,17 +100,17 @@ class BVA24(ProsthesisSystem):
                       '21f', '21g', '21h', '21i', '21j',
                       '21k', '21l', '21m'])
         names.extend(['R1', 'R2'])
-        
+
         # Rotate the grid:
         rotmat = np.array([np.cos(rot), -np.sin(rot),
                            np.sin(rot), np.cos(rot)]).reshape((2, 2))
         xy = np.matmul(rotmat, np.vstack((x_arr, y_arr)))
         x_arr = xy[0, :]
         y_arr = xy[1, :]
-    
+
         # Apply offset to make the grid centered at (x, y):
         x_arr += x
         y_arr += y
-        
+
         for x, y, z, r, name in zip(x_arr, y_arr, z_arr, r_arr, names):
             self.earray.add_electrode(name, DiskElectrode(x, y, z, r))

--- a/pulse2percept/implants/tests/test_base.py
+++ b/pulse2percept/implants/tests/test_base.py
@@ -382,28 +382,44 @@ def test_ElectrodeGrid_get_params(gtype):
     params = {'shape': (2, 3), 'x': 0, 'y': 0, 'z': 0, 'etype': DiskElectrode,
               'rot': 0, 'spacing': 40, 'name_cols': '1',
               'name_rows': 'A', 'r': 20}
-    npt.assert_equal(egrid.get_params(), params)
+    for key, value in params.items():
+        if isinstance(value, float):
+            npt.assert_almost_equal(getattr(egrid, key), value)
+        else:
+            npt.assert_equal(getattr(egrid, key), value)
     # test the nondefault value for all the parameters
     egrid = ElectrodeGrid((2, 3), 30, x=10, y=20, z=30, rot=10, type=gtype,
                           names=('A', '1'), etype=DiskElectrode, r=20)
     params = {'shape': (2, 3), 'x': 10, 'y': 20, 'z': 30, 'rot': 10,
               'spacing': 30, 'name_cols': '1', 'name_rows': 'A',
               'etype': DiskElectrode, 'r': 20}
-    npt.assert_equal(egrid.get_params(), params)
+    for key, value in params.items():
+        if isinstance(value, float):
+            npt.assert_almost_equal(getattr(egrid, key), value)
+        else:
+            npt.assert_equal(getattr(egrid, key), value)
     # When the electrode_type is 'PointSource'
     # test the default value
     egrid = ElectrodeGrid((2, 3), 20, type=gtype, etype=PointSource)
     params = {'shape': (2, 3), 'x': 0, 'y': 0, 'z': 0, 'etype': PointSource,
               'rot': 0, 'spacing': 20, 'name_cols': '1',
               'name_rows': 'A'}
-    npt.assert_equal(egrid.get_params(), params)
+    for key, value in params.items():
+        if isinstance(value, float):
+            npt.assert_almost_equal(getattr(egrid, key), value)
+        else:
+            npt.assert_equal(getattr(egrid, key), value)
     # test the nondefault value for all the parameters
     egrid = ElectrodeGrid((2, 3), 30, x=10, y=20, z=30, rot=10, type=gtype,
                           names=('A', '1'), etype=PointSource)
     params = {'shape': (2, 3), 'x': 10, 'y': 20, 'z': 30, 'rot': 10,
               'spacing': 30, 'etype': PointSource, 'name_cols': '1',
               'name_rows': 'A'}
-    npt.assert_equal(egrid.get_params(), params)
+    for key, value in params.items():
+        if isinstance(value, float):
+            npt.assert_almost_equal(getattr(egrid, key), value)
+        else:
+            npt.assert_equal(getattr(egrid, key), value)
 
 
 @pytest.mark.parametrize('gtype', ('rect', 'hex'))

--- a/pulse2percept/models/base.py
+++ b/pulse2percept/models/base.py
@@ -117,8 +117,8 @@ class BaseModel(Frozen, PrettyPrint, metaclass=abc.ABCMeta):
         }
         return params
 
-    def get_params(self):
-        """Get a dictionary of all model parameters (don't override!)"""
+    def _pprint_params(self):
+        """Return dict of class attributes to pretty-print"""
         return {key: getattr(self, key)
                 for key, _ in self._get_default_params().items()}
 

--- a/pulse2percept/models/tests/test_base.py
+++ b/pulse2percept/models/tests/test_base.py
@@ -50,10 +50,10 @@ def test_BaseModel___init__():
     npt.assert_almost_equal(model._private, 2)
 
 
-def test_BaseModel_get_params():
-    # We can overwrite default param values if they are in ``get_params``:
+def test_BaseModel__pprint_params():
+    # We can overwrite default param values if they are in ``_pprint_params``:
     model = ValidBaseModel(engine='serial')
-    for key, value in model.get_params().items():
+    for key, value in model._pprint_params().items():
         if key in ('xrange', 'yrange', 'grid_type'):
             continue
         npt.assert_equal(getattr(model, key), value)
@@ -73,7 +73,7 @@ def test_BaseModel_build():
 
     # Params passed to ``build`` must take effect:
     model = ValidBaseModel(engine='serial')
-    model_params = model.get_params()
+    model_params = model._pprint_params()
     for key, value in model_params.items():
         if isinstance(value, (int, float)):
             set_param = {key: 0.1234}

--- a/pulse2percept/stimuli/base.py
+++ b/pulse2percept/stimuli/base.py
@@ -143,8 +143,8 @@ class Stimulus(PrettyPrint):
         # Extract the data and coordinates (electrodes, time) from the source:
         self._factory(source, electrodes, time, compress)
 
-    def get_params(self):
-        """Return a dictionary of class attributes"""
+    def _pprint_params(self):
+        """Return dict of class attributes to pretty-print"""
         return {'data': self.data, 'electrodes': self.electrodes,
                 'time': self.time, 'shape': self.shape,
                 'metadata': self.metadata}

--- a/pulse2percept/utils/base.py
+++ b/pulse2percept/utils/base.py
@@ -17,7 +17,7 @@ class PrettyPrint(object, metaclass=abc.ABCMeta):
     inspired by scikit-learn.
 
     Classes deriving from PrettyPrint are required to implement a
-    ``get_params`` method that returns a dictionary containing all the
+    ``_pprint_params`` method that returns a dictionary containing all the
     attributes to prettyprint.
 
     Examples
@@ -28,14 +28,14 @@ class PrettyPrint(object, metaclass=abc.ABCMeta):
     ...         self.a = a
     ...         self.b = b
     ...
-    ...     def get_params(self):
+    ...     def _pprint_params(self):
     ...         return {'a': self.a, 'b': self.b}
     >>> MyClass(1, 2)
     MyClass(a=1, b=2)
     """
 
     @abc.abstractmethod
-    def get_params(self):
+    def _pprint_params(self):
         """Return a dictionary of class attributes"""
         raise NotImplementedError
 
@@ -46,7 +46,7 @@ class PrettyPrint(object, metaclass=abc.ABCMeta):
         # Line width:
         lwidth = 60
         # Sort list of parameters alphabetically:
-        sorted_params = coll.OrderedDict(sorted(self.get_params().items()))
+        sorted_params = coll.OrderedDict(sorted(self._pprint_params().items()))
         # Start string with class name, followed by all arguments:
         str_params = self.__class__.__name__ + '('
         # New line indent (align with class name on first line):


### PR DESCRIPTION
Refactors `PrettyPrint.get_params` into `_pprint_params` to clarify its purpose and hide it in the docs.