### PR TITLE
[FIX] Axon map in Argus plotters

### DIFF
--- a/pulse2percept/version.py
+++ b/pulse2percept/version.py
@@ -1,1 +1,1 @@
-__version__ = '0.8.0.dev0'
+__version__ = '0.7.1.dev0'

--- a/pulse2percept/viz/tests/test_argus.py
+++ b/pulse2percept/viz/tests/test_argus.py
@@ -52,4 +52,5 @@ def test_plot_argus_simulated_phosphenes(implant):
 
     # Add axon map:
     _, ax = plt.subplots()
-    plot_argus_phosphenes(percepts, implant, ax=ax, axon_map=AxonMapModel())
+    plot_argus_simulated_phosphenes(percepts, implant, ax=ax,
+                                    axon_map=AxonMapModel())

--- a/pulse2percept/viz/tests/test_argus.py
+++ b/pulse2percept/viz/tests/test_argus.py
@@ -52,4 +52,4 @@ def test_plot_argus_simulated_phosphenes(implant):
 
     # Add axon map:
     _, ax = plt.subplots()
-    plot_argus_phosphenes(df, implant, ax=ax, axon_map=AxonMapModel())
+    plot_argus_phosphenes(percepts, implant, ax=ax, axon_map=AxonMapModel())

--- a/pulse2percept/viz/tests/test_argus.py
+++ b/pulse2percept/viz/tests/test_argus.py
@@ -4,9 +4,10 @@ import numpy.testing as npt
 import pytest
 import matplotlib.pyplot as plt
 
-from pulse2percept.models import AxonMapModel
+from pulse2percept.models import AxonMapModel, ScoreboardModel
 from pulse2percept.implants import ArgusI, ArgusII, AlphaAMS
-from pulse2percept.viz import plot_argus_phosphenes
+from pulse2percept.viz import (plot_argus_phosphenes,
+                               plot_argus_simulated_phosphenes)
 
 
 def test_plot_argus_phosphenes():
@@ -37,3 +38,18 @@ def test_plot_argus_phosphenes():
     # Works only for Argus:
     with pytest.raises(TypeError):
         plot_argus_phosphenes(df, AlphaAMS())
+    # Works only for axon maps:
+    with pytest.raises(TypeError):
+        plot_argus_phosphenes(df, ArgusI(), ax=ax, axon_map=ScoreboardModel())
+
+
+@pytest.mark.parametrize('implant', (ArgusI(), ArgusII()))
+def test_plot_argus_simulated_phosphenes(implant):
+    implant.stim = {'A1': [1, 0, 0], 'B2': [0, 1, 0], 'C3': [0, 0, 1]}
+    percepts = ScoreboardModel().build().predict_percept(implant)
+
+    plot_argus_simulated_phosphenes(percepts, implant)
+
+    # Add axon map:
+    _, ax = plt.subplots()
+    plot_argus_phosphenes(df, implant, ax=ax, axon_map=AxonMapModel())


### PR DESCRIPTION
Fix the visualization of the axon map in `p2p.viz.plot_argus_phosphenes` and its simulated phosphene equivalent (closes issue #365)