### PR TITLE
[REF] Add __slots__

### DIFF
--- a/doc/developers/style_guide.rst
+++ b/doc/developers/style_guide.rst
@@ -1,0 +1,141 @@
+.. _dev-style_guide:
+
+==================
+Coding style guide
+==================
+
+The main principles behind pulse2percept development are:
+
+-  **Robustness**: The results of a piece of code must be verified
+   systematically, enhancing stability and reducing redundancies.
+
+-  **Readability**: The code is read much more frequently than it is written,
+   and should be easy to understand by other developers.
+   Documentation is essential.
+
+-  **Consistency**: Following these guidelines will ease reading the code and
+   will make it less error-prone.
+
+Coding style
+============
+
+pulse2percept uses the standard Python `PEP8`_ style guide to ensure
+readibility and consistency of the code base.
+
+.. note::
+
+    There are `tools <https://pypi.org/project/pep8>`_ that allow you to
+    automatically check your Python code against `PEP8`_ style conventions.
+
+    For example, if you work with Sublime, you can use the `PEP8 Autoformat`_
+    package. For convenience, make sure the setting ``autoformat_on_save`` is
+    set to ``true``.
+
+A few general guidelines:
+
+-  Use 4 spaces instead of tab.
+-  Limit all lines to a maximum of 79 characters.
+-  Write code for Python 3.5+.
+
+.. _PEP8: https://www.python.org/dev/peps/pep-0008
+.. _PEP8 Autoformat: https://packagecontrol.io/packages/Python%20PEP8%20Autoformat
+
+Imports
+-------
+
+pulse2percept recommends using the following package shorthands to increase
+consistency and readibility across the library:
+
+.. code-block:: python
+
+    import numpy as np
+    import numpy.testing as npt
+    import scipy as sp
+    import pandas as pd
+
+    import pulse2percept as p2p
+
+Whitespace and blank lines
+--------------------------
+
+Don't use spaces around the ``=`` sign to indicate a keyword argument:
+
+.. code-block:: python
+
+    # Good:
+    def complex(real, image=0.0):
+        return magic(r=real, i=imag)
+
+    # Bad:
+    def complex(real, image = 0.0):
+        return magic(r = real, i = imag)
+
+           
+Surround top-level function and class definitions with two blank lines.
+Use blank lines in functions, sparingly, to indicate logical sections.
+
+Breaking long lines (W503 vs W504)
+----------------------------------
+
+The recommended style is to break a line after binary operators:
+
+.. code-block:: python
+
+    # Good:
+    income = (gross_wages +
+              taxable_interest -
+              student_loan_interest)
+
+    # Bad:
+    income = (gross_wages
+              + taxable_interest
+              - student_loan_interest)
+
+Yes, we are aware of the ongoing `W503 vs W504 discussion <https://www.python.org/dev/peps/pep-0008/#should-a-line-break-before-or-after-a-binary-operator>`_.
+W504 would improve readibility.
+However, for now, we want to ensure consistency with the existing code.
+
+Class layout (slots, properties)
+--------------------------------
+
+Classes can have ``__slots__`` that list all class attributes.
+This can have several advantages:
+
+-  Users cannot add new class attributes on-the-fly. This is desirable for
+   models (e.g., ``AxonMapModel``), which has a predefined number of
+   attributes.
+-  Slots reduce memory usage. This is desirable for stimuli (e.g.,
+   ``TimeSeries``), for which a large number of instances are created.
+
+Subclasses that inherit from classes with ``__slots__`` must themselves
+implement slots. The top-level class must inherit from ``object``, and
+attributes cannot be listed more than once:
+
+.. code-block:: python
+
+    class Vehicle(object):
+
+        __slots__ = ('owner')
+
+        def __init__(self, owner):
+            self.owner = owner
+
+
+    class Car(Vehicle):
+
+        __slots__ = ('n_doors')
+
+        def __init__(self, owner, n_doors):
+            self.owner = owner
+            self.n_doors = n_doors
+
+If you did it right, then neither ``Vehicle`` nor ``Car`` should have a
+``__dict__`` attribute:
+
+.. code-block:: python
+
+	car = Car('myself', 4)
+	assert hasattr(car, '__slots__')
+    assert not hasattr(car, '__dict__')
+
+*This guide was inspired by the `DIPY style guide <https://dipy.org/documentation/1.1.1./devel/coding_style_guideline>`_.*

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -32,6 +32,7 @@
    :hidden:
 
    developers/contributing
+   developers/style_guide
    developers/extending
    developers/releases
 

--- a/pulse2percept/implants/alpha.py
+++ b/pulse2percept/implants/alpha.py
@@ -145,8 +145,8 @@ class AlphaAMS(ProsthesisSystem):
 
     >>> from pulse2percept.implants import AlphaAMS
     >>> AlphaAMS(x=0, y=0, z=100, rot=0)  # doctest: +NORMALIZE_WHITESPACE
-    AlphaAMS(earray=pulse2percept.implants.base.ElectrodeGrid, eye='RE',
-             shape=(40, 40), stim=None)
+    AlphaAMS(earray=ElectrodeGrid(shape=(40, 40), type='rect'),
+             eye='RE', shape=(40, 40), stim=None)
 
     Get access to the third electrode in the top row (by name or by row/column
     index):

--- a/pulse2percept/implants/alpha.py
+++ b/pulse2percept/implants/alpha.py
@@ -59,6 +59,8 @@ class AlphaIMS(ProsthesisSystem):
     DiskElectrode(r=50.0, x=-1152.0, y=-1296.0, z=100.0)
 
     """
+    # Frozen class: User cannot add more class attributes
+    __slots__ = ('shape',)
 
     def __init__(self, x=0, y=0, z=0, rot=0, eye='RE', stim=None):
         self.eye = eye
@@ -156,6 +158,8 @@ class AlphaAMS(ProsthesisSystem):
     DiskElectrode(r=15.0, x=-1225.0, y=-1365.0, z=100.0)
 
     """
+    # Frozen class: User cannot add more class attributes
+    __slots__ = ('shape',)
 
     def __init__(self, x=0, y=0, z=0, rot=0, eye='RE', stim=None):
         self.eye = eye

--- a/pulse2percept/implants/alpha.py
+++ b/pulse2percept/implants/alpha.py
@@ -46,8 +46,8 @@ class AlphaIMS(ProsthesisSystem):
 
     >>> from pulse2percept.implants import AlphaIMS
     >>> AlphaIMS(x=0, y=0, z=100, rot=0)  # doctest: +NORMALIZE_WHITESPACE
-    AlphaIMS(earray=pulse2percept.implants.base.ElectrodeGrid, eye='RE',
-             shape=(37, 37), stim=None)
+    AlphaIMS(earray=ElectrodeGrid(shape=(37, 37), type='rect'),
+             eye='RE', shape=(37, 37), stim=None)
 
     Get access to the third electrode in the top row (by name or by row/column
     index):

--- a/pulse2percept/implants/argus.py
+++ b/pulse2percept/implants/argus.py
@@ -60,8 +60,8 @@ class ArgusI(ProsthesisSystem):
 
     >>> from pulse2percept.implants import ArgusI
     >>> ArgusI(x=0, y=0, z=100, rot=0)  # doctest: +NORMALIZE_WHITESPACE
