### PR TITLE
[FIX][REF] Biphasic parameter update and initialization fix 

### DIFF
--- a/pulse2percept/models/granley2021.py
+++ b/pulse2percept/models/granley2021.py
@@ -40,9 +40,9 @@ class DefaultBrightModel(BaseModel):
         params = {
             'a0': 2.095,
             'a1': 0.054326,
-            'a2': 1.84,
-            'a3': 0.2,
-            'a4': 3.0986,
+            'a2': 0.1492147,
+            'a3': 0.0163851,
+            'a4': 0.25191869,
             'do_thresholding': False
         }
         return params

--- a/pulse2percept/models/granley2021.py
+++ b/pulse2percept/models/granley2021.py
@@ -181,7 +181,6 @@ class DefaultStreakModel(BaseModel):
 
 class BiphasicAxonMapSpatial(AxonMapSpatial):
     """ BiphasicAxonMapModel of [Granley2021]_ (spatial model)
-
     An AxonMapModel where phosphene brightness, size, and streak length scale
     according to amplitude, frequency, and pulse duration
 
@@ -239,11 +238,6 @@ class BiphasicAxonMapSpatial(AxonMapSpatial):
             use ``x_range=(0, 1)`` and ``xystep=0.5``.
         grid_type : {'rectangular', 'hexagonal'}
             Whether to simulate points on a rectangular or hexagonal grid
-        retinotopy : :py:class:`~pulse2percept.utils.VisualFieldMap`, optional
-            An instance of a :py:class:`~pulse2percept.utils.VisualFieldMap`
-            object that provides ``ret2dva`` and ``dva2ret`` methods.
-            By default, :py:class:`~pulse2percept.utils.Watson2014Map` is
-            used.
         loc_od, loc_od: (x,y), optional
             Location of the optic disc in degrees of visual angle. Note that the
             optic disc in a left eye will be corrected to have a negative x
@@ -268,7 +262,6 @@ class BiphasicAxonMapSpatial(AxonMapSpatial):
         ignore_pickle: bool, optional
             A flag whether to ignore the pickle file in future calls to
             ``model.build()``.
-
     """
 
     def __init__(self, **params):
@@ -280,21 +273,27 @@ class BiphasicAxonMapSpatial(AxonMapSpatial):
             self.size_model = DefaultSizeModel(self.rho)
         if self.streak_model is None:
             self.streak_model = DefaultStreakModel(self.axlambda)
+        
+        # need to set params again to ensure effect params get passed
+        for key, val in params.items():
+            if key in ['bright_model', 'size_model', 'streak_model']:
+                continue
+            setattr(self, key, val)
 
     def __getattr__(self, attr):
         # Called when normal get attribute fails
-        # If we are in the initializer, or if trying to access
+        # If we are in the initializer, or if trying to access 
         # an effects model, raise an error which is caught and causes
         # the parameter to be created.
-        if (sys._getframe(3).f_code.co_name == '__init__' and
-                "pulse2percept/models/base.py" in
-                sys._getframe(3).f_code.co_filename) or \
-                (attr in ['bright_model', 'streak_model', 'size_model']):
+        if (sys._getframe(3).f_code.co_name == '__init__' and \
+            "pulse2percept/models/base.py" in \
+            sys._getframe(3).f_code.co_filename) or \
+            (attr in ['bright_model', 'streak_model', 'size_model']):
             # We can set new class attributes in the constructor. Reaching this
             # point means the default attribute access failed - most likely
             # because we are trying to create a variable. In this case, simply
             # raise an exception:
-            # Note that this gets called from __init__ of BaseModel, not directly from
+            # Note that this gets called from __init__ of BaseModel, not directly from 
             # BiphasicAxonMap
             raise AttributeError("%s not found" % attr)
         # Check if bright/size/streak model has param
