### PR TITLE
[FIX] HDF5 decoding of bytestrings

### DIFF
--- a/examples/datasets/plot_data_beyeler2019.py
+++ b/examples/datasets/plot_data_beyeler2019.py
@@ -35,6 +35,11 @@ from pulse2percept.datasets import fetch_beyeler2019
 data = fetch_beyeler2019()
 print(data)
 
+print(p2p.datasets.get_data_dir())
+
+data = fetch_beyeler2019(data_path='.')
+print(data)
+
 ###############################################################################
 #
 # Inspecting the DataFrame tells us that there are 400 phosphene drawings
@@ -117,7 +122,7 @@ data['img_y_dva'] = pd.Series([(-22.5, 22.5)] * len(data), index=data.index)
 # the center of the electrode that was used to obtain the drawing:
 
 from pulse2percept.viz import plot_argus_phosphenes
-plot_argus_phosphenes(data, argus)
+# plot_argus_phosphenes(data, argus)
 
 ###############################################################################
 # Great! We have just reproduced a panel from Figure 2 in [Beyeler2019]_.
@@ -134,7 +139,7 @@ plot_argus_phosphenes(data, argus)
 
 from pulse2percept.models import AxonMapModel
 model = AxonMapModel(loc_od=(14, 2.4))
-plot_argus_phosphenes(data, argus, axon_map=model)
+# plot_argus_phosphenes(data, argus, axon_map=model)
 
 ###############################################################################
 # Analyzing phosphene shape

--- a/examples/datasets/plot_data_beyeler2019.py
+++ b/examples/datasets/plot_data_beyeler2019.py
@@ -31,11 +31,7 @@ The data itself will be provided as a Pandas ``DataFrame``:
 """
 # sphinx_gallery_thumbnail_number = 2
 
-from pulse2percept.datasets import fetch_beyeler2019, get_data_dir
-data = fetch_beyeler2019()
-print(data)
-
-print(get_data_dir())
+from pulse2percept.datasets import fetch_beyeler2019
 
 data = fetch_beyeler2019(data_path='.')
 print(data)
@@ -111,8 +107,10 @@ argus = ArgusII(x=-1331, y=-850, rot=-0.495, eye='RE')
 # For now, we add the necessary columns ourselves.)
 import pandas as pd
 data = fetch_beyeler2019(subjects='S2')
-data['img_x_dva'] = pd.Series([(-30, 30)] * len(data), index=data.index)
-data['img_y_dva'] = pd.Series([(-22.5, 22.5)] * len(data), index=data.index)
+data['img_x_dva'] = pd.Series([(-30, 30)] * len(data), index=data.index,
+                              dtype=float)
+data['img_y_dva'] = pd.Series([(-22.5, 22.5)] * len(data), index=data.index,
+                              dtype=float)
 
 ###############################################################################
 # Passing both ``data`` and ``argus`` to
@@ -122,7 +120,7 @@ data['img_y_dva'] = pd.Series([(-22.5, 22.5)] * len(data), index=data.index)
 # the center of the electrode that was used to obtain the drawing:
 
 from pulse2percept.viz import plot_argus_phosphenes
-# plot_argus_phosphenes(data, argus)
+plot_argus_phosphenes(data, argus)
 
 ###############################################################################
 # Great! We have just reproduced a panel from Figure 2 in [Beyeler2019]_.
@@ -139,7 +137,7 @@ from pulse2percept.viz import plot_argus_phosphenes
 
 from pulse2percept.models import AxonMapModel
 model = AxonMapModel(loc_od=(14, 2.4))
-# plot_argus_phosphenes(data, argus, axon_map=model)
+plot_argus_phosphenes(data, argus, axon_map=model)
 
 ###############################################################################
 # Analyzing phosphene shape
@@ -166,4 +164,4 @@ plt.xlabel('phosphene elongation')
 
 ###############################################################################
 # Phosphenes are not pixels!
-# And we have just reproduced Fig. 3C of [Beyeler2019]_.
+# And with that we have just reproduced Fig. 3C of [Beyeler2019]_.

--- a/examples/datasets/plot_data_beyeler2019.py
+++ b/examples/datasets/plot_data_beyeler2019.py
@@ -31,11 +31,11 @@ The data itself will be provided as a Pandas ``DataFrame``:
 """
 # sphinx_gallery_thumbnail_number = 2
 
-from pulse2percept.datasets import fetch_beyeler2019
+from pulse2percept.datasets import fetch_beyeler2019, get_data_dir
 data = fetch_beyeler2019()
 print(data)
 
-print(p2p.datasets.get_data_dir())
+print(get_data_dir())
 
 data = fetch_beyeler2019(data_path='.')
 print(data)

