### PR TITLE
[REF] Update threshold scaling with pulse duration

### DIFF
--- a/pulse2percept/models/granley2021.py
+++ b/pulse2percept/models/granley2021.py
@@ -50,9 +50,9 @@ class DefaultBrightModel(BaseModel):
     def scale_threshold(self, pdur):
         """ 
         Based on eq 3 in paper, this function produces the factor that amplitude
-        will be scaled by to produce a_tilde. Computes (A_0 * t + A_1)^-1
+        will be scaled by to produce a_tilde. Computes A_0 * t + A_1 (1/threshold)
         """
-        return 1 / (self.a1 + self.a0*pdur)
+        return self.a1 + self.a0*pdur
 
     def predict_freq_amp(self, amp, freq):
         """ Eq 4 in paper, A_2*A_tilde + A_3*f + A_4 """
@@ -119,9 +119,9 @@ class DefaultSizeModel(BaseModel):
     def scale_threshold(self, pdur):
         """ 
         Based on eq 3 in paper, this function produces the factor that amplitude
-        will be scaled by to produce a_tilde. Computes (A_0 * t + A_1)^-1
+        will be scaled by to produce a_tilde. Computes A_0 * t + A_1 (1/threshold)
         """
-        return 1 / (self.a1 + self.a0*pdur)
+        return self.a1 + self.a0*pdur
 
     def __call__(self, freq, amp, pdur):
         """

--- a/pulse2percept/models/tests/test_granley2021.py
+++ b/pulse2percept/models/tests/test_granley2021.py
@@ -113,17 +113,17 @@ def test_biphasicAxonMapSpatial(engine):
     npt.assert_equal(np.any(percept.data[:, :, 1:]), False)
 
     # Test that default models give expected values
-    model = BiphasicAxonMapSpatial(engine=engine, rho=600, axlambda=600, xystep=1,
+    model = BiphasicAxonMapSpatial(engine=engine, rho=400, axlambda=600, xystep=1,
                            xrange=(-20, 20), yrange=(-15, 15))
     model.build()
     implant = ArgusII()
     implant.stim = Stimulus({'A4' : BiphasicPulseTrain(20, 1, 1)})
     percept = model.predict_percept(implant)
-    npt.assert_equal(np.sum(percept.data > 1), 53)
-    npt.assert_equal(np.sum(percept.data > 2), 36)
-    npt.assert_equal(np.sum(percept.data > 3), 25)
-    npt.assert_equal(np.sum(percept.data > 5), 12)
-    npt.assert_equal(np.sum(percept.data > 7), 4)
+    npt.assert_equal(np.sum(percept.data > 1), 82)
+    npt.assert_equal(np.sum(percept.data > 2), 59)
+    npt.assert_equal(np.sum(percept.data > 3), 44)
+    npt.assert_equal(np.sum(percept.data > 5), 25)
+    npt.assert_equal(np.sum(percept.data > 7), 14)
 
 
 @pytest.mark.parametrize('engine', ('serial', 'cython', 'jax'))


### PR DESCRIPTION
## Description
Updates a0 and a1, and the scale_threshold equation used to scale perceptual threshold (and eventually, amp factor) based on changes in pulse duration to use thresholds from Horsager 2009 instead of Weitz 2015.

## Type of Change

Please delete options that are not relevant.

- [ ] Refactor existing code
