### PR TITLE
[REF] Make implants use degrees for rotations

### DIFF
--- a/doc/users/release_notes.rst
+++ b/doc/users/release_notes.rst
@@ -6,10 +6,10 @@ Release Notes
 
 .. important::
 
-    pulse2percept 0.4.3 is the last release to support Python 2.7 and 3.4.
-    pulse2percept 0.5+ requires **Python 3.5 or newer**.
+    **pulse2percept 0.6 was the last version to support Python <= 3.5.**
+    pulse2percept 0.7+ requires Python 3.6+.
 
-v0.7.0 (2020, planned)
+v0.7.0 (2021, planned)
 ----------------------
 
 Highlights
@@ -49,6 +49,7 @@ API changes
 Backward-incompatible changes
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+*  Implants rotation angles are now speicified in degrees, not radians (:pull:`357`)
 *  pulse2percept now requires Matplotlib 3.0.2 or newer (:pull:`223`)
 *  FFMPEG and scikit-video dependencies have been removed (:pull:`196`)
 *  ``TimeSeries`` has been removed. Please use

--- a/examples/datasets/plot_data_beyeler2019.py
+++ b/examples/datasets/plot_data_beyeler2019.py
@@ -97,7 +97,7 @@ plt.imshow(data.loc[0, 'image'], cmap='gray')
 # in the following location:
 
 from pulse2percept.implants import ArgusII
-argus = ArgusII(x=-1331, y=-850, rot=-0.495, eye='RE')
+argus = ArgusII(x=-1331, y=-850, rot=-28.4, eye='RE')
 
 ###############################################################################
 # For now, let's focus on the data from Subject 2:

--- a/examples/implants/plot_electrode_grid.py
+++ b/examples/implants/plot_electrode_grid.py
@@ -17,7 +17,7 @@ To create a rectangular grid, we need to specify:
    of rows and columns
 -  The electrode-to-electrode ``spacing`` in microns
 -  The (``x``, ``y``) location of the center of the array
--  The rotation angle ``rot`` of the grid in radians, where positive angles
+-  The rotation angle ``rot`` of the grid in degrees, where positive angles
    rotate all electrodes in the array in a counter-clockwise fashion on the
    retinal surface.
 
@@ -113,7 +113,7 @@ hex_grid.plot()
 
 from numpy import pi
 offset_grid = ElectrodeGrid((11, 13), 500, type='hex', x=-600, y=200, z=150,
-                            rot=-pi / 4, etype=DiskElectrode, r=100)
+                            rot=-45, etype=DiskElectrode, r=100)
 
 ##############################################################################
 # .. note::

--- a/examples/implants/plot_implants.py
+++ b/examples/implants/plot_implants.py
@@ -38,12 +38,12 @@ fig, ax = plt.subplots(ncols=2, figsize=(10, 6))
 model = AxonMapModel()
 model.plot(ax=ax[0])
 # Argus I is typically implanted at a 30-45deg angle:
-ArgusI(rot=-0.52).plot(ax=ax[0], annotate=True)
+ArgusI(rot=-30).plot(ax=ax[0], annotate=True)
 ax[0].set_title('Argus I')
 
 model.plot(ax=ax[1])
 # Argus II is typically implanted at a 30-45deg angle:
-ArgusII(rot=-0.52).plot(ax=ax[1], annotate=False)
+ArgusII(rot=-30).plot(ax=ax[1], annotate=False)
 ax[1].set_title('Argus II')
 
 ###############################################################################

--- a/examples/models/plot_axon_map.py
+++ b/examples/models/plot_axon_map.py
@@ -177,7 +177,7 @@ ax.set_title('Predicted percept')
 # depending on the location of the implant. You can convince yourself of that
 # by re-running the model on an implant shifted and rotated across the retina:
 
-implant = ArgusII(x=-50, y=50, rot=np.deg2rad(-45))
+implant = ArgusII(x=-50, y=50, rot=-45)
 model.plot()
 implant.plot()
 

--- a/pulse2percept/implants/alpha.py
+++ b/pulse2percept/implants/alpha.py
@@ -14,7 +14,7 @@ class AlphaIMS(ProsthesisSystem):
     50um in diameter) as described in [Stingl2013]_, and places it in the
     subretinal space, such that the center of the array is located at (x,y,z),
     given in microns, and the array is rotated by rotation angle ``rot``,
-    given in radians.
+    given in degrees.
 
     The device consists of 1500 50um-wide square pixels, arranged on a 39x39
     rectangular grid with 72um pixel pitch.
