### PR TITLE
[FIX] Stimulus dt for merging time axes

### DIFF
--- a/pulse2percept/stimuli/__init__.py
+++ b/pulse2percept/stimuli/__init__.py
@@ -19,6 +19,10 @@
 # charge-balanced (here expressed in microamps):
 MIN_AMP = 1e-5
 
+# Sampling time step (ms); defines the duration of the signal edge
+# transitions:
+DT = 1e-3
+
 from .base import Stimulus
 from .pulses import AsymmetricBiphasicPulse, BiphasicPulse, MonophasicPulse
 from .pulse_trains import (PulseTrain, BiphasicPulseTrain,

--- a/pulse2percept/stimuli/base.py
+++ b/pulse2percept/stimuli/base.py
@@ -652,6 +652,14 @@ class Stimulus(PrettyPrint):
                                  "number of columns in the data array "
                                  "(%d)." % (len(stim['time']),
                                             stim['data'].shape[1]))
+            if len(stim['time']) > 1:
+                dt = np.diff(stim['time'])
+                if np.isclose(np.min(dt), 0):
+                    idx_min = np.argmin(dt)
+                    err_str = ("Time points must be unique, but time[%d] == "
+                               "time[%d] == %f." % (idx_min, idx_min + 1,
+                                                    stim['time'][idx_min]))
+                    raise ValueError(err_str)
         elif len(stim['data']) > 0:
             if stim['data'].shape[1] > 1:
                 raise ValueError("Number of columns in the data array must be "
@@ -704,3 +712,11 @@ class Stimulus(PrettyPrint):
             err_s = ("The attribute `is_compressed` can only be set in the "
                      "constructor or in `compress`, not in `%s`." % f_caller)
             raise AttributeError(err_s)
+
+    @property
+    def dt(self):
+        """Sampling time step (ms)
+
+        Defines the duration of the signal edge transitions.
+        """
+        return np.min(np.diff(self.time))

--- a/pulse2percept/stimuli/base.py
+++ b/pulse2percept/stimuli/base.py
@@ -655,7 +655,7 @@ class Stimulus(PrettyPrint):
             if len(stim['time']) > 1:
                 # Beware of floating point issues by slightly decreasing the
                 # tolerance level (relative to how the stimuli are built):
-                n_unique = len(unique(stim['time'], tol=0.9 * DT))
+                n_unique = len(unique(stim['time'], tol=0.8 * DT))
                 if n_unique != len(stim['time']):
                     idx_min = np.argmin(np.diff(stim['time']))
                     err_str = ("Time points must be unique up to %d "

--- a/pulse2percept/stimuli/base.py
+++ b/pulse2percept/stimuli/base.py
@@ -8,8 +8,9 @@ np.set_printoptions(precision=2, threshold=5, edgeitems=2)
 
 import logging
 
-from ..utils import PrettyPrint, parfor
+from . import DT
 from ._base import fast_compress
+from ..utils import PrettyPrint, parfor, unique
 
 
 class Stimulus(PrettyPrint):
@@ -148,15 +149,14 @@ class Stimulus(PrettyPrint):
         # identical:
         identical = True
         for t in _time:
-            if not np.all(t == _time[0]):
+            if len(t) != len(_time[0]) or not np.allclose(t, _time[0]):
                 identical = False
                 break
         if identical:
             return _data, [_time[0]]
         # Otherwise, we need to interpolate. Keep only the unique time points
         # across stimuli:
-        # TODO: consider unique within a range TOL
-        new_time = np.unique(np.concatenate(_time))
+        new_time = unique(np.concatenate(_time), tol=DT)
         # Now we need to interpolate the data values at each of these
         # new time points.
         new_data = []
@@ -653,12 +653,15 @@ class Stimulus(PrettyPrint):
                                  "(%d)." % (len(stim['time']),
                                             stim['data'].shape[1]))
             if len(stim['time']) > 1:
-                dt = np.diff(stim['time'])
-                if np.isclose(np.min(dt), 0):
-                    idx_min = np.argmin(dt)
-                    err_str = ("Time points must be unique, but time[%d] == "
-                               "time[%d] == %f." % (idx_min, idx_min + 1,
-                                                    stim['time'][idx_min]))
+                # Beware of floating point issues by slightly decreasing the
+                # tolerance level (relative to how the stimuli are built):
+                n_unique = len(unique(stim['time'], tol=0.9 * DT))
+                if n_unique != len(stim['time']):
+                    idx_min = np.argmin(np.diff(stim['time']))
+                    err_str = ("Time points must be unique up to %d "
+                               "decimals, but time [%d] == time[%d] == "
+                               "(%f)." % (int(-np.log10(DT)), idx_min,
+                                          idx_min + 1, stim['time'][idx_min]))
                     raise ValueError(err_str)
         elif len(stim['data']) > 0:
             if stim['data'].shape[1] > 1:
@@ -718,5 +721,8 @@ class Stimulus(PrettyPrint):
         """Sampling time step (ms)
 
         Defines the duration of the signal edge transitions.
+
+        .. versionadded:: 0.7
+
         """
-        return np.min(np.diff(self.time))
+        return DT

--- a/pulse2percept/stimuli/tests/test_base.py
+++ b/pulse2percept/stimuli/tests/test_base.py
@@ -7,7 +7,7 @@ from collections import OrderedDict as ODict
 from matplotlib.axes import Subplot
 import matplotlib.pyplot as plt
 
-from pulse2percept.stimuli import Stimulus
+from pulse2percept.stimuli import Stimulus, DT
 
 
 def test_Stimulus():
@@ -311,9 +311,9 @@ def test_Stimulus__stim():
     data['time'] = np.arange(1)
     stim._stim = data
 
-    data['data'] = np.ones((3, 7))
+    data['data'] = np.ones((3, 4))
     data['electrodes'] = np.arange(3)
-    data['time'] = np.arange(7)
+    data['time'] = np.array([0, 1, 1 + DT, 2])
     stim._stim = data
 
 
@@ -445,7 +445,8 @@ def test_Stimulus_merge():
     stim2 = Stimulus([[0, 1, 2]], time=[-0.5, 1.5, 4.5])
     merge = Stimulus([stim1, stim2])
     npt.assert_almost_equal(merge.time, np.unique(np.hstack((stim1.time,
-                                                             stim2.time))))
+                                                             stim2.time))),
+                            decimal=6)
     npt.assert_almost_equal(merge[0, [0, -1]], stim1[0, [0, -1]])
     npt.assert_almost_equal(merge[1, [0, -1]], stim2[0, [0, -1]])
 
