### PR TITLE
[FIX] Stimulus indexing

### DIFF
--- a/pulse2percept/stimuli/base.py
+++ b/pulse2percept/stimuli/base.py
@@ -317,12 +317,17 @@ class Stimulus(PrettyPrint):
             electrodes = item[0]
             time = item[1]
             if isinstance(time, slice):
-                # Currently the only supported slice is ':'
-                # TODO: you could slice/interpolate time tstart:tend:tstep but
-                # you would need a step size to get a unique solution.
-                if time.start or time.stop or time.step:
-                    raise NotImplementedError("Slicing the time axis is not "
-                                              "yet supported.")
+                if not time.step:
+                    # We can't interpolate if we don't know the step size, so
+                    # the only allowed option is slice(None, None, None), which
+                    # is the same as ':'
+                    if time.start or time.stop:
+                        raise ValueError("You must provide a step size when "
+                                         "slicing the time axis.")
+                else:
+                    start = self.time[0] if time.start is None else time.start
+                    stop = self.time[-1] if time.stop is None else time.stop
+                    time = np.arange(start, stop, time.step)
             else:
                 if not np.any(time == Ellipsis):
                     # Convert to float so time is not mistaken for column index

--- a/pulse2percept/stimuli/base.py
+++ b/pulse2percept/stimuli/base.py
@@ -299,14 +299,14 @@ class Stimulus(PrettyPrint):
     def __getitem__(self, item):
         """Returns an item from the data array, interpolated if necessary
 
-        There are many potential used cases:
+        There are many potential use cases:
 
         *  ``stim[i]`` or ``stim[i, :]``: access electrode ``i`` (int or str)
         *  ``stim[[i0,i1]]`` or ``stim[[i0, i1], :]``
         *  ``stim[stim.electrodes != 'A1', :]``
         *  ``stim[:, 1]``: always interpreted as t=1.0, not index=1
         *  ``stim[:, 1.234]``: interpolated time
-        *  ``stim[:, stim.time < 0.4]``
+        *  ``stim[:, stim.time < 0.4]``, ``stim[:, 0.3:1.9:0.001]``
 
         """
         # STEP 1: AVOID CONFUSING TIME POINTS WITH COLUMN INDICES
@@ -331,13 +331,12 @@ class Stimulus(PrettyPrint):
             else:
                 if not np.any(time == Ellipsis):
                     # Convert to float so time is not mistaken for column index
-                    item = (electrodes, np.float32(time))
+                    time = np.float32(time)
         else:
             electrodes = item
             time = None
 
         # STEP 2: ELECTRODES COULD BE SPECIFIED AS INT OR STR
-        # if not isinstance(electrodes, slice) and electrodes != Ellipsis:
         if isinstance(electrodes, (list, np.ndarray)) or np.isscalar(electrodes):
             # Electrodes cannot be interpolated, so convert from slice,
             # ellipsis or indices into a list:

--- a/pulse2percept/stimuli/base.py
+++ b/pulse2percept/stimuli/base.py
@@ -327,11 +327,12 @@ class Stimulus(PrettyPrint):
                 else:
                     start = self.time[0] if time.start is None else time.start
                     stop = self.time[-1] if time.stop is None else time.stop
-                    time = np.arange(start, stop, time.step)
+                    time = np.arange(start, stop, time.step, dtype=np.float32)
             else:
                 if not np.any(time == Ellipsis):
                     # Convert to float so time is not mistaken for column index
-                    time = np.float32(time)
+                    if np.array(time).dtype != np.bool:
+                        time = np.float32(time)
         else:
             electrodes = item
             time = None
@@ -517,8 +518,7 @@ class Stimulus(PrettyPrint):
         if len(self.time) == 1:
             # Special case: Duplicate data with slightly different time points
             # so we can set up an interp1d:
-            eps = np.finfo(np.float32).eps
-            time = np.array([self.time - eps, self.time + eps]).flatten()
+            time = np.array([self.time - 1e-12, self.time + 1e-12]).flatten()
             data = np.repeat(self.data, 2, axis=1)
         else:
             time = self.time

--- a/pulse2percept/stimuli/tests/test_base.py
+++ b/pulse2percept/stimuli/tests/test_base.py
@@ -295,10 +295,17 @@ def test_Stimulus___getitem__():
     npt.assert_equal(stim[0, :], stim.data[0, :])
     npt.assert_equal(stim[0, ...], stim.data[0, ...])
     npt.assert_equal(stim[..., 0], stim.data[..., 0])
