### PR TITLE
[FIX] AxonMapModel on single pixel

### DIFF
--- a/pulse2percept/models/beyeler2019.py
+++ b/pulse2percept/models/beyeler2019.py
@@ -473,11 +473,12 @@ class AxonMapSpatial(SpatialModel):
 
         # Look up the axon ID for every axon segment:
         closest_idx = axon_idx[closest_seg]
-        closest_axon = [bundles[n] for n in closest_idx]
+        if len(closest_idx) == 1:
+            closest_idx = closest_idx[0]
+            closest_axon = bundles[closest_idx]
+        else:
+            closest_axon = [bundles[n] for n in closest_idx]
         if return_index:
-            # if there was only one query, return result instead of list
-            if len(closest_idx) == 0:
-                return closest_axon[0], closest_idx[0]
             return closest_axon, closest_idx
         return closest_axon
 
@@ -623,6 +624,8 @@ class AxonMapSpatial(SpatialModel):
         if need_axons:
             bundles = self.grow_axon_bundles()
             axons = self.find_closest_axon(bundles)
+            if type(axons) != list:
+                axons = [axons]
         # Calculate axon contributions (depends on axlambda):
         # Axon contribution is a list of (differently shaped) NumPy arrays,
         # and a list cannot be accessed in parallel without the gil. Instead

--- a/pulse2percept/models/beyeler2019.py
+++ b/pulse2percept/models/beyeler2019.py
@@ -473,12 +473,11 @@ class AxonMapSpatial(SpatialModel):
 
         # Look up the axon ID for every axon segment:
         closest_idx = axon_idx[closest_seg]
-        if len(closest_idx) == 1:
-            closest_idx = closest_idx[0]
-            closest_axon = bundles[closest_idx]
-        else:
-            closest_axon = [bundles[n] for n in closest_idx]
+        closest_axon = [bundles[n] for n in closest_idx]
         if return_index:
+            # if there was only one query, return result instead of list
+            if len(closest_idx) == 0:
+                return closest_axon[0], closest_idx[0]
             return closest_axon, closest_idx
         return closest_axon
 


### PR DESCRIPTION
Prior to #370 , AxonMapModel could used for a single pixel. This is useful for fast, single pixel brightness predictions (e.g. embc 21 paper) and is also used in the tutorials online. 

After #370, find_closest_axon returns a single point instead of a list of points for individual queries. This causes model.build() to fail for a single pixel. 

For example, `AxonMapModel(xrange=(0,0), yrange=(0,0)).build()` fails

To fix, in build(), if the point returned by find_closest_axon is not a list, it is made into a list so the remaining functions work properly. Find_closest_axon behavior is unchanged 