### PR TITLE
[REF] [FIX] Refactor retinotopy

### DIFF
--- a/doc/users/faq.rst
+++ b/doc/users/faq.rst
@@ -20,14 +20,14 @@ How are retinal coordinates mapped to visual field coordinates?
 Studies often assume a linear mapping between retinal and visual field
 coordinates (e.g., [Hayes2003]_, [Thompson2003]_), based on the work by
 [Curcio1990]_
-(see :py:class:`~pulse2percept.utils.Curcio1990Transform`).
+(see :py:class:`~pulse2percept.utils.Curcio1990Map`).
 
 A more exact transformation is given in [Watson2014]_
-(see :py:class:`~pulse2percept.utils.Watson2014Transform`
-and :py:class:`~pulse2percept.utils.Watson2014DisplaceTransform`).
+(see :py:class:`~pulse2percept.utils.Watson2014Map`
+and :py:class:`~pulse2percept.utils.Watson2014DisplaceMap`).
 
 You can also write your own
-:py:class:`~pulse2percept.utils.RetinalCoordTransform`.
+:py:class:`~pulse2percept.utils.VisualFieldMap`.
 
 In any case, note that stimulation of the inferior (superior) retina leads to
 phosphenes appearing in the upper (lower) visual field.

--- a/examples/models/plot_retinotopy.py
+++ b/examples/models/plot_retinotopy.py
@@ -1,0 +1,125 @@
+# -*- coding: utf-8 -*-
+"""
+===============================================================================
+Retinotopy: Predicting the perceptual effects of different visual field maps
+===============================================================================
+
+Every computational model needs to assume a mapping between retinal and visual
+field coordinates. A number of these visual field maps are provided in the
+:py:mod:`~pulse2percept.utils.geometry` module of the utilities subpackage:
+
+*  :py:class:`~pulse2percept.utils.Curcio1990Map`: The [Curcio1990]_ model
+   simply assumes that one degree of visual angle (dva) is equal to 280 um on
+   the retina.
+*  :py:class:`~pulse2percept.utils.Watson2014Map`: The [Watson2014]_ model
+   extends [Curcio1990]_ by recognizing that the transformation between dva and
+   retinal eccentricity is not linear (see Eq. A5 in [Watson2014]_). However,
+   within 40 degrees of eccentricity, the transform is virtually
+   indistuingishable from [Curcio1990]_.
+*  :py:class:`~pulse2percept.utils.Watson2014DisplaceMap`: [Watson2014]_ also
+   describes the retinal ganglion cell (RGC) density at different retinal
+   eccentricities. In specific, there is a central retinal zone where RGC bodies
+   are displaced centrifugally some distance from the inner segments of the
+   cones to which they are connected through the bipolar cells, and thus from
+   their receptive field (see Eq. 5 [Watson2014]_).
+
+All of these visual field maps follow the
+:py:class:`~pulse2percept.utils.VisualFieldMap` template.
+This means that they have to specify a ``dva2ret`` method, which transforms
+visual field coordinates into retinal coordinates, and a complementary 
+``ret2dva`` method.
+
+"""
+# sphinx_gallery_thumbnail_number = 4
+
+###############################################################################
+# Visual field maps
+# -----------------
+#
+# To appreciate the difference between the available visual field maps, let us
+# look at a rectangular grid in visual field coordinates:
+
+import pulse2percept as p2p
+import matplotlib.pyplot as plt
+
+grid = p2p.utils.Grid2D((-50, 50), (-50, 50), step=5)
+plt.scatter(grid.x, grid.y)
+plt.xlabel('x (degrees of visual angle)')
+plt.ylabel('y (degrees of visual angle)')
+plt.axis('square')
+
+###############################################################################
+# Such a grid is typically created during a model's ``build`` process and
+# defines at which (x,y) locations the percept is to be evaluated.
+#
+# However, these visual field coordinates are mapped onto different retinal
+# coordinates under the three visual field maps:
+
+transforms = [p2p.utils.Curcio1990Map,
+              p2p.utils.Watson2014Map,
+              p2p.utils.Watson2014DisplaceMap]
+fig, axes = plt.subplots(ncols=3, sharey=True, figsize=(13, 4))
+for ax, transform in zip(axes, transforms):
+    ax.scatter(*transform().dva2ret(grid.x, grid.y))
+    ax.set_title(transform().__class__.__name__)
+    ax.set_xlabel('x (microns)')
+    ax.set_ylabel('y (microns)')
+    ax.axis('equal')
+
+###############################################################################
+# Whereas the [Curcio1990]_ map applies a simple scaling factor to the visual
+# field coordinates, [Watson2014]_ uses a nonlinear transform.
+# One thing to note is the RGC displacement zone in the third panel, which might
+# lead to distortions in the fovea.
+#
+# Perceptual distortions
+# ----------------------
+#
+# The perceptual consequences of these visual field maps become apparent when
+# used in combination with an implant.
+#
+# For this purpose, let us create an :py:class:`~pulse2percept.models.AlphaAMS`
+# device on the fovea and feed it a suitable stimulus:
+
+implant = p2p.implants.AlphaAMS(stim=p2p.stimuli.LogoUCSB())
+implant.stim.plot()
+
+###############################################################################
+# We can easily switch out the visual field maps by passing a ``retinotopy``
+# attribute to :py:class:`~pulse2percept.models.ScoreboardModel` (by default,
+# the scoreboard model will use [Curcio1990]_):
+
+fig, axes = plt.subplots(ncols=3, sharey=True, figsize=(13, 4))
+for ax, transform in zip(axes, transforms):
+    model = p2p.models.ScoreboardModel(xrange=(-6, 6), yrange=(-6, 6),
+                                       retinotopy=transform())
+    model.build()
+    model.predict_percept(implant).plot(ax=ax)
+    ax.set_title(transform().__class__.__name__)
+
+###############################################################################
+# Whereas the left and center panel look virtually identical, the rightmost
+# panel predicts a rather striking perceptual effect of the RGC displacement
+# zone.
+#
+# Creating your own visual field map
+# ----------------------------------
+#
+# To create your own visual field map, you need to subclass the
+# :py:class:`~pulse2percept.utils.VisualFieldMap` template and provide your own
+# ``dva2ret`` and ``ret2dva`` methods.
+# For example, the following class would (wrongly) assume that retinal
+# coordinates are identical to visual field coordinates:
+#
+# .. code-block:: python
+#
+#     class MyVisualFieldMap(p2p.utils.VisualFieldMap):
+#
+#         def dva2ret(self, xdva, ydva):
+#             return xdva, ydva
+#
+#         def ret2dva(self, xret, yret):
+#             return xret, yret
+#
+# To use it with a model, you need to pass ``retinotopy=MyVisualFieldMap()``
+# to the model's constructor.

--- a/pulse2percept/models/base.py
+++ b/pulse2percept/models/base.py
@@ -195,12 +195,12 @@ class SpatialModel(BaseModel, metaclass=ABCMeta):
         return params
 
     @abstractmethod
-    def dva2ret(self, xdva):
+    def dva2ret(self, xdva, ydva):
         """Convert degrees of visual angle (dva) into retinal coords (um)"""
         raise NotImplementedError
 
     @abstractmethod
-    def ret2dva(self, xret):
+    def ret2dva(self, xret, yret):
         """Convert retinal corods (um) to degrees of visual angle (dva)"""
         raise NotImplementedError
 
@@ -230,8 +230,7 @@ class SpatialModel(BaseModel, metaclass=ABCMeta):
         # Build the spatial grid:
         self.grid = Grid2D(self.xrange, self.yrange, step=self.xystep,
                            grid_type=self.grid_type)
-        self.grid.xret = self.dva2ret(self.grid.x)
-        self.grid.yret = self.dva2ret(self.grid.y)
+        self.grid.xret, self.grid.yret = self.dva2ret(self.grid.x, self.grid.y)
         self._build()
         self.is_built = True
         return self

--- a/pulse2percept/models/base.py
+++ b/pulse2percept/models/base.py
@@ -8,7 +8,7 @@ import numpy as np
 from ..implants import ProsthesisSystem
 from ..stimuli import Stimulus
 from ..percepts import Percept
-from ..utils import (Curcio1990Transform, PrettyPrint, Frozen, FreezeError,
+from ..utils import (Curcio1990Map, PrettyPrint, Frozen, FreezeError,
                      Grid2D, bisect)
 from ..utils.constants import ZORDER
 
@@ -194,7 +194,7 @@ class SpatialModel(BaseModel, metaclass=ABCMeta):
             # Below threshold, percept has brightness zero:
             'thresh_percept': 0,
             # Retinotopic map to be used:
-            'retinotopy': Curcio1990Transform(),
+            'retinotopy': Curcio1990Map(),
             # JobLib or Dask can be used to parallelize computations:
             'engine': 'serial',
             'scheduler': 'threading',

--- a/pulse2percept/models/beyeler2019.py
+++ b/pulse2percept/models/beyeler2019.py
@@ -8,7 +8,7 @@ from scipy.spatial import cKDTree
 import matplotlib.pyplot as plt
 from matplotlib.patches import Ellipse
 
-from ..utils import parfor, Watson2014Transform
+from ..utils import parfor, Watson2014Map
 from ..utils.constants import ZORDER
 from ..implants import ProsthesisSystem, ElectrodeArray
 from ..stimuli import Stimulus
@@ -54,10 +54,10 @@ class ScoreboardSpatial(SpatialModel):
         use ``xrange=(0, 1)`` and ``xystep=0.5``.
     grid_type : {'rectangular', 'hexagonal'}, optional
         Whether to simulate points on a rectangular or hexagonal grid
-    retinotopy : :py:class:`~pulse2percept.utils.RetinalCoordTransform`, optional
-        An instance of a :py:class:`~pulse2percept.utils.RetinalCoordTransform`
+    retinotopy : :py:class:`~pulse2percept.utils.VisualFieldMap`, optional
+        An instance of a :py:class:`~pulse2percept.utils.VisualFieldMap`
         object that provides ``ret2dva`` and ``dva2ret`` methods.
-        By default, :py:class:`~pulse2percept.utils.Watson2014Transform` is
+        By default, :py:class:`~pulse2percept.utils.Watson2014Map` is
         used.
 
     .. important ::
@@ -70,7 +70,7 @@ class ScoreboardSpatial(SpatialModel):
     def get_default_params(self):
         """Returns all settable parameters of the scoreboard model"""
         base_params = super(ScoreboardSpatial, self).get_default_params()
-        params = {'rho': 100, 'retinotopy': Watson2014Transform()}
+        params = {'rho': 100, 'retinotopy': Watson2014Map()}
         return {**base_params, **params}
 
     def _predict_spatial(self, earray, stim):
@@ -121,10 +121,10 @@ class ScoreboardModel(Model):
         use ``xrange=(0, 1)`` and ``xystep=0.5``.
     grid_type : {'rectangular', 'hexagonal'}, optional
         Whether to simulate points on a rectangular or hexagonal grid
-    retinotopy : :py:class:`~pulse2percept.utils.RetinalCoordTransform`, optional
-        An instance of a :py:class:`~pulse2percept.utils.RetinalCoordTransform`
+    retinotopy : :py:class:`~pulse2percept.utils.VisualFieldMap`, optional
+        An instance of a :py:class:`~pulse2percept.utils.VisualFieldMap`
         object that provides ``ret2dva`` and ``dva2ret`` methods.
-        By default, :py:class:`~pulse2percept.utils.Watson2014Transform` is
+        By default, :py:class:`~pulse2percept.utils.Watson2014Map` is
         used.
 
     .. important ::
@@ -177,10 +177,10 @@ class AxonMapSpatial(SpatialModel):
         use ``xrange=(0, 1)`` and ``xystep=0.5``.
     grid_type : {'rectangular', 'hexagonal'}, optional
         Whether to simulate points on a rectangular or hexagonal grid
-    retinotopy : :py:class:`~pulse2percept.utils.RetinalCoordTransform`, optional
-        An instance of a :py:class:`~pulse2percept.utils.RetinalCoordTransform`
+    retinotopy : :py:class:`~pulse2percept.utils.VisualFieldMap`, optional
+        An instance of a :py:class:`~pulse2percept.utils.VisualFieldMap`
         object that provides ``ret2dva`` and ``dva2ret`` methods.
-        By default, :py:class:`~pulse2percept.utils.Watson2014Transform` is
+        By default, :py:class:`~pulse2percept.utils.Watson2014Map` is
         used.
     loc_od, loc_od: (x,y), optional
         Location of the optic disc in degrees of visual angle. Note that the
@@ -253,7 +253,7 @@ class AxonMapSpatial(SpatialModel):
             # You can force a build by ignoring pickles:
             'ignore_pickle': False,
             # Use the Watson transform for dva <=> ret:
-            'retinotopy': Watson2014Transform()
+            'retinotopy': Watson2014Map()
         }
         return {**base_params, **params}
 
