### PR TITLE
[ENH] ElectrodeGrid spacing and hex grid layout

### DIFF
--- a/pulse2percept/implants/electrode_arrays.py
+++ b/pulse2percept/implants/electrode_arrays.py
@@ -511,14 +511,14 @@ class ElectrodeGrid(ElectrodeArray):
             if orientation.lower() == 'horizontal':
                 # Shift every other row:
                 x_arr_shift = np.zeros_like(x_arr)
-                x_arr_shift[1::2] = 0.5 * x_spc
+                x_arr_shift[::2] = 0.5 * x_spc
                 x_arr += x_arr_shift
                 # Make sure the center is at (0, 0)
                 x_arr -= 0.25 * x_spc
             elif orientation.lower() == 'vertical':
                 # Shift every other column:
                 y_arr_shift = np.zeros_like(y_arr)
-                y_arr_shift[:, 1::2] = 0.5 * y_spc
+                y_arr_shift[:, ::2] = 0.5 * y_spc
                 y_arr += y_arr_shift
                 # Make sure the center is at (0, 0)
                 y_arr -= 0.25 * y_spc

--- a/pulse2percept/implants/electrode_arrays.py
+++ b/pulse2percept/implants/electrode_arrays.py
@@ -282,8 +282,8 @@ class ElectrodeGrid(ElectrodeArray):
     names: (name_rows, name_cols), each of which either 'A' or '1'
         Naming convention for rows and columns, respectively.
         If 'A', rows or columns will be labeled alphabetically: A-Z, AA-AZ,
-        BA-BZ, CA-CZ, etc.
-        If '1', rows or columns will be labeled numerically.
+        BA-BZ, CA-CZ, etc. '-A' will reverse the order.
+        If '1', rows or columns will be labeled numerically. '-1' will reverse.
         Letters will always precede numbers in electrode names.
         For example ('1', 'A') will number rows numerically and columns
         alphabetically; first row: 'A1', 'B1', 'C1', NOT '1A', '1B', '1C'.
@@ -459,19 +459,31 @@ class ElectrodeGrid(ElectrodeArray):
                 raise TypeError("Column name must be a string, not "
                                 "%s." % type(name_cols))
             # Row names:
+            reverse_rows = False
+            if '-' in name_rows:
+                reverse_rows = True
+                name_rows = name_rows.replace('-', '')
             if name_rows.isalpha():
                 rws = _get_alphabetic_names(rows)
             elif name_rows.isdigit():
                 rws = _get_numeric_names(rows)
             else:
                 raise ValueError("Row name must be alphabetic or numeric.")
+            if reverse_rows:
+                rws = rws[::-1]
             # Column names:
+            reverse_cols = False
+            if '-' in name_cols:
+                reverse_cols = True
+                name_cols = name_cols.replace('-', '')
             if name_cols.isalpha():
                 clms = _get_alphabetic_names(cols)
             elif name_cols.isdigit():
                 clms = _get_numeric_names(cols)
             else:
                 raise ValueError("Column name must be alphabetic or numeric.")