@@ -313,15 +312,6 @@ class BiphasicAxonMapSpatial(AxonMapSpatial):
         ``model.a = X`` can be used as a shorthand to set ``model.bright_model.a``,
         etc
         """
-        try:
-            if sys._getframe(2).f_code.co_name == '__init__' or  \
-               sys._getframe(3).f_code.co_name == '__init__':
-                super().__setattr__(name, value)
-                return
-        except FreezeError:
-            pass
-        # Check whether the attribute is a part of any
-        # bright/size/streak model
         found = False
         # try to set it ourselves, but can't use get_attr
         try:
@@ -331,13 +321,26 @@ class BiphasicAxonMapSpatial(AxonMapSpatial):
             found = True
         except AttributeError:
             pass
-        for m in [self.bright_model, self.size_model, self.streak_model]:
+        # Check whether the attribute is a part of any
+        # bright/size/streak model
+        if name not in ['bright_model', 'size_model', 'streak_model']:
+            for m in [self.bright_model, self.size_model, self.streak_model]:
+                try:
+                    if hasattr(m, name):
+                        setattr(m, name, value)
+                        found = True
+                except (AttributeError, FreezeError):
+                    pass
+        if not found:
             try:
-                if hasattr(m, name):
-                    setattr(m, name, value)
-                    found = True
-            except (AttributeError, FreezeError):
+                if sys._getframe(2).f_code.co_name == '__init__' or  \
+                sys._getframe(3).f_code.co_name == '__init__':
+                    super().__setattr__(name, value)
+                    print("Making a param")
+                    return
+            except FreezeError:
                 pass
+        
         if not found:
             err_str = ("'%s' not found. You cannot add attributes to %s "
                        "outside the constructor." % (name,
@@ -359,7 +362,8 @@ class BiphasicAxonMapSpatial(AxonMapSpatial):
             # Use probabilistic thresholding
             'do_thresholding': False
         }
-        return {**base_params, **params}
+        params.update(base_params)
+        return params
 
     def _build(self):
         if not callable(self.bright_model):
@@ -374,7 +378,7 @@ class BiphasicAxonMapSpatial(AxonMapSpatial):
         """Predicts the percept"""
         if not isinstance(earray, ElectrodeArray):
             raise TypeError("Implant must be of type ElectrodeArray but it is " +
-                            str(type(earray)))
+                str(type(earray)))
         if not isinstance(stim, Stimulus):
             raise TypeError(
                 "Stim must be of type Stimulus but it is " + str(type(stim)))
@@ -399,10 +403,8 @@ class BiphasicAxonMapSpatial(AxonMapSpatial):
                 np.array(bright_effects, dtype=np.float32),
                 np.array(size_effects, dtype=np.float32),
                 np.array(streak_effects, dtype=np.float32),
-                np.array([earray[e].x for e in stim.electrodes],
-                         dtype=np.float32),
-                np.array([earray[e].y for e in stim.electrodes],
-                         dtype=np.float32),
+                np.array([earray[e].x for e in stim.electrodes], dtype=np.float32),
+                np.array([earray[e].y for e in stim.electrodes], dtype=np.float32),
                 self.axon_contrib,
                 self.axon_idx_start.astype(np.uint32),
                 self.axon_idx_end.astype(np.uint32),
@@ -477,7 +479,6 @@ class BiphasicAxonMapSpatial(AxonMapSpatial):
 
 class BiphasicAxonMapModel(Model):
     """ BiphasicAxonMapModel of [Granley2021]_ (standalone model)
-
     An AxonMapModel where phosphene brightness, size, and streak length scale
     according to amplitude, frequency, and pulse duration
 
@@ -511,7 +512,6 @@ class BiphasicAxonMapModel(Model):
         Use probabilistic sigmoid thresholding, default: False
     **params: dict, optional
         Arguments to be passed to AxonMapSpatial
-
         Options:
         ---------
         axlambda: double, optional
@@ -535,11 +535,6 @@ class BiphasicAxonMapModel(Model):
             use ``x_range=(0, 1)`` and ``xystep=0.5``.
         grid_type : {'rectangular', 'hexagonal'}
             Whether to simulate points on a rectangular or hexagonal grid
-        retinotopy : :py:class:`~pulse2percept.utils.VisualFieldMap`, optional
-            An instance of a :py:class:`~pulse2percept.utils.VisualFieldMap`
-            object that provides ``ret2dva`` and ``dva2ret`` methods.
-            By default, :py:class:`~pulse2percept.utils.Watson2014Map` is
-            used.
         loc_od, loc_od: (x,y), optional
             Location of the optic disc in degrees of visual angle. Note that the
             optic disc in a left eye will be corrected to have a negative x
