### PR TITLE
[FIX] Fixed BiphasicAxonMapModel init bug

### DIFF
--- a/pulse2percept/models/granley2021.py
+++ b/pulse2percept/models/granley2021.py
@@ -283,6 +283,8 @@ class BiphasicAxonMapSpatial(AxonMapSpatial):
             # point means the default attribute access failed - most likely
             # because we are trying to create a variable. In this case, simply
             # raise an exception:
+            # Note that this gets called from __init__ of BaseModel, not directly from 
+            # BiphasicAxonMap
             raise AttributeError("%s not found" % attr)
         # Check if bright/size/streak model has param
         for m in [self.bright_model, self.size_model, self.streak_model]:


### PR DESCRIPTION
## Description
The `__getattr__` function in `BiphasicAxonMapModel` checks to see if it is being called from the `__init__` method (of base_model) by checking the name of `sys._getframe(3)`. If it is, then it raises an exception (which is processed later and allows for a new parameter to be created).

This works most of the time, however, if `getattr(model, attr)` is called inside the `__init__` function of a different class, and if `attr` is a parameter from an effects model (e.g. a0, which causes `__getattribute__` to fail and call `__getattr__` instead) then this exception is also raised, which is not the desired behavior. 

To fix, in addition to checking that `sys._getframe(3)` is the initializer, it also makes sure that it is from `p2p.models.base.py`

Code that leads to bug:
```
class Test():
    def __init__(self):
        BiphasicAxonMapModel().a0
```
Raises an attribute error that there is no a0 parameter
## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)


Note that the tests do not all pass, but the only failing one is from datasets/basemodel, which is trying to fetch data from a URL and is unrelated.
