### PR TITLE
[ENH] Add model.set_params() for sklearn compatibility

### DIFF
--- a/pulse2percept/models/base.py
+++ b/pulse2percept/models/base.py
@@ -61,6 +61,11 @@ class BaseModel(Frozen, PrettyPrint, metaclass=ABCMeta):
         """Return a dict of user-settable model parameters"""
         raise NotImplementedError
 
+    def set_params(self, **params):
+        """Set the parameters of this model"""
+        for key, value in params.items():
+            setattr(self, key, value)
+
     def _pprint_params(self):
         """Return a dict of class attributes to display when pretty-printing"""
         return {key: getattr(self, key)

--- a/pulse2percept/models/tests/test_base.py
+++ b/pulse2percept/models/tests/test_base.py
@@ -27,6 +27,11 @@ def test_BaseModel():
     model = ValidBaseModel(b=3)
     npt.assert_almost_equal(model.b, 3)
 
+    # Use the sklearn syntax:
+    model.set_params(a=5, b=5)
+    npt.assert_almost_equal(model.a, 5)
+    npt.assert_almost_equal(model.b, 5)
+
     # Cannot add more attributes:
     with pytest.raises(FreezeError):
         model.c = 3


### PR DESCRIPTION
This PR adds a `set_params` method to `BaseModel` so it can be used in sklearn contexts (e.g.,  `GridSearchCV`).