### PR TITLE
[FIX] Fix missing BiphasicAxonMapModel effect model params

### DIFF
--- a/pulse2percept/models/granley2021.py
+++ b/pulse2percept/models/granley2021.py
@@ -286,7 +286,7 @@ class BiphasicAxonMapSpatial(AxonMapSpatial):
         # Check if bright/size/streak model has param
         for m in [self.bright_model, self.size_model, self.streak_model]:
             if hasattr(m, attr):
-                return getattr(self.bright_model, attr)
+                return getattr(m, attr)
         raise AttributeError("%s not found" % attr)
 
     def __setattr__(self, name, value):

--- a/pulse2percept/models/tests/test_granley2021.py
+++ b/pulse2percept/models/tests/test_granley2021.py
@@ -137,6 +137,8 @@ def test_biphasicAxonMapModel(engine):
         npt.assert_equal(hasattr(model.spatial, param), True)
 
     # We can set and get effects model params
+    for atr in ['a' + str(i) for i in range(0, 10)]:
+        npt.assert_equal(hasattr(model, atr), True)
     model.a0 = 5
     # Should propogate to size and bright model
     # But should not be a member of streak or spatial


### PR DESCRIPTION
Previously `BiphasicAxonMapSpatial` failed to return the correct effect model parameter unless it was a part of `self.bright_model`

Failing test case to test that every default effect model parameter is accessible (now added):
```
for atr in ['a' + str(i) for i in range(0, 10)]:
        npt.assert_equal(hasattr(model, atr), True)
```
