### PR TITLE
[ENH] Add image processing methods for VideoStimulus

### DIFF
--- a/pulse2percept/stimuli/images.py
+++ b/pulse2percept/stimuli/images.py
@@ -49,7 +49,7 @@ class ImageStimulus(Stimulus):
         https://imageio.readthedocs.io/en/stable/formats.html.
 
     resize : (height, width) or None, optional
-        Shape of the resized image. If one of the dimensions is set to -1, 
+        Shape of the resized image. If one of the dimensions is set to -1,
         its value will be inferred by keeping a constant aspect ratio.
 
     as_gray : bool, optional
@@ -160,7 +160,7 @@ class ImageStimulus(Stimulus):
         Returns
         -------
         stim : `ImageStimulus`
-            A copy of the stimulus object with all RGB values converted to 
+            A copy of the stimulus object with all RGB values converted to
             grayscale in the range [0, 1].
 
         Notes
@@ -310,7 +310,7 @@ class ImageStimulus(Stimulus):
         return ImageStimulus(img, electrodes=self.electrodes,
                              metadata=self.metadata)
 
-    def rotate(self, angle, center=None, mode='constant'):
+    def rotate(self, angle, mode='constant'):
         """Rotate the image
 
         Parameters

--- a/pulse2percept/stimuli/tests/test_images.py
+++ b/pulse2percept/stimuli/tests/test_images.py
@@ -183,7 +183,6 @@ def test_ImageStimulus_center():
     # Center phosphene:
     stim = ImageStimulus(fname)
     npt.assert_almost_equal(stim.data, stim.center().data)
-    npt.assert_almost_equal(stim.data, stim.center().data)
     npt.assert_almost_equal(stim.data, stim.shift(0, 2).center().data)
     os.remove(fname)
 

--- a/pulse2percept/stimuli/tests/test_videos.py
+++ b/pulse2percept/stimuli/tests/test_videos.py
@@ -94,16 +94,14 @@ def test_VideoStimulus_resize():
 
 def test_VideoStimulus_rotate():
     # Create a horizontal bar:
-    fname = 'test.mp4'
     shape = (5, 5, 3)
     ndarray = np.zeros(shape, dtype=np.uint8)
     ndarray[2, :, :] = 255
-    mimwrite(fname, ndarray, fps=1)
-    stim = VideoStimulus(fname)
+    stim = VideoStimulus(ndarray)
     # Vertical line:
     vert = stim.rotate(90, mode='constant')
     data = vert.data.reshape(vert.vid_shape)
-    for i in data.shape[-1]:
+    for i in range(data.shape[-1]):
         npt.assert_almost_equal(data[:, 0, i], 0)
         npt.assert_almost_equal(data[:, 1, i], 0)
         npt.assert_almost_equal(data[:, 2, i], 1)
@@ -112,22 +110,21 @@ def test_VideoStimulus_rotate():
     # Diagonal, bottom-left to top-right:
     diag = stim.rotate(45, mode='constant')
     data = diag.data.reshape(diag.vid_shape)
-    for i in data.shape[-1]:
-        npt.assert_almost_equal(data[0, 4, i], 1)
+    for i in range(data.shape[-1]):
+        npt.assert_almost_equal(data[1, 3, i], 1)
         npt.assert_almost_equal(data[2, 2, i], 1)
-        npt.assert_almost_equal(data[4, 0, i], 1)
+        npt.assert_almost_equal(data[3, 1, i], 1)
         npt.assert_almost_equal(data[0, 0, i], 0)
         npt.assert_almost_equal(data[4, 4, i], 0)
     # Diagonal, top-left to bottom-right:
     diag = stim.rotate(-45, mode='constant')
     data = diag.data.reshape(diag.vid_shape)
-    for i in data.shape[-1]:
-        npt.assert_almost_equal(data[0, 0, i], 1)
+    for i in range(data.shape[-1]):
+        npt.assert_almost_equal(data[1, 1, i], 1)
         npt.assert_almost_equal(data[2, 2, i], 1)
-        npt.assert_almost_equal(data[4, 4, i], 1)
+        npt.assert_almost_equal(data[3, 3, i], 1)
         npt.assert_almost_equal(data[0, 4, i], 0)
         npt.assert_almost_equal(data[4, 0, i], 0)
-    os.remove(fname)
 
 
 def test_VideoStimulus_filter():

--- a/pulse2percept/stimuli/tests/test_videos.py
+++ b/pulse2percept/stimuli/tests/test_videos.py
@@ -127,6 +127,62 @@ def test_VideoStimulus_rotate():
         npt.assert_almost_equal(data[4, 0, i], 0)
 
 
+def test_VideoStimulus_shift():
+    # Create a horizontal bar:
+    shape = (5, 5, 3)
+    ndarray = np.zeros(shape, dtype=np.uint8)
+    ndarray[2, :, :] = 255
+    stim = VideoStimulus(ndarray)
+    # Top row:
+    top = stim.shift(0, -2)
+    data = top.data.reshape(top.vid_shape)
+    for i in range(data.shape[-1]):
+        npt.assert_almost_equal(top.data.reshape(stim.vid_shape)[0, :, i], 1)
+        npt.assert_almost_equal(top.data.reshape(stim.vid_shape)[1:, :, i], 0)
+    # Bottom row:
+    bottom = stim.shift(0, 2)
+    data = bottom.data.reshape(bottom.vid_shape)
+    for i in range(data.shape[-1]):
+        npt.assert_almost_equal(bottom.data.reshape(stim.vid_shape)[:4, :, i],
+                                0)
+        npt.assert_almost_equal(bottom.data.reshape(stim.vid_shape)[4, :, i],
+                                1)
+    # Bottom right pixel:
+    bottom = stim.shift(4, 2)
+    data = bottom.data.reshape(bottom.vid_shape)
+    for i in range(data.shape[-1]):
+        npt.assert_almost_equal(bottom.data.reshape(stim.vid_shape)[4, 4, i],
+                                1)
+        npt.assert_almost_equal(bottom.data.reshape(stim.vid_shape)[:4, :, i],
+                                0)
+        npt.assert_almost_equal(bottom.data.reshape(stim.vid_shape)[:, :4, i],
+                                0)
+
+
+def test_ImageStimulus_center():
+    # Create a horizontal bar:
+    ndarray = np.zeros((5, 5, 3), dtype=np.uint8)
+    ndarray[2, :, :] = 255
+    # Center phosphene:
+    stim = VideoStimulus(ndarray)
+    npt.assert_almost_equal(stim.data, stim.center().data)
+    npt.assert_almost_equal(stim.data, stim.shift(0, 2).center().data)
+
+
+def test_ImageStimulus_scale():
+    # Create a horizontal bar:
+    ndarray = np.zeros((5, 5, 3), dtype=np.uint8)
+    ndarray[2, :, :] = 255
+    stim = VideoStimulus(ndarray)
+    npt.assert_almost_equal(stim.data, stim.scale(1).data)
+    for i in range(stim.shape[-1]):
+        npt.assert_almost_equal(stim.scale(0.1)[12, i], 1)
+        npt.assert_almost_equal(stim.scale(0.1)[:12, i], 0)
+        npt.assert_almost_equal(stim.scale(0.1)[13:, i], 0)
+    with pytest.raises(ValueError):
+        stim.scale(0)
+
+
 def test_VideoStimulus_filter():
     fname = 'test.mp4'
     shape = (10, 32, 48)

--- a/pulse2percept/stimuli/videos.py
+++ b/pulse2percept/stimuli/videos.py
@@ -5,7 +5,7 @@ import matplotlib.pyplot as plt
 from matplotlib.animation import FuncAnimation
 
 from skimage.color import rgb2gray
-from skimage.transform import resize as vid_resize
+from skimage.transform import (resize as vid_resize, rotate as vid_rotate)
 from skimage.filters import scharr, sobel, median
 from skimage.feature import canny
 
@@ -211,6 +211,26 @@ class VideoStimulus(Stimulus):
         vid = vid_resize(self.data.reshape(self.vid_shape),
                          (height, width, *self.vid_shape[2:]))
         return VideoStimulus(vid, electrodes=electrodes, time=self.time,
+                             metadata=self.metadata)
+
+    def rotate(self, angle, mode='constant'):
+        """Rotate each frame of the video
+
+        Parameters
+        ----------
+        angle : float
+            Angle by which to rotate each video frame (degrees).
+            Positive: counter-clockwise, negative: clockwise
+
+        Returns
+        -------
+        stim : `VideoStimulus`
+            A copy of the stimulus object containing the rotated video
+
+        """
+        vid = vid_rotate(self.data.reshape(self.vid_shape), angle, mode=mode,
+                         resize=False)
+        return VideoStimulus(vid, electrodes=self.electrodes,
                              metadata=self.metadata)
 
     def filter(self, filt, **kwargs):

--- a/pulse2percept/utils/__init__.py
+++ b/pulse2percept/utils/__init__.py
@@ -6,6 +6,7 @@
     base
     geometry
     array
+    images
     convolution
     optimize
     stats
@@ -18,6 +19,7 @@ from .geometry import (Grid2D, RetinalCoordTransform, Curcio1990Transform,
                        Watson2014Transform, Watson2014DisplaceTransform,
                        cart2pol, pol2cart, delta_angle)
 from .array import radial_mask, unique
+from .images import center_image, scale_image, shift_image, trim_image
 from .convolution import center_vector, conv
 from .optimize import bisect
 from .stats import r2_score, circ_r2_score
@@ -28,7 +30,10 @@ __all__ = [
     'bisect',
     'cached',
     'cart2pol',
+    'center_image',
+    'center_vector',
     'circ_r2_score',
+    'conv',
     'Curcio1990Transform',
     'Data',
     'delta_angle',
@@ -43,6 +48,9 @@ __all__ = [
     'r2_score',
     'radial_mask',
     'RetinalCoordTransform',
+    'scale_image',
+    'shift_image',
+    'trim_image',
     'unique',
     'Watson2014DisplaceTransform',
     'Watson2014Transform'

--- a/pulse2percept/utils/images.py
+++ b/pulse2percept/utils/images.py
@@ -1,0 +1,187 @@
+"""`center_image`, `scale_image`, `shift_image`, `trim_image`"""
+import numpy as np
+from skimage import img_as_bool, img_as_ubyte, img_as_float32
+from skimage.measure import moments
+from skimage.transform import warp, SimilarityTransform
+
+
+def shift_image(img, shift_cols, shift_rows):
+    """Shift the image foreground
+
+    This function shifts the center of mass (CoM) of the image by the
+    specified number of rows and columns.
+    The background of the image is assumed to be black (0 grayscale).
+
+    .. versionadded:: 0.7
+
+    Parameters
+    ----------
+    img : ndarray
+        A 2D NumPy array representing a (height, width) grayscale image, or a
+        3D NumPy array representing a (height, width, channels) RGB image
+    shift_cols : float
+        Number of columns by which to shift the CoM.
+        Positive: to the right, negative: to the left
+    shift_rows : float
+        Number of rows by which to shift the CoM.
+        Positive: downward, negative: upward
+
+    Returns
+    -------
+    img : ndarray
+        A copy of the shifted image
+
+    """
+    if img.ndim < 2 or img.ndim > 3:
+        raise ValueError("Only 2D and 3D images are allowed, not "
+                         "%dD." % img.ndim)
+    tf = SimilarityTransform(translation=[shift_cols, shift_rows])
+    img_warped = warp(img, tf.inverse)
+    # Warp automatically converts to double, so we need to convert the image
+    # back to its original format:
+    if img.dtype == np.bool:
+        return img_as_bool(img_warped)
+    if img.dtype == np.uint8:
+        return img_as_ubyte(img_warped)
+    if img.dtype == np.float32:
+        return img_as_float32(img_warped)
+    return img_warped
+
+
+def center_image(img, loc=None):
+    """Center the image foreground
+
+    This function shifts the center of mass (CoM) to the image center.
+    The background of the image is assumed to be black (0 grayscale).
+
+    .. versionadded:: 0.7
+
+    Parameters
+    ----------
+    img : ndarray
+        A 2D NumPy array representing a (height, width) grayscale image, or a
+        3D NumPy array representing a (height, width, channels) RGB image
+    loc : (col, row), optional
+        The pixel location at which to center the CoM. By default, shifts
+        the CoM to the image center.
+
+    Returns
+    -------
+    img : ndarray
+        A copy of the image centered at ``loc``
+
+    """
+    if img.ndim < 2 or img.ndim > 3:
+        raise ValueError("Only 2D and 3D images are allowed, not "
+                         "%dD." % img.ndim)
+    m = moments(img, order=1)
+    # No area found:
+    if np.isclose(m[0, 0], 0):
+        return img
+    # Center location:
+    if loc is None:
+        loc = np.array(img.shape[::-1]) / 2.0 - 0.5
+    # Shift the image by -centroid, +image center:
+    transl = (loc[0] - m[0, 1] / m[0, 0], loc[1] - m[1, 0] / m[0, 0])
+    return shift_image(img, *transl)
+
+
+def scale_image(img, scaling_factor):
+    """Scale the image foreground
+
+    This function scales the image foreground by a factor.
+    The background of the image is assumed to be black (0 grayscale).
+
+    .. versionadded:: 0.7
+
+    Parameters
+    ----------
+    img : ndarray
+        A 2D NumPy array representing a (height, width) grayscale image, or a
+        3D NumPy array representing a (height, width, channels) RGB image
+    scaling_factor : float
+        Factory by which to scale the image
+
+    Returns
+    -------
+    img : ndarray
+        A copy of the scaled image
+
+    """
+    if img.ndim < 2 or img.ndim > 3:
+        raise ValueError("Only 2D and 3D images are allowed, not "
+                         "%dD." % img.ndim)
+    if scaling_factor <= 0:
+        raise ValueError("Scaling factor must be greater than zero")
+    # Calculate center of mass:
+    m = moments(img, order=1)
+    # No area found:
+    if np.isclose(m[0, 0], 0):
+        return img
+    # Shift the phosphene to (0, 0):
+    center_mass = np.array([m[0, 1] / m[0, 0], m[1, 0] / m[0, 0]])
+    tf_shift = SimilarityTransform(translation=-center_mass)
+    # Scale the phosphene:
+    tf_scale = SimilarityTransform(scale=scaling_factor)
+    # Shift the phosphene back to where it was:
+    tf_shift_inv = SimilarityTransform(translation=center_mass)
+    # Combine all three transforms:
+    tf = tf_shift + tf_scale + tf_shift_inv
+    img_warped = warp(img, tf.inverse)
+    # Warp automatically converts to double, so we need to convert the image
+    # back to its original format:
+    if img.dtype == np.bool:
+        return img_as_bool(img_warped)
+    if img.dtype == np.uint8:
+        return img_as_ubyte(img_warped)
+    if img.dtype == np.float32:
+        return img_as_float32(img_warped)
+    return img_warped
+
+
+def trim_image(img, tol=0):
+    """Remove any black border around the image
+
+    .. versionadded:: 0.7
+
+    Parameters
+    ----------
+    img : ndarray
+        A 2D NumPy array representing a (height, width) grayscale image, or a
+        3D NumPy array representing a (height, width, channels) RGB image.
+        If an alpha channel is present, the image will first be blended with
+        black.
+    tol : float, optional
+        Any pixels with gray levels > tol will be trimmed.
+    return_coords : bool, optional
+        If True, will also return the row and column coordinates of the
+        retained image
+
+    Returns
+    -------
+    img : ndarray
+        A copy of the image with trimmed borders.
+
+    """
+    if img.ndim < 2 or img.ndim > 3:
+        raise ValueError("Only 2D and 3D images are allowed, not "
+                         "%dD." % img.ndim)
+    if tol < 0:
+        raise ValueError("'tol' cannot be negative.")
+    # Convert to grayscale if necessary:
+    if img.ndim == 3 and img.shape[2] == 4:
+        # Blend the background with black:
+        img = rgba2rgb(img, background=(0, 0, 0))
+    if img.ndim == 3:
+        img = rgb2gray(img)
+    m, n = img.shape
+    mask = img > tol
+    if not np.any(mask):
+        return np.array([[]])
+    # Determine the extent of the non-zero region:
+    mask0, mask1 = mask.any(0), mask.any(1)
+    col_start, col_end = mask0.argmax(), n - mask0[::-1].argmax()
+    row_start, row_end = mask1.argmax(), m - mask1[::-1].argmax()
+    # Trim the border by cropping out the relevant part:
+    img = img[row_start:row_end, col_start:col_end, ...]
+    return img

--- a/pulse2percept/utils/images.py
+++ b/pulse2percept/utils/images.py
@@ -1,6 +1,7 @@
 """`center_image`, `scale_image`, `shift_image`, `trim_image`"""
 import numpy as np
 from skimage import img_as_bool, img_as_ubyte, img_as_float32
+from skimage.color import rgba2rgb, rgb2gray
 from skimage.measure import moments
 from skimage.transform import warp, SimilarityTransform
 

--- a/pulse2percept/utils/tests/test_images.py
+++ b/pulse2percept/utils/tests/test_images.py
@@ -1,0 +1,81 @@
+import numpy as np
+import numpy.testing as npt
+import pytest
+
+from pulse2percept.utils import (center_image, shift_image, scale_image,
+                                 trim_image)
+
+
+def test_shift_image():
+    img = np.zeros((5, 5), dtype=np.uint8)
+    img[2, :] = 255
+    # Top row:
+    top = shift_image(img, 0, -2)
+    npt.assert_almost_equal(top[0, :], 255)
+    npt.assert_almost_equal(top[1:, :], 0)
+    # Bottom row:
+    bottom = shift_image(img, 0, 2)
+    npt.assert_almost_equal(bottom[:4, :], 0)
+    npt.assert_almost_equal(bottom[4, :], 255)
+    # Bottom right pixel:
+    bottom = shift_image(img, 4, 2)
+    npt.assert_almost_equal(bottom[4, 4], 255)
+    npt.assert_almost_equal(bottom[:4, :], 0)
+    npt.assert_almost_equal(bottom[:, :4], 0)
+    with pytest.raises(ValueError):
+        shift_image(np.ones(10), 1, 1)
+    with pytest.raises(ValueError):
+        shift_image(np.ones((3, 4, 5, 6)), 1, 1)
+
+
+def test_center_image():
+    # Create a horizontal bar:
+    img = np.zeros((5, 5), dtype=np.uint8)
+    img[2, :] = 255
+    # Center phosphene:
+    npt.assert_almost_equal(img, center_image(img), decimal=3)
+    npt.assert_almost_equal(img, center_image(shift_image(img, 0, 2)))
+    with pytest.raises(ValueError):
+        center_image(np.ones(10))
+    with pytest.raises(ValueError):
+        center_image(np.ones((3, 4, 5, 6)))
+
+
+def test_scale_image():
+        # Create a horizontal bar:
+    img = np.zeros((5, 5), dtype=np.uint8)
+    img[2, :] = 255
+    # Scale phosphene:
+    npt.assert_almost_equal(img, scale_image(img, 1))
+    npt.assert_almost_equal(scale_image(img, 0.1).ravel()[12], 255)
+    npt.assert_almost_equal(scale_image(img, 0.1).ravel()[:12], 0)
+    npt.assert_almost_equal(scale_image(img, 0.1).ravel()[13:], 0)
+    with pytest.raises(ValueError):
+        scale_image(np.ones(10), 1)
+    with pytest.raises(ValueError):
+        scale_image(np.ones((3, 4, 5, 6)), 1)
+    with pytest.raises(ValueError):
+        scale_image(img, 0)
+
+
+@pytest.mark.parametrize('n_channels', (1, 3, 4))
+def test_trim_image(n_channels):
+    shape = (13, 29, n_channels)
+    img = np.zeros(shape, dtype=float)
+    img[1:-1, 1:-1, :3] = 0.1
+    img[2:-2, 2:-2, :3] = 0.2
+    npt.assert_equal(trim_image(img).shape, (shape[0] - 2, shape[1] - 2))
+    npt.assert_equal(trim_image(img, tol=0.05).shape,
+                     (shape[0] - 2, shape[1] - 2))
+    npt.assert_equal(trim_image(img, tol=0.1).shape,
+                     (shape[0] - 4, shape[1] - 4))
+    npt.assert_equal(trim_image(img, tol=0.2).shape, (1, 0))
+    npt.assert_equal(trim_image(img, tol=0.1).shape,
+                     trim_image(trim_image(img), tol=0.1).shape)
+
+    with pytest.raises(ValueError):
+        trim_image(np.ones(10))
+    with pytest.raises(ValueError):
+        trim_image(np.ones((3, 4, 5, 6)))
+    with pytest.raises(ValueError):
+        trim_image(img, tol=-1)

--- a/pulse2percept/utils/tests/test_images.py
+++ b/pulse2percept/utils/tests/test_images.py
@@ -58,20 +58,20 @@ def test_scale_image():
         scale_image(img, 0)
 
 
-@pytest.mark.parametrize('n_channels', (1, 3, 4))
+@pytest.mark.parametrize('n_channels', (1, 3))
 def test_trim_image(n_channels):
-    shape = (13, 29, n_channels)
-    img = np.zeros(shape, dtype=float)
-    img[1:-1, 1:-1, :3] = 0.1
-    img[2:-2, 2:-2, :3] = 0.2
-    npt.assert_equal(trim_image(img).shape, (shape[0] - 2, shape[1] - 2))
-    npt.assert_equal(trim_image(img, tol=0.05).shape,
+    img = np.squeeze(np.zeros((13, 29, n_channels), dtype=float))
+    shape = img.shape
+    img[1:-1, 1:-1, ...] = 0.1
+    img[2:-2, 2:-2, ...] = 0.2
+    npt.assert_equal(trim_image(img).shape[:2], (shape[0] - 2, shape[1] - 2))
+    npt.assert_equal(trim_image(img, tol=0.05).shape[:2],
                      (shape[0] - 2, shape[1] - 2))
-    npt.assert_equal(trim_image(img, tol=0.1).shape,
+    npt.assert_equal(trim_image(img, tol=0.1).shape[:2],
                      (shape[0] - 4, shape[1] - 4))
-    npt.assert_equal(trim_image(img, tol=0.2).shape, (1, 0))
-    npt.assert_equal(trim_image(img, tol=0.1).shape,
-                     trim_image(trim_image(img), tol=0.1).shape)
+    npt.assert_equal(trim_image(img, tol=0.2).shape[:2], (1, 0))
+    npt.assert_equal(trim_image(img, tol=0.1).shape[:2],
+                     trim_image(trim_image(img), tol=0.1).shape[:2])
 
     with pytest.raises(ValueError):
         trim_image(np.ones(10))


### PR DESCRIPTION
- [X] Add `shift`, `scale`, `rotate`, `center` for `VideoStimulus`, performed on every frame of the movie
- [X] Move core image processing methods to `pulse2percept/utils/images.py`
- [X] Refactor `ImageStimulus` and `VideoStimulus` methods to rely on core image processing utilities
- [X] Allow passing of positional arguments to `stim.apply()`