### PR TITLE
[FIX] Missing first frame in percept.play()

### DIFF
--- a/pulse2percept/percepts/base.py
+++ b/pulse2percept/percepts/base.py
@@ -251,6 +251,7 @@ class Percept(Data):
 
         def data_gen():
             try:
+                self.rewind()
                 # Advance to the next frame:
                 while True:
                     yield next(self)

--- a/pulse2percept/stimuli/videos.py
+++ b/pulse2percept/stimuli/videos.py
@@ -399,8 +399,10 @@ class VideoStimulus(Stimulus):
 
     def play(self, fps=None, repeat=True, annotate_time=True, ax=None):
         """Animate the percept as HTML with JavaScript
+
         The percept will be played in an interactive player in IPython or
         Jupyter Notebook.
+        
         Parameters
         ----------
         fps : float or None
@@ -414,6 +416,7 @@ class VideoStimulus(Stimulus):
             title of the panel.
         ax : matplotlib.axes.AxesSubplot, optional
             A Matplotlib axes object. If None, will create a new Axes object
+        
         Returns
         -------
         ani : matplotlib.animation.FuncAnimation
@@ -429,6 +432,7 @@ class VideoStimulus(Stimulus):
 
         def data_gen():
             try:
+                self.rewind()
                 # Advance to the next frame:
                 while True:
                     yield next(self)


### PR DESCRIPTION
`Percept.play()` and `VideoStimulus.play()` were missing the first frame due to wrong initialization (closes #322)