### PR TITLE
[ENH] Remove estimator cloning during PSO optimization

### DIFF
--- a/pulse2percept/model_selection/optimizers.py
+++ b/pulse2percept/model_selection/optimizers.py
@@ -403,7 +403,7 @@ class ParticleSwarmOptimizer(BaseOptimizer):
         # Clone the estimator to make sure we have a clean slate, then fit:
         if fit_params is None:
             fit_params = {}
-        estimator = clone_estimator(self.estimator)
+        estimator = self.estimator
         estimator.set_params(**search_params)
         estimator.fit(X, y=y, **fit_params)
         # If score is not a loss function, we need to invert here:


### PR DESCRIPTION
## Description
Removes the call to `sklearn.clone` to copy the estimator during each iteration of particle swarm fitting. This allows for estimators to store their own hyperparameters that are not optimized over (for example, a model or implant placement). 

This does not currently seem to have an impact on how parallelizable the optimizer is
## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