@@ -564,7 +559,6 @@ class BiphasicAxonMapModel(Model):
         ignore_pickle: bool, optional
             A flag whether to ignore the pickle file in future calls to
             ``model.build()``.
-
     """
 
     def __init__(self, **params):

--- a/pulse2percept/models/granley2021.py
+++ b/pulse2percept/models/granley2021.py
@@ -181,6 +181,7 @@ class DefaultStreakModel(BaseModel):
 
 class BiphasicAxonMapSpatial(AxonMapSpatial):
     """ BiphasicAxonMapModel of [Granley2021]_ (spatial model)
+
     An AxonMapModel where phosphene brightness, size, and streak length scale
     according to amplitude, frequency, and pulse duration
 
@@ -238,6 +239,11 @@ class BiphasicAxonMapSpatial(AxonMapSpatial):
             use ``x_range=(0, 1)`` and ``xystep=0.5``.
         grid_type : {'rectangular', 'hexagonal'}
             Whether to simulate points on a rectangular or hexagonal grid
+        retinotopy : :py:class:`~pulse2percept.utils.VisualFieldMap`, optional
+            An instance of a :py:class:`~pulse2percept.utils.VisualFieldMap`
+            object that provides ``ret2dva`` and ``dva2ret`` methods.
+            By default, :py:class:`~pulse2percept.utils.Watson2014Map` is
+            used.
         loc_od, loc_od: (x,y), optional
             Location of the optic disc in degrees of visual angle. Note that the
             optic disc in a left eye will be corrected to have a negative x
@@ -262,6 +268,7 @@ class BiphasicAxonMapSpatial(AxonMapSpatial):
         ignore_pickle: bool, optional
             A flag whether to ignore the pickle file in future calls to
             ``model.build()``.
+
     """
 
     def __init__(self, **params):
@@ -273,8 +280,7 @@ class BiphasicAxonMapSpatial(AxonMapSpatial):
             self.size_model = DefaultSizeModel(self.rho)
         if self.streak_model is None:
             self.streak_model = DefaultStreakModel(self.axlambda)
-        
-        # need to set params again to ensure effect params get passed
+
         for key, val in params.items():
             if key in ['bright_model', 'size_model', 'streak_model']:
                 continue
@@ -282,18 +288,18 @@ class BiphasicAxonMapSpatial(AxonMapSpatial):
 
     def __getattr__(self, attr):
         # Called when normal get attribute fails
-        # If we are in the initializer, or if trying to access 
+        # If we are in the initializer, or if trying to access
         # an effects model, raise an error which is caught and causes
         # the parameter to be created.
-        if (sys._getframe(3).f_code.co_name == '__init__' and \
-            "pulse2percept/models/base.py" in \
-            sys._getframe(3).f_code.co_filename) or \
-            (attr in ['bright_model', 'streak_model', 'size_model']):
+        if (sys._getframe(3).f_code.co_name == '__init__' and
+                "pulse2percept/models/base.py" in
+                sys._getframe(3).f_code.co_filename) or \
+                (attr in ['bright_model', 'streak_model', 'size_model']):
             # We can set new class attributes in the constructor. Reaching this
             # point means the default attribute access failed - most likely
             # because we are trying to create a variable. In this case, simply
             # raise an exception:
-            # Note that this gets called from __init__ of BaseModel, not directly from 
+            # Note that this gets called from __init__ of BaseModel, not directly from
             # BiphasicAxonMap
             raise AttributeError("%s not found" % attr)
         # Check if bright/size/streak model has param
@@ -304,11 +310,9 @@ class BiphasicAxonMapSpatial(AxonMapSpatial):
 
     def __setattr__(self, name, value):
         """Called when an attribute is set
-
         This method is called when a new attribute is set(e.g.,
         ``model.a=2``). This is allowed in the constructor, but will raise a
         ``FreezeError`` elsewhere.
