### PR TITLE
[FIX] Percept plotting and animation

### DIFF
--- a/pulse2percept/percepts/base.py
+++ b/pulse2percept/percepts/base.py
@@ -50,6 +50,33 @@ class Percept(Data):
             'metadata': metadata
         }
 
+    def argmax(self, axis=None):
+        """Return the indices of the maximum values along an axis
+
+        Parameters
+        ----------
+        axis : None or 'frames'
+            Axis along which to operate.
+            By default, the index of the brightest pixel is returned.
+            Set ``axis='frames'`` to get the index of the brightest frame.
+
+        Returns
+        -------
+        argmax : ndarray or scalar
+            Indices at which the maxima of ``percept.data`` along an axis occur.
+            If `axis` is None, the result is a scalar value.
+            If `axis` is 'frames', the result is the time of the brightest
+            frame.
+        """
+        if axis is not None and not isinstance(axis, str):
+            raise TypeError('"axis" must be a string or None.')
+        if axis is None:
+            return self.data.argmax()
+        elif axis.lower() == 'frames':
+            return np.argmax(np.max(self.data, axis=(0, 1)))
+        raise ValueError('Unknown axis value "%s". Use "frames" or '
+                         'None.' % axis)
+
     def max(self, axis=None):
         """Brightest pixel or frame
 
@@ -72,7 +99,7 @@ class Percept(Data):
         if axis is None:
             return self.data.max()
         elif axis.lower() == 'frames':
-            return self.data[..., np.argmax(np.max(self.data, axis=(0, 1)))]
+            return self.data[..., self.argmax(axis='frames')]
         raise ValueError('Unknown axis value "%s". Use "frames" or '
                          'None.' % axis)
 
@@ -110,8 +137,15 @@ class Percept(Data):
         self._next_frame += 1
         return self.data[..., this_frame]
 
-    def plot(self, time=None, kind='pcolor', ax=None, **kwargs):
+    def plot(self, kind='pcolor', ax=None, **kwargs):
         """Plot the percept
+
+        For a spatial percept, will plot the perceived brightness across the
+        x, y grid.
+        For a temporal percept, will plot the evolution of perceived brightness
+        over time.
+        For a spatiotemporal percept, will plot the brightest frame.
+        Use ``percept.play()`` to animate the percept across time points.
 
         Parameters
         ----------
@@ -122,13 +156,11 @@ class Percept(Data):
                (e.g., ``vmin``, ``vmax``) can be passed as keyword arguments.
             *  'hex': using Matplotlib's ``hexbin``. Additional parameters
                (e.g., ``gridsize``) can be passed as keyword arguments.
-
-        time : None, optional
-            The time point to plot. If None, plots the brightest frame.
-            Use ``play`` to play the percept frame-by-frame.
         ax : matplotlib.axes.AxesSubplot, optional
             A Matplotlib axes object. If None, will either use the current axes
             (if exists) or create a new Axes object
+        **kwargs :
+            Other optional arguments passed down to the Matplotlib function
 
         Returns
         -------
