### PR TITLE
[ENH] Stimulus metadata improvements

### DIFF
--- a/doc/topics/stimuli.rst
+++ b/doc/topics/stimuli.rst
@@ -290,8 +290,7 @@ in ''metadata["electrodes"][electrode]["metadata"]''
     stim.metadata
 
     # Multiple source metadata
-    stim = Stimulus({'A1' : BiphasicPulseTrain(1,1,1, metadata='A1 metadata'), 
-                     'B2' : BiphasicPulseTrain(1,1,1, metadata='B2 metadata')},
+    stim = Stimulus({'A1' : Stimulus(1, metadata='A1 metadata'),
+                     'B2' : Stimulus(1, metadata='B2 metadata')},
                     metadata='stimulus metadata')
     stim.metadata
-

--- a/doc/topics/stimuli.rst
+++ b/doc/topics/stimuli.rst
@@ -273,9 +273,9 @@ before and after compression:
     :heading-level: -
 
 Accessing stimulus metadata
-^^^^^^^^^^^^^^^^^^^^^^
-Stimuli can store additional information in the ''metadata'' dictionary. 
-Users can pass their own metadata, which will be stored in ''metadata["user"]''
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Stimuli can store additional relevant information in the ''metadata'' dictionary. 
+Users can also pass their own metadata, which will be stored in ''metadata["user"]''
 Stimuli built from a collection of sources store the metadata for each source 
 in ''metadata["electrodes"][electrode]["metadata"]''
 
@@ -293,5 +293,5 @@ in ''metadata["electrodes"][electrode]["metadata"]''
     stim = Stimulus({'A1' : BiphasicPulseTrain(1,1,1, metadata='A1 metadata'), 
                      'B2' : BiphasicPulseTrain(1,1,1, metadata='B2 metadata')},
                     metadata='stimulus metadata')
+    stim.metadata
 
-                    

--- a/doc/topics/stimuli.rst
+++ b/doc/topics/stimuli.rst
@@ -290,7 +290,7 @@ in ''metadata["electrodes"][electrode]["metadata"]''
     stim.metadata
 
     # Multiple source metadata
-    stim = Stimulus({'A1' : Stimulus(1, metadata='A1 metadata'),
-                     'B2' : Stimulus(1, metadata='B2 metadata')},
+    stim = Stimulus({'A1' : BiphasicPulseTrain(1,1,1, metadata='A1 metadata'),
+                     'B2' : BiphasicPulseTrain(1,1,1, metadata='B2 metadata')},
                     metadata='stimulus metadata')
     stim.metadata

--- a/doc/topics/stimuli.rst
+++ b/doc/topics/stimuli.rst
@@ -271,3 +271,27 @@ before and after compression:
 .. minigallery:: pulse2percept.stimuli.Stimulus
     :add-heading: Examples using ``Stimulus``
     :heading-level: -
+
+Accessing stimulus metadata
+^^^^^^^^^^^^^^^^^^^^^^
+Stimuli can store additional information in the ''metadata'' dictionary. 
+Users can pass their own metadata, which will be stored in ''metadata["user"]''
+Stimuli built from a collection of sources store the metadata for each source 
+in ''metadata["electrodes"][electrode]["metadata"]''
+
+.. ipython:: python
+
+    # Accessing metadata
+    stim = Stimulus([[0, 1, 2, 3]], metadata='user_metadata')
+    stim.metadata
+
+    # Some objects store their own metadata
+    stim = BiphasicPulseTrain(1,1,1, metadata='user_metadata')
+    stim.metadata
+
+    # Multiple source metadata
+    stim = Stimulus({'A1' : BiphasicPulseTrain(1,1,1, metadata='A1 metadata'), 
+                     'B2' : BiphasicPulseTrain(1,1,1, metadata='B2 metadata')},
+                    metadata='stimulus metadata')
+
+                    

--- a/doc/topics/stimuli.rst
+++ b/doc/topics/stimuli.rst
@@ -268,16 +268,13 @@ before and after compression:
     # Notice how the time axis have changed:
     stim
 
-.. minigallery:: pulse2percept.stimuli.Stimulus
-    :add-heading: Examples using ``Stimulus``
-    :heading-level: -
-
 Accessing stimulus metadata
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 Stimuli can store additional relevant information in the ``metadata`` dictionary. 
 Users can also pass their own metadata, which will be stored in ``metadata["user"]``
 Stimuli built from a collection of sources store the metadata for each source 
-in ``metadata["electrodes"][electrode]["metadata"]``
+in ``metadata["electrodes"][electrode]["metadata"]``:
 
 .. ipython:: python
 
@@ -294,3 +291,7 @@ in ``metadata["electrodes"][electrode]["metadata"]``
                      'B2' : BiphasicPulseTrain(1,1,1, metadata='B2 metadata')},
                     metadata='stimulus metadata')
     stim.metadata
