### PR TITLE
[Fix] Stimulus metadata creation 

### DIFF
--- a/pulse2percept/models/base.py
+++ b/pulse2percept/models/base.py
@@ -306,6 +306,7 @@ class SpatialModel(BaseModel, metaclass=ABCMeta):
             # Calculate the Stimulus at requested time points:
             if t_percept is not None:
                 # Save electrode parameters
+                stim = Stimulus(stim) # make sure stimulus is in proper format
                 stim = Stimulus(stim[:, t_percept].reshape((-1, n_time)),
                                 electrodes=stim.electrodes, time=t_percept,
                                 metadata=stim.metadata)

--- a/pulse2percept/stimuli/base.py
+++ b/pulse2percept/stimuli/base.py
@@ -226,6 +226,12 @@ class Stimulus(PrettyPrint):
             _data = source.data
             _time = source.time
             _electrodes = source.electrodes
+            if 'electrodes' not in source.metadata.keys():
+                self.metadata['electrodes'][str(_electrodes[0])] = {'metadata' : source.metadata, 'type' : type(source)}
+            else:
+                self.metadata = source.metadata
+
+
         elif isinstance(source, np.ndarray):
             # A NumPy array is either 1-D (list of electrodes, time=None) or
             # 2-D (electrodes x time points):

--- a/pulse2percept/stimuli/base.py
+++ b/pulse2percept/stimuli/base.py
@@ -230,8 +230,6 @@ class Stimulus(PrettyPrint):
                 self.metadata['electrodes'][str(_electrodes[0])] = {'metadata' : source.metadata, 'type' : type(source)}
             else:
                 self.metadata = source.metadata
-
-
         elif isinstance(source, np.ndarray):
             # A NumPy array is either 1-D (list of electrodes, time=None) or
             # 2-D (electrodes x time points):


### PR DESCRIPTION
This PR fixes 2 bugs that caused stimulus metadata be lost:
- stimuli/base.py: If a stimulus is created from another stimulus source (e.g. `Stimulus(BiphasicPulseTrain())`), the metadata was previously lost
- models/base.py: If a stimulus subclass was passed to predict_percept (e.g. `BiphasicPulseTrain()`), the metadata would not be associated with an electrode, which caused predict_percept to fail. Now, the stimulus is restructured if necessary to ensure the metadata is specified per electrode.

This PR is neccesary for the BiphasicAxonMapModel and the EMBC21 notebook