-
         ``model.a = X`` can be used as a shorthand to set ``model.bright_model.a``,
         etc
         """
@@ -324,13 +328,13 @@ class BiphasicAxonMapSpatial(AxonMapSpatial):
         # Check whether the attribute is a part of any
         # bright/size/streak model
         if name not in ['bright_model', 'size_model', 'streak_model']:
-            for m in [self.bright_model, self.size_model, self.streak_model]:
-                try:
+            try:
+                for m in [self.bright_model, self.size_model, self.streak_model]:
                     if hasattr(m, name):
                         setattr(m, name, value)
                         found = True
-                except (AttributeError, FreezeError):
-                    pass
+            except (AttributeError, FreezeError):
+                pass
         if not found:
             try:
                 if sys._getframe(2).f_code.co_name == '__init__' or  \
@@ -345,6 +349,7 @@ class BiphasicAxonMapSpatial(AxonMapSpatial):
                        "outside the constructor." % (name,
                                                      self.__class__.__name__))
             raise FreezeError(err_str)
+        
 
     def get_default_params(self):
         base_params = super(BiphasicAxonMapSpatial, self).get_default_params()
@@ -361,8 +366,7 @@ class BiphasicAxonMapSpatial(AxonMapSpatial):
             # Use probabilistic thresholding
             'do_thresholding': False
         }
-        params.update(base_params)
-        return params
+        return {**base_params, **params}
 
     def _build(self):
         if not callable(self.bright_model):
@@ -377,7 +381,7 @@ class BiphasicAxonMapSpatial(AxonMapSpatial):
         """Predicts the percept"""
         if not isinstance(earray, ElectrodeArray):
             raise TypeError("Implant must be of type ElectrodeArray but it is " +
-                str(type(earray)))
+                            str(type(earray)))
         if not isinstance(stim, Stimulus):
             raise TypeError(
                 "Stim must be of type Stimulus but it is " + str(type(stim)))
@@ -402,8 +406,10 @@ class BiphasicAxonMapSpatial(AxonMapSpatial):
                 np.array(bright_effects, dtype=np.float32),
                 np.array(size_effects, dtype=np.float32),
                 np.array(streak_effects, dtype=np.float32),
-                np.array([earray[e].x for e in stim.electrodes], dtype=np.float32),
-                np.array([earray[e].y for e in stim.electrodes], dtype=np.float32),
+                np.array([earray[e].x for e in stim.electrodes],
+                         dtype=np.float32),
+                np.array([earray[e].y for e in stim.electrodes],
+                         dtype=np.float32),
                 self.axon_contrib,
                 self.axon_idx_start.astype(np.uint32),
                 self.axon_idx_end.astype(np.uint32),
@@ -478,6 +484,7 @@ class BiphasicAxonMapSpatial(AxonMapSpatial):
 
 class BiphasicAxonMapModel(Model):
     """ BiphasicAxonMapModel of [Granley2021]_ (standalone model)
+
     An AxonMapModel where phosphene brightness, size, and streak length scale
     according to amplitude, frequency, and pulse duration
 
@@ -511,6 +518,7 @@ class BiphasicAxonMapModel(Model):
         Use probabilistic sigmoid thresholding, default: False
     **params: dict, optional
         Arguments to be passed to AxonMapSpatial
+
         Options:
         ---------
         axlambda: double, optional
@@ -534,6 +542,11 @@ class BiphasicAxonMapModel(Model):
             use ``x_range=(0, 1)`` and ``xystep=0.5``.
         grid_type : {'rectangular', 'hexagonal'}
             Whether to simulate points on a rectangular or hexagonal grid
+        retinotopy : :py:class:`~pulse2percept.utils.VisualFieldMap`, optional
+            An instance of a :py:class:`~pulse2percept.utils.VisualFieldMap`
+            object that provides ``ret2dva`` and ``dva2ret`` methods.
+            By default, :py:class:`~pulse2percept.utils.Watson2014Map` is
+            used.
         loc_od, loc_od: (x,y), optional
             Location of the optic disc in degrees of visual angle. Note that the
             optic disc in a left eye will be corrected to have a negative x