+    
+.. minigallery:: pulse2percept.stimuli.Stimulus
+    :add-heading: Examples using ``Stimulus``
+    :heading-level: -

--- a/doc/topics/stimuli.rst
+++ b/doc/topics/stimuli.rst
@@ -274,10 +274,10 @@ before and after compression:
 
 Accessing stimulus metadata
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Stimuli can store additional relevant information in the ''metadata'' dictionary. 
-Users can also pass their own metadata, which will be stored in ''metadata["user"]''
+Stimuli can store additional relevant information in the ``metadata`` dictionary. 
+Users can also pass their own metadata, which will be stored in ``metadata["user"]``
 Stimuli built from a collection of sources store the metadata for each source 
-in ''metadata["electrodes"][electrode]["metadata"]''
+in ``metadata["electrodes"][electrode]["metadata"]``
 
 .. ipython:: python
 

--- a/pulse2percept/models/base.py
+++ b/pulse2percept/models/base.py
@@ -304,8 +304,10 @@ class SpatialModel(BaseModel, metaclass=ABCMeta):
         else:
             # Calculate the Stimulus at requested time points:
             if t_percept is not None:
+                # Save electrode parameters
                 stim = Stimulus(stim[:, t_percept].reshape((-1, n_time)),
-                                electrodes=stim.electrodes, time=t_percept)
+                                electrodes=stim.electrodes, time=t_percept,
+                                metadata=stim.metadata)
             resp = self._predict_spatial(implant.earray, stim)
         return Percept(resp.reshape(list(self.grid.x.shape) + [-1]),
                        space=self.grid, time=t_percept)

--- a/pulse2percept/stimuli/base.py
+++ b/pulse2percept/stimuli/base.py
@@ -127,11 +127,9 @@ class Stimulus(PrettyPrint):
 
     def __init__(self, source, electrodes=None, time=None, metadata=None,
                  compress=False):
-        if isinstance(metadata, dict):
-           self.metadata = metadata 
-           if 'electrodes' not in metadata.keys():
-               metadata['electrodes'] = {}
-        elif isinstance(self, Stimulus):
+        if isinstance(metadata, dict) and 'electrodes' in metadata.keys():
+            self.metadata = metadata
+        else:
             self.metadata = {'electrodes' : {}, 'user' : metadata}
         # Flag will be flipped in the compress method:
         self.is_compressed = False

--- a/pulse2percept/stimuli/base.py
+++ b/pulse2percept/stimuli/base.py
@@ -129,7 +129,7 @@ class Stimulus(PrettyPrint):
                  compress=False):
         if isinstance(metadata, dict) and 'electrodes' in metadata.keys():
            self.metadata = metadata 
-        else:
+        elif isinstance(self, Stimulus):
             self.metadata = {'electrodes' : {}, 'user' : metadata}
         # Flag will be flipped in the compress method:
         self.is_compressed = False