@@ -841,10 +841,10 @@ class AxonMapModel(Model):
         use ``xrange=(0, 1)`` and ``xystep=0.5``.
     grid_type : {'rectangular', 'hexagonal'}, optional
         Whether to simulate points on a rectangular or hexagonal grid
-    retinotopy : :py:class:`~pulse2percept.utils.RetinalCoordTransform`, optional
-        An instance of a :py:class:`~pulse2percept.utils.RetinalCoordTransform`
+    retinotopy : :py:class:`~pulse2percept.utils.VisualFieldMap`, optional
+        An instance of a :py:class:`~pulse2percept.utils.VisualFieldMap`
         object that provides ``ret2dva`` and ``dva2ret`` methods.
-        By default, :py:class:`~pulse2percept.utils.Watson2014Transform` is
+        By default, :py:class:`~pulse2percept.utils.Watson2014Map` is
         used.
     loc_od, loc_od: (x,y), optional
         Location of the optic disc in degrees of visual angle. Note that the

--- a/pulse2percept/models/beyeler2019.py
+++ b/pulse2percept/models/beyeler2019.py
@@ -39,28 +39,32 @@ class ScoreboardSpatial(SpatialModel):
     ----------
     rho : double, optional
         Exponential decay constant describing phosphene size (microns).
-    x_range : (x_min, x_max), optional
+    xrange : (x_min, x_max), optional
         A tuple indicating the range of x values to simulate (in degrees of
         visual angle). In a right eye, negative x values correspond to the
         temporal retina, and positive x values to the nasal retina. In a left
         eye, the opposite is true.
-    y_range : tuple, (y_min, y_max)
+    yrange : tuple, (y_min, y_max), optional
         A tuple indicating the range of y values to simulate (in degrees of
         visual angle). Negative y values correspond to the superior retina,
         and positive y values to the inferior retina.
-    xystep : int, double, tuple
+    xystep : int, double, tuple, optional
         Step size for the range of (x,y) values to simulate (in degrees of
         visual angle). For example, to create a grid with x values [0, 0.5, 1]
-        use ``x_range=(0, 1)`` and ``xystep=0.5``.
-    grid_type : {'rectangular', 'hexagonal'}
+        use ``xrange=(0, 1)`` and ``xystep=0.5``.
+    grid_type : {'rectangular', 'hexagonal'}, optional
         Whether to simulate points on a rectangular or hexagonal grid
+    retinotopy : :py:class:`~pulse2percept.utils.RetinalCoordTransform`, optional
+        An instance of a :py:class:`~pulse2percept.utils.RetinalCoordTransform`
+        object that provides ``ret2dva`` and ``dva2ret`` methods.
+        By default, :py:class:`~pulse2percept.utils.Watson2014Transform` is
+        used.
 
     .. important ::
 
         If you change important model parameters outside the constructor (e.g.,
-        by directly setting ``model.axlambda = 100``), you will have to call
+        by directly setting ``model.xrange = (-10, 10)``), you will have to call
         ``model.build()`` again for your changes to take effect.
-
     """
 
     def get_default_params(self):
@@ -100,25 +104,35 @@ class ScoreboardModel(Model):
         Use :py:class:`~pulse2percept.models.ScoreboardSpatial` if you want
         to combine the spatial model with a temporal model.
 
-    Parameters
-    ----------
     rho : double, optional
         Exponential decay constant describing phosphene size (microns).
-    x_range : (x_min, x_max), optional
+    xrange : (x_min, x_max), optional
         A tuple indicating the range of x values to simulate (in degrees of
         visual angle). In a right eye, negative x values correspond to the
         temporal retina, and positive x values to the nasal retina. In a left
         eye, the opposite is true.
-    y_range : tuple, (y_min, y_max)
+    yrange : tuple, (y_min, y_max), optional
         A tuple indicating the range of y values to simulate (in degrees of
         visual angle). Negative y values correspond to the superior retina,
         and positive y values to the inferior retina.
-    xystep : int, double, tuple
+    xystep : int, double, tuple, optional
         Step size for the range of (x,y) values to simulate (in degrees of
         visual angle). For example, to create a grid with x values [0, 0.5, 1]
-        use ``x_range=(0, 1)`` and ``xystep=0.5``.
-    grid_type : {'rectangular', 'hexagonal'}
+        use ``xrange=(0, 1)`` and ``xystep=0.5``.
+    grid_type : {'rectangular', 'hexagonal'}, optional
         Whether to simulate points on a rectangular or hexagonal grid
+    retinotopy : :py:class:`~pulse2percept.utils.RetinalCoordTransform`, optional
+        An instance of a :py:class:`~pulse2percept.utils.RetinalCoordTransform`
+        object that provides ``ret2dva`` and ``dva2ret`` methods.
+        By default, :py:class:`~pulse2percept.utils.Watson2014Transform` is
+        used.
+
+    .. important ::
+
+        If you change important model parameters outside the constructor (e.g.,
+        by directly setting ``model.xrange = (-10, 10)``), you will have to call
+        ``model.build()`` again for your changes to take effect.
+
     """
 
     def __init__(self, **params):
@@ -153,16 +167,21 @@ class AxonMapSpatial(SpatialModel):
         visual angle). In a right eye, negative x values correspond to the
         temporal retina, and positive x values to the nasal retina. In a left
         eye, the opposite is true.
-    yrange : tuple, (y_min, y_max)
+    yrange : (y_min, y_max), optional
         A tuple indicating the range of y values to simulate (in degrees of
         visual angle). Negative y values correspond to the superior retina,
         and positive y values to the inferior retina.
-    xystep : int, double, tuple
+    xystep : int or double or tuple, optional
         Step size for the range of (x,y) values to simulate (in degrees of
         visual angle). For example, to create a grid with x values [0, 0.5, 1]
-        use ``x_range=(0, 1)`` and ``xystep=0.5``.
-    grid_type : {'rectangular', 'hexagonal'}
+        use ``xrange=(0, 1)`` and ``xystep=0.5``.
+    grid_type : {'rectangular', 'hexagonal'}, optional
         Whether to simulate points on a rectangular or hexagonal grid
+    retinotopy : :py:class:`~pulse2percept.utils.RetinalCoordTransform`, optional
+        An instance of a :py:class:`~pulse2percept.utils.RetinalCoordTransform`
+        object that provides ``ret2dva`` and ``dva2ret`` methods.
+        By default, :py:class:`~pulse2percept.utils.Watson2014Transform` is
+        used.
     loc_od, loc_od: (x,y), optional
         Location of the optic disc in degrees of visual angle. Note that the
         optic disc in a left eye will be corrected to have a negative x
@@ -191,6 +210,12 @@ class AxonMapSpatial(SpatialModel):
     ignore_pickle: bool, optional
         A flag whether to ignore the pickle file in future calls to
         ``model.build()``.
+
+    .. important ::
+
+        If you change important model parameters outside the constructor (e.g.,
+        by directly setting ``model.axlambda = 100``), you will have to call
+        ``model.build()`` again for your changes to take effect.
 
     Notes
     -----
@@ -806,16 +831,21 @@ class AxonMapModel(Model):
         visual angle). In a right eye, negative x values correspond to the
         temporal retina, and positive x values to the nasal retina. In a left
         eye, the opposite is true.
-    yrange : tuple, (y_min, y_max)
+    yrange : (y_min, y_max), optional
         A tuple indicating the range of y values to simulate (in degrees of
         visual angle). Negative y values correspond to the superior retina,
         and positive y values to the inferior retina.
-    xystep : int, double, tuple
+    xystep : int or double or tuple, optional
         Step size for the range of (x,y) values to simulate (in degrees of
         visual angle). For example, to create a grid with x values [0, 0.5, 1]
-        use ``x_range=(0, 1)`` and ``xystep=0.5``.
-    grid_type : {'rectangular', 'hexagonal'}
+        use ``xrange=(0, 1)`` and ``xystep=0.5``.
+    grid_type : {'rectangular', 'hexagonal'}, optional
         Whether to simulate points on a rectangular or hexagonal grid
+    retinotopy : :py:class:`~pulse2percept.utils.RetinalCoordTransform`, optional
+        An instance of a :py:class:`~pulse2percept.utils.RetinalCoordTransform`
+        object that provides ``ret2dva`` and ``dva2ret`` methods.
+        By default, :py:class:`~pulse2percept.utils.Watson2014Transform` is
+        used.
     loc_od, loc_od: (x,y), optional
         Location of the optic disc in degrees of visual angle. Note that the
         optic disc in a left eye will be corrected to have a negative x
@@ -844,6 +874,12 @@ class AxonMapModel(Model):
     ignore_pickle: bool, optional
         A flag whether to ignore the pickle file in future calls to
         ``model.build()``.
+
+    .. important ::
+
+        If you change important model parameters outside the constructor (e.g.,
+        by directly setting ``model.axlambda = 100``), you will have to call
+        ``model.build()`` again for your changes to take effect.
 
     Notes
     -----

--- a/pulse2percept/models/granley2021.py
+++ b/pulse2percept/models/granley2021.py
@@ -239,10 +239,10 @@ class BiphasicAxonMapSpatial(AxonMapSpatial):
             use ``x_range=(0, 1)`` and ``xystep=0.5``.
         grid_type : {'rectangular', 'hexagonal'}
             Whether to simulate points on a rectangular or hexagonal grid
-        retinotopy : :py:class:`~pulse2percept.utils.RetinalCoordTransform`, optional
-            An instance of a :py:class:`~pulse2percept.utils.RetinalCoordTransform`
+        retinotopy : :py:class:`~pulse2percept.utils.VisualFieldMap`, optional
+            An instance of a :py:class:`~pulse2percept.utils.VisualFieldMap`
             object that provides ``ret2dva`` and ``dva2ret`` methods.
-            By default, :py:class:`~pulse2percept.utils.Watson2014Transform` is
+            By default, :py:class:`~pulse2percept.utils.Watson2014Map` is
             used.
         loc_od, loc_od: (x,y), optional
             Location of the optic disc in degrees of visual angle. Note that the
@@ -535,10 +535,10 @@ class BiphasicAxonMapModel(Model):
             use ``x_range=(0, 1)`` and ``xystep=0.5``.
         grid_type : {'rectangular', 'hexagonal'}
             Whether to simulate points on a rectangular or hexagonal grid