+            if reverse_cols:
+                clms = clms[::-1]
             # Letters before digits:
             if name_cols.isalpha() and not name_rows.isalpha():
                 names = [clms[j] + rws[i] for i in range(len(rws))

--- a/pulse2percept/implants/electrode_arrays.py
+++ b/pulse2percept/implants/electrode_arrays.py
@@ -256,10 +256,19 @@ class ElectrodeGrid(ElectrodeArray):
     ----------
     shape : (rows, cols)
         A tuple containing the number of rows x columns in the grid
-    spacing : double
+    spacing : double or (x_spacing, y_spacing)
         Electrode-to-electrode spacing in microns.
+        Must be either a tuple specifying the spacing in x and y directions or
+        a float (assuming the same spacing in x and y).
+        If a tuple is specified for a horizontal hex grid, ``x_spacing`` will
+        define the electrode-to-electrode distance, and ``y_spacing`` will
+        define the vertical distance between adjacent hexagon centers.
+        In a vertical hex grid, the order is reversed.
     type : {'rect', 'hex'}, optional
         Grid type ('rect': rectangular, 'hex': hexagonal).
+    orientation : {'horizontal', 'vertical'}, optional
+        In a hex grid, 'horizontal' orientation will shift every other row
+        to the right, whereas 'vertical' will shift every other column up.
     x/y/z : double
         3D location of the center of the grid.
         The coordinate system is centered over the fovea.
@@ -481,63 +490,38 @@ class ElectrodeGrid(ElectrodeArray):
             # If `z` is a scalar, choose same height for all electrodes:
             z_arr = np.ones(n_elecs, dtype=float) * z
 
-        spc = self.spacing
-        if self.type.lower() == 'rect':
-            # Rectangular grid from x, y coordinates:
-            # For example, cols=3 with spacing=100 should give: [-100, 0, 100]
-            x_arr = (np.arange(cols) * spc - (cols / 2.0 - 0.5) * spc)
-            y_arr = (np.arange(rows) * spc - (rows / 2.0 - 0.5) * spc)
-            x_arr, y_arr = np.meshgrid(x_arr, y_arr, sparse=False)
-        elif self.type.lower() == 'hex':
-            # When orientation is horizontal, x_arr is shifting to create the
-            # hex grid
-            if orientation == 'horizontal':
-                # Hexagonal grid from x,y coordinates:
-                x_arr_lshift = ((np.arange(cols) * spc -
-                                 (cols / 2.0 - 0.5) * spc - spc * 0.25))
-                x_arr_rshift = ((np.arange(cols) * spc -
-                                 (cols / 2.0 - 0.5) * spc + spc * 0.25))
-                y_arr = (np.arange(rows) * np.sqrt(3) * spc / 2.0 -
-                         (rows / 2.0 - 0.5) * spc)
-                x_arr_lshift, _ = np.meshgrid(x_arr_lshift, y_arr)
-                x_arr_rshift, y_arr_rshift = np.meshgrid(x_arr_rshift, y_arr)
-                # Shift every other row to get an interleaved pattern:
-                x_arr = []
-                for row in range(rows):
-                    if row % 2:
-                        x_arr.append(x_arr_rshift[row])
-                    else:
-                        x_arr.append(x_arr_lshift[row])
-                x_arr = np.array(x_arr)
-                y_arr = y_arr_rshift
-            # When orientation is vertical, y_arr is shifting to create the hex
-            # grid
-            elif orientation == 'vertical':
-                # Hexagonal grid from x,y coordinates:
-                x_arr = (np.arange(cols) * np.sqrt(3) * spc / 2.0 -
-                         (cols / 2.0 - 0.5) * spc)
-                y_arr_downshift = ((np.arange(rows) * spc -
-                                    (rows / 2.0 - 0.5) * spc - spc * 0.25))
-                y_arr_upshift = ((np.arange(rows) * spc -
-                                  (rows / 2.0 - 0.5) * spc + spc * 0.25))
-                x_arr_downshift, y_arr_downshift = np.meshgrid(x_arr,
-                                                               y_arr_downshift,
-                                                               sparse=False)
-                x_arr_upshift, y_arr_upshift = np.meshgrid(x_arr,
-                                                           y_arr_upshift,
-                                                           sparse=False)
-                # Shift every other column to get an interleaved pattern:
-                y_arr = np.zeros(shape=(rows, cols))
-                for row in range(rows):
-                    for col in range(cols):
-                        if col % 2:
-                            y_arr[row][col] = y_arr_downshift[row][col]
-                        else:
-                            y_arr[row][col] = y_arr_upshift[row][col]
-                x_arr = x_arr_upshift
-                y_arr = np.array(y_arr)
+        # Spacing can be different for x and y (tuple) or the same (float):
+        if isinstance(self.spacing, (list, np.ndarray, tuple)):
+            x_spc, y_spc = self.spacing[:2]
         else:
-            raise NotImplementedError
+            x_spc = y_spc = self.spacing
+            if self.type.lower() == 'hex':
+                # In a hex grid, we need to adjust the spacing so that
+                # neighboring electrodes are separated by self.spacing:
+                if orientation.lower() == 'horizontal':
+                    y_spc = x_spc * np.sqrt(3) / 2
+                else:
+                    x_spc = y_spc * np.sqrt(3) / 2
+
+        # Start with a rectangular grid:
+        x_arr = (np.arange(cols) * x_spc - 0.5 * (cols - 1) * x_spc)
+        y_arr = (np.arange(rows) * y_spc - 0.5 * (rows - 1) * y_spc)
+        x_arr, y_arr = np.meshgrid(x_arr, y_arr, sparse=False)
+        if self.type.lower() == 'hex':
+            if orientation.lower() == 'horizontal':
+                # Shift every other row:
+                x_arr_shift = np.zeros_like(x_arr)
+                x_arr_shift[1::2] = 0.5 * x_spc
+                x_arr += x_arr_shift
+                # Make sure the center is at (0, 0)
+                x_arr -= 0.25 * x_spc
+            elif orientation.lower() == 'vertical':
+                # Shift every other column:
+                y_arr_shift = np.zeros_like(y_arr)
+                y_arr_shift[:, 1::2] = 0.5 * y_spc
+                y_arr += y_arr_shift
+                # Make sure the center is at (0, 0)
+                y_arr -= 0.25 * y_spc
 
         # Rotate the grid:
         rot_rad = np.deg2rad(rot)

--- a/pulse2percept/implants/tests/test_electrode_arrays.py
+++ b/pulse2percept/implants/tests/test_electrode_arrays.py
@@ -294,8 +294,8 @@ def test_ElectrodeGrid__make_grid(gtype, orientation):
                                     (grid['A1'].y - grid['A2'].y) ** 2),
                             spacing)
     if gtype == 'hex':