--- a/pulse2percept/stimuli/base.py
+++ b/pulse2percept/stimuli/base.py
@@ -127,8 +127,10 @@ class Stimulus(PrettyPrint):
 
     def __init__(self, source, electrodes=None, time=None, metadata=None,
                  compress=False):
-        if isinstance(metadata, dict) and 'electrodes' in metadata.keys():
+        if isinstance(metadata, dict):
            self.metadata = metadata 
+           if 'electrodes' not in metadata.keys():
+               metadata['electrodes'] = {}
         elif isinstance(self, Stimulus):
             self.metadata = {'electrodes' : {}, 'user' : metadata}
         # Flag will be flipped in the compress method:

--- a/pulse2percept/stimuli/base.py
+++ b/pulse2percept/stimuli/base.py
@@ -127,7 +127,10 @@ class Stimulus(PrettyPrint):
 
     def __init__(self, source, electrodes=None, time=None, metadata=None,
                  compress=False):
-        self.metadata = metadata
+        if isinstance(metadata, dict) and 'electrodes' in metadata.keys():
+           self.metadata = metadata 
+        else:
+            self.metadata = {'electrodes' : {}, 'user' : metadata}
         # Flag will be flipped in the compress method:
         self.is_compressed = False
         # Extract the data and coordinates (electrodes, time) from the source:
@@ -257,6 +260,8 @@ class Stimulus(PrettyPrint):
                     # In all other cases, use the electrode names specified by
                     # the source (unless they're None):
                     _electrodes.append(e if e is not None else ele)
+                if 'metadata' in dir(src) and src.metadata is not None:
+                    self.metadata['electrodes'][str(ele)] = {'params' : src.metadata, 'type' : type(src)}
             # Make sure all stimuli have time=None or none of them do:
             if len(np.unique([t is None for t in _time])) > 1:
                 raise ValueError("If one stimulus has time=None, all others "

--- a/pulse2percept/stimuli/base.py
+++ b/pulse2percept/stimuli/base.py
@@ -261,7 +261,7 @@ class Stimulus(PrettyPrint):
                     # the source (unless they're None):
                     _electrodes.append(e if e is not None else ele)
                 if 'metadata' in dir(src) and src.metadata is not None:
-                    self.metadata['electrodes'][str(ele)] = {'params' : src.metadata, 'type' : type(src)}
+                    self.metadata['electrodes'][str(ele)] = {'metadata' : src.metadata, 'type' : type(src)}
             # Make sure all stimuli have time=None or none of them do:
             if len(np.unique([t is None for t in _time])) > 1:
                 raise ValueError("If one stimulus has time=None, all others "

--- a/pulse2percept/stimuli/images.py
+++ b/pulse2percept/stimuli/images.py
@@ -79,6 +79,8 @@ class ImageStimulus(Stimulus):
                  electrodes=None, metadata=None, compress=False):
         if metadata is None:
             metadata = {}
+        elif type(metadata) != dict:
+            metadata = {'user' : metadata}
         if isinstance(source, str):
             # Filename provided:
             img = imread(source, format=format)
@@ -121,6 +123,7 @@ class ImageStimulus(Stimulus):
                                             time=None, electrodes=electrodes,
                                             metadata=metadata,
                                             compress=compress)
+        self.metadata = metadata
 
     def _pprint_params(self):
         params = super(ImageStimulus, self)._pprint_params()

--- a/pulse2percept/stimuli/pulse_trains.py
+++ b/pulse2percept/stimuli/pulse_trains.py
@@ -176,6 +176,13 @@ class BiphasicPulseTrain(Stimulus):
         self.freq = freq
         self.cathodic_first = cathodic_first
 
+        # Store metadata for BiphasicAxonMapModel
+        self.metadata = {'freq' : freq,
+                         'amp' : amp,
+                         'phase_dur' : phase_dur,
+                         'delay_dur' : delay_dur,
+                         'user' : metadata}
+
     def _pprint_params(self):
         """Return a dict of class arguments to pretty-print"""
         params = super(BiphasicPulseTrain, self)._pprint_params()

