### PR TITLE
[FIX] setuptools 50.0 on Windows2019

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip wheel setuptools==49.6
+        python -m pip install --upgrade pip wheel setuptools!=50.0
         # Install p2p requirements:
         pip install -r requirements.txt
         pip install -r requirements-dev.txt

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip wheel setuptools<50.0
+        python -m pip install --upgrade pip wheel
         # Install p2p requirements:
         pip install -r requirements.txt
         pip install -r requirements-dev.txt

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip wheel setuptools
+        python -m pip install --upgrade pip wheel setuptools==49.6
         # Install p2p requirements:
         pip install -r requirements.txt
         pip install -r requirements-dev.txt

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip wheel setuptools!=50.0
+        python -m pip install --upgrade pip wheel setuptools<50.0
         # Install p2p requirements:
         pip install -r requirements.txt
         pip install -r requirements-dev.txt

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,7 +14,7 @@ pr:
 
 variables:
   # Install p2p in Docker container
-  install_p2p: "pip install -r requirements.txt && pip install -e ."
+  install_p2p: "pip install -r requirements.txt && pip install -U setuptools!=50.0 && pip install -e ."
   CIBW_BEFORE_BUILD: $(install_p2p)
   # On Linux, need to install Matplotlib depedencies in Docker container.
   # Also need Cython/NumPy before installing all the other requirements,
@@ -55,7 +55,7 @@ jobs:
       inputs:
         versionSpec: 3.5
     - bash: |
-        python -m pip install --upgrade pip setuptools!=50.0
+        python -m pip install --upgrade pip
         pip install cibuildwheel==1.0.0
         cibuildwheel --output-dir wheelhouse .
     - task: PublishBuildArtifacts@1

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,7 +14,7 @@ pr:
 
 variables:
   # Install p2p in Docker container
-  install_p2p: "pip install -r requirements.txt && pip install -U setuptools<50.0 && pip install -e ."
+  install_p2p: "pip install -r requirements.txt && pip install -e ."
   CIBW_BEFORE_BUILD: $(install_p2p)
   # On Linux, need to install Matplotlib depedencies in Docker container.
   # Also need Cython/NumPy before installing all the other requirements,

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -55,7 +55,7 @@ jobs:
       inputs:
         versionSpec: 3.5
     - bash: |
-        python -m pip install --upgrade pip
+        python -m pip install --upgrade pip setuptools!=50.0
         pip install cibuildwheel==1.0.0
         cibuildwheel --output-dir wheelhouse .
     - task: PublishBuildArtifacts@1

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,7 +14,7 @@ pr:
 
 variables:
   # Install p2p in Docker container
-  install_p2p: "pip install -r requirements.txt && pip install -U setuptools!=50.0 && pip install -e ."
+  install_p2p: "pip install -r requirements.txt && pip install -U setuptools<50.0 && pip install -e ."
   CIBW_BEFORE_BUILD: $(install_p2p)
   # On Linux, need to install Matplotlib depedencies in Docker container.
   # Also need Cython/NumPy before installing all the other requirements,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 cython>=0.28
 numpy>=1.11
+setuptools<50.0
 scipy>=1.0.1
 scikit_image>=0.14
 matplotlib>=3.0.2


### PR DESCRIPTION
Setuptools 50.0 broke numpy/distutils.

One option is to set the `SETUPTOOLS_USE_DISTUTILS` environment variable to "stdlib". We'd have to do that in all the Windows builds, e.g. `azure-pipelines.yml`:

```
- powershell: |
   $env:SETUPTOOLS_USE_DISTUTILS = "stdlib"
```

This would fix our tests run with GitHub Actions and the pip-installable stable version. However, this would not help people who `pip install git+https://github.com/pulse2percept/pulse2percept`.

Instead, we prefer to require `setuptools<50.0` for now.