### PR TITLE
[FIX] Fix frame rate of VideoStimulus loaded from file

### DIFF
--- a/pulse2percept/stimuli/tests/test_videos.py
+++ b/pulse2percept/stimuli/tests/test_videos.py
@@ -9,7 +9,7 @@ from skimage.io import imsave
 from pulse2percept.stimuli import VideoStimulus, BostonTrain
 
 
-@pytest.mark.parametrize('fps', [1, 10, 33])
+@pytest.mark.parametrize('fps', [1, 5])
 def test_VideoStimulus(fps):
     # Create a dummy video:
     fname = 'test.mp4'
@@ -17,6 +17,7 @@ def test_VideoStimulus(fps):
     ndarray = np.random.rand(*shape)
     mimwrite(fname, (255 * ndarray).astype(np.uint8), fps=fps)
     stim = VideoStimulus(fname, as_gray=True)
+    print(stim.shape)
     npt.assert_equal(stim.shape, (np.prod(shape[1:]), shape[0]))
     npt.assert_almost_equal(stim.data,
                             ndarray.reshape((shape[0], -1)).transpose(),
@@ -29,7 +30,7 @@ def test_VideoStimulus(fps):
 
     # Resize the video:
     ndarray = np.ones(shape)
-    mimwrite(fname, (255 * ndarray).astype(np.uint8), fps=1)
+    mimwrite(fname, (255 * ndarray).astype(np.uint8), fps=fps)
     resize = (16, 32)
     stim = VideoStimulus(fname, as_gray=True, resize=resize)
     npt.assert_equal(stim.shape, (np.prod(resize), shape[0]))
@@ -37,7 +38,7 @@ def test_VideoStimulus(fps):
                             np.ones((np.prod(resize), shape[0])), decimal=1)
     npt.assert_equal(stim.metadata['source'], fname)
     npt.assert_equal(stim.metadata['source_size'], (shape[2], shape[1]))
-    npt.assert_equal(stim.time, np.arange(shape[0]))
+    npt.assert_almost_equal(stim.time, np.arange(shape[0]) * 1000 / fps)
     npt.assert_equal(stim.electrodes, np.arange(np.prod(resize)))
     os.remove(fname)
 

--- a/pulse2percept/stimuli/tests/test_videos.py
+++ b/pulse2percept/stimuli/tests/test_videos.py
@@ -9,21 +9,21 @@ from skimage.io import imsave
 from pulse2percept.stimuli import VideoStimulus, BostonTrain
 
 
-def test_VideoStimulus():
+@pytest.mark.parametrize('fps', [1, 10, 33])
+def test_VideoStimulus(fps):
     # Create a dummy video:
     fname = 'test.mp4'
     shape = (10, 32, 48)
     ndarray = np.random.rand(*shape)
-    mimwrite(fname, (255 * ndarray).astype(np.uint8), fps=1)
+    mimwrite(fname, (255 * ndarray).astype(np.uint8), fps=fps)
     stim = VideoStimulus(fname, as_gray=True)
-    print(stim.shape)
     npt.assert_equal(stim.shape, (np.prod(shape[1:]), shape[0]))
     npt.assert_almost_equal(stim.data,
                             ndarray.reshape((shape[0], -1)).transpose(),
                             decimal=1)
     npt.assert_equal(stim.metadata['source'], fname)
     npt.assert_equal(stim.metadata['source_size'], (shape[2], shape[1]))
-    npt.assert_equal(stim.time, np.arange(shape[0]))
+    npt.assert_almost_equal(stim.time, np.arange(shape[0]) * 1000.0 / fps)
     npt.assert_equal(stim.electrodes, np.arange(np.prod(shape[1:])))
     os.remove(fname)
 

--- a/pulse2percept/stimuli/tests/test_videos.py
+++ b/pulse2percept/stimuli/tests/test_videos.py
@@ -17,7 +17,6 @@ def test_VideoStimulus(fps):
     ndarray = np.random.rand(*shape)
     mimwrite(fname, (255 * ndarray).astype(np.uint8), fps=fps)
     stim = VideoStimulus(fname, as_gray=True)
-    print(stim.shape)
     npt.assert_equal(stim.shape, (np.prod(shape[1:]), shape[0]))
     npt.assert_almost_equal(stim.data,
                             ndarray.reshape((shape[0], -1)).transpose(),

--- a/pulse2percept/stimuli/videos.py
+++ b/pulse2percept/stimuli/videos.py
@@ -98,7 +98,7 @@ class VideoStimulus(Stimulus):
             metadata['source'] = source
             metadata['source_shape'] = vid.shape
             # Infer the time points from the video frame rate:
-            time = np.arange(vid.shape[-1]) * meta['fps']
+            time = np.arange(vid.shape[-1]) * 1000.0 / meta['fps']
         elif isinstance(source, VideoStimulus):
             vid = source.data.reshape(source.vid_shape)
             metadata.update(source.metadata)


### PR DESCRIPTION
When `VideoStimulus` loads a video from file, it uses the wrong frame rate