### PR TITLE
[MNT] Deprecate Python 3.6

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       # Test on all supported platforms using all supported Python versions:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9]
         os: [ubuntu-latest, ubuntu-16.04, windows-latest, macOS-latest]
     
     steps:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -25,7 +25,7 @@ jobs:
         uses: joerick/cibuildwheel@v1.10.0
         env:
           CIBW_BEFORE_BUILD: "pip install -r requirements.txt && pip install -e ."
-          CIBW_SKIP: "cp27-* cp35-* pp*"
+          CIBW_SKIP: "cp27-* cp35-* cp36-* pp*"
 
       - uses: actions/upload-artifact@v2
         with:

--- a/README.rst
+++ b/README.rst
@@ -77,13 +77,13 @@ can be installed with pip:
 
 .. code-block:: bash
 
-    pip3 install pulse2percept
+    pip install pulse2percept
 
 The `bleeding-edge version`_ of pulse2percept can be installed via:
 
 .. code-block:: bash
 
-    pip3 install git+https://github.com/pulse2percept/pulse2percept
+    pip install git+https://github.com/pulse2percept/pulse2percept
 
 .. _stable release: https://pulse2percept.readthedocs.io/en/stable/index.html
 .. _bleeding-edge version: https://pulse2percept.readthedocs.io/en/latest/index.html
@@ -98,12 +98,12 @@ Detailed instructions for different platforms can be found in our
 Dependencies
 ------------
 
-**pulse2percept 0.6 was the last version to support Python <= 3.5.**
-pulse2percept 0.7+ requires Python 3.6+.
+**pulse2percept 0.7 was the last version to support Python <= 3.6.**
+pulse2percept 0.8+ requires Python 3.7+.
 
 pulse2percept requires:
 
-1.  `Python`_ (>= 3.6)
+1.  `Python`_ (>= 3.7)
 2.  `Cython`_ (>= 0.28)
 3.  `NumPy`_ (>= 1.9)
 4.  `SciPy`_ (>= 1.0.1)
@@ -143,14 +143,14 @@ of the git repository, and can be installed with the following command:
 
     git clone https://github.com/pulse2percept/pulse2percept.git
     cd pulse2percept
-    pip3 install -r requirements.txt
+    pip install -r requirements.txt
 
 All packages required for development (including all optional packages) are
 listed in ``requirements-dev.txt`` and can be installed via:
 
 .. code-block:: bash
 
-    pip3 install -r requirements-dev.txt
+    pip install -r requirements-dev.txt
 
 Where to go from here
 =====================

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -40,8 +40,8 @@ If you don't have Python, you have several options:
 
 .. important::
 
-    pulse2percept 0.6 was the last release to support Python <= 3.5.
-    pulse2percept 0.7+ requires **Python 3.6+**.
+    pulse2percept 0.7 was the last release to support Python <= 3.6.
+    pulse2percept 0.8+ requires **Python 3.7+**.
 
 On some platforms (e.g., macOS), you might also have to install pip yourself.
 You can check if pip is installed on your system by typing ``pip --version``
@@ -73,13 +73,13 @@ release can be installed with pip:
 
 .. code-block:: bash
 
-    pip3 install pulse2percept
+    pip install pulse2percept
 
 You can also install a specific version:
 
 .. code-block:: bash
 
-    pip3 install pulse2percept==0.6.0
+    pip install pulse2percept==0.6.0
 
 Then from any Python console or script, try:
 
@@ -107,7 +107,7 @@ Installing version |version| from source
 Prerequisites
 -------------
 
-1.  **Python** (>= 3.6): Make sure to :ref:`install Python <install-python>`
+1.  **Python** (>= 3.7): Make sure to :ref:`install Python <install-python>`
     first.
 
 2.  **XCode**: On macOS, make sure to install `Apple XCode`_.
@@ -120,14 +120,14 @@ Prerequisites
     1.  Install **Build Tools for Visual Studio 2019** from the
         `Microsoft website`_.
         Note that the build tools for Visual Studio 2015 or 2017 should work as
-        well (Python >= 3.6 requires C++ 14.X to be exact).
+        well (Python >= 3.7 requires C++ 14.X to be exact).
         Also note that you don't need to install Visual Studio itself.
 
     2.  `Install Cython`_:
 
         .. code-block:: bash
 
-            pip3 install Cython
+            pip install Cython
 
         If you get an error saying ``unable to find vcvarsall.bat``, then there
         is a problem with your Build Tools installation, in which case you
@@ -205,7 +205,7 @@ Obtaining the latest code from GitHub
 
     .. code-block:: bash
 
-        pip3 install -r requirements.txt
+        pip install -r requirements.txt
 
     This includes Cython. If you are on Windows, you will also need a suitable
     C compiler (see :ref:`Prerequisites <install-source-prerequisites>` above).
@@ -216,7 +216,7 @@ Obtaining the latest code from GitHub
 
     .. code-block:: bash
 
-       pip3 install -r requirements-dev.txt
+       pip install -r requirements-dev.txt
 
 .. _pulse2percept on GitHub: https://github.com/pulse2percept/pulse2percept
 .. _GitHub account: https://help.github.com/articles/signing-up-for-a-new-github-account
@@ -229,7 +229,7 @@ Assuming you are still in the root directory of the git clone, type
 
 .. code-block:: bash
 
-    pip3 install -e .
+    pip install -e .
 
 Then from any Python console or script, try:
 
@@ -269,7 +269,7 @@ To upgrade to the newest stable release, use the ``-U`` option with pip:
 
 .. code-block:: bash
 
-    pip3 install -U pulse2percept
+    pip install -U pulse2percept
 
 To upgrade to the bleedingest-edge version, navigate to the directory where you
 cloned the git repository. If you have never upgraded your code before, add
@@ -298,7 +298,7 @@ You can uninstall pulse2percept using pip:
 
 .. code-block:: python
 
-   pip3 uninstall pulse2percept
+   pip uninstall pulse2percept
 
 This works for both stable and latest releases.
 
@@ -322,7 +322,7 @@ You can check the installation location:
 
 .. code-block:: python
 
-   pip3 show pulse2percept
+   pip show pulse2percept
 
 Then add the specificed location to ``$PATH``; see `PATH on Windows`_, 
 `PATH on macOS`_, `PATH on Linux`_.
@@ -340,7 +340,7 @@ issue:
 
 .. code-block:: python
 
-  pip3 install -U numpy
+  pip install -U numpy
 
 .. note::
 

--- a/setup.py
+++ b/setup.py
@@ -253,7 +253,7 @@ def setup_package():
                         'build_ext': openmp_build_ext(),
                         'sdist': sdist
                     },
-                    python_requires=">=3.6",
+                    python_requires=">=3.7",
                     install_requires=[
                         'numpy>={}'.format(NUMPY_MIN_VERSION),
                         'scipy>={}'.format(SCIPY_MIN_VERSION),


### PR DESCRIPTION
Deprecate Python 3.6 for the next planned release (life cycle ends in December, issue #349). We're already running into issues with building on MacOS x64.