@@ -454,7 +455,8 @@ def test_Stimulus_merge():
     merge2 = Stimulus([merge, stim3])
     npt.assert_almost_equal(merge2.time, np.unique((np.hstack((stim1.time,
                                                                stim2.time,
-                                                               stim3.time)))))
+                                                               stim3.time)))),
+                            decimal=6)
     npt.assert_almost_equal(merge2[0, [0, -1]], stim1[0, [0, -1]])
     npt.assert_almost_equal(merge2[1, [0, -1]], stim2[0, [0, -1]])
     npt.assert_almost_equal(merge2[2, [0, -1]], stim3[0, [0, -1]])

--- a/pulse2percept/stimuli/tests/test_base.py
+++ b/pulse2percept/stimuli/tests/test_base.py
@@ -294,6 +294,12 @@ def test_Stimulus__stim():
         data['electrodes'] = np.arange(3)
         data['time'] = np.arange(7)
         stim._stim = data
+    with pytest.raises(ValueError):
+        # Time points must be unique:
+        data['data'] = np.array([[1, 0, 1, 0, 2, 0, 1]])
+        data['time'] = np.array([0, 1, 1.5, 2, 2.1, 2.10000000000001, 2.2])
+        data['electrodes'] = np.arange(1)
+        stim._stim = data
     # But if you do all the things right, you can reset the stimulus by hand:
     data['data'] = np.ones((3, 1))
     data['electrodes'] = np.arange(3)
@@ -307,7 +313,7 @@ def test_Stimulus__stim():
 
     data['data'] = np.ones((3, 7))
     data['electrodes'] = np.arange(3)
-    data['time'] = np.ones(7)
+    data['time'] = np.arange(7)
     stim._stim = data
 
 

