### PR TITLE
[FIX] Switch to np.interp for stimulus interpolation

### DIFF
--- a/examples/models/plot_nanduri2012.py
+++ b/examples/models/plot_nanduri2012.py
@@ -97,8 +97,8 @@ model.build()
 # The input to the model is an implant containing a stimulus (usually a pulse
 # train), which is processed in time by a number of linear filtering steps as
 # well as a stationary nonlinearity (a sigmoid).
-
-percept = model.predict_percept(implant)
+import numpy as np
+percept = model.predict_percept(implant, t_percept=np.arange(1000))
 
 ###############################################################################
 # The output of the model is a :py:class:`~pulse2percept.percepts.Percept`
@@ -117,7 +117,6 @@ bright_th
 # then drop off slowly (over the time course of seconds).
 # This is consistent with behavioral reports from Argus II users.
 
-import numpy as np
 fig, ax = plt.subplots(figsize=(12, 5))
 ax.plot(implant.stim.time,
         -0.02 + 0.01 * implant.stim.data[0, :] / implant.stim.data.max(),

--- a/pulse2percept/implants/base.py
+++ b/pulse2percept/implants/base.py
@@ -156,14 +156,13 @@ class ProsthesisSystem(PrettyPrint):
         else:
             if isinstance(data, Stimulus):
                 # Already a stimulus object:
-                stim = Stimulus(data, extrapolate=True)
+                stim = data
             elif isinstance(data, dict):
                 # Electrode names already provided by keys:
-                stim = Stimulus(data, extrapolate=True)
+                stim = Stimulus(data)
             else:
                 # Use electrode names as stimulus coordinates:
-                stim = Stimulus(data, electrodes=list(self.earray.keys()),
-                                extrapolate=True)
+                stim = Stimulus(data, electrodes=list(self.earray.keys()))
 
             # Make sure all electrode names are valid:
             for electrode in stim.electrodes:

--- a/pulse2percept/stimuli/base.py
+++ b/pulse2percept/stimuli/base.py
@@ -7,7 +7,6 @@ import numpy as np
 np.set_printoptions(precision=2, threshold=5, edgeitems=2)
 
 import logging
-from scipy.interpolate import interp1d
 
 from ..utils import PrettyPrint, parfor
 from ._base import fast_compress
@@ -81,19 +80,6 @@ class Stimulus(PrettyPrint):
         For example, in a pulse train, only the signal edges are saved. This
         drastically reduces the memory footprint of the stimulus.
 
-    interp_method : str or int, optional, default: 'linear'
-        For SciPy's ``interp1`` method, specifies the kind of interpolation as
-        a string ('linear', 'nearest', 'zero', 'slinear', 'quadratic', 'cubic',
-        'previous', 'next') or as an integer specifying the order of the spline
-        interpolator to use.
-
-        Here, 'zero', 'slinear', 'quadratic' and 'cubic' refer to a spline
-        interpolation of zeroth, first, second or third order; 'previous' and
-        'next' simply return the previous or next value of the point.
-
-    extrapolate : bool, optional, default: False
-        Whether to extrapolate data points outside the given range.
-
     Notes
     -----
     *  Depending on the source type, a stimulus might have a time component or
@@ -103,6 +89,8 @@ class Stimulus(PrettyPrint):
        a column index but a time point.
     *  If the time point is not explicitly stored in the ``data`` container,
        its value will be automatically interpolated from neighboring values.
+    *  If a requested time point lies outside the range of stored data,
+       the value of its closest end point will be returned.
 
     Examples
     --------
@@ -132,15 +120,11 @@ class Stimulus(PrettyPrint):
 
     """
     # Frozen class: Only the following class attributes are allowed
-    __slots__ = ('metadata', '_interp', '_interp_method', '_extrapolate',
-                 '_is_compressed', '__stim')
+    __slots__ = ('metadata', '_is_compressed', '__stim')
 
     def __init__(self, source, electrodes=None, time=None, metadata=None,
-                 compress=False, interp_method='linear', extrapolate=False):
+                 compress=False):
         self.metadata = metadata
-        # Private: User is not supposed to overwrite these later on:
-        self._interp_method = interp_method
-        self._extrapolate = extrapolate
         # Flag will be flipped in the compress method:
         self.is_compressed = False
         # Extract the data and coordinates (electrodes, time) from the source:
@@ -158,7 +142,7 @@ class Stimulus(PrettyPrint):
         When a collection of source types is passed, it is possible that they
         have different time axes (e.g., different time steps, or a different
         stimulus duration). In this case, we need to merge all time axes into a
-        single, coherent one. This is expensive, because of interp1d.
+        single, coherent one. This is expensive, because of interpolation.
         """
         # We can skip the costly interpolation if all `_time` vectors are
         # identical:
@@ -173,17 +157,14 @@ class Stimulus(PrettyPrint):
         # across stimuli:
         new_time = np.unique(np.concatenate(_time))
         # Now we need to interpolate the data values at each of these
-        # new time points:
+        # new time points.
         new_data = []
         for t, d in zip(_time, _data):
-            if len(t) == 1:
-                # Special case: Duplicate data with slightly different
-                # time points so we can set up an interp1d:
-                t = np.array([t - 1e-12, t + 1e-12], dtype=np.float32)
-                d = np.repeat(d, 2, axis=1)
-            itp = interp1d(t.ravel(), d, bounds_error=None,
-                           fill_value='extrapolate')
-            new_data.append(itp(new_time))
+            # t is a 1D vector, d is a 2D data matrix and might have more than
+            # one row:
+            new_rows = [np.interp(new_time, t, row) for row in d]
+            new_rows = np.array(new_rows).reshape((-1, len(new_time)))
+            new_data.append(new_rows)
         return new_data, [new_time]
 
     def _from_source(self, source):
@@ -277,7 +258,7 @@ class Stimulus(PrettyPrint):
                 raise ValueError("If one stimulus has time=None, all others "
                                  "must have time=None as well.")
             # When none of the stimuli have time=None, we need to merge the
-            # time axes (this is expensive because of interp1d):
+            # time axes (this is expensive because of interpolation):
             if len(_time) > 1 and _time[0] is not None:
                 _data, _time = self._merge_time_axes(_data, _time)
             # Now make `_data` a 2-D NumPy array, with `_electrodes` as rows
@@ -536,17 +517,17 @@ class Stimulus(PrettyPrint):
         # STEP 3: INTERPOLATE TIME
         # From here on out, we know that ``item`` is a tuple, otherwise we
         # would have raised an IndexError above.
-        # First of all, if time=None, then _interp=None, and we won't interp:
-        if self._interp is None:
+        # First of all, if time=None, we won't interp:
+        if self.time is None:
             raise ValueError("Cannot interpolate time if time=None.")
-        # Build a list of interpolation objects:
+        time = np.array([time]).flatten()
         if (not isinstance(electrodes, (list, np.ndarray)) and
                 electrodes == Ellipsis):
-            interp = np.array(self._interp)
+            data = self.data
         else:
-            interp = np.array([self._interp[electrodes]]).flatten()
-        time = np.array([time]).flatten()
-        data = np.array([[ip(t) for t in time] for ip in interp])
+            data = self.data[electrodes, :].reshape(-1, len(self.time))
+        data = [np.interp(time, self.time, row) for row in data]
+        data = np.array(data).reshape((-1, len(time)))
         # Return a single element as scalar:
         if data.size == 1:
             data = data.ravel()[0]
@@ -670,29 +651,6 @@ class Stimulus(PrettyPrint):
                                  "1 if time=None.")
         # All checks passed, store the data:
         self.__stim = stim