@@ -558,6 +571,7 @@ class BiphasicAxonMapModel(Model):
         ignore_pickle: bool, optional
             A flag whether to ignore the pickle file in future calls to
             ``model.build()``.
+
     """
 
     def __init__(self, **params):

--- a/pulse2percept/models/granley2021.py
+++ b/pulse2percept/models/granley2021.py
@@ -336,7 +336,6 @@ class BiphasicAxonMapSpatial(AxonMapSpatial):
                 if sys._getframe(2).f_code.co_name == '__init__' or  \
                 sys._getframe(3).f_code.co_name == '__init__':
                     super().__setattr__(name, value)
-                    print("Making a param")
                     return
             except FreezeError:
                 pass

--- a/pulse2percept/models/tests/test_granley2021.py
+++ b/pulse2percept/models/tests/test_granley2021.py
@@ -164,6 +164,13 @@ def test_biphasicAxonMapModel(engine):
     npt.assert_equal(model.axlambda, 450)
     npt.assert_equal(model.do_thresholding, True)
 
+    # Effect model parameters can be passed even in constructor
+    model = BiphasicAxonMapModel(engine=engine, a0=5, rho=432)
+    npt.assert_equal(model.a0, 5)
+    npt.assert_equal(model.spatial.bright_model.a0, 5)
+    npt.assert_equal(model.rho, 432)
+    npt.assert_equal(model.spatial.size_model.rho, 432)
+
     # If parameter is not an effects model param, it cant be set
     with pytest.raises(FreezeError):
         model.invalid_param = 5

--- a/pulse2percept/models/tests/test_granley2021.py
+++ b/pulse2percept/models/tests/test_granley2021.py
@@ -124,11 +124,11 @@ def test_biphasicAxonMapSpatial(engine):
     implant = ArgusII()
     implant.stim = Stimulus({'A4': BiphasicPulseTrain(20, 1, 1)})
     percept = model.predict_percept(implant)
-    npt.assert_equal(np.sum(percept.data > 1), 81)
-    npt.assert_equal(np.sum(percept.data > 2), 59)
-    npt.assert_equal(np.sum(percept.data > 3), 44)
-    npt.assert_equal(np.sum(percept.data > 5), 26)
-    npt.assert_equal(np.sum(percept.data > 7), 14)
+    npt.assert_equal(np.sum(percept.data > 0.0813), 81)
+    npt.assert_equal(np.sum(percept.data > 0.1626), 59)
+    npt.assert_equal(np.sum(percept.data > 0.2439), 44)
+    npt.assert_equal(np.sum(percept.data > 0.4065), 26)
+    npt.assert_equal(np.sum(percept.data > 0.5691), 14)
 
 
 @pytest.mark.parametrize('engine', ('serial', 'cython', 'jax'))


### PR DESCRIPTION
## Description
This PR contains 2 Biphasic model updates:
1) Closes #423; now you can set effects model parameters (e.g. a0-a10) in the `BiphasicAxonMapModel` constructor. 
2) Percept brightness scale now matches Beyeler 2019 instead of Nanduri 2012 / Greenwald 2009.


**1)** Previously, if a parameter was passed, it couldn't be distributed to the effects models because the effects models had not been instantiated yet during model initialization. 
Instantiating the effect models before calling `super.__init__()`, as suggest in bug report, doesn't work due to `getattr` / `setattr`logic , and because pre-initialization the `Frozen` class hasn't been applied yet so it cannot access the correct superclass `getattr`. The simplest way remaining seems to be simply setting all of the attributes passed in `**params` again after the super `__init__` finishes.

**2)** The values of `a2`, `a3`, and `a4` in `DefaultBrightModel` were scaled by 1 over the brightness of a reference pulse at amplitude 2x threshold (i.e. multiplied by 1 / 12.3). This means that the brightness should be centered on the same point as Beyeler 2019, although with this model percepts can get arbitrarily bright, so the range of possible brightness is still different. This also means that rho / lambda should be on the same scale as with the `AxonMapModel`, since the `Biphasic` brightness is normalized at 2xTh and the `AxonMapModel` is fit to 2xTh percepts. 

Added test cases to test passing effect model params in constructor, and modified test cases to reflect scaled brightness

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor


