### PR TITLE
[ENH] Update Beyeler2019 dataset

### DIFF
--- a/examples/datasets/plot_data_beyeler2019.py
+++ b/examples/datasets/plot_data_beyeler2019.py
@@ -17,7 +17,7 @@ single-electrode stimulation.
 Loading the dataset
 -------------------
 
-Due to its size (263 MB), the dataset is not included with pulse2percept, but
+Due to its size (66 MB), the dataset is not included with pulse2percept, but
 can be downloaded from the Open Science Framework (OSF).
 
 By default, the dataset will be stored in a local directory
@@ -100,17 +100,9 @@ from pulse2percept.implants import ArgusII
 argus = ArgusII(x=-1331, y=-850, rot=-0.495, eye='RE')
 
 ###############################################################################
-# (We also need to specify the dimensions of the screens that the subject used,
-# expressed in degrees of visual angle, so that we can scale the phosphene
-# drawing appropriately. This should really be part of the Beyeler dataset and
-# will be fixed in a future version.
-# For now, we add the necessary columns ourselves.)
-import pandas as pd
+# For now, let's focus on the data from Subject 2:
+
 data = fetch_beyeler2019(subjects='S2')
-data['img_x_dva'] = pd.Series([(-30, 30)] * len(data), index=data.index,
-                              dtype=float)
-data['img_y_dva'] = pd.Series([(-22.5, 22.5)] * len(data), index=data.index,
-                              dtype=float)
 
 ###############################################################################
 # Passing both ``data`` and ``argus`` to
@@ -132,11 +124,11 @@ plot_argus_phosphenes(data, argus)
 # To see how the phosphene drawings line up with the NFBs, we can also pass an
 # :py:class:`~pulse2percept.models.AxonMapModel` to the function.
 # Of course, we need to make sure that we use the correct dimensions. Subject
-# S2 had their optic disc center located 14 deg nasally, 2.4 deg superior from
-# the fovea:
+# S2 had their optic disc center located 16.2 deg nasally, 1.38 deg superior
+# from the fovea:
 
 from pulse2percept.models import AxonMapModel
-model = AxonMapModel(loc_od=(14, 2.4))
+model = AxonMapModel(loc_od=(16.2, 1.38))
 plot_argus_phosphenes(data, argus, axon_map=model)
 
 ###############################################################################