--- a/pulse2percept/utils/__init__.py
+++ b/pulse2percept/utils/__init__.py
@@ -11,7 +11,7 @@
     parallel
 
 """
-from .base import PrettyPrint, FreezeError, Frozen, Data, gamma
+from .base import PrettyPrint, FreezeError, Frozen, Data, gamma, unique
 from .geometry import (Grid2D, RetinalCoordTransform, Curcio1990Transform,
                        Watson2014Transform, Watson2014DisplaceTransform,
                        cart2pol, pol2cart)
@@ -34,6 +34,7 @@ __all__ = [
     'pol2cart',
     'PrettyPrint',
     'RetinalCoordTransform',
+    'unique',
     'Watson2014DisplaceTransform',
     'Watson2014Transform'
 ]

--- a/pulse2percept/utils/base.py
+++ b/pulse2percept/utils/base.py
@@ -311,22 +311,24 @@ def gamma(n, tau, tsample, tol=0.01):
 
 
 def unique(a, tol=1e-6, return_index=False):
-    """Find the unique elements of an array
+    """Find the unique elements of a sorted 1D array
 
-    Extends ``numpy.unique`` with a tolerance level ``tol``.
+    Special case of ``numpy.unique`` (array is flat, sortened) with a tolerance
+    level ``tol``.
 
     .. versionadded:: 0.7
 
     Parameters
     ----------
     a : array_like
-        Input array. This will be flattened if it is not already 1-D.
+        Input array: must be sorted, and will be flattened if it is not
+        already 1-D.
     tol : float, optional
         If the difference between two elements in the array is smaller than
         ``tol``, the two elements are considered equal.
     return_index : bool, optional
-        If True, also return the indices of `ar` (along the specified axis,
-        if provided, or in the flattened array) that result in the unique array.
+        If True, also return the indices of ``a`` that result in the unique
+        array.
 
     Returns
     -------

--- a/pulse2percept/utils/base.py
+++ b/pulse2percept/utils/base.py
@@ -1,4 +1,4 @@
-"""`PrettyPrint`, `Frozen`, `gamma`"""
+"""`PrettyPrint`, `Frozen`, `gamma`, `unique`"""
 import numpy as np
 import sys
 import abc
@@ -308,3 +308,38 @@ def gamma(n, tau, tsample, tol=0.01):
         y = y[:small_vals[0] + peak]
 
     return t, y
+
+
+def unique(a, tol=1e-6, return_index=False):
+    """Find the unique elements of an array
+
+    Extends ``numpy.unique`` with a tolerance level ``tol``.
+
+    .. versionadded:: 0.7
+
+    Parameters
+    ----------
+    a : array_like
+        Input array. This will be flattened if it is not already 1-D.
+    tol : float, optional
+        If the difference between two elements in the array is smaller than
+        ``tol``, the two elements are considered equal.
+    return_index : bool, optional
+        If True, also return the indices of `ar` (along the specified axis,
+        if provided, or in the flattened array) that result in the unique array.
+
+    Returns
+    -------
+    unique : ndarray
+        The sorted unique values
+    unique_indices : ndarray, optional
+        The indices of the first occurrences of the unique values in the
+        original array. Only provided if `return_index` is True.
+
+    """
+    result = np.unique(np.round(np.asarray(a) / tol),
+                       return_index=return_index)
+    if return_index:
+        unique, unique_indices = result
+        return tol * unique, unique_indices
+    return tol * result

--- a/pulse2percept/utils/tests/test_base.py
+++ b/pulse2percept/utils/tests/test_base.py
@@ -3,7 +3,8 @@ import copy
 import pytest
 import numpy.testing as npt
 
-from pulse2percept.utils import Frozen, FreezeError, PrettyPrint, Data, gamma
+from pulse2percept.utils import (Frozen, FreezeError, PrettyPrint, Data, gamma,
+                                 unique)
 
 
 class PrettyPrinter(PrettyPrint):
@@ -161,3 +162,18 @@ def test_gamma():
 
             # Make sure peak sits correctly
             npt.assert_almost_equal(g.argmax() * tsample, tau * (n - 1))
+
+
+def test_unique():
+    a = [0, 0.001, 0.1, 0.2, 1]
+    npt.assert_almost_equal(unique(a, tol=1e-6), a)
+    npt.assert_almost_equal(unique(a, tol=0.001), a)
+    npt.assert_almost_equal(unique(a, tol=0.01), [0, 0.1, 0.2, 1])
+    npt.assert_almost_equal(unique(a, tol=1), [0, 1])
+
+    val, idx = unique(a, tol=1e-6, return_index=True)
+    npt.assert_almost_equal(val, a)
+    npt.assert_almost_equal(idx, np.arange(len(a)))
+    val, idx = unique(a, tol=1, return_index=True)
+    npt.assert_almost_equal(val, [0, 1])
+    npt.assert_almost_equal(idx, [0, 4])

--- a/pulse2percept/utils/tests/test_base.py
+++ b/pulse2percept/utils/tests/test_base.py
@@ -168,7 +168,7 @@ def test_unique():
     a = [0, 0.001, 0.1, 0.2, 1]
     npt.assert_almost_equal(unique(a, tol=1e-6), a)
     npt.assert_almost_equal(unique(a, tol=0.001), a)
-    npt.assert_almost_equal(unique(a, tol=0.01), [0, 0.1, 0.2, 1])
+    npt.assert_almost_equal(unique(a, tol=0.1), [0, 0.1, 0.2, 1])
     npt.assert_almost_equal(unique(a, tol=1), [0, 1])
 
     val, idx = unique(a, tol=1e-6, return_index=True)


### PR DESCRIPTION
- [X] Enforce all stimulus time points to be unique
- [X] Re-implement pulses and pulse trains to make sure there are no duplicate time points
- [X] Add constant `DT=1e-3`, which assures that all signal transitions have 1e-3 ms = 1 ns duration
- [X] Add `pulse2percept.utils.unique`, which extends `numpy.unique` to provide a tolerance level for floating point operations
- [X] Improve tests