### PR TITLE
[FIX] BVT24 electrode naming convention

### DIFF
--- a/doc/users/release_notes.rst
+++ b/doc/users/release_notes.rst
@@ -12,16 +12,16 @@ Release Notes
 v0.7.1 (2021, planned)
 ----------------------
 
-Enhancements
+New features
 ~~~~~~~~~~~~
 
 *  Add :py:class:`~pulse2percept.models.FadingTemporal`, a generic phosphene fading model (:pull:`378`)
-*  Speed up :py:meth:`pulse2percept.implants.ElectrodeArray.plot` that is used by all implants (:pull:`375`)
-*  Further speed up the :py:class:`~pulse2percept.models.AxonMapModel` build process (:pull:`369`)
 
 Maintenance
 ~~~~~~~~~~~
 
+*  Speed up :py:meth:`pulse2percept.implants.ElectrodeArray.plot` that is used by all implants (:pull:`375`)
+*  Further speed up the :py:class:`~pulse2percept.models.AxonMapModel` build process (:pull:`369`)
 *  Improve documentation and usability of various :py:class:`~pulse2percept.models.AxonMapModel` methods (:pull:`370`)
 *  Disallow lambda<10 for :py:class:`~pulse2percept.models.AxonMapModel` (:pull:`370`)
 *  Show a warning when :py:class:`~pulse2percept.models.ScoreboardModel` or
@@ -30,6 +30,8 @@ Maintenance
 Bug fixes
 ~~~~~~~~~
 
+*  Fix issues with plotting and animating :py:class:`~pulse2percept.percepts.Percept` (:pull:`379`)
+*  Fix inconsistencies and missing parameters in the [Nanduri2012]_ dataset (:pull:`376`)
 *  Fix :py:meth:`pulse2percept.models.AxonMapModel.plot` for left eyes (:pull:`367`)
 *  Fix axon map visualization in :py:meth:`~pulse2percept.viz.plot_argus_phosphenes` (:pull:`366`)
 

--- a/pulse2percept/implants/bvt.py
+++ b/pulse2percept/implants/bvt.py
@@ -19,16 +19,16 @@ class BVT24(ProsthesisSystem):
 
     -   33 platinum stimulating electrodes:
 
-        -   30 electrodes with 600um diameter (Electrodes 1-20 (except
-            9, 17, 19) and Electrodes 21a-m),
+        -   30 electrodes with 600um diameter (Electrodes C1-20 (except
+            C9, C17, C19) and Electrodes C21a-m),
 
-        -   3 electrodes with 400um diameter (Electrodes 9, 17, 19)
+        -   3 electrodes with 400um diameter (Electrodes C9, C17, C19)
 
-    -   2 return electrodes with 2000um diameter (Electrodes 22, 23)
+    -   2 return electrodes with 2000um diameter (Electrodes R1, R2)
 
-    Electrodes 21a-m are typically being ganged to provide an external
+    Electrodes C21a-m are typically being ganged to provide an external
     ring for common ground. The center of the array is assumed to lie
-    between Electrodes 7, 8, 9, and 13.
+    between Electrodes C7, C8, C9, and C13.
 
     .. note::
 
@@ -97,11 +97,11 @@ class BVT24(ProsthesisSystem):
         r_arr[8] = r_arr[16] = r_arr[18] = 200.0
         # the radius of the return electrodes is 1000.0 um
         r_arr[33] = r_arr[34] = 1000.0
-        # the names of the electrodes 1-20, 21a-21m, R1 and R2
-        names = [str(name) for name in range(1, 21)]
-        names.extend(['21a', '21b', '21c', '21d', '21e',
-                      '21f', '21g', '21h', '21i', '21j',
-                      '21k', '21l', '21m'])
+        # the names of the electrodes C1-20, C21a-21m, R1 and R2
+        names = ["C%s" % name for name in range(1, 21)]
+        names.extend(['C21a', 'C21b', 'C21c', 'C21d', 'C21e',
+                      'C21f', 'C21g', 'C21h', 'C21i', 'C21j',
+                      'C21k', 'C21l', 'C21m'])
         names.extend(['R1', 'R2'])
 
         # Rotate the grid:

--- a/pulse2percept/implants/tests/test_bvt.py
+++ b/pulse2percept/implants/tests/test_bvt.py
@@ -30,49 +30,49 @@ def test_BVT24(x, y, rot):
 
     # Then off-set: Make sure first electrode is placed
     # correctly
-    npt.assert_almost_equal(bva['1'].x, xy[0] + x)
-    npt.assert_almost_equal(bva['1'].y, xy[1] + y)
-    npt.assert_almost_equal(bva['21m'].x, xy2[0] + x)
-    npt.assert_almost_equal(bva['21m'].y, xy2[1] + y)
+    npt.assert_almost_equal(bva['C1'].x, xy[0] + x)
+    npt.assert_almost_equal(bva['C1'].y, xy[1] + y)
+    npt.assert_almost_equal(bva['C21m'].x, xy2[0] + x)
+    npt.assert_almost_equal(bva['C21m'].y, xy2[1] + y)
 
     # Check radii of electrodes
-    for e in ['1', '5', '8', '15', '20']:
+    for e in ['C1', 'C5', 'C8', 'C15', 'C20']:
         npt.assert_almost_equal(bva[e].r, 300.0)
-    for e in ['9', '17', '19']:
+    for e in ['C9', 'C17', 'C19']:
         npt.assert_almost_equal(bva[e].r, 200.0)
     for e in ['R1', 'R2']:
         npt.assert_almost_equal(bva[e].r, 1000.0)
 
     # Check the center is still at (x,y)
-    y_center = (bva['8'].y + bva['13'].y) / 2
+    y_center = (bva['C8'].y + bva['C13'].y) / 2
     npt.assert_almost_equal(y_center, y)
-    x_center = (bva['8'].x + bva['13'].x) / 2
+    x_center = (bva['C8'].x + bva['C13'].x) / 2
     npt.assert_almost_equal(x_center, x)
 
     # Right-eye implant:
     xc, yc = 500, -500
     bva_re = BVT24(eye='RE', x=xc, y=yc)
-    npt.assert_equal(bva_re['1'].x < bva_re['6'].x, True)
-    npt.assert_equal(bva_re['1'].y, bva_re['1'].y)
+    npt.assert_equal(bva_re['C1'].x < bva_re['C6'].x, True)
+    npt.assert_equal(bva_re['C1'].y, bva_re['C1'].y)
 
     # Left-eye implant:
     xc, yc = 500, -500
     bva_le = BVT24(eye='LE', x=xc, y=yc)
-    npt.assert_equal(bva_le['1'].x > bva_le['6'].x, True)
-    npt.assert_equal(bva_le['1'].y, bva_le['1'].y)
+    npt.assert_equal(bva_le['C1'].x > bva_le['C6'].x, True)
+    npt.assert_equal(bva_le['C1'].y, bva_le['C1'].y)
 
 
 def test_BVT24_stim():
     # Assign a stimulus:
     implant = BVT24()
-    implant.stim = {'1': 1}
-    npt.assert_equal(implant.stim.electrodes, ['1'])
+    implant.stim = {'C1': 1}
+    npt.assert_equal(implant.stim.electrodes, ['C1'])
     npt.assert_equal(implant.stim.time, None)
     npt.assert_equal(implant.stim.data, [[1]])
 
     # You can also assign the stimulus in the constructor:
-    BVT24(stim={'1': 1})
-    npt.assert_equal(implant.stim.electrodes, ['1'])
+    BVT24(stim={'C1': 1})
+    npt.assert_equal(implant.stim.electrodes, ['C1'])
     npt.assert_equal(implant.stim.time, None)
     npt.assert_equal(implant.stim.data, [[1]])
 


### PR DESCRIPTION
Changes electrode naming convention from '1' through '21' to 'C1' through 'C21'. The indexer gets confused with the numbers: `implant[1]` is not the same as `implant['1']`