-    ArgusI(earray=pulse2percept.implants.base.ElectrodeGrid, eye='RE',
-           shape=(4, 4), stim=None)
+    ArgusI(earray=ElectrodeGrid(shape=(4, 4), type='rect'),
+           eye='RE', shape=(4, 4), stim=None)
 
     Get access to electrode 'B1', either by name or by row/column index:
 
@@ -185,8 +185,8 @@ class ArgusII(ProsthesisSystem):
 
     >>> from pulse2percept.implants import ArgusII
     >>> ArgusII(x=0, y=0, z=100, rot=0)  # doctest: +NORMALIZE_WHITESPACE
-    ArgusII(earray=pulse2percept.implants.base.ElectrodeGrid, eye='RE',
-            shape=(6, 10), stim=None)
+    ArgusII(earray=ElectrodeGrid(shape=(6, 10), type='rect'),
+            eye='RE', shape=(6, 10), stim=None)
 
     Get access to electrode 'E7', either by name or by row/column index:
 

--- a/pulse2percept/implants/argus.py
+++ b/pulse2percept/implants/argus.py
@@ -1,6 +1,6 @@
 """`ArgusI`, `ArgusII`"""
 import numpy as np
-import collections as coll
+from collections import OrderedDict
 from .base import (DiskElectrode, ElectrodeArray, ElectrodeGrid,
                    ProsthesisSystem)
 
@@ -72,6 +72,8 @@ class ArgusI(ProsthesisSystem):
     DiskElectrode(r=260.0, x=-400.0, y=-1200.0, z=100.0)
 
     """
+    # Frozen class: User cannot add more class attributes
+    __slots__ = ('shape',)
 
     def __init__(self, x=0, y=0, z=0, rot=0, eye='RE', stim=None,
                  use_legacy_names=False):
@@ -86,11 +88,11 @@ class ArgusI(ProsthesisSystem):
         spacing = 800.0
 
         # In older papers, Argus I electrodes go by L and M:
-        self.old_names = names = ['L6', 'L2', 'M8', 'M4',
-                                  'L5', 'L1', 'M7', 'M3',
-                                  'L8', 'L4', 'M6', 'M2',
-                                  'L7', 'L3', 'M5', 'M1']
-        names = self.old_names if use_legacy_names else ('1', 'A')
+        old_names = names = ['L6', 'L2', 'M8', 'M4',
+                             'L5', 'L1', 'M7', 'M3',
+                             'L8', 'L4', 'M6', 'M2',
+                             'L7', 'L3', 'M5', 'M1']
+        names = old_names if use_legacy_names else ('1', 'A')
         self.earray = ElectrodeGrid(self.shape, spacing, x=x, y=y, z=z,
                                     rot=rot, etype=DiskElectrode, r=r_arr,
                                     names=names)
@@ -115,7 +117,7 @@ class ArgusI(ProsthesisSystem):
             for row in range(self.earray.shape[0]):
                 names[row] = names[row][::-1]
             # Build a new ordered dict:
-            electrodes = coll.OrderedDict([])
+            electrodes = OrderedDict()
             for name, obj in zip(names.ravel(), objects):
                 electrodes.update({name: obj})
             # Assign the new ordered dict to earray:
@@ -195,6 +197,8 @@ class ArgusII(ProsthesisSystem):
     DiskElectrode(r=100.0, x=787.5, y=787.5, z=100.0)
 
     """
+    # Frozen class: User cannot add more class attributes
+    __slots__ = ('shape',)
 
     def __init__(self, x=0, y=0, z=0, rot=0, eye='RE', stim=None):
         # Argus II is a 6x10 grid of electrodes with 200um in diamater, spaced
@@ -206,7 +210,6 @@ class ArgusII(ProsthesisSystem):
         names = ('A', '1')
         self.earray = ElectrodeGrid(self.shape, spacing, x=x, y=y, z=z, r=r,
                                     rot=rot, names=names, etype=DiskElectrode)
-        self.shape = self.earray.shape
 
         # Set stimulus if available:
         self.stim = stim
@@ -228,7 +231,7 @@ class ArgusII(ProsthesisSystem):
             for row in range(self.earray.shape[0]):
                 names[row] = names[row][::-1]
             # Build a new ordered dict:
-            electrodes = coll.OrderedDict([])
+            electrodes = OrderedDict()
             for name, obj in zip(names.ravel(), objects):
                 electrodes.update({name: obj})
             # Assign the new ordered dict to earray:

--- a/pulse2percept/implants/base.py
+++ b/pulse2percept/implants/base.py
@@ -364,9 +364,7 @@ class ElectrodeGrid(ElectrodeArray):
     >>> from pulse2percept.implants import ElectrodeGrid, DiskElectrode
     >>> ElectrodeGrid((2, 4), 20, x=10, y=20, z=500, names=('A', '1'), r=10,
     ...               type='rect', etype=DiskElectrode) # doctest: +NORMALIZE_WHITESPACE +ELLIPSIS
-    ElectrodeGrid(..., name_cols='1',
-                  name_rows='A', r=10..., rot=0..., shape=(2, 4),
-                  spacing=20..., x=10..., y=20..., z=500...)
+    ElectrodeGrid(shape=(2, 4), type='rect')
 
     There are three ways to access (e.g.) the last electrode in the grid,
     either by name (``grid['C3']``), by row/column index (``grid[2, 2]``), or

--- a/pulse2percept/implants/base.py
+++ b/pulse2percept/implants/base.py
@@ -341,7 +341,7 @@ class ElectrodeGrid(ElectrodeArray):
     electrodes with 10um radius spaced 20um apart, centered at (10, 20)um, and
     located 500um away from the retinal surface, with names like this:
 
-    .. code-block:: none
+    .. raw:: html
 
         A1    A2    A3    A4
            B1    B2    B3    B4
@@ -350,15 +350,13 @@ class ElectrodeGrid(ElectrodeArray):
     >>> from pulse2percept.implants import ElectrodeGrid, DiskElectrode
     >>> ElectrodeGrid((3, 4), 20, x=10, y=20, z=500, names=('A', '1'), r=10,
     ...               type='hex', etype=DiskElectrode) # doctest: +NORMALIZE_WHITESPACE +ELLIPSIS
-    ElectrodeGrid(..., name_cols='1',
-                  name_rows='A', r=10..., rot=0..., shape=(3, 4),
-                  spacing=20..., x=10..., y=20..., z=500...)
+    ElectrodeGrid(shape=(3, 4), type='hex')
 
     A rectangulr electrode grid with 2 rows and 4 columns, made of disk
     electrodes with 10um radius spaced 20um apart, centered at (10, 20)um, and
     located 500um away from the retinal surface, with names like this:
 
-    .. code-block:: none
+    .. raw:: html
 
         A1 A2 A3 A4
         B1 B2 B3 B4

--- a/pulse2percept/implants/base.py
+++ b/pulse2percept/implants/base.py
@@ -424,12 +424,7 @@ class ElectrodeGrid(ElectrodeArray):
 
     def _pprint_params(self):
         """Return dict of class attributes to pretty-print"""
-        params = {'shape': self.shape, 'spacing': self.spacing,
-                  'x': self.x, 'y': self.y, 'z': self.z,
-                  'rot': self.rot, 'etype': self.etype,
-                  'name_cols': self.name_cols, 'name_rows': self.name_rows}
-        if issubclass(self.etype, DiskElectrode):
-            params.update({'r': self.r})
+        params = {'shape': self.shape, 'type': self.type}
         return params
 
     def __getitem__(self, item):

--- a/pulse2percept/implants/base.py
+++ b/pulse2percept/implants/base.py
@@ -2,8 +2,12 @@
    `ElectrodeGrid`, `ProsthesisSystem`"""
 import numpy as np
 from abc import ABCMeta, abstractmethod
-import collections as coll
 import math
+# Using or importing the ABCs from 'collections' instead of from
+# 'collections.abc' is deprecated, and in 3.8 it will stop working:
+from collections.abc import Sequence
+from collections import OrderedDict
+
 
 from ..stimuli import Stimulus
 from ..utils import PrettyPrint
@@ -14,13 +18,14 @@ class Electrode(PrettyPrint, metaclass=ABCMeta):
 
     Abstract base class for all electrodes.
     """
+    __slots__ = ('x', 'y', 'z')
 
     def __init__(self, x, y, z):
-        if isinstance(x, (coll.Sequence, np.ndarray)):
+        if isinstance(x, (Sequence, np.ndarray)):
             raise TypeError("x must be a scalar, not %s." % (type(x)))
-        if isinstance(y, (coll.Sequence, np.ndarray)):
+        if isinstance(y, (Sequence, np.ndarray)):
             raise TypeError("y must be a scalar, not %s." % type(y))
-        if isinstance(z, (coll.Sequence, np.ndarray)):
+        if isinstance(z, (Sequence, np.ndarray)):
             raise TypeError("z must be a scalar, not %s." % type(z))
         self.x = x
         self.y = y
@@ -37,6 +42,8 @@ class Electrode(PrettyPrint, metaclass=ABCMeta):
 
 class PointSource(Electrode):
     """Point source"""
+    # Frozen class: User cannot add more class attributes
+    __slots__ = ()
 
     def electric_potential(self, x, y, z, amp, sigma):
         """Calculate electric potential at (x, y, z)
@@ -84,10 +91,12 @@ class DiskElectrode(Electrode):
     r : double
         Disk radius in the x,y plane
     """
+    # Frozen class: User cannot add more class attributes
+    __slots__ = ('r',)
 
     def __init__(self, x, y, z, r):
         super(DiskElectrode, self).__init__(x, y, z)
-        if isinstance(r, (coll.Sequence, np.ndarray)):
+        if isinstance(r, (Sequence, np.ndarray)):
             raise TypeError("Electrode radius must be a scalar.")
         if r <= 0:
             raise ValueError("Electrode radius must be > 0, not %f." % r)
@@ -182,9 +191,11 @@ class ElectrodeArray(PrettyPrint):
     OrderedDict([('A1', DiskElectrode(r=100..., x=0..., y=0..., z=0...))])
 
     """
+    # Frozen class: User cannot add more class attributes
+    __slots__ = ('_electrodes',)
 
     def __init__(self, electrodes):
-        self.electrodes = coll.OrderedDict()
+        self.electrodes = OrderedDict()
         if isinstance(electrodes, dict):
             for name, electrode in electrodes.items():
                 self.add_electrode(name, electrode)
@@ -381,6 +392,8 @@ class ElectrodeGrid(ElectrodeArray):
      DiskElectrode(r=10..., x=20.0, y=-20.0, z=0...)]
 
     """
+    # Frozen class: User cannot add more class attributes
+    __slots__ = ('shape', 'type')
 
     def __init__(self, shape, spacing, x=0, y=0, z=0, rot=0, names=('A', '1'),
                  type='rect', etype=PointSource, **kwargs):
@@ -401,25 +414,13 @@ class ElectrodeGrid(ElectrodeArray):
         if issubclass(etype, DiskElectrode):
             if 'r' not in kwargs.keys():
                 raise ValueError("A DiskElectrode needs a radius ``r``.")
-            self.r = kwargs['r']
 
-        # Extract rows and columns from shape:
         self.shape = shape
-        self.x = x
-        self.y = y
-        self.z = z
-        self.rot = rot
-        self.spacing = spacing
         self.type = type
-        self.etype = etype  # add etype variable under the class
-        # Store names for rows/cols separately:
-        if len(names) == 2:
-            self.name_rows, self.name_cols = names
-        self.names = names
         # Instantiate empty collection of electrodes. This dictionary will be
         # populated in a private method ``_set_egrid``:
-        self.electrodes = coll.OrderedDict()
-        self._make_grid()
+        self.electrodes = OrderedDict()
+        self._make_grid(spacing, x, y, z, rot, names, etype, **kwargs)
 
     def _pprint_params(self):
         """Return dict of class attributes to pretty-print"""
@@ -470,57 +471,57 @@ class ElectrodeGrid(ElectrodeArray):
                     # Index not found:
                     return None
 
-    def _make_grid(self):
+    def _make_grid(self, spacing, x, y, z, rot, names, etype, **kwargs):
         """Private method to build the electrode grid"""
         n_elecs = np.prod(self.shape)
         rows, cols = self.shape
 
         # The user did not specify a unique naming scheme:
-        if len(self.names) == 2:
+        if len(names) == 2:
+            name_rows, name_cols = names
             # Create electrode names, using either A-Z or 1-n:
-            if self.name_rows.isalpha():
-                rws = [chr(i) for i in range(
-                    ord(self.name_rows), ord(self.name_rows) + rows + 1)]
-            elif self.name_rows.isdigit():
+            if name_rows.isalpha():
+                rws = [chr(i) for i in range(ord(name_rows),
+                                             ord(name_rows) + rows + 1)]
+            elif name_rows.isdigit():
                 rws = [str(i) for i in range(
-                    int(self.name_rows), rows + int(self.name_rows))]
+                    int(name_rows), rows + int(name_rows))]
             else:
                 raise ValueError("rows must be alphabetic or numeric")
 
-            if self.name_cols.isalpha():
-                clms = [chr(i) for i in range(ord(self.name_cols),
-                                              ord(self.name_cols) + cols)]
-            elif self.name_cols.isdigit():
-                clms = [str(i) for i in range(
-                    int(self.name_cols), cols + int(self.name_cols))]
+            if name_cols.isalpha():
+                clms = [chr(i) for i in range(ord(name_cols),
+                                              ord(name_cols) + cols)]
+            elif name_cols.isdigit():
+                clms = [str(i) for i in range(int(name_cols),
+                                              cols + int(name_cols))]
             else:
                 raise ValueError("Columns must be alphabetic or numeric.")
 
             # facilitating Argus I naming scheme
-            if self.name_cols.isalpha() and not self.name_rows.isalpha():
+            if name_cols.isalpha() and not name_rows.isalpha():
                 names = [clms[j] + rws[i] for i in range(len(rws))
                          for j in range(len(clms))]
             else:
                 names = [rws[i] + clms[j] for i in range(len(rws))
                          for j in range(len(clms))]
         else:
-            if len(self.names) != n_elecs:
+            if len(names) != n_elecs:
                 raise ValueError("If `names` specifies more than row/column "
                                  "names, it must have %d entries, not "
-                                 "%d)." % (n_elecs, len(self.names)))
-            names = self.names
+                                 "%d)." % (n_elecs, len(names)))
 
-        if isinstance(self.z, (list, np.ndarray)):
+        if isinstance(z, (list, np.ndarray)):
             # Specify different height for every electrode in a list:
-            z_arr = np.asarray(self.z).flatten()
+            z_arr = np.asarray(z).flatten()
             if z_arr.size != n_elecs:
                 raise ValueError("If `h` is a list, it must have %d entries, "
-                                 "not %d." % (n_elecs, len(self.z)))
+                                 "not %d." % (n_elecs, len(z)))
         else:
             # If `z` is a scalar, choose same height for all electrodes:
-            z_arr = np.ones(n_elecs, dtype=float) * self.z
+            z_arr = np.ones(n_elecs, dtype=float) * z
 
-        spc = self.spacing
+        spc = spacing
         if self.type.lower() == 'rect':
             # Rectangular grid from x, y coordinates:
             # For example, cols=3 with spacing=100 should give: [-100, 0, 100]
@@ -552,32 +553,32 @@ class ElectrodeGrid(ElectrodeArray):
             raise NotImplementedError
 
         # Rotate the grid:
-        rotmat = np.array([np.cos(self.rot), -np.sin(self.rot),
-                           np.sin(self.rot), np.cos(self.rot)]).reshape((2, 2))
+        rotmat = np.array([np.cos(rot), -np.sin(rot),
+                           np.sin(rot), np.cos(rot)]).reshape((2, 2))
         xy = np.matmul(rotmat, np.vstack((x_arr.flatten(), y_arr.flatten())))
         x_arr = xy[0, :]
         y_arr = xy[1, :]
 
-        # Apply offset to make the grid centered at (self.x, self.y):
-        x_arr += self.x
-        y_arr += self.y
+        # Apply offset to make the grid centered at (x, y):
+        x_arr += x
+        y_arr += y
 
-        if issubclass(self.etype, DiskElectrode):
-            if isinstance(self.r, (list, np.ndarray)):
+        if issubclass(etype, DiskElectrode):
+            if isinstance(kwargs['r'], (list, np.ndarray)):
                 # Specify different radius for every electrode in a list:
-                if len(self.r) != n_elecs:
+                if len(kwargs['r']) != n_elecs:
                     err_s = ("If `r` is a list, it must have %d entries, not "
-                             "%d)." % (n_elecs, len(self.r)))
+                             "%d)." % (n_elecs, len(kwargs['r'])))
                     raise ValueError(err_s)
-                r_arr = self.r
+                r_arr = kwargs['r']
             else:
                 # If `r` is a scalar, choose same radius for all electrodes:
-                r_arr = np.ones(n_elecs, dtype=float) * self.r
+                r_arr = np.ones(n_elecs, dtype=float) * kwargs['r']
 
             # Create a grid of DiskElectrode objects:
             for x, y, z, r, name in zip(x_arr, y_arr, z_arr, r_arr, names):
                 self.add_electrode(name, DiskElectrode(x, y, z, r))
-        elif issubclass(self.etype, PointSource):
+        elif issubclass(etype, PointSource):
             # Create a grid of PointSource objects:
             for x, y, z, name in zip(x_arr, y_arr, z_arr, names):
                 self.add_electrode(name, PointSource(x, y, z))
@@ -619,6 +620,8 @@ class ProsthesisSystem(PrettyPrint):
         A stimulus can also be assigned later (see
         :py:attr:`~pulse2percept.implants.ProsthesisSystem.stim`).
     """
+    # Frozen class: User cannot add more class attributes
+    __slots__ = ('_earray', '_stim', '_eye')
 
     def __init__(self, earray, stim=None, eye='RE'):
         self.earray = earray

--- a/pulse2percept/implants/bva.py
+++ b/pulse2percept/implants/bva.py
@@ -15,9 +15,12 @@ class BVA24(ProsthesisSystem):
     The array consists of:
 
     -   33 platinum stimulating electrodes:
+
         -   30 electrodes with 600um diameter (Electrodes 1-20 (except
             9, 17, 19) and Electrodes 21a-m),
+
         -   3 electrodes with 400um diameter (Electrodes 9, 17, 19)
+
     -   2 return electrodes with 2000um diameter (Electrodes 22, 23)
 
     Electrodes 21a-m are typically being ganged to provide an external

--- a/pulse2percept/implants/bva.py
+++ b/pulse2percept/implants/bva.py
@@ -46,6 +46,8 @@ class BVA24(ProsthesisSystem):
         Eye in which array is implanted.
 
     """
+    # Frozen class: User cannot add more class attributes
+    __slots__ = ()
 
     def __init__(self, x=0, y=0, z=0, rot=0, eye='RE', stim=None):
         self.earray = ElectrodeArray([])

--- a/pulse2percept/implants/tests/test_alpha.py
+++ b/pulse2percept/implants/tests/test_alpha.py
@@ -17,6 +17,10 @@ def test_AlphaIMS(ztype, x, y, r):
     rot = np.deg2rad(r)
     alpha = implants.AlphaIMS(x=x, y=y, z=z, rot=rot)
 
+    # Slots:
+    npt.assert_equal(hasattr(alpha, '__slots__'), True)
+    npt.assert_equal(hasattr(alpha, '__dict__'), False)
+
     # Coordinates of first electrode
     # 18.5 *spacing - spacing/2 for middle coordinate if (0,0) is upper-left
     # corner
@@ -89,6 +93,10 @@ def test_AlphaAMS(ztype, x, y, r):
     # Convert rotation angle to rad
     rot = np.deg2rad(r)
     alpha = implants.AlphaAMS(x=x, y=y, z=z, rot=rot)
+
+    # Slots:
+    npt.assert_equal(hasattr(alpha, '__slots__'), True)
+    npt.assert_equal(hasattr(alpha, '__dict__'), False)
 
     # TODO
     # Coordinates of first electrode

--- a/pulse2percept/implants/tests/test_argus.py
+++ b/pulse2percept/implants/tests/test_argus.py
@@ -18,6 +18,10 @@ def test_ArgusI(ztype, x, y, r):
 
     argus = implants.ArgusI(x, y, z=z, rot=rot)
 
+    # Slots:
+    npt.assert_equal(hasattr(argus, '__slots__'), True)
+    npt.assert_equal(hasattr(argus, '__dict__'), False)
+
     # Coordinates of first electrode
     xy = np.array([-1200, -1200]).T
 
@@ -114,6 +118,10 @@ def test_ArgusII(ztype, x, y, r):
     # Convert rotation angle to rad
     rot = np.deg2rad(r)
     argus = implants.ArgusII(x=x, y=y, z=z, rot=rot)
