### PR TITLE
[ENH] Resize ImageStimulus

### DIFF
--- a/pulse2percept/stimuli/images.py
+++ b/pulse2percept/stimuli/images.py
@@ -50,7 +50,8 @@ class ImageStimulus(Stimulus):
 
     resize : (height, width) or None, optional
         A tuple specifying the desired height and the width of the image
-        stimulus.
+        stimulus. One shape dimension can be -1. In this case, the value is
+        inferred from the other dimension by keeping a constant aspect ratio.
 
     as_gray : bool, optional
         Flag whether to convert the image to grayscale.
@@ -104,7 +105,14 @@ class ImageStimulus(Stimulus):
             img = rgb2gray(img)
         # Resize if necessary:
         if resize is not None:
-            img = img_resize(img, resize)
+            height, width = resize
+            if height < 0 and width < 0:
+                raise ValueError('"height" and "width" cannot both be -1.')
+            if height < 0:
+                height = int(img.shape[0] * width / img.shape[1])
+            if width < 0:
+                width = int(img.shape[1] * height / img.shape[0])
+            img = img_resize(img, (height, width))
         # Store the original image shape for resizing and color conversion:
         self.img_shape = img.shape
         # Convert to float array in [0, 1] and call the Stimulus constructor:
@@ -246,7 +254,15 @@ class ImageStimulus(Stimulus):
             A copy of the stimulus object containing the resized image
 
         """
-        img = img_resize(self.data.reshape(self.img_shape), shape)
+        height, width = shape
+        if height < 0 and width < 0:
+            raise ValueError('"height" and "width" cannot both be -1.')
+        if height < 0:
+            height = int(self.img_shape[0] * width / self.img_shape[1])
+        if width < 0:
+            width = int(self.img_shape[1] * height / self.img_shape[0])
+        img = img_resize(self.data.reshape(self.img_shape), (height, width))
+
         return ImageStimulus(img, electrodes=electrodes,
                              metadata=self.metadata)
 

--- a/pulse2percept/stimuli/tests/test_images.py
+++ b/pulse2percept/stimuli/tests/test_images.py
@@ -90,7 +90,11 @@ def test_ImageStimulus_resize():
     # Gray levels are between 0 and 1, and can be inverted:
     stim = ImageStimulus(fname)
     npt.assert_almost_equal(stim.data, gray)
-    npt.assert_equal(stim.resize((13, 24)).img_shape, (13, 24, 3))
+    npt.assert_equal(stim.resize((13, -1)).img_shape, (13, 19, 3))
+    # Resize with one dimension -1:
+    npt.assert_equal(stim.resize((-1, 24)).img_shape, (16, 24, 3))
+    with pytest.raises(ValueError):
+        stim.resize((-1, -1))
     os.remove(fname)
 
 


### PR DESCRIPTION
Adds an option where one of the `resize` dimensions of an `ImageStimulus` can be -1, just like `numpy.reshape`.