@@ -40,7 +40,7 @@ class AlphaIMS(ProsthesisSystem):
         Distance of the array to the retinal surface (um). Either a list
         with 1500 entries or a scalar.
     rot : float
-        Rotation angle of the array (rad). Positive values denote
+        Rotation angle of the array (deg). Positive values denote
         counter-clock-wise (CCW) rotations in the retinal coordinate
         system.
     eye : {'RE', 'LE'}, optional
@@ -49,10 +49,10 @@ class AlphaIMS(ProsthesisSystem):
     Examples
     --------
     Create an Alpha-IMS array centered on the fovea, at 100um distance from
-    the retina:
+    the retina, rotated counter-clockwise by 5 degrees:
 
     >>> from pulse2percept.implants import AlphaIMS
-    >>> AlphaIMS(x=0, y=0, z=100, rot=0)  # doctest: +NORMALIZE_WHITESPACE
+    >>> AlphaIMS(x=0, y=0, z=100, rot=5)  # doctest: +NORMALIZE_WHITESPACE
     AlphaIMS(earray=ElectrodeGrid, eye='RE', shape=(39, 39),
              stim=None)
 
@@ -139,7 +139,7 @@ class AlphaAMS(ProsthesisSystem):
     30um in diameter) as described in [Stingl2017]_, and places it in the
     subretinal space, such that the center of the array is located at (x,y,z),
     given in microns, and the array is rotated by rotation angle ``rot``,
-    given in radians.
+    given in degrees.
 
     The device consists of 1600 30um-wide round pixels, arranged on a 40x40
     rectangular grid with 70um pixel pitch.
@@ -165,7 +165,7 @@ class AlphaAMS(ProsthesisSystem):
         Distance of the array to the retinal surface (um). Either a list
         with 60 entries or a scalar.
     rot : float
-        Rotation angle of the array (rad). Positive values denote
+        Rotation angle of the array (deg). Positive values denote
         counter-clock-wise (CCW) rotations in the retinal coordinate
         system.
     eye : {'RE', 'LE'}, optional
@@ -174,10 +174,10 @@ class AlphaAMS(ProsthesisSystem):
     Examples
     --------
     Create an AlphaAMS array centered on the fovea, at 100um distance from
-    the retina:
+    the retina, rotated counter-clockwise by 5 degrees:
 
     >>> from pulse2percept.implants import AlphaAMS
-    >>> AlphaAMS(x=0, y=0, z=100, rot=0)  # doctest: +NORMALIZE_WHITESPACE
+    >>> AlphaAMS(x=0, y=0, z=100, rot=5)  # doctest: +NORMALIZE_WHITESPACE
     AlphaAMS(earray=ElectrodeGrid, eye='RE', shape=(40, 40),
              stim=None)
 

--- a/pulse2percept/implants/argus.py
+++ b/pulse2percept/implants/argus.py
@@ -13,7 +13,7 @@ class ArgusI(ProsthesisSystem):
     This function creates an Argus I array and places it on the retina
     such that the center of the array is located at 3D location (x,y,z),
     given in microns, and the array is rotated by rotation angle ``rot``,
-    given in radians.
+    given in degrees.
 
     Argus I is a modified cochlear implant containing 16 electrodes in a 4x4
     array with a center-to-center separation of 800 um, and two electrode
@@ -54,7 +54,7 @@ class ArgusI(ProsthesisSystem):
         Distance of the array to the retinal surface (um). Either a list
         with 16 entries or a scalar.
     rot : float, optional
-        Rotation angle of the array (rad). Positive values denote
+        Rotation angle of the array (deg). Positive values denote
         counter-clock-wise (CCW) rotations in the retinal coordinate
         system.
     eye : {'RE', 'LE'}, optional
@@ -63,10 +63,10 @@ class ArgusI(ProsthesisSystem):
     Examples
     --------
     Create an Argus I array centered on the fovea, at 100um distance from
-    the retina:
+    the retina, rotated counter-clockwise by 5 degrees:
 
     >>> from pulse2percept.implants import ArgusI
-    >>> ArgusI(x=0, y=0, z=100, rot=0)  # doctest: +NORMALIZE_WHITESPACE
+    >>> ArgusI(x=0, y=0, z=100, rot=5)  # doctest: +NORMALIZE_WHITESPACE
     ArgusI(earray=ElectrodeGrid, eye='RE', shape=(4, 4),
            stim=None)
 
@@ -141,7 +141,7 @@ class ArgusII(ProsthesisSystem):
     This function creates an Argus II array and places it on the retina
     such that the center of the array is located at (x,y,z), given in
     microns, and the array is rotated by rotation angle ``rot``, given in
