### PR TITLE
[FIX] Race condition in stimulus assignment for BVA24

### DIFF
--- a/pulse2percept/implants/alpha.py
+++ b/pulse2percept/implants/alpha.py
@@ -71,7 +71,8 @@ class AlphaIMS(ProsthesisSystem):
                                     rot=rot, etype=DiskElectrode,
                                     r=elec_radius)
 
-        # Set stimulus if available:
+        # Beware of race condition: Stim must be set last, because it requires
+        # indexing into self.electrodes:
         self.stim = stim
 
         # Set left/right eye:
@@ -171,7 +172,8 @@ class AlphaAMS(ProsthesisSystem):
                                     rot=rot, etype=DiskElectrode,
                                     r=elec_radius)
 
-        # Set stimulus if available:
+        # Beware of race condition: Stim must be set last, because it requires
+        # indexing into self.electrodes:
         self.stim = stim
 
         # Set left/right eye:

--- a/pulse2percept/implants/argus.py
+++ b/pulse2percept/implants/argus.py
@@ -99,7 +99,8 @@ class ArgusI(ProsthesisSystem):
                                     rot=rot, etype=DiskElectrode, r=r_arr,
                                     names=names)
 
-        # Set stimulus if available:
+        # Beware of race condition: Stim must be set last, because it requires
+        # indexing into self.electrodes:
         self.stim = stim
 
         # Set left/right eye:
@@ -213,7 +214,8 @@ class ArgusII(ProsthesisSystem):
         self.earray = ElectrodeGrid(self.shape, spacing, x=x, y=y, z=z, r=r,
                                     rot=rot, names=names, etype=DiskElectrode)
 
-        # Set stimulus if available:
+        # Beware of race condition: Stim must be set last, because it requires
+        # indexing into self.electrodes:
         self.stim = stim
 
         # Set left/right eye:

--- a/pulse2percept/implants/bva.py
+++ b/pulse2percept/implants/bva.py
@@ -56,7 +56,6 @@ class BVA24(ProsthesisSystem):
 
     def __init__(self, x=0, y=0, z=0, rot=0, eye='RE', stim=None):
         self.earray = ElectrodeArray([])
-        self.stim = stim
         n_elecs = 35
 
         # Set left/right eye:
@@ -121,3 +120,7 @@ class BVA24(ProsthesisSystem):
 
         for x, y, z, r, name in zip(x_arr, y_arr, z_arr, r_arr, names):
             self.earray.add_electrode(name, DiskElectrode(x, y, z, r))
+
+        # Beware of race condition: Stim must be set last, because it requires
+        # indexing into self.electrodes:
+        self.stim = stim

--- a/pulse2percept/implants/tests/test_bva.py
+++ b/pulse2percept/implants/tests/test_bva.py
@@ -61,3 +61,23 @@ def test_BVA24(x, y, r):
     bva_le = BVA24(eye='LE', x=xc, y=yc)
     npt.assert_equal(bva_le['1'].x > bva_le['6'].x, True)
     npt.assert_equal(bva_le['1'].y, bva_le['1'].y)
+
+
+def test_BVA24_stim():
+    # Assign a stimulus:
+    implant = BVA24()
+    implant.stim = {'1': 1}
+    npt.assert_equal(implant.stim.electrodes, ['1'])
+    npt.assert_equal(implant.stim.time, None)
+    npt.assert_equal(implant.stim.data, [[1]])
+
+    # You can also assign the stimulus in the constructor:
+    BVA24(stim={'1': 1})
+    npt.assert_equal(implant.stim.electrodes, ['1'])
+    npt.assert_equal(implant.stim.time, None)
+    npt.assert_equal(implant.stim.data, [[1]])
+
+    # Set a stimulus via array:
+    implant = BVA24(stim=np.ones(35))
+    npt.assert_equal(implant.stim.shape, (35, 1))
+    npt.assert_almost_equal(implant.stim.data, 1)

--- a/pulse2percept/version.py
+++ b/pulse2percept/version.py
@@ -1,1 +1,1 @@
-__version__ = '0.7.0.dev0'
+__version__ = '0.6.1.dev0'


### PR DESCRIPTION
Fixes a race condition in the BVA24 constructor that makes `p2p.implants.BVA24(stim={'1': 1})` fail, whereas `bva = p2p.implants.BVA24(); bva.stim = {'1': 1}` works (see issue #185).