+
+    # Slots:
+    npt.assert_equal(hasattr(argus, '__slots__'), True)
+    npt.assert_equal(hasattr(argus, '__dict__'), False)
 
     # Coordinates of first electrode
     xy = np.array([-2362.5, -1312.5]).T

--- a/pulse2percept/implants/tests/test_base.py
+++ b/pulse2percept/implants/tests/test_base.py
@@ -10,6 +10,7 @@ from pulse2percept.stimuli import Stimulus
 
 
 class ValidElectrode(Electrode):
+    __slots__ = ()
 
     def electric_potential(self, x, y, z):
         r = np.sqrt((x - self.x) ** 2 + (y - self.y) ** 2 + (z - self.z) ** 2)
@@ -28,6 +29,9 @@ def test_Electrode():
         ValidElectrode(0, np.array([1, 2]), 2)
     with pytest.raises(TypeError):
         ValidElectrode(0, 1, [2, 3])
+    # Slots:
+    npt.assert_equal(hasattr(electrode, '__slots__'), True)
+    npt.assert_equal(hasattr(electrode, '__dict__'), False)
 
 
 def test_PointSource():
@@ -38,6 +42,9 @@ def test_PointSource():
     npt.assert_almost_equal(electrode.electric_potential(0, 1, 2, 1, 1), 1)
     npt.assert_almost_equal(electrode.electric_potential(0, 0, 0, 1, 1), 0.035,
                             decimal=3)
+    # Slots:
+    npt.assert_equal(hasattr(electrode, '__slots__'), True)
+    npt.assert_equal(hasattr(electrode, '__dict__'), False)
 
 
 def test_DiskElectrode():
@@ -68,6 +75,9 @@ def test_DiskElectrode():
     # Some distance away from the electrode (z>2):
     npt.assert_almost_equal(electrode.electric_potential(0, 1, 38, 1), 0.780,
                             decimal=3)
+    # Slots:
+    npt.assert_equal(hasattr(electrode, '__slots__'), True)
+    npt.assert_equal(hasattr(electrode, '__dict__'), False)
 
 
 def test_ElectrodeArray():
@@ -101,6 +111,9 @@ def test_ElectrodeArray():
     earray = ElectrodeArray({'A01': ps1, 'D07': ps2})
     npt.assert_equal(earray['A01'], ps1)
     npt.assert_equal(earray['D07'], ps2)
+    # Slots:
+    npt.assert_equal(hasattr(earray, '__slots__'), True)
+    npt.assert_equal(hasattr(earray, '__dict__'), False)
 
 
 def test_ElectrodeArray_add_electrode():
@@ -272,9 +285,6 @@ def test_ElectrodeGrid(gtype):
                           etype=DiskElectrode, r=radius)
     npt.assert_equal(egrid.shape, gshape)
     npt.assert_equal(egrid.n_electrodes, np.prod(gshape))
-    npt.assert_equal(egrid.x, x)
-    npt.assert_equal(egrid.y, y)
-    npt.assert_almost_equal(egrid.spacing, spacing)
     # Make sure different electrodes have different coordinates:
     npt.assert_equal(len(np.unique([e.x for e in egrid.values()])), gshape[1])
     npt.assert_equal(len(np.unique([e.y for e in egrid.values()])), gshape[0])
@@ -291,7 +301,6 @@ def test_ElectrodeGrid(gtype):
     z = 12
     egrid = ElectrodeGrid(gshape, spacing, z=z, type=gtype,
                           etype=DiskElectrode, r=radius)
-    npt.assert_equal(egrid.z, z)
     for i in egrid.values():
         npt.assert_equal(i.z, z)
 
@@ -299,7 +308,6 @@ def test_ElectrodeGrid(gtype):
     z = np.arange(np.prod(gshape))
     egrid = ElectrodeGrid(gshape, spacing, z=z, type=gtype,
                           etype=DiskElectrode, r=radius)
-    npt.assert_equal(egrid.z, z)
     x = -1
     for i in egrid.values():
         npt.assert_equal(i.z, x + 1)
@@ -372,6 +380,9 @@ def test_ElectrodeGrid(gtype):
                           names=['53', '18', '00', '81', '11', '12'])
     npt.assert_equal([e for e in egrid.keys()],
                      ['53', '18', '00', '81', '11', '12'])
+    # Slots:
+    npt.assert_equal(hasattr(egrid, '__slots__'), True)
+    npt.assert_equal(hasattr(egrid, '__dict__'), False)
 
 
 @pytest.mark.parametrize('gtype', ('rect', 'hex'))
@@ -379,47 +390,8 @@ def test_ElectrodeGrid_get_params(gtype):
     # When the electrode_type is 'DiskElectrode'
     # test the default value
     egrid = ElectrodeGrid((2, 3), 40, type=gtype, etype=DiskElectrode, r=20)
-    params = {'shape': (2, 3), 'x': 0, 'y': 0, 'z': 0, 'etype': DiskElectrode,
-              'rot': 0, 'spacing': 40, 'name_cols': '1',
-              'name_rows': 'A', 'r': 20}
-    for key, value in params.items():
-        if isinstance(value, float):
-            npt.assert_almost_equal(getattr(egrid, key), value)
-        else:
-            npt.assert_equal(getattr(egrid, key), value)
-    # test the nondefault value for all the parameters
-    egrid = ElectrodeGrid((2, 3), 30, x=10, y=20, z=30, rot=10, type=gtype,
-                          names=('A', '1'), etype=DiskElectrode, r=20)
-    params = {'shape': (2, 3), 'x': 10, 'y': 20, 'z': 30, 'rot': 10,
-              'spacing': 30, 'name_cols': '1', 'name_rows': 'A',
-              'etype': DiskElectrode, 'r': 20}
-    for key, value in params.items():
-        if isinstance(value, float):
-            npt.assert_almost_equal(getattr(egrid, key), value)
-        else:
-            npt.assert_equal(getattr(egrid, key), value)
-    # When the electrode_type is 'PointSource'
-    # test the default value
-    egrid = ElectrodeGrid((2, 3), 20, type=gtype, etype=PointSource)
-    params = {'shape': (2, 3), 'x': 0, 'y': 0, 'z': 0, 'etype': PointSource,
-              'rot': 0, 'spacing': 20, 'name_cols': '1',
-              'name_rows': 'A'}
-    for key, value in params.items():
-        if isinstance(value, float):
-            npt.assert_almost_equal(getattr(egrid, key), value)
-        else:
-            npt.assert_equal(getattr(egrid, key), value)
-    # test the nondefault value for all the parameters
-    egrid = ElectrodeGrid((2, 3), 30, x=10, y=20, z=30, rot=10, type=gtype,
-                          names=('A', '1'), etype=PointSource)
-    params = {'shape': (2, 3), 'x': 10, 'y': 20, 'z': 30, 'rot': 10,
-              'spacing': 30, 'etype': PointSource, 'name_cols': '1',
-              'name_rows': 'A'}
-    for key, value in params.items():
-        if isinstance(value, float):
-            npt.assert_almost_equal(getattr(egrid, key), value)
-        else:
-            npt.assert_equal(getattr(egrid, key), value)
+    npt.assert_equal(egrid.shape, (2, 3))
+    npt.assert_equal(egrid.type, gtype)
 
 
 @pytest.mark.parametrize('gtype', ('rect', 'hex'))