-        # Set up the interpolator:
-        self._interp = None
-        if self.time is None or self._interp_method is None:
-            return
-        if len(self.time) == 1:
-            # Special case: Duplicate data with slightly different time points
-            # so we can set up an interp1d:
-            time = np.array([self.time - 1e-12, self.time + 1e-12]).flatten()
-            data = np.repeat(self.data, 2, axis=1)
-        else:
-            time = self.time
-            data = self.data
-        if self._extrapolate:
-            bounds_error = False
-            fill_value = 'extrapolate'
-        else:
-            bounds_error = True
-            fill_value = None
-        self._interp = np.array([interp1d(time, row, kind=self._interp_method,
-                                          assume_sorted=True,
-                                          bounds_error=bounds_error,
-                                          fill_value=fill_value)
-                                 for row in data])
 
     @property
     def data(self):

--- a/pulse2percept/stimuli/pulse_trains.py
+++ b/pulse2percept/stimuli/pulse_trains.py
@@ -325,14 +325,15 @@ class BiphasicTripletTrain(Stimulus):
         # Create the triplet train:
         pt = PulseTrain(freq, triplet, n_pulses=n_pulses, stim_dur=stim_dur)
         # Set up the Stimulus object through the constructor:
-        super().__init__(pt.data, time=pt.time, compress=False)
+        super(BiphasicTripletTrain, self).__init__(pt.data, time=pt.time,
+                                                   compress=False)
         self.freq = freq
         self.cathodic_first = cathodic_first
         self.charge_balanced = pt.charge_balanced
 
     def _pprint_params(self):
         """Return a dict of class arguments to pretty-print"""