-    # More advanced slicing is not yet implemented:
-    with pytest.raises(NotImplementedError):
-        # This is ambiguous because no step size is given:
-        a = stim[1, 2:5]
+    # More advanced slicing of time is possible, but needs a step size:
+    with pytest.raises(ValueError):
+        stim[:, 2:5]
+    with pytest.raises(ValueError):
+        stim[:, :3]
+    with pytest.raises(ValueError):
+        stim[:, 2:]
+    npt.assert_almost_equal(stim[0, 1.2:1.65:0.15], [[2.2, 2.35, 2.5]])
+    npt.assert_almost_equal(stim[0, :0.6:0.2], [[1.0, 1.2, 1.4]])
+    npt.assert_almost_equal(stim[0, 2.7::0.2], [[3.7, 3.9]])
+    npt.assert_almost_equal(stim[0, ::2.6], [[1.0, 3.6]])
     # Single element:
     npt.assert_equal(stim[0, 0], stim.data[0, 0])
     # Interpolating time:

--- a/pulse2percept/stimuli/tests/test_base.py
+++ b/pulse2percept/stimuli/tests/test_base.py
@@ -278,8 +278,8 @@ def test_Stimulus___eq__():
     # Different data points:
     npt.assert_equal(stim == Stimulus(np.ones((2, 3)) * 1.1), False)
     # Different type:
-    npt.assert_equal(stim == np.ones((2, 3)), False)
-    npt.assert_equal(stim != np.ones((2, 3)), True)
+    npt.assert_equal(stim == ODict(), False)
+    npt.assert_equal(stim != ODict(), True)
     # Annoying but possible:
     npt.assert_equal(Stimulus([]), Stimulus(()))
 
@@ -291,10 +291,10 @@ def test_Stimulus___getitem__():
     npt.assert_equal(stim[...], stim.data)
     npt.assert_equal(stim[:, :], stim.data)
     npt.assert_equal(stim[:2], stim.data[:2])
-    npt.assert_equal(stim[:, 0], stim.data[:, 0].reshape((-1, 1)))
+    npt.assert_equal(stim[:, 0], stim.data[:, 0])
     npt.assert_equal(stim[0, :], stim.data[0, :])
     npt.assert_equal(stim[0, ...], stim.data[0, ...])
-    npt.assert_equal(stim[..., 0], stim.data[..., 0].reshape((-1, 1)))
+    npt.assert_equal(stim[..., 0], stim.data[..., 0])
     # More advanced slicing is not yet implemented:
     with pytest.raises(NotImplementedError):
         # This is ambiguous because no step size is given:
@@ -307,7 +307,7 @@ def test_Stimulus___getitem__():
                             decimal=3)
     # The second dimension is not a column index!
     npt.assert_almost_equal(stim[0, 0], 1.0)
-    npt.assert_almost_equal(stim[0, [0, 1]], np.array([[1.0, 2.0]]))
+    npt.assert_almost_equal(stim[0, [0, 1]], np.array([1.0, 2.0]))
     npt.assert_almost_equal(stim[0, [0.21, 1]], np.array([[1.21, 2.0]]))
     npt.assert_almost_equal(stim[[0, 1], [0.21, 1]],
                             np.array([[1.21, 2.0], [5.21, 6.0]]))
@@ -315,7 +315,7 @@ def test_Stimulus___getitem__():
     # "Valid" index errors:
     with pytest.raises(IndexError):
         stim[10, :]
-    with pytest.raises(TypeError):
+    with pytest.raises(IndexError):
         stim[3.3, 0]
 
     # Extrapolating should be disabled by default:
@@ -344,3 +344,32 @@ def test_Stimulus___getitem__():
     npt.assert_almost_equal(stim[:], stim.data)
     with pytest.raises(IndexError):
         stim[0]