-        npt.assert_almost_equal(np.sqrt((grid['A2'].x - grid['B1'].x) ** 2 +
-                                        (grid['A2'].y - grid['B1'].y) ** 2),
+        npt.assert_almost_equal(np.sqrt((grid['A1'].x - grid['B2'].x) ** 2 +
+                                        (grid['A1'].y - grid['B2'].y) ** 2),
                                 spacing)
 
     # Different spacing in x and y:

--- a/pulse2percept/implants/tests/test_electrode_arrays.py
+++ b/pulse2percept/implants/tests/test_electrode_arrays.py
@@ -361,6 +361,13 @@ def test_ElectrodeGrid__make_grid(gtype, orientation):
     egrid = ElectrodeGrid(gshape, spacing, type=gtype, names=('A', '2'))
     npt.assert_equal([e for e in egrid.electrode_names],
                      ['A1', 'A2', 'A3', 'B1', 'B2', 'B3'])
+    # Reversal:
+    egrid = ElectrodeGrid(gshape, spacing, type=gtype, names=('-A', '1'))
+    npt.assert_equal([e for e in egrid.electrode_names],
+                     ['B1', 'B2', 'B3', 'A1', 'A2', 'A3'])
+    egrid = ElectrodeGrid(gshape, spacing, type=gtype, names=('A', '-1'))
+    npt.assert_equal([e for e in egrid.electrode_names],
+                     ['A3', 'A2', 'A1', 'B3', 'B2', 'B1'])
 
     # test unique names
     egrid = ElectrodeGrid(gshape, spacing, type=gtype,

--- a/pulse2percept/implants/tests/test_electrode_arrays.py
+++ b/pulse2percept/implants/tests/test_electrode_arrays.py
@@ -215,29 +215,21 @@ def test_ElectrodeGrid(gtype):
     with pytest.raises(ValueError):
         ElectrodeGrid(gshape, spacing, type='unknown')
 
-    # Verify spacing is correct:
-    grid = ElectrodeGrid(gshape, spacing, type=gtype, etype=DiskElectrode,
-                         r=30)
-    npt.assert_almost_equal(np.sqrt((grid['A1'].x - grid['A2'].x) ** 2 +
-                                    (grid['A1'].y - grid['A2'].y) ** 2),
-                            spacing)
-    npt.assert_almost_equal(np.sqrt((grid['A1'].x - grid['B1'].x) ** 2 +
-                                    (grid['A1'].y - grid['B1'].y) ** 2),
-                            spacing)
-    grid = ElectrodeGrid(gshape, spacing, type=gtype, orientation='vertical',
-                         etype=DiskElectrode, r=30)
-    npt.assert_almost_equal(np.sqrt((grid['B1'].x - grid['B2'].x) ** 2 +
-                                    (grid['B1'].y - grid['B2'].y) ** 2),
-                            spacing)
-    npt.assert_almost_equal(np.sqrt((grid['A1'].x - grid['B1'].x) ** 2 +
-                                    (grid['A1'].y - grid['B1'].y) ** 2),
-                            spacing)
+    # Slots:
+    npt.assert_equal(hasattr(grid, '__slots__'), True)
+    npt.assert_equal(hasattr(grid, '__dict__'), False)
 
+
+@pytest.mark.parametrize('gtype', ('rect', 'hex'))
+@pytest.mark.parametrize('orientation', ('vertical', 'horizontal'))
+def test_ElectrodeGrid__make_grid(gtype, orientation):
     # A valid 2x5 grid centered at (0, 500):
     x, y = 0, 500
     radius = 30
-    egrid = ElectrodeGrid(gshape, spacing, x=x, y=y, type='rect',
-                          etype=DiskElectrode, r=radius)
+    gshape = (4, 6)
+    spacing = 100
+    egrid = ElectrodeGrid(gshape, spacing, x=x, y=y, type='rect', r=radius,
+                          etype=DiskElectrode, orientation=orientation)
     npt.assert_equal(egrid.shape, gshape)
     npt.assert_equal(egrid.n_electrodes, np.prod(gshape))
     # Make sure different electrodes have different coordinates:
@@ -256,15 +248,15 @@ def test_ElectrodeGrid(gtype):
 
     # Test whether egrid.z is set correctly, when z is a constant:
     z = 12
-    egrid = ElectrodeGrid(gshape, spacing, z=z, type=gtype,
-                          etype=DiskElectrode, r=radius)
+    egrid = ElectrodeGrid(gshape, spacing, z=z, type=gtype, r=radius,
+                          etype=DiskElectrode, orientation=orientation)
     for i in egrid.electrode_objects:
         npt.assert_equal(i.z, z)
 
     # and when every electrode has a different z:
     z = np.arange(np.prod(gshape))
-    egrid = ElectrodeGrid(gshape, spacing, z=z, type=gtype,
-                          etype=DiskElectrode, r=radius)
+    egrid = ElectrodeGrid(gshape, spacing, z=z, type=gtype, r=radius,
+                          etype=DiskElectrode, orientation=orientation)
     x = -1
     for i in egrid.electrode_objects:
         npt.assert_equal(i.z, x + 1)
@@ -272,9 +264,9 @@ def test_ElectrodeGrid(gtype):
 
     # TODO test rotation, making sure positive angles rotate CCW
     egrid1 = ElectrodeGrid((2, 2), spacing, type=gtype, etype=DiskElectrode,
-                           r=radius)
-    egrid2 = ElectrodeGrid((2, 2), spacing, rot=10, type=gtype,
-                           etype=DiskElectrode, r=radius)
+                           r=radius, orientation=orientation)
+    egrid2 = ElectrodeGrid((2, 2), spacing, rot=10, type=gtype, r=radius,
+                           etype=DiskElectrode, orientation=orientation)
     npt.assert_equal(egrid1["A1"].x < egrid2["A1"].x, True)
     npt.assert_equal(egrid1["A1"].y > egrid2["A1"].y, True)
     npt.assert_equal(egrid1["B2"].x > egrid2["B2"].x, True)
@@ -282,20 +274,42 @@ def test_ElectrodeGrid(gtype):
 
     # Smallest possible grid:
     egrid = ElectrodeGrid((1, 1), spacing, type=gtype, etype=DiskElectrode,
-                          r=radius)
+                          r=radius, orientation=orientation)
     npt.assert_equal(egrid.shape, (1, 1))
     npt.assert_equal(egrid.n_electrodes, 1)
