### PR TITLE
[ENH] Additional options for scatter-correlation plot

### DIFF
--- a/pulse2percept/viz/base.py
+++ b/pulse2percept/viz/base.py
@@ -61,7 +61,6 @@ def scatter_correlation(x, y, marker='o', marker_size=50, marker_alpha=0.5,
         annot_str += "\n$y$=%.3f$x$+%.3f" % (slope, intercept)
     annot_str += "\n$r$=%.3f, $p$=%s" % (rval, pval)
     a = ax.axis()
-    print(a)
     t = ax.text(0.98 * (a[1] - a[0]) + a[0], 0.05 * (a[3] - a[2]) + a[2],
                 annot_str, va='bottom', ha='right', fontsize=text_size)
     t.set_bbox(dict(facecolor='w', edgecolor='w', alpha=0.5))

--- a/pulse2percept/viz/tests/test_base.py
+++ b/pulse2percept/viz/tests/test_base.py
@@ -12,7 +12,6 @@ def test_scatter_correlation():
     _, ax = plt.subplots()
     ax = scatter_correlation(x, x, ax=ax)
     npt.assert_equal(len(ax.texts), 1)
-    print(ax.texts)
     npt.assert_equal('$r$=1.000' in ax.texts[0].get_text(), True)
     # Ignore NaN:
     ax = scatter_correlation([0, 1, np.nan, 3], [0, 1, 2, 3])


### PR DESCRIPTION
This PR allows for further customization of `p2p.viz.scatter_correlation`:
- Print slope/intercept
- Text/label size
- Marker size
- Marker alpha