-    radians.
+    degrees.
 
     Argus II contains 60 electrodes of 225 um diameter arranged in a 6 x 10
     grid (575 um center-to-center separation) [Yue2020]_.
@@ -180,7 +180,7 @@ class ArgusII(ProsthesisSystem):
         Distance of the array to the retinal surface (um). Either a list
         with 60 entries or a scalar.
     rot : float
-        Rotation angle of the array (rad). Positive values denote
+        Rotation angle of the array (deg). Positive values denote
         counter-clock-wise (CCW) rotations in the retinal coordinate
         system.
     eye : {'RE', 'LE'}, optional
@@ -189,10 +189,10 @@ class ArgusII(ProsthesisSystem):
     Examples
     --------
     Create an ArgusII array centered on the fovea, at 100um distance from
-    the retina:
+    the retina, rotated counter-clockwise by 5 degrees:
 
     >>> from pulse2percept.implants import ArgusII
-    >>> ArgusII(x=0, y=0, z=100, rot=0)  # doctest: +NORMALIZE_WHITESPACE
+    >>> ArgusII(x=0, y=0, z=100, rot=5)  # doctest: +NORMALIZE_WHITESPACE
     ArgusII(earray=ElectrodeGrid, eye='RE', shape=(6, 10),
             stim=None)
 

--- a/pulse2percept/implants/bvt.py
+++ b/pulse2percept/implants/bvt.py
@@ -13,7 +13,7 @@ class BVT24(ProsthesisSystem):
     [Layton2014]_, which was developed by the Bionic Vision Australia
     Consortium and commercialized by Bionic Vision Technologies (BVT).
     The center of the array is located at (x,y,z), given in microns, and the
-    array is rotated by rotation angle ``rot``, given in radians.
+    array is rotated by rotation angle ``rot``, given in degrees.
 
     The array consists of:
 
@@ -47,7 +47,7 @@ class BVT24(ProsthesisSystem):
         Distance of the array to the retinal surface (um). Either a list
         with 60 entries or a scalar.
     rot : float
-        Rotation angle of the array (rad). Positive values denote
+        Rotation angle of the array (deg). Positive values denote
         counter-clock-wise (CCW) rotations in the retinal coordinate
         system.
     eye : {'RE', 'LE'}, optional
@@ -105,8 +105,9 @@ class BVT24(ProsthesisSystem):
         names.extend(['R1', 'R2'])
 
         # Rotate the grid:
-        rotmat = np.array([np.cos(rot), -np.sin(rot),
-                           np.sin(rot), np.cos(rot)]).reshape((2, 2))
+        rot_rad = np.deg2rad(rot)
+        rotmat = np.array([np.cos(rot_rad), -np.sin(rot_rad),
+                           np.sin(rot_rad), np.cos(rot_rad)]).reshape((2, 2))
         xy = np.matmul(rotmat, np.vstack((x_arr, y_arr)))
         x_arr = xy[0, :]
         y_arr = xy[1, :]

--- a/pulse2percept/implants/electrode_arrays.py
+++ b/pulse2percept/implants/electrode_arrays.py
@@ -218,7 +218,7 @@ class ElectrodeGrid(ElectrodeArray):
     x, y, z : double, optional
         3D coordinates of the center of the grid
     rot : double, optional
-        Rotation of the grid in radians (positive angle: counter-clockwise
+        Rotation of the grid in degrees (positive angle: counter-clockwise
         rotation on the retinal surface)
     names: (name_rows, name_cols), each of which either 'A' or '1'
         Naming convention for rows and columns, respectively.
@@ -327,7 +327,6 @@ class ElectrodeGrid(ElectrodeArray):
                 raise ValueError("'names' must either have two entries for "
                                  "rows/columns or %d entries, not "
                                  "%d" % (np.prod(shape), len(names)))
-
         self.shape = shape
         self.type = type
         self.spacing = spacing
@@ -488,8 +487,9 @@ class ElectrodeGrid(ElectrodeArray):
             raise NotImplementedError
 
         # Rotate the grid:
-        rotmat = np.array([np.cos(rot), -np.sin(rot),
-                           np.sin(rot), np.cos(rot)]).reshape((2, 2))
+        rot_rad = np.deg2rad(rot)
+        rotmat = np.array([np.cos(rot_rad), -np.sin(rot_rad),
+                           np.sin(rot_rad), np.cos(rot_rad)]).reshape((2, 2))
         xy = np.matmul(rotmat, np.vstack((x_arr.flatten(), y_arr.flatten())))
         x_arr = xy[0, :]
         y_arr = xy[1, :]

--- a/pulse2percept/implants/prima.py
+++ b/pulse2percept/implants/prima.py
@@ -64,7 +64,7 @@ class PRIMA(ProsthesisSystem):
     100um in diameter) as used in the clinical trial [Palanker2020]_, and
     places it in the subretinal space such that the center of the array is
     located at 3D location (x,y,z), given in microns, and the array is rotated
