### PR TITLE
[ENH] Subset selector for Horsager data

### DIFF
--- a/examples/models/plot_horsager2009.py
+++ b/examples/models/plot_horsager2009.py
@@ -29,13 +29,13 @@ data.shape
 #
 # Loading the data
 # ^^^^^^^^^^^^^^^^
+#
 # The data includes a number of thresholds measured on single-pulse stimuli.
 # We can load a subset of these data; for example, for subject S05 and
 # Electrode C3:
 
-single_pulse = data[(data.stim_type == 'single_pulse') &
-                    (data.subject == 'S05') &
-                    (data.electrode == 'C3')]
+single_pulse = load_horsager2009(subjects='S05', electrodes='C3',
+                                 stim_types == 'single_pulse')
 single_pulse
 
 ###############################################################################

--- a/pulse2percept/datasets/horsager2009.py
+++ b/pulse2percept/datasets/horsager2009.py
@@ -32,7 +32,10 @@ def load_horsager2009(subjects=None, electrodes=None, stim_types=None,
     implant               Argus I
     electrode             Electrode ID, A1-F10
     task                  'threshold' or 'matching'
-    stim_type             'single_pulse', 'fixed_duration', ...
+    stim_type             'single_pulse', 'fixed_duration',
+                          'variable_duration', 'fixed_duration_supra',
+                          'bursting_triplets', 'bursting_triplets_supra',
+                          'latent_addition'
     stim_dur              Stimulus duration (ms)
     stim_freq             Stimulus frequency (Hz)
     stim_amp              Stimulus amplitude (uA)
@@ -59,8 +62,15 @@ def load_horsager2009(subjects=None, electrodes=None, stim_types=None,
 
     Parameters
     ----------
-    subjects : str or None, optional, default: None
-
+    subjects : str | list of strings | None, optional, default: None
+        Select data from a subject or list of subjects. By default, all
+        subjects are selected.
+    electrodes : str | list of strings | None, optional, default: None
+        Select data from a single electrode or a list of electrodes.
+        By default, all electrodes are selected.
+    stim_types : str | list of strings | None, optional, default: None
+        Select data from a single stimulus type or a list of stimulus types.
+        By default, all stimulus types are selected.
     shuffle : boolean, optional, default: False
         If True, the rows of the DataFrame are shuffled.
     random_state : int | numpy.random.RandomState | None, optional, default: 0
@@ -70,7 +80,7 @@ def load_horsager2009(subjects=None, electrodes=None, stim_types=None,
     Returns
     -------
     data: pd.DataFrame
-        The whole dataset is returned in a 400x16 Pandas DataFrame
+        The whole dataset is returned in a 552x21 Pandas DataFrame
     """
     if not has_pandas:
         raise ImportError("You do not have pandas installed. "

--- a/pulse2percept/datasets/horsager2009.py
+++ b/pulse2percept/datasets/horsager2009.py
@@ -1,5 +1,6 @@
 """`load_horsager2009`, `VariableDuration`"""
 from os.path import dirname, join
+import numpy as np
 
 try:
     import pandas as pd
@@ -8,7 +9,8 @@ except ImportError:
     has_pandas = False
 
 
-def load_horsager2009(shuffle=False, random_state=0):
+def load_horsager2009(subjects=None, electrodes=None, stim_types=None,
+                      shuffle=False, random_state=0):
     """Load data from [Horsager2009]_
 
     .. versionadded:: 0.6
@@ -57,6 +59,8 @@ def load_horsager2009(shuffle=False, random_state=0):
 
     Parameters
     ----------
+    subjects : str or None, optional, default: None
+
     shuffle : boolean, optional, default: False
         If True, the rows of the DataFrame are shuffled.
     random_state : int | numpy.random.RandomState | None, optional, default: 0
@@ -75,6 +79,31 @@ def load_horsager2009(shuffle=False, random_state=0):
     module_path = dirname(__file__)
     file_path = join(module_path, 'data', 'horsager2009.csv')
     df = pd.read_csv(file_path)
+
+    # Select subset of data:
+    idx = np.ones_like(df.index, dtype=np.bool)
+    if subjects:
+        if isinstance(subjects, str):
+            subjects = [subjects]
+        idx_subject = np.zeros_like(df.index, dtype=np.bool)
+        for subject in subjects:
+            idx_subject |= df.subject == subject
+        idx &= idx_subject
+    if electrodes:
+        if isinstance(electrodes, str):
+            electrodes = [electrodes]
+        idx_electrode = np.zeros_like(df.index, dtype=np.bool)
+        for electrode in electrodes:
+            idx_electrode |= df.electrode == electrode
+        idx &= idx_electrode
+    if stim_types:
+        if isinstance(stim_types, str):
+            stim_types = [stim_types]
+        idx_type = np.zeros_like(df.index, dtype=np.bool)
+        for stim_type in stim_types:
+            idx_type |= df.stim_type == stim_type
+        idx &= idx_type
+    df = df[idx]
 
     if shuffle:
         df = df.sample(n=len(df), random_state=random_state)

--- a/pulse2percept/datasets/tests/test_horsager2009.py
+++ b/pulse2percept/datasets/tests/test_horsager2009.py
@@ -4,11 +4,11 @@ import pytest
 from unittest import mock
 from importlib import reload
 
-from pulse2percept import datasets
+from pulse2percept.datasets import load_horsager2009
 
 
 def test_load_horsager2009():
-    data = datasets.load_horsager2009(shuffle=False)
+    data = load_horsager2009(shuffle=False)
 
     npt.assert_equal(isinstance(data, pd.DataFrame), True)
     columns = ['subject', 'implant', 'electrode', 'task', 'stim_type',
@@ -23,10 +23,52 @@ def test_load_horsager2009():
     npt.assert_equal(data.subject.unique(), ['S05', 'S06'])
 
     # Shuffle dataset (index will always be range(552), but rows are shuffled):
-    data = datasets.load_horsager2009(shuffle=True, random_state=42)
+    data = load_horsager2009(shuffle=True, random_state=42)
     npt.assert_equal(data.loc[0, 'subject'], 'S06')
     npt.assert_equal(data.loc[0, 'electrode'], 'D1')
     npt.assert_equal(data.loc[0, 'stim_type'], 'latent_addition')
     npt.assert_equal(data.loc[551, 'subject'], 'S06')
     npt.assert_equal(data.loc[551, 'electrode'], 'A1')
     npt.assert_equal(data.loc[551, 'stim_type'], 'fixed_duration')
+
+    # Select subjects:
+    data = load_horsager2009(subjects='S05')
+    npt.assert_equal(data.shape, (272, 21))
+    npt.assert_equal(data.subject.unique(), 'S05')
+    data = load_horsager2009(subjects=['S05', 'S07'])  # 'S07' doesnt' exist
+    npt.assert_equal(data.shape, (272, 21))
+    npt.assert_equal(data.subject.unique(), 'S05')
+    data = load_horsager2009(subjects=['S05', 'S06'])  # same as None
+    npt.assert_equal(data.shape, (552, 21))
+    data = load_horsager2009(subjects='S6')  # 'S6' doesn't exist
+    npt.assert_equal(data.shape, (0, 21))
+    npt.assert_equal(data.subject.unique(), [])
+
+    # Select electrodes:
+    data = load_horsager2009(electrodes='A1')
+    npt.assert_equal(data.shape, (106, 21))
+    npt.assert_equal(data.electrode.unique(), 'A1')
+    npt.assert_equal(data.subject.unique(), ['S06', 'S05'])
+    data = load_horsager2009(electrodes=['A1', 'A9'])  # 'A9' doesn't exist
+    npt.assert_equal(data.shape, (106, 21))
+    npt.assert_equal(data.electrode.unique(), 'A1')
+    npt.assert_equal(data.subject.unique(), ['S06', 'S05'])
+
+    # Select stimulus types:
+    data = load_horsager2009(stim_types='single_pulse')
+    npt.assert_equal(data.shape, (80, 21))
+    npt.assert_equal(data.stim_type.unique(), 'single_pulse')
+    npt.assert_equal(list(data.subject.unique()), ['S05', 'S06'])
+    data = load_horsager2009(stim_types=['single_pulse', 'fixed_duration'])
+    npt.assert_equal(data.shape, (200, 21))
+    npt.assert_equal(list(data.stim_type.unique()),
+                     ['single_pulse', 'fixed_duration'])
+    npt.assert_equal(list(data.subject.unique()), ['S05', 'S06'])
+
+    # Subject + electrode + stim type:
+    data = load_horsager2009(subjects='S05', electrodes=['A1', 'C3'],
+                             stim_types='single_pulse')
+    npt.assert_equal(data.shape, (16, 21))
+    npt.assert_equal(data.subject.unique(), 'S05')
+    npt.assert_equal(list(data.electrode.unique()), ['C3', 'A1'])
+    npt.assert_equal(data.stim_type.unique(), 'single_pulse')


### PR DESCRIPTION
Allows for a subset of the Horsager be selected (see issue #213):

```
from pulse2percept.datasets import load_horsager2009
data = load_horsager2009(subjects=['S05', 'S06'], electrodes='A1')
```