### PR TITLE
[FIX] Show warning when Scoreboard / AxonMap models are used with implant.z > 0

### DIFF
--- a/pulse2percept/models/beyeler2019.py
+++ b/pulse2percept/models/beyeler2019.py
@@ -15,6 +15,11 @@ from ..models import Model, SpatialModel
 from ._beyeler2019 import (fast_scoreboard, fast_axon_map, fast_jansonius,
                            fast_find_closest_axon)
 
+# Log all warnings.warn() at the WARNING level:
+import warnings
+import logging
+logging.captureWarnings(True)
+
 
 class ScoreboardSpatial(SpatialModel):
     """Scoreboard model of [Beyeler2019]_ (spatial module only)
@@ -68,6 +73,10 @@ class ScoreboardSpatial(SpatialModel):
 
     def _predict_spatial(self, earray, stim):
         """Predicts the brightness at spatial locations"""
+        if not np.allclose([e.z for e in earray.values()], 0):
+            msg = ("Nonzero electrode-retina distances do not have any effect "
+                   "on the model output.")
+            warnings.warn(msg)
         # This does the expansion of a compact stimulus and a list of
         # electrodes to activation values at X,Y grid locations:
         return fast_scoreboard(stim.data,
@@ -521,10 +530,12 @@ class AxonMapSpatial(SpatialModel):
 
     def _predict_spatial(self, earray, stim):
         """Predicts the brightness at specific times ``t``"""
+        if not np.allclose([e.z for e in earray.values()], 0):
+            msg = ("Nonzero electrode-retina distances do not have any effect "
+                   "on the model output.")
+            warnings.warn(msg)
         # This does the expansion of a compact stimulus and a list of
         # electrodes to activation values at X,Y grid locations:
-        assert isinstance(earray, ElectrodeArray)
-        assert isinstance(stim, Stimulus)
         return fast_axon_map(stim.data,
                              np.array([earray[e].x for e in stim.electrodes],
                                       dtype=np.float32),

--- a/pulse2percept/stimuli/_base.pyx
+++ b/pulse2percept/stimuli/_base.pyx
@@ -1,11 +1,11 @@
 # distutils: language = c++
 # ^ needed for bool
 
+from libc.math cimport(fabs as c_abs, fmax as c_max)
+from libcpp cimport bool
 import numpy as np
 cimport numpy as cnp
 
-from libcpp cimport bool
-from libc.math cimport(fabs as c_abs, fmax as c_max)
 
 ctypedef cnp.float32_t float32
 
@@ -32,7 +32,7 @@ cpdef bool[::1] fast_compress(float32[:, ::1] data, float32[::1] time):
 
     n_elec = data.shape[0]  # Py overhead
     n_time = data.shape[1]  # Py overhead
-    idx_time = np.zeros(n_time, dtype=np.bool)  # Py overhead
+    idx_time = np.zeros(n_time, dtype=np.bool_)  # Py overhead
 
     for t in range(n_time):
         if t == 0 or t == n_time - 1:

--- a/pulse2percept/stimuli/base.py
+++ b/pulse2percept/stimuli/base.py
@@ -538,7 +538,7 @@ class Stimulus(PrettyPrint):
             else:
                 if not np.any(time == Ellipsis):
                     # Convert to float so time is not mistaken for column index
-                    if np.array(time).dtype != np.bool:
+                    if np.array(time).dtype != bool:
                         time = np.float32(time)
         else:
             electrodes = item

--- a/pulse2percept/utils/testing.py
+++ b/pulse2percept/utils/testing.py
@@ -2,6 +2,7 @@
 
 import pytest
 import numpy.testing as npt
+import warnings
 
 
 def assert_warns_msg(expected_warning, func, msg, *args, **kwargs):
@@ -23,8 +24,19 @@ def assert_warns_msg(expected_warning, func, msg, *args, **kwargs):
     \*\*kwargs: keyword arguments to ``func``
 
     """
+    # Make sure we are not leaking warnings:
+    warnings.resetwarnings()
+    # Run the function that is supposed to produce a warning:
     with pytest.warns(expected_warning) as record:
         func(*args, **kwargs)
+    # Check the number of generated warnings:
+    if len(record) != 1:
+        print('Generated warnings:')
+        for r in record:
+            print('-', r)
     npt.assert_equal(len(record), 1)
+    # Check the message:
     if msg is not None:
         npt.assert_equal(msg in record[0].message.args[0], True)
+    # Remove generated warnings from registry:
+    warnings.resetwarnings()


### PR DESCRIPTION
Although implants have an `electric_potential` method, `ScoreboardModel` and `AxonMapModel` do not make use of it. Therefore, setting an electrode's z value > 0 does not have an effect on the model output. This is now being communicated to the user with a warning message (closes issue #169)