-
-    # Grid has same size as 'names':
-    egrid = ElectrodeGrid((1, 2), spacing, type=gtype, names=('C1', '4'))
-    npt.assert_equal(egrid[0, 0], egrid['C1'])
-    npt.assert_equal(egrid[0, 1], egrid['4'])
 
     # Can't have a zero-sized grid:
     with pytest.raises(ValueError):
         egrid = ElectrodeGrid((0, 0), spacing, type=gtype)
     with pytest.raises(ValueError):
         egrid = ElectrodeGrid((5, 0), spacing, type=gtype)
+
+    # Verify spacing is correct:
+    grid = ElectrodeGrid(gshape, spacing, type=gtype, etype=DiskElectrode,
+                         r=30, orientation=orientation)
+    npt.assert_almost_equal(np.sqrt((grid['A1'].x - grid['B1'].x) ** 2 +
+                                    (grid['A1'].y - grid['B1'].y) ** 2),
+                            spacing)
+    npt.assert_almost_equal(np.sqrt((grid['A1'].x - grid['A2'].x) ** 2 +
+                                    (grid['A1'].y - grid['A2'].y) ** 2),
+                            spacing)
+    if gtype == 'hex':
+        npt.assert_almost_equal(np.sqrt((grid['A2'].x - grid['B1'].x) ** 2 +
+                                        (grid['A2'].y - grid['B1'].y) ** 2),
+                                spacing)
+
+    # Different spacing in x and y:
+    x_spc, y_spc = 50, 100
+    grid = ElectrodeGrid(gshape, (x_spc, y_spc), type=gtype, r=30,
+                         etype=DiskElectrode, orientation=orientation)
+    print(gtype, orientation)
+    npt.assert_almost_equal(grid['A2'].x - grid['A1'].x, x_spc)
+    npt.assert_almost_equal(grid['B2'].y - grid['A2'].y, y_spc)
+
+    # Grid has same size as 'names':
+    egrid = ElectrodeGrid((1, 2), spacing, type=gtype, names=('C1', '4'))
+    npt.assert_equal(egrid[0, 0], egrid['C1'])
+    npt.assert_equal(egrid[0, 1], egrid['4'])
 
     # Invalid naming conventions:
     with pytest.raises(ValueError):