-        retinotopy : :py:class:`~pulse2percept.utils.RetinalCoordTransform`, optional
-            An instance of a :py:class:`~pulse2percept.utils.RetinalCoordTransform`
+        retinotopy : :py:class:`~pulse2percept.utils.VisualFieldMap`, optional
+            An instance of a :py:class:`~pulse2percept.utils.VisualFieldMap`
             object that provides ``ret2dva`` and ``dva2ret`` methods.
-            By default, :py:class:`~pulse2percept.utils.Watson2014Transform` is
+            By default, :py:class:`~pulse2percept.utils.Watson2014Map` is
             used.
         loc_od, loc_od: (x,y), optional
             Location of the optic disc in degrees of visual angle. Note that the

--- a/pulse2percept/models/granley2021.py
+++ b/pulse2percept/models/granley2021.py
@@ -181,6 +181,7 @@ class DefaultStreakModel(BaseModel):
 
 class BiphasicAxonMapSpatial(AxonMapSpatial):
     """ BiphasicAxonMapModel of [Granley2021]_ (spatial model)
+
     An AxonMapModel where phosphene brightness, size, and streak length scale
     according to amplitude, frequency, and pulse duration
 
@@ -238,6 +239,11 @@ class BiphasicAxonMapSpatial(AxonMapSpatial):
             use ``x_range=(0, 1)`` and ``xystep=0.5``.
         grid_type : {'rectangular', 'hexagonal'}
             Whether to simulate points on a rectangular or hexagonal grid
+        retinotopy : :py:class:`~pulse2percept.utils.RetinalCoordTransform`, optional
+            An instance of a :py:class:`~pulse2percept.utils.RetinalCoordTransform`
+            object that provides ``ret2dva`` and ``dva2ret`` methods.
+            By default, :py:class:`~pulse2percept.utils.Watson2014Transform` is
+            used.
         loc_od, loc_od: (x,y), optional
             Location of the optic disc in degrees of visual angle. Note that the
             optic disc in a left eye will be corrected to have a negative x
@@ -262,6 +268,7 @@ class BiphasicAxonMapSpatial(AxonMapSpatial):
         ignore_pickle: bool, optional
             A flag whether to ignore the pickle file in future calls to
             ``model.build()``.
+
     """
 
     def __init__(self, **params):
@@ -470,6 +477,7 @@ class BiphasicAxonMapSpatial(AxonMapSpatial):
 
 class BiphasicAxonMapModel(Model):
     """ BiphasicAxonMapModel of [Granley2021]_ (standalone model)
+
     An AxonMapModel where phosphene brightness, size, and streak length scale
     according to amplitude, frequency, and pulse duration
 
@@ -503,6 +511,7 @@ class BiphasicAxonMapModel(Model):
         Use probabilistic sigmoid thresholding, default: False
     **params: dict, optional
         Arguments to be passed to AxonMapSpatial
+
         Options:
         ---------
         axlambda: double, optional
@@ -526,6 +535,11 @@ class BiphasicAxonMapModel(Model):
             use ``x_range=(0, 1)`` and ``xystep=0.5``.
         grid_type : {'rectangular', 'hexagonal'}
             Whether to simulate points on a rectangular or hexagonal grid
+        retinotopy : :py:class:`~pulse2percept.utils.RetinalCoordTransform`, optional
+            An instance of a :py:class:`~pulse2percept.utils.RetinalCoordTransform`
+            object that provides ``ret2dva`` and ``dva2ret`` methods.
+            By default, :py:class:`~pulse2percept.utils.Watson2014Transform` is
+            used.
         loc_od, loc_od: (x,y), optional
             Location of the optic disc in degrees of visual angle. Note that the
             optic disc in a left eye will be corrected to have a negative x
@@ -550,6 +564,7 @@ class BiphasicAxonMapModel(Model):
         ignore_pickle: bool, optional
             A flag whether to ignore the pickle file in future calls to
             ``model.build()``.
+
     """
 
     def __init__(self, **params):

--- a/pulse2percept/models/granley2021.py
+++ b/pulse2percept/models/granley2021.py
@@ -276,18 +276,18 @@ class BiphasicAxonMapSpatial(AxonMapSpatial):
 
     def __getattr__(self, attr):
         # Called when normal get attribute fails
-        # If we are in the initializer, or if trying to access 
+        # If we are in the initializer, or if trying to access
         # an effects model, raise an error which is caught and causes
         # the parameter to be created.
-        if (sys._getframe(3).f_code.co_name == '__init__' and \
-            "pulse2percept/models/base.py" in \
-            sys._getframe(3).f_code.co_filename) or \
-            (attr in ['bright_model', 'streak_model', 'size_model']):
+        if (sys._getframe(3).f_code.co_name == '__init__' and
+                "pulse2percept/models/base.py" in
+                sys._getframe(3).f_code.co_filename) or \
+                (attr in ['bright_model', 'streak_model', 'size_model']):
             # We can set new class attributes in the constructor. Reaching this
             # point means the default attribute access failed - most likely
             # because we are trying to create a variable. In this case, simply
             # raise an exception:
-            # Note that this gets called from __init__ of BaseModel, not directly from 
+            # Note that this gets called from __init__ of BaseModel, not directly from
             # BiphasicAxonMap
             raise AttributeError("%s not found" % attr)
         # Check if bright/size/streak model has param
@@ -352,8 +352,7 @@ class BiphasicAxonMapSpatial(AxonMapSpatial):
             # Use probabilistic thresholding
             'do_thresholding': False
         }
-        params.update(base_params)
-        return params
+        return {**base_params, **params}
 
     def _build(self):
         if not callable(self.bright_model):
@@ -368,7 +367,7 @@ class BiphasicAxonMapSpatial(AxonMapSpatial):
         """Predicts the percept"""
         if not isinstance(earray, ElectrodeArray):
             raise TypeError("Implant must be of type ElectrodeArray but it is " +
-                str(type(earray)))
+                            str(type(earray)))
         if not isinstance(stim, Stimulus):
             raise TypeError(
                 "Stim must be of type Stimulus but it is " + str(type(stim)))
@@ -393,8 +392,10 @@ class BiphasicAxonMapSpatial(AxonMapSpatial):
                 np.array(bright_effects, dtype=np.float32),
                 np.array(size_effects, dtype=np.float32),
                 np.array(streak_effects, dtype=np.float32),
-                np.array([earray[e].x for e in stim.electrodes], dtype=np.float32),
-                np.array([earray[e].y for e in stim.electrodes], dtype=np.float32),
+                np.array([earray[e].x for e in stim.electrodes],
+                         dtype=np.float32),
+                np.array([earray[e].y for e in stim.electrodes],
+                         dtype=np.float32),
                 self.axon_contrib,
                 self.axon_idx_start.astype(np.uint32),
                 self.axon_idx_end.astype(np.uint32),

--- a/pulse2percept/models/nanduri2012.py
+++ b/pulse2percept/models/nanduri2012.py
@@ -5,7 +5,6 @@ from .base import Model, SpatialModel, TemporalModel
 from ._nanduri2012 import spatial_fast, temporal_fast
 from ..implants import ElectrodeArray, DiskElectrode
 from ..stimuli import Stimulus
-from ..utils import Curcio1990Transform
 
 
 class Nanduri2012Spatial(SpatialModel):
@@ -47,22 +46,6 @@ class Nanduri2012Spatial(SpatialModel):
         params = super(Nanduri2012Spatial, self).get_default_params()
         params.update({'atten_a': 14000, 'atten_n': 1.69})
         return params
-
-    def dva2ret(self, xdva, ydva):
-        """Convert degrees of visual angle (dva) to retinal eccentricity (um)
-
-        Assumes that one degree of visual angle is equal to 280 um on the
-        retina.
-        """
-        return Curcio1990Transform.dva2ret(xdva, ydva)
-
-    def ret2dva(self, xret, yret):
-        """Convert retinal eccentricity (um) to degrees of visual angle (dva)
-
-        Assumes that one degree of visual angle is equal to 280 um on the
-        retina.
-        """
-        return Curcio1990Transform.ret2dva(xret, yret)
 
     def _predict_spatial(self, earray, stim):
         """Predicts the brightness at spatial locations"""

--- a/pulse2percept/models/nanduri2012.py
+++ b/pulse2percept/models/nanduri2012.py
@@ -38,10 +38,10 @@ class Nanduri2012Spatial(SpatialModel):
         Nominator of the attentuation function
     atten_n : float32, optional
         Exponent of the attenuation function's denominator
-    retinotopy : :py:class:`~pulse2percept.utils.RetinalCoordTransform`, optional
-        An instance of a :py:class:`~pulse2percept.utils.RetinalCoordTransform`
+    retinotopy : :py:class:`~pulse2percept.utils.VisualFieldMap`, optional
+        An instance of a :py:class:`~pulse2percept.utils.VisualFieldMap`
         object that provides ``ret2dva`` and ``dva2ret`` methods.
-        By default, :py:class:`~pulse2percept.utils.Curcio1990Transform` is
+        By default, :py:class:`~pulse2percept.utils.Curcio1990Map` is
         used.
 
     """
@@ -206,10 +206,10 @@ class Nanduri2012Model(Model):
         A scaling factor applied to the output of the model
     thresh_percept: float, optional
         Below threshold, the percept has brightness zero.
-    retinotopy : :py:class:`~pulse2percept.utils.RetinalCoordTransform`, optional
-        An instance of a :py:class:`~pulse2percept.utils.RetinalCoordTransform`
+    retinotopy : :py:class:`~pulse2percept.utils.VisualFieldMap`, optional
+        An instance of a :py:class:`~pulse2percept.utils.VisualFieldMap`
         object that provides ``ret2dva`` and ``dva2ret`` methods.
-        By default, :py:class:`~pulse2percept.utils.Curcio1990Transform` is
+        By default, :py:class:`~pulse2percept.utils.Curcio1990Map` is
         used.
     """
 

--- a/pulse2percept/models/nanduri2012.py
+++ b/pulse2percept/models/nanduri2012.py
@@ -38,14 +38,19 @@ class Nanduri2012Spatial(SpatialModel):
         Nominator of the attentuation function
     atten_n : float32, optional
         Exponent of the attenuation function's denominator