-    by rotation angle ``rot``, given in radians.
+    by rotation angle ``rot``, given in degrees.
 
     The device consists of 378 85um-wide pixels separated by 15um trenches,
     arranged in a 2-mm wide hexagonal pattern.
@@ -84,7 +84,7 @@ class PRIMA(ProsthesisSystem):
         Distance of the array to the retinal surface (um). Either a list
         with 378 entries or a scalar.
     rot : float, optional
-        Rotation angle of the array (rad). Positive values denote
+        Rotation angle of the array (deg). Positive values denote
         counter-clock-wise (CCW) rotations in the retinal coordinate
         system.
     eye : {'RE', 'LE'}, optional
@@ -152,7 +152,7 @@ class PRIMA75(ProsthesisSystem):
     in diameter) as described in [Lorach2015]_, and places it in the subretinal
     space, such that that the center of the array is located at 3D location
     (x,y,z), given in microns, and the array is rotated by rotation angle
-    ``rot``, given in radians.
+    ``rot``, given in degrees.
 
     The device consists of 142 70um-wide pixels separated by 5um trenches,
     arranged in a 1-mm wide hexagonal pattern.
@@ -172,7 +172,7 @@ class PRIMA75(ProsthesisSystem):
         Distance of the array to the retinal surface (um). Either a list
         with 142 entries or a scalar.
     rot : float, optional
-        Rotation angle of the array (rad). Positive values denote
+        Rotation angle of the array (deg). Positive values denote
         counter-clock-wise (CCW) rotations in the retinal coordinate
         system.
     eye : {'RE', 'LE'}, optional
@@ -237,7 +237,7 @@ class PRIMA55(ProsthesisSystem):
     This class creates a PRIMA array with 273 photovoltaic pixels (each 55um
     in diameter), and places it in the subretinal space, such that that the
     center of the array is located at 3D location (x,y,z), given in microns,
-    and the array is rotated by rotation angle ``rot``, given in radians.
+    and the array is rotated by rotation angle ``rot``, given in degrees.
 
     The device consists of 273 50um-wide pixels separated by 5um trenches,
     arranged in a 1-mm wide hexagonal pattern.
@@ -263,7 +263,7 @@ class PRIMA55(ProsthesisSystem):
         Distance of the array to the retinal surface (um). Either a list
         with 378 entries or a scalar.
     rot : float, optional
-        Rotation angle of the array (rad). Positive values denote
+        Rotation angle of the array (deg). Positive values denote
         counter-clock-wise (CCW) rotations in the retinal coordinate
         system.
     eye : {'RE', 'LE'}, optional
@@ -333,7 +333,7 @@ class PRIMA40(ProsthesisSystem):
     This class creates a PRIMA array with 532 photovoltaic pixels (each 40um
     in diameter), and places it in the subretinal space, such that that the
     center of the array is located at 3D location (x,y,z), given in microns,
-    and the array is rotated by rotation angle ``rot``, given in radians.
+    and the array is rotated by rotation angle ``rot``, given in degrees.
 
     The device consists of 532 35um-wide pixels separated by 5um trenches,
     arranged in a 1-mm wide hexagonal pattern.
@@ -359,7 +359,7 @@ class PRIMA40(ProsthesisSystem):
         Distance of the array to the retinal surface (um). Either a list
         with 378 entries or a scalar.
     rot : float, optional
-        Rotation angle of the array (rad). Positive values denote
+        Rotation angle of the array (deg). Positive values denote
         counter-clock-wise (CCW) rotations in the retinal coordinate
         system.
     eye : {'LE', 'RE'}, optional

--- a/pulse2percept/implants/tests/test_alpha.py
+++ b/pulse2percept/implants/tests/test_alpha.py
@@ -8,10 +8,8 @@ from pulse2percept.implants import AlphaIMS, AlphaAMS
 @pytest.mark.parametrize('ztype', ('float', 'list'))
 @pytest.mark.parametrize('x', (-100, 200))
 @pytest.mark.parametrize('y', (-200, 400))