+
+    # Electrodes by string:
+    stim = Stimulus([[0, 1], [2, 3]], electrodes=['A1', 'B2'])
+    npt.assert_almost_equal(stim['A1'], [0, 1])
+    npt.assert_almost_equal(stim['A1', :], [0, 1])
+    npt.assert_almost_equal(stim[['A1', 'B2'], 0], [0, 2])
+    npt.assert_almost_equal(stim[['A1', 'B2'], :], stim.data)
+
+    # Electrodes by slice:
+    stim = Stimulus(np.arange(10))
+    npt.assert_almost_equal(stim[1::3], np.array([[1], [4], [7]]))
+
+    # Binary arrays:
+    stim = Stimulus(np.arange(6).reshape((2, 3)),
+                    electrodes=['A1', 'B2'],
+                    time=[0.1, 0.3, 0.5])
+    npt.assert_almost_equal(stim[stim.electrodes != 'A1', :], [[3, 4, 5]])
+    npt.assert_almost_equal(stim[stim.electrodes == 'B2', :], [[3, 4, 5]])
+    npt.assert_almost_equal(stim[stim.electrodes == 'C9', :], np.zeros((0, 3)))
+    npt.assert_almost_equal(stim[stim.electrodes == 'C9', 0.1], [])
+    npt.assert_almost_equal(stim[stim.electrodes == 'B2', 0.1001], 3.0005,
+                            decimal=3)
+    npt.assert_almost_equal(stim[stim.electrodes == 'B2', 0.2], 3.5)
+    npt.assert_almost_equal(stim[:, stim.time < 0.4], [[0, 1], [3, 4]])
+    npt.assert_almost_equal(stim[stim.electrodes == 'B2', stim.time < 0.4],
+                            [3, 4])
+    npt.assert_almost_equal(stim[:, stim.time > 0.6], np.zeros((2, 0)))
+    npt.assert_almost_equal(stim['A1', stim.time > 0.6], [])
+    npt.assert_almost_equal(stim['A1', np.isclose(stim.time, 0.3)], [1])

--- a/pulse2percept/stimuli/tests/test_base.py
+++ b/pulse2percept/stimuli/tests/test_base.py
@@ -291,10 +291,10 @@ def test_Stimulus___getitem__():
     npt.assert_equal(stim[...], stim.data)
     npt.assert_equal(stim[:, :], stim.data)
     npt.assert_equal(stim[:2], stim.data[:2])
-    npt.assert_equal(stim[:, 0], stim.data[:, 0])
+    npt.assert_equal(stim[:, 0.0], stim.data[:, 0].reshape((-1, 1)))
     npt.assert_equal(stim[0, :], stim.data[0, :])
     npt.assert_equal(stim[0, ...], stim.data[0, ...])
-    npt.assert_equal(stim[..., 0], stim.data[..., 0])
+    npt.assert_equal(stim[..., 0], stim.data[..., 0].reshape((-1, 1)))
     # More advanced slicing of time is possible, but needs a step size:
     with pytest.raises(ValueError):
         stim[:, 2:5]
@@ -314,7 +314,7 @@ def test_Stimulus___getitem__():
                             decimal=3)
     # The second dimension is not a column index!
     npt.assert_almost_equal(stim[0, 0], 1.0)
-    npt.assert_almost_equal(stim[0, [0, 1]], np.array([1.0, 2.0]))
+    npt.assert_almost_equal(stim[0, [0, 1]], np.array([[1.0, 2.0]]))
     npt.assert_almost_equal(stim[0, [0.21, 1]], np.array([[1.21, 2.0]]))
     npt.assert_almost_equal(stim[[0, 1], [0.21, 1]],
                             np.array([[1.21, 2.0], [5.21, 6.0]]))
@@ -356,7 +356,7 @@ def test_Stimulus___getitem__():
     stim = Stimulus([[0, 1], [2, 3]], electrodes=['A1', 'B2'])
     npt.assert_almost_equal(stim['A1'], [0, 1])
     npt.assert_almost_equal(stim['A1', :], [0, 1])
-    npt.assert_almost_equal(stim[['A1', 'B2'], 0], [0, 2])
+    npt.assert_almost_equal(stim[['A1', 'B2'], 0], [[0], [2]])
     npt.assert_almost_equal(stim[['A1', 'B2'], :], stim.data)
 
     # Electrodes by slice:


### PR DESCRIPTION
`Stimulus` indexing was wrong for the following cases:
- string indices for electrodes; e.g., `stim['A1']`, `stim['A1', 0.4]`, `stim[['A1', 'B2'], :]`
- binary indexing; e.g., `stim[stim.electrodes != 'B1', :]`, `stim[:, stim.time < 0.4]`

In addition, you can now slice+interpolate the time axis; e.g., `stim[:, 0.3:2.5:0.01]`