### PR TITLE
[ENH] Add percept gray levels

### DIFF
--- a/pulse2percept/models/base.py
+++ b/pulse2percept/models/base.py
@@ -195,6 +195,8 @@ class SpatialModel(BaseModel, metaclass=ABCMeta):
             'thresh_percept': 0,
             # Retinotopic map to be used:
             'retinotopy': Curcio1990Map(),
+            # Number of gray levels to use in the percept:
+            'n_gray': None,
             # JobLib or Dask can be used to parallelize computations:
             'engine': 'serial',
             'scheduler': 'threading',
@@ -315,7 +317,7 @@ class SpatialModel(BaseModel, metaclass=ABCMeta):
             resp = self._predict_spatial(implant.earray, stim)
         return Percept(resp.reshape(list(self.grid.x.shape) + [-1]),
                        space=self.grid, time=t_percept,
-                       metadata={'stim': stim})
+                       metadata={'stim': stim}, n_gray=self.n_gray)
 
     def find_threshold(self, implant, bright_th, amp_range=(0, 999), amp_tol=1,
                        bright_tol=0.1, max_iter=100):

--- a/pulse2percept/models/beyeler2019.py
+++ b/pulse2percept/models/beyeler2019.py
@@ -59,6 +59,10 @@ class ScoreboardSpatial(SpatialModel):
         object that provides ``ret2dva`` and ``dva2ret`` methods.
         By default, :py:class:`~pulse2percept.utils.Watson2014Map` is
         used.
+    n_gray : int, optional
+        The number of gray levels to use. If an integer is given, k-means
+        clustering is used to compress the color space of the percept into
+        ``n_gray`` bins. If None, no compression is performed.
 
     .. important ::
 
@@ -126,6 +130,10 @@ class ScoreboardModel(Model):
         object that provides ``ret2dva`` and ``dva2ret`` methods.
         By default, :py:class:`~pulse2percept.utils.Watson2014Map` is
         used.
+    n_gray : int, optional
+        The number of gray levels to use. If an integer is given, k-means
+        clustering is used to compress the color space of the percept into
+        ``n_gray`` bins. If None, no compression is performed.
 
     .. important ::
 
@@ -182,6 +190,10 @@ class AxonMapSpatial(SpatialModel):
         object that provides ``ret2dva`` and ``dva2ret`` methods.
         By default, :py:class:`~pulse2percept.utils.Watson2014Map` is
         used.
+    n_gray : int, optional
+        The number of gray levels to use. If an integer is given, k-means
+        clustering is used to compress the color space of the percept into
+        ``n_gray`` bins. If None, no compression is performed.
     loc_od, loc_od: (x,y), optional
         Location of the optic disc in degrees of visual angle. Note that the
         optic disc in a left eye will be corrected to have a negative x
@@ -668,10 +680,10 @@ class AxonMapSpatial(SpatialModel):
         if need_axons:
             # Pickle axons along with all important parameters:
             params = {'loc_od': self.loc_od,
-                    'n_axons': self.n_axons, 'axons_range': self.axons_range,
-                    'xrange': self.xrange, 'yrange': self.yrange,
-                    'xystep': self.xystep, 'n_ax_segments': self.n_ax_segments,
-                    'ax_segments_range': self.ax_segments_range}
+                      'n_axons': self.n_axons, 'axons_range': self.axons_range,
+                      'xrange': self.xrange, 'yrange': self.yrange,
+                      'xystep': self.xystep, 'n_ax_segments': self.n_ax_segments,
+                      'ax_segments_range': self.ax_segments_range}
             pickle.dump((params, axons), open(self.axon_pickle, 'wb'))
 
     def _predict_spatial(self, earray, stim):

--- a/pulse2percept/models/granley2021.py
+++ b/pulse2percept/models/granley2021.py
@@ -218,6 +218,10 @@ class BiphasicAxonMapSpatial(AxonMapSpatial):
 
         Options:
         --------
+        n_gray : int, optional
+            The number of gray levels to use. If an integer is given, k-means
+            clustering is used to compress the color space of the percept into
+            ``n_gray`` bins. If None, no compression is performed.
         axlambda: double, optional
             Exponential decay constant along the axon(microns).
         rho: double, optional
@@ -521,6 +525,10 @@ class BiphasicAxonMapModel(Model):
 
         Options:
         ---------
