### PR TITLE
[ENH] Add Stimulus arithmetic

### DIFF
--- a/examples/models/plot_horsager2009.py
+++ b/examples/models/plot_horsager2009.py
@@ -217,7 +217,7 @@ phase_dur = 0.075
 amp_th = 20
 
 # Cathodic phase of the standard pulse::
-cath_standard = MonophasicPulse(-0.5 * amp_th, phase_dur)
+cath_stand = MonophasicPulse(-0.5 * amp_th, phase_dur)
 
 ###############################################################################
 # The delay between the start of the conditioning pulse and the start of the
@@ -236,7 +236,7 @@ cath_test = MonophasicPulse(-amp_test, phase_dur, delay_dur=delay_dur)
 ###############################################################################
 # The anodic phase were always presented 20 ms after the second cathodic phase:
 
-anod_standard = MonophasicPulse(0.5 * amp_th, phase_dur, delay_dur=20)
+anod_stand = MonophasicPulse(0.5 * amp_th, phase_dur, delay_dur=20)
 
 anod_test = MonophasicPulse(amp_test, phase_dur, delay_dur=delay_dur)
 
@@ -245,13 +245,5 @@ anod_test = MonophasicPulse(amp_test, phase_dur, delay_dur=delay_dur)
 
 from pulse2percept.stimuli import Stimulus
 
-data = []
-time = []
-time_tracker = 0
-for pulse in (cath_standard, cath_test, anod_standard, anod_test):
-    data.append(pulse.data)
-    time.append(pulse.time + time_tracker)
-    time_tracker += pulse.time[-1] + 1e-3
-
-latent_add = Stimulus(np.concatenate(data, axis=1), time=np.concatenate(time))
+latent_add = cath_stand.append(cath_test).append(anod_stand).append(anod_test)
 latent_add.plot()

--- a/examples/stimuli/plot_pulses.py
+++ b/examples/stimuli/plot_pulses.py
@@ -65,7 +65,7 @@ biphasic.plot()
 # A biphasic pulse is typically considered "charge-balanced" (i.e., its net
 # current sums to zero over time):
 
-biphasic.charge_balanced
+biphasic.is_charge_balanced
 
 ##############################################################################
 # .. note ::
@@ -92,7 +92,7 @@ asymmetric.plot()
 # When choosing amplitudes and durations accordingly, it is still possible to
 # generate a charge-balanced pulse:
 
-asymmetric.charge_balanced
+asymmetric.is_charge_balanced
 
 ##############################################################################
 # Multi-electrode stimuli

--- a/examples/stimuli/plot_sinusoidal.py
+++ b/examples/stimuli/plot_sinusoidal.py
@@ -47,7 +47,7 @@ plt.legend()
 # We can turn this signal into a :py:class:`~pulse2percept.stimuli.Stimulus`
 # object as follows:
 
-from pulse2percept.stimuli import Stimulus
+from pulse2percept.stimuli import Stimulus, DT
 
 stim = Stimulus(10 * data.reshape((1, -1)), time=t)
 stim.plot()
@@ -59,7 +59,7 @@ stim.plot()
 
 class SinusoidalPulse(Stimulus):
 