@@ -460,3 +432,7 @@ def test_ProsthesisSystem():
     with pytest.raises(TypeError):
         # Invalid stim type:
         implant.stim = "stim"
+
+    # Slots:
+    npt.assert_equal(hasattr(implant, '__slots__'), True)
+    npt.assert_equal(hasattr(implant, '__dict__'), False)

--- a/pulse2percept/implants/tests/test_bva.py
+++ b/pulse2percept/implants/tests/test_bva.py
@@ -4,6 +4,7 @@ import numpy.testing as npt
 from pulse2percept.implants.base import ProsthesisSystem
 from pulse2percept.implants.bva import BVA24
 
+
 @pytest.mark.parametrize('x', (-100, 200))
 @pytest.mark.parametrize('y', (-200, 400))
 @pytest.mark.parametrize('r', (-45, 60))
@@ -12,25 +13,29 @@ def test_BVA24(x, y, r):
     # Convert rotation angle to rad
     rot = np.deg2rad(r)
     bva = BVA24(x=x, y=y, rot=rot)
-    
+
+    # Slots:
+    npt.assert_equal(hasattr(bva, '__slots__'), True)
+    npt.assert_equal(hasattr(bva, '__dict__'), False)
+
     # Coordinate of first electrode (electrode '1')
     xy = np.array([-1275.0, 1520.0]).T
     # Coordinate of last electrode (electrode '21m')
     xy2 = np.array([-850.0, -2280.0]).T
-    
+
     # Rotate
     R = np.array([np.cos(rot), -np.sin(rot),
-                  np.sin(rot), np.cos(rot)]).reshape((2,2))
+                  np.sin(rot), np.cos(rot)]).reshape((2, 2))
     xy = np.matmul(R, xy)
     xy2 = np.matmul(R, xy2)
-    
+
     # Then off-set: Make sure first electrode is placed
     # correctly
     npt.assert_almost_equal(bva['1'].x, xy[0] + x)
     npt.assert_almost_equal(bva['1'].y, xy[1] + y)
     npt.assert_almost_equal(bva['21m'].x, xy2[0] + x)
     npt.assert_almost_equal(bva['21m'].y, xy2[1] + y)
-    
+
     # Check radii of electrodes
     for e in ['1', '5', '8', '15', '20']:
         npt.assert_almost_equal(bva[e].r, 300.0)
@@ -38,21 +43,21 @@ def test_BVA24(x, y, r):
         npt.assert_almost_equal(bva[e].r, 200.0)
     for e in ['R1', 'R2']:
         npt.assert_almost_equal(bva[e].r, 1000.0)
-    
+
     # Check the center is still at (x,y)
-    y_center = (bva['8'].y + bva['13'].y)/2
+    y_center = (bva['8'].y + bva['13'].y) / 2
     npt.assert_almost_equal(y_center, y)
-    x_center = (bva['8'].x + bva['13'].x)/2
+    x_center = (bva['8'].x + bva['13'].x) / 2
     npt.assert_almost_equal(x_center, x)
-    
+
     # Right-eye implant:
-    xc,yc = 500, -500
+    xc, yc = 500, -500
     bva_re = BVA24(eye='RE', x=xc, y=yc)
     npt.assert_equal(bva_re['1'].x < bva_re['6'].x, True)
     npt.assert_equal(bva_re['1'].y, bva_re['1'].y)
-    
+
     # Left-eye implant:
-    xc,yc = 500, -500
+    xc, yc = 500, -500
     bva_le = BVA24(eye='LE', x=xc, y=yc)
     npt.assert_equal(bva_le['1'].x > bva_le['6'].x, True)
     npt.assert_equal(bva_le['1'].y, bva_le['1'].y)

--- a/pulse2percept/models/axon_map.py
+++ b/pulse2percept/models/axon_map.py
@@ -22,6 +22,11 @@ class AxonMapModel(Watson2014ConversionMixin, BaseModel):
     rho : double
         Exponential decay constant away from the axon (microns).
     """
+    # Frozen class: User cannot add more class attributes
+    __slots__ = ('eye', 'rho', 'axlambda', 'loc_od_x', 'loc_od_y', 'n_axons',
+                 'axons_range', 'n_ax_segments', 'ax_segments_range',
+                 'axon_pickle', 'ignore_pickle', 'xret', 'yret',
+                 'axon_contrib')
 
     def __init__(self, **kwargs):
         super(AxonMapModel, self).__init__(**kwargs)

--- a/pulse2percept/models/base.py
+++ b/pulse2percept/models/base.py
@@ -3,7 +3,7 @@ import sys
 import abc
 
 from ..implants import ProsthesisSystem
-from ..utils import Frozen, PrettyPrint, GridXY, parfor
+from ..utils import PrettyPrint, GridXY, parfor
 
 
 class NotBuiltError(ValueError, AttributeError):
@@ -14,7 +14,7 @@ class NotBuiltError(ValueError, AttributeError):
     """
 
 
-class BaseModel(Frozen, PrettyPrint, metaclass=abc.ABCMeta):
+class BaseModel(PrettyPrint, metaclass=abc.ABCMeta):
     """Base model
 
     The BaseModel class defines which methods and attributes a model must
@@ -64,6 +64,9 @@ class BaseModel(Frozen, PrettyPrint, metaclass=abc.ABCMeta):
     idea of how to write a complete model.
 
     """