+        n_gray : int, optional
+            The number of gray levels to use. If an integer is given, k-means
+            clustering is used to compress the color space of the percept into
+            ``n_gray`` bins. If None, no compression is performed.
         axlambda: double, optional
             Exponential decay constant along the axon(microns).
         rho: double, optional

--- a/pulse2percept/models/nanduri2012.py
+++ b/pulse2percept/models/nanduri2012.py
@@ -43,6 +43,10 @@ class Nanduri2012Spatial(SpatialModel):
         object that provides ``ret2dva`` and ``dva2ret`` methods.
         By default, :py:class:`~pulse2percept.utils.Curcio1990Map` is
         used.
+    n_gray : int, optional
+        The number of gray levels to use. If an integer is given, k-means
+        clustering is used to compress the color space of the percept into
+        ``n_gray`` bins. If None, no compression is performed.
 
     """
 

--- a/pulse2percept/models/tests/test_granley2021.py
+++ b/pulse2percept/models/tests/test_granley2021.py
@@ -95,7 +95,7 @@ def test_biphasicAxonMapSpatial(engine):
     percept = model.predict_percept(implant)
     percept_axon = axon_map.predict_percept(implant)
     npt.assert_almost_equal(
-        percept.data[:, :, 0], percept_axon.get_brightest_frame())
+        percept.data[:, :, 0], percept_axon.max(axis='frames'))
 
     # Effect models must be callable
     model = BiphasicAxonMapSpatial(engine=engine, xystep=2)

--- a/pulse2percept/percepts/base.py
+++ b/pulse2percept/percepts/base.py
@@ -52,6 +52,7 @@ class Percept(Data):
             if n_gray <= 1:
                 raise ValueError(('"n_gray" must be greater than 1, not '
                                   '%d.' % n_gray))
+            data = np.asarray(data, dtype=np.float32)
             centroids, labels = kmeans2(data.ravel(), n_gray)
             data = centroids[labels].reshape(data.shape)
         if time is not None:

--- a/pulse2percept/percepts/base.py
+++ b/pulse2percept/percepts/base.py
@@ -107,23 +107,6 @@ class Percept(Data):
         raise ValueError('Unknown axis value "%s". Use "frames" or '
                          'None.' % axis)
 
-    @deprecated(deprecated_version='0.7', removed_version='0.8',
-                alt_func='percept.max()')
-    def get_brightest_frame(self):
-        """Return the brightest frame
-
-        Looks for the brightest pixel in the percept, determines at what point
-        in time it happened, and returns all brightness values at that point
-        in a 2D NumPy array
-
-        Returns
-        -------
-        frame : 2D NumPy array
-            A slice ``percept.data[..., tmax]`` where ``tmax`` is the time at
-            which the percept reached its maximum brightness.
-        """
-        return self.data[..., np.argmax(np.max(self.data, axis=(0, 1)))]
-
     def rewind(self):
         """Rewind the iterator"""
         self._next_frame = 0

--- a/pulse2percept/percepts/base.py
+++ b/pulse2percept/percepts/base.py
@@ -201,7 +201,6 @@ class Percept(Data):
                 raise ValueError(('"n_gray" must be greater than 1, not '
                                   '%d.' % n_gray))
             centroids, labels = kmeans2(frame.ravel(), n_gray)
-            print(centroids, len(centroids))
             frame = centroids[labels].reshape(frame.shape)
 
         vmin = kwargs['vmin'] if 'vmin' in kwargs.keys() else frame.min()

--- a/pulse2percept/percepts/tests/test_base.py
+++ b/pulse2percept/percepts/tests/test_base.py
@@ -47,8 +47,17 @@ def test_Percept():
     npt.assert_almost_equal(percept.ydva, grid._yflat)
     npt.assert_almost_equal(percept.time, [0])
 
+    # Gray levels
+    for n_gray in [2, 4, 6]:
+        percept = Percept(np.random.rand(7, 7, 1), n_gray=n_gray)
+        npt.assert_equal(len(np.unique(percept.data)), n_gray)
+
     with pytest.raises(TypeError):
         Percept(ndarray, space={'x': [0, 1, 2], 'y': [0, 1, 2, 3, 4]})
+    with pytest.raises(ValueError):
+        Percept(ndarray, n_gray=1.2)
+    with pytest.raises(ValueError):
+        Percept(ndarray, n_gray=-3)
 
 
 def test_Percept__iter__():
@@ -96,7 +105,7 @@ def test_Percept_plot():
     ax = percept.plot(kind='pcolor')
     npt.assert_equal(isinstance(ax, Subplot), True)
     npt.assert_almost_equal(ax.axis(), [*x_range, *y_range])
-    frame = percept.get_brightest_frame()
+    frame = percept.max(axis='frames')
     npt.assert_almost_equal(ax.collections[0].get_clim(),
                             [frame.min(), frame.max()])
 
@@ -121,22 +130,11 @@ def test_Percept_plot():
     ax = percept.plot(vmin=2, vmax=4)
     npt.assert_equal(ax.collections[0].get_clim(), (2., 4.))
 
-    # Gray levels
-    percept = Percept(np.random.rand(7, 7, 1))
-    for n_gray in [2, 4, 6]:
-        ax.clear()
-        ax = percept.plot(n_gray=n_gray)
-        npt.assert_equal(len(np.unique(ax.collections[0].get_array())), n_gray)
-
     # Invalid calls:
     with pytest.raises(ValueError):
         percept.plot(kind='invalid')
     with pytest.raises(TypeError):
         percept.plot(ax='invalid')
-    with pytest.raises(ValueError):
-        percept.plot(n_gray=1.2)
-    with pytest.raises(ValueError):
-        percept.plot(n_gray=-3)
 
 
 @pytest.mark.parametrize('n_frames', (2, 3, 10, 14))

--- a/pulse2percept/percepts/tests/test_base.py
+++ b/pulse2percept/percepts/tests/test_base.py
@@ -86,12 +86,6 @@ def test_Percept_max():
         percept.max(axis='invalid')
 
 
-def test_Percept_get_brightest_frame():
-    percept = Percept(np.arange(30).reshape((3, 5, 2)))
-    npt.assert_almost_equal(percept.get_brightest_frame(),
-                            percept.data[..., 1])
-
-
 def test_Percept_plot():
     y_range = (-1, 1)
     x_range = (-2, 2)

--- a/pulse2percept/percepts/tests/test_base.py
+++ b/pulse2percept/percepts/tests/test_base.py
@@ -127,11 +127,22 @@ def test_Percept_plot():
     ax = percept.plot(vmin=2, vmax=4)
     npt.assert_equal(ax.collections[0].get_clim(), (2., 4.))
 
+    # Gray levels
+    percept = Percept(np.random.rand(7, 7, 1))
+    for n_gray in [2, 4, 6]:
+        ax.clear()
+        ax = percept.plot(n_gray=n_gray)
+        npt.assert_equal(len(np.unique(ax.collections[0].get_array())), n_gray)
+
     # Invalid calls:
     with pytest.raises(ValueError):
         percept.plot(kind='invalid')
     with pytest.raises(TypeError):
         percept.plot(ax='invalid')
+    with pytest.raises(ValueError):
+        percept.plot(n_gray=1.2)
+    with pytest.raises(ValueError):
+        percept.plot(n_gray=-3)
 
 
 @pytest.mark.parametrize('n_frames', (2, 3, 10, 14))

--- a/pulse2percept/percepts/tests/test_base.py
+++ b/pulse2percept/percepts/tests/test_base.py
@@ -161,7 +161,6 @@ def test_Percept_save(dtype):
 
     # Save multiple frames as a gif or movie:
     for fname in ['test.mp4', 'test.avi', 'test.mov', 'test.wmv', 'test.gif']:
-        print(fname)
         percept.save(fname)
         npt.assert_equal(os.path.isfile(fname), True)
         # Normalized to [0, 255] with some loss of precision:

--- a/pulse2percept/percepts/tests/test_base.py
+++ b/pulse2percept/percepts/tests/test_base.py
@@ -49,7 +49,8 @@ def test_Percept():
 
     # Gray levels
     for n_gray in [2, 4, 6]:
-        percept = Percept(np.random.rand(7, 7, 1), n_gray=n_gray)
+        percept = Percept(np.arange(49, dtype=float).reshape((7, 7, 1)),
+                          n_gray=n_gray)
         npt.assert_equal(len(np.unique(percept.data)), n_gray)
 
     with pytest.raises(TypeError):


### PR DESCRIPTION
Adds an option to limit the number of gray levels in a percept.

![image](https://user-images.githubusercontent.com/5214334/144465225-a793f454-01e7-4486-b4a4-62b689d617e2.png)
