### PR TITLE
[FIX] Fix bug on accessing model parameters inside __init__ of another class

### DIFF
--- a/pulse2percept/models/base.py
+++ b/pulse2percept/models/base.py
@@ -691,13 +691,7 @@ class Model(PrettyPrint):
             *  if the attribtue is not found, raises an AttributeError.
 
         """
-        if sys._getframe(2).f_code.co_name == '__init__':
-            # We can set new class attributes in the constructor. Reaching this
-            # point means the default attribute access failed - most likely
-            # because we are trying to create a variable. In this case, simply
-            # raise an exception:
-            raise AttributeError("%s not found" % attr)
-        # Outside the constructor, we need to check the spatial/temporal model:
+        # Check the spatial/temporal model:
         try:
             spatial = getattr(self.spatial, attr)
             spatial_valid = True
@@ -709,6 +703,8 @@ class Model(PrettyPrint):
         except AttributeError:
             temporal_valid = False
         if not spatial_valid and not temporal_valid:
+            # If we are in the constructor, this will be caught later and
+            # a new variable will be constructed
             raise AttributeError("%s has no attribute "
                                  "'%s'." % (self.__class__.__name__,
                                             attr))


### PR DESCRIPTION
## Description

Previously, if called 2 frames below the constructor, `BaseModel` `__getattr__` raises an [attribute error](https://github.com/pulse2percept/pulse2percept/blob/master/pulse2percept/models/base.py#L694-L699), which is caught later and the attribute created. 

The problem is that it is also possible to be 2 frames below a different classes `__init__` , and then during `__getattr__` even if the spatial/temporal part of the model has the attribute, this init check is done first, so an exception is still raised. 

It is actually possible to completely remove this `__init__` check. This is because the only possibilities are that 1) we already have the attribute in either the spatial or the temporal model, in which case just return it. Or 2) the attribute does not exist in either the spatial or temporal model. In this case, the action is the same whether or not we are in the initializer: raise an AttributeError. If we are in our own initializer, then Frozen class logic that is already implemented will catch the exception and create the attribute. Thus these lines can simply be deleted.


## Code to reproduce error:
```
class Test:
    def __init__(self):
        self.model = AxonMapModel()
        self.test_fn()
    
    def test_fn(self):
        self.rho = self.model.rho
        print(self.rho)
        
Test()
```
Raises AttributeError caused by https://github.com/pulse2percept/pulse2percept/blob/master/pulse2percept/models/base.py#L694-L699

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)

