### PR TITLE
[ENH] Various implant upgrades

### DIFF
--- a/doc/topics/implants.rst
+++ b/doc/topics/implants.rst
@@ -51,6 +51,28 @@ A mathematical model is then used to compute the neural stimulus response and
 predict the resulting visual percept
 (see :ref:`Computational Models <topics-models>`).
 
+Understanding the coordinate system
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The easiest way to understand the coordinate system is to look at the
+organization of the optic fiber layer:
+
+.. ipython:: python
+
+    from pulse2percept.models import AxonMapModel
+    AxonMapModel(eye='RE').plot()
+
+Here you can see that:
+
+*  the coordinate system is centered on the fovea
+*  in a right eye, positive :math:`x` values correspond to the nasal retina
+*  in a right eye, positive :math:`y` values correspond to the superior retina
+
+Positive :math:`z` values move an electrode away from the retina into the
+vitreous humor (:math:`z` is sometimes called electrode-retina distance).
+Analogously, negative :math:`z` values move an electrode through the different
+retinal layers towards the outer retina.
+
 Understanding the ProsthesisSystem class
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -91,7 +113,7 @@ prosthesis system is a Python dictionary:
 .. ipython:: python
 
     from pulse2percept.implants import ArgusI
-    for name, electrode in ArgusI().items():
+    for name, electrode in ArgusI().electrodes.items():
         print(name, electrode)
 
 

--- a/examples/implants/plot_electrode_grid.py
+++ b/examples/implants/plot_electrode_grid.py
@@ -40,6 +40,9 @@ Let's say we want to create a 2x3 rectangular grid of
 
 """
 # sphinx_gallery_thumbnail_number = 3
+from pulse2percept.models import AxonMapModel
+from numpy import pi
+from pulse2percept.implants import DiskElectrode
 from pulse2percept.implants import ElectrodeGrid
 
 grid = ElectrodeGrid((2, 3), 500)
@@ -69,7 +72,7 @@ grid[:]
 ##############################################################################
 # We can iterate over all electrodes as if we were dealing with a dictionary:
 
-for name, electrode in grid.items():
+for name, electrode in grid.electrodes.items():
     print(name, electrode)
 
 ##############################################################################
@@ -77,7 +80,6 @@ for name, electrode in grid.items():
 # we need to explicitly specify the electrode type (``etype``) and the radius
 # to use (``r``):
 
-from pulse2percept.implants import DiskElectrode
 
 # 11x13 grid, 100-um disk electrodes spaced 500um apart:
 disk_grid = ElectrodeGrid((11, 13), 500, etype=DiskElectrode, r=100)
@@ -111,7 +113,6 @@ hex_grid.plot()
 # z=150um away from the retinal surface, and rotates it clockwise by 45 degrees
 # (note the minus sign):
 
-from numpy import pi
 offset_grid = ElectrodeGrid((11, 13), 500, type='hex', x=-600, y=200, z=150,
                             rot=-45, etype=DiskElectrode, r=100)
 
@@ -123,7 +124,6 @@ offset_grid = ElectrodeGrid((11, 13), 500, type='hex', x=-600, y=200, z=150,
 #
 # We can also plot the grid on top of a map of retinal nerve fiber bundles:
 
-from pulse2percept.models import AxonMapModel
 
 AxonMapModel().plot()
 offset_grid.plot()

--- a/pulse2percept/datasets/tests/test_beyeler2019.py
+++ b/pulse2percept/datasets/tests/test_beyeler2019.py
@@ -30,7 +30,7 @@ def test_fetch_beyeler2019():
     for expected_col in columns:
         npt.assert_equal(expected_col in data.columns, True)
 
-    npt.assert_equal(data.shape, (400, 16))
+    npt.assert_equal(data.shape, (400, 18))
     npt.assert_equal(data.subject.unique(), ['S1', 'S2', 'S3', 'S4'])
     npt.assert_equal(list(data[data.subject == 'S1'].img_shape.unique()[0]),
                      [192, 192])
@@ -39,17 +39,17 @@ def test_fetch_beyeler2019():
 
     # Subset selection:
     subset = datasets.fetch_beyeler2019(subjects='S2')
-    npt.assert_equal(subset.shape, (110, 16))
+    npt.assert_equal(subset.shape, (110, 18))
     subset = datasets.fetch_beyeler2019(subjects=['S2', 'S3'])
-    npt.assert_equal(subset.shape, (220, 16))
+    npt.assert_equal(subset.shape, (200, 18))
     subset = datasets.fetch_beyeler2019(subjects='invalid')
-    npt.assert_equal(subset.shape, (0, 16))
+    npt.assert_equal(subset.shape, (0, 18))
     subset = datasets.fetch_beyeler2019(electrodes=['A1'])
-    npt.assert_equal(subset.shape, (10, 16))
+    npt.assert_equal(subset.shape, (10, 18))
     subset = datasets.fetch_beyeler2019(electrodes=['A1', 'C3'])
-    npt.assert_equal(subset.shape, (20, 16))
+    npt.assert_equal(subset.shape, (20, 18))
     subset = datasets.fetch_beyeler2019(electrodes='invalid')
-    npt.assert_equal(subset.shape, (0, 16))
+    npt.assert_equal(subset.shape, (0, 18))
 
     # Shuffle dataset (index will always be range(400), but rows are shuffled):
     data = datasets.fetch_beyeler2019(shuffle=True, random_state=42)

--- a/pulse2percept/implants/alpha.py
+++ b/pulse2percept/implants/alpha.py
@@ -59,8 +59,8 @@ class AlphaIMS(ProsthesisSystem):
 
     >>> from pulse2percept.implants import AlphaIMS
     >>> AlphaIMS(x=0, y=0, z=100, rot=5)  # doctest: +NORMALIZE_WHITESPACE
-    AlphaIMS(earray=ElectrodeGrid, eye='RE', shape=(39, 39),
-             stim=None)
+    AlphaIMS(earray=ElectrodeGrid, eye='RE', preprocess=True,
+             safe_mode=False, shape=(39, 39), stim=None)
 
     Get access to the third electrode in the top row (by name or by row/column
     index):
@@ -76,7 +76,7 @@ class AlphaIMS(ProsthesisSystem):
     __slots__ = ('shape',)
 
     def __init__(self, x=0, y=0, z=-100, rot=0, eye='RE', stim=None,
-                 preprocess=False, safe_mode=False):
+                 preprocess=True, safe_mode=False):
         self.eye = eye
         self.preprocess = preprocess
         self.safe_mode = safe_mode
@@ -193,8 +193,8 @@ class AlphaAMS(ProsthesisSystem):
 
     >>> from pulse2percept.implants import AlphaAMS
     >>> AlphaAMS(x=0, y=0, z=100, rot=5)  # doctest: +NORMALIZE_WHITESPACE
-    AlphaAMS(earray=ElectrodeGrid, eye='RE', shape=(40, 40),
-             stim=None)
+    AlphaAMS(earray=ElectrodeGrid, eye='RE', preprocess=True,
+             safe_mode=False, shape=(40, 40), stim=None)
 
     Get access to the third electrode in the top row (by name or by row/column
     index):
@@ -210,7 +210,7 @@ class AlphaAMS(ProsthesisSystem):
     __slots__ = ('shape',)
 
     def __init__(self, x=0, y=0, z=0, rot=0, eye='RE', stim=None,
-                 preprocess=False, safe_mode=False):
+                 preprocess=True, safe_mode=False):
         self.eye = eye
         self.preprocess = preprocess
         self.safe_mode = safe_mode

--- a/pulse2percept/implants/alpha.py
+++ b/pulse2percept/implants/alpha.py
@@ -66,10 +66,12 @@ class AlphaIMS(ProsthesisSystem):
     index):
 
     >>> alpha_ims = AlphaIMS(x=0, y=0, z=100, rot=0)
-    >>> alpha_ims['A3']
-    SquareElectrode(a=50.0, name='A3', x=-1224.0, y=-1368.0, z=100.0)
-    >>> alpha_ims[0, 2]
-    SquareElectrode(a=50.0, name='A3', x=-1224.0, y=-1368.0, z=100.0)
+    >>> alpha_ims['A3']  # doctest: +NORMALIZE_WHITESPACE
+    SquareElectrode(a=50.0, activated=True, name='A3',
+                    x=-1224.0, y=-1368.0, z=100.0)
+    >>> alpha_ims[0, 2]  # doctest: +NORMALIZE_WHITESPACE
+    SquareElectrode(a=50.0, activated=True, name='A3',
+                    x=-1224.0, y=-1368.0, z=100.0)
 
     """
     # Frozen class: User cannot add more class attributes
@@ -200,10 +202,12 @@ class AlphaAMS(ProsthesisSystem):
     index):
 
     >>> alpha_ims = AlphaAMS(x=0, y=0, z=100, rot=0)
-    >>> alpha_ims['A3']
-    DiskElectrode(name='A3', r=15.0, x=-1225.0, y=-1365.0, z=100.0)
-    >>> alpha_ims[0, 2]
-    DiskElectrode(name='A3', r=15.0, x=-1225.0, y=-1365.0, z=100.0)
+    >>> alpha_ims['A3']  # doctest: +NORMALIZE_WHITESPACE
+    DiskElectrode(activated=True, name='A3', r=15.0, x=-1225.0,
+                  y=-1365.0, z=100.0)
+    >>> alpha_ims[0, 2]  # doctest: +NORMALIZE_WHITESPACE
+    DiskElectrode(activated, True, name='A3', r=15.0, x=-1225.0,
+                  y=-1365.0, z=100.0)
 
     """
     # Frozen class: User cannot add more class attributes

--- a/pulse2percept/implants/alpha.py
+++ b/pulse2percept/implants/alpha.py
@@ -89,8 +89,8 @@ class AlphaIMS(ProsthesisSystem):
         if eye == 'LE':
             # FIXME: Would be better to have more flexibility in the naming
             # convention. This is a quick-and-dirty fix:
-            names = list(self.earray.keys())
-            objects = list(self.earray.values())
+            names = self.earray.electrode_names
+            objects = self.earray.electrode_objects
             names = np.array(names).reshape(self.earray.shape)
             # Reverse column names:
             for row in range(self.earray.shape[0]):
@@ -100,7 +100,7 @@ class AlphaIMS(ProsthesisSystem):
             for name, obj in zip(names.ravel(), objects):
                 electrodes.update({name: obj})
             # Assign the new ordered dict to earray:
-            self.earray.electrodes = electrodes
+            self.earray._electrodes = electrodes
 
         # Remove electrodes:
         extra_elecs = ['AM39', 'AL39', 'AK39', 'AJ39', 'AI39', 'AH39', 'AG39',
@@ -118,7 +118,7 @@ class AlphaIMS(ProsthesisSystem):
             if z_arr.size != self.n_electrodes:
                 raise ValueError("If `z` is a list, it must have %d entries, "
                                  "not %d." % (self.n_electrodes, z_arr.size))
-            for elec, z_elec in zip(self.earray.values(), z):
+            for elec, z_elec in zip(self.earray.electrode_objects, z):
                 elec.z = z_elec
 
         # Beware of race condition: Stim must be set last, because it requires
@@ -213,8 +213,8 @@ class AlphaAMS(ProsthesisSystem):
         if eye == 'LE':
             # FIXME: Would be better to have more flexibility in the naming
             # convention. This is a quick-and-dirty fix:
-            names = list(self.earray.keys())
-            objects = list(self.earray.values())
+            names = self.earray.electrode_names
+            objects = self.earray.electrode_objects
             names = np.array(names).reshape(self.earray.shape)
             # Reverse column names:
             for row in range(self.earray.shape[0]):
@@ -224,7 +224,7 @@ class AlphaAMS(ProsthesisSystem):
             for name, obj in zip(names.ravel(), objects):
                 electrodes.update({name: obj})
             # Assign the new ordered dict to earray:
-            self.earray.electrodes = electrodes
+            self.earray._electrodes = electrodes
 
     def _pprint_params(self):
         """Return dict of class attributes to pretty-print"""

--- a/pulse2percept/implants/alpha.py
+++ b/pulse2percept/implants/alpha.py
@@ -32,13 +32,15 @@ class AlphaIMS(ProsthesisSystem):
 
     Parameters
     ----------
-    x : float
-        x coordinate of the array center (um)
-    y : float
-        y coordinate of the array center (um)
-    z: float or array_like
-        Distance of the array to the retinal surface (um). Either a list
-        with 1500 entries or a scalar.
+    x/y/z : double
+        3D location of the center of the electrode array.
+        The coordinate system is centered over the fovea.
+        Positive ``x`` values move the electrode into the nasal retina.
+        Positive ``y`` values move the electrode into the superior retina.
+        Positive ``z`` values move the electrode away from the retina into the
+        vitreous humor (sometimes called electrode-retina distance).
+        ``z`` can either be a list with 1500 entries or a scalar that is applied
+        to all electrodes.
     rot : float
         Rotation angle of the array (deg). Positive values denote
         counter-clock-wise (CCW) rotations in the retinal coordinate
@@ -168,13 +170,15 @@ class AlphaAMS(ProsthesisSystem):
 
     Parameters
     ----------
-    x : float
-        x coordinate of the array center (um)
-    y : float
-        y coordinate of the array center (um)
-    z: float or array_like
-        Distance of the array to the retinal surface (um). Either a list
-        with 60 entries or a scalar.
+    x/y/z : double
+        3D location of the center of the electrode array.
+        The coordinate system is centered over the fovea.
+        Positive ``x`` values move the electrode into the nasal retina.
+        Positive ``y`` values move the electrode into the superior retina.
+        Positive ``z`` values move the electrode away from the retina into the
+        vitreous humor (sometimes called electrode-retina distance).
+        ``z`` can either be a list with 1600 entries or a scalar that is applied
+        to all electrodes.
     rot : float
         Rotation angle of the array (deg). Positive values denote
         counter-clock-wise (CCW) rotations in the retinal coordinate

--- a/pulse2percept/implants/alpha.py
+++ b/pulse2percept/implants/alpha.py
@@ -67,9 +67,9 @@ class AlphaIMS(ProsthesisSystem):
 
     >>> alpha_ims = AlphaIMS(x=0, y=0, z=100, rot=0)
     >>> alpha_ims['A3']
-    SquareElectrode(a=50.0, x=-1224.0, y=-1368.0, z=100.0)
+    SquareElectrode(a=50.0, name='A3', x=-1224.0, y=-1368.0, z=100.0)
     >>> alpha_ims[0, 2]
-    SquareElectrode(a=50.0, x=-1224.0, y=-1368.0, z=100.0)
+    SquareElectrode(a=50.0, name='A3', x=-1224.0, y=-1368.0, z=100.0)
 
     """
     # Frozen class: User cannot add more class attributes
@@ -201,9 +201,9 @@ class AlphaAMS(ProsthesisSystem):
 
     >>> alpha_ims = AlphaAMS(x=0, y=0, z=100, rot=0)
     >>> alpha_ims['A3']
-    DiskElectrode(r=15.0, x=-1225.0, y=-1365.0, z=100.0)
+    DiskElectrode(name='A3', r=15.0, x=-1225.0, y=-1365.0, z=100.0)
     >>> alpha_ims[0, 2]
-    DiskElectrode(r=15.0, x=-1225.0, y=-1365.0, z=100.0)
+    DiskElectrode(name='A3', r=15.0, x=-1225.0, y=-1365.0, z=100.0)
 
     """
     # Frozen class: User cannot add more class attributes

--- a/pulse2percept/implants/alpha.py
+++ b/pulse2percept/implants/alpha.py
@@ -210,7 +210,7 @@ class AlphaAMS(ProsthesisSystem):
     DiskElectrode(activated=True, name='A3', r=15.0, x=-1225.0,
                   y=-1365.0, z=100.0)
     >>> alpha_ims[0, 2]  # doctest: +NORMALIZE_WHITESPACE
-    DiskElectrode(activated, True, name='A3', r=15.0, x=-1225.0,
+    DiskElectrode(activated=True, name='A3', r=15.0, x=-1225.0,
                   y=-1365.0, z=100.0)
 
     """

--- a/pulse2percept/implants/alpha.py
+++ b/pulse2percept/implants/alpha.py
@@ -45,6 +45,12 @@ class AlphaIMS(ProsthesisSystem):
         system.
     eye : {'RE', 'LE'}, optional
         Eye in which array is implanted.
+    preprocess : bool or callable, optional
+        Either True/False to indicate whether to execute the implant's default
+        preprocessing method whenever a new stimulus is assigned, or a custom
+        function (callable).
+    safe_mode : bool, optional
+        If safe mode is enabled, only charge-balanced stimuli are allowed.
 
     Examples
     --------
@@ -69,8 +75,11 @@ class AlphaIMS(ProsthesisSystem):
     # Frozen class: User cannot add more class attributes
     __slots__ = ('shape',)
 
-    def __init__(self, x=0, y=0, z=-100, rot=0, eye='RE', stim=None):
+    def __init__(self, x=0, y=0, z=-100, rot=0, eye='RE', stim=None,
+                 preprocess=False, safe_mode=False):
         self.eye = eye
+        self.preprocess = preprocess
+        self.safe_mode = safe_mode
         self.shape = (39, 39)
         elec_width = 50.0  # um
         e_spacing = 72.0  # um
@@ -170,6 +179,12 @@ class AlphaAMS(ProsthesisSystem):
         system.
     eye : {'RE', 'LE'}, optional
         Eye in which array is implanted.
+    preprocess : bool or callable, optional
+        Either True/False to indicate whether to execute the implant's default
+        preprocessing method whenever a new stimulus is assigned, or a custom
+        function (callable).
+    safe_mode : bool, optional
+        If safe mode is enabled, only charge-balanced stimuli are allowed.
 
     Examples
     --------
@@ -194,8 +209,11 @@ class AlphaAMS(ProsthesisSystem):
     # Frozen class: User cannot add more class attributes
     __slots__ = ('shape',)
 
-    def __init__(self, x=0, y=0, z=0, rot=0, eye='RE', stim=None):
+    def __init__(self, x=0, y=0, z=0, rot=0, eye='RE', stim=None,
+                 preprocess=False, safe_mode=False):
         self.eye = eye
+        self.preprocess = preprocess
+        self.safe_mode = safe_mode
         self.shape = (40, 40)
         elec_radius = 15.0
         e_spacing = 70.0  # um

--- a/pulse2percept/implants/argus.py
+++ b/pulse2percept/implants/argus.py
@@ -115,8 +115,8 @@ class ArgusI(ProsthesisSystem):
         if eye == 'LE':
             # FIXME: Would be better to have more flexibility in the naming
             # convention. This is a quick-and-dirty fix:
-            names = list(self.earray.keys())
-            objects = list(self.earray.values())
+            names = self.earray.electrode_names
+            objects = self.earray.electrode_objects
             names = np.array(names).reshape(self.earray.shape)
             # Reverse column names:
             for row in range(self.earray.shape[0]):
@@ -126,7 +126,7 @@ class ArgusI(ProsthesisSystem):
             for name, obj in zip(names.ravel(), objects):
                 electrodes.update({name: obj})
             # Assign the new ordered dict to earray:
-            self.earray.electrodes = electrodes
+            self.earray._electrodes = electrodes
 
     def _pprint_params(self):
         """Return dict of class attributes to pretty-print"""
@@ -230,8 +230,8 @@ class ArgusII(ProsthesisSystem):
         if eye == 'LE':
             # TODO: Would be better to have more flexibility in the naming
             # convention. This is a quick-and-dirty fix:
-            names = list(self.earray.keys())
-            objects = list(self.earray.values())
+            names = self.earray.electrode_names
+            objects = self.earray.electrode_objects
             names = np.array(names).reshape(self.earray.shape)
             # Reverse column names:
             for row in range(self.earray.shape[0]):
@@ -241,7 +241,7 @@ class ArgusII(ProsthesisSystem):
             for name, obj in zip(names.ravel(), objects):
                 electrodes.update({name: obj})
             # Assign the new ordered dict to earray:
-            self.earray.electrodes = electrodes
+            self.earray._electrodes = electrodes
 
     def _pprint_params(self):
         """Return dict of class attributes to pretty-print"""

--- a/pulse2percept/implants/argus.py
+++ b/pulse2percept/implants/argus.py
@@ -217,10 +217,10 @@ class ArgusII(ProsthesisSystem):
 
     >>> argus = ArgusII(x=0, y=0, z=100, rot=0)
     >>> argus['E7']
-    DiskElectrode(name='E7', r=112.5, x=862.5, y=862.5,
+    DiskElectrode(name='E7', r=112.5, x=862.5, y=862.5,...
                   z=100.0)
     >>> argus[4, 6]
-    DiskElectrode(name='E7', r=112.5, x=862.5, y=862.5,
+    DiskElectrode(name='E7', r=112.5, x=862.5, y=862.5,...
                   z=100.0)
 
     """

--- a/pulse2percept/implants/argus.py
+++ b/pulse2percept/implants/argus.py
@@ -76,8 +76,8 @@ class ArgusI(ProsthesisSystem):
 
     >>> from pulse2percept.implants import ArgusI
     >>> ArgusI(x=0, y=0, z=100, rot=5)  # doctest: +NORMALIZE_WHITESPACE
-    ArgusI(earray=ElectrodeGrid, eye='RE', shape=(4, 4),
-           stim=None)
+    ArgusI(earray=ElectrodeGrid, eye='RE', preprocess=True,
+           safe_mode=False, shape=(4, 4), stim=None)
 
     Get access to electrode 'B1', either by name or by row/column index:
 
@@ -92,7 +92,7 @@ class ArgusI(ProsthesisSystem):
     __slots__ = ('shape',)
 
     def __init__(self, x=0, y=0, z=0, rot=0, eye='RE', stim=None,
-                 preprocess=False, safe_mode=False, use_legacy_names=False):
+                 preprocess=True, safe_mode=False, use_legacy_names=False):
         self.eye = eye
         self.preprocess = preprocess
         self.safe_mode = safe_mode
@@ -210,8 +210,8 @@ class ArgusII(ProsthesisSystem):
 
     >>> from pulse2percept.implants import ArgusII
     >>> ArgusII(x=0, y=0, z=100, rot=5)  # doctest: +NORMALIZE_WHITESPACE
-    ArgusII(earray=ElectrodeGrid, eye='RE', shape=(6, 10),
-            stim=None)
+    ArgusII(earray=ElectrodeGrid, eye='RE', preprocess=True,
+            safe_mode=False, shape=(6, 10), stim=None)
 
     Get access to electrode 'E7', either by name or by row/column index:
 
@@ -226,7 +226,7 @@ class ArgusII(ProsthesisSystem):
     __slots__ = ('shape',)
 
     def __init__(self, x=0, y=0, z=0, rot=0, eye='RE', stim=None,
-                 preprocess=False, safe_mode=False):
+                 preprocess=True, safe_mode=False):
         self.safe_mode = safe_mode
         self.preprocess = preprocess
         self.shape = (6, 10)

--- a/pulse2percept/implants/argus.py
+++ b/pulse2percept/implants/argus.py
@@ -217,9 +217,11 @@ class ArgusII(ProsthesisSystem):
 
     >>> argus = ArgusII(x=0, y=0, z=100, rot=0)
     >>> argus['E7']
-    DiskElectrode(name='E7', r=112.5, x=862.5, y=862.5, z=100.0)
+    DiskElectrode(name='E7', r=112.5, x=862.5, y=862.5,
+                  z=100.0)
     >>> argus[4, 6]
-    DiskElectrode(name='E7', r=112.5, x=862.5, y=862.5, z=100.0)
+    DiskElectrode(name='E7', r=112.5, x=862.5, y=862.5,
+                  z=100.0)
 
     """
     # Frozen class: User cannot add more class attributes

--- a/pulse2percept/implants/argus.py
+++ b/pulse2percept/implants/argus.py
@@ -84,10 +84,12 @@ class ArgusI(ProsthesisSystem):
     Get access to electrode 'B1', either by name or by row/column index:
 
     >>> argus = ArgusI(x=0, y=0, z=100, rot=0)
-    >>> argus['B1']
-    DiskElectrode(name='B1', r=250.0, x=-400.0, y=-1200.0, z=100.0)
-    >>> argus[0, 1]
-    DiskElectrode(name='B1', r=250.0, x=-400.0, y=-1200.0, z=100.0)
+    >>> argus['B1']  # doctest: +NORMALIZE_WHITESPACE
+    DiskElectrode(activated=True, name='B1', r=250.0, x=-400.0,
+                  y=-1200.0, z=100.0)
+    >>> argus[0, 1]  # doctest: +NORMALIZE_WHITESPACE
+    DiskElectrode(activated=True, name='B1', r=250.0, x=-400.0,
+                  y=-1200.0, z=100.0)
 
     """
     # Frozen class: User cannot add more class attributes
@@ -220,12 +222,12 @@ class ArgusII(ProsthesisSystem):
     Get access to electrode 'E7', either by name or by row/column index:
 
     >>> argus = ArgusII(x=0, y=0, z=100, rot=0)
-    >>> argus['E7']
-    DiskElectrode(name='E7', r=112.5, x=862.5, y=862.5,...
-                  z=100.0)
-    >>> argus[4, 6]
-    DiskElectrode(name='E7', r=112.5, x=862.5, y=862.5,...
-                  z=100.0)
+    >>> argus['E7']  # doctest: +NORMALIZE_WHITESPACE
+    DiskElectrode(activated=True, name='E7', r=112.5, x=862.5,
+                  y=862.5, z=100.0)
+    >>> argus[4, 6]  # doctest: +NORMALIZE_WHITESPACE
+    DiskElectrode(activated=True, name='E7', r=112.5, x=862.5,
+                  y=862.5, z=100.0)
 
     """
     # Frozen class: User cannot add more class attributes

--- a/pulse2percept/implants/argus.py
+++ b/pulse2percept/implants/argus.py
@@ -83,9 +83,9 @@ class ArgusI(ProsthesisSystem):
 
     >>> argus = ArgusI(x=0, y=0, z=100, rot=0)
     >>> argus['B1']
-    DiskElectrode(r=250.0, x=-400.0, y=-1200.0, z=100.0)
+    DiskElectrode(name='B1', r=250.0, x=-400.0, y=-1200.0, z=100.0)
     >>> argus[0, 1]
-    DiskElectrode(r=250.0, x=-400.0, y=-1200.0, z=100.0)
+    DiskElectrode(name='B1', r=250.0, x=-400.0, y=-1200.0, z=100.0)
 
     """
     # Frozen class: User cannot add more class attributes
@@ -217,9 +217,9 @@ class ArgusII(ProsthesisSystem):
 
     >>> argus = ArgusII(x=0, y=0, z=100, rot=0)
     >>> argus['E7']
-    DiskElectrode(r=112.5, x=862.5, y=862.5, z=100.0)
+    DiskElectrode(name='E7', r=112.5, x=862.5, y=862.5, z=100.0)
     >>> argus[4, 6]
-    DiskElectrode(r=112.5, x=862.5, y=862.5, z=100.0)
+    DiskElectrode(name='E7', r=112.5, x=862.5, y=862.5, z=100.0)
 
     """
     # Frozen class: User cannot add more class attributes

--- a/pulse2percept/implants/argus.py
+++ b/pulse2percept/implants/argus.py
@@ -59,6 +59,15 @@ class ArgusI(ProsthesisSystem):
         system.
     eye : {'RE', 'LE'}, optional
         Eye in which array is implanted.
+    preprocess : bool or callable, optional
+        Either True/False to indicate whether to execute the implant's default
+        preprocessing method whenever a new stimulus is assigned, or a custom
+        function (callable).
+    safe_mode : bool, optional
+        If safe mode is enabled, only charge-balanced stimuli are allowed.
+    use_legacy_names : bool, optional
+        If True, uses L/M based electrode names from older papers (e.g., L6,
+        L2) instead of A1-A16.
 
     Examples
     --------
@@ -83,8 +92,10 @@ class ArgusI(ProsthesisSystem):
     __slots__ = ('shape',)
 
     def __init__(self, x=0, y=0, z=0, rot=0, eye='RE', stim=None,
-                 use_legacy_names=False):
+                 preprocess=False, safe_mode=False, use_legacy_names=False):
         self.eye = eye
+        self.preprocess = preprocess
+        self.safe_mode = safe_mode
         self.shape = (4, 4)
         r_arr = np.array([250, 500, 250, 500]) / 2.0
         r_arr = np.concatenate((r_arr, r_arr[::-1], r_arr, r_arr[::-1]),
@@ -185,6 +196,12 @@ class ArgusII(ProsthesisSystem):
         system.
     eye : {'RE', 'LE'}, optional
         Eye in which array is implanted.
+    preprocess : bool or callable, optional
+        Either True/False to indicate whether to execute the implant's default
+        preprocessing method whenever a new stimulus is assigned, or a custom
+        function (callable).
+    safe_mode : bool, optional
+        If safe mode is enabled, only charge-balanced stimuli are allowed.
 
     Examples
     --------
@@ -209,7 +226,7 @@ class ArgusII(ProsthesisSystem):
     __slots__ = ('shape',)
 
     def __init__(self, x=0, y=0, z=0, rot=0, eye='RE', stim=None,
-                 safe_mode=True, preprocess=False):
+                 preprocess=False, safe_mode=False):
         self.safe_mode = safe_mode
         self.preprocess = preprocess
         self.shape = (6, 10)
@@ -252,22 +269,3 @@ class ArgusII(ProsthesisSystem):
         params.update({'shape': self.shape, 'safe_mode': self.safe_mode,
                        'preprocess': self.preprocess})
         return params
-
-    def check_stim(self, stim):
-        """Quality-check the stimulus
-
-        If ``safe_mode`` is set to True, will only allow charge-balanced pulses.
-
-        This method is executed every time a new value is assigned to ``stim``.
-
-        No checks are performed by default, but the user can define their own
-        checks in implants that inherit from
-        :py:class:`~pulse2percept.implants.ProsthesisSystem`.
-
-        Parameters
-        ----------
-        stim : :py:class:`~pulse2percept.stimuli.Stimulus` source type
-            A valid source type for the
-            :py:class:`~pulse2percept.stimuli.Stimulus` object (e.g., scalar,
-            NumPy array, pulse train).
-        """

--- a/pulse2percept/implants/argus.py
+++ b/pulse2percept/implants/argus.py
@@ -46,13 +46,15 @@ class ArgusI(ProsthesisSystem):
 
     Parameters
     ----------
-    x : float, optional
-        x coordinate of the array center (um)
-    y : float, optional
-        y coordinate of the array center (um)
-    z : float or array_like, optional
-        Distance of the array to the retinal surface (um). Either a list
-        with 16 entries or a scalar.
+    x/y/z : double
+        3D location of the center of the electrode array.
+        The coordinate system is centered over the fovea.
+        Positive ``x`` values move the electrode into the nasal retina.
+        Positive ``y`` values move the electrode into the superior retina.
+        Positive ``z`` values move the electrode away from the retina into the
+        vitreous humor (sometimes called electrode-retina distance).
+        ``z`` can either be a list with 16 entries or a scalar that is applied
+        to all electrodes.
     rot : float, optional
         Rotation angle of the array (deg). Positive values denote
         counter-clock-wise (CCW) rotations in the retinal coordinate
@@ -183,13 +185,15 @@ class ArgusII(ProsthesisSystem):
 
     Parameters
     ----------
-    x : float
-        x coordinate of the array center (um)
-    y : float
-        y coordinate of the array center (um)
-    z: float or array_like
-        Distance of the array to the retinal surface (um). Either a list
-        with 60 entries or a scalar.
+    x/y/z : double
+        3D location of the center of the electrode array.
+        The coordinate system is centered over the fovea.
+        Positive ``x`` values move the electrode into the nasal retina.
+        Positive ``y`` values move the electrode into the superior retina.
+        Positive ``z`` values move the electrode away from the retina into the
+        vitreous humor (sometimes called electrode-retina distance).
+        ``z`` can either be a list with 60 entries or a scalar that is applied
+        to all electrodes.
     rot : float
         Rotation angle of the array (deg). Positive values denote
         counter-clock-wise (CCW) rotations in the retinal coordinate

--- a/pulse2percept/implants/argus.py
+++ b/pulse2percept/implants/argus.py
@@ -208,7 +208,10 @@ class ArgusII(ProsthesisSystem):
     # Frozen class: User cannot add more class attributes
     __slots__ = ('shape',)
 
-    def __init__(self, x=0, y=0, z=0, rot=0, eye='RE', stim=None):
+    def __init__(self, x=0, y=0, z=0, rot=0, eye='RE', stim=None,
+                 safe_mode=True, preprocess=False):
+        self.safe_mode = safe_mode
+        self.preprocess = preprocess
         self.shape = (6, 10)
         r = 225.0 / 2.0
         spacing = 575.0
@@ -246,5 +249,25 @@ class ArgusII(ProsthesisSystem):
     def _pprint_params(self):
         """Return dict of class attributes to pretty-print"""
         params = super()._pprint_params()
-        params.update({'shape': self.shape})
+        params.update({'shape': self.shape, 'safe_mode': self.safe_mode,
+                       'preprocess': self.preprocess})
         return params
+
+    def check_stim(self, stim):
+        """Quality-check the stimulus
+
+        If ``safe_mode`` is set to True, will only allow charge-balanced pulses.
+
+        This method is executed every time a new value is assigned to ``stim``.
+
+        No checks are performed by default, but the user can define their own
+        checks in implants that inherit from
+        :py:class:`~pulse2percept.implants.ProsthesisSystem`.
+
+        Parameters
+        ----------
+        stim : :py:class:`~pulse2percept.stimuli.Stimulus` source type
+            A valid source type for the
+            :py:class:`~pulse2percept.stimuli.Stimulus` object (e.g., scalar,
+            NumPy array, pulse train).
+        """

--- a/pulse2percept/implants/base.py
+++ b/pulse2percept/implants/base.py
@@ -141,6 +141,12 @@ class ProsthesisSystem(PrettyPrint):
         """
         return self.earray.plot(annotate=annotate, autoscale=autoscale, ax=ax)
 
+    def activate(self, electrodes):
+        self.earray.activate(electrodes)
+
+    def deactivate(self, electrodes):
+        self.earray.deactivate(electrodes)
+
     @property
     def earray(self):
         """Electrode array
@@ -216,6 +222,8 @@ class ProsthesisSystem(PrettyPrint):
                 # Use electrode names as stimulus coordinates:
                 stim = Stimulus(data, electrodes=self.electrode_names)
 
+            print(stim)
+
             if len(stim.electrodes) > self.n_electrodes:
                 if (isinstance(stim, (ImageStimulus, VideoStimulus)) and
                         hasattr(self.earray, 'shape')):
@@ -231,8 +239,11 @@ class ProsthesisSystem(PrettyPrint):
             for electrode in stim.electrodes:
                 # Invalid index will return None:
                 if not self.earray[electrode]:
-                    raise ValueError("Electrode '%s' not found in "
-                                     "implant." % electrode)
+                    raise ValueError('Electrode "%s" not found in '
+                                     'implant.' % electrode)
+                if not self.earray[electrode].activated:
+                    raise ValueError('Cannot assign stimulus to deactivated '
+                                     'Electrode "%s".' % electrode)
             # Perform safety checks, etc.:
             self.check_stim(stim)
             # Store stimulus:

--- a/pulse2percept/implants/base.py
+++ b/pulse2percept/implants/base.py
@@ -33,6 +33,8 @@ class ProsthesisSystem(PrettyPrint):
         Either True/False to indicate whether to execute the implant's default
         preprocessing method whenever a new stimulus is assigned, or a custom
         function (callable).
+    safe_mode : bool, optional
+        If safe mode is enabled, only charge-balanced stimuli are allowed.
 
     Examples
     --------
@@ -52,8 +54,8 @@ class ProsthesisSystem(PrettyPrint):
     # Frozen class: User cannot add more class attributes
     __slots__ = ('_earray', '_stim', '_eye')
 
-    def __init__(self, earray, stim=None, eye='RE', safe_mode=False,
-                 preprocess=False):
+    def __init__(self, earray, stim=None, eye='RE', preprocess=False,
+                 safe_mode=False):
         self.earray = earray
         self.stim = stim
         self.eye = eye
@@ -63,7 +65,7 @@ class ProsthesisSystem(PrettyPrint):
     def _pprint_params(self):
         """Return dict of class attributes to pretty-print"""
         return {'earray': self.earray, 'stim': self.stim, 'eye': self.eye,
-                'safe_mode': self.safe_mode, 'preprocess:' self.preprocess}
+                'safe_mode': self.safe_mode, 'preprocess': self.preprocess}
 
     @staticmethod
     def _require_charge_balanced(stim):

--- a/pulse2percept/implants/base.py
+++ b/pulse2percept/implants/base.py
@@ -162,7 +162,7 @@ class ProsthesisSystem(PrettyPrint):
                 stim = Stimulus(data)
             else:
                 # Use electrode names as stimulus coordinates:
-                stim = Stimulus(data, electrodes=list(self.earray.keys()))
+                stim = Stimulus(data, electrodes=self.electrode_names)
 
             if len(stim.electrodes) > self.n_electrodes:
                 raise ValueError("Number of electrodes in the stimulus (%d) "
@@ -224,29 +224,30 @@ class ProsthesisSystem(PrettyPrint):
     def __iter__(self):
         return iter(self.earray)
 
-    def keys(self):
-        """Return all electrode names in the electrode array"""
-        return self.earray.keys()
-
-    def values(self):
-        """Return all electrode objects in the electrode array"""
-        return self.earray.values()
-
-    def items(self):
+    @property
+    def electrodes(self):
         """Return all electrode names and objects in the electrode array
 
-        Internally, electrodes are stored in a dictionary in
-        ``earray.electrodes``. For convenience, electrodes can also be accessed
-        via ``items``.
+        Internally, electrodes are stored in an ordered dictionary.
+        You can iterate over different electrodes in the array as follows:
 
-        Examples
-        --------
-        Save the x-coordinates of all electrodes of Argus I in a dictionary:
+        .. code::
 
-        >>> from pulse2percept.implants import ArgusI
-        >>> xcoords = {}
-        >>> for name, electrode in ArgusI().items():
-        ...     xcoords[name] = electrode.x
+            for name, electrode in implant.electrodes.items():
+                print(name, electrode)
+
+        You can access an individual electrode by indexing directly into the
+        prosthesis system object, e.g. ``implant['A1']`` or ``implant[0]``.
 
         """
-        return self.earray.items()
+        return self.earray.electrodes
+
+    @property
+    def electrode_names(self):
+        """Return a list of all electrode names in the electrode array"""
+        return self.earray.electrode_names
+
+    @property
+    def electrode_objects(self):
+        """Return a list of all electrode objects in the array"""
+        return self.earray.electrode_objects

--- a/pulse2percept/implants/base.py
+++ b/pulse2percept/implants/base.py
@@ -52,7 +52,7 @@ class ProsthesisSystem(PrettyPrint):
 
     """
     # Frozen class: User cannot add more class attributes
-    __slots__ = ('_earray', '_stim', '_eye')
+    __slots__ = ('_earray', '_stim', '_eye', 'safe_mode', 'preprocess')
 
     def __init__(self, earray, stim=None, eye='RE', preprocess=False,
                  safe_mode=False):
@@ -69,7 +69,8 @@ class ProsthesisSystem(PrettyPrint):
 
     @staticmethod
     def _require_charge_balanced(stim):
-        if not self.is_charge_balanced:
+        # Stimuli without a time component return None, others return True/False
+        if stim.is_charge_balanced is False:
             raise ValueError("Safety check: Stimulus must be charge-balanced.")
 
     def check_stim(self, stim):
@@ -91,7 +92,7 @@ class ProsthesisSystem(PrettyPrint):
             NumPy array, pulse train).
         """
         if self.safe_mode:
-            self._require_charge_balanced()
+            self._require_charge_balanced(stim)
 
     def preprocess_stim(self, stim):
         """Preprocess the stimulus
@@ -222,7 +223,7 @@ class ProsthesisSystem(PrettyPrint):
                                      "implant." % electrode)
             # Preprocess can be a function (callable) or True/False:
             if callable(self.preprocess):
-                stim = self.preprocess(stim):
+                stim = self.preprocess(stim)
             elif self.preprocess:
                 stim = self.preprocess_stim(stim)
             # Perform safety checks, etc.:

--- a/pulse2percept/implants/base.py
+++ b/pulse2percept/implants/base.py
@@ -222,8 +222,6 @@ class ProsthesisSystem(PrettyPrint):
                 # Use electrode names as stimulus coordinates:
                 stim = Stimulus(data, electrodes=self.electrode_names)
 
-            print(stim)
-
             if len(stim.electrodes) > self.n_electrodes:
                 if (isinstance(stim, (ImageStimulus, VideoStimulus)) and
                         hasattr(self.earray, 'shape')):

--- a/pulse2percept/implants/base.py
+++ b/pulse2percept/implants/base.py
@@ -57,10 +57,10 @@ class ProsthesisSystem(PrettyPrint):
     def __init__(self, earray, stim=None, eye='RE', preprocess=False,
                  safe_mode=False):
         self.earray = earray
-        self.stim = stim
         self.eye = eye
         self.safe_mode = safe_mode
         self.preprocess = preprocess
+        self.stim = stim
 
     def _pprint_params(self):
         """Return dict of class attributes to pretty-print"""

--- a/pulse2percept/implants/base.py
+++ b/pulse2percept/implants/base.py
@@ -200,6 +200,12 @@ class ProsthesisSystem(PrettyPrint):
         if data is None:
             self._stim = None
         else:
+            # Preprocess can be a function (callable) or True/False:
+            if callable(self.preprocess):
+                data = self.preprocess(data)
+            elif self.preprocess:
+                data = self.preprocess_stim(data)
+            # Convert to stimulus object:
             if isinstance(data, Stimulus):
                 # Already a stimulus object:
                 stim = data
@@ -221,11 +227,6 @@ class ProsthesisSystem(PrettyPrint):
                 if not self.earray[electrode]:
                     raise ValueError("Electrode '%s' not found in "
                                      "implant." % electrode)
-            # Preprocess can be a function (callable) or True/False:
-            if callable(self.preprocess):
-                stim = self.preprocess(stim)
-            elif self.preprocess:
-                stim = self.preprocess_stim(stim)
             # Perform safety checks, etc.:
             self.check_stim(stim)
             # Store stimulus:

--- a/pulse2percept/implants/base.py
+++ b/pulse2percept/implants/base.py
@@ -4,7 +4,7 @@ from copy import deepcopy
 
 from .electrodes import Electrode
 from .electrode_arrays import ElectrodeArray
-from ..stimuli import Stimulus
+from ..stimuli import Stimulus, ImageStimulus, VideoStimulus
 from ..utils import PrettyPrint
 
 
@@ -217,10 +217,16 @@ class ProsthesisSystem(PrettyPrint):
                 stim = Stimulus(data, electrodes=self.electrode_names)
 
             if len(stim.electrodes) > self.n_electrodes:
-                raise ValueError("Number of electrodes in the stimulus (%d) "
-                                 "does not match the number of electrodes in "
-                                 "the implant (%d)." % (len(stim.electrodes),
-                                                        self.n_electrodes))
+                if (isinstance(stim, (ImageStimulus, VideoStimulus)) and
+                        hasattr(self.earray, 'shape')):
+                    # Convenience function for electrode grids:
+                    stim = stim.rgb2gray().resize(self.earray.shape)
+                else:
+                    err_str = ("Number of electrodes in the stimulus (%d) "
+                               "does not match the number of electrodes in "
+                               "the implant (%d)." % (len(stim.electrodes),
+                                                      self.n_electrodes))
+                    raise ValueError(err_str)
             # Make sure all electrode names are valid:
             for electrode in stim.electrodes:
                 # Invalid index will return None:

--- a/pulse2percept/implants/bvt.py
+++ b/pulse2percept/implants/bvt.py
@@ -39,13 +39,15 @@ class BVT24(ProsthesisSystem):
 
     Parameters
     ----------
-    x : float
-        x coordinate of the array center (um)
-    y : float
-        y coordinate of the array center (um)
-    z: float or array_like
-        Distance of the array to the retinal surface (um). Either a list
-        with 60 entries or a scalar.
+    x/y/z : double
+        3D location of the center of the electrode array.
+        The coordinate system is centered over the fovea.
+        Positive ``x`` values move the electrode into the nasal retina.
+        Positive ``y`` values move the electrode into the superior retina.
+        Positive ``z`` values move the electrode away from the retina into the
+        vitreous humor (sometimes called electrode-retina distance).
+        ``z`` can either be a list with 35 entries or a scalar that is applied
+        to all electrodes.
     rot : float
         Rotation angle of the array (deg). Positive values denote
         counter-clock-wise (CCW) rotations in the retinal coordinate

--- a/pulse2percept/implants/bvt.py
+++ b/pulse2percept/implants/bvt.py
@@ -52,13 +52,22 @@ class BVT24(ProsthesisSystem):
         system.
     eye : {'RE', 'LE'}, optional
         Eye in which array is implanted.
+    preprocess : bool or callable, optional
+        Either True/False to indicate whether to execute the implant's default
+        preprocessing method whenever a new stimulus is assigned, or a custom
+        function (callable).
+    safe_mode : bool, optional
+        If safe mode is enabled, only charge-balanced stimuli are allowed.
 
     """
     # Frozen class: User cannot add more class attributes
     __slots__ = ()
 
-    def __init__(self, x=0, y=0, z=0, rot=0, eye='RE', stim=None):
+    def __init__(self, x=0, y=0, z=0, rot=0, eye='RE', stim=None,
+                 preprocess=False, safe_mode=False):
         self.eye = eye
+        self.preprocess = preprocess
+        self.safe_mode = safe_mode
         self.earray = ElectrodeArray([])
         n_elecs = 35
 

--- a/pulse2percept/implants/electrode_arrays.py
+++ b/pulse2percept/implants/electrode_arrays.py
@@ -286,7 +286,7 @@ class ElectrodeGrid(ElectrodeArray):
     >>> from pulse2percept.implants import ElectrodeGrid, DiskElectrode
     >>> ElectrodeGrid((2, 4), 20, x=10, y=20, z=500, names=('A', '1'), r=10,
     ...               type='rect', etype=DiskElectrode) # doctest: +NORMALIZE_WHITESPACE +ELLIPSIS
-    ElectrodeGrid(shape=(2, 4), spacing=20, type='rect')
+    ElectrodeGrid(rot=0, shape=(2, 4), spacing=20, type='rect')
 
     There are three ways to access (e.g.) the last electrode in the grid,
     either by name (``grid['C3']``), by row/column index (``grid[2, 2]``), or

--- a/pulse2percept/implants/electrode_arrays.py
+++ b/pulse2percept/implants/electrode_arrays.py
@@ -295,7 +295,7 @@ class ElectrodeGrid(ElectrodeArray):
     >>> from pulse2percept.implants import ElectrodeGrid
     >>> grid = ElectrodeGrid((3, 3), 20, names=('A', '1'))
     >>> grid['C3']  # doctest: +ELLIPSIS
-    PointSource(x=20..., y=20..., z=0...)
+    PointSource(name='C3', x=20..., y=20..., z=0...)
     >>> grid['C3'] == grid[8] == grid[2, 2]
     True
 
@@ -305,9 +305,9 @@ class ElectrodeGrid(ElectrodeArray):
     >>> from pulse2percept.implants import ElectrodeGrid, DiskElectrode
     >>> grid = ElectrodeGrid((3, 3), 20, etype=DiskElectrode, r=10)
     >>> grid[['A1', 1, (0, 2)]]  # doctest: +NORMALIZE_WHITESPACE +ELLIPSIS
-    [DiskElectrode(r=10..., x=-20.0, y=-20.0, z=0...),
-     DiskElectrode(r=10..., x=0.0, y=-20.0, z=0...),
-     DiskElectrode(r=10..., x=20.0, y=-20.0, z=0...)]
+    [DiskElectrode(name='A1', r=10..., x=-20.0, y=-20.0, z=0...),
+     DiskElectrode(name='A2', r=10..., x=0.0, y=-20.0, z=0...),
+     DiskElectrode(name='A3', r=10..., x=20.0, y=-20.0, z=0...)]
 
     """
     # Frozen class: User cannot add more class attributes

--- a/pulse2percept/implants/electrode_arrays.py
+++ b/pulse2percept/implants/electrode_arrays.py
@@ -311,7 +311,7 @@ class ElectrodeGrid(ElectrodeArray):
 
     """
     # Frozen class: User cannot add more class attributes
-    __slots__ = ('shape', 'type', 'spacing')
+    __slots__ = ('shape', 'type', 'spacing', 'rot')
 
     def __init__(self, shape, spacing, x=0, y=0, z=0, rot=0, names=('A', '1'),
                  type='rect', orientation='horizontal', etype=PointSource,
@@ -350,6 +350,7 @@ class ElectrodeGrid(ElectrodeArray):
         self.shape = shape
         self.type = type
         self.spacing = spacing
+        self.rot = rot
         # Instantiate empty collection of electrodes. This dictionary will be
         # populated in a private method ``_set_egrid``:
         self._electrodes = OrderedDict()
@@ -358,7 +359,7 @@ class ElectrodeGrid(ElectrodeArray):
     def _pprint_params(self):
         """Return dict of class attributes to pretty-print"""
         params = {'shape': self.shape, 'spacing': self.spacing,
-                  'type': self.type}
+                  'type': self.type, 'rot': self.rot}
         return params
 
     def __getitem__(self, item):

--- a/pulse2percept/implants/electrode_arrays.py
+++ b/pulse2percept/implants/electrode_arrays.py
@@ -33,14 +33,14 @@ class ElectrodeArray(PrettyPrint):
     >>> from pulse2percept.implants import ElectrodeArray, DiskElectrode
     >>> earray = ElectrodeArray(DiskElectrode(0, 0, 0, 100))
     >>> earray.electrodes  # doctest: +NORMALIZE_WHITESPACE +ELLIPSIS
-    OrderedDict([(0, DiskElectrode(r=100..., x=0..., y=0..., z=0...))])
+    OrderedDict([(0, DiskElectrode(name=None, r=100..., x=0..., y=0..., z=0...))])
 
     Electrode array made from a single DiskElectrode with name 'A1':
 
     >>> from pulse2percept.implants import ElectrodeArray, DiskElectrode
     >>> earray = ElectrodeArray({'A1': DiskElectrode(0, 0, 0, 100)})
     >>> earray.electrodes  # doctest: +NORMALIZE_WHITESPACE +ELLIPSIS
-    OrderedDict([('A1', DiskElectrode(r=100..., x=0..., y=0..., z=0...))])
+    OrderedDict([('A1', DiskElectrode(name=None, r=100..., x=0..., y=0..., z=0...))])
 
     """
     # Frozen class: User cannot add more class attributes
@@ -272,7 +272,7 @@ class ElectrodeGrid(ElectrodeArray):
     >>> from pulse2percept.implants import ElectrodeGrid, DiskElectrode
     >>> ElectrodeGrid((3, 4), 20, x=10, y=20, z=500, names=('A', '1'), r=10,
     ...               type='hex', etype=DiskElectrode) # doctest: +NORMALIZE_WHITESPACE +ELLIPSIS
-    ElectrodeGrid(shape=(3, 4), spacing=20, type='hex')
+    ElectrodeGrid(rot=0, shape=(3, 4), spacing=20, type='hex')
 
     A rectangulr electrode grid with 2 rows and 4 columns, made of disk
     electrodes with 10um radius spaced 20um apart, centered at (10, 20)um, and

--- a/pulse2percept/implants/electrode_arrays.py
+++ b/pulse2percept/implants/electrode_arrays.py
@@ -260,8 +260,13 @@ class ElectrodeGrid(ElectrodeArray):
         Electrode-to-electrode spacing in microns.
     type : {'rect', 'hex'}, optional
         Grid type ('rect': rectangular, 'hex': hexagonal).
-    x, y, z : double, optional
-        3D coordinates of the center of the grid
+    x/y/z : double
+        3D location of the center of the grid.
+        The coordinate system is centered over the fovea.
+        Positive ``x`` values move the electrode into the nasal retina.
+        Positive ``y`` values move the electrode into the superior retina.
+        Positive ``z`` values move the electrode away from the retina into the
+        vitreous humor (sometimes called electrode-retina distance).
     rot : double, optional
         Rotation of the grid in degrees (positive angle: counter-clockwise
         rotation on the retinal surface)

--- a/pulse2percept/implants/electrodes.py
+++ b/pulse2percept/implants/electrodes.py
@@ -16,6 +16,13 @@ class Electrode(PrettyPrint, metaclass=ABCMeta):
     """Electrode
 
     Abstract base class for all electrodes.
+
+    Parameters
+    ----------
+    x/y/z : double
+        3D location of the point source
+    name : str, optional
+        Electrode name
     """
     __slots__ = ('x', 'y', 'z', 'name', 'plot_patch', 'plot_kwargs')
 
@@ -87,6 +94,8 @@ class PointSource(Electrode):
     ----------
     x/y/z : double
         3D location of the point source
+    name : str, optional
+        Electrode name
 
     """
     # Frozen class: User cannot add more class attributes
@@ -144,6 +153,8 @@ class DiskElectrode(Electrode):
         3D location that is the center of the disk electrode
     r : double
         Disk radius in the x,y plane
+    name : str, optional
+        Electrode name
 
     """
     # Frozen class: User cannot add more class attributes
@@ -226,6 +237,8 @@ class SquareElectrode(Electrode):
         3D location that is the center of the square electrode
     a : double
         Side length of the square
+    name : str, optional
+        Electrode name
 
     """
     # Frozen class: User cannot add more class attributes
@@ -265,6 +278,8 @@ class HexElectrode(Electrode):
     a : double
         Length of line drawn from the center of the hexagon to the midpoint of
         one of its sides.
+    name : str, optional
+        Electrode name
 
     """
     # Frozen class: User cannot add more class attributes

--- a/pulse2percept/implants/electrodes.py
+++ b/pulse2percept/implants/electrodes.py
@@ -17,9 +17,9 @@ class Electrode(PrettyPrint, metaclass=ABCMeta):
 
     Abstract base class for all electrodes.
     """
-    __slots__ = ('x', 'y', 'z', 'plot_patch', 'plot_kwargs')
+    __slots__ = ('x', 'y', 'z', 'name', 'plot_patch', 'plot_kwargs')
 
-    def __init__(self, x, y, z):
+    def __init__(self, x, y, z, name=None):
         if isinstance(x, (Sequence, np.ndarray)):
             raise TypeError("x must be a scalar, not %s." % (type(x)))
         if isinstance(y, (Sequence, np.ndarray)):
@@ -29,6 +29,7 @@ class Electrode(PrettyPrint, metaclass=ABCMeta):
         self.x = x
         self.y = y
         self.z = z
+        self.name = name
         # A matplotlib.patches object (e.g., Circle, Rectangle) that can be
         # used to plot the electrode:
         self.plot_patch = None
@@ -38,7 +39,7 @@ class Electrode(PrettyPrint, metaclass=ABCMeta):
 
     def _pprint_params(self):
         """Return dict of class attributes to pretty-print"""
-        return {'x': self.x, 'y': self.y, 'z': self.z}
+        return {'x': self.x, 'y': self.y, 'z': self.z, 'name': self.name}
 
     @abstractmethod
     def electric_potential(self, x, y, z, *args, **kwargs):
@@ -91,8 +92,8 @@ class PointSource(Electrode):
     # Frozen class: User cannot add more class attributes
     __slots__ = ()
 
-    def __init__(self, x, y, z):
-        super(PointSource, self).__init__(x, y, z)
+    def __init__(self, x, y, z, name=None):
+        super(PointSource, self).__init__(x, y, z, name=name)
         self.plot_patch = Circle
         self.plot_kwargs = {'radius': 5, 'linewidth': 2,
                             'ec': (0.3, 0.3, 0.3, 1),
@@ -148,8 +149,8 @@ class DiskElectrode(Electrode):
     # Frozen class: User cannot add more class attributes
     __slots__ = ('r',)
 
-    def __init__(self, x, y, z, r):
-        super(DiskElectrode, self).__init__(x, y, z)
+    def __init__(self, x, y, z, r, name=None):
+        super(DiskElectrode, self).__init__(x, y, z, name)
         if isinstance(r, (Sequence, np.ndarray)):
             raise TypeError("Electrode radius must be a scalar.")
         if r <= 0:
@@ -230,8 +231,8 @@ class SquareElectrode(Electrode):
     # Frozen class: User cannot add more class attributes
     __slots__ = ('a')
 
-    def __init__(self, x, y, z, a):
-        super(SquareElectrode, self).__init__(x, y, z)
+    def __init__(self, x, y, z, a, name=None):
+        super(SquareElectrode, self).__init__(x, y, z, name=name)
         if isinstance(a, (Sequence, np.ndarray)):
             raise TypeError("Side length must be a scalar.")
         if a <= 0:
@@ -269,8 +270,8 @@ class HexElectrode(Electrode):
     # Frozen class: User cannot add more class attributes
     __slots__ = ('a')
 
-    def __init__(self, x, y, z, a):
-        super(HexElectrode, self).__init__(x, y, z)
+    def __init__(self, x, y, z, a, name=None):
+        super(HexElectrode, self).__init__(x, y, z, name=name)
         if isinstance(a, (Sequence, np.ndarray)):
             raise TypeError("Apothem of the hexagon must be a scalar.")
         if a <= 0:

--- a/pulse2percept/implants/electrodes.py
+++ b/pulse2percept/implants/electrodes.py
@@ -20,7 +20,12 @@ class Electrode(PrettyPrint, metaclass=ABCMeta):
     Parameters
     ----------
     x/y/z : double
-        3D location of the point source
+        3D location of the electrode.
+        The coordinate system is centered over the fovea.
+        Positive ``x`` values move the electrode into the nasal retina.
+        Positive ``y`` values move the electrode into the superior retina.
+        Positive ``z`` values move the electrode away from the retina into the
+        vitreous humor (sometimes called electrode-retina distance).
     name : str, optional
         Electrode name
     activated : bool
@@ -103,7 +108,12 @@ class PointSource(Electrode):
     Parameters
     ----------
     x/y/z : double
-        3D location of the point source
+        3D location of the electrode.
+        The coordinate system is centered over the fovea.
+        Positive ``x`` values move the electrode into the nasal retina.
+        Positive ``y`` values move the electrode into the superior retina.
+        Positive ``z`` values move the electrode away from the retina into the
+        vitreous humor (sometimes called electrode-retina distance).
     name : str, optional
         Electrode name
     activated : bool
@@ -167,7 +177,12 @@ class DiskElectrode(Electrode):
     Parameters
     ----------
     x/y/z : double
-        3D location that is the center of the disk electrode
+        3D location of the electrode.
+        The coordinate system is centered over the fovea.
+        Positive ``x`` values move the electrode into the nasal retina.
+        Positive ``y`` values move the electrode into the superior retina.
+        Positive ``z`` values move the electrode away from the retina into the
+        vitreous humor (sometimes called electrode-retina distance).
     r : double
         Disk radius in the x,y plane
     name : str, optional
@@ -257,7 +272,12 @@ class SquareElectrode(Electrode):
     Parameters
     ----------
     x/y/z : double
-        3D location that is the center of the square electrode
+        3D location of the electrode.
+        The coordinate system is centered over the fovea.
+        Positive ``x`` values move the electrode into the nasal retina.
+        Positive ``y`` values move the electrode into the superior retina.
+        Positive ``z`` values move the electrode away from the retina into the
+        vitreous humor (sometimes called electrode-retina distance).
     a : double
         Side length of the square
     name : str, optional
@@ -305,7 +325,12 @@ class HexElectrode(Electrode):
     Parameters
     ----------
     x/y/z : double
-        3D location that is the center of the hexagonal electrode
+        3D location of the electrode.
+        The coordinate system is centered over the fovea.
+        Positive ``x`` values move the electrode into the nasal retina.
+        Positive ``y`` values move the electrode into the superior retina.
+        Positive ``z`` values move the electrode away from the retina into the
+        vitreous humor (sometimes called electrode-retina distance).
     a : double
         Length of line drawn from the center of the hexagon to the midpoint of
         one of its sides.

--- a/pulse2percept/implants/prima.py
+++ b/pulse2percept/implants/prima.py
@@ -31,8 +31,8 @@ class PhotovoltaicPixel(HexElectrode):
     # Frozen class: User cannot add more class attributes
     __slots__ = ('r', 'a')
 
-    def __init__(self, x, y, z, r, a):
-        super(PhotovoltaicPixel, self).__init__(x, y, z, a)
+    def __init__(self, x, y, z, r, a, name=None):
+        super(PhotovoltaicPixel, self).__init__(x, y, z, a, name=name)
         if isinstance(r, (Sequence, np.ndarray)):
             raise TypeError("Radius of the active electrode must be a scalar.")
         if r <= 0:
@@ -137,7 +137,7 @@ class PRIMA(ProsthesisSystem):
             if z_arr.size != self.n_electrodes:
                 raise ValueError("If `z` is a list, it must have %d entries, "
                                  "not %d." % (self.n_electrodes, z_arr.size))
-            for elec, z_elec in zip(self.earray.values(), z):
+            for elec, z_elec in zip(self.earray.electrode_objects, z):
                 elec.z = z_elec
 
         # Beware of race condition: Stim must be set last, because it requires
@@ -223,7 +223,7 @@ class PRIMA75(ProsthesisSystem):
             if z_arr.size != self.n_electrodes:
                 raise ValueError("If `z` is a list, it must have %d entries, "
                                  "not %d." % (self.n_electrodes, z_arr.size))
-            for elec, z_elec in zip(self.earray.values(), z):
+            for elec, z_elec in zip(self.earray.electrode_objects, z):
                 elec.z = z_elec
 
         # Beware of race condition: Stim must be set last, because it requires
@@ -319,7 +319,7 @@ class PRIMA55(ProsthesisSystem):
             if z_arr.size != self.n_electrodes:
                 raise ValueError("If `z` is a list, it must have %d entries, "
                                  "not %d." % (self.n_electrodes, z_arr.size))
-            for elec, z_elec in zip(self.earray.values(), z):
+            for elec, z_elec in zip(self.earray.electrode_objects, z):
                 elec.z = z_elec
 
         # Beware of race condition: Stim must be set last, because it requires
@@ -422,7 +422,7 @@ class PRIMA40(ProsthesisSystem):
             if z_arr.size != self.n_electrodes:
                 raise ValueError("If `z` is a list, it must have %d entries, "
                                  "not %d." % (self.n_electrodes, z_arr.size))
-            for elec, z_elec in zip(self.earray.values(), z):
+            for elec, z_elec in zip(self.earray.electrode_objects, z):
                 elec.z = z_elec
 
         # Beware of race condition: Stim must be set last, because it requires

--- a/pulse2percept/implants/prima.py
+++ b/pulse2percept/implants/prima.py
@@ -26,13 +26,17 @@ class PhotovoltaicPixel(HexElectrode):
     a : double
         Length of line drawn from the center of the hexagon to the midpoint of
         one of its sides.
+    activated : bool
+        To deactivate, set to ``False``. Deactivated electrodes cannot receive
+        stimuli.
 
     """
     # Frozen class: User cannot add more class attributes
     __slots__ = ('r', 'a')
 
-    def __init__(self, x, y, z, r, a, name=None):
-        super(PhotovoltaicPixel, self).__init__(x, y, z, a, name=name)
+    def __init__(self, x, y, z, r, a, name=None, activated=True):
+        super(PhotovoltaicPixel, self).__init__(x, y, z, a, name=name,
+                                                activated=activated)
         if isinstance(r, (Sequence, np.ndarray)):
             raise TypeError("Radius of the active electrode must be a scalar.")
         if r <= 0:
@@ -42,10 +46,15 @@ class PhotovoltaicPixel(HexElectrode):
         # Plot two objects: hex honeycomb and circular active electrode
         self.plot_patch = [RegularPolygon, Circle]
         self.plot_kwargs = [{'radius': a, 'numVertices': 6, 'alpha': 0.2,
-                             'orientation': np.radians(30), 'fc': 'k',
-                             'ec': 'k'},
+                             'orientation': np.radians(30),
+                             'fc': 'k', 'ec': 'k'},
                             {'radius': r, 'linewidth': 0, 'color': 'k',
                              'alpha': 0.5}]
+        self.plot_deactivated_kwargs = [{'radius': a, 'numVertices': 6,
+                                         'orientation': np.radians(30),
+                                         'fc': 'k', 'ec': 'k', 'alpha': 0.1},
+                                        {'radius': r, 'linewidth': 0,
+                                         'color': 'k', 'alpha': 0.2}]
 
     def _pprint_params(self):
         """Return dict of class attributes to pretty-print"""

--- a/pulse2percept/implants/prima.py
+++ b/pulse2percept/implants/prima.py
@@ -89,6 +89,12 @@ class PRIMA(ProsthesisSystem):
         system.
     eye : {'RE', 'LE'}, optional
         Eye in which array is implanted.
+    preprocess : bool or callable, optional
+        Either True/False to indicate whether to execute the implant's default
+        preprocessing method whenever a new stimulus is assigned, or a custom
+        function (callable).
+    safe_mode : bool, optional
+        If safe mode is enabled, only charge-balanced stimuli are allowed.
 
     Notes
     -----
@@ -99,7 +105,8 @@ class PRIMA(ProsthesisSystem):
     # Frozen class: User cannot add more class attributes
     __slots__ = ('shape', 'spacing', 'trench')
 
-    def __init__(self, x=0, y=0, z=-100, rot=0, eye='RE', stim=None):
+    def __init__(self, x=0, y=0, z=-100, rot=0, eye='RE', stim=None,
+                 preprocess=False, safe_mode=False):
         # 85 um pixels with 15 um trenches, 28 um active electrode:
         self.trench = 15  # um
         self.spacing = 100  # um
@@ -107,6 +114,8 @@ class PRIMA(ProsthesisSystem):
         # Roughly a 19x22 grid, but edges are trimmed off:
         self.shape = (19, 22)
         self.eye = eye
+        self.preprocess = preprocess
+        self.safe_mode = safe_mode
 
         # The user might provide a list of z values for each of the
         # 378 resulting electrodes, not for the 22x19 initial ones.
@@ -177,12 +186,19 @@ class PRIMA75(ProsthesisSystem):
         system.
     eye : {'RE', 'LE'}, optional
         Eye in which array is implanted.
+    preprocess : bool or callable, optional
+        Either True/False to indicate whether to execute the implant's default
+        preprocessing method whenever a new stimulus is assigned, or a custom
+        function (callable).
+    safe_mode : bool, optional
+        If safe mode is enabled, only charge-balanced stimuli are allowed.
 
     """
     # Frozen class: User cannot add more class attributes
     __slots__ = ('shape', 'spacing', 'trench')
 
-    def __init__(self, x=0, y=0, z=-100, rot=0, eye='RE', stim=None):
+    def __init__(self, x=0, y=0, z=-100, rot=0, eye='RE', stim=None,
+                 preprocess=False, safe_mode=False):
         # 70 um pixels with 5 um trenches, 20 um active electrode:
         self.spacing = 75  # um
         self.trench = 5  # um
@@ -190,6 +206,8 @@ class PRIMA75(ProsthesisSystem):
         # Roughly a 12x15 grid, but edges are trimmed off:
         self.shape = (12, 15)
         self.eye = eye
+        self.preprocess = preprocess
+        self.safe_mode = safe_mode
 
         # The user might provide a list of z values for each of the
         # 378 resulting electrodes, not for the 22x19 initial ones.
@@ -268,12 +286,19 @@ class PRIMA55(ProsthesisSystem):
         system.
     eye : {'RE', 'LE'}, optional
         Eye in which array is implanted.
+    preprocess : bool or callable, optional
+        Either True/False to indicate whether to execute the implant's default
+        preprocessing method whenever a new stimulus is assigned, or a custom
+        function (callable).
+    safe_mode : bool, optional
+        If safe mode is enabled, only charge-balanced stimuli are allowed.
 
     """
     # Frozen class: User cannot add more class attributes
     __slots__ = ('shape', 'spacing', 'trench')
 
-    def __init__(self, x=0, y=0, z=-100, rot=0, eye='RE', stim=None):
+    def __init__(self, x=0, y=0, z=-100, rot=0, eye='RE', stim=None,
+                 preprocess=False, safe_mode=False):
         # 50 um pixels with 5 um trenches, 16 um active electrode:
         self.spacing = 55  # um
         self.trench = 5
@@ -281,6 +306,8 @@ class PRIMA55(ProsthesisSystem):
         # Roughly a 18x21 grid, but edges are trimmed off:
         self.shape = (18, 21)
         self.eye = eye
+        self.preprocess = preprocess
+        self.safe_mode = safe_mode
 
         # The user might provide a list of z values for each of the
         # 378 resulting electrodes, not for the 22x19 initial ones.
@@ -364,12 +391,19 @@ class PRIMA40(ProsthesisSystem):
         system.
     eye : {'LE', 'RE'}, optional
         Eye in which array is implanted.
+    preprocess : bool or callable, optional
+        Either True/False to indicate whether to execute the implant's default
+        preprocessing method whenever a new stimulus is assigned, or a custom
+        function (callable).
+    safe_mode : bool, optional
+        If safe mode is enabled, only charge-balanced stimuli are allowed.
 
     """
     # Frozen class: User cannot add more class attributes
     __slots__ = ('shape', 'spacing', 'trench')
 
-    def __init__(self, x=0, y=0, z=-100, rot=0, eye='RE', stim=None):
+    def __init__(self, x=0, y=0, z=-100, rot=0, eye='RE', stim=None,
+                 preprocess=False, safe_mode=False):
         # 35 um pixels with 5 um trenches, 16 um active electrode:
         self.spacing = 40  # um
         self.trench = 5  # um
@@ -377,6 +411,8 @@ class PRIMA40(ProsthesisSystem):
         # Roughly a 25x28 grid, but edges are trimmed off:
         self.shape = (25, 28)
         self.eye = eye
+        self.preprocess = preprocess
+        self.safe_mode = safe_mode
 
         # The user might provide a list of z values for each of the
         # 378 resulting electrodes, not for the 22x19 initial ones.

--- a/pulse2percept/implants/prima.py
+++ b/pulse2percept/implants/prima.py
@@ -20,7 +20,12 @@ class PhotovoltaicPixel(HexElectrode):
     Parameters
     ----------
     x/y/z : double
-        3D location that is the center of the disk electrode
+        3D location of the electrode.
+        The coordinate system is centered over the fovea.
+        Positive ``x`` values move the electrode into the nasal retina.
+        Positive ``y`` values move the electrode into the superior retina.
+        Positive ``z`` values move the electrode away from the retina into the
+        vitreous humor (sometimes called electrode-retina distance).
     r : double
         Disk radius in the x,y plane
     a : double
@@ -85,13 +90,15 @@ class PRIMA(ProsthesisSystem):
 
     Parameters
     ----------
-    x : float, optional
-        x coordinate of the array center (um)
-    y : float, optional
-        y coordinate of the array center (um)
-    z: float or array_like, optional
-        Distance of the array to the retinal surface (um). Either a list
-        with 378 entries or a scalar.
+    x/y/z : double
+        3D location of the center of the electrode array.
+        The coordinate system is centered over the fovea.
+        Positive ``x`` values move the electrode into the nasal retina.
+        Positive ``y`` values move the electrode into the superior retina.
+        Positive ``z`` values move the electrode away from the retina into the
+        vitreous humor (sometimes called electrode-retina distance).
+        ``z`` can either be a list with 378 entries or a scalar that is applied
+        to all electrodes.
     rot : float, optional
         Rotation angle of the array (deg). Positive values denote
         counter-clock-wise (CCW) rotations in the retinal coordinate
@@ -182,13 +189,15 @@ class PRIMA75(ProsthesisSystem):
 
     Parameters
     ----------
-    x : float, optional
-        x coordinate of the array center (um)
-    y : float, optional
-        y coordinate of the array center (um)
-    z: float or array_like, optional
-        Distance of the array to the retinal surface (um). Either a list
-        with 142 entries or a scalar.
+    x/y/z : double
+        3D location of the center of the electrode array.
+        The coordinate system is centered over the fovea.
+        Positive ``x`` values move the electrode into the nasal retina.
+        Positive ``y`` values move the electrode into the superior retina.
+        Positive ``z`` values move the electrode away from the retina into the
+        vitreous humor (sometimes called electrode-retina distance).
+        ``z`` can either be a list with 142 entries or a scalar that is applied
+        to all electrodes.
     rot : float, optional
         Rotation angle of the array (deg). Positive values denote
         counter-clock-wise (CCW) rotations in the retinal coordinate
@@ -282,13 +291,15 @@ class PRIMA55(ProsthesisSystem):
 
     Parameters
     ----------
-    x : float, optional
-        x coordinate of the array center (um)
-    y : float, optional
-        y coordinate of the array center (um)
-    z: float or array_like, optional
-        Distance of the array to the retinal surface (um). Either a list
-        with 378 entries or a scalar.
+    x/y/z : double
+        3D location of the center of the electrode array.
+        The coordinate system is centered over the fovea.
+        Positive ``x`` values move the electrode into the nasal retina.
+        Positive ``y`` values move the electrode into the superior retina.
+        Positive ``z`` values move the electrode away from the retina into the
+        vitreous humor (sometimes called electrode-retina distance).
+        ``z`` can either be a list with 378 entries or a scalar that is applied
+        to all electrodes.
     rot : float, optional
         Rotation angle of the array (deg). Positive values denote
         counter-clock-wise (CCW) rotations in the retinal coordinate
@@ -387,13 +398,15 @@ class PRIMA40(ProsthesisSystem):
 
     Parameters
     ----------
-    x : float, optional
-        x coordinate of the array center (um)
-    y : float, optional
-        y coordinate of the array center (um)
-    z: float or array_like, optional
-        Distance of the array to the retinal surface (um). Either a list
-        with 378 entries or a scalar.
+    x/y/z : double
+        3D location of the center of the electrode array.
+        The coordinate system is centered over the fovea.
+        Positive ``x`` values move the electrode into the nasal retina.
+        Positive ``y`` values move the electrode into the superior retina.
+        Positive ``z`` values move the electrode away from the retina into the
+        vitreous humor (sometimes called electrode-retina distance).
+        ``z`` can either be a list with 532 entries or a scalar that is applied
+        to all electrodes.
     rot : float, optional
         Rotation angle of the array (deg). Positive values denote
         counter-clock-wise (CCW) rotations in the retinal coordinate

--- a/pulse2percept/implants/tests/test_alpha.py
+++ b/pulse2percept/implants/tests/test_alpha.py
@@ -13,11 +13,11 @@ def test_AlphaIMS(ztype, x, y, rot):
     # Height `h` can either be a float or a list
     if ztype == 'float':
         alpha = AlphaIMS(x=x, y=y, z=-100, rot=rot)
-        for e in alpha.values():
+        for e in alpha.electrode_objects:
             npt.assert_almost_equal(e.z, -100)
     else:
         alpha = AlphaIMS(x=x, y=y, z=np.arange(1500), rot=rot)
-        for i, e in enumerate(alpha.values()):
+        for i, e in enumerate(alpha.electrode_objects):
             npt.assert_almost_equal(e.z, i)
 
     # Slots:
@@ -58,7 +58,7 @@ def test_AlphaIMS(ztype, x, y, rot):
     alpha = AlphaIMS()
     # enumerate returns ((0, alpha.items()[0]), (1, alpha.items()[1]), ...)
     # idx = 0, ... 36. name = A1, ... e37. electrode = DiskElectrode(...)
-    for idx, (name, electrode) in enumerate(alpha.items()):
+    for idx, (name, electrode) in enumerate(alpha.electrodes.items()):
         npt.assert_equal(electrode, alpha[idx])
         npt.assert_equal(electrode, alpha[name])
         npt.assert_equal(alpha["unlikely name for an electrode"], None)
@@ -97,11 +97,11 @@ def test_AlphaAMS(ztype, x, y, rot):
     # Height `h` can either be a float or a list
     if ztype == 'float':
         alpha = AlphaAMS(x=x, y=y, z=-100, rot=rot)
-        for e in alpha.values():
+        for e in alpha.electrode_objects:
             npt.assert_almost_equal(e.z, -100)
     else:
         alpha = AlphaAMS(x=x, y=y, z=np.arange(1600), rot=rot)
-        for i, e in enumerate(alpha.values()):
+        for i, e in enumerate(alpha.electrode_objects):
             npt.assert_almost_equal(e.z, i)
 
     # Slots:
@@ -137,7 +137,7 @@ def test_AlphaAMS(ztype, x, y, rot):
     alpha = AlphaAMS()
     # enumerate returns ((0, alpha.items()[0]), (1, alpha.items()[1]), ...)
     # idx = 0, ... 36. name = A1, ... e37. electrode = DiskElectrode(...)
-    for idx, (name, electrode) in enumerate(alpha.items()):
+    for idx, (name, electrode) in enumerate(alpha.electrodes.items()):
         npt.assert_equal(electrode, alpha[idx])
         npt.assert_equal(electrode, alpha[name])
         npt.assert_equal(alpha["unlikely name for an electrode"], None)

--- a/pulse2percept/implants/tests/test_argus.py
+++ b/pulse2percept/implants/tests/test_argus.py
@@ -59,7 +59,7 @@ def test_ArgusI(ztype, x, y, rot):
     # Indexing must work for both integers and electrode names
     for use_legacy_names in [True, False]:
         argus = implants.ArgusI(use_legacy_names=use_legacy_names)
-        for idx, (name, electrode) in enumerate(argus.items()):
+        for idx, (name, electrode) in enumerate(argus.electrodes.items()):
             npt.assert_equal(electrode, argus[idx])
             npt.assert_equal(electrode, argus[name])
         npt.assert_equal(argus["unlikely name for an electrode"], None)
@@ -86,12 +86,12 @@ def test_ArgusI(ztype, x, y, rot):
 
     # Check naming scheme
     argus = implants.ArgusI(use_legacy_names=False)
-    npt.assert_equal(list(argus.keys())[15], 'D4')
-    npt.assert_equal(list(argus.keys())[0], 'A1')
+    npt.assert_equal(argus.electrode_names[15], 'D4')
+    npt.assert_equal(argus.electrode_names[0], 'A1')
 
     argus = implants.ArgusI(use_legacy_names=True)
-    npt.assert_equal(list(argus.keys())[15], 'M1')
-    npt.assert_equal(list(argus.keys())[0], 'L6')
+    npt.assert_equal(argus.electrode_names[15], 'M1')
+    npt.assert_equal(argus.electrode_names[0], 'L6')
 
     # Set a stimulus via dict:
     argus = implants.ArgusI(stim={'B3': 13})
@@ -150,7 +150,7 @@ def test_ArgusII(ztype, x, y, rot):
 
     # Indexing must work for both integers and electrode names
     argus = implants.ArgusII()
-    for idx, (name, electrode) in enumerate(argus.items()):
+    for idx, (name, electrode) in enumerate(argus.electrodes.items()):
         npt.assert_equal(electrode, argus[idx])
         npt.assert_equal(electrode, argus[name])
     npt.assert_equal(argus["unlikely name for an electrode"], None)

--- a/pulse2percept/implants/tests/test_base.py
+++ b/pulse2percept/implants/tests/test_base.py
@@ -63,3 +63,14 @@ def test_ProsthesisSystem_stim():
     stim = Stimulus(np.ones((13 * 13 + 1, 5)))
     with pytest.raises(ValueError):
         implant.stim = stim
+
+    # Deactivated electrodes cannot receive stimuli:
+    implant.deactivate('H4')
+    npt.assert_equal(implant['H4'].activated, False)
+    with pytest.raises(ValueError):
+        implant.stim = {'H4': 1}
+    implant.deactivate('all')
+    with pytest.raises(ValueError):
+        implant.stim = [1] * implant.n_electrodes
+    implant.activate('all')
+    implant.stim = {'H4': 1}

--- a/pulse2percept/implants/tests/test_base.py
+++ b/pulse2percept/implants/tests/test_base.py
@@ -21,7 +21,7 @@ def test_ProsthesisSystem():
     implant = ProsthesisSystem(PointSource(0, 0, 0))
     npt.assert_equal(implant.n_electrodes, 1)
     npt.assert_equal(implant[0], implant.earray[0])
-    npt.assert_equal(implant.keys(), implant.earray.keys())
+    npt.assert_equal(implant.electrode_names, implant.earray.electrode_names)
     for i, e in zip(implant, implant.earray):
         npt.assert_equal(i, e)
 

--- a/pulse2percept/implants/tests/test_base.py
+++ b/pulse2percept/implants/tests/test_base.py
@@ -48,6 +48,10 @@ def test_ProsthesisSystem():
         implant.stim = {'A1': 1}
     with pytest.raises(ValueError):
         implant.stim = Stimulus({'A1': 1})
+    # Safe mode requires charge-balanced pulses:
+    with pytest.raises(ValueError):
+        implant = ProsthesisSystem(PointSource(0, 0, 0), safe_mode=True)
+        implant.stim = 1
 
     # Slots:
     npt.assert_equal(hasattr(implant, '__slots__'), True)

--- a/pulse2percept/implants/tests/test_electrode_arrays.py
+++ b/pulse2percept/implants/tests/test_electrode_arrays.py
@@ -177,11 +177,11 @@ def test_ElectrodeGrid(gtype):
     spacing = 100
     grid = ElectrodeGrid(gshape, spacing, type=gtype, etype=DiskElectrode,
                          r=13)
-    for e in grid.values():
+    for (_, e) in grid.electrodes.items():
         npt.assert_almost_equal(e.r, 13)
     grid = ElectrodeGrid(gshape, spacing, type=gtype, etype=DiskElectrode,
                          r=np.arange(1, np.prod(gshape) + 1))
-    for i, e in enumerate(grid.values()):
+    for i, (_, e) in enumerate(grid.electrodes.items()):
         npt.assert_almost_equal(e.r, i + 1)
     with pytest.raises(ValueError):
         ElectrodeGrid(gshape, spacing, type=gtype, etype=DiskElectrode)
@@ -241,22 +241,24 @@ def test_ElectrodeGrid(gtype):
     npt.assert_equal(egrid.shape, gshape)
     npt.assert_equal(egrid.n_electrodes, np.prod(gshape))
     # Make sure different electrodes have different coordinates:
-    npt.assert_equal(len(np.unique([e.x for e in egrid.values()])), gshape[1])
-    npt.assert_equal(len(np.unique([e.y for e in egrid.values()])), gshape[0])
+    npt.assert_equal(len(np.unique([e.x for e in egrid.electrode_objects])),
+                     gshape[1])
+    npt.assert_equal(len(np.unique([e.y for e in egrid.electrode_objects])),
+                     gshape[0])
     # Make sure the average of all x-coordinates == x:
     # (Note: egrid has all electrodes in a dictionary, with (name, object)
     # as (key, value) pairs. You can get the electrode names by iterating over
     # egrid.keys(). You can get the electrode objects by iterating over
     # egrid.values().)
-    npt.assert_almost_equal(np.mean([e.x for e in egrid.values()]), x)
+    npt.assert_almost_equal(np.mean([e.x for e in egrid.electrode_objects]), x)
     # Same for y:
-    npt.assert_almost_equal(np.mean([e.y for e in egrid.values()]), y)
+    npt.assert_almost_equal(np.mean([e.y for e in egrid.electrode_objects]), y)
 
     # Test whether egrid.z is set correctly, when z is a constant:
     z = 12
     egrid = ElectrodeGrid(gshape, spacing, z=z, type=gtype,
                           etype=DiskElectrode, r=radius)
-    for i in egrid.values():
+    for i in egrid.electrode_objects:
         npt.assert_equal(i.z, z)
 
     # and when every electrode has a different z:
@@ -264,7 +266,7 @@ def test_ElectrodeGrid(gtype):
     egrid = ElectrodeGrid(gshape, spacing, z=z, type=gtype,
                           etype=DiskElectrode, r=radius)
     x = -1
-    for i in egrid.values():
+    for i in egrid.electrode_objects:
         npt.assert_equal(i.z, x + 1)
         x = i.z
 
@@ -321,35 +323,35 @@ def test_ElectrodeGrid(gtype):
     gshape = (2, 3)
     egrid = ElectrodeGrid(gshape, spacing, type=gtype, names=('A', '1'))
     # print([e for e in egrid.keys()])
-    npt.assert_equal([e for e in egrid.keys()],
+    npt.assert_equal([e for e in egrid.electrode_names],
                      ['A1', 'A2', 'A3', 'B1', 'B2', 'B3'])
     egrid = ElectrodeGrid(gshape, spacing, type=gtype, names=('1', 'A'))
     # print([e for e in egrid.keys()])
     # egrid = ElectrodeGrid(shape, names=('A', '1'))
-    npt.assert_equal([e for e in egrid.keys()],
+    npt.assert_equal([e for e in egrid.electrode_names],
                      ['A1', 'B1', 'C1', 'A2', 'B2', 'C2'])
 
     egrid = ElectrodeGrid(gshape, spacing, type=gtype, names=('1', '1'))
     # print([e for e in egrid.keys()])
-    npt.assert_equal([e for e in egrid.keys()],
+    npt.assert_equal([e for e in egrid.electrode_names],
                      ['11', '12', '13', '21', '22', '23'])
     egrid = ElectrodeGrid(gshape, spacing, type=gtype, names=('A', 'A'))
     # print([e for e in egrid.keys()])
-    npt.assert_equal([e for e in egrid.keys()],
+    npt.assert_equal([e for e in egrid.electrode_names],
                      ['AA', 'AB', 'AC', 'BA', 'BB', 'BC'])
 
     # Still starts at A:
     egrid = ElectrodeGrid(gshape, spacing, type=gtype, names=('B', '1'))
-    npt.assert_equal([e for e in egrid.keys()],
+    npt.assert_equal([e for e in egrid.electrode_names],
                      ['A1', 'A2', 'A3', 'B1', 'B2', 'B3'])
     egrid = ElectrodeGrid(gshape, spacing, type=gtype, names=('A', '2'))
-    npt.assert_equal([e for e in egrid.keys()],
+    npt.assert_equal([e for e in egrid.electrode_names],
                      ['A1', 'A2', 'A3', 'B1', 'B2', 'B3'])
 
     # test unique names
     egrid = ElectrodeGrid(gshape, spacing, type=gtype,
                           names=['53', '18', '00', '81', '11', '12'])
-    npt.assert_equal([e for e in egrid.keys()],
+    npt.assert_equal([e for e in egrid.electrode_names],
                      ['53', '18', '00', '81', '11', '12'])
 
     # Slots:

--- a/pulse2percept/implants/tests/test_electrodes.py
+++ b/pulse2percept/implants/tests/test_electrodes.py
@@ -16,10 +16,11 @@ class ValidElectrode(Electrode):
 
 
 def test_Electrode():
-    electrode = ValidElectrode(0, 1, 2)
+    electrode = ValidElectrode(0, 1, 2, name='A001')
     npt.assert_almost_equal(electrode.x, 0)
     npt.assert_almost_equal(electrode.y, 1)
     npt.assert_almost_equal(electrode.z, 2)
+    npt.assert_equal(electrode.name, 'A001')
     npt.assert_almost_equal(electrode.electric_potential(0, 1, 2), 0)
     with pytest.raises(TypeError):
         ValidElectrode([0], 1, 2)
@@ -33,10 +34,11 @@ def test_Electrode():
 
 
 def test_PointSource():
-    electrode = PointSource(0, 1, 2)
+    electrode = PointSource(0, 1, 2, name='A001')
     npt.assert_almost_equal(electrode.x, 0)
     npt.assert_almost_equal(electrode.y, 1)
     npt.assert_almost_equal(electrode.z, 2)
+    npt.assert_equal(electrode.name, 'A001')
     npt.assert_almost_equal(electrode.electric_potential(0, 1, 2, 1, 1), 1)
     npt.assert_almost_equal(electrode.electric_potential(0, 0, 0, 1, 1), 0.035,
                             decimal=3)
@@ -59,10 +61,11 @@ def test_DiskElectrode():
     with pytest.raises(ValueError):
         DiskElectrode(0, 0, 0, -5)
     # Check params:
-    electrode = DiskElectrode(0, 1, 2, 100)
+    electrode = DiskElectrode(0, 1, 2, 100, name='A001')
     npt.assert_almost_equal(electrode.x, 0)
     npt.assert_almost_equal(electrode.y, 1)
     npt.assert_almost_equal(electrode.z, 2)
+    npt.assert_equal(electrode.name, 'A001')
     # On the electrode surface (z=2, x^2+y^2<=100^2)
     npt.assert_almost_equal(electrode.electric_potential(0, 1, 2, 1), 1)
     npt.assert_almost_equal(electrode.electric_potential(30, -30, 2, 1), 1)
@@ -97,11 +100,12 @@ def test_SquareElectrode():
     with pytest.raises(ValueError):
         SquareElectrode(0, 0, 0, -5)
     # Check params:
-    electrode = SquareElectrode(0, 1, 2, 100)
+    electrode = SquareElectrode(0, 1, 2, 100, name='A001')
     npt.assert_almost_equal(electrode.x, 0)
     npt.assert_almost_equal(electrode.y, 1)
     npt.assert_almost_equal(electrode.z, 2)
     npt.assert_almost_equal(electrode.a, 100)
+    npt.assert_equal(electrode.name, 'A001')
     # Slots:
     npt.assert_equal(hasattr(electrode, '__slots__'), True)
     npt.assert_equal(hasattr(electrode, '__dict__'), False)
@@ -121,11 +125,12 @@ def test_HexElectrode():
     with pytest.raises(ValueError):
         HexElectrode(0, 0, 0, -5)
     # Check params:
-    electrode = HexElectrode(0, 1, 2, 100)
+    electrode = HexElectrode(0, 1, 2, 100, name='A001')
     npt.assert_almost_equal(electrode.x, 0)
     npt.assert_almost_equal(electrode.y, 1)
     npt.assert_almost_equal(electrode.z, 2)
     npt.assert_almost_equal(electrode.a, 100)
+    npt.assert_equal(electrode.name, 'A001')
     # Slots:
     npt.assert_equal(hasattr(electrode, '__slots__'), True)
     npt.assert_equal(hasattr(electrode, '__dict__'), False)

--- a/pulse2percept/models/beyeler2019.py
+++ b/pulse2percept/models/beyeler2019.py
@@ -80,7 +80,7 @@ class ScoreboardSpatial(SpatialModel):
 
     def _predict_spatial(self, earray, stim):
         """Predicts the brightness at spatial locations"""
-        if not np.allclose([e.z for e in earray.values()], 0):
+        if not np.allclose([e.z for e in earray.electrode_objects], 0):
             msg = ("Nonzero electrode-retina distances do not have any effect "
                    "on the model output.")
             warnings.warn(msg)
@@ -643,7 +643,7 @@ class AxonMapSpatial(SpatialModel):
 
     def _predict_spatial(self, earray, stim):
         """Predicts the brightness at specific times ``t``"""
-        if not np.allclose([e.z for e in earray.values()], 0):
+        if not np.allclose([e.z for e in earray.electrode_objects], 0):
             msg = ("Nonzero electrode-retina distances do not have any effect "
                    "on the model output.")
             warnings.warn(msg)

--- a/pulse2percept/models/nanduri2012.py
+++ b/pulse2percept/models/nanduri2012.py
@@ -85,7 +85,7 @@ class Nanduri2012Spatial(SpatialModel):
 
     def predict_percept(self, implant, t_percept=None):
         if not np.all([isinstance(e, DiskElectrode)
-                       for e in implant.values()]):
+                       for e in implant.electrode_objects]):
             raise TypeError("The Nanduri2012 spatial model only supports "
                             "DiskElectrode arrays.")
         return super(Nanduri2012Spatial, self).predict_percept(

--- a/pulse2percept/stimuli/base.py
+++ b/pulse2percept/stimuli/base.py
@@ -329,7 +329,6 @@ class Stimulus(PrettyPrint):
         data = self.data
         electrodes = self.electrodes
         time = self.time
-        print(data.shape, data.dtype)
         # Remove rows (electrodes) with all zeros:
         keep_el = fast_compress_space(data)
         data = data[keep_el]
@@ -859,11 +858,13 @@ class Stimulus(PrettyPrint):
         """Flag indicating whether the stimulus is charge-balanced
 
         A stimulus with a time component is considered charge-balanced if its
-        net current is smaller than 10 pico Amps
+        net current is smaller than 10 pico Amps.
+        For the whole stimulus to be charge-balanced, every electrode must be
+        charge-balanced as well.
         """
         if self.time is None:
-            return None
-        return np.isclose(np.trapz(self.data, self.time)[0], 0, atol=MIN_AMP)
+            return np.allclose(self.data, 0, atol=MIN_AMP)
+        return np.allclose(np.trapz(self.data, x=self.time), 0, atol=MIN_AMP)
 
     @property
     def duration(self):

--- a/pulse2percept/stimuli/tests/test_base.py
+++ b/pulse2percept/stimuli/tests/test_base.py
@@ -120,6 +120,15 @@ def test_Stimulus():
     npt.assert_equal(stim.electrodes, [0, 1])
     npt.assert_almost_equal(stim.time, [0, 0.4])
 
+    # Charge-balanced:
+    npt.assert_equal(Stimulus(0).is_charge_balanced, True)
+    npt.assert_equal(Stimulus(1).is_charge_balanced, False)
+    npt.assert_equal(Stimulus([0, 0]).is_charge_balanced, True)
+    npt.assert_equal(Stimulus([[0, 0]]).is_charge_balanced, True)
+    npt.assert_equal(Stimulus([1, -1]).is_charge_balanced, False)
+    npt.assert_equal(Stimulus([[1, -1]]).is_charge_balanced, True)
+    npt.assert_equal(Stimulus([[1, -1], [0, 0.5]]).is_charge_balanced, False)
+
     # Not allowed:
     with pytest.raises(ValueError):
         # First one doesn't have time:

--- a/pulse2percept/viz/argus.py
+++ b/pulse2percept/viz/argus.py
@@ -122,8 +122,8 @@ def plot_argus_phosphenes(data, argus, scale=1.0, axon_map=None,
 
     # Add some padding to the output image so the array is not cut off:
     pad = 2000  # microns
-    x_el = [e.x for e in argus.values()]
-    y_el = [e.y for e in argus.values()]
+    x_el = [e.x for e in argus.electrode_objects]
+    y_el = [e.y for e in argus.electrode_objects]
     x_min = Watson2014Transform.ret2dva(np.min(x_el) - pad)
     x_max = Watson2014Transform.ret2dva(np.max(x_el) + pad)
     y_min = Watson2014Transform.ret2dva(np.min(y_el) - pad)
@@ -142,7 +142,7 @@ def plot_argus_phosphenes(data, argus, scale=1.0, axon_map=None,
             out_shape = data.image.values[0].shape
         except IndexError:
             out_shape = (768, 1024)
-    for xy, e in zip(px_argus, argus.values()):
+    for xy, e in zip(px_argus, argus.electrode_objects):
         x_dva, y_dva = Watson2014Transform.ret2dva([e.x, e.y])
         x_out = (x_dva - x_min) / (x_max - x_min) * (out_shape[1] - 1)
         y_out = (y_dva - y_min) / (y_max - y_min) * (out_shape[0] - 1)

--- a/pulse2percept/viz/axon_map.py
+++ b/pulse2percept/viz/axon_map.py
@@ -182,12 +182,16 @@ def plot_implant_on_axon_map(implant, loc_od=(15.5, 1.5), n_bundles=100,
     pad = 1500
     prec = 500
     if xlim is None:
-        xmin = np.ceil(np.min([el.x - pad for el in implant.values()]) / prec)
-        xmax = np.ceil(np.max([el.x + pad for el in implant.values()]) / prec)
+        xmin = np.ceil(np.min([el.x - pad
+                               for el in implant.electrode_objects]) / prec)
+        xmax = np.ceil(np.max([el.x + pad
+                               for el in implant.electrode_objects]) / prec)
         xlim = (prec * xmin, prec * xmax)
     if ylim is None:
-        ymin = np.ceil(np.min([el.y - pad for el in implant.values()]) / prec)
-        ymax = np.ceil(np.max([el.y + pad for el in implant.values()]) / prec)
+        ymin = np.ceil(np.min([el.y - pad
+                               for el in implant.electrode_objects]) / prec)
+        ymax = np.ceil(np.max([el.y + pad
+                               for el in implant.electrode_objects]) / prec)
         ylim = (prec * ymin, prec * ymax)
 
     ax = plot_axon_map(eye=implant.eye, loc_od=loc_od, ax=ax,
@@ -197,7 +201,7 @@ def plot_implant_on_axon_map(implant, loc_od=(15.5, 1.5), n_bundles=100,
 
     # Determine marker size for electrodes:
     radii = []
-    for el in implant.values():
+    for el in implant.electrode_objects:
         # Use electrode radius (if exists), else constant radius:
         if hasattr(el, 'r'):
             radii.append(el.r)
@@ -215,7 +219,7 @@ def plot_implant_on_axon_map(implant, loc_od=(15.5, 1.5), n_bundles=100,
 
     # Plot all electrodes and label them (optional):
     circles = []
-    for i, (name, el) in enumerate(implant.items()):
+    for i, (name, el) in enumerate(implant.electrodes.items()):
         if annotate_implant:
             ax.text(el.x, el.y, name, horizontalalignment='center',
                     verticalalignment='center',


### PR DESCRIPTION
This PR fixes miscellaneous usability issues & adds several upgrades for interacting with implants:

- [X] Iterate over `earray.electrodes.items()`, use `earray.electrode_names` and `earray.electrode_objects` properties
- [X] Fix `stim.is_charge_balanced` for various stim types
- [X] Add `safe_mode` where implant requires a charge-balanced stimulus
- [x] Easy conversion from `ImageStimulus` to `implant.stim`
- [x] Deactivate electrodes in an array
- [x] Explain x,y,z coordinate system