--- a/pulse2percept/stimuli/pulse_trains.py
+++ b/pulse2percept/stimuli/pulse_trains.py
@@ -104,6 +104,7 @@ class PulseTrain(Stimulus):
                          compress=False)
         self.freq = freq
         self.pulse_type = pulse.__class__.__name__
+        self.metadata = {'user' : metadata}
 
     def _pprint_params(self):
         """Return a dict of class arguments to pretty-print"""
@@ -170,8 +171,7 @@ class BiphasicPulseTrain(Stimulus):
                               cathodic_first=cathodic_first,
                               electrode=electrode)
         # Concatenate the pulses:
-        pt = PulseTrain(freq, pulse, n_pulses=n_pulses, stim_dur=stim_dur,
-                        metadata=metadata)
+        pt = PulseTrain(freq, pulse, n_pulses=n_pulses, stim_dur=stim_dur)
         super().__init__(pt.data, time=pt.time, compress=False)
         self.freq = freq
         self.cathodic_first = cathodic_first
@@ -243,11 +243,11 @@ class AsymmetricBiphasicPulseTrain(Stimulus):
                                         cathodic_first=cathodic_first,
                                         electrode=electrode)
         # Concatenate the pulses:
-        pt = PulseTrain(freq, pulse, n_pulses=n_pulses, stim_dur=stim_dur,
-                        metadata=metadata)
+        pt = PulseTrain(freq, pulse, n_pulses=n_pulses, stim_dur=stim_dur)
         super().__init__(pt.data, time=pt.time, compress=False)
         self.freq = freq
         self.cathodic_first = cathodic_first
+        self.metadata = {'user' : metadata}
 
     def _pprint_params(self):
         """Return a dict of class arguments to pretty-print"""
@@ -329,6 +329,7 @@ class BiphasicTripletTrain(Stimulus):
                                                    compress=False)
         self.freq = freq
         self.cathodic_first = cathodic_first
+        self.metadata = {'user' : metadata}
 
     def _pprint_params(self):
         """Return a dict of class arguments to pretty-print"""

--- a/pulse2percept/stimuli/tests/test_base.py
+++ b/pulse2percept/stimuli/tests/test_base.py
@@ -69,7 +69,7 @@ def test_Stimulus():
     # Saves metadata:
     metadata = {'a': 0, 'b': 1}
     stim = Stimulus(3, metadata=metadata)
-    npt.assert_equal(stim.metadata, metadata)
+    npt.assert_equal(stim.metadata['user'], metadata)
     # List of lists instead of 2D NumPy array:
     stim = Stimulus([[1, 1, 1, 1, 1], [1, 1, 1, 1, 1]], compress=True)
     npt.assert_equal(stim.shape, (2, 2))