@@ -353,10 +367,6 @@ def test_ElectrodeGrid(gtype):
                           names=['53', '18', '00', '81', '11', '12'])
     npt.assert_equal([e for e in egrid.electrode_names],
                      ['53', '18', '00', '81', '11', '12'])
-
-    # Slots:
-    npt.assert_equal(hasattr(egrid, '__slots__'), True)
-    npt.assert_equal(hasattr(egrid, '__dict__'), False)
 
 
 @pytest.mark.parametrize('gtype', ('rect', 'hex'))

--- a/pulse2percept/implants/tests/test_prima.py
+++ b/pulse2percept/implants/tests/test_prima.py
@@ -50,7 +50,7 @@ def test_PRIMA(ztype, x, y, rot):
     npt.assert_equal(len(prima.earray.electrodes), n_elec)
 
     # Coordinates of A6 when device is not rotated:
-    xy = np.array([-616.99, -925.0]).T
+    xy = np.array([-476.31, -925.0]).T
     # Rotate
     rot_rad = np.deg2rad(rot)
     R = np.array([np.cos(rot_rad), -np.sin(rot_rad),
@@ -101,7 +101,7 @@ def test_PRIMA75(ztype, x, y, rot):
     npt.assert_equal(prima.n_electrodes, n_elec)
 
     # Coordinates of A6 when device is not rotated:
-    xy = np.array([-200.24, -431.25]).T
+    xy = np.array([-129.90, -431.25]).T
     # Rotate
     rot_rad = np.deg2rad(rot)
     R = np.array([np.cos(rot_rad), -np.sin(rot_rad),
@@ -152,7 +152,7 @@ def test_PRIMA55(ztype, x, y, rot):
     npt.assert_equal(prima.n_electrodes, n_elec)
 
     # Coordinates of C8 when device is not rotated:
-    xy = np.array([-216.58, -371.25]).T
+    xy = np.array([-142.89, -371.25]).T
     # Rotate
     rot_rad = np.deg2rad(rot)
     R = np.array([np.cos(rot_rad), -np.sin(rot_rad),
@@ -203,7 +203,7 @@ def test_PRIMA40(ztype, x, y, rot):
     npt.assert_equal(prima.n_electrodes, n_elec)
 
     # Coordinates of D16 when device is not rotated:
-    xy = np.array([-20.38, -370.0]).T
+    xy = np.array([51.96, -370.0]).T
     # Rotate
     rot_rad = np.deg2rad(rot)
     R = np.array([np.cos(rot_rad), -np.sin(rot_rad),


### PR DESCRIPTION
- [X] Allow different `ElectrodeGrid` spacings in `x` and `y` direction
- [X] Center hex grid
- [X] Fix hex grid spacing
- [X] Allow reverse labeling of rows/columns