-@pytest.mark.parametrize('r', (-45, 60))
-def test_AlphaIMS(ztype, x, y, r):
-    # Convert rotation angle to rad
-    rot = np.deg2rad(r)
+@pytest.mark.parametrize('rot', (-45, 60))
+def test_AlphaIMS(ztype, x, y, rot):
     # Height `h` can either be a float or a list
     if ztype == 'float':
         alpha = AlphaIMS(x=x, y=y, z=-100, rot=rot)
@@ -32,8 +30,9 @@ def test_AlphaIMS(ztype, x, y, r):
     xy = np.array([-1368, -1368]).T
 
     # Rotate
-    R = np.array([np.cos(rot), -np.sin(rot),
-                  np.sin(rot), np.cos(rot)]).reshape((2, 2))
+    rot_rad = np.deg2rad(rot)
+    R = np.array([np.cos(rot_rad), -np.sin(rot_rad),
+                  np.sin(rot_rad), np.cos(rot_rad)]).reshape((2, 2))
     xy = np.matmul(R, xy)
 
     # Then off-set: Make sure first electrode is placed
@@ -79,7 +78,7 @@ def test_AlphaIMS(ztype, x, y, r):
     # counter-clock-wise (CCW): for (x>0,y>0), decreasing x and increasing y
     for eye, el in zip(['LE', 'RE'], ['A1', 'A37']):
         before = AlphaIMS(eye=eye)
-        after = AlphaIMS(eye=eye, rot=np.deg2rad(10))
+        after = AlphaIMS(eye=eye, rot=10)
         npt.assert_equal(after[el].x > before[el].x, True)
         npt.assert_equal(after[el].y > before[el].y, True)
 
@@ -93,10 +92,8 @@ def test_AlphaIMS(ztype, x, y, r):
 @pytest.mark.parametrize('ztype', ('float', 'list'))
 @pytest.mark.parametrize('x', (-100, 200))
 @pytest.mark.parametrize('y', (-200, 400))
-@pytest.mark.parametrize('r', (-45, 60))
-def test_AlphaAMS(ztype, x, y, r):
-    # Convert rotation angle to rad
-    rot = np.deg2rad(r)
+@pytest.mark.parametrize('rot', (-45, 60))
+def test_AlphaAMS(ztype, x, y, rot):
     # Height `h` can either be a float or a list
     if ztype == 'float':
         alpha = AlphaAMS(x=x, y=y, z=-100, rot=rot)
@@ -112,9 +109,10 @@ def test_AlphaAMS(ztype, x, y, r):
     npt.assert_equal(hasattr(alpha, '__dict__'), False)
 
     # Rotate coordinates of first electrode:
+    rot_rad = np.deg2rad(rot)
     xy = np.array([-1365, -1365]).T
-    R = np.array([np.cos(rot), -np.sin(rot),
-                  np.sin(rot), np.cos(rot)]).reshape((2, 2))
+    R = np.array([np.cos(rot_rad), -np.sin(rot_rad),
+                  np.sin(rot_rad), np.cos(rot_rad)]).reshape((2, 2))
     xy = np.matmul(R, xy)
     # Then off-set: Make sure first electrode is placed
     # correctly
@@ -159,7 +157,7 @@ def test_AlphaAMS(ztype, x, y, r):
     # counter-clock-wise (CCW): for (x>0,y>0), decreasing x and increasing y
     for eye, el in zip(['LE', 'RE'], ['A1', 'A40']):
         before = AlphaAMS(eye=eye)
-        after = AlphaAMS(eye=eye, rot=np.deg2rad(10))
+        after = AlphaAMS(eye=eye, rot=10)
         npt.assert_equal(after[el].x > before[el].x, True)
         npt.assert_equal(after[el].y > before[el].y, True)
 

--- a/pulse2percept/implants/tests/test_argus.py
+++ b/pulse2percept/implants/tests/test_argus.py
@@ -8,13 +8,11 @@ from pulse2percept import implants
 @pytest.mark.parametrize('ztype', ('float', 'list'))
 @pytest.mark.parametrize('x', (-100, 200))
 @pytest.mark.parametrize('y', (-200, 400))
-@pytest.mark.parametrize('r', (-45, 60))
-def test_ArgusI(ztype, x, y, r):
+@pytest.mark.parametrize('rot', (-45, 60))
+def test_ArgusI(ztype, x, y, rot):
     # Create an ArgusI and make sure location is correct
     # Height `z` can either be a float or a list
     z = 100 if ztype == 'float' else np.ones(16) * 20
-    # Convert rotation angle to rad
-    rot = r * np.pi / 180
 
     argus = implants.ArgusI(x, y, z=z, rot=rot)
 