+    __slots__ = ('xrange', 'yrange', 'xystep', 'grid', 'grid_type',
+                 'thresh_percept', 'engine', 'scheduler', 'n_jobs', 'verbose',
+                 '__is_built')
 
     def __init__(self, **kwargs):
         """Constructor
@@ -133,10 +136,13 @@ class BaseModel(Frozen, PrettyPrint, metaclass=abc.ABCMeta):
         # getframe(0) is '_is_built', getframe(1) is 'set_attr'.
         # getframe(2) is the one we are looking for, and has to be either the
         # construct or ``build``:
-        f_caller = sys._getframe(2).f_code.co_name
+        f_caller = sys._getframe(1).f_code.co_name
         if f_caller in ["__init__", "build"]:
             self.__is_built = val
         else:
+            print(sys._getframe(0).f_code.co_name)
+            print(sys._getframe(1).f_code.co_name)
+            print(sys._getframe(2).f_code.co_name)
             err_s = ("The attribute `_is_built` can only be set in the "
                      "constructor or in ``build``, not in ``%s``." % f_caller)
             raise AttributeError(err_s)

--- a/pulse2percept/models/scoreboard.py
+++ b/pulse2percept/models/scoreboard.py
@@ -6,6 +6,8 @@ from ..models._scoreboard import scoreboard
 
 class ScoreboardModel(Watson2014ConversionMixin, BaseModel):
     """Scoreboard model"""
+    # Frozen class: User cannot add more class attributes
+    __slots__ = ('rho',)
 
     def _get_default_params(self):
         """Returns all settable parameters of the scoreboard model"""

--- a/pulse2percept/models/tests/test_axon_map.py
+++ b/pulse2percept/models/tests/test_axon_map.py
@@ -15,6 +15,9 @@ def test_AxonMapModel():
     model = models.AxonMapModel()
     for param in set_params:
         npt.assert_equal(hasattr(model, param), True)
+    # Slots:
+    npt.assert_equal(hasattr(model, '__slots__'), True)
+    npt.assert_equal(hasattr(model, '__dict__'), False)
 
     # User can override default values
     for key, value in set_params.items():

--- a/pulse2percept/models/tests/test_base.py
+++ b/pulse2percept/models/tests/test_base.py
@@ -10,9 +10,11 @@ from pulse2percept import implants
 class ValidBaseModel(models.BaseModel):
     """A class that implements all abstract methods of BaseModel"""
 
+    __slots__ = ('_private', 'valid')
+
     def __init__(self, **kwargs):
         super(ValidBaseModel, self).__init__(**kwargs)
-        # It must be allowed to set additional variables in the constructor:
+        # You can only add attributes that are listed in slots:
         self._private = 0
 
     def _get_default_params(self):
@@ -38,10 +40,13 @@ def test_BaseModel___init__():
     # Set new value for existing param:
     model.valid = 2
     npt.assert_almost_equal(model.valid, 2)
-    # However, creating new params outside the constructor is not allowed:
+    # Slots:
+    npt.assert_equal(hasattr(model, '__slots__'), True)
+    npt.assert_equal(hasattr(model, '__dict__'), False)
+    # However, creating new params is not allowed:
     with pytest.raises(AttributeError):
         model.newparam = 0
-    # Passing parameters that are not in get_params() is not allowed:
+    # Passing parameters that are not in slots is not allowed:
     with pytest.raises(AttributeError):
         ValidBaseModel(newparam=0)
     # Technically, nobody stops you from calling model.key = value on other

--- a/pulse2percept/models/tests/test_scoreboard.py
+++ b/pulse2percept/models/tests/test_scoreboard.py
@@ -10,6 +10,9 @@ def test_ScoreboardModel():
     # ScoreboardModel automatically sets `rho`:
     model = models.ScoreboardModel(engine='serial', xystep=5)
     npt.assert_equal(hasattr(model, 'rho'), True)
+    # Slots:
+    npt.assert_equal(hasattr(model, '__slots__'), True)
+    npt.assert_equal(hasattr(model, '__dict__'), False)
 
     # User can set `rho`:
     model.rho = 123

--- a/pulse2percept/models/tests/test_watson2014.py
+++ b/pulse2percept/models/tests/test_watson2014.py
@@ -10,6 +10,9 @@ def test_Watson2014ConversionMixin():
     trafo = Watson2014ConversionMixin()
     npt.assert_almost_equal(trafo.get_tissue_coords(0, 0), 0)
     npt.assert_almost_equal(trafo.get_tissue_coords(6, 6), 1618.53, decimal=2)
+    # Slots:
+    npt.assert_equal(hasattr(trafo, '__slots__'), True)
+    npt.assert_equal(hasattr(trafo, '__dict__'), False)
 
 
 def test_Watson2014DisplacementMixin():
@@ -29,6 +32,9 @@ def test_Watson2014DisplacementMixin():
     all_displace = trafo._watson_displacement(radii, meridian='nasal')
     npt.assert_almost_equal(np.max(all_displace), 1.9228664)
     npt.assert_almost_equal(radii[np.argmax(all_displace)], 2.1212121)
+    # Slots:
+    npt.assert_equal(hasattr(trafo, '__slots__'), True)
+    npt.assert_equal(hasattr(trafo, '__dict__'), False)
 
 
 def test_ret2dva():

--- a/pulse2percept/models/watson2014.py
+++ b/pulse2percept/models/watson2014.py
@@ -14,6 +14,7 @@ class Watson2014ConversionMixin(object):
     in [Watson2014]_.
 
     """
+    __slots__ = ()
 
     def get_tissue_coords(self, xdva, ydva):
         """Converts dva to retinal coords
@@ -45,6 +46,7 @@ class Watson2014DisplacementMixin(object):
     [Watson2014]_.
 
     """
+    __slots__ = ()
 
     @staticmethod
     def _watson_displacement(r, meridian='temporal'):

--- a/pulse2percept/stimuli/base.py
+++ b/pulse2percept/stimuli/base.py
@@ -133,6 +133,9 @@ class Stimulus(PrettyPrint):
     3.45...
 
     """
+    # Frozen class: Only the following class attributes are allowed
+    __slots__ = ('metadata', '_interp', '_interp_method', '_extrapolate',
+                 '__stim')
 
     def __init__(self, source, electrodes=None, time=None, metadata=None,
                  compress=False, interp_method='linear', extrapolate=False):
@@ -353,16 +356,14 @@ class Stimulus(PrettyPrint):
         Examples
         --------
         >>> from pulse2percept.stimuli import Stimulus
-        >>> stim1 = Stimulus(np.ones(3))
-        >>> stim2 = Stimulus(np.zeros(5))
-        >>> stim1 == stim2
+        >>> Stimulus([1, 2, 3]) == Stimulus([1, 2, 3])
+        True
+        >>> Stimulus(np.ones(3)) == Stimulus(np.zeros(5))
         False
 
         Compare a Stimulus with something else entirely:
 
-        >>> from pulse2percept.stimuli import Stimulus
-        >>> stim1 = Stimulus(np.ones(3))
-        >>> stim1 == 1
+        >>> Stimulus(np.ones(3)) == 1
         False
 
         """
@@ -380,7 +381,7 @@ class Stimulus(PrettyPrint):
                 return False
         if len(self.electrodes) != len(other.electrodes):
             return False
-        if not np.all(self.electrodes == other.electrodes):
+        if not np.array_equal(self.electrodes, other.electrodes):
             return False
         if self.shape != other.shape:
             return False

--- a/pulse2percept/stimuli/pulse_trains.py
+++ b/pulse2percept/stimuli/pulse_trains.py
@@ -18,12 +18,13 @@ class TimeSeries(object):
     data : array_like
         Time series data sampled at every ``tsample`` seconds.
     """
+    __slots__ = ('data', 'tsample', 'duration', 'shape')
 
     def __init__(self, tsample, data):
-        self.data = data
+        self.data = np.asarray(data)
         self.tsample = tsample
         self.duration = self.data.shape[-1] * tsample
-        self.shape = data.shape
+        self.shape = self.data.shape
 
     def __getitem__(self, y):
         return TimeSeries(self.tsample, self.data[y])
@@ -180,6 +181,7 @@ class MonophasicPulse(TimeSeries):
         the stimulus duration. Default: No additional zero padding,
         ``stim_dur`` is ``pdur`` + ``delay_dur``.
     """
+    __slots__ = ()
 
     def __init__(self, ptype, pdur, tsample, delay_dur=0, stim_dur=None):
         if tsample <= 0:
@@ -203,7 +205,7 @@ class MonophasicPulse(TimeSeries):
 
         pulse = np.concatenate((np.zeros(delay_size), pulse,
                                 np.zeros(stim_size)))
