### PR TITLE
[FIX] Grid2D when range is not divisible by step

### DIFF
--- a/pulse2percept/models/base.py
+++ b/pulse2percept/models/base.py
@@ -8,7 +8,7 @@ import numpy as np
 from ..implants import ProsthesisSystem
 from ..stimuli import Stimulus
 from ..percepts import Percept
-from ..utils import PrettyPrint, Frozen, FreezeError, GridXY, bisect
+from ..utils import PrettyPrint, Frozen, FreezeError, Grid2D, bisect
 
 
 class NotBuiltError(ValueError, AttributeError):
@@ -218,7 +218,7 @@ class SpatialModel(BaseModel, metaclass=ABCMeta):
         for key, val in build_params.items():
             setattr(self, key, val)
         # Build the spatial grid:
-        self.grid = GridXY(self.xrange, self.yrange, step=self.xystep,
+        self.grid = Grid2D(self.xrange, self.yrange, step=self.xystep,
                            grid_type=self.grid_type)
         self.grid.xret = self.dva2ret(self.grid.x)
         self.grid.yret = self.dva2ret(self.grid.y)

--- a/pulse2percept/models/beyeler2019.py
+++ b/pulse2percept/models/beyeler2019.py
@@ -4,7 +4,7 @@ import os
 import numpy as np
 import pickle
 
-from ..utils import parfor, GridXY, Watson2014Transform
+from ..utils import parfor, Grid2D, Watson2014Transform
 from ..implants import ProsthesisSystem, ElectrodeArray
 from ..stimuli import Stimulus
 from ..models import Model, SpatialModel

--- a/pulse2percept/models/tests/test_base.py
+++ b/pulse2percept/models/tests/test_base.py
@@ -9,7 +9,7 @@ from pulse2percept.stimuli import Stimulus
 from pulse2percept.percepts import Percept
 from pulse2percept.models import (BaseModel, Model, NotBuiltError,
                                   SpatialModel, TemporalModel)
-from pulse2percept.utils import FreezeError, GridXY
+from pulse2percept.utils import FreezeError, Grid2D
 
 
 class ValidBaseModel(BaseModel):
@@ -66,7 +66,7 @@ def test_SpatialModel():
     npt.assert_equal(model.is_built, False)
     model.build()
     npt.assert_equal(model.is_built, True)
-    npt.assert_equal(isinstance(model.grid, GridXY), True)
+    npt.assert_equal(isinstance(model.grid, Grid2D), True)
     npt.assert_equal(isinstance(model.grid.xret, np.ndarray), True)
 
     # Can overwrite default values:

--- a/pulse2percept/percepts/base.py
+++ b/pulse2percept/percepts/base.py
@@ -6,7 +6,7 @@ if platform == "darwin":  # OS X
 import matplotlib.pyplot as plt
 from matplotlib.axes import Subplot
 
-from ..utils import Data, GridXY
+from ..utils import Data, Grid2D
 
 
 class Percept(Data):
@@ -18,7 +18,7 @@ class Percept(Data):
     ----------
     data : 3D NumPy array
         A NumPy array specifying the percept in (Y, X, T) dimensions
-    space : :py:class:`~pulse2percept.utils.GridXY`
+    space : :py:class:`~pulse2percept.utils.Grid2D`
         A grid object specifying the (x,y) coordinates in space
     time : 1D array
         A list of time points
@@ -31,8 +31,8 @@ class Percept(Data):
         xdva = None
         ydva = None
         if space is not None:
-            if not isinstance(space, GridXY):
-                raise TypeError("'space' must be a GridXY object, not "
+            if not isinstance(space, Grid2D):
+                raise TypeError("'space' must be a Grid2D object, not "
                                 "%s." % type(space))
             xdva = space._xflat
             ydva = space._yflat

--- a/pulse2percept/percepts/tests/test_base.py
+++ b/pulse2percept/percepts/tests/test_base.py
@@ -5,7 +5,7 @@ import matplotlib.pyplot as plt
 from matplotlib.axes import Subplot
 
 from pulse2percept.percepts import Percept
-from pulse2percept.utils import GridXY
+from pulse2percept.utils import Grid2D
 
 
 def test_Percept():
@@ -30,12 +30,12 @@ def test_Percept():
     # Labels from a grid.
     y_range = (-1, 1)
     x_range = (-2, 2)
-    grid = GridXY(x_range, y_range)
+    grid = Grid2D(x_range, y_range)
     percept = Percept(ndarray, space=grid)
     npt.assert_almost_equal(percept.xdva, grid._xflat)
     npt.assert_almost_equal(percept.ydva, grid._yflat)
     npt.assert_almost_equal(percept.time, [0])
-    grid = GridXY(x_range, y_range)
+    grid = Grid2D(x_range, y_range)
     percept = Percept(ndarray, space=grid)
     npt.assert_almost_equal(percept.xdva, grid._xflat)
     npt.assert_almost_equal(percept.ydva, grid._yflat)
@@ -45,7 +45,7 @@ def test_Percept():
 def test_Percept_plot():
     y_range = (-1, 1)
     x_range = (-2, 2)
-    grid = GridXY(x_range, y_range)
+    grid = Grid2D(x_range, y_range)
     percept = Percept(np.arange(15).reshape((3, 5, 1)), space=grid)
 
     # Basic usage of pcolor:

--- a/pulse2percept/utils/__init__.py
+++ b/pulse2percept/utils/__init__.py
@@ -12,7 +12,7 @@
 
 """
 from .base import PrettyPrint, FreezeError, Frozen, Data, gamma
-from .geometry import (GridXY, RetinalCoordTransform, Curcio1990Transform,
+from .geometry import (Grid2D, RetinalCoordTransform, Curcio1990Transform,
                        Watson2014Transform, Watson2014DisplaceTransform,
                        cart2pol, pol2cart)
 from .convolution import center_vector, conv
@@ -29,7 +29,7 @@ __all__ = [
     'FreezeError',
     'Frozen',
     'gamma',
-    'GridXY',
+    'Grid2D',
     'parfor',
     'pol2cart',
     'PrettyPrint',

--- a/pulse2percept/utils/tests/test_geometry.py
+++ b/pulse2percept/utils/tests/test_geometry.py
@@ -3,15 +3,15 @@ import pytest
 import numpy.testing as npt
 
 from pulse2percept.utils import (RetinalCoordTransform, Curcio1990Transform,
-                                 GridXY, Watson2014Transform,
+                                 Grid2D, Watson2014Transform,
                                  Watson2014DisplaceTransform,
                                  cart2pol, pol2cart)
 
 
 @pytest.mark.parametrize('x_range', [(0, 0), (-3, 3), (4, -2), (1, -1)])
 @pytest.mark.parametrize('y_range', [(0, 0), (0, 7), (-3, 3), (2, -2)])
-def test_GridXY(x_range, y_range):
-    grid = GridXY(x_range, y_range, step=1, grid_type='rectangular')
+def test_Grid2D(x_range, y_range):
+    grid = Grid2D(x_range, y_range, step=1, grid_type='rectangular')
     npt.assert_equal(grid.x_range, x_range)
     npt.assert_equal(grid.y_range, y_range)
     npt.assert_equal(grid.step, 1)
@@ -31,6 +31,50 @@ def test_GridXY(x_range, y_range):
     npt.assert_almost_equal(grid.y[0, -1], y_range[0])
     npt.assert_almost_equal(grid.y[-1, 0], y_range[1])
     npt.assert_almost_equal(grid.y[-1, -1], y_range[1])
+
+
+def test_Grid2D_make_rectangular_grid():
+    # Range is a multiple of step size:
+    grid = Grid2D((-1, 1), (0, 0), step=1)
+    npt.assert_almost_equal(grid.x, [[-1, 0, 1]])
+    npt.assert_almost_equal(grid.y, [[0, 0, 0]])
+    for mlt in [0.01, 0.1, 1, 10, 100]:
+        grid = Grid2D((-10 * mlt, 10 * mlt), (-10 * mlt, 10 * mlt),
+                      step=5 * mlt)
+        npt.assert_almost_equal(grid.x[0], mlt * np.array([-10, -5, 0, 5, 10]))
+        npt.assert_almost_equal(grid.y[:, 0],
+                                mlt * np.array([-10, -5, 0, 5, 10]))
+
+    # Another way to verify this is to manually check the step size:
+    for step in [0.25, 0.5, 1, 2]:
+        print(step)
+        grid = Grid2D((-20, 20), (-40, 40), step=step)
+        npt.assert_equal(len(np.unique(np.diff(grid.x[0, :]))), 1)
+        npt.assert_equal(len(np.unique(np.diff(grid.y[:, 0]))), 1)
+        npt.assert_almost_equal(np.unique(np.diff(grid.x[0, :]))[0], step)
+        npt.assert_almost_equal(np.unique(np.diff(grid.y[:, 0]))[0], step)
+
+    # Step size just a little too small/big to fit into range. In this case,
+    # the step size gets adjusted so that the range is as specified by the
+    # user:
+    grid = Grid2D((-1, 1), (0, 0), step=0.33)
+    npt.assert_almost_equal(grid.x, [[-1, -2 / 3, -1 / 3, 0, 1 / 3, 2 / 3, 1]])
+    npt.assert_almost_equal(grid.y, [[0, 0, 0, 0, 0, 0, 0]])
+    grid = Grid2D((-1, 1), (0, 0), step=0.34)
+    npt.assert_almost_equal(grid.x, [[-1, -2 / 3, -1 / 3, 0, 1 / 3, 2 / 3, 1]])
+    npt.assert_almost_equal(grid.y, [[0, 0, 0, 0, 0, 0, 0]])
+
+    # Different step size for x and y:
+    grid = Grid2D((-1, 1), (0, 0), step=(0.5, 1))
+    npt.assert_almost_equal(grid.x, [[-1, -0.5, 0, 0.5, 1]])
+    npt.assert_almost_equal(grid.y, [[0, 0, 0, 0, 0]])
+    grid = Grid2D((0, 0), (-1, 1), step=(2, 0.5))
+    npt.assert_almost_equal(grid.x, [[0], [0], [0], [0], [0]])
+    npt.assert_almost_equal(grid.y[:, 0], [-1, -0.5, 0, 0.5, 1])
+
+    # Same step size, but given explicitly:
+    npt.assert_almost_equal(Grid2D((-3, 3), (8, 12), step=0.123).x,
+                            Grid2D((-3, 3), (8, 12), step=(0.123, 0.123)).x)
 
 
 class ValidCoordTransform(RetinalCoordTransform):


### PR DESCRIPTION
Fixes the problem where the step size returned by `Grid2D` is slightly off, because the specified range is not divisible by step, 