@@ -136,13 +168,6 @@ class Percept(Data):
             Returns the axes with the plot on it
 
         """
-        if time is None:
-            idx = np.argmax(np.max(self.data, axis=(0, 1)))
-            frame = self.data[..., idx]
-        else:
-            # Need to be smart about what to do when plotting more than one
-            # frame.
-            raise NotImplementedError
         if ax is None:
             ax = plt.gca()
             if 'figsize' in kwargs:
@@ -151,6 +176,17 @@ class Percept(Data):
             if not isinstance(ax, Subplot):
                 raise TypeError("'ax' must be a Matplotlib axis, not "
                                 "%s." % type(ax))
+        if self.xdva is None and self.ydva is None and self.time is not None:
+            # Special case of a purely temporal percept:
+            ax.plot(self.time, self.data.squeeze(), linewidth=2, **kwargs)
+            ax.set_xlabel('time ms)')
+            ax.set_ylabel('Perceived brightness (a.u.)')
+            return ax
+
+        # A spatial or spatiotemporal percept: Find the brightest frame
+        idx = np.argmax(np.max(self.data, axis=(0, 1)))
+        frame = self.data[..., idx]
+
         vmin = kwargs['vmin'] if 'vmin' in kwargs.keys() else frame.min()
         vmax = kwargs['vmax'] if 'vmax' in kwargs.keys() else frame.max()
         cmap = kwargs['cmap'] if 'cmap' in kwargs.keys() else 'gray'
@@ -244,7 +280,8 @@ class Percept(Data):
                 pass
 
         if self.time is None:
-            raise ValueError("Cannot animate a percept with time=None.")
+            raise ValueError("Cannot animate a percept with time=None. Use "
+                             "percept.plot() instead.")
 
         # There are several options to animate a percept in Jupyter/IPython
         # (see https://stackoverflow.com/a/46878531). Displaying the animation

--- a/pulse2percept/percepts/base.py
+++ b/pulse2percept/percepts/base.py
@@ -9,7 +9,7 @@ import logging
 from skimage import img_as_uint
 from skimage.transform import resize
 
-from ..utils import Data, Grid2D, deprecated
+from ..utils import Data, Grid2D, deprecated, unique
 
 
 class Percept(Data):
@@ -224,17 +224,6 @@ class Percept(Data):
         ax.set_ylabel('y (degrees of visual angle)')
         return ax
 
-    def _get_interval(self):
-        # Determine the frame rate from the time axis. Problem is that
-        # np.unique doesn't work well with floats, so we need to specify a
-        # tolerance `TOL`:
-        interval = np.diff(self.time)
-        TOL = interval.min()
-        # Two time points are the same if they are within `TOL` from each
-        # other:
-        interval = np.unique(np.floor(interval / TOL).astype(int)) * TOL
-        return interval
-
     def play(self, fps=None, repeat=True, annotate_time=True, ax=None):
         """Animate the percept as HTML with JavaScript
 
@@ -301,7 +290,7 @@ class Percept(Data):
                            va='center')
         plt.close(fig)
         if fps is None:
-            interval = self._get_interval()
+            interval = unique(np.diff(self.time))
             if len(interval) > 1:
                 raise NotImplementedError
             interval = interval[0]
@@ -365,7 +354,7 @@ class Percept(Data):
         else:
             # With time component, store as a movie:
             if fps is None:
-                interval = self._get_interval()
+                interval = unique(np.diff(self.time))
                 if len(interval) > 1:
                     raise NotImplementedError
                 fps = 1000.0 / interval[0]

--- a/pulse2percept/percepts/base.py
+++ b/pulse2percept/percepts/base.py
@@ -190,6 +190,7 @@ class Percept(Data):
         vmin = kwargs['vmin'] if 'vmin' in kwargs.keys() else frame.min()
         vmax = kwargs['vmax'] if 'vmax' in kwargs.keys() else frame.max()
         cmap = kwargs['cmap'] if 'cmap' in kwargs.keys() else 'gray'
+        shading = kwargs['shading'] if 'shading' in kwargs.keys() else 'nearest'
         X, Y = np.meshgrid(self.xdva, self.ydva, indexing='xy')
         if kind == 'pcolor':
             # Create a pseudocolor plot. Make sure to pass additional keyword
@@ -198,7 +199,7 @@ class Percept(Data):
                             for key in (kwargs.keys() - ['figsize', 'cmap',
                                                          'vmin', 'vmax'])}
             ax.pcolormesh(X, Y, np.flipud(frame), cmap=cmap, vmin=vmin,
-                          vmax=vmax, **other_kwargs)
+                          vmax=vmax, shading=shading, **other_kwargs)
         elif kind == 'hex':
             # Create a hexbin plot:
             gridsize = kwargs['gridsize'] if 'gridsize' in kwargs else 80