+    retinotopy : :py:class:`~pulse2percept.utils.RetinalCoordTransform`, optional
+        An instance of a :py:class:`~pulse2percept.utils.RetinalCoordTransform`
+        object that provides ``ret2dva`` and ``dva2ret`` methods.
+        By default, :py:class:`~pulse2percept.utils.Curcio1990Transform` is
+        used.
 
     """
 
     def get_default_params(self):
         """Returns all settable parameters of the Nanduri model"""
-        params = super(Nanduri2012Spatial, self).get_default_params()
-        params.update({'atten_a': 14000, 'atten_n': 1.69})
-        return params
+        base_params = super(Nanduri2012Spatial, self).get_default_params()
+        params = {'atten_a': 14000, 'atten_n': 1.69}
+        return {**base_params, **params}
 
     def _predict_spatial(self, earray, stim):
         """Predicts the brightness at spatial locations"""
@@ -135,12 +140,7 @@ class Nanduri2012Temporal(TemporalModel):
             # Scale the output:
             'scale_out': 1.0
         }
-        # This is subtle: Rather than calling `params.update(base_params)`, we
-        # call `base_params.update(params)`. This will overwrite `base_params`
-        # with values from `params`, which allows us to set `thresh_percept`=0
-        # rather than what the BaseModel dictates:
-        base_params.update(params)
-        return base_params
+        return {**base_params, **params}
 
     def _predict_temporal(self, stim, t_percept):
         """Predict the temporal response"""
@@ -175,7 +175,6 @@ class Nanduri2012Model(Model):
        calculate the spatial activation function, which is assumed to be
        equivalent to the "current spread" described as a function of distance
        from the center of the stimulating electrode (see Eq.2 in the paper).
-
     *  :py:class:`~pulse2percept.models.Nanduri2012Temporal` is used to
        calculate the temporal activation function, which is assumed to be the
        output of a linear-nonlinear cascade model (see Fig.6 in the paper).
@@ -207,6 +206,11 @@ class Nanduri2012Model(Model):
         A scaling factor applied to the output of the model
     thresh_percept: float, optional
         Below threshold, the percept has brightness zero.
+    retinotopy : :py:class:`~pulse2percept.utils.RetinalCoordTransform`, optional
+        An instance of a :py:class:`~pulse2percept.utils.RetinalCoordTransform`
+        object that provides ``ret2dva`` and ``dva2ret`` methods.
+        By default, :py:class:`~pulse2percept.utils.Curcio1990Transform` is
+        used.
     """
 
     def __init__(self, **params):

--- a/pulse2percept/models/nanduri2012.py
+++ b/pulse2percept/models/nanduri2012.py
@@ -48,21 +48,21 @@ class Nanduri2012Spatial(SpatialModel):
         params.update({'atten_a': 14000, 'atten_n': 1.69})
         return params
 
-    def dva2ret(self, xdva):
+    def dva2ret(self, xdva, ydva):
         """Convert degrees of visual angle (dva) to retinal eccentricity (um)
 
         Assumes that one degree of visual angle is equal to 280 um on the
         retina.
         """
-        return Curcio1990Transform.dva2ret(xdva)
+        return Curcio1990Transform.dva2ret(xdva, ydva)
 
-    def ret2dva(self, xret):
+    def ret2dva(self, xret, yret):
         """Convert retinal eccentricity (um) to degrees of visual angle (dva)
 
         Assumes that one degree of visual angle is equal to 280 um on the
         retina.
         """
-        return Curcio1990Transform.ret2dva(xret)
+        return Curcio1990Transform.ret2dva(xret, yret)
 
     def _predict_spatial(self, earray, stim):
         """Predicts the brightness at spatial locations"""

--- a/pulse2percept/models/tests/test_base.py
+++ b/pulse2percept/models/tests/test_base.py
@@ -50,11 +50,11 @@ def test_BaseModel():
 
 class ValidSpatialModel(SpatialModel):
 
-    def dva2ret(self, dva):
-        return Watson2014Transform.dva2ret(dva)
+    def dva2ret(self, xdva, ydva):
+        return Watson2014Transform.dva2ret(xdva, ydva)
 
-    def ret2dva(self, ret):
-        return Watson2014Transform.ret2dva(ret)
+    def ret2dva(self, xret, yret):
+        return Watson2014Transform.ret2dva(xret, yret)
 
     def _predict_spatial(self, earray, stim):
         if not self.is_built:
@@ -124,7 +124,7 @@ def test_SpatialModel_plot():
     npt.assert_almost_equal(ax.get_xlim(), (-22.55, 22.55))
     ax = model.plot(use_dva=False)
     npt.assert_almost_equal(ax.get_xlim(), (-6122.87, 6122.87), decimal=2)
-    npt.assert_almost_equal(ax.get_ylim(), (-4805.75, 4805.75), decimal=2)
+    npt.assert_almost_equal(ax.get_ylim(), (-4808.7, 4808.7), decimal=2)
 
     # Figure size can be changed:
     ax = model.plot(figsize=(8, 7))

--- a/pulse2percept/models/tests/test_base.py
+++ b/pulse2percept/models/tests/test_base.py
@@ -50,11 +50,10 @@ def test_BaseModel():
 
 class ValidSpatialModel(SpatialModel):
 
-    def dva2ret(self, xdva, ydva):
-        return Watson2014Transform.dva2ret(xdva, ydva)
-
-    def ret2dva(self, xret, yret):
-        return Watson2014Transform.ret2dva(xret, yret)
+    def get_default_params(self):
+        params = super(ValidSpatialModel, self).get_default_params()
+        params.update({'retinotopy': Watson2014Transform()})
+        return params
 
     def _predict_spatial(self, earray, stim):
         if not self.is_built:

--- a/pulse2percept/models/tests/test_base.py
+++ b/pulse2percept/models/tests/test_base.py
@@ -8,7 +8,7 @@ from pulse2percept.stimuli import Stimulus
 from pulse2percept.percepts import Percept
 from pulse2percept.models import (BaseModel, Model, NotBuiltError,
                                   SpatialModel, TemporalModel)
-from pulse2percept.utils import FreezeError, Grid2D, Watson2014Transform
+from pulse2percept.utils import FreezeError, Grid2D, Watson2014Map
 
 
 class ValidBaseModel(BaseModel):
@@ -52,7 +52,7 @@ class ValidSpatialModel(SpatialModel):
 
     def get_default_params(self):
         params = super(ValidSpatialModel, self).get_default_params()
-        params.update({'retinotopy': Watson2014Transform()})
+        params.update({'retinotopy': Watson2014Map()})
         return params
 
     def _predict_spatial(self, earray, stim):

--- a/pulse2percept/models/tests/test_beyeler2019.py
+++ b/pulse2percept/models/tests/test_beyeler2019.py
@@ -28,8 +28,8 @@ def test_ScoreboardSpatial():
     npt.assert_equal(model.predict_percept(ArgusI()), None)
 
     # Converting ret <=> dva
-    npt.assert_almost_equal(model.ret2dva(0), 0)
-    npt.assert_almost_equal(model.dva2ret(0), 0)
+    npt.assert_almost_equal(model.ret2dva(0, 0), (0, 0))
+    npt.assert_almost_equal(model.dva2ret(0, 0), (0, 0))
 
     implant = ArgusI(stim=np.zeros(16))
     # Zero in = zero out:
@@ -107,7 +107,7 @@ def test_ScoreboardModel_predict_percept():
     model.build()
     percept = model.predict_percept(ArgusII(stim=np.ones(60)))
     npt.assert_equal(np.sum(np.isclose(percept.data, 0.8, rtol=0.1, atol=0.1)),
-                     92)
+                     88)
 
     # Model gives same outcome as Spatial:
     spatial = ScoreboardSpatial(engine='serial', xystep=1, rho=100)
@@ -135,8 +135,8 @@ def test_AxonMapSpatial(engine):
     npt.assert_equal(model.rho, 987)
 
     # Converting ret <=> dva
-    npt.assert_almost_equal(model.ret2dva(0), 0)
-    npt.assert_almost_equal(model.dva2ret(0), 0)
+    npt.assert_almost_equal(model.ret2dva(0, 0), (0, 0))
+    npt.assert_almost_equal(model.dva2ret(0, 0), (0, 0))
 
     # Nothing in, None out:
     npt.assert_equal(model.predict_percept(ArgusI()), None)
@@ -385,7 +385,7 @@ def test_AxonMapModel_calc_bundle_tangent(engine):
     npt.assert_almost_equal(model.spatial.calc_bundle_tangent(0, 0), 0.4819,
                             decimal=3)
     npt.assert_almost_equal(model.spatial.calc_bundle_tangent(0, 1000),
-                            -0.5532, decimal=3)
+                            -0.5514, decimal=3)
     with pytest.raises(TypeError):
         model.spatial.calc_bundle_tangent([0], 1000)
     with pytest.raises(TypeError):
@@ -412,9 +412,9 @@ def test_AxonMapModel_predict_percept(engine):
     npt.assert_equal(np.sum(percept.data > 0.8), 1)
     npt.assert_equal(np.sum(percept.data > 0.6), 2)
     npt.assert_equal(np.sum(percept.data > 0.1), 7)
-    npt.assert_equal(np.sum(percept.data > 0.0001), 32)
+    npt.assert_equal(np.sum(percept.data > 0.0001), 31)
     # Overall only a few bright pixels:
-    npt.assert_almost_equal(np.sum(percept.data), 3.31321, decimal=3)
+    npt.assert_almost_equal(np.sum(percept.data), 3.3087, decimal=3)
     # Brightest pixel is in lower right:
     npt.assert_almost_equal(percept.data[33, 46, 0], np.max(percept.data))
     # Top half is empty:

--- a/pulse2percept/models/tests/test_beyeler2019.py
+++ b/pulse2percept/models/tests/test_beyeler2019.py
@@ -11,7 +11,7 @@ from pulse2percept.implants import ArgusI, ArgusII
 from pulse2percept.percepts import Percept
 from pulse2percept.models import (AxonMapSpatial, AxonMapModel,
                                   ScoreboardSpatial, ScoreboardModel)
-from pulse2percept.utils import Watson2014Transform, Watson2014DisplaceTransform
+from pulse2percept.utils import Watson2014Map, Watson2014DisplaceMap
 from pulse2percept.utils.testing import assert_warns_msg
 
 
@@ -29,11 +29,11 @@ def test_ScoreboardSpatial():
     npt.assert_equal(model.predict_percept(ArgusI()), None)
 
     # Converting ret <=> dva
-    npt.assert_equal(isinstance(model.retinotopy, Watson2014Transform), True)
+    npt.assert_equal(isinstance(model.retinotopy, Watson2014Map), True)
     npt.assert_almost_equal(model.retinotopy.ret2dva(0, 0), (0, 0))
     npt.assert_almost_equal(model.retinotopy.dva2ret(0, 0), (0, 0))