--- a/pulse2percept/stimuli/tests/test_pulse_trains.py
+++ b/pulse2percept/stimuli/tests/test_pulse_trains.py
@@ -212,3 +212,22 @@ def test_BiphasicTripletTrain(amp, interphase_dur, interpulse_dur, delay_dur, ca
         pt = BiphasicPulseTrain(500, 30, 0.05, n_pulses=n_pulses, stim_dur=19)
         npt.assert_almost_equal(np.sum(np.isclose(pt.data, 30)), 2 * n_pulses)
         npt.assert_almost_equal(pt.time[-1], 19)
+
+# Test metadata collecting 
+def test_metadata():
+    stim = BiphasicPulseTrain(10, 10, 1, metadata='userdata')
+    assert(type(stim) == dict)
+    npt.assert_equal(stim['user'], 'userdata')
+    npt.assert_equal(stim['freq'], 10)
+    npt.assert_equal(stim['amp'], 10)
+    npt.assert_equal(stim['phase_dur'], 1)
+    npt.assert_equal(stim['delay_dur'], 0)
+
+    stim = Stimulus({'A2' : BiphasicPulseTrain(10, 10, 1, metadata='userdataA2'),
+                     'B1' : BiphasicPulseTrain(11, 9, 2, metadata='userdataB1'),
+                     'C3' : BiphasicPulseTrain(12, 8, 3, metadata='userdataC3')}, metadata='stimulus_userdata')
+    assert(type(stim) == dict)
+    npt.assert_equal(stim.metadata['user'], 'stimulus_userdata')
+    npt.assert_equal(stim.metadata['electrodes']['A2']['type'], BiphasicPulseTrain)
+    npt.assert_equal(stim.metadata['electrodes']['B1']['metadata']['freq'], 11)
+    npt.assert_equal(stim.metadata['electrodes']['C3']['metadata']['user'], 'userdataC3')

--- a/pulse2percept/stimuli/tests/test_pulse_trains.py
+++ b/pulse2percept/stimuli/tests/test_pulse_trains.py
@@ -216,17 +216,17 @@ def test_BiphasicTripletTrain(amp, interphase_dur, interpulse_dur, delay_dur, ca
 # Test metadata collecting 
 def test_metadata():
     stim = BiphasicPulseTrain(10, 10, 1, metadata='userdata')
-    assert(type(stim) == dict)
-    npt.assert_equal(stim['user'], 'userdata')
-    npt.assert_equal(stim['freq'], 10)
-    npt.assert_equal(stim['amp'], 10)
-    npt.assert_equal(stim['phase_dur'], 1)
-    npt.assert_equal(stim['delay_dur'], 0)
+    assert(type(stim.metadata) == dict)
+    npt.assert_equal(stim.metadata['user'], 'userdata')
+    npt.assert_equal(stim.metadata['freq'], 10)
+    npt.assert_equal(stim.metadata['amp'], 10)
+    npt.assert_equal(stim.metadata['phase_dur'], 1)
+    npt.assert_equal(stim.metadata['delay_dur'], 0)
 
     stim = Stimulus({'A2' : BiphasicPulseTrain(10, 10, 1, metadata='userdataA2'),
                      'B1' : BiphasicPulseTrain(11, 9, 2, metadata='userdataB1'),
                      'C3' : BiphasicPulseTrain(12, 8, 3, metadata='userdataC3')}, metadata='stimulus_userdata')
-    assert(type(stim) == dict)
+    assert(type(stim.metadata) == dict)
     npt.assert_equal(stim.metadata['user'], 'stimulus_userdata')
     npt.assert_equal(stim.metadata['electrodes']['A2']['type'], BiphasicPulseTrain)
     npt.assert_equal(stim.metadata['electrodes']['B1']['metadata']['freq'], 11)

--- a/pulse2percept/stimuli/videos.py
+++ b/pulse2percept/stimuli/videos.py
@@ -80,6 +80,8 @@ class VideoStimulus(Stimulus):
                  electrodes=None, time=None, metadata=None, compress=False):
         if metadata is None:
             metadata = {}
+        elif type(metadata) != dict:
+            metadata = {'user' : metadata}
         if isinstance(source, str):
             # Filename provided, read the video:
             reader = video_reader(source, format=format)
@@ -134,6 +136,7 @@ class VideoStimulus(Stimulus):
                                             time=time, electrodes=electrodes,
                                             metadata=metadata,
                                             compress=compress)
+        self.metadata = metadata
         self.rewind()
 
     def _pprint_params(self):


### PR DESCRIPTION
Previously, stimulus metadata was lost in various places as stimuli were created, and during percept prediction.

Now, metadata information is passed along as stimuli are created/manipulated.
If a stimulus is created from a collection of sources, the stimulus object collects the metadata from each of the sources and stores it in the corresponding electrode in stim.metadata['electrodes']

Additionally, BiphasicPulseTrain is modified to store its stimulus parameters (such as frequency, amplitude, etc) in its metadata. This ensures the information is not lost when a stimulus is created from multiple BiphasicPulseTrains, and enables extension models such as BiphasicAxonMapModel

New test cases were added to test stimulus metadata