--- a/pulse2percept/percepts/tests/test_base.py
+++ b/pulse2percept/percepts/tests/test_base.py
@@ -61,11 +61,25 @@ def test_Percept__iter__():
         npt.assert_almost_equal(frame, i)
 
 
+def test_Percept_argmax():
+    percept = Percept(np.arange(30).reshape((3, 5, 2)))
+    npt.assert_almost_equal(percept.argmax(), 29)
+    npt.assert_almost_equal(percept.argmax(axis="frames"), 1)
+    with pytest.raises(TypeError):
+        percept.argmax(axis=(0, 1))
+    with pytest.raises(ValueError):
+        percept.argmax(axis='invalid')
+
+
 def test_Percept_max():
     percept = Percept(np.arange(30).reshape((3, 5, 2)))
     npt.assert_almost_equal(percept.max(), 29)
-    npt.assert_almost_equal(percept.max(axis='frames'),
+    npt.assert_almost_equal(percept.max(axis="frames"),
                             percept.data[..., 1])
+    npt.assert_almost_equal(percept.max(),
+                            percept.data.ravel()[percept.argmax()])
+    npt.assert_almost_equal(percept.max(axis='frames'),
+                            percept.data[..., percept.argmax(axis='frames')])
     with pytest.raises(TypeError):
         percept.max(axis=(0, 1))
     with pytest.raises(ValueError):
@@ -109,7 +123,7 @@ def test_Percept_plot():
     npt.assert_almost_equal(ax.figure.get_size_inches(), (6, 4))
 
     # Test vmin and vmax
-    ax.clear() 
+    ax.clear()
     ax = percept.plot(vmin=2, vmax=4)
     npt.assert_equal(ax.collections[0].get_clim(), (2., 4.))
 
@@ -118,10 +132,6 @@ def test_Percept_plot():
         percept.plot(kind='invalid')
     with pytest.raises(TypeError):
         percept.plot(ax='invalid')
-
-    # TODO
-    with pytest.raises(NotImplementedError):
-        percept.plot(time=3.3)
 
 
 @pytest.mark.parametrize('n_frames', (2, 3, 10, 14))

--- a/pulse2percept/stimuli/videos.py
+++ b/pulse2percept/stimuli/videos.py
@@ -14,7 +14,7 @@ from skimage import img_as_float32
 from imageio import get_reader as video_reader
 
 from .base import Stimulus
-from ..utils import center_image, shift_image, scale_image
+from ..utils import center_image, shift_image, scale_image, unique
 
 
 class VideoStimulus(Stimulus):
@@ -386,17 +386,6 @@ class VideoStimulus(Stimulus):
         self._next_frame += 1
         return self.data[..., this_frame]
 
-    def _get_interval(self):
-        # Determine the frame rate from the time axis. Problem is that
-        # np.unique doesn't work well with floats, so we need to specify a
-        # tolerance `TOL`:
-        interval = np.diff(self.time)
-        TOL = interval.min()
-        # Two time points are the same if they are within `TOL` from each
-        # other:
-        interval = np.unique(np.floor(interval / TOL).astype(int)) * TOL
-        return interval
-
     def play(self, fps=None, repeat=True, annotate_time=True, ax=None):
         """Animate the percept as HTML with JavaScript
 
@@ -460,7 +449,7 @@ class VideoStimulus(Stimulus):
         cbar.ax.set_ylabel('Brightness (a.u.)', rotation=-90, va='center')
         plt.close(fig)
         if fps is None:
-            interval = self._get_interval()
+            interval = unique(np.diff(self.time))
             if len(interval) > 1:
                 raise NotImplementedError
             interval = interval[0]


### PR DESCRIPTION
Various improvements for `Percept`:

- [X] Fix the `percept.plot()` method for temporal percepts (time series only, no spatial component)
- [X] Use the built-in unique() to find the time interval (issue #299)
- [x] Fix deprecation warning on `percept.plot()` (issue #345)