### PR TITLE
[FIX] Wheels for Py>=3.7

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -21,12 +21,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Build Py3.10 wheels
-        uses: pypa/cibuildwheel@v2.1.3
-        env:
-          CIBW_BEFORE_BUILD: "python -m pip install -U pip && python -m pip install -U Pillow && python -m pip install -r requirements.txt && python -m pip install -e ."
-          CIBW_BUILD: "cp310-*"
-
       - name: Build Py3.9 wheels
         uses: pypa/cibuildwheel@v2.1.3
         env:


### PR DESCRIPTION
Things I tried that don't work:
- ❌  Upgrade Cython
- ❌  Upgrade pip
- ❌  Upgrade Pillow
- ❌  easy_install Pillow

Things that work for Py37 & Py38, but not Py39 or Py310:
- ✔️  Install Pillow==6.2.2

Things that work for Py39 and up:
- ✔️ Install Pillow==8.3.2

Py310 still unsupported...even latest Pillow breaks...