### PR TITLE
[FIX] Deprecate Python 3.5, add 3.9 to test suite

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       # Test on all supported platforms using all supported Python versions:
       matrix:
-        python-version: [3.5, 3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8, 3.9]
         os: [ubuntu-latest, ubuntu-16.04, windows-latest, macOS-latest]
     
     steps:

--- a/README.rst
+++ b/README.rst
@@ -98,12 +98,12 @@ Detailed instructions for different platforms can be found in our
 Dependencies
 ------------
 
-**pulse2percept 0.4.3 was the last version to support Python 2.7 and 3.4.**
-pulse2percept 0.5+ requires Python 3.5+.
+**pulse2percept 0.6 was the last version to support Python <= 3.5.**
+pulse2percept 0.7+ requires Python 3.6+.
 
 pulse2percept requires:
 
-1.  `Python`_ (>= 3.5)
+1.  `Python`_ (>= 3.6)
 2.  `Cython`_ (>= 0.28)
 3.  `NumPy`_ (>= 1.9)
 4.  `SciPy`_ (>= 1.0.1)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -21,7 +21,7 @@ variables:
   # because skimage uses NumPy in their setup.py:
   CIBW_BEFORE_BUILD_LINUX: "yum -y install freetype-devel pkgconfig libpng-devel && pip install Cython numpy && $(install_p2p)"
   # Skip building on Python 2.7 on all platforms
-  CIBW_SKIP: "cp27-*"
+  CIBW_SKIP: "cp27-* cp35-*"
 
 jobs:
 - job: linux
@@ -29,7 +29,7 @@ jobs:
   steps: 
     - task: UsePythonVersion@0
       inputs:
-        versionSpec: 3.6
+        versionSpec: '3.6'
     - bash: |
         python -m pip install --upgrade pip
         pip install cibuildwheel==1.0.0
@@ -41,7 +41,7 @@ jobs:
   steps: 
     - task: UsePythonVersion@0
       inputs:
-        versionSpec: 3.6
+        versionSpec: '3.6'
     - bash: |
         python -m pip install --upgrade pip
         pip install cibuildwheel==1.0.0
@@ -53,7 +53,7 @@ jobs:
   steps: 
     - task: UsePythonVersion@0
       inputs:
-        versionSpec: 3.6
+        versionSpec: '3.6'
     - bash: |
         python -m pip install --upgrade pip
         pip install cibuildwheel==1.0.0

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -29,7 +29,7 @@ jobs:
   steps: 
     - task: UsePythonVersion@0
       inputs:
-        versionSpec: 3.5
+        versionSpec: 3.6
     - bash: |
         python -m pip install --upgrade pip
         pip install cibuildwheel==1.0.0
@@ -41,7 +41,7 @@ jobs:
   steps: 
     - task: UsePythonVersion@0
       inputs:
-        versionSpec: 3.5
+        versionSpec: 3.6
     - bash: |
         python -m pip install --upgrade pip
         pip install cibuildwheel==1.0.0
@@ -53,7 +53,7 @@ jobs:
   steps: 
     - task: UsePythonVersion@0
       inputs:
-        versionSpec: 3.5
+        versionSpec: 3.6
     - bash: |
         python -m pip install --upgrade pip
         pip install cibuildwheel==1.0.0

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -40,8 +40,8 @@ If you don't have Python, you have several options:
 
 .. important::
 
-    pulse2percept 0.4.3 was the last release to support Python 2.7 and 3.4.
-    pulse2percept 0.5+ requires **Python 3.5+**.
+    pulse2percept 0.6 was the last release to support Python <= 3.5.
+    pulse2percept 0.7+ requires **Python 3.6+**.
 
 On some platforms (e.g., macOS), you might also have to install pip yourself.
 You can check if pip is installed on your system by typing ``pip --version``
@@ -79,7 +79,7 @@ You can also install a specific version:
 
 .. code-block:: bash
 
-    pip3 install pulse2percept==0.5.2
+    pip3 install pulse2percept==0.6.0
 
 Then from any Python console or script, try:
 
@@ -107,7 +107,7 @@ Installing version |version| from source
 Prerequisites
 -------------
 
-1.  **Python** (>= 3.5): Make sure to :ref:`install Python <install-python>`
+1.  **Python** (>= 3.6): Make sure to :ref:`install Python <install-python>`
     first.
 
 2.  **XCode**: On macOS, make sure to install `Apple XCode`_.
@@ -120,7 +120,7 @@ Prerequisites
     1.  Install **Build Tools for Visual Studio 2019** from the
         `Microsoft website`_.
         Note that the build tools for Visual Studio 2015 or 2017 should work as
-        well (Python >= 3.5 requires C++ 14.X to be exact).
+        well (Python >= 3.6 requires C++ 14.X to be exact).
         Also note that you don't need to install Visual Studio itself.
 
     2.  `Install Cython`_:

--- a/setup.py
+++ b/setup.py
@@ -253,7 +253,7 @@ def setup_package():
                         'build_ext': openmp_build_ext(),
                         'sdist': sdist
                     },
-                    python_requires=">=3.5",
+                    python_requires=">=3.6",
                     install_requires=[
                         'numpy>={}'.format(NUMPY_MIN_VERSION),
                         'scipy>={}'.format(SCIPY_MIN_VERSION),
@@ -279,9 +279,9 @@ def setup_package():
 
         metadata['version'] = VERSION
     else:
-        if sys.version_info < (3, 5):
+        if sys.version_info < (3, 6):
             raise RuntimeError(
-                "pulse2percept requires Python 3.5 or later. The current"
+                "pulse2percept requires Python 3.6 or later. The current"
                 " Python version is %s installed in %s."
                 % (platform.python_version(), sys.executable))
 


### PR DESCRIPTION
RIP Python 3.5 - it has reached its [end of life](https://endoflife.date/python). p2p v0.7+ will only support Python 3.6+.