### PR TITLE
[ENH] Speed up AxonMap build

### DIFF
--- a/doc/users/release_notes.rst
+++ b/doc/users/release_notes.rst
@@ -12,9 +12,16 @@ Release Notes
 v0.7.1 (2021, planned)
 ----------------------
 
+Performance enhancements
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+*  Further speed up the :py:class:`~pulse2percept.models.AxonMapModel` build process (:pull:`369`)
+
 Bug fixes
 ~~~~~~~~~
 
+*  Show a warning when :py:class:`~pulse2percept.models.ScoreboardModel` or
+   :py:class:`~pulse2percept.models.AxonMapModel` is used with a nonzero electrode-retina distance (:pull:`368`)
 *  Fix :py:meth:`pulse2percept.models.AxonMapModel.plot` for left eyes (:pull:`367`)
 *  Fix axon map visualization in :py:meth:`~pulse2percept.viz.plot_argus_phosphenes` (:pull:`366`)
 
@@ -77,7 +84,7 @@ Backward-incompatible changes
 Deprecations
 ^^^^^^^^^^^^
 
-*  ``plot_axon_map``: Use :py:meth`pulse2percept.models.AxonMapModel.plot`
+*  ``plot_axon_map``: Use :py:meth:`pulse2percept.models.AxonMapModel.plot`
 *  ``plot_implant_on_axon_map``: Use
    :py:meth:`pulse2percept.implants.ProsthesisSystem.plot` on top of
    :py:meth`pulse2percept.models.AxonMapModel.plot`

--- a/pulse2percept/models/beyeler2019.py
+++ b/pulse2percept/models/beyeler2019.py
@@ -426,7 +426,7 @@ class AxonMapSpatial(SpatialModel):
             # Cut off the part of the fiber that goes beyond the soma:
             axon = np.flipud(bundle[0: idx + 1, :])
             # Add the exact location of the soma:
-            axon = np.insert(axon, 0, xy, axis=0)
+            axon = np.concatenate((xy.reshape((1, -1)), axon), axis=0)
             # For every axon segment, calculate distance from soma by
             # summing up the individual distances between neighboring axon
             # segments (by "walking along the axon"):
@@ -434,7 +434,7 @@ class AxonMapSpatial(SpatialModel):
                                    np.diff(axon[:, 1], axis=0) ** 2)) ** 2
             idx_d2 = d2 < max_d2
             sensitivity = np.exp(-d2[idx_d2] / (2.0 * self.axlambda ** 2))
-            idx_d2 = np.insert(idx_d2, 0, False)
+            idx_d2 = np.concatenate(([False], idx_d2))
             contrib = np.column_stack((axon[idx_d2, :], sensitivity))
             axon_contrib.append(contrib)
         return axon_contrib


### PR DESCRIPTION
Replace `np.insert` with `np.concatenate`, get an immediate speed boost.

To get even a bigger speed boost, we could translate `calc_axon_contribution` to Cython - however, the function does a lot of re-indexing, flipping indices, and extending arrays. This sounds like a pain to do in Cython...