-        params = super(BiphasicPulseTrain, self)._pprint_params()
+        params = super(BiphasicTripletTrain, self)._pprint_params()
         params.update({'cathodic_first': self.cathodic_first,
                        'charge_balanced': self.charge_balanced,
                        'freq': self.freq})

--- a/pulse2percept/stimuli/tests/test_base.py
+++ b/pulse2percept/stimuli/tests/test_base.py
@@ -381,25 +381,19 @@ def test_Stimulus___getitem__():
     with pytest.raises(IndexError):
         stim[3.3, 0]
 
-    # Extrapolating should be disabled by default:
-    with pytest.raises(ValueError):
-        stim[0, 9.9]
-    # But you can enable it:
-    stim = Stimulus(1 + np.arange(12).reshape((3, 4)), extrapolate=True)
-    npt.assert_almost_equal(stim[0, 9.901], 10.901)
+    # Times can be extrapolated (take on value of end points):
+    stim = Stimulus(1 + np.arange(12).reshape((3, 4)))
+    npt.assert_almost_equal(stim[0, 9.901], 4)
     # If time=None, you cannot interpolate/extrapolate:
-    stim = Stimulus([3, 4, 5], extrapolate=True)
+    stim = Stimulus([3, 4, 5])
     npt.assert_almost_equal(stim[0], stim.data[0, 0])
     with pytest.raises(ValueError):
         stim[0, 0.2]
 
     # With a single time point, interpolate is still possible:
-    stim = Stimulus(np.arange(3).reshape((-1, 1)), extrapolate=False)
+    stim = Stimulus(np.arange(3).reshape((-1, 1)))
     npt.assert_almost_equal(stim[0], stim.data[0, 0])
     npt.assert_almost_equal(stim[0, 0], stim.data[0, 0])
-    with pytest.raises(ValueError):
-        stim[0, 3.33]
-    stim = Stimulus(np.arange(3).reshape((-1, 1)), extrapolate=True)
     npt.assert_almost_equal(stim[0, 3.33], stim.data[0, 0])
 
     # Annoying but possible:
@@ -426,7 +420,7 @@ def test_Stimulus___getitem__():
     npt.assert_almost_equal(stim[stim.electrodes != 'A1', :], [[3, 4, 5]])
     npt.assert_almost_equal(stim[stim.electrodes == 'B2', :], [[3, 4, 5]])
     npt.assert_almost_equal(stim[stim.electrodes == 'C9', :], np.zeros((0, 3)))
