### PR TITLE
[ENH] Add KDTree to find closest axon in AxonMapModel

### DIFF
--- a/pulse2percept/models/beyeler2019.py
+++ b/pulse2percept/models/beyeler2019.py
@@ -206,7 +206,7 @@ class AxonMapSpatial(SpatialModel):
             'axlambda': 200,
             # Set the (x,y) location of the optic disc:
             'loc_od': (15.5, 1.5),
-            'n_axons': 500,
+            'n_axons': 1000,
             'axons_range': (-180, 180),
             # Number of sampling points along the radial axis (polar coords):
             'n_ax_segments': 500,
@@ -641,12 +641,12 @@ class AxonMapModel(Model):
         Exponential decay constant away from the axon(microns).
     eye: {'RE', LE'}, optional
         Eye for which to generate the axon map.
-    x_range : (x_min, x_max), optional
+    xrange : (x_min, x_max), optional
         A tuple indicating the range of x values to simulate (in degrees of
         visual angle). In a right eye, negative x values correspond to the
         temporal retina, and positive x values to the nasal retina. In a left
         eye, the opposite is true.
-    y_range : tuple, (y_min, y_max)
+    yrange : tuple, (y_min, y_max)
         A tuple indicating the range of y values to simulate (in degrees of
         visual angle). Negative y values correspond to the superior retina,
         and positive y values to the inferior retina.
@@ -675,6 +675,9 @@ class AxonMapModel(Model):
         Axon segments whose contribution to brightness is smaller than this
         value will be pruned to improve computational efficiency. Set to a
         value between 0 and 1.
+    use_legacy_build: bool, optional
+        If true, searches over axons instead of using KDTree. Build will 
+        likely be slower if True
     axon_pickle: str, optional
         File name in which to store precomputed axon maps.
     ignore_pickle: bool, optional

--- a/pulse2percept/models/beyeler2019.py
+++ b/pulse2percept/models/beyeler2019.py
@@ -4,7 +4,6 @@ import os
 import numpy as np
 import pickle
 from sklearn.neighbors import KDTree
-import time
 
 import matplotlib.pyplot as plt
 from matplotlib.patches import Ellipse

--- a/pulse2percept/models/beyeler2019.py
+++ b/pulse2percept/models/beyeler2019.py
@@ -3,7 +3,7 @@
 import os
 import numpy as np
 import pickle
-from sklearn.neighbors import KDTree
+from scipy.spatial import cKDTree
 
 import matplotlib.pyplot as plt
 from matplotlib.patches import Ellipse
@@ -396,11 +396,11 @@ class AxonMapSpatial(SpatialModel):
                                for x, y in zip(xret.ravel(),
                                                yret.ravel())]
         else: 
-            kdtree = KDTree(flat_bundles, leaf_size=60)
+            kdtree = cKDTree(flat_bundles, leafsize=60)
             # Create query list of xy pairs
             query = np.stack((xret.ravel(), yret.ravel()), axis=1)
             # Find index of closest segment
-            closest_seg = [x[0] for x in kdtree.query(query, return_distance=False)]
+            _, closest_seg = kdtree.query(query)
 
         # Look up the axon ID for every axon segment:
         closest_axon = axon_idx[closest_seg]

--- a/pulse2percept/models/tests/test_beyeler2019.py
+++ b/pulse2percept/models/tests/test_beyeler2019.py
@@ -337,7 +337,8 @@ def test_AxonMapModel_calc_bundle_tangent(engine):
 def test_AxonMapModel_predict_percept(engine):
     model = AxonMapModel(xystep=0.55, axlambda=100, rho=100,
                          thresh_percept=0, engine=engine,
-                         xrange=(-20, 20), yrange=(-15, 15))
+                         xrange=(-20, 20), yrange=(-15, 15),
+                         n_axons=500)
     model.build()
     # Single-electrode stim:
     img_stim = np.zeros(60)
@@ -359,7 +360,7 @@ def test_AxonMapModel_predict_percept(engine):
 
     # Full Argus II with small lambda: 60 bright spots
     model = AxonMapModel(engine='serial', xystep=1, rho=100, axlambda=40,
-                         xrange=(-20, 20), yrange=(-15, 15))
+                         xrange=(-20, 20), yrange=(-15, 15), n_axons=500)
     model.build()
     percept = model.predict_percept(ArgusII(stim=np.ones(60)))
     # Most spots are pretty bright, but there are 2 dimmer ones (due to their

