### PR TITLE
[ENH] Grid2D NaN & plot upgrades

### DIFF
--- a/examples/models/plot_retinotopy.py
+++ b/examples/models/plot_retinotopy.py
@@ -29,21 +29,20 @@ This means that they have to specify a ``dva2ret`` method, which transforms
 visual field coordinates into retinal coordinates, and a complementary 
 ``ret2dva`` method.
 
+Visual field maps
+-----------------
+
+To appreciate the difference between the available visual field maps, let us
+look at a rectangular grid in visual field coordinates:
+
 """
 # sphinx_gallery_thumbnail_number = 4
-
-###############################################################################
-# Visual field maps
-# -----------------
-#
-# To appreciate the difference between the available visual field maps, let us
-# look at a rectangular grid in visual field coordinates:
 
 import pulse2percept as p2p
 import matplotlib.pyplot as plt
 
 grid = p2p.utils.Grid2D((-50, 50), (-50, 50), step=5)
-plt.scatter(grid.x, grid.y)
+grid.plot(style='scatter')
 plt.xlabel('x (degrees of visual angle)')
 plt.ylabel('y (degrees of visual angle)')
 plt.axis('square')
@@ -60,7 +59,7 @@ transforms = [p2p.utils.Curcio1990Map,
               p2p.utils.Watson2014DisplaceMap]
 fig, axes = plt.subplots(ncols=3, sharey=True, figsize=(13, 4))
 for ax, transform in zip(axes, transforms):
-    ax.scatter(*transform().dva2ret(grid.x, grid.y))
+    grid.plot(transform=transform().dva2ret, style='cell', ax=ax)
     ax.set_title(transform().__class__.__name__)
     ax.set_xlabel('x (microns)')
     ax.set_ylabel('y (microns)')

--- a/pulse2percept/models/_nanduri2012.pyx
+++ b/pulse2percept/models/_nanduri2012.pyx
@@ -1,6 +1,7 @@
 from ..utils._fast_math cimport c_fmax, c_expit
 
-from libc.math cimport pow as c_pow, fabs as c_abs, sqrt as c_sqrt
+from libc.math cimport(pow as c_pow, fabs as c_abs, sqrt as c_sqrt,
+                       isnan as c_isnan)
 from cython.parallel import prange, parallel
 from cython import cdivision  # modulo, division by zero
 import numpy as np
@@ -66,6 +67,10 @@ cpdef spatial_fast(const float32[:, ::1] stim,
         # For each entry in the output matrix:
         idx_space = idx_bright % n_space
         idx_time = idx_bright / n_space
+
+        if c_isnan(xgrid[idx_space]) or c_isnan(ygrid[idx_space]):
+            bright[idx_space, idx_time] = 0.0
+            continue
 
         # At each pixel to be rendered, we need to sum up the contribution of
         # each electrode:

--- a/pulse2percept/models/base.py
+++ b/pulse2percept/models/base.py
@@ -366,7 +366,8 @@ class SpatialModel(BaseModel, metaclass=ABCMeta):
                       x_lo=amp_range[0], x_hi=amp_range[1], x_tol=amp_tol,
                       y_tol=bright_tol, max_iter=max_iter)
 
-    def plot(self, use_dva=False, autoscale=True, ax=None, figsize=None):
+    def plot(self, use_dva=False, style='hull', autoscale=True, ax=None,
+             figsize=None):
         """Plot the model
 
         Parameters
@@ -374,6 +375,14 @@ class SpatialModel(BaseModel, metaclass=ABCMeta):
         use_dva : bool, optional
             Uses degrees of visual angle (dva) if True, else retinal
             coordinates (microns)
+        style : {'hull', 'scatter', 'cell'}, optional
+            Grid plotting style:
+
+            * 'hull': Show the convex hull of the grid (that is, the outline of
+              the smallest convex set that contains all grid points).
+            * 'scatter': Scatter plot all grid points
+            * 'cell': Show the outline of each grid cell as a polygon. Note that
+              this can be costly for a high-resolution grid.
         autoscale : bool, optional
             Whether to adjust the x,y limits of the plot to fit the implant
         ax : matplotlib.axes._subplots.AxesSubplot, optional