-    npt.assert_almost_equal(stim[stim.electrodes == 'C9', 0.1], [])
+    npt.assert_almost_equal(stim[stim.electrodes == 'C9', 0.1].size, 0)
     npt.assert_almost_equal(stim[stim.electrodes == 'B2', 0.1001], 3.0005,
                             decimal=3)
     npt.assert_almost_equal(stim[stim.electrodes == 'B2', 0.2], 3.5)
@@ -434,10 +428,26 @@ def test_Stimulus___getitem__():
     npt.assert_almost_equal(stim[stim.electrodes == 'B2', stim.time < 0.4],
                             [3, 4])
     npt.assert_almost_equal(stim[:, stim.time > 0.6], np.zeros((2, 0)))
-    npt.assert_almost_equal(stim['A1', stim.time > 0.6], [])
+    npt.assert_almost_equal(stim['A1', stim.time > 0.6].size, 0)
     npt.assert_almost_equal(stim['A1', np.isclose(stim.time, 0.3)], [1])
 
 
 def test_Stimulus_merge():
-    stim = Stimulus([[1, 0.3, 0.0, 0.6, 2.0]], time=np.arange(5))
-    merge = Stimulus([stim, stim])
+    # We can stack multiple stimuli together - their time axes will be merged:
+    stim1 = Stimulus([[0, 1, 2, 3, 4]], time=[0, 1, 2, 3, 4])
+    stim2 = Stimulus([[0, 1, 2]], time=[-0.5, 1.5, 4.5])
+    merge = Stimulus([stim1, stim2])
+    npt.assert_almost_equal(merge.time, np.unique(np.hstack((stim1.time,
+                                                             stim2.time))))
+    npt.assert_almost_equal(merge[0, [0, -1]], stim1[0, [0, -1]])
+    npt.assert_almost_equal(merge[1, [0, -1]], stim2[0, [0, -1]])
+
+    # We can keep stacking - even when nested:
+    stim3 = Stimulus([[14]], time=[9.7])
+    merge2 = Stimulus([merge, stim3])
+    npt.assert_almost_equal(merge2.time, np.unique((np.hstack((stim1.time,
+                                                               stim2.time,
+                                                               stim3.time)))))
+    npt.assert_almost_equal(merge2[0, [0, -1]], stim1[0, [0, -1]])
+    npt.assert_almost_equal(merge2[1, [0, -1]], stim2[0, [0, -1]])
+    npt.assert_almost_equal(merge2[2, [0, -1]], stim3[0, [0, -1]])

--- a/pulse2percept/stimuli/tests/test_pulse_trains.py
+++ b/pulse2percept/stimuli/tests/test_pulse_trains.py
@@ -164,9 +164,13 @@ def test_BiphasicTripletTrain(amp, interphase_dur, delay_dur, cathodic_first):
                               interphase_dur=interphase_dur,
                               delay_dur=delay_dur, stim_dur=stim_dur,
                               cathodic_first=cathodic_first, dt=dt)
+    print(freq, amp, phase_dur, interphase_dur,
+          delay_dur, stim_dur, cathodic_first)
     for i in range(n_pulses):
         t_win = i * window_dur
-        npt.assert_almost_equal(pt[0, t_win], 0)
+        print(i, window_dur, t_win, pt.time[-1])
+        print(pt[0, t_win])
+        npt.assert_almost_equal(pt[0, np.floor(t_win)], 0)
         npt.assert_almost_equal(pt[0, t_win + mid_first_pulse], first_amp)
         if interphase_dur > 0:
             npt.assert_almost_equal(pt[0, t_win + mid_interphase], 0)

--- a/pulse2percept/stimuli/videos.py
+++ b/pulse2percept/stimuli/videos.py
@@ -72,23 +72,10 @@ class VideoStimulus(Stimulus):
         * Remove electrodes with all-zero activation.
         * Retain only the time points at which the stimulus changes.
 