--- a/examples/datasets/plot_data_beyeler2019.py
+++ b/examples/datasets/plot_data_beyeler2019.py
@@ -123,7 +123,7 @@ data['img_y_dva'] = pd.Series([(-22.5, 22.5)] * len(data), index=data.index,
 # the center of the electrode that was used to obtain the drawing:
 
 from pulse2percept.viz import plot_argus_phosphenes
-plot_argus_phosphenes(data, argus)
+# plot_argus_phosphenes(data, argus)
 
 ###############################################################################
 # Great! We have just reproduced a panel from Figure 2 in [Beyeler2019]_.
@@ -140,7 +140,7 @@ plot_argus_phosphenes(data, argus)
 
 from pulse2percept.models import AxonMapModel
 model = AxonMapModel(loc_od=(14, 2.4))
-plot_argus_phosphenes(data, argus, axon_map=model)
+# plot_argus_phosphenes(data, argus, axon_map=model)
 
 ###############################################################################
 # Analyzing phosphene shape

--- a/examples/datasets/plot_data_beyeler2019.py
+++ b/examples/datasets/plot_data_beyeler2019.py
@@ -33,7 +33,7 @@ The data itself will be provided as a Pandas ``DataFrame``:
 
 from pulse2percept.datasets import fetch_beyeler2019
 
-data = fetch_beyeler2019(data_path='.')
+data = fetch_beyeler2019()
 print(data)
 
 ###############################################################################
@@ -56,14 +56,11 @@ data.columns
 
 data.subject.unique()
 
-import pandas as pd
-print(pd.__version__)
-
 ###############################################################################
 # To select all drawings from Subject 2, we can index into the DataFrame as
 # follows:
 
-print(data[data.subject == 'S2'])
+print(data[data.subject == b'S2'])
 
 ###############################################################################
 # This leaves us with 110 rows, each of which correspond to one phosphene

--- a/examples/datasets/plot_data_beyeler2019.py
+++ b/examples/datasets/plot_data_beyeler2019.py
@@ -60,7 +60,7 @@ data.subject.unique()
 # To select all drawings from Subject 2, we can index into the DataFrame as
 # follows:
 
-print(data[data.subject == b'S2'])
+print(data[data.subject == 'S2'])
 
 ###############################################################################
 # This leaves us with 110 rows, each of which correspond to one phosphene
@@ -120,7 +120,7 @@ data['img_y_dva'] = pd.Series([(-22.5, 22.5)] * len(data), index=data.index,
 # the center of the electrode that was used to obtain the drawing:
 
 from pulse2percept.viz import plot_argus_phosphenes
-# plot_argus_phosphenes(data, argus)
+plot_argus_phosphenes(data, argus)
 
 ###############################################################################
 # Great! We have just reproduced a panel from Figure 2 in [Beyeler2019]_.
@@ -137,7 +137,7 @@ from pulse2percept.viz import plot_argus_phosphenes
 
 from pulse2percept.models import AxonMapModel
 model = AxonMapModel(loc_od=(14, 2.4))
-# plot_argus_phosphenes(data, argus, axon_map=model)
+plot_argus_phosphenes(data, argus, axon_map=model)
 
 ###############################################################################
 # Analyzing phosphene shape

--- a/examples/datasets/plot_data_beyeler2019.py
+++ b/examples/datasets/plot_data_beyeler2019.py
@@ -56,6 +56,9 @@ data.columns
 
 data.subject.unique()
 
+import pandas as pd
+print(pd.__version__)
+
 ###############################################################################
 # To select all drawings from Subject 2, we can index into the DataFrame as
 # follows:

--- a/pulse2percept/datasets/beyeler2019.py
+++ b/pulse2percept/datasets/beyeler2019.py
@@ -135,8 +135,14 @@ def fetch_beyeler2019(subjects=None, electrodes=None, data_path=None,
                          "found" % len(df))
     # Convert byte string to regular string, otherwise subset selection won't
     # work:
-    df['subject'] = df['subject'].apply(str)
-    df['electrode'] = df['electrode'].apply(str)
+    try:
+        df['subject'] = df['subject'].apply(lambda x: x.decode("utf-8"))
+    except (UnicodeDecodeError, AttributeError):
+        pass
+    try:
+        df['electrode'] = df['electrode'].apply(lambda x: x.decode("utf-8"))
+    except (UnicodeDecodeError, AttributeError):
+        pass
 
     # Select subset of data:
     idx = np.ones_like(df.index, dtype=np.bool)

--- a/pulse2percept/datasets/beyeler2019.py
+++ b/pulse2percept/datasets/beyeler2019.py
@@ -133,6 +133,10 @@ def fetch_beyeler2019(subjects=None, electrodes=None, data_path=None,
     if len(df) != 400:
         raise ValueError("Try reloading the dataset: only %d/400 rows "
                          "found" % len(df))
+    # Convert byte string to regular string, otherwise subset selection won't
+    # work:
+    df['subject'] = df['subject'].apply(str)
+    df['electrode'] = df['electrode'].apply(str)
 
     # Select subset of data:
     idx = np.ones_like(df.index, dtype=np.bool)

--- a/pulse2percept/datasets/tests/test_beyeler2019.py
+++ b/pulse2percept/datasets/tests/test_beyeler2019.py
@@ -36,6 +36,20 @@ def test_fetch_beyeler2019():
     npt.assert_equal(list(data[data.subject != 'S1'].img_shape.unique()[0]),
                      [768, 1024])
 
+    # Subset selection:
+    subset = datasets.fetch_beyeler2019(subjects='S2')
+    npt.assert_equal(subset.shape, (110, 16))
+    subset = datasets.fetch_beyeler2019(subjects=['S2', 'S3'])
+    npt.assert_equal(subset.shape, (220, 16))
+    subset = datasets.fetch_beyeler2019(subjects='invalid')
+    npt.assert_equal(subset.shape, (0, 16))
+    subset = datasets.fetch_beyeler2019(electrodes=['A1'])
+    npt.assert_equal(subset.shape, (10, 16))
+    subset = datasets.fetch_beyeler2019(electrodes=['A1', 'C3'])
+    npt.assert_equal(subset.shape, (20, 16))
+    subset = datasets.fetch_beyeler2019(electrodes='invalid')
+    npt.assert_equal(subset.shape, (0, 16))
+
     # Shuffle dataset (index will always be range(400), but rows are shuffled):
     data = datasets.fetch_beyeler2019(shuffle=True, random_state=42)
     npt.assert_equal(data.loc[0, 'subject'], 'S3')


### PR DESCRIPTION
Due to a recent HDF5 change, strings in the Beyeler2019 dataset are stored as bytestrings, which breaks the subset selection (e.g., `fetch_beyeler2019(subjects='S2')`. This PR fixes that.