@@ -388,16 +397,15 @@ class SpatialModel(BaseModel, metaclass=ABCMeta):
             Returns the axis object of the plot
         """
         if not self.is_built:
-            raise NotBuiltError("You need to build the model first before "
-                                "you can plot it.")
+            self.build()
         if use_dva:
-            ax = self.grid.plot(autoscale=autoscale, ax=ax,
+            ax = self.grid.plot(autoscale=autoscale, ax=ax, style=style,
                                 zorder=ZORDER['background'], figsize=figsize)
             ax.set_xlabel('x (dva)')
             ax.set_ylabel('y (dva)')
         else:
             ax = self.grid.plot(transform=self.retinotopy.dva2ret, ax=ax,
-                                zorder=ZORDER['background'] + 1,
+                                zorder=ZORDER['background'] + 1, style=style,
                                 figsize=figsize, autoscale=autoscale)
             ax.set_xlabel('x (microns)')
             ax.set_ylabel('y (microns)')

--- a/pulse2percept/models/beyeler2019.py
+++ b/pulse2percept/models/beyeler2019.py
@@ -696,8 +696,8 @@ class AxonMapSpatial(SpatialModel):
         else:
             raise NotImplementedError("Jax will be supported in future release")
 
-    def plot(self, use_dva=False, annotate=True, autoscale=True, ax=None,
-             figsize=None):
+    def plot(self, use_dva=False, style='hull', annotate=True, autoscale=True,
+             ax=None, figsize=None):
         """Plot the axon map
 
         Parameters
@@ -705,6 +705,14 @@ class AxonMapSpatial(SpatialModel):
         use_dva : bool, optional
             Uses degrees of visual angle (dva) if True, else retinal
             coordinates (microns)
+        style : {'hull', 'scatter', 'cell'}, optional
+            Grid plotting style:
+
+            * 'hull': Show the convex hull of the grid (that is, the outline of
+              the smallest convex set that contains all grid points).
+            * 'scatter': Scatter plot all grid points
+            * 'cell': Show the outline of each grid cell as a polygon. Note that
+              this can be costly for a high-resolution grid.
         annotate : bool, optional
             Flag whether to label the four retinal quadrants
         autoscale : bool, optional
@@ -782,7 +790,7 @@ class AxonMapSpatial(SpatialModel):
                              color='white', zorder=ZORDER['background'] + 1))
         # Show extent of simulated grid:
         if self.is_built:
-            self.grid.plot(ax=ax, transform=grid_transform,
+            self.grid.plot(ax=ax, transform=grid_transform, style=style,
                            zorder=ZORDER['background'] + 2)
         ax.set_xlabel('x (%s)' % units)
         ax.set_ylabel('y (%s)' % units)

--- a/pulse2percept/models/tests/test_base.py
+++ b/pulse2percept/models/tests/test_base.py
@@ -112,9 +112,6 @@ def test_SpatialModel():
 
 def test_SpatialModel_plot():
     model = ValidSpatialModel()
-    with pytest.raises(NotBuiltError):
-        model.plot()
-
     model.build()
     # Simulated area might be larger than that:
     model = ValidSpatialModel(xrange=(-20.5, 20.5), yrange=(-16.1, 16.1))

--- a/pulse2percept/utils/tests/test_geometry.py
+++ b/pulse2percept/utils/tests/test_geometry.py
@@ -92,6 +92,11 @@ def test_Grid2D_plot():
     ax = grid.plot(figsize=(9, 7))
     npt.assert_almost_equal(ax.figure.get_size_inches(), (9, 7))
 
+    # You can change the style (smoke test):
+    ax = grid.plot(style='hull')
+    ax = grid.plot(style='cell')
+    ax = grid.plot(style='scatter')
+
 
 class ValidCoordTransform(VisualFieldMap):
 


### PR DESCRIPTION
Improves handling/usability of `pulse2percept.utils.Grid2D`:
- [x] Allow `dva2ret` to yield NaN, in which case all models predict 0 brightness and the plotter does not show the grid point
- [x] Add different plotting styles: "hull" which show the convex hull, "scatter" will scatter plot the center points of each grid cell, and "cell" will show a polygon outline of each grid cell

Example `grid.plot()` for the `Watson2014DisplaceMap`:

![image](https://user-images.githubusercontent.com/5214334/141521020-99538522-aa67-4731-96e1-cc73fcd6a195.png)