-    interp_method : str or int, optional, default: 'linear'
-        For SciPy's ``interp1`` method, specifies the kind of interpolation as
-        a string ('linear', 'nearest', 'zero', 'slinear', 'quadratic', 'cubic',
-        'previous', 'next') or as an integer specifying the order of the spline
-        interpolator to use.
-        Here, 'zero', 'slinear', 'quadratic' and 'cubic' refer to a spline
-        interpolation of zeroth, first, second or third order; 'previous' and
-        'next' simply return the previous or next value of the point.
-
-    extrapolate : bool, optional, default: False
-        Whether to extrapolate data points outside the given range.
-
     """
 
     def __init__(self, source, format=None, resize=None, as_gray=False,
-                 electrodes=None, time=None, metadata=None, compress=False,
-                 interp_method='linear', extrapolate=False):
+                 electrodes=None, time=None, metadata=None, compress=False):
         if metadata is None:
             metadata = {}
         if isinstance(source, str):
@@ -144,9 +131,7 @@ class VideoStimulus(Stimulus):
         super(VideoStimulus, self).__init__(vid.reshape((-1, vid.shape[-1])),
                                             time=time, electrodes=electrodes,
                                             metadata=metadata,
-                                            compress=compress,
-                                            interp_method=interp_method,
-                                            extrapolate=extrapolate)
+                                            compress=compress)
         self.rewind()
 
     def _pprint_params(self):
@@ -166,9 +151,7 @@ class VideoStimulus(Stimulus):
         """
         return VideoStimulus(1.0 - self.data.reshape(self.vid_shape),
                              electrodes=self.electrodes, time=self.time,
-                             metadata=self.metadata,
-                             interp_method=self._interp_method,
-                             extrapolate=self._extrapolate)
+                             metadata=self.metadata)
 
     def rgb2gray(self, electrodes=None):
         """Convert the video to grayscale
@@ -193,9 +176,7 @@ class VideoStimulus(Stimulus):
         vid = self.data.reshape(self.vid_shape)
         vid = rgb2gray(vid.transpose((0, 1, 3, 2)))
         return VideoStimulus(vid, electrodes=electrodes, time=self.time,
-                             metadata=self.metadata,
-                             interp_method=self._interp_method,
-                             extrapolate=self._extrapolate)
+                             metadata=self.metadata)
 
     def resize(self, shape, electrodes=None):
         """Resize the video
@@ -230,9 +211,7 @@ class VideoStimulus(Stimulus):
         vid = vid_resize(self.data.reshape(self.vid_shape),
                          (height, width, *self.vid_shape[2:]))
         return VideoStimulus(vid, electrodes=electrodes, time=self.time,
-                             metadata=self.metadata,
-                             interp_method=self._interp_method,
-                             extrapolate=self._extrapolate)
+                             metadata=self.metadata)
 
     def filter(self, filt, **kwargs):
         """Filter each frame of the video
@@ -275,9 +254,7 @@ class VideoStimulus(Stimulus):
         vid = np.array([filt(frame.reshape(self.vid_shape[:-1]), **kwargs)
                         for frame in self]).transpose((1, 2, 0))
         return VideoStimulus(vid, electrodes=self.electrodes, time=self.time,
-                             metadata=self.metadata,
-                             interp_method=self._interp_method,
-                             extrapolate=self._extrapolate)
+                             metadata=self.metadata)
 
     def apply(self, func, **kwargs):
         """Apply a function to each frame of the video
@@ -298,9 +275,7 @@ class VideoStimulus(Stimulus):
         vid = np.array([func(frame.reshape(self.vid_shape[:-1]), **kwargs)
                         for frame in self]).transpose((1, 2, 0))
         return VideoStimulus(vid, electrodes=self.electrodes, time=self.time,
-                             metadata=self.metadata,
-                             interp_method=self._interp_method,
-                             extrapolate=self._extrapolate)
+                             metadata=self.metadata)
 
     def rewind(self):
         """Rewind the iterator"""


### PR DESCRIPTION
Simplifies and speeds up stimulus interpolation by switching from `scipy.optimize.interp1d` to the linear 1D `np.interp`.