-    def __init__(self, amp, freq, phase, stim_dur, n_levels=5, dt=0.001):
+    def __init__(self, amp, freq, phase, stim_dur, n_levels=5, dt=DT):
         """Sinusoidal pulse
 
         Parameters

--- a/pulse2percept/models/tests/test_horsager2009.py
+++ b/pulse2percept/models/tests/test_horsager2009.py
@@ -54,7 +54,7 @@ def test_Horsager2009Temporal():
                                   stim_dur=200, cathodic_first=True)
         t_percept = np.arange(0, stim.time[-1] + model.dt / 2, model.dt)
         percept = model.predict_percept(stim, t_percept=t_percept)
-        npt.assert_almost_equal(percept.data.max(), 36.3, decimal=2)
+        npt.assert_almost_equal(percept.data.max(), 37.02, decimal=2)
 
 
 def test_Horsager2009Model():

--- a/pulse2percept/models/tests/test_horsager2009.py
+++ b/pulse2percept/models/tests/test_horsager2009.py
@@ -49,12 +49,12 @@ def test_Horsager2009Temporal():
 
     # Fixed-duration brightness from Fig.4:
     model = Horsager2009Temporal().build()
-    for amp, freq in zip([136.02, 120.35, 57.71], [5, 15, 225]):
+    for amp, freq in zip([136.01, 120.34, 57.37], [5, 15, 225]):
         stim = BiphasicPulseTrain(freq, amp, 0.075, interphase_dur=0.075,
                                   stim_dur=200, cathodic_first=True)
         t_percept = np.arange(0, stim.time[-1] + model.dt / 2, model.dt)
         percept = model.predict_percept(stim, t_percept=t_percept)
-        npt.assert_almost_equal(percept.data.max(), 37.02, decimal=2)
+        npt.assert_almost_equal(percept.data.max(), 36.29, decimal=2)
 
 
 def test_Horsager2009Model():

--- a/pulse2percept/stimuli/__init__.py
+++ b/pulse2percept/stimuli/__init__.py
@@ -21,7 +21,7 @@ MIN_AMP = 1e-5
 
 # Sampling time step (ms); defines the duration of the signal edge
 # transitions:
-DT = 1e-2
+DT = 1e-4
 
 from .base import Stimulus
 from .pulses import AsymmetricBiphasicPulse, BiphasicPulse, MonophasicPulse

--- a/pulse2percept/stimuli/__init__.py
+++ b/pulse2percept/stimuli/__init__.py
@@ -21,7 +21,7 @@ MIN_AMP = 1e-5
 
 # Sampling time step (ms); defines the duration of the signal edge
 # transitions:
-DT = 1e-3
+DT = 1e-2
 
 from .base import Stimulus
 from .pulses import AsymmetricBiphasicPulse, BiphasicPulse, MonophasicPulse

--- a/pulse2percept/stimuli/base.py
+++ b/pulse2percept/stimuli/base.py
@@ -660,6 +660,9 @@ class Stimulus(PrettyPrint):
         """Divide every data point in the stimulus by a scalar"""
         return self._apply_operator(self.data, ops.truediv, scalar)
 
+    def __neg__(self):
+        return self.__mul__(-1)
+
     @property
     def _stim(self):
         """A dictionary containing all the stimulus data"""

--- a/pulse2percept/stimuli/base.py
+++ b/pulse2percept/stimuli/base.py
@@ -10,7 +10,7 @@ np.set_printoptions(precision=2, threshold=5, edgeitems=2)
 
 import logging
 
-from . import DT
+from . import DT, MIN_AMP
 from ._base import fast_compress
 from ..utils import PrettyPrint, parfor, unique
 
@@ -136,7 +136,8 @@ class Stimulus(PrettyPrint):
     def _pprint_params(self):
         """Return dict of class attributes to pretty-print"""
         return {'data': self.data, 'electrodes': self.electrodes,
-                'time': self.time, 'shape': self.shape,
+                'time': self.time, 'shape': self.shape, 'dt': self.dt,
+                'is_charge_balanced': self.is_charge_balanced,
                 'metadata': self.metadata}
 
     def _merge_time_axes(self, _data, _time):
@@ -772,3 +773,14 @@ class Stimulus(PrettyPrint):
 
         """
         return DT
+
+    @property
+    def is_charge_balanced(self):
+        """Flag indicating whether the stimulus is charge-balanced
+
+        A stimulus with a time component is considered charge-balanced if its
+        net current is smaller than 10 pico Amps
+        """
+        if self.time is None:
+            return None
+        return np.isclose(np.trapz(self.data, self.time)[0], 0, atol=MIN_AMP)

--- a/pulse2percept/stimuli/pulse_trains.py
+++ b/pulse2percept/stimuli/pulse_trains.py
@@ -3,11 +3,9 @@ import numpy as np
 import copy
 import logging
 
-# MIN_AMP: Pulses with net currents smaller than MIN_AMP uA are considered
-# charge-balanced
 # DT: Sampling time step (ms); defines the duration of the signal edge
 # transitions:
-from . import MIN_AMP, DT
+from . import DT
 from .base import Stimulus
 from .pulses import BiphasicPulse, AsymmetricBiphasicPulse
 from ..utils import unique
@@ -113,15 +111,12 @@ class PulseTrain(Stimulus):
                          compress=False)
         self.freq = freq
         self.pulse_type = pulse.__class__.__name__
-        self.charge_balanced = np.isclose(np.trapz(data, time)[0], 0,
-                                          atol=MIN_AMP)
 
     def _pprint_params(self):
         """Return a dict of class arguments to pretty-print"""
         params = super(PulseTrain, self)._pprint_params()
         params.update({'freq': self.freq,
-                       'pulse_type': self.pulse_type,
-                       'charge_balanced': self.charge_balanced})
+                       'pulse_type': self.pulse_type})
         return params
 
 
@@ -187,13 +182,11 @@ class BiphasicPulseTrain(Stimulus):
         super().__init__(pt.data, time=pt.time, compress=False)
         self.freq = freq
         self.cathodic_first = cathodic_first
-        self.charge_balanced = pt.charge_balanced
 
     def _pprint_params(self):
         """Return a dict of class arguments to pretty-print"""
         params = super(BiphasicPulseTrain, self)._pprint_params()
         params.update({'cathodic_first': self.cathodic_first,
-                       'charge_balanced': self.charge_balanced,
                        'freq': self.freq})
         return params
 
@@ -255,13 +248,11 @@ class AsymmetricBiphasicPulseTrain(Stimulus):
         super().__init__(pt.data, time=pt.time, compress=False)
         self.freq = freq
         self.cathodic_first = cathodic_first
-        self.charge_balanced = pt.charge_balanced
 
     def _pprint_params(self):
         """Return a dict of class arguments to pretty-print"""
         params = super(AsymmetricBiphasicPulseTrain, self)._pprint_params()
         params.update({'cathodic_first': self.cathodic_first,
-                       'charge_balanced': self.charge_balanced,
                        'freq': self.freq})
         return params
 
@@ -333,12 +324,10 @@ class BiphasicTripletTrain(Stimulus):
                                                    compress=False)
         self.freq = freq
         self.cathodic_first = cathodic_first
-        self.charge_balanced = pt.charge_balanced
 
     def _pprint_params(self):
         """Return a dict of class arguments to pretty-print"""
         params = super(BiphasicTripletTrain, self)._pprint_params()
         params.update({'cathodic_first': self.cathodic_first,
-                       'charge_balanced': self.charge_balanced,
                        'freq': self.freq})
         return params

--- a/pulse2percept/stimuli/pulse_trains.py
+++ b/pulse2percept/stimuli/pulse_trains.py
@@ -88,24 +88,18 @@ class PulseTrain(Stimulus):
                 pt = pt.append(pulse >> shift)
             data = pt.data
             time = pt.time
-        # If stimulus is longer than the requested `stim_dur`, trim it. Make
-        # sure to interpolate the end point:
         if time[-1] > stim_dur + DT:
-            print('stim too long')
+            # If stimulus is longer than the requested `stim_dur`, trim it.
+            # Make sure to interpolate the end point:
             last_col = [np.interp(stim_dur, time, row) for row in data]
             last_col = np.array(last_col).reshape((-1, 1))
             t_idx = time < stim_dur
             data = np.hstack((data[:, t_idx], last_col))
             time = np.append(time[t_idx], stim_dur)
-        # If stimulus is shorter than the requested `stim_dur`, add a zero:
-        if time[-1] < stim_dur - DT:
-            print('stim too short')
+        elif time[-1] < stim_dur - DT:
+            # If stimulus is shorter than the requested `stim_dur`, add a zero:
             data = np.hstack((data, np.zeros((pulse.data.shape[0], 1))))
             time = np.append(time, stim_dur)
-        # Finally, if the last point is not exactly `stim_dur`, correct it:
-        if np.abs(time[-1] - stim_dur) < DT:
-            print('stim not exact')
-            time[-1] = stim_dur
         super().__init__(data, time=time, electrodes=electrode, metadata=None,
                          compress=False)
         self.freq = freq

--- a/pulse2percept/stimuli/pulses.py
+++ b/pulse2percept/stimuli/pulses.py
@@ -1,11 +1,9 @@
 """`MonophasicPulse`, `BiphasicPulse`, `AsymmetricBiphasicPulse`"""
 import numpy as np
 
-# MIN_AMP: Pulses with net currents smaller than MIN_AMP uA are considered
-# charge-balanced
 # DT: Sampling time step (ms); defines the duration of the signal edge
 # transitions:
-from . import MIN_AMP, DT
+from . import DT
 from .base import Stimulus
 from ..utils import unique
 
@@ -89,14 +87,11 @@ class MonophasicPulse(Stimulus):
         time = np.array(time, dtype=np.float32)
         super().__init__(data, electrodes=electrode, time=time, compress=False)
         self.cathodic = amp <= 0
-        self.charge_balanced = np.isclose(np.trapz(data, time)[0], 0,
-                                          atol=MIN_AMP)
 
     def _pprint_params(self):
         """Return a dict of class arguments to pretty-print"""
         params = super(MonophasicPulse, self)._pprint_params()
-        params.update({'cathodic': self.cathodic,
-                       'charge_balanced': self.charge_balanced})
+        params.update({'cathodic': self.cathodic})
         return params
 
 
@@ -195,14 +190,11 @@ class BiphasicPulse(Stimulus):
         time = np.array(time, dtype=np.float32)
         super().__init__(data, electrodes=electrode, time=time, compress=False)
         self.cathodic_first = cathodic_first
-        self.charge_balanced = np.isclose(np.trapz(data, time)[0], 0,
-                                          atol=MIN_AMP)
 
     def _pprint_params(self):
         """Return a dict of class arguments to pretty-print"""
         params = super(BiphasicPulse, self)._pprint_params()
-        params.update({'cathodic_first': self.cathodic_first,
-                       'charge_balanced': self.charge_balanced})
+        params.update({'cathodic_first': self.cathodic_first})
         return params
 
 
@@ -315,12 +307,9 @@ class AsymmetricBiphasicPulse(Stimulus):
         time = np.array(time, dtype=np.float32)
         super().__init__(data, electrodes=electrode, time=time, compress=False)
         self.cathodic_first = cathodic_first
-        self.charge_balanced = np.isclose(np.trapz(data, time)[0], 0,
-                                          atol=MIN_AMP)
 
     def _pprint_params(self):
         """Return a dict of class arguments to pretty-print"""
         params = super(AsymmetricBiphasicPulse, self)._pprint_params()
-        params.update({'cathodic_first': self.cathodic_first,
-                       'charge_balanced': self.charge_balanced})
+        params.update({'cathodic_first': self.cathodic_first})
         return params

--- a/pulse2percept/stimuli/tests/test_base.py
+++ b/pulse2percept/stimuli/tests/test_base.py
@@ -490,7 +490,7 @@ def test_Stimulus_merge():
     npt.assert_almost_equal(merge2[2, [0, -1]], stim3[0, [0, -1]])
 
 
-@pytest.mark.parametrize('scalar', (10, -2.3, np.pi))
+@pytest.mark.parametrize('scalar', (12345.678, -2.3, np.pi))
 def test_Stimulus_arithmetic(scalar):
     stim = Stimulus([[0, 21, -13, 0, 0]], time=[0, 1, 2, 3, 4])
     npt.assert_almost_equal((stim + scalar).data,

--- a/pulse2percept/stimuli/tests/test_base.py
+++ b/pulse2percept/stimuli/tests/test_base.py
@@ -460,3 +460,36 @@ def test_Stimulus_merge():
     npt.assert_almost_equal(merge2[0, [0, -1]], stim1[0, [0, -1]])
     npt.assert_almost_equal(merge2[1, [0, -1]], stim2[0, [0, -1]])
     npt.assert_almost_equal(merge2[2, [0, -1]], stim3[0, [0, -1]])
+
+
+@pytest.mark.parametrize('scalar', (10, np.pi))
+def test_Stimulus_arithmetic(scalar):
+    stim = Stimulus([[0, 21, -13, 0, 0]], time=[0, 1, 2, 3, 4])
+    npt.assert_almost_equal((stim + scalar).data.max(),
+                            stim.data.max() + scalar, decimal=5)
+    npt.assert_almost_equal((scalar + stim).data.max(),
+                            scalar + stim.data.max(), decimal=5)
+    npt.assert_almost_equal((stim - scalar).data.max(),
+                            stim.data.max() - scalar, decimal=5)
+    npt.assert_almost_equal((scalar - stim).data.max(),
+                            (scalar - stim.data).max(), decimal=5)
+    npt.assert_almost_equal((stim * scalar).data.max(),
+                            stim.data.max() * scalar, decimal=5)
+    npt.assert_almost_equal((scalar * stim).data.max(),
+                            scalar * stim.data.max(), decimal=5)
+    npt.assert_almost_equal((stim / scalar).data.max(),
+                            stim.data.max() / scalar, decimal=5)
+    npt.assert_almost_equal((-stim).data.max(),
+                            (-1 * stim.data).max(), decimal=5)
+    # 10 / stim is not supported because it will always give a division by
+    # zero error:
+    with pytest.raises(TypeError):
+        scalar / stim
+    with pytest.raises(TypeError):
+        stim + stim
+    with pytest.raises(TypeError):
+        stim - stim
+    with pytest.raises(TypeError):
+        stim * stim
+    with pytest.raises(TypeError):
+        stim / stim

--- a/pulse2percept/stimuli/tests/test_base.py
+++ b/pulse2percept/stimuli/tests/test_base.py
@@ -190,12 +190,13 @@ def test_Stimulus_append():
     stim = Stimulus([[0, 1, 0]], time=[0, 1, 2])
     stim2 = Stimulus([[0, 2]], time=[0, 0.5])
     comb = stim.append(stim2)
-    npt.assert_almost_equal(comb.data, [[0, 1, 0, 0, 2]])
-    npt.assert_almost_equal(comb.time, [0, 1, 2 - DT, 2, 2.5])
+    # End point of stim and starting point of stim2 will be merged:
+    npt.assert_almost_equal(comb.data, [[0, 1, 0, 2]])
+    npt.assert_almost_equal(comb.time, [0, 1, 2, 2.5])
 
     # When other stimulus is shifted:
     comb = stim.append(stim2 >> 10)
-    npt.assert_almost_equal(comb.time, [0, 1, 2 - DT, 12, 12.5])
+    npt.assert_almost_equal(comb.time, [0, 1, 2, 12, 12.5])
 
     with pytest.raises(TypeError):
         # 'other' must be Stimulus:
@@ -208,6 +209,9 @@ def test_Stimulus_append():
         Stimulus(3).append(stim)
     with pytest.raises(ValueError):
         stim.append(Stimulus([[1, 2]], electrodes='B1'))
+    with pytest.raises(NotImplementedError):
+        # negative time axis:
+        stim.append(Stimulus([[0, 2]], time=[-1, 0]))
 
 
 def test_Stimulus_plot():

--- a/pulse2percept/stimuli/tests/test_pulse_trains.py
+++ b/pulse2percept/stimuli/tests/test_pulse_trains.py
@@ -74,7 +74,7 @@ def test_BiphasicPulseTrain(amp, interphase_dur, delay_dur, cathodic_first):
     npt.assert_almost_equal(pt.time[0], 0)
     npt.assert_almost_equal(pt.time[-1], stim_dur, decimal=2)
     npt.assert_equal(pt.cathodic_first, cathodic_first)
-    npt.assert_equal(pt.charge_balanced,
+    npt.assert_equal(pt.is_charge_balanced,
                      np.isclose(np.trapz(pt.data, pt.time)[0], 0, atol=1e-5))
 
     # Zero frequency:
@@ -130,7 +130,7 @@ def test_AsymmetricBiphasicPulseTrain(amp1, amp2, interphase_dur, delay_dur,
     npt.assert_almost_equal(pt.time[0], 0)
     npt.assert_almost_equal(pt.time[-1], stim_dur, decimal=2)
     npt.assert_equal(pt.cathodic_first, cathodic_first)
-    npt.assert_equal(pt.charge_balanced,
+    npt.assert_equal(pt.is_charge_balanced,
                      np.isclose(np.trapz(pt.data, pt.time)[0], 0, atol=1e-5))
 
     # Zero frequency:
@@ -185,7 +185,7 @@ def test_BiphasicTripletTrain(amp, interphase_dur, delay_dur, cathodic_first):
     npt.assert_almost_equal(pt.time[0], 0)
     npt.assert_almost_equal(pt.time[-1], stim_dur, decimal=2)
     npt.assert_equal(pt.cathodic_first, cathodic_first)
-    npt.assert_equal(pt.charge_balanced,
+    npt.assert_equal(pt.is_charge_balanced,
                      np.isclose(np.trapz(pt.data, pt.time)[0], 0, atol=1e-5))
 
     # Zero frequency:

--- a/pulse2percept/stimuli/tests/test_pulse_trains.py
+++ b/pulse2percept/stimuli/tests/test_pulse_trains.py
@@ -5,7 +5,7 @@ import numpy.testing as npt
 
 from pulse2percept.stimuli import (Stimulus, PulseTrain, BiphasicPulseTrain,
                                    BiphasicTripletTrain,
-                                   AsymmetricBiphasicPulseTrain)
+                                   AsymmetricBiphasicPulseTrain, DT)
 
 
 def test_PulseTrain():
@@ -65,7 +65,7 @@ def test_BiphasicPulseTrain(amp, interphase_dur, delay_dur, cathodic_first):
                             stim_dur=stim_dur, cathodic_first=cathodic_first)
     for i in range(n_pulses):
         t_win = i * window_dur
-        npt.assert_almost_equal(pt[0, t_win], 0)
+        npt.assert_almost_equal(pt[0, t_win - DT], 0)
         npt.assert_almost_equal(pt[0, t_win + mid_first_pulse], first_amp)
         if interphase_dur > 0:
             npt.assert_almost_equal(pt[0, t_win + mid_interphase], 0)
@@ -123,9 +123,10 @@ def test_AsymmetricBiphasicPulseTrain(amp1, amp2, interphase_dur, delay_dur,
                                       cathodic_first=cathodic_first)
     for i in range(n_pulses):
         t_win = i * window_dur
-        npt.assert_almost_equal(pt[0, t_win], 0)
+        npt.assert_almost_equal(pt[0, t_win - DT], 0)
         npt.assert_almost_equal(pt[0, t_win + mid_first_pulse], first_amp)
-        npt.assert_almost_equal(pt[0, t_win + mid_interphase], 0)
+        if interphase_dur > 0:
+            npt.assert_almost_equal(pt[0, t_win + mid_interphase], 0)
         npt.assert_almost_equal(pt[0, t_win + mid_second_pulse], second_amp)
     npt.assert_almost_equal(pt.time[0], 0)
     npt.assert_almost_equal(pt.time[-1], stim_dur, decimal=2)

--- a/pulse2percept/stimuli/tests/test_pulses.py
+++ b/pulse2percept/stimuli/tests/test_pulses.py
@@ -21,7 +21,7 @@ def test_MonophasicPulse(amp, delay_dur):
     npt.assert_almost_equal(pulse.time[-1], phase_dur + delay_dur,
                             decimal=DECIMAL)
     npt.assert_equal(pulse.cathodic, amp <= 0)
-    npt.assert_equal(pulse.charge_balanced, False)
+    npt.assert_equal(pulse.is_charge_balanced, False)
 
     # Custom stim dur:
     pulse = MonophasicPulse(amp, phase_dur, delay_dur=delay_dur, stim_dur=100)
@@ -43,7 +43,7 @@ def test_MonophasicPulse(amp, delay_dur):
     npt.assert_almost_equal(pulse.time[0], 0)
     npt.assert_almost_equal(pulse.time[-1], phase_dur + delay_dur,
                             decimal=DECIMAL)
-    npt.assert_equal(pulse.charge_balanced, True)
+    npt.assert_equal(pulse.is_charge_balanced, True)
     npt.assert_equal(pulse.electrodes, 'A1')
 
     # You can wrap a pulse in a Stimulus to overwrite attributes:
@@ -94,7 +94,7 @@ def test_BiphasicPulse(amp, interphase_dur, delay_dur, cathodic_first):
     npt.assert_almost_equal(pulse.time[0], 0)
     npt.assert_almost_equal(pulse.time[-1], min_dur, decimal=3)
     npt.assert_equal(pulse.cathodic_first, cathodic_first)
-    npt.assert_equal(pulse.charge_balanced, True)
+    npt.assert_equal(pulse.is_charge_balanced, True)
 
     # Custom stim dur:
     pulse = BiphasicPulse(amp, phase_dur, interphase_dur=interphase_dur,
@@ -122,7 +122,7 @@ def test_BiphasicPulse(amp, interphase_dur, delay_dur, cathodic_first):
     npt.assert_almost_equal(pulse.data, 0)
     npt.assert_almost_equal(pulse.time[0], 0)
     npt.assert_almost_equal(pulse.time[-1], min_dur, decimal=3)
-    npt.assert_equal(pulse.charge_balanced, True)
+    npt.assert_equal(pulse.is_charge_balanced, True)
 
     # You can wrap a pulse in a Stimulus to overwrite attributes:
     stim = Stimulus(pulse, electrodes='AA1')
@@ -185,7 +185,7 @@ def test_AsymmetricBiphasicPulse(amp1, amp2, interphase_dur, delay_dur,
     npt.assert_almost_equal(pulse.time[0], 0)
     npt.assert_almost_equal(pulse.time[-1], min_dur, decimal=3)
     npt.assert_equal(pulse.cathodic_first, cathodic_first)
-    npt.assert_equal(pulse.charge_balanced,
+    npt.assert_equal(pulse.is_charge_balanced,
                      np.isclose(np.trapz(pulse.data, pulse.time)[0], 0))
 
     # Custom stim dur:
@@ -220,7 +220,7 @@ def test_AsymmetricBiphasicPulse(amp1, amp2, interphase_dur, delay_dur,
     npt.assert_almost_equal(pulse.data, 0)
     npt.assert_almost_equal(pulse.time[0], 0)
     npt.assert_almost_equal(pulse.time[-1], min_dur, decimal=3)
-    npt.assert_equal(pulse.charge_balanced,
+    npt.assert_equal(pulse.is_charge_balanced,
                      np.isclose(np.trapz(pulse.data, pulse.time)[0], 0))
 
     # If both phases have the same values, it's basically a symmetric biphasic

--- a/pulse2percept/stimuli/tests/test_pulses.py
+++ b/pulse2percept/stimuli/tests/test_pulses.py
@@ -279,3 +279,12 @@ def test_AsymmetricBiphasicPulse(amp1, amp2, interphase_dur, delay_dur,
         AsymmetricBiphasicPulse(amp1, amp2, phase_dur1, phase_dur2,
                                 interphase_dur=interphase_dur,
                                 delay_dur=delay_dur, electrode=['A1', 'B2'])
+
+
+@pytest.mark.parametrize('amp', (-1.234, -13))
+@pytest.mark.parametrize('phase_dur', (0.001, 2.2, np.pi))
+def test_pulse_append(amp, phase_dur):
+    # Build a biphasic pulse from two monophasic pulses:
+    mono = MonophasicPulse(amp, phase_dur)
+    bi = BiphasicPulse(amp, phase_dur)
+    npt.assert_equal(mono.append(-mono) == bi, True)


### PR DESCRIPTION
Overload arithmetic operators of the `Stimulus` object:
- add/subtract/multiply/divide amplitudes element-wise
- negate
- append other stimulus
- shift stimuli in time

This PR closes #300.