### PR TITLE
[FIX] ElectrodeGrid naming convention

### DIFF
--- a/pulse2percept/implants/alpha.py
+++ b/pulse2percept/implants/alpha.py
@@ -46,8 +46,8 @@ class AlphaIMS(ProsthesisSystem):
 
     >>> from pulse2percept.implants import AlphaIMS
     >>> AlphaIMS(x=0, y=0, z=100, rot=0)  # doctest: +NORMALIZE_WHITESPACE
-    AlphaIMS(earray=ElectrodeGrid(shape=(37, 37), type='rect'),
-             eye='RE', shape=(37, 37), stim=None)
+    AlphaIMS(earray=ElectrodeGrid, eye='RE', shape=(37, 37),
+             stim=None)
 
     Get access to the third electrode in the top row (by name or by row/column
     index):

--- a/pulse2percept/implants/alpha.py
+++ b/pulse2percept/implants/alpha.py
@@ -146,8 +146,8 @@ class AlphaAMS(ProsthesisSystem):
 
     >>> from pulse2percept.implants import AlphaAMS
     >>> AlphaAMS(x=0, y=0, z=100, rot=0)  # doctest: +NORMALIZE_WHITESPACE
-    AlphaAMS(earray=ElectrodeGrid(shape=(40, 40), type='rect'),
-             eye='RE', shape=(40, 40), stim=None)
+    AlphaAMS(earray=ElectrodeGrid, eye='RE', shape=(40, 40),
+             stim=None)
 
     Get access to the third electrode in the top row (by name or by row/column
     index):

--- a/pulse2percept/implants/argus.py
+++ b/pulse2percept/implants/argus.py
@@ -65,8 +65,8 @@ class ArgusI(ProsthesisSystem):
 
     >>> from pulse2percept.implants import ArgusI
     >>> ArgusI(x=0, y=0, z=100, rot=0)  # doctest: +NORMALIZE_WHITESPACE
-    ArgusI(earray=ElectrodeGrid(shape=(4, 4), type='rect'),
-           eye='RE', shape=(4, 4), stim=None)
+    ArgusI(earray=ElectrodeGrid, eye='RE', shape=(4, 4),
+           stim=None)
 
     Get access to electrode 'B1', either by name or by row/column index:
 
@@ -191,8 +191,8 @@ class ArgusII(ProsthesisSystem):
 
     >>> from pulse2percept.implants import ArgusII
     >>> ArgusII(x=0, y=0, z=100, rot=0)  # doctest: +NORMALIZE_WHITESPACE
-    ArgusII(earray=ElectrodeGrid(shape=(6, 10), type='rect'),
-            eye='RE', shape=(6, 10), stim=None)
+    ArgusII(earray=ElectrodeGrid, eye='RE', shape=(6, 10),
+            stim=None)
 
     Get access to electrode 'E7', either by name or by row/column index:
 

--- a/pulse2percept/implants/base.py
+++ b/pulse2percept/implants/base.py
@@ -3,11 +3,12 @@
 import numpy as np
 from abc import ABCMeta, abstractmethod
 from copy import deepcopy
+from string import ascii_uppercase
+from itertools import product
 # Using or importing the ABCs from 'collections' instead of from
 # 'collections.abc' is deprecated, and in 3.8 it will stop working:
 from collections.abc import Sequence
 from collections import OrderedDict
-
 
 from ..stimuli import Stimulus
 from ..utils import PrettyPrint
@@ -321,7 +322,8 @@ class ElectrodeGrid(ElectrodeArray):
         rotation on the retinal surface)
     names: (name_rows, name_cols), each of which either 'A' or '1'
         Naming convention for rows and columns, respectively.
-        If 'A', rows or columns will be labeled alphabetically.
+        If 'A', rows or columns will be labeled alphabetically: A-Z, AA-AZ,
+        BA-BZ, CA-CZ, etc.
         If '1', rows or columns will be labeled numerically.
         Columns and rows may only be strings and integers.
         For example ('1', 'A') will number rows numerically and columns
@@ -350,7 +352,7 @@ class ElectrodeGrid(ElectrodeArray):
     >>> from pulse2percept.implants import ElectrodeGrid, DiskElectrode
     >>> ElectrodeGrid((3, 4), 20, x=10, y=20, z=500, names=('A', '1'), r=10,
     ...               type='hex', etype=DiskElectrode) # doctest: +NORMALIZE_WHITESPACE +ELLIPSIS
-    ElectrodeGrid(shape=(3, 4), type='hex')
+    ElectrodeGrid(shape=(3, 4), spacing=20, type='hex')
 
     A rectangulr electrode grid with 2 rows and 4 columns, made of disk
     electrodes with 10um radius spaced 20um apart, centered at (10, 20)um, and
@@ -364,7 +366,7 @@ class ElectrodeGrid(ElectrodeArray):
     >>> from pulse2percept.implants import ElectrodeGrid, DiskElectrode
     >>> ElectrodeGrid((2, 4), 20, x=10, y=20, z=500, names=('A', '1'), r=10,
     ...               type='rect', etype=DiskElectrode) # doctest: +NORMALIZE_WHITESPACE +ELLIPSIS
-    ElectrodeGrid(shape=(2, 4), type='rect')
+    ElectrodeGrid(shape=(2, 4), spacing=20, type='rect')
 
     There are three ways to access (e.g.) the last electrode in the grid,
     either by name (``grid['C3']``), by row/column index (``grid[2, 2]``), or
@@ -389,7 +391,7 @@ class ElectrodeGrid(ElectrodeArray):
 
     """
     # Frozen class: User cannot add more class attributes
-    __slots__ = ('shape', 'type')
+    __slots__ = ('shape', 'type', 'spacing')
 
     def __init__(self, shape, spacing, x=0, y=0, z=0, rot=0, names=('A', '1'),
                  type='rect', orientation='horizontal', etype=PointSource,
@@ -420,6 +422,7 @@ class ElectrodeGrid(ElectrodeArray):
 
         self.shape = shape
         self.type = type
+        self.spacing = spacing
         # Instantiate empty collection of electrodes. This dictionary will be
         # populated in a private method ``_set_egrid``:
         self.electrodes = OrderedDict()
@@ -428,7 +431,8 @@ class ElectrodeGrid(ElectrodeArray):
 
     def _pprint_params(self):
         """Return dict of class attributes to pretty-print"""
-        params = {'shape': self.shape, 'type': self.type}
+        params = {'shape': self.shape, 'spacing': self.spacing,
+                  'type': self.type}
         return params
 
     def __getitem__(self, item):
@@ -479,22 +483,24 @@ class ElectrodeGrid(ElectrodeArray):
         # The user did not specify a unique naming scheme:
         if len(names) == 2:
             name_rows, name_cols = names
-            # Create electrode names, using either A-Z or 1-n:
             if name_rows.isalpha():
-                rws = [chr(i) for i in range(ord(name_rows),
-                                             ord(name_rows) + rows + 1)]
+                # Create electrode names A-Z, AA-AZ, BA-BZ, etc.:
+                n_times = int(np.ceil(rows / 26))
+                rws = [''.join(chars) for r in range(1, n_times + 1)
+                       for chars in product(ascii_uppercase, repeat=r)][:rows]
             elif name_rows.isdigit():
-                rws = [str(i) for i in range(
-                    int(name_rows), rows + int(name_rows))]
+                # Create electrode names 1-n:
+                rws = [str(i) for i in range(1, rows + 1)]
             else:
                 raise ValueError("rows must be alphabetic or numeric")
 
             if name_cols.isalpha():
-                clms = [chr(i) for i in range(ord(name_cols),
-                                              ord(name_cols) + cols)]
+                # Create electrode names A-Z, AA-AZ, BA-BZ, etc.:
+                n_times = int(np.ceil(cols / 26))
+                clms = [''.join(chars) for r in range(1, n_times + 1)
+                        for chars in product(ascii_uppercase, repeat=r)][:cols]
             elif name_cols.isdigit():
-                clms = [str(i) for i in range(int(name_cols),
-                                              cols + int(name_cols))]
+                clms = [str(i) for i in range(1, cols + 1)]
             else:
                 raise ValueError("Columns must be alphabetic or numeric.")
 
@@ -578,7 +584,6 @@ class ElectrodeGrid(ElectrodeArray):
                             y_arr[row][col] = y_arr_upshift[row][col]
                 x_arr = x_arr_upshift
                 y_arr = np.array(y_arr)
-
         else:
             raise NotImplementedError
 
@@ -604,7 +609,6 @@ class ElectrodeGrid(ElectrodeArray):
             else:
                 # If `r` is a scalar, choose same radius for all electrodes:
                 r_arr = np.ones(n_elecs, dtype=float) * kwargs['r']
-
             # Create a grid of DiskElectrode objects:
             for x, y, z, r, name in zip(x_arr, y_arr, z_arr, r_arr, names):
                 self.add_electrode(name, DiskElectrode(x, y, z, r))

--- a/pulse2percept/implants/tests/test_alpha.py
+++ b/pulse2percept/implants/tests/test_alpha.py
@@ -36,12 +36,6 @@ def test_AlphaIMS(ztype, x, y, r):
     npt.assert_almost_equal(alpha['A1'].x, xy[0] + x)
     npt.assert_almost_equal(alpha['A1'].y, xy[1] + y)
 
-    # Make sure array center is still (x,y)
-    y_center = alpha['e1'].y + (alpha['A37'].y - alpha['e1'].y) / 2
-    npt.assert_almost_equal(y_center, y)
-    x_center = alpha['A1'].x + (alpha['e37'].x - alpha['A1'].x) / 2
-    npt.assert_almost_equal(x_center, x)
-
     # Check radii of electrodes
     for e in ['A1', 'B2', 'C3']:
         npt.assert_equal(alpha[e].r, 50)
@@ -50,8 +44,7 @@ def test_AlphaIMS(ztype, x, y, r):
     with pytest.raises(ValueError):
         implants.AlphaIMS(x=-100, y=10, z=np.zeros(38))
     with pytest.raises(ValueError):
-        implants.AlphaIMS(x=-100, y=10, z=[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
-                                           16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36])
+        implants.AlphaIMS(x=-100, y=10, z=np.arange(1, 37))
 
     # Indexing must work for both integers and electrode names
     alpha = implants.AlphaIMS()
@@ -70,7 +63,7 @@ def test_AlphaIMS(ztype, x, y, r):
 
     # Left-eye implant:
     alpha_le = implants.AlphaIMS(eye='LE', x=xc, y=yc)
-    npt.assert_equal(alpha_le['A1'].x > alpha_le['e37'].x, True)
+    npt.assert_equal(alpha_le['A1'].x > alpha_le['AE37'].x, True)
     npt.assert_almost_equal(alpha_le['A37'].y, alpha_le['A1'].y)
 
     # In both left and right eyes, rotation with positive angle should be
@@ -114,9 +107,9 @@ def test_AlphaAMS(ztype, x, y, r):
     npt.assert_almost_equal(alpha['A1'].y, xy[1] + y)
 
     # Make sure array center is still (x,y)
-    y_center = alpha['h1'].y + (alpha['A40'].y - alpha['h1'].y) / 2
+    y_center = alpha['AN1'].y + (alpha['A40'].y - alpha['AN1'].y) / 2
     npt.assert_almost_equal(y_center, y)
-    x_center = alpha['A1'].x + (alpha['h40'].x - alpha['A1'].x) / 2
+    x_center = alpha['A1'].x + (alpha['AN40'].x - alpha['A1'].x) / 2
     npt.assert_almost_equal(x_center, x)
 
     # Check radii of electrodes
@@ -127,8 +120,7 @@ def test_AlphaAMS(ztype, x, y, r):
     with pytest.raises(ValueError):
         implants.AlphaAMS(x=-100, y=10, z=np.zeros(41))
     with pytest.raises(ValueError):
-        implants.AlphaAMS(x=-100, y=10, z=[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
-                                           16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39])
+        implants.AlphaAMS(x=-100, y=10, z=np.arange(1, 40))
 
     # Indexing must work for both integers and electrode names
     alpha = implants.AlphaAMS()
@@ -147,7 +139,7 @@ def test_AlphaAMS(ztype, x, y, r):
 
     # Left-eye implant:
     alpha_le = implants.AlphaAMS(eye='LE', x=xc, y=yc)
-    npt.assert_equal(alpha_le['A1'].x > alpha_le['e40'].x, True)
+    npt.assert_equal(alpha_le['A1'].x > alpha_le['AE40'].x, True)
     npt.assert_almost_equal(alpha_le['A40'].y, alpha_le['A1'].y)
 
     # In both left and right eyes, rotation with positive angle should be

--- a/pulse2percept/implants/tests/test_base.py
+++ b/pulse2percept/implants/tests/test_base.py
@@ -235,12 +235,12 @@ def test_ElectrodeGrid(gtype):
         ElectrodeGrid((2, 3), 10, type=gtype, etype=ElectrodeArray)
     with pytest.raises(TypeError):
         ElectrodeGrid((2, 3), 10, type=gtype, etype="foo")
-    
+
     # Must pass in valid Orientation value:
     with pytest.raises(ValueError):
-        ElectrodeGrid((2,3), 10, type=gtype, orientation="foo")
+        ElectrodeGrid((2, 3), 10, type=gtype, orientation="foo")
     with pytest.raises(TypeError):
-        ElectrodeGrid((2,3),10, type=gtype, orientation=False)
+        ElectrodeGrid((2, 3), 10, type=gtype, orientation=False)
 
     # Must pass in radius `r` for grid of DiskElectrode objects:
     gshape = (4, 5)
@@ -286,7 +286,7 @@ def test_ElectrodeGrid(gtype):
     grid = ElectrodeGrid(gshape, spacing, type=gtype, orientation='vertical',
                          etype=DiskElectrode, r=30)
     npt.assert_almost_equal(np.sqrt((grid['B1'].x - grid['B2'].x) ** 2 +
-                                (grid['B1'].y - grid['B2'].y) ** 2),
+                                    (grid['B1'].y - grid['B2'].y) ** 2),
                             spacing)
     npt.assert_almost_equal(np.sqrt((grid['A1'].x - grid['B1'].x) ** 2 +
                                     (grid['A1'].y - grid['B1'].y) ** 2),
@@ -381,13 +381,13 @@ def test_ElectrodeGrid(gtype):
     npt.assert_equal([e for e in egrid.keys()],
                      ['AA', 'AB', 'AC', 'BA', 'BB', 'BC'])
 
-    # rows and columns start at values other than A or 1
+    # Still starts at A:
     egrid = ElectrodeGrid(gshape, spacing, type=gtype, names=('B', '1'))
     npt.assert_equal([e for e in egrid.keys()],
-                     ['B1', 'B2', 'B3', 'C1', 'C2', 'C3'])
+                     ['A1', 'A2', 'A3', 'B1', 'B2', 'B3'])
     egrid = ElectrodeGrid(gshape, spacing, type=gtype, names=('A', '2'))
     npt.assert_equal([e for e in egrid.keys()],
-                     ['A2', 'A3', 'A4', 'B2', 'B3', 'B4'])
+                     ['A1', 'A2', 'A3', 'B1', 'B2', 'B3'])
 
     # test unique names
     egrid = ElectrodeGrid(gshape, spacing, type=gtype,
@@ -410,14 +410,14 @@ def test_ElectrodeGrid_get_params(gtype):
 
 @pytest.mark.parametrize('gtype', ('rect', 'hex'))
 def test_ElectrodeGrid___get_item__(gtype):
-    grid = ElectrodeGrid((2, 4), 20, names=('C', '3'), type=gtype,
+    grid = ElectrodeGrid((2, 4), 20, names=('A', '1'), type=gtype,
                          etype=DiskElectrode, r=20)
-    npt.assert_equal(grid[0], grid['C3'])
-    npt.assert_equal(grid[0, 0], grid['C3'])
-    npt.assert_equal(grid[1], grid['C4'])
-    npt.assert_equal(grid[0, 1], grid['C4'])
-    npt.assert_equal(grid[['C3', 1, (0, 2)]],
-                     [grid['C3'], grid['C4'], grid['C5']])
+    npt.assert_equal(grid[0], grid['A1'])
+    npt.assert_equal(grid[0, 0], grid['A1'])
+    npt.assert_equal(grid[1], grid['A2'])
+    npt.assert_equal(grid[0, 1], grid['A2'])
+    npt.assert_equal(grid[['A1', 1, (0, 2)]],
+                     [grid['A1'], grid['A2'], grid['A3']])
 
 
 def test_ProsthesisSystem():


### PR DESCRIPTION
Fixes `ElectrodeGrid` naming convention when there are more than 26 alphabetic rows/columns (issue #189): new ordering is `A-Z`, then `AA-AZ`, then `BA-BZ`, etc.