-    model2 = ScoreboardSpatial(retinotopy=Watson2014DisplaceTransform())
-    npt.assert_equal(isinstance(model2.retinotopy, Watson2014DisplaceTransform),
+    model2 = ScoreboardSpatial(retinotopy=Watson2014DisplaceMap())
+    npt.assert_equal(isinstance(model2.retinotopy, Watson2014DisplaceMap),
                      True)
 
     implant = ArgusI(stim=np.zeros(16))
@@ -73,11 +73,11 @@ def test_ScoreboardModel():
     npt.assert_equal(model.spatial.rho, 987)
 
     # Converting ret <=> dva
-    npt.assert_equal(isinstance(model.retinotopy, Watson2014Transform), True)
+    npt.assert_equal(isinstance(model.retinotopy, Watson2014Map), True)
     npt.assert_almost_equal(model.retinotopy.ret2dva(0, 0), (0, 0))
     npt.assert_almost_equal(model.retinotopy.dva2ret(0, 0), (0, 0))
-    model2 = ScoreboardModel(retinotopy=Watson2014DisplaceTransform())
-    npt.assert_equal(isinstance(model2.retinotopy, Watson2014DisplaceTransform),
+    model2 = ScoreboardModel(retinotopy=Watson2014DisplaceMap())
+    npt.assert_equal(isinstance(model2.retinotopy, Watson2014DisplaceMap),
                      True)
     # Nothing in, None out:
     npt.assert_equal(model.predict_percept(ArgusI()), None)
@@ -147,11 +147,11 @@ def test_AxonMapSpatial(engine):
     npt.assert_equal(model.rho, 987)
 
     # Converting ret <=> dva
-    npt.assert_equal(isinstance(model.retinotopy, Watson2014Transform), True)
+    npt.assert_equal(isinstance(model.retinotopy, Watson2014Map), True)
     npt.assert_almost_equal(model.retinotopy.ret2dva(0, 0), (0, 0))
     npt.assert_almost_equal(model.retinotopy.dva2ret(0, 0), (0, 0))
-    model2 = AxonMapSpatial(retinotopy=Watson2014DisplaceTransform())
-    npt.assert_equal(isinstance(model2.retinotopy, Watson2014DisplaceTransform),
+    model2 = AxonMapSpatial(retinotopy=Watson2014DisplaceMap())
+    npt.assert_equal(isinstance(model2.retinotopy, Watson2014DisplaceMap),
                      True)
 
     # Nothing in, None out:
@@ -238,11 +238,11 @@ def test_AxonMapModel(engine):
         npt.assert_equal(getattr(model.spatial, key), value)
 
     # Converting ret <=> dva
-    npt.assert_equal(isinstance(model.retinotopy, Watson2014Transform), True)
+    npt.assert_equal(isinstance(model.retinotopy, Watson2014Map), True)
     npt.assert_almost_equal(model.retinotopy.ret2dva(0, 0), (0, 0))
     npt.assert_almost_equal(model.retinotopy.dva2ret(0, 0), (0, 0))
-    model2 = AxonMapModel(retinotopy=Watson2014DisplaceTransform())
-    npt.assert_equal(isinstance(model2.retinotopy, Watson2014DisplaceTransform),
+    model2 = AxonMapModel(retinotopy=Watson2014DisplaceMap())
+    npt.assert_equal(isinstance(model2.retinotopy, Watson2014DisplaceMap),
                      True)
 
     # Zeros in, zeros out:

--- a/pulse2percept/models/tests/test_beyeler2019.py
+++ b/pulse2percept/models/tests/test_beyeler2019.py
@@ -11,6 +11,7 @@ from pulse2percept.implants import ArgusI, ArgusII
 from pulse2percept.percepts import Percept
 from pulse2percept.models import (AxonMapSpatial, AxonMapModel,
                                   ScoreboardSpatial, ScoreboardModel)
+from pulse2percept.utils import Watson2014Transform, Watson2014DisplaceTransform
 from pulse2percept.utils.testing import assert_warns_msg
 
 
@@ -28,8 +29,12 @@ def test_ScoreboardSpatial():
     npt.assert_equal(model.predict_percept(ArgusI()), None)
 
     # Converting ret <=> dva
-    npt.assert_almost_equal(model.ret2dva(0, 0), (0, 0))
-    npt.assert_almost_equal(model.dva2ret(0, 0), (0, 0))
+    npt.assert_equal(isinstance(model.retinotopy, Watson2014Transform), True)
+    npt.assert_almost_equal(model.retinotopy.ret2dva(0, 0), (0, 0))
+    npt.assert_almost_equal(model.retinotopy.dva2ret(0, 0), (0, 0))
+    model2 = ScoreboardSpatial(retinotopy=Watson2014DisplaceTransform())
+    npt.assert_equal(isinstance(model2.retinotopy, Watson2014DisplaceTransform),
+                     True)
 
     implant = ArgusI(stim=np.zeros(16))
     # Zero in = zero out:
@@ -67,6 +72,13 @@ def test_ScoreboardModel():
     npt.assert_equal(model.rho, 987)
     npt.assert_equal(model.spatial.rho, 987)
 
+    # Converting ret <=> dva
+    npt.assert_equal(isinstance(model.retinotopy, Watson2014Transform), True)
+    npt.assert_almost_equal(model.retinotopy.ret2dva(0, 0), (0, 0))
+    npt.assert_almost_equal(model.retinotopy.dva2ret(0, 0), (0, 0))
+    model2 = ScoreboardModel(retinotopy=Watson2014DisplaceTransform())
+    npt.assert_equal(isinstance(model2.retinotopy, Watson2014DisplaceTransform),
+                     True)
     # Nothing in, None out:
     npt.assert_equal(model.predict_percept(ArgusI()), None)
 
@@ -123,7 +135,7 @@ def test_ScoreboardModel_predict_percept():
     assert_warns_msg(UserWarning, model.predict_percept, msg, implant)
 
 
-@pytest.mark.parametrize('engine', ('serial', 'cython', 'jax'))
+@ pytest.mark.parametrize('engine', ('serial', 'cython', 'jax'))
 def test_AxonMapSpatial(engine):
     # AxonMapSpatial automatically sets `rho`, `axlambda`:
     model = AxonMapSpatial(engine=engine, xystep=5)
@@ -135,8 +147,12 @@ def test_AxonMapSpatial(engine):
     npt.assert_equal(model.rho, 987)
 
     # Converting ret <=> dva
-    npt.assert_almost_equal(model.ret2dva(0, 0), (0, 0))
-    npt.assert_almost_equal(model.dva2ret(0, 0), (0, 0))
+    npt.assert_equal(isinstance(model.retinotopy, Watson2014Transform), True)
+    npt.assert_almost_equal(model.retinotopy.ret2dva(0, 0), (0, 0))
+    npt.assert_almost_equal(model.retinotopy.dva2ret(0, 0), (0, 0))
+    model2 = AxonMapSpatial(retinotopy=Watson2014DisplaceTransform())
+    npt.assert_equal(isinstance(model2.retinotopy, Watson2014DisplaceTransform),
+                     True)
 
     # Nothing in, None out:
     npt.assert_equal(model.predict_percept(ArgusI()), None)
@@ -202,7 +218,7 @@ def test_AxonMapSpatial_plot():
         plt.close(fig)
 
 
-@pytest.mark.parametrize('engine', ('serial', 'cython', 'jax'))
+@ pytest.mark.parametrize('engine', ('serial', 'cython', 'jax'))
 def test_AxonMapModel(engine):
     set_params = {'xystep': 2, 'engine': engine, 'rho': 432, 'axlambda': 20,
                   'n_axons': 9, 'n_ax_segments': 50,
@@ -220,6 +236,14 @@ def test_AxonMapModel(engine):
     model.build(**set_params)
     for key, value in set_params.items():
         npt.assert_equal(getattr(model.spatial, key), value)
+
+    # Converting ret <=> dva
+    npt.assert_equal(isinstance(model.retinotopy, Watson2014Transform), True)
+    npt.assert_almost_equal(model.retinotopy.ret2dva(0, 0), (0, 0))
+    npt.assert_almost_equal(model.retinotopy.dva2ret(0, 0), (0, 0))
+    model2 = AxonMapModel(retinotopy=Watson2014DisplaceTransform())
+    npt.assert_equal(isinstance(model2.retinotopy, Watson2014DisplaceTransform),
+                     True)
 
     # Zeros in, zeros out:
     implant = ArgusII(stim=np.zeros(60))
@@ -241,10 +265,10 @@ def test_AxonMapModel(engine):
         AxonMapModel(axlambda=9).build()
 
 
-@pytest.mark.parametrize('eye', ('LE', 'RE'))
-@pytest.mark.parametrize('loc_od', ((15.5, 1.5), (7.0, 3.0), (-2.0, -2.0)))
-@pytest.mark.parametrize('sign', (-1.0, 1.0))
-@pytest.mark.parametrize('engine', ('serial', 'cython', 'jax'))
+@ pytest.mark.parametrize('eye', ('LE', 'RE'))
+@ pytest.mark.parametrize('loc_od', ((15.5, 1.5), (7.0, 3.0), (-2.0, -2.0)))
+@ pytest.mark.parametrize('sign', (-1.0, 1.0))
+@ pytest.mark.parametrize('engine', ('serial', 'cython', 'jax'))
 def test_AxonMapModel__jansonius2009(eye, loc_od, sign, engine):
     # With `rho` starting at 0, all axons should originate in the optic disc
     # center
@@ -299,7 +323,7 @@ def test_AxonMapModel__jansonius2009(eye, loc_od, sign, engine):
         npt.assert_almost_equal(single_fiber[0], loc_od)
 
 
-@pytest.mark.parametrize('engine', ('serial', 'cython', 'jax'))
+@ pytest.mark.parametrize('engine', ('serial', 'cython', 'jax'))
 def test_AxonMapModel_grow_axon_bundles(engine):
     for n_axons in [1, 2, 3, 5, 10]:
         model = AxonMapModel(xystep=2, engine=engine, n_axons=n_axons,
@@ -309,7 +333,7 @@ def test_AxonMapModel_grow_axon_bundles(engine):
         npt.assert_equal(len(bundles), n_axons)
 
 
-@pytest.mark.parametrize('engine', ('serial', 'cython', 'jax'))
+@ pytest.mark.parametrize('engine', ('serial', 'cython', 'jax'))
 def test_AxonMapModel_find_closest_axon(engine):
     model = AxonMapModel(xystep=1, engine=engine, n_axons=5,
                          xrange=(-20, 20), yrange=(-15, 15),
@@ -341,7 +365,7 @@ def test_AxonMapModel_find_closest_axon(engine):
     npt.assert_equal(closest_idx, 0)
 
 
-@pytest.mark.parametrize('engine', ('serial', 'cython', 'jax'))
+@ pytest.mark.parametrize('engine', ('serial', 'cython', 'jax'))
 def test_AxonMapModel_calc_axon_sensitivity(engine):
     model = AxonMapModel(xystep=2, engine=engine, n_axons=10,
                          xrange=(-20, 20), yrange=(-15, 15),
@@ -376,7 +400,7 @@ def test_AxonMapModel_calc_axon_sensitivity(engine):
         npt.assert_almost_equal(sensitivity, model_ax[:, 2])
 
 
-@pytest.mark.parametrize('engine', ('serial', 'cython', 'jax'))
+@ pytest.mark.parametrize('engine', ('serial', 'cython', 'jax'))
 def test_AxonMapModel_calc_bundle_tangent(engine):
     model = AxonMapModel(xystep=5, engine=engine, n_axons=500,
                          xrange=(-20, 20), yrange=(-15, 15),
@@ -392,7 +416,7 @@ def test_AxonMapModel_calc_bundle_tangent(engine):
         model.spatial.calc_bundle_tangent(0, [1000])
 
 
-@pytest.mark.parametrize('engine', ('serial', 'cython', 'jax'))
+@ pytest.mark.parametrize('engine', ('serial', 'cython', 'jax'))
 def test_AxonMapModel_predict_percept(engine):
     model = AxonMapModel(xystep=0.55, axlambda=100, rho=100,
                          thresh_percept=0, engine=engine,

--- a/pulse2percept/models/tests/test_granley2021.py
+++ b/pulse2percept/models/tests/test_granley2021.py
@@ -1,7 +1,7 @@
 from multiprocessing import Value
 from typing import Type
 from pulse2percept.models.granley2021 import DefaultBrightModel, \
-                                             DefaultSizeModel, DefaultStreakModel
+    DefaultSizeModel, DefaultStreakModel
 from pulse2percept.utils.base import FreezeError
 import numpy as np
 import pytest
@@ -11,7 +11,7 @@ from pulse2percept.implants import ArgusI, ArgusII
 from pulse2percept.percepts import Percept
 from pulse2percept.stimuli import Stimulus, BiphasicPulseTrain
 from pulse2percept.models import BiphasicAxonMapModel, BiphasicAxonMapSpatial, \
-                                 AxonMapSpatial
+    AxonMapSpatial
 from pulse2percept.utils.testing import assert_warns_msg
 
 
@@ -23,26 +23,30 @@ def test_effects_models():
 
     # Test rho scaling on size model
     model = DefaultSizeModel(200)
-    npt.assert_almost_equal(np.sqrt(model(0.01, 0.01, 0.45) * 200 * 200), model.min_rho)
+    npt.assert_almost_equal(
+        np.sqrt(model(0.01, 0.01, 0.45) * 200 * 200), model.min_rho)
 
     # Test lambda scaling on streak model
     model = DefaultStreakModel(200)
-    npt.assert_almost_equal(np.sqrt(model(10, 1, 10000) * 200 * 200), model.min_lambda)
+    npt.assert_almost_equal(
+        np.sqrt(model(10, 1, 10000) * 200 * 200), model.min_lambda)
 
-    coeffs = {'a' + str(i) : i for i in range(9)}
+    coeffs = {'a' + str(i): i for i in range(9)}
     # Models can take correct coeffs
-    model_coeffs = {k:v for k,v in coeffs if hasattr(DefaultBrightModel(), k)}
+    model_coeffs = {k: v for k, v in coeffs if hasattr(DefaultBrightModel(), k)}
     model = DefaultBrightModel(**model_coeffs)
     npt.assert_equal(hasattr(model, 'a0'), True)
     npt.assert_equal(hasattr(model, 'a9'), False)
-    model_coeffs = {k:v for k,v in coeffs if hasattr(DefaultSizeModel(200), k)}
+    model_coeffs = {k: v for k, v in coeffs if hasattr(
+        DefaultSizeModel(200), k)}
     model = DefaultSizeModel(200, **model_coeffs)
     npt.assert_equal(hasattr(model, 'a0'), True)
     npt.assert_equal(hasattr(model, 'a9'), False)
-    model_coeffs = {k:v for k,v in coeffs if hasattr(DefaultStreakModel(200), k)}
+    model_coeffs = {k: v for k, v in coeffs if hasattr(
+        DefaultStreakModel(200), k)}
     model = DefaultStreakModel(200, **model_coeffs)
     npt.assert_equal(hasattr(model, 'a0'), False)
-    npt.assert_equal(hasattr(model, 'a9'), True) 
+    npt.assert_equal(hasattr(model, 'a9'), True)
 
 
 @pytest.mark.parametrize('engine', ('serial', 'cython', 'jax'))
@@ -56,7 +60,7 @@ def test_biphasicAxonMapSpatial(engine):
     if engine == 'jax':
         with pytest.raises(NotImplementedError):
             implant = ArgusII()
-            implant.stim = Stimulus({'A5' : BiphasicPulseTrain(20, 1, 0.45)})
+            implant.stim = Stimulus({'A5': BiphasicPulseTrain(20, 1, 0.45)})
             percept = model.predict_percept(implant)
         return
 
@@ -87,10 +91,11 @@ def test_biphasicAxonMapSpatial(engine):
     model.build()
     axon_map = AxonMapSpatial(xystep=2).build()
     implant = ArgusII()
-    implant.stim = Stimulus({'A5' : BiphasicPulseTrain(20, 1, 0.45)})
+    implant.stim = Stimulus({'A5': BiphasicPulseTrain(20, 1, 0.45)})
     percept = model.predict_percept(implant)
     percept_axon = axon_map.predict_percept(implant)
-    npt.assert_almost_equal(percept.data[:, :, 0], percept_axon.get_brightest_frame())
+    npt.assert_almost_equal(
+        percept.data[:, :, 0], percept_axon.get_brightest_frame())
 
     # Effect models must be callable
     model = BiphasicAxonMapSpatial(engine=engine, xystep=2)
@@ -98,11 +103,11 @@ def test_biphasicAxonMapSpatial(engine):
     with pytest.raises(TypeError):
         model.build()
 
-    # If t_percept is not specified, there should only be one frame 
+    # If t_percept is not specified, there should only be one frame
     model = BiphasicAxonMapSpatial(engine=engine, xystep=2)
     model.build()
     implant = ArgusII()
-    implant.stim = Stimulus({'A5' : BiphasicPulseTrain(20, 1, 0.45)})
+    implant.stim = Stimulus({'A5': BiphasicPulseTrain(20, 1, 0.45)})
     percept = model.predict_percept(implant)
     npt.assert_equal(percept.time is None, True)
     # If t_percept is specified, only first frame should have data
@@ -113,16 +118,16 @@ def test_biphasicAxonMapSpatial(engine):
     npt.assert_equal(np.any(percept.data[:, :, 1:]), False)
 
     # Test that default models give expected values
-    model = BiphasicAxonMapSpatial(engine=engine, rho=400, axlambda=600, xystep=1,
-                           xrange=(-20, 20), yrange=(-15, 15))
+    model = BiphasicAxonMapSpatial(engine=engine, rho=400, axlambda=600,
+                                   xystep=1, xrange=(-20, 20), yrange=(-15, 15))
     model.build()
     implant = ArgusII()
-    implant.stim = Stimulus({'A4' : BiphasicPulseTrain(20, 1, 1)})
+    implant.stim = Stimulus({'A4': BiphasicPulseTrain(20, 1, 1)})
     percept = model.predict_percept(implant)
-    npt.assert_equal(np.sum(percept.data > 1), 82)
+    npt.assert_equal(np.sum(percept.data > 1), 81)
     npt.assert_equal(np.sum(percept.data > 2), 59)
     npt.assert_equal(np.sum(percept.data > 3), 44)
-    npt.assert_equal(np.sum(percept.data > 5), 25)
+    npt.assert_equal(np.sum(percept.data > 5), 26)
     npt.assert_equal(np.sum(percept.data > 7), 14)
 
 
@@ -131,7 +136,7 @@ def test_biphasicAxonMapModel(engine):
     set_params = {'xystep': 2, 'engine': engine, 'rho': 432, 'axlambda': 20,
                   'n_axons': 9, 'n_ax_segments': 50,
                   'xrange': (-30, 30), 'yrange': (-20, 20),
-                  'loc_od': (5, 6), 'do_thresholding' : False}
+                  'loc_od': (5, 6), 'do_thresholding': False}
     model = BiphasicAxonMapModel(engine=engine)
     for param in set_params:
         npt.assert_equal(hasattr(model.spatial, param), True)
@@ -165,9 +170,11 @@ def test_biphasicAxonMapModel(engine):
 
     # Custom parameters also propogate to effects models
     model = BiphasicAxonMapModel(engine=engine)
+
     class TestSizeModel():
         def __init__(self):
             self.test_param = 5
+
         def __call__(self, freq, amp, pdur):
             return 1
     model.size_model = TestSizeModel()
@@ -183,6 +190,7 @@ def test_biphasicAxonMapModel(engine):
             self.model = BiphasicAxonMapModel()
             # This shouldnt raise an error
             self.model.a0
+
     class TestInitClassBad():
         def __init__(self):
             self.model = BiphasicAxonMapModel()

--- a/pulse2percept/models/tests/test_nanduri2012.py
+++ b/pulse2percept/models/tests/test_nanduri2012.py
@@ -54,10 +54,11 @@ def test_Nanduri2012Spatial():
 
     # Nanduri model uses a linear dva2ret conversion factor:
     for factor in [0.0, 1.0, 2.0]:
-        npt.assert_almost_equal(model.dva2ret(factor, factor),
+        npt.assert_almost_equal(model.retinotopy.dva2ret(factor, factor),
                                 (280.0 * factor, 280.0 * factor))
     for factor in [0.0, 1.0, 2.0]:
-        npt.assert_almost_equal(model.ret2dva(280.0 * factor, 280.0 * factor),
+        npt.assert_almost_equal(model.retinotopy.ret2dva(280.0 * factor,
+                                                         280.0 * factor),
                                 (factor, factor))
 
 

--- a/pulse2percept/models/tests/test_nanduri2012.py
+++ b/pulse2percept/models/tests/test_nanduri2012.py
@@ -54,9 +54,11 @@ def test_Nanduri2012Spatial():
 
     # Nanduri model uses a linear dva2ret conversion factor:
     for factor in [0.0, 1.0, 2.0]:
-        npt.assert_almost_equal(model.dva2ret(factor), 280.0 * factor)
+        npt.assert_almost_equal(model.dva2ret(factor, factor),
+                                (280.0 * factor, 280.0 * factor))
     for factor in [0.0, 1.0, 2.0]:
-        npt.assert_almost_equal(model.ret2dva(280.0 * factor), factor)
+        npt.assert_almost_equal(model.ret2dva(280.0 * factor, 280.0 * factor),
+                                (factor, factor))
 
 
 @pytest.mark.parametrize('scale_out', (1, 2))

--- a/pulse2percept/utils/__init__.py
+++ b/pulse2percept/utils/__init__.py
@@ -17,8 +17,8 @@
 """
 from .base import (PrettyPrint, FreezeError, Frozen, Data, bijective26_name,
                    cached, gamma)
-from .geometry import (Grid2D, RetinalCoordTransform, Curcio1990Transform,
-                       Watson2014Transform, Watson2014DisplaceTransform,
+from .geometry import (Grid2D, VisualFieldMap, Curcio1990Map,
+                       Watson2014Map, Watson2014DisplaceMap,
                        cart2pol, pol2cart, delta_angle)
 from .array import is_strictly_increasing, radial_mask, unique
 from .images import center_image, scale_image, shift_image, trim_image
@@ -37,7 +37,7 @@ __all__ = [
     'center_vector',
     'circ_r2_score',
     'conv',
-    'Curcio1990Transform',
+    'Curcio1990Map',
     'Data',
     'delta_angle',
     'deprecated',
@@ -51,11 +51,11 @@ __all__ = [
     'PrettyPrint',
     'r2_score',
     'radial_mask',
-    'RetinalCoordTransform',
     'scale_image',
     'shift_image',
     'trim_image',
     'unique',
-    'Watson2014DisplaceTransform',
-    'Watson2014Transform'
+    'VisualFieldMap',
+    'Watson2014DisplaceMap',
+    'Watson2014Map'
 ]

--- a/pulse2percept/utils/geometry.py
+++ b/pulse2percept/utils/geometry.py
@@ -1,6 +1,6 @@
 """
-`Grid2D`, `RetinalCoordTransform`, `Curcio1990Transform`,
-`Watson2014Transform`, `Watson2014DisplaceTransform`, `cart2pol`, `pol2cart`, 'delta_angle'
+`Grid2D`, `VisualFieldMap`, `Curcio1990Map`, `Watson2014Map`,
+`Watson2014DisplaceMap`, `cart2pol`, `pol2cart`, `delta_angle`
 
 """
 import numpy as np
@@ -171,8 +171,8 @@ class Grid2D(PrettyPrint):
         return ax
 
 
-class RetinalCoordTransform(object, metaclass=ABCMeta):
-    """Base class for a retinal coordinate transform
+class VisualFieldMap(object, metaclass=ABCMeta):
+    """Base class for a visual field map (retinotopy)
 
     A template
 
@@ -189,7 +189,7 @@ class RetinalCoordTransform(object, metaclass=ABCMeta):
         raise NotImplementedError
 
 
-class Curcio1990Transform(RetinalCoordTransform):
+class Curcio1990Map(VisualFieldMap):
     """Converts between visual angle and retinal eccentricity [Curcio1990]_"""
 
     @staticmethod
@@ -211,7 +211,7 @@ class Curcio1990Transform(RetinalCoordTransform):
         return xret / 280.0, yret / 280.0
 
 
-class Watson2014Transform(RetinalCoordTransform):
+class Watson2014Map(VisualFieldMap):
     """Converts between visual angle and retinal eccentricity [Watson2014]_"""
 
     @staticmethod
@@ -278,7 +278,7 @@ class Watson2014Transform(RetinalCoordTransform):
         raise ValueError('Unknown coordinate system "%s".' % coords)
 
 
-class Watson2014DisplaceTransform(Watson2014Transform):
+class Watson2014DisplaceMap(Watson2014Map):
     """Converts between visual angle and retinal eccentricity using RGC
        displacement [Watson2014]_
 
@@ -350,7 +350,7 @@ class Watson2014DisplaceTransform(Watson2014Transform):
         rho_dva += self.watson_displacement(rho_dva, meridian=meridian)
         # Convert back to x, y (dva):
         x, y = pol2cart(theta, rho_dva)
-        return super(Watson2014DisplaceTransform, self).dva2ret(x, y)
+        return super(Watson2014DisplaceMap, self).dva2ret(x, y)
 
     def ret2dva(self, xret, yret):
         raise NotImplementedError

--- a/pulse2percept/utils/geometry.py
+++ b/pulse2percept/utils/geometry.py
@@ -135,7 +135,9 @@ class Grid2D(PrettyPrint):
         ----------
         transform : function, optional
             A coordinate transform to be applied to the (x,y) coordinates of
-            the grid (e.g., :py:meth:`Curcio1990Transform.dva2ret`)
+            the grid (e.g., :py:meth:`Curcio1990Transform.dva2ret`). It must
+            accept two input arguments (x and y) and output two variables (the
+            transformed x and y).
         autoscale : bool, optional
             Whether to adjust the x,y limits of the plot to fit the implant
         zorder : int, optional
@@ -158,8 +160,8 @@ class Grid2D(PrettyPrint):
 
         x, y = self.x, self.y
         if transform is not None:
-            x, y = transform(self.x), transform(self.y)
-            
+            x, y = transform(self.x, self.y)
+
         points = np.vstack((x.ravel(), y.ravel())).T
         hull = ConvexHull(points)
         ax.add_patch(Polygon(points[hull.vertices, :], alpha=0.3, ec='k',
@@ -177,12 +179,12 @@ class RetinalCoordTransform(object, metaclass=ABCMeta):
     """
 
     @abstractmethod
-    def dva2ret(self):
+    def dva2ret(self, x, y):
         """Convert degrees of visual angle (dva) to retinal coords (um)"""
         raise NotImplementedError
 
     @abstractmethod
-    def ret2dva(self):
+    def ret2dva(self, x, y):
         """Convert retinal coords (um) to degrees of visual angle (dva)"""
         raise NotImplementedError
 
@@ -191,29 +193,29 @@ class Curcio1990Transform(RetinalCoordTransform):
     """Converts between visual angle and retinal eccentricity [Curcio1990]_"""
 
     @staticmethod
-    def dva2ret(xdva):
+    def dva2ret(xdva, ydva):
         """Convert degrees of visual angle (dva) to retinal eccentricity (um)
 
         Assumes that one degree of visual angle is equal to 280 um on the
         retina [Curcio1990]_.
         """
-        return 280.0 * xdva
+        return 280.0 * xdva, 280.0 * ydva
 
     @staticmethod
-    def ret2dva(xret):
+    def ret2dva(xret, yret):
         """Convert retinal eccentricity (um) to degrees of visual angle (dva)
 
         Assumes that one degree of visual angle is equal to 280 um on the
         retina [Curcio1990]_
         """
-        return xret / 280.0
+        return xret / 280.0, yret / 280.0
 
 
 class Watson2014Transform(RetinalCoordTransform):
     """Converts between visual angle and retinal eccentricity [Watson2014]_"""
 
     @staticmethod
-    def ret2dva(r_um):
+    def ret2dva(x_um, y_um, coords='cart'):
         """Converts retinal distances (um) to visual angles (deg)
 
         This function converts an eccentricity measurement on the retinal
@@ -222,22 +224,30 @@ class Watson2014Transform(RetinalCoordTransform):
 
         Parameters
         ----------
-        r_um : double or array-like
-            Eccentricity in microns
+        x_um, y_um : double or array-like
+            Original x and y coordinates on the retina (microns)
+        coords : {'cart', 'polar'}
+            Whether to return the result in Cartesian or polar coordinates
 
         Returns
         -------
-        r_dva : double or array-like
-            Eccentricity in degrees of visual angle (dva)
+        x_dva, y_dva : double or array-like
+            Transformed x and y coordinates (degrees of visual angle, dva)
         """
+        phi_um, r_um = cart2pol(x_um, y_um)
         sign = np.sign(r_um)
         r_mm = 1e-3 * np.abs(r_um)
         r_deg = 3.556 * r_mm + 0.05993 * r_mm ** 2 - 0.007358 * r_mm ** 3
         r_deg += 3.027e-4 * r_mm ** 4
-        return sign * r_deg
+        r_deg *= sign
+        if coords.lower() == 'cart':
+            return pol2cart(phi_um, r_deg)
+        elif coords.lower() == 'polar':
+            return phi_um, r_deg
+        raise ValueError('Unknown coordinate system "%s".' % coords)
 
     @staticmethod
-    def dva2ret(r_deg):
+    def dva2ret(x_deg, y_deg, coords='cart'):
         """Converts visual angles (deg) into retinal distances (um)
 
         This function converts degrees of visual angle into a retinal distance 
@@ -245,24 +255,30 @@ class Watson2014Transform(RetinalCoordTransform):
 
         Parameters
         ----------
-        r_dva : double or array-like
-            Eccentricity in degrees of visual angle (dva)
+        x_dva, y_dva : double or array-like
+            Original x and y coordinates (degrees of visual angle, dva)
+        coords : {'cart', 'polar'}
+            Whether to return the result in Cartesian or polar coordinates
 
         Returns
         -------
-        r_um : double or array-like
-            Eccentricity in microns
-
+        x_ret, y_ret : double or array-like
+            Transformed x and y coordinates on the retina (microns)
 
         """
+        phi_deg, r_deg = cart2pol(x_deg, y_deg)
         sign = np.sign(r_deg)
         r_deg = np.abs(r_deg)
         r_mm = 0.268 * r_deg + 3.427e-4 * r_deg ** 2 - 8.3309e-6 * r_deg ** 3
-        r_um = 1e3 * r_mm
-        return sign * r_um
+        r_um = 1e3 * r_mm * sign
+        if coords.lower() == 'cart':
+            return pol2cart(phi_deg, r_um)
+        elif coords.lower() == 'polar':
+            return phi_deg, r_um
+        raise ValueError('Unknown coordinate system "%s".' % coords)
 
 
-class Watson2014DisplaceTransform(RetinalCoordTransform):
+class Watson2014DisplaceTransform(Watson2014Transform):
     """Converts between visual angle and retinal eccentricity using RGC
        displacement [Watson2014]_
 
@@ -327,17 +343,14 @@ class Watson2014DisplaceTransform(RetinalCoordTransform):
         xret, yret : double or array-like
             Corresponding x,y coordinates in microns
         """
-        if self.eye == 'LE':
-            raise NotImplementedError
         # Convert x, y (dva) into polar coordinates:
-        theta, rho_dva = utils.cart2pol(xdva, ydva)
+        theta, rho_dva = cart2pol(xdva, ydva)
         # Add RGC displacement:
         meridian = np.where(xdva < 0, 'temporal', 'nasal')
         rho_dva += self.watson_displacement(rho_dva, meridian=meridian)
         # Convert back to x, y (dva):
-        x, y = utils.pol2cart(theta, rho_dva)
-        # Convert to retinal coords:
-        return dva2ret(x), dva2ret(y)
+        x, y = pol2cart(theta, rho_dva)
+        return super(Watson2014DisplaceTransform, self).dva2ret(x, y)
 
     def ret2dva(self, xret, yret):
         raise NotImplementedError
@@ -345,12 +358,12 @@ class Watson2014DisplaceTransform(RetinalCoordTransform):
 
 def cart2pol(x, y):
     """Convert Cartesian to polar coordinates
-    
+
     Parameters
     ----------
     x, y : scalar or array-like
         The x,y Cartesian coordinates
-        
+
     Returns
     -------
     theta, rho : scalar or array-like
@@ -363,12 +376,12 @@ def cart2pol(x, y):
 
 def pol2cart(theta, rho):
     """Convert polar to Cartesian coordinates
-    
+
     Parameters
     ----------
     theta, rho : scalar or array-like
         The polar coordinates
-       
+
     Returns
     -------
     x, y : scalar or array-like

--- a/pulse2percept/utils/tests/test_geometry.py
+++ b/pulse2percept/utils/tests/test_geometry.py
@@ -3,9 +3,9 @@ import pytest
 import numpy.testing as npt
 from matplotlib.axes import Axes
 
-from pulse2percept.utils import (RetinalCoordTransform, Curcio1990Transform,
-                                 Grid2D, Watson2014Transform,
-                                 Watson2014DisplaceTransform,
+from pulse2percept.utils import (VisualFieldMap, Curcio1990Map,
+                                 Grid2D, Watson2014Map,
+                                 Watson2014DisplaceMap,
                                  cart2pol, pol2cart, delta_angle)
 
 
@@ -93,7 +93,7 @@ def test_Grid2D_plot():
     npt.assert_almost_equal(ax.figure.get_size_inches(), (9, 7))
 
 
-class ValidCoordTransform(RetinalCoordTransform):
+class ValidCoordTransform(VisualFieldMap):
 
     @staticmethod
     def dva2ret(x_dva, y_dva):
@@ -104,24 +104,24 @@ class ValidCoordTransform(RetinalCoordTransform):
         return x_ret, y_ret
 
 
-def test_RetinalCoordTransform():
+def test_VisualFieldMap():
     npt.assert_almost_equal(ValidCoordTransform.dva2ret(1.1, 0), (1.1, 0))
     npt.assert_almost_equal(ValidCoordTransform.ret2dva(1.1, 0), (1.1, 0))
 
 
-def test_Curcio1990Transform():
+def test_Curcio1990Map():
     # Curcio1990 uses a linear dva2ret conversion factor:
     for factor in [0.0, 1.0, 2.0]:
-        npt.assert_almost_equal(Curcio1990Transform.dva2ret(factor, factor),
+        npt.assert_almost_equal(Curcio1990Map.dva2ret(factor, factor),
                                 (280.0 * factor, 280.0 * factor))
     for factor in [0.0, 1.0, 2.0]:
-        npt.assert_almost_equal(Curcio1990Transform.ret2dva(280.0 * factor,
-                                                            280.0 * factor),
+        npt.assert_almost_equal(Curcio1990Map.ret2dva(280.0 * factor,
+                                                      280.0 * factor),
                                 (factor, factor))
 
 
-def test_Watson2014Transform():
-    trafo = Watson2014Transform()
+def test_Watson2014Map():
+    trafo = Watson2014Map()
     with pytest.raises(ValueError):
         trafo.ret2dva(0, 0, coords='invalid')
     with pytest.raises(ValueError):
@@ -145,8 +145,8 @@ def test_Watson2014Transform():
                                     decimal=-exp)  # adjust precision
 
 
-def test_Watson2014DisplaceTransform():
-    trafo = Watson2014DisplaceTransform()
+def test_Watson2014DisplaceMap():
+    trafo = Watson2014DisplaceMap()
     with pytest.raises(ValueError):
         trafo.watson_displacement(0, meridian='invalid')
     npt.assert_almost_equal(trafo.watson_displacement(0), 0.4957506)

--- a/pulse2percept/utils/tests/test_geometry.py
+++ b/pulse2percept/utils/tests/test_geometry.py
@@ -84,7 +84,7 @@ def test_Grid2D_plot():
     npt.assert_almost_equal(ax.get_xlim(), (-22, 22))
 
     # You can change the scaling:
-    ax = grid.plot(transform=lambda x: 2*x)
+    ax = grid.plot(transform=lambda x, y: (2*x, 2*y))
     npt.assert_equal(isinstance(ax, Axes), True)
     npt.assert_almost_equal(ax.get_xlim(), (-44, 44))
 
@@ -96,46 +96,52 @@ def test_Grid2D_plot():
 class ValidCoordTransform(RetinalCoordTransform):
 
     @staticmethod
-    def dva2ret(dva):
-        return dva
+    def dva2ret(x_dva, y_dva):
+        return x_dva, y_dva
 
     @staticmethod
-    def ret2dva(ret):
-        return ret
+    def ret2dva(x_ret, y_ret):
+        return x_ret, y_ret
 
 
 def test_RetinalCoordTransform():
-    npt.assert_almost_equal(ValidCoordTransform.dva2ret(1.1), 1.1)
-    npt.assert_almost_equal(ValidCoordTransform.ret2dva(1.1), 1.1)
+    npt.assert_almost_equal(ValidCoordTransform.dva2ret(1.1, 0), (1.1, 0))
+    npt.assert_almost_equal(ValidCoordTransform.ret2dva(1.1, 0), (1.1, 0))
 
 
 def test_Curcio1990Transform():
     # Curcio1990 uses a linear dva2ret conversion factor:
     for factor in [0.0, 1.0, 2.0]:
-        npt.assert_almost_equal(Curcio1990Transform.dva2ret(factor),
-                                280.0 * factor)
+        npt.assert_almost_equal(Curcio1990Transform.dva2ret(factor, factor),
+                                (280.0 * factor, 280.0 * factor))
     for factor in [0.0, 1.0, 2.0]:
-        npt.assert_almost_equal(Curcio1990Transform.ret2dva(280.0 * factor),
-                                factor)
+        npt.assert_almost_equal(Curcio1990Transform.ret2dva(280.0 * factor,
+                                                            280.0 * factor),
+                                (factor, factor))
 
 
 def test_Watson2014Transform():
     trafo = Watson2014Transform()
+    with pytest.raises(ValueError):
+        trafo.ret2dva(0, 0, coords='invalid')
+    with pytest.raises(ValueError):
+        trafo.dva2ret(0, 0, coords='invalid')
+
     # Below 15mm eccentricity, relationship is linear with slope 3.731
-    npt.assert_equal(trafo.ret2dva(0.0), 0.0)
+    npt.assert_equal(trafo.ret2dva(0.0, 0.0), (0.0, 0.0))
     for sign in [-1, 1]:
         for exp in [2, 3, 4]:
             ret = sign * 10 ** exp  # mm
             dva = 3.731 * sign * 10 ** (exp - 3)  # dva
-            npt.assert_almost_equal(trafo.ret2dva(ret), dva,
+            npt.assert_almost_equal(trafo.ret2dva(0, ret)[1], dva,
                                     decimal=3 - exp)  # adjust precision
     # Below 50deg eccentricity, relationship is linear with slope 0.268
-    npt.assert_equal(trafo.dva2ret(0.0), 0.0)
+    npt.assert_equal(trafo.dva2ret(0.0, 0.0), (0.0, 0.0))
     for sign in [-1, 1]:
         for exp in [-2, -1, 0]:
             dva = sign * 10 ** exp  # deg
             ret = 0.268 * sign * 10 ** (exp + 3)  # mm
-            npt.assert_almost_equal(trafo.dva2ret(dva), ret,
+            npt.assert_almost_equal(trafo.dva2ret(0, dva)[1], ret,
                                     decimal=-exp)  # adjust precision
 
 
@@ -156,6 +162,8 @@ def test_Watson2014DisplaceTransform():
     all_displace = trafo.watson_displacement(radii, meridian='nasal')
     npt.assert_almost_equal(np.max(all_displace), 1.9228664)
     npt.assert_almost_equal(radii[np.argmax(all_displace)], 2.1212121)
+    # Smoke test
+    trafo.dva2ret(0, 0)
 
 
 def test_cart2pol():

--- a/pulse2percept/viz/argus.py
+++ b/pulse2percept/viz/argus.py
@@ -125,10 +125,10 @@ def plot_argus_phosphenes(data, argus, scale=1.0, axon_map=None,
     pad = 2000  # microns
     x_el = [e.x for e in argus.electrode_objects]
     y_el = [e.y for e in argus.electrode_objects]
-    x_min = Watson2014Transform.ret2dva(np.min(x_el) - pad)
-    x_max = Watson2014Transform.ret2dva(np.max(x_el) + pad)
-    y_min = Watson2014Transform.ret2dva(np.min(y_el) - pad)
-    y_max = Watson2014Transform.ret2dva(np.max(y_el) + pad)
+    x_min, y_min = Watson2014Transform.ret2dva(np.min(x_el) - pad,
+                                               np.min(y_el) - pad)
+    x_max, y_max = Watson2014Transform.ret2dva(np.max(x_el) + pad,
+                                               np.max(y_el) + pad)
 
     # Coordinate transform from degrees of visual angle to output, and from
     # image coordinates to output image:
@@ -144,7 +144,7 @@ def plot_argus_phosphenes(data, argus, scale=1.0, axon_map=None,
         except IndexError:
             out_shape = (768, 1024)
     for xy, e in zip(px_argus, argus.electrode_objects):
-        x_dva, y_dva = Watson2014Transform.ret2dva([e.x, e.y])
+        x_dva, y_dva = Watson2014Transform.ret2dva(e.x, e.y)
         x_out = (x_dva - x_min) / (x_max - x_min) * (out_shape[1] - 1)
         y_out = (y_dva - y_min) / (y_max - y_min) * (out_shape[0] - 1)
         pts_in.append(xy)
@@ -166,8 +166,8 @@ def plot_argus_phosphenes(data, argus, scale=1.0, axon_map=None,
     all_imgs = np.zeros(out_shape)
     num_imgs = data.groupby('electrode')['image'].count()
     for _, row in data.iterrows():
-        e_pos = Watson2014Transform.ret2dva((argus[row['electrode']].x,
-                                             argus[row['electrode']].y))
+        e_pos = Watson2014Transform.ret2dva(argus[row['electrode']].x,
+                                            argus[row['electrode']].y)
         align_center = dva2out(e_pos)[0]
         img_drawing = scale_image(row['image'], scale)
         img_drawing = center_image(img_drawing, loc=align_center)
@@ -200,7 +200,8 @@ def plot_argus_phosphenes(data, argus, scale=1.0, axon_map=None,
         # Draw axon pathways:
         for bundle in axon_bundles:
             # Flip y upside down for dva:
-            bundle = Watson2014Transform.ret2dva(bundle) * [1, -1]
+            bundle = Watson2014Transform.ret2dva(bundle[:, 0], -bundle[:, 1])
+            bundle = np.array(bundle).T
             # Set segments outside the drawing window to NaN:
             x_idx = np.logical_or(bundle[:, 0] < x_min, bundle[:, 0] > x_max)
             bundle[x_idx, 0] = np.nan

--- a/pulse2percept/viz/argus.py
+++ b/pulse2percept/viz/argus.py
@@ -12,7 +12,7 @@ from pkg_resources import resource_filename
 
 from ..implants import ArgusI, ArgusII
 from ..models import AxonMapModel
-from ..utils import Watson2014Transform, scale_image, center_image
+from ..utils import Watson2014Map, scale_image, center_image
 from ..utils.constants import ZORDER
 
 PATH_ARGUS1 = resource_filename('pulse2percept', 'viz/data/argus1.png')
@@ -125,10 +125,8 @@ def plot_argus_phosphenes(data, argus, scale=1.0, axon_map=None,
     pad = 2000  # microns
     x_el = [e.x for e in argus.electrode_objects]
     y_el = [e.y for e in argus.electrode_objects]
-    x_min, y_min = Watson2014Transform.ret2dva(np.min(x_el) - pad,
-                                               np.min(y_el) - pad)
-    x_max, y_max = Watson2014Transform.ret2dva(np.max(x_el) + pad,
-                                               np.max(y_el) + pad)
+    x_min, y_min = Watson2014Map.ret2dva(np.min(x_el) - pad, np.min(y_el) - pad)
+    x_max, y_max = Watson2014Map.ret2dva(np.max(x_el) + pad, np.max(y_el) + pad)
 
     # Coordinate transform from degrees of visual angle to output, and from
     # image coordinates to output image:
@@ -144,7 +142,7 @@ def plot_argus_phosphenes(data, argus, scale=1.0, axon_map=None,
         except IndexError:
             out_shape = (768, 1024)
     for xy, e in zip(px_argus, argus.electrode_objects):
-        x_dva, y_dva = Watson2014Transform.ret2dva(e.x, e.y)
+        x_dva, y_dva = Watson2014Map.ret2dva(e.x, e.y)
         x_out = (x_dva - x_min) / (x_max - x_min) * (out_shape[1] - 1)
         y_out = (y_dva - y_min) / (y_max - y_min) * (out_shape[0] - 1)
         pts_in.append(xy)
@@ -166,8 +164,8 @@ def plot_argus_phosphenes(data, argus, scale=1.0, axon_map=None,
     all_imgs = np.zeros(out_shape)
     num_imgs = data.groupby('electrode')['image'].count()
     for _, row in data.iterrows():
-        e_pos = Watson2014Transform.ret2dva(argus[row['electrode']].x,
-                                            argus[row['electrode']].y)
+        e_pos = Watson2014Map.ret2dva(argus[row['electrode']].x,
+                                      argus[row['electrode']].y)
         align_center = dva2out(e_pos)[0]
         img_drawing = scale_image(row['image'], scale)
         img_drawing = center_image(img_drawing, loc=align_center)
@@ -200,7 +198,7 @@ def plot_argus_phosphenes(data, argus, scale=1.0, axon_map=None,
         # Draw axon pathways:
         for bundle in axon_bundles:
             # Flip y upside down for dva:
-            bundle = Watson2014Transform.ret2dva(bundle[:, 0], -bundle[:, 1])
+            bundle = Watson2014Map.ret2dva(bundle[:, 0], -bundle[:, 1])
             bundle = np.array(bundle).T
             # Set segments outside the drawing window to NaN:
             x_idx = np.logical_or(bundle[:, 0] < x_min, bundle[:, 0] > x_max)


### PR DESCRIPTION
This PR refactors retinotopy used to convert between retinal and visual field coordinates:
- [x] All models now have a `retinotopy` attribute that replaces the abstract `dva2ret`/`ret2dva` methods
- [x] `RetinalCoordTransform` has been renamed to `VisualFieldMap`
- [x] The other transforms are now also called maps
- [x] All `dva2ret` and `ret2dva` methods of these maps are refactored into `x_ret, y_ret = dva2ret(x_dva, y_dva)` and `x_dva, y_dva = ret2dva(x_ret, y_ret)`, respectively
- [x] By default, `BaseModel` will use `Curcio1990Transform` and the Beyeler work will use `Watson2014Transform`
- [x] There is a new gallery example that explains & shows the difference between different visual field maps

Related bug fixes:
-  [x] `AxonMapModel` did not always use `dva2ret` correctly: When calculating the bundle locations, `dva2ret` was applied to the `x` and `y` coordinates separately instead of `r` (polar). Fortunately, the effect on the output is minimal, since within 40deg dva it's pretty much a 1-1 mapping (see Fig. A1 in Watson, 2014).
- [x] `xrange` and `yrange` of the Beyeler models are called `x_range` and `y_range` in the docs (see issue #419)