### PR TITLE
[FIX] More sensible default value for tau in FadingTemporal

### DIFF
--- a/pulse2percept/models/temporal.py
+++ b/pulse2percept/models/temporal.py
@@ -44,7 +44,7 @@ class FadingTemporal(TemporalModel):
         base_params = super(FadingTemporal, self).get_default_params()
         params = {
             # Time constant for the exponential decay:
-            'tau': 0.01,
+            'tau': 100,
         }
         # This is subtle: Rather than calling `params.update(base_params)`, we
         # call `base_params.update(params)`. This will overwrite `base_params`


### PR DESCRIPTION
The default value in `FadingTemporal` for `tau` was set to 0.01 - that's way too small. Change to 100