### PR TITLE
[FIX] Fix percept.plot() normalization bug

### DIFF
--- a/pulse2percept/percepts/base.py
+++ b/pulse2percept/percepts/base.py
@@ -167,8 +167,14 @@ class Percept(Data):
             if not isinstance(ax, Subplot):
                 raise TypeError("'ax' must be a Matplotlib axis, not "
                                 "%s." % type(ax))
-
-        vmin, vmax = frame.min(), frame.max()
+        if 'vmin' in kwargs.keys():
+            vmin = kwargs['vmin']
+        else:
+            vmin = frame.min()
+        if 'vmax' in kwargs.keys():
+            vmax = kwargs['vmax']
+        else:
+            vmax = frame.max()
         cmap = kwargs['cmap'] if 'cmap' in kwargs else 'gray'
         X, Y = np.meshgrid(self.xdva, self.ydva, indexing='xy')
         if kind == 'pcolor':

--- a/pulse2percept/percepts/base.py
+++ b/pulse2percept/percepts/base.py
@@ -167,15 +167,9 @@ class Percept(Data):
             if not isinstance(ax, Subplot):
                 raise TypeError("'ax' must be a Matplotlib axis, not "
                                 "%s." % type(ax))
-        if 'vmin' in kwargs.keys():
-            vmin = kwargs['vmin']
-        else:
-            vmin = frame.min()
-        if 'vmax' in kwargs.keys():
-            vmax = kwargs['vmax']
-        else:
-            vmax = frame.max()
-        cmap = kwargs['cmap'] if 'cmap' in kwargs else 'gray'
+        vmin = kwargs['vmin'] if 'vmin' in kwargs.keys() else frame.min()
+        vmax = kwargs['vmax'] if 'vmax' in kwargs.keys() else frame.max()
+        cmap = kwargs['cmap'] if 'cmap' in kwargs.keys() else 'gray'
         X, Y = np.meshgrid(self.xdva, self.ydva, indexing='xy')
         if kind == 'pcolor':
             # Create a pseudocolor plot. Make sure to pass additional keyword

--- a/pulse2percept/percepts/tests/test_base.py
+++ b/pulse2percept/percepts/tests/test_base.py
@@ -108,6 +108,11 @@ def test_Percept_plot():
     ax = percept.plot(kind='pcolor', figsize=(6, 4))
     npt.assert_almost_equal(ax.figure.get_size_inches(), (6, 4))
 
+    # Test vmin and vmax
+    ax.clear() 
+    ax = percept.plot(vmin=2, vmax=4)
+    npt.assert_equal(ax.collections[0].get_clim(), (2., 4.))
+
     # Invalid calls:
     with pytest.raises(ValueError):
         percept.plot(kind='invalid')


### PR DESCRIPTION
Fixes a bug where if the user passed vmin and vmax parameters to percept.plot() they were ignored and reset to frame.min() and frame.max(). 