@@ -26,8 +24,9 @@ def test_ArgusI(ztype, x, y, r):
     xy = np.array([-1200, -1200]).T
 
     # Rotate
-    R = np.array([np.cos(rot), -np.sin(rot),
-                  np.sin(rot), np.cos(rot)]).reshape((2, 2))
+    rot_rad = np.deg2rad(rot)
+    R = np.array([np.cos(rot_rad), -np.sin(rot_rad),
+                  np.sin(rot_rad), np.cos(rot_rad)]).reshape((2, 2))
     xy = np.matmul(R, xy)
 
     # Then off-set: Make sure first electrode is placed
@@ -81,7 +80,7 @@ def test_ArgusI(ztype, x, y, r):
     # counter-clock-wise (CCW): for (x>0,y>0), decreasing x and increasing y
     for eye, el in zip(['LE', 'RE'], ['A1', 'D1']):
         before = implants.ArgusI(eye=eye)
-        after = implants.ArgusI(eye=eye, rot=np.deg2rad(10))
+        after = implants.ArgusI(eye=eye, rot=10)
         npt.assert_equal(after[el].x > before[el].x, True)
         npt.assert_equal(after[el].y > before[el].y, True)
 
@@ -108,13 +107,11 @@ def test_ArgusI(ztype, x, y, r):
 @pytest.mark.parametrize('ztype', ('float', 'list'))
 @pytest.mark.parametrize('x', (-100, 200))
 @pytest.mark.parametrize('y', (-200, 400))
-@pytest.mark.parametrize('r', (-45, 60))
-def test_ArgusII(ztype, x, y, r):
+@pytest.mark.parametrize('rot', (-45, 60))
+def test_ArgusII(ztype, x, y, rot):
     # Create an ArgusII and make sure location is correct
     # Height `h` can either be a float or a list
     z = 100 if ztype == 'float' else np.ones(60) * 20
-    # Convert rotation angle to rad
-    rot = np.deg2rad(r)
     argus = implants.ArgusII(x=x, y=y, z=z, rot=rot)
 
     # Slots:
@@ -125,8 +122,9 @@ def test_ArgusII(ztype, x, y, r):
     xy = np.array([-2587.5, -1437.5]).T
 
     # Rotate
-    R = np.array([np.cos(rot), -np.sin(rot),
-                  np.sin(rot), np.cos(rot)]).reshape((2, 2))
+    rot_rad = np.deg2rad(rot)
+    R = np.array([np.cos(rot_rad), -np.sin(rot_rad),
+                  np.sin(rot_rad), np.cos(rot_rad)]).reshape((2, 2))
     xy = np.matmul(R, xy)
 
     # Then off-set: Make sure first electrode is placed
@@ -175,7 +173,7 @@ def test_ArgusII(ztype, x, y, r):
         # 'F10' in a right eye (because the columns are reversed). Thus both
         # cases are testing an electrode with x>0, y>0:
         before = implants.ArgusII(eye=eye)
-        after = implants.ArgusII(eye=eye, rot=np.deg2rad(20))
+        after = implants.ArgusII(eye=eye, rot=20)
         npt.assert_equal(after[el].x < before[el].x, True)
         npt.assert_equal(after[el].y > before[el].y, True)
 

--- a/pulse2percept/implants/tests/test_bvt.py
+++ b/pulse2percept/implants/tests/test_bvt.py
@@ -7,11 +7,9 @@ from pulse2percept.implants.bvt import BVT24
 
 @pytest.mark.parametrize('x', (-100, 200))
 @pytest.mark.parametrize('y', (-200, 400))
-@pytest.mark.parametrize('r', (-45, 60))
-def test_BVT24(x, y, r):
+@pytest.mark.parametrize('rot', (-45, 60))
+def test_BVT24(x, y, rot):
     # Create a BVT24 and make sure location is correct
-    # Convert rotation angle to rad
-    rot = np.deg2rad(r)
     bva = BVT24(x=x, y=y, rot=rot)
 
     # Slots:
@@ -24,8 +22,9 @@ def test_BVT24(x, y, r):
     xy2 = np.array([-850.0, -2280.0]).T
 
     # Rotate
-    R = np.array([np.cos(rot), -np.sin(rot),
-                  np.sin(rot), np.cos(rot)]).reshape((2, 2))
+    rot_rad = np.deg2rad(rot)
+    R = np.array([np.cos(rot_rad), -np.sin(rot_rad),
+                  np.sin(rot_rad), np.cos(rot_rad)]).reshape((2, 2))
     xy = np.matmul(R, xy)
     xy2 = np.matmul(R, xy2)
 

