### PR TITLE
[FIX] Error message for number of electrodes in implant.stim

### DIFF
--- a/pulse2percept/implants/base.py
+++ b/pulse2percept/implants/base.py
@@ -164,8 +164,8 @@ class ProsthesisSystem(PrettyPrint):
                 # Use electrode names as stimulus coordinates:
                 stim = Stimulus(data, electrodes=list(self.earray.keys()))
 
-            if len(stim.electrodes) != self.n_electrodes:
-                raise ValueError("Number of electrodes in the stimulus (%d)"
+            if len(stim.electrodes) > self.n_electrodes:
+                raise ValueError("Number of electrodes in the stimulus (%d) "
                                  "does not match the number of electrodes in "
                                  "the implant (%d)." % (len(stim.electrodes),
                                                         self.n_electrodes))

--- a/pulse2percept/implants/base.py
+++ b/pulse2percept/implants/base.py
@@ -164,11 +164,11 @@ class ProsthesisSystem(PrettyPrint):
                 # Use electrode names as stimulus coordinates:
                 stim = Stimulus(data, electrodes=list(self.earray.keys()))
 
-            if len(stim.electrodes) != len(self.n_electrodes):
+            if len(stim.electrodes) != self.n_electrodes:
                 raise ValueError("Number of electrodes in the stimulus (%d)"
                                  "does not match the number of electrodes in "
                                  "the implant (%d)." % (len(stim.electrodes),
-                                                        len(self.n_electrodes)))
+                                                        self.n_electrodes))
             # Make sure all electrode names are valid:
             for electrode in stim.electrodes:
                 # Invalid index will return None:

--- a/pulse2percept/implants/base.py
+++ b/pulse2percept/implants/base.py
@@ -164,6 +164,11 @@ class ProsthesisSystem(PrettyPrint):
                 # Use electrode names as stimulus coordinates:
                 stim = Stimulus(data, electrodes=list(self.earray.keys()))
 
+            if len(stim.electrodes) != len(self.n_electrodes):
+                raise ValueError("Number of electrodes in the stimulus (%d)"
+                                 "does not match the number of electrodes in "
+                                 "the implant (%d)." % (len(stim.electrodes),
+                                                        len(self.n_electrodes)))
             # Make sure all electrode names are valid:
             for electrode in stim.electrodes:
                 # Invalid index will return None:

--- a/pulse2percept/implants/tests/test_base.py
+++ b/pulse2percept/implants/tests/test_base.py
@@ -57,6 +57,6 @@ def test_ProsthesisSystem():
 
 def test_ProsthesisSystem_stim():
     implant = ProsthesisSystem(ElectrodeGrid((13, 13), 20))
-    stim = Stimulus(np.ones((13, 13, 3)))
+    stim = Stimulus(np.ones((13 * 13 + 1, 5)))
     with pytest.raises(ValueError):
         implant.stim = stim

--- a/pulse2percept/implants/tests/test_base.py
+++ b/pulse2percept/implants/tests/test_base.py
@@ -4,7 +4,7 @@ import pytest
 import numpy.testing as npt
 from matplotlib.patches import Circle
 
-from pulse2percept.implants import (PointSource, ElectrodeArray,
+from pulse2percept.implants import (PointSource, ElectrodeArray, ElectrodeGrid,
                                     ProsthesisSystem)
 from pulse2percept.stimuli import Stimulus
 
@@ -53,3 +53,10 @@ def test_ProsthesisSystem():
     # Slots:
     npt.assert_equal(hasattr(implant, '__slots__'), True)
     npt.assert_equal(hasattr(implant, '__dict__'), False)
+
+
+def test_ProsthesisSystem_stim():
+    implant = ProsthesisSystem(ElectrodeGrid((13, 13), 20))
+    stim = Stimulus(np.ones((13, 13, 3)))
+    with pytest.raises(ValueError):
+        implant.stim = stim


### PR DESCRIPTION
When a stimulus has the wrong number of electrodes for `implant.stim`, the error message is confusing (closes #355)