--- a/pulse2percept/datasets/beyeler2019.py
+++ b/pulse2percept/datasets/beyeler2019.py
@@ -22,7 +22,7 @@ def fetch_beyeler2019(subjects=None, electrodes=None, data_path=None,
     """Load the phosphene drawing dataset from [Beyeler2019]_
 
     Download the phosphene drawing dataset described in [Beyeler2019]_ from
-    https://osf.io/6v2tb (263MB) to ``data_path``. By default, all datasets are
+    https://osf.io/28uqg (66MB) to ``data_path``. By default, all datasets are
     stored in '~/pulse2percept_data/', but a different path can be specified.
 
     ===================   =====================
@@ -49,9 +49,15 @@ def fetch_beyeler2019(subjects=None, electrodes=None, data_path=None,
     eccentricity          Phosphene elongation (see [Beyeler2019]_)
     compactness           Phosphene compactness (see [Beyeler2019]_)
     x_center, y_center    Phosphene center of mass (see [Beyeler2019]_)
+    xrange, yrange        Screen size in deg (see [Beyeler2019]_)
     ====================  ================================================
 
     .. versionadded:: 0.6
+
+    .. versionchanged:: 0.7
+
+        Redirected download to 66MB version of the dataset that includes
+        the fields ``x_center`` and ``y_center``.
 
     Parameters
     ----------
@@ -92,8 +98,8 @@ def fetch_beyeler2019(subjects=None, electrodes=None, data_path=None,
     file_path = join(data_path, 'beyeler2019.h5')
     if not isfile(file_path):
         if download_if_missing:
-            url = 'https://osf.io/6v2tb/download'
-            checksum = '211818c598c27d33d4e0cd5cdbac9e3ad23106031eb7b51c1a78ccaff000e156'
+            url = 'https://osf.io/28uqg/download'
+            checksum = '4774a7cc768fbfb80d1e3f675efd66273e5034ea0e6e74d415acc66badfee442'
             fetch_url(url, file_path, remote_checksum=checksum)
         else:
             raise IOError("No local file %s found" % file_path)
@@ -127,7 +133,10 @@ def fetch_beyeler2019(subjects=None, electrodes=None, data_path=None,
     # Combine 'img_shape_x' and 'img_shape_y' into 'img_shape' tuple
     df['img_shape'] = df.apply(lambda x: (x['img_shape_x'], x['img_shape_y']),
                                axis=1)
-    df.drop(columns=['img_shape_x', 'img_shape_y'], inplace=True)
+    dfs['xrange'] = dfs.apply(lambda x: (x['xrange_x'], x['xrange_y']), axis=1)
+    dfs['yrange'] = dfs.apply(lambda x: (x['yrange_x'], x['yrange_y']), axis=1)
+    dfs.drop(columns=['img_shape_x', 'img_shape_y', 'xrange_x', 'xrange_y',
+                      'yrange_x', 'yrange_y'], inplace=True)
 
     # Verify integrity of the dataset:
     if len(df) != 400:

--- a/pulse2percept/datasets/beyeler2019.py
+++ b/pulse2percept/datasets/beyeler2019.py
@@ -99,7 +99,7 @@ def fetch_beyeler2019(subjects=None, electrodes=None, data_path=None,
     if not isfile(file_path):
         if download_if_missing:
             url = 'https://osf.io/28uqg/download'
-            checksum = '4774a7cc768fbfb80d1e3f675efd66273e5034ea0e6e74d415acc66badfee442'
+            checksum = '19817990a615d289cdc93b928c138f71977ea2cab54fd1b35d186f3b5a3c4ff5'
             fetch_url(url, file_path, remote_checksum=checksum)
         else:
             raise IOError("No local file %s found" % file_path)
@@ -133,10 +133,10 @@ def fetch_beyeler2019(subjects=None, electrodes=None, data_path=None,
     # Combine 'img_shape_x' and 'img_shape_y' into 'img_shape' tuple
     df['img_shape'] = df.apply(lambda x: (x['img_shape_x'], x['img_shape_y']),
                                axis=1)
-    dfs['xrange'] = dfs.apply(lambda x: (x['xrange_x'], x['xrange_y']), axis=1)
-    dfs['yrange'] = dfs.apply(lambda x: (x['yrange_x'], x['yrange_y']), axis=1)
-    dfs.drop(columns=['img_shape_x', 'img_shape_y', 'xrange_x', 'xrange_y',
-                      'yrange_x', 'yrange_y'], inplace=True)
+    df['xrange'] = df.apply(lambda x: (x['xrange_x'], x['xrange_y']), axis=1)
+    df['yrange'] = df.apply(lambda x: (x['yrange_x'], x['yrange_y']), axis=1)
+    df.drop(columns=['img_shape_x', 'img_shape_y', 'xrange_x', 'xrange_y',
+                     'yrange_x', 'yrange_y'], inplace=True)
 
     # Verify integrity of the dataset:
     if len(df) != 400:

--- a/pulse2percept/datasets/tests/test_beyeler2019.py
+++ b/pulse2percept/datasets/tests/test_beyeler2019.py
@@ -25,16 +25,17 @@ def test_fetch_beyeler2019():
     npt.assert_equal(isinstance(data, pd.DataFrame), True)
     columns = ['subject', 'amp', 'area', 'compactness', 'date', 'eccentricity',
                'electrode', 'filename', 'freq', 'image', 'orientation', 'pdur',
-               'stim_class', 'x_center', 'y_center', 'img_shape']
+               'stim_class', 'x_center', 'y_center', 'img_shape',
+               'xrange', 'yrange']
     for expected_col in columns:
         npt.assert_equal(expected_col in data.columns, True)
 
     npt.assert_equal(data.shape, (400, 16))
     npt.assert_equal(data.subject.unique(), ['S1', 'S2', 'S3', 'S4'])
     npt.assert_equal(list(data[data.subject == 'S1'].img_shape.unique()[0]),
-                     [384, 384])
+                     [192, 192])
     npt.assert_equal(list(data[data.subject != 'S1'].img_shape.unique()[0]),
-                     [768, 1024])
+                     [384, 512])
 
     # Subset selection:
     subset = datasets.fetch_beyeler2019(subjects='S2')

--- a/pulse2percept/models/base.py
+++ b/pulse2percept/models/base.py
@@ -311,7 +311,7 @@ class SpatialModel(BaseModel, metaclass=ABCMeta):
             resp = self._predict_spatial(implant.earray, stim)
         return Percept(resp.reshape(list(self.grid.x.shape) + [-1]),
                        space=self.grid, time=t_percept,
-                       metadata={'stim': implant.stim})
+                       metadata={'stim': stim})
 
     def find_threshold(self, implant, bright_th, amp_range=(0, 999), amp_tol=1,
                        bright_tol=0.1, max_iter=100):
@@ -553,7 +553,7 @@ class TemporalModel(BaseModel, metaclass=ABCMeta):
             resp = self._predict_temporal(_stim, t_percept)
         return Percept(resp.reshape(_space + [t_percept.size]),
                        space=None, time=t_percept,
-                       metadata={'stim': implant.stim})
+                       metadata={'stim': stim})
 
     def find_threshold(self, stim, bright_th, amp_range=(0, 999), amp_tol=1,
                        bright_tol=0.1, max_iter=100, t_percept=None):

--- a/pulse2percept/models/base.py
+++ b/pulse2percept/models/base.py
@@ -310,7 +310,8 @@ class SpatialModel(BaseModel, metaclass=ABCMeta):
                                 metadata=stim.metadata)
             resp = self._predict_spatial(implant.earray, stim)
         return Percept(resp.reshape(list(self.grid.x.shape) + [-1]),
-                       space=self.grid, time=t_percept)
+                       space=self.grid, time=t_percept,
+                       metadata={'stim': implant.stim})
 
     def find_threshold(self, implant, bright_th, amp_range=(0, 999), amp_tol=1,
                        bright_tol=0.1, max_iter=100):
@@ -551,7 +552,8 @@ class TemporalModel(BaseModel, metaclass=ABCMeta):
             # Calculate the Stimulus at requested time points:
             resp = self._predict_temporal(_stim, t_percept)
         return Percept(resp.reshape(_space + [t_percept.size]),
-                       space=None, time=t_percept)
+                       space=None, time=t_percept,
+                       metadata={'stim': implant.stim})
 
     def find_threshold(self, stim, bright_th, amp_range=(0, 999), amp_tol=1,
                        bright_tol=0.1, max_iter=100, t_percept=None):

--- a/pulse2percept/viz/__init__.py
+++ b/pulse2percept/viz/__init__.py
@@ -9,12 +9,13 @@
 """
 
 from .base import scatter_correlation, correlation_matrix
-from .argus import plot_argus_phosphenes
+from .argus import plot_argus_phosphenes, plot_argus_simulated_phosphenes
 from .axon_map import plot_axon_map, plot_implant_on_axon_map
 
 __all__ = [
     'correlation_matrix',
     'plot_argus_phosphenes',
+    'plot_argus_simulated_phosphenes',
     'plot_axon_map',
     'plot_implant_on_axon_map'
     'scatter_correlation'

--- a/pulse2percept/viz/argus.py
+++ b/pulse2percept/viz/argus.py
@@ -1,3 +1,4 @@
+"""`plot_argus_phosphenes`"""
 import numpy as np
 import pandas as pd
 from skimage.io import imread

--- a/pulse2percept/viz/argus.py
+++ b/pulse2percept/viz/argus.py
@@ -1,4 +1,4 @@
-"""`plot_argus_phosphenes`"""
+"""`plot_argus_phosphenes`, `plot_argus_simulated_phosphenes`"""
 import numpy as np
 import pandas as pd
 from skimage.io import imread
@@ -11,7 +11,7 @@ from matplotlib import patches
 from pkg_resources import resource_filename
 
 from ..implants import ArgusI, ArgusII
-from ..utils import Watson2014Transform
+from ..utils import Watson2014Transform, scale_image, center_image
 
 PATH_ARGUS1 = resource_filename('pulse2percept', 'viz/data/argus1.png')
 PATH_ARGUS2 = resource_filename('pulse2percept', 'viz/data/argus2.png')
@@ -61,88 +61,18 @@ PX_ARGUS2 = np.array([
 ])
 
 
-def center_phosphene(img, loc=None):
-    """Center the image foreground
-
-    This function shifts the center of mass (CoM) to the image center.
-
-    .. versionadded:: 0.7
-
-    Parameters
-    ----------
-    loc : (col, row), optional
-        The pixel location at which to center the CoM. By default, shifts
-        the CoM to the image center.
-
-    Returns
-    -------
-    stim : `ImageStimulus`
-        A copy of the stimulus object containing the centered image
-
-    """
-    # Calculate center of mass:
-    m = img_moments(img, order=1)
-    # No area found:
-    if np.isclose(m[0, 0], 0):
-        return img
-    # Center location:
-    if loc is None:
-        loc = np.array(self.img_shape[::-1]) / 2.0 - 0.5
-    # Shift the image by -centroid, +image center:
-    transl = (loc[0] - m[0, 1] / m[0, 0], loc[1] - m[1, 0] / m[0, 0])
-    tf_shift = SimilarityTransform(translation=transl)
-    img = img_warp(img, tf_shift.inverse)
-    return img
-
-
-def scale_phosphene(img, scaling_factor):
-    """Scale the image foreground
-
-    This function scales the image foreground (excluding black pixels)
-    by a factor.
-
-    .. versionadded:: 0.7
-
-    Parameters
-    ----------
-    scaling_factor : float
-        Factory by which to scale the image
-
-    Returns
-    -------
-    stim : `ImageStimulus`
-        A copy of the stimulus object containing the scaled image
-
-    """
-    if scaling_factor <= 0:
-        raise ValueError("Scaling factor must be greater than zero")
-    # Calculate center of mass:
-    m = img_moments(img, order=1)
-    # No area found:
-    if np.isclose(m[0, 0], 0):
-        return img
-    # Shift the phosphene to (0, 0):
-    center_mass = np.array([m[0, 1] / m[0, 0], m[1, 0] / m[0, 0]])
-    tf_shift = SimilarityTransform(translation=-center_mass)
-    # Scale the phosphene:
-    tf_scale = SimilarityTransform(scale=scaling_factor)
-    # Shift the phosphene back to where it was:
-    tf_shift_inv = SimilarityTransform(translation=center_mass)
-    # Combine all three transforms:
-    tf = tf_shift + tf_scale + tf_shift_inv
-    img = img_warp(img, tf.inverse)
-    return img
-
-
-def plot_argus_phosphenes(X, argus, scale=1.0, axon_map=None, show_fovea=True,
-                          ax=None):
+def plot_argus_phosphenes(data, argus, scale=1.0, axon_map=None,
+                          show_fovea=True, ax=None):
     """Plots phosphenes centered over the corresponding electrodes
 
     .. versionadded:: 0.7
 
     Parameters
     ----------
-    X : pd.DataFrame
+    data : pd.DataFrame
+        The Beyeler2019 dataset, a subset thereof, or a DataFrame with
+        identical organization (i.e., must contain columns 'subject', 'image',
+        'xrange', and 'yrange').
     argus : :py:class:`~pulse2percept.implants.ArgusI` or :py:class:`~pulse2percept.implants.ArgusII`
         Either an Argus I or Argus II implant
     scale : float
@@ -152,15 +82,17 @@ def plot_argus_phosphenes(X, argus, scale=1.0, axon_map=None, show_fovea=True,
     ax : axis
         Matplotlib axis
     """
-    if not isinstance(X, pd.DataFrame):
-        raise TypeError('"X" must be a Pandas DataFrame, not %s.' % type(X))
-    req_cols = ['subject', 'electrode', 'image', 'img_x_dva', 'img_y_dva']
-    if not all(col in X.columns for col in req_cols):
-        raise ValueError('"X" must have columns %s.' % req_cols)
-    if len(X) == 0:
-        raise ValueError('"X" is empty.')
-    if len(X.subject.unique()) > 1:
-        raise ValueError('"X" cannot contain data from more than one subject.')
+    if not isinstance(data, pd.DataFrame):
+        raise TypeError('"data" must be a Pandas DataFrame, not '
+                        '%s.' % type(data))
+    req_cols = ['subject', 'electrode', 'image', 'xrange', 'yrange']
+    if not all(col in data.columns for col in req_cols):
+        raise ValueError('"data" must have columns %s.' % req_cols)
+    if len(data) == 0:
+        raise ValueError('"data" is empty.')
+    if len(data.subject.unique()) > 1:
+        raise ValueError('"data" cannot contain data from more than one '
+                         'subject.')
     if not isinstance(argus, (ArgusI, ArgusII)):
         raise TypeError('"argus" must be an Argus I or Argus II implant, not '
                         '%s.' % type(argus))
@@ -197,11 +129,11 @@ def plot_argus_phosphenes(X, argus, scale=1.0, axon_map=None, show_fovea=True,
     pts_dva = []
     pts_out = []
     try:
-        out_shape = X.img_shape.values[0]
+        out_shape = data.img_shape.values[0]
     except AttributeError:
         # Dataset does not have 'img_shape' column:
         try:
-            out_shape = X.image.values[0].shape
+            out_shape = data.image.values[0].shape
         except IndexError:
             out_shape = (768, 1024)
     for xy, e in zip(px_argus, argus.values()):
@@ -218,20 +150,20 @@ def plot_argus_phosphenes(X, argus, scale=1.0, axon_map=None, show_fovea=True,
     argus2out = img_transform('similarity', pts_in, pts_out)
 
     # Top left, top right, bottom left, bottom right corners:
-    x_range = X.img_x_dva
-    y_range = X.img_y_dva
+    x_range = data.xrange
+    y_range = data.yrange
     pts_dva = [[x_range[0], y_range[0]], [x_range[0], y_range[1]],
                [x_range[1], y_range[0]], [x_range[1], y_range[1]]]
 
     # Calculate average drawings, but don't binarize:
     all_imgs = np.zeros(out_shape)
-    num_imgs = X.groupby('electrode')['image'].count()
-    for _, row in X.iterrows():
+    num_imgs = data.groupby('electrode')['image'].count()
+    for _, row in data.iterrows():
         e_pos = Watson2014Transform.ret2dva((argus[row['electrode']].x,
                                              argus[row['electrode']].y))
         align_center = dva2out(e_pos)[0]
-        img_drawing = scale_phosphene(row['image'], scale)
-        img_drawing = center_phosphene(img_drawing, loc=align_center)
+        img_drawing = scale_image(row['image'], scale)
+        img_drawing = center_image(img_drawing, loc=align_center)
         # We normalize by the number of phosphenes per electrode, so that if
         # all phosphenes are the same, their brightness would add up to 1:
         all_imgs += 1.0 / num_imgs[row['electrode']] * img_drawing
@@ -271,3 +203,42 @@ def plot_argus_phosphenes(X, argus, scale=1.0, axon_map=None, show_fovea=True,
                     linewidth=2, zorder=1)
 
     return ax
+
+
+def plot_argus_simulated_phosphenes(percepts, argus, scale=1.0, axon_map=None,
+                                    show_fovea=True, ax=None):
+    """Plots simulated phosphenes centered over the corresponding electrodes
+
+    .. versionadded:: 0.7
+
+    Parameters
+    ----------
+    percepts : :py:class:`~pulse2percept.percepts.Percept`
+        A Percept object containing multiple frames, where each frame is the
+        percept produced by activating a single electrode.
+    argus : :py:class:`~pulse2percept.implants.ArgusI` or :py:class:`~pulse2percept.implants.ArgusII`
+        Either an Argus I or Argus II implant
+    scale : float
+        Scaling factor to apply to the phosphenes
+    show_fovea : bool
+        Whether to indicate the location of the fovea with a square
+    ax : axis
+        Matplotlib axis
+
+    """
+    stim = percepts.metadata['stim']
+    if not np.allclose(stim.data.sum(axis=0), 1):
+        raise ValueError("This function only works for stimuli where one "
+                         "electrodes is active at a time.")
+    # Build the missing DataFrame columns from Percept metadata:
+    df = []
+    for p, s in zip(percepts, stim.data.T):
+        df.append({
+            'subject': 'S000',
+            'electrode': stim.electrodes[np.asarray(s, dtype=np.bool)][0],
+            'image': p,
+            'xrange': (percepts.xdva.min(), percepts.xdva.max()),
+            'yrange': (percepts.ydva.min(), percepts.ydva.max())
+        })
+    plot_argus_phosphenes(pd.DataFrame(df), argus, scale=scale, ax=ax,
+                          axon_map=axon_map, show_fovea=show_fovea)

--- a/pulse2percept/viz/tests/test_argus.py
+++ b/pulse2percept/viz/tests/test_argus.py
@@ -12,9 +12,9 @@ from pulse2percept.viz import plot_argus_phosphenes
 def test_plot_argus_phosphenes():
     df = pd.DataFrame([
         {'subject': 'S1', 'electrode': 'A1', 'image': np.random.rand(10, 10),
-         'img_x_dva': (-10, 10), 'img_y_dva': (-10, 10)},
+         'xrange': (-10, 10), 'yrange': (-10, 10)},
         {'subject': 'S1', 'electrode': 'B2', 'image': np.random.rand(10, 10),
-         'img_x_dva': (-10, 10), 'img_y_dva': (-10, 10)},
+         'xrange': (-10, 10), 'yrange': (-10, 10)},
     ])
     _, ax = plt.subplots()
     plot_argus_phosphenes(df, ArgusI(), ax=ax)


### PR DESCRIPTION
This PR provides a number of enhancements for the Beyeler2019 dataset (issue #344):
- [X] import the downscaled version of the dataset (66 MB)
- [X] add screen size as metadata
- [X] add `plot_argus_simulated_phosphenes` that plots phosphenes from a `Percept` object on the Argus schematic (issue #341)
- [X] store `Stimulus` as `Percept` metadata
- [X] fix `plot_beyeler2019` gallery example (issue #342) and add `AxonMap` simulations 