--- a/pulse2percept/models/tests/test_beyeler2019.py
+++ b/pulse2percept/models/tests/test_beyeler2019.py
@@ -116,9 +116,10 @@ def test_ScoreboardModel_predict_percept():
 
 
 @pytest.mark.parametrize('engine', ('serial', 'cython'))
-def test_AxonMapSpatial(engine):
+@pytest.mark.parametrize('use_legacy_build', (True, False))
+def test_AxonMapSpatial(engine, use_legacy_build):
     # AxonMapSpatial automatically sets `rho`, `axlambda`:
-    model = AxonMapSpatial(engine=engine, xystep=5)
+    model = AxonMapSpatial(engine=engine, xystep=5, use_legacy_build=use_legacy_build)
 
     # User can set `rho`:
     model.rho = 123
@@ -173,11 +174,12 @@ def test_AxonMapSpatial_plot():
 
 
 @pytest.mark.parametrize('engine', ('serial', 'cython'))
-def test_AxonMapModel(engine):
+@pytest.mark.parametrize('use_legacy_build', (True, False))
+def test_AxonMapModel(engine, use_legacy_build):
     set_params = {'xystep': 2, 'engine': engine, 'rho': 432, 'axlambda': 2,
                   'n_axons': 9, 'n_ax_segments': 50,
                   'xrange': (-30, 30), 'yrange': (-20, 20),
-                  'loc_od': (5, 6)}
+                  'loc_od': (5, 6), 'use_legacy_build' : use_legacy_build}
     model = AxonMapModel()
     for param in set_params:
         npt.assert_equal(hasattr(model.spatial, param), True)
@@ -276,10 +278,12 @@ def test_AxonMapModel_grow_axon_bundles(engine):
 
 
 @pytest.mark.parametrize('engine', ('serial', 'cython'))
-def test_AxonMapModel_find_closest_axon(engine):
+@pytest.mark.parametrize('use_legacy_build', (True, False))
+def test_AxonMapModel_find_closest_axon(engine, use_legacy_build):
     model = AxonMapModel(xystep=1, engine=engine, n_axons=5,
                          xrange=(-20, 20), yrange=(-15, 15),
-                         axons_range=(-45, 45))
+                         axons_range=(-45, 45), 
+                         use_legacy_build=use_legacy_build)
     model.build()
     # Pretend there is an axon close to each point on the grid:
     bundles = [np.array([x + 0.001, y - 0.001],


### PR DESCRIPTION
## Description
When building the axon map model, a KDTree is now used to find the nearest axon to each simulated point, instead of searching over each axon segment. This changes closest axon lookup time to scale logarithmically in number of axon segments instead of linearly, resulting in speedups of around 150-200x (for closest axon lookup, not for build) using default parameters. The remaining bottleneck in building the model is calculating axon contribution.

Using KDTree is now the default. This can be overridden by passing use_legacy_build=True in the constructor, which uses the old method of searching over all axons. 

The default number of axons is now set to 1000. This could easily be set much higher without significant effect on build time. 

Full list of changes:
- Added [cKDTree ](https://docs.scipy.org/doc/scipy/reference/generated/scipy.spatial.cKDTree.html) from scipy as default to find closest axons 
- Added use_legacy_build parameter to AxonMapModel and AxonMapSpatial, with docstring
- Set default n_axons=1000
- Added test cases for use_legacy_model = True and False
- Refactored predict_percept test cases to no longer rely on the default n_axons to be 500
- Fixed docstrings for xrange and yrange (docstring and parameter name didn't match before)


Notes:
The tree is built inside of find_closest_axon and discarded after use because of the simpler implementation, and relatively quick build time. This means that if find_closest_axon() is repeatedly called on the same set of bundles, performance may suffer. During the AxonMapModel build, find_closest_axon() is only called once, so this is not a problem. If the model is ever changed to call find_closest_axon() again postbuild, it would be better to build the KDTree in _build() instead and store it for later use. 