-        TimeSeries.__init__(self, tsample, pulse[:stim_size])
+        super(MonophasicPulse, self).__init__(tsample, pulse[:stim_size])
 
 
 class BiphasicPulse(TimeSeries):
@@ -225,6 +227,7 @@ class BiphasicPulse(TimeSeries):
         Duration of inter-phase interval (between positive and negative
         pulse) in seconds. Default: 0.
     """
+    __slots__ = ()
 
     def __init__(self, ptype, pdur, tsample, interphase_dur=0):
         if tsample <= 0:
@@ -248,7 +251,7 @@ class BiphasicPulse(TimeSeries):
         else:
             raise ValueError("Acceptable values for `type` are "
                              "'anodicfirst' or 'cathodicfirst'")
-        TimeSeries.__init__(self, tsample, pulse)
+        super(BiphasicPulse, self).__init__(tsample, pulse)
 
 
 class PulseTrain(TimeSeries):
@@ -279,6 +282,7 @@ class PulseTrain(TimeSeries):
         'pulsefirst' has the pulse first, followed by the gap.
         'gapfirst' has it the other way round.
     """
+    __slots__ = ()
 
     def __init__(self, tsample, freq=20, amp=20, dur=0.5, delay=0,
                  pulse_dur=0.45 / 1000, interphase_dur=0.45 / 1000,
@@ -352,4 +356,4 @@ class PulseTrain(TimeSeries):
         # Trim to correct length (takes care of too long arrays, too)
         pulse_train = pulse_train[:stim_size]
 
-        TimeSeries.__init__(self, tsample, pulse_train)
+        super(PulseTrain, self).__init__(tsample, pulse_train)

--- a/pulse2percept/stimuli/tests/test_base.py
+++ b/pulse2percept/stimuli/tests/test_base.py
@@ -8,6 +8,9 @@ from pulse2percept.stimuli import Stimulus, PulseTrain
 
 
 def test_Stimulus():
+    # Slots:
+    npt.assert_equal(hasattr(Stimulus(1), '__slots__'), True)
+    npt.assert_equal(hasattr(Stimulus(1), '__dict__'), False)
     # One electrode:
     stim = Stimulus(3)
     npt.assert_equal(stim.shape, (1, 1))

--- a/pulse2percept/stimuli/tests/test_pulse_trains.py
+++ b/pulse2percept/stimuli/tests/test_pulse_trains.py
@@ -8,6 +8,10 @@ from pulse2percept.stimuli import (TimeSeries, MonophasicPulse, BiphasicPulse,
 
 
 def test_TimeSeries():
+    # Slots:
+    npt.assert_equal(hasattr(TimeSeries(1, [1]), '__slots__'), True)
+    npt.assert_equal(hasattr(TimeSeries(1, [1]), '__dict__'), False)
+
     max_val = 2.0
     max_idx = 156
     data_orig = np.random.rand(10, 10, 1000)
@@ -105,6 +109,9 @@ def test_MonophasicPulse(ptype, sdur):
     for pdur in range(10):
         for ddur in range(10):
             pulse = MonophasicPulse(ptype, pdur, tsample, ddur, sdur)
+            # Slots:
+            npt.assert_equal(hasattr(pulse, '__slots__'), True)
+            npt.assert_equal(hasattr(pulse, '__dict__'), False)
 
             # Make sure the pulse length is correct:
             # When stimulus duration is not specified, stimulus must
@@ -156,11 +163,16 @@ def test_BiphasicPulse(ptype, pdur, tsample):
         # generate pulse
         pulse = BiphasicPulse(ptype, pdur, tsample, interphase_dur)
 
+        # Slots:
+        npt.assert_equal(hasattr(pulse, '__slots__'), True)
+        npt.assert_equal(hasattr(pulse, '__dict__'), False)
+
         # predicted length
         pulse_gap_dur = 2 * pdur + interphase_dur
 
         # make sure length is correct
-        npt.assert_equal(pulse.shape[-1], int(np.round(pulse_gap_dur / tsample)))
+        npt.assert_equal(
+            pulse.shape[-1], int(np.round(pulse_gap_dur / tsample)))
 
         # make sure amplitude is correct: negative peak,
         # zero (in case of nonnegative interphase dur),
@@ -210,6 +222,10 @@ def test_PulseTrain(pulsetype, delay, pulseorder):
         npt.assert_equal(pt.data[0], -ampl * scale)
         npt.assert_equal(pt.data[-1], ampl * scale)
         npt.assert_equal(len(pt.data), 10)
+
+    # Slots:
+    npt.assert_equal(hasattr(pt, '__slots__'), True)
+    npt.assert_equal(hasattr(pt, '__dict__'), False)
 
     # Then some more general ones...
     # Size of array given stimulus duration

--- a/pulse2percept/utils/__init__.py
+++ b/pulse2percept/utils/__init__.py
@@ -9,8 +9,8 @@
     parallel
 
 """
-from .base import (Frozen, FreezeError, PrettyPrint, GridXY, cart2pol,
-                   find_files_like, gamma, pol2cart)
+from .base import (PrettyPrint, GridXY, cart2pol, find_files_like, gamma,
+                   pol2cart)
 from .convolution import center_vector, conv
 from .deprecation import deprecated
 from .parallel import parfor
@@ -19,8 +19,6 @@ __all__ = [
     'cart2pol',
     'deprecated',
     'find_files_like',
-    'FreezeError',
-    'Frozen',
     'gamma',
     'GridXY',
     'parfor',

--- a/pulse2percept/utils/tests/test_base.py
+++ b/pulse2percept/utils/tests/test_base.py
@@ -3,30 +3,7 @@ import copy
 import pytest
 import numpy.testing as npt
 
-from pulse2percept.utils import (Frozen, FreezeError, gamma, find_files_like,
-                                 cart2pol, pol2cart)
-
-
-class FrozenChild(Frozen):
-
-    def __init__(self, a, b=0):
-        self.a = a
-        self.b = b
-
-
-def test_Frozen():
-    # Cannot set attributes outside constructor:
-    with pytest.raises(FreezeError):
-        frozen = Frozen()
-        frozen.newvar = 0
-
-    # Setting attributes in constructor is fine:
-    frozen_child = FrozenChild(1)
-    npt.assert_almost_equal(frozen_child.a, 1)
-    npt.assert_almost_equal(frozen_child.b, 0)
-    # But not outside constructor:
-    with pytest.raises(FreezeError):
-        frozen_child.c = 3
+from pulse2percept.utils import (gamma, find_files_like, cart2pol, pol2cart)
 
 
 def test_gamma():


### PR DESCRIPTION
Adds [`__slots__`](https://docs.python.org/3/reference/datamodel.html#slots) to all relevant classes (see issue #123). This has the following advantages:
- Slots can reduce memory usage by preventing the creation of `__dict__` and `__weakref__`. This is especially useful when a large number of objects is created (e.g., `TimeSeries` for each electrode, copied to each core)
- Slots can speed up attribute lookup
- Slots prevent the user from adding more class attributes (e.g., `model.newvar = 3`), which is exactly what `utils.FrozenClass` was trying to achieve