--- a/pulse2percept/implants/tests/test_electrode_arrays.py
+++ b/pulse2percept/implants/tests/test_electrode_arrays.py
@@ -268,13 +268,10 @@ def test_ElectrodeGrid(gtype):
         npt.assert_equal(i.z, x + 1)
         x = i.z
 
-    # TODO display a warning when rot > 2pi (meaning it might be in degrees).
-    # I think we did this somewhere in the old Argus code
-
     # TODO test rotation, making sure positive angles rotate CCW
     egrid1 = ElectrodeGrid((2, 2), spacing, type=gtype, etype=DiskElectrode,
                            r=radius)
-    egrid2 = ElectrodeGrid((2, 2), spacing, rot=np.deg2rad(10), type=gtype,
+    egrid2 = ElectrodeGrid((2, 2), spacing, rot=10, type=gtype,
                            etype=DiskElectrode, r=radius)
     npt.assert_equal(egrid1["A1"].x < egrid2["A1"].x, True)
     npt.assert_equal(egrid1["A1"].y > egrid2["A1"].y, True)

--- a/pulse2percept/implants/tests/test_prima.py
+++ b/pulse2percept/implants/tests/test_prima.py
@@ -29,8 +29,8 @@ def test_PhotovoltaicPixel():
 @pytest.mark.parametrize('ztype', ('float', 'list'))
 @pytest.mark.parametrize('x', (-100, 200))
 @pytest.mark.parametrize('y', (-200, 400))
-@pytest.mark.parametrize('r', (-45, 60))
-def test_PRIMA(ztype, x, y, r):
+@pytest.mark.parametrize('rot', (-45, 60))
+def test_PRIMA(ztype, x, y, rot):
     # 85 um pixel with 15 um trenches:
     spacing = 100
     # Roughly a 12x15 grid, but edges are trimmed off:
@@ -38,8 +38,6 @@ def test_PRIMA(ztype, x, y, r):
     # Create an Prima and make sure location is correct
     # Height `z` can either be a float or a list
     z = -100 if ztype == 'float' else -np.ones(378) * 20
-    # Convert rotation angle to rad
-    rot = r * np.pi / 180
 
     prima = PRIMA(x, y, z=z, rot=rot)
 
@@ -54,8 +52,9 @@ def test_PRIMA(ztype, x, y, r):
     # Coordinates of A6 when device is not rotated:
     xy = np.array([-616.99, -925.0]).T
     # Rotate
-    R = np.array([np.cos(rot), -np.sin(rot),
-                  np.sin(rot), np.cos(rot)]).reshape((2, 2))
+    rot_rad = np.deg2rad(rot)
+    R = np.array([np.cos(rot_rad), -np.sin(rot_rad),
+                  np.sin(rot_rad), np.cos(rot_rad)]).reshape((2, 2))
     xy = np.matmul(R, xy)
     # Then off-set: Make sure first electrode is placed
     # correctly
@@ -81,8 +80,8 @@ def test_PRIMA(ztype, x, y, r):
 @pytest.mark.parametrize('ztype', ('float', 'list'))
 @pytest.mark.parametrize('x', (-100, 200))
 @pytest.mark.parametrize('y', (-200, 400))
-@pytest.mark.parametrize('r', (-45, 60))
-def test_PRIMA75(ztype, x, y, r):
+@pytest.mark.parametrize('rot', (-45, 60))
+def test_PRIMA75(ztype, x, y, rot):
     # 70 um pixel with 5 um trenches:
     spacing = 75
     # Roughly a 12x15 grid, but edges are trimmed off:
@@ -90,8 +89,6 @@ def test_PRIMA75(ztype, x, y, r):
     # Create an Prima and make sure location is correct
     # Height `z` can either be a float or a list
     z = -100 if ztype == 'float' else -np.ones(142) * 20
-    # Convert rotation angle to rad
-    rot = r * np.pi / 180
 
     prima = PRIMA75(x, y, z=z, rot=rot)
 
@@ -106,8 +103,9 @@ def test_PRIMA75(ztype, x, y, r):
     # Coordinates of A6 when device is not rotated:
     xy = np.array([-200.24, -431.25]).T
     # Rotate
-    R = np.array([np.cos(rot), -np.sin(rot),
-                  np.sin(rot), np.cos(rot)]).reshape((2, 2))
+    rot_rad = np.deg2rad(rot)
+    R = np.array([np.cos(rot_rad), -np.sin(rot_rad),
+                  np.sin(rot_rad), np.cos(rot_rad)]).reshape((2, 2))
     xy = np.matmul(R, xy)
     # Then off-set: Make sure first electrode is placed
     # correctly
@@ -133,8 +131,8 @@ def test_PRIMA75(ztype, x, y, r):
 @pytest.mark.parametrize('ztype', ('float', 'list'))
 @pytest.mark.parametrize('x', (-100, 200))
 @pytest.mark.parametrize('y', (-200, 400))
-@pytest.mark.parametrize('r', (-45, 60))
-def test_PRIMA55(ztype, x, y, r):
+@pytest.mark.parametrize('rot', (-45, 60))
+def test_PRIMA55(ztype, x, y, rot):
     # 50 um pixels with 5 um trenches:
     spacing = 55
     # Roughly a 18x21 grid, but edges are trimmed off:
@@ -142,8 +140,6 @@ def test_PRIMA55(ztype, x, y, r):
     # Create an Prima and make sure location is correct
     # Height `z` can either be a float or a list
     z = -100 if ztype == 'float' else -np.ones(273) * 20
-    # Convert rotation angle to rad
-    rot = r * np.pi / 180
 
     prima = PRIMA55(x, y, z=z, rot=rot)
 
@@ -158,8 +154,9 @@ def test_PRIMA55(ztype, x, y, r):
     # Coordinates of C8 when device is not rotated:
     xy = np.array([-216.58, -371.25]).T
     # Rotate
-    R = np.array([np.cos(rot), -np.sin(rot),
-                  np.sin(rot), np.cos(rot)]).reshape((2, 2))
+    rot_rad = np.deg2rad(rot)
+    R = np.array([np.cos(rot_rad), -np.sin(rot_rad),
+                  np.sin(rot_rad), np.cos(rot_rad)]).reshape((2, 2))
     xy = np.matmul(R, xy)
     # Then off-set: Make sure first electrode is placed
     # correctly
@@ -185,8 +182,8 @@ def test_PRIMA55(ztype, x, y, r):
 @pytest.mark.parametrize('ztype', ('float', 'list'))
 @pytest.mark.parametrize('x', (-100, 200))
 @pytest.mark.parametrize('y', (-200, 400))
-@pytest.mark.parametrize('r', (-45, 60))
-def test_PRIMA40(ztype, x, y, r):
+@pytest.mark.parametrize('rot', (-45, 60))
+def test_PRIMA40(ztype, x, y, rot):
     # 35 um pixel with 5 um trenches:
     spacing = 40
     # Roughly a 25x28 grid, but edges are trimmed off:
@@ -194,8 +191,6 @@ def test_PRIMA40(ztype, x, y, r):
     # Create an Prima and make sure location is correct
     # Height `z` can either be a float or a list
     z = -100 if ztype == 'float' else -np.ones(532) * 20
-    # Convert rotation angle to rad
-    rot = r * np.pi / 180
 
     prima = PRIMA40(x, y, z=z, rot=rot)
 
@@ -210,8 +205,9 @@ def test_PRIMA40(ztype, x, y, r):
     # Coordinates of D16 when device is not rotated:
     xy = np.array([-20.38, -370.0]).T
     # Rotate
-    R = np.array([np.cos(rot), -np.sin(rot),
-                  np.sin(rot), np.cos(rot)]).reshape((2, 2))
+    rot_rad = np.deg2rad(rot)
+    R = np.array([np.cos(rot_rad), -np.sin(rot_rad),
+                  np.sin(rot_rad), np.cos(rot_rad)]).reshape((2, 2))
     xy = np.matmul(R, xy)
     # Then off-set: Make sure first electrode is placed
     # correctly

--- a/pulse2percept/stimuli/tests/test_videos.py
+++ b/pulse2percept/stimuli/tests/test_videos.py
@@ -9,12 +9,12 @@ from skimage.io import imsave
 from pulse2percept.stimuli import VideoStimulus, BostonTrain
 
 
-@pytest.mark.parametrize('fps', [1, 5])
-def test_VideoStimulus(fps):
+def test_VideoStimulus():
     # Create a dummy video:
     fname = 'test.mp4'
     shape = (10, 32, 48)
     ndarray = np.random.rand(*shape)
+    fps = 1
     mimwrite(fname, (255 * ndarray).astype(np.uint8), fps=fps)
     stim = VideoStimulus(fname, as_gray=True)
     npt.assert_equal(stim.shape, (np.prod(shape[1:]), shape[0]))


### PR DESCRIPTION
To be consistent with all the other submodules, implants should use degrees for rotations, not radians (closes #326).