### PR TITLE
[FIX] stim.plot() should include end points

### DIFF
--- a/pulse2percept/stimuli/base.py
+++ b/pulse2percept/stimuli/base.py
@@ -171,6 +171,7 @@ class Stimulus(PrettyPrint):
             return _data, [_time[0]]
         # Otherwise, we need to interpolate. Keep only the unique time points
         # across stimuli:
+        # TODO: consider unique within a range TOL
         new_time = np.unique(np.concatenate(_time))
         # Now we need to interpolate the data values at each of these
         # new time points:

--- a/pulse2percept/stimuli/base.py
+++ b/pulse2percept/stimuli/base.py
@@ -47,7 +47,7 @@ class Stimulus(PrettyPrint):
         * List or tuple: List elements will be assigned to electrodes in order.
         * Dictionary: Dictionary keys are used to address electrodes by name.
 
-    electrodes : int, string or list thereof; optional, default: None
+    electrodes : int, string or list thereof; optional
         Optionally, you can provide your own electrode names. If none are
         given, electrode names will be extracted from the source type (e.g.,
         the keys from a dictionary). If a scalar or NumPy array is passed,
@@ -58,7 +58,7 @@ class Stimulus(PrettyPrint):
            The number of electrode names provided must match the number of
            electrodes extracted from the source type (i.e., N).
 
-    time : int, float or list thereof; optional, default: None
+    time : int, float or list thereof; optional
         Optionally, you can provide the time points of the source data.
         If none are given, time steps will be numbered 0..M.
 
@@ -69,10 +69,10 @@ class Stimulus(PrettyPrint):
            Stimuli created from scalars or 1-D NumPy arrays will have no time
            componenet, in which case you cannot provide your own time points.
 
-    metadata : dict, optional, default: None
+    metadata : dict, optional
         Additional stimulus metadata can be stored in a dictionary.
 
-    compress : bool, optional, default: False
+    compress : bool, optional
         If True, will compress the source data in two ways:
 
         * Remove electrodes with all-zero activation.
@@ -81,7 +81,7 @@ class Stimulus(PrettyPrint):
         For example, in a pulse train, only the signal edges are saved. This
         drastically reduces the memory footprint of the stimulus.
 
-    interp_method : str or int, optional, default: 'linear'
+    interp_method : str or int, optional
         For SciPy's ``interp1`` method, specifies the kind of interpolation as
         a string ('linear', 'nearest', 'zero', 'slinear', 'quadratic', 'cubic',
         'previous', 'next') or as an integer specifying the order of the spline
@@ -91,8 +91,8 @@ class Stimulus(PrettyPrint):
         interpolation of zeroth, first, second or third order; 'previous' and
         'next' simply return the previous or next value of the point.
 
-    extrapolate : bool, optional, default: False
-        Whether to extrapolate data points outside the given range.
+    extrapolate : bool, optional
+        Whether to allow extrapolation of data points outside the given range.
 
     Notes
     -----
@@ -359,6 +359,8 @@ class Stimulus(PrettyPrint):
     def plot(self, electrodes=None, time=None, fmt='k-', ax=None):
         """Plot the stimulus
 
+        .. versionadded:: 0.7
+
         Parameters
         ----------
         electrodes : int, string, or list thereof; optional, default: None
@@ -389,14 +391,18 @@ class Stimulus(PrettyPrint):
         elif isinstance(electrodes, (int, str)):
             # Convert to list so we can iterate over it:
             electrodes = [electrodes]
+        # The user can ask for a range, slice, or list of time points, which
+        # are either interpolated or loaded directly.
         if time is None:
             # Ask for a slice instead of `self.time` to avoid interpolation,
             # which can be time-consuming for an uncompressed stimulus:
             time = slice(None)
         if isinstance(time, tuple):
             # Return a range of time points:
-            t_idx = (self.time >= time[0]) & (self.time < time[1])
-            t_vals = self.time[t_idx]
+            t_idx = (self.time > time[0]) & (self.time < time[1])
+            # Include the end points (might have to be interpolated):
+            t_vals = [time[0]] + list(self.time[t_idx]) + [time[1]]
+            t_idx = t_vals
         elif isinstance(time, (list, np.ndarray)):
             # Return list of exact time points:
             t_idx = time

--- a/pulse2percept/stimuli/tests/test_base.py
+++ b/pulse2percept/stimuli/tests/test_base.py
@@ -200,14 +200,15 @@ def test_Stimulus_plot():
                                 stim.data.max())
         plt.close(fig)
 
-    # Plot a range of time values (times are sliced, not interpolated):
+    # Plot a range of time values (times are sliced, but end points are
+    # interpolated):
     fig, ax = plt.subplots()
     ax = stim.plot(time=(0.2, 0.6), ax=ax)
     npt.assert_equal(isinstance(ax, Subplot), True)
     npt.assert_equal(len(ax.lines), 1)
     t_vals = ax.lines[0].get_data()[0]
-    npt.assert_almost_equal(t_vals[0], 0.3)
-    npt.assert_almost_equal(t_vals[-1], 0.5)
+    npt.assert_almost_equal(t_vals[0], 0.2)
+    npt.assert_almost_equal(t_vals[-1], 0.6)
     plt.close(fig)
 
     # Plot exact time points:


### PR DESCRIPTION
 `stim.plot(time=(t_min, t_max))` should include `t_min` and `t_max` even when they need to be interpolated (issue #202)
