### PR TITLE
[FIX] Set stimulus DT=1e-3ms

### DIFF
--- a/pulse2percept/models/tests/test_horsager2009.py
+++ b/pulse2percept/models/tests/test_horsager2009.py
@@ -49,7 +49,7 @@ def test_Horsager2009Temporal():
 
     # Fixed-duration brightness from Fig.4:
     model = Horsager2009Temporal().build()
-    for amp, freq in zip([136.01, 120.34, 57.37], [5, 15, 225]):
+    for amp, freq in zip([136.01, 120.34, 57.73], [5, 15, 225]):
         stim = BiphasicPulseTrain(freq, amp, 0.075, interphase_dur=0.075,
                                   stim_dur=200, cathodic_first=True)
         t_percept = np.arange(0, stim.time[-1] + model.dt / 2, model.dt)

--- a/pulse2percept/stimuli/__init__.py
+++ b/pulse2percept/stimuli/__init__.py
@@ -21,7 +21,7 @@ MIN_AMP = 1e-5
 
 # Sampling time step (ms); defines the duration of the signal edge
 # transitions:
-DT = 1e-4
+DT = 1e-3
 
 from .base import Stimulus
 from .pulses import AsymmetricBiphasicPulse, BiphasicPulse, MonophasicPulse

--- a/pulse2percept/stimuli/tests/test_pulses.py
+++ b/pulse2percept/stimuli/tests/test_pulses.py
@@ -282,7 +282,7 @@ def test_AsymmetricBiphasicPulse(amp1, amp2, interphase_dur, delay_dur,
 
 
 @pytest.mark.parametrize('amp', (-1.234, -13))
-@pytest.mark.parametrize('phase_dur', (0.001, 2.2, np.pi))
+@pytest.mark.parametrize('phase_dur', (0.022, 2.2, np.pi))
 def test_pulse_append(amp, phase_dur):
     # Build a biphasic pulse from two monophasic pulses:
     mono = MonophasicPulse(amp, phase_dur)


### PR DESCRIPTION
The smallest stimulus time step got accidentally reverted to an earlier version. This PR corrects that mistake and fixes the tests.