### PR TITLE
[ENH] Merging of Stimulus time axes

### DIFF
--- a/pulse2percept/stimuli/setup.py
+++ b/pulse2percept/stimuli/setup.py
@@ -16,6 +16,6 @@ def configuration(parent_package='', top_path=None):
                              sources=['_base.pyx'],
                              include_dirs=[numpy.get_include()],
                              libraries=libraries)
-    config.add_subpackage("tests")
+    config.add_subpackage('tests')
 
     return config

--- a/pulse2percept/stimuli/tests/test_base.py
+++ b/pulse2percept/stimuli/tests/test_base.py
@@ -197,6 +197,7 @@ def test_Stimulus_plot():
                                 stim.data.min())
         npt.assert_almost_equal(ax.lines[0].get_data()[1].max(),
                                 stim.data.max())
+        ax.clear()
 
     # Plot a range of time values (times are sliced, not interpolated):
     ax = stim.plot(time=(0.2, 0.6))
@@ -205,6 +206,7 @@ def test_Stimulus_plot():
     t_vals = ax.lines[0].get_data()[0]
     npt.assert_almost_equal(t_vals[0], 0.3)
     npt.assert_almost_equal(t_vals[-1], 0.5)
+    ax.clear()
 
     # Plot exact time points:
     t_vals = [0.2, 0.3, 0.4]


### PR DESCRIPTION
Skips the (unnecessary) merging of time axes when a `Stimulus` is created from a large NumPy array (issue #218), thereby speeding up the loading of videos.