### PR TITLE
[FIX] Ignore stimuli of deactivated electrodes

### DIFF
--- a/pulse2percept/implants/base.py
+++ b/pulse2percept/implants/base.py
@@ -196,6 +196,8 @@ class ProsthesisSystem(PrettyPrint):
 
     def deactivate(self, electrodes):
         self.earray.deactivate(electrodes)
+        if self.stim is not None:
+            self.stim.remove(electrodes)
 
     @property
     def earray(self):
@@ -284,9 +286,9 @@ class ProsthesisSystem(PrettyPrint):
                 if not self.earray[electrode]:
                     raise ValueError('Electrode "%s" not found in '
                                      'implant.' % electrode)
-                if not self.earray[electrode].activated:
-                    raise ValueError('Cannot assign stimulus to deactivated '
-                                     'Electrode "%s".' % electrode)
+            # Remove deactivated electrodes from the stimulus:
+            stim.remove([name for (name, e) in self.electrodes.items()
+                         if not e.activated])
             # Perform safety checks, etc.:
             self.check_stim(stim)
             # Store stimulus:

--- a/pulse2percept/implants/tests/test_base.py
+++ b/pulse2percept/implants/tests/test_base.py
@@ -69,13 +69,14 @@ def test_ProsthesisSystem_stim():
     # Deactivated electrodes cannot receive stimuli:
     implant.deactivate('H4')
     npt.assert_equal(implant['H4'].activated, False)
-    with pytest.raises(ValueError):
-        implant.stim = {'H4': 1}
+    implant.stim = {'H4': 1}
+    npt.assert_equal('H4' in implant.stim.electrodes, False)
+
     implant.deactivate('all')
-    with pytest.raises(ValueError):
-        implant.stim = [1] * implant.n_electrodes
+    npt.assert_equal(not implant.stim.data, True)
     implant.activate('all')
     implant.stim = {'H4': 1}
+    npt.assert_equal('H4' in implant.stim.electrodes, True)
 
 
 @pytest.mark.parametrize('rot', (0, 30, 92))
@@ -103,3 +104,13 @@ def test_ProsthesisSystem_reshape_stim(rot, gtype, n_frames):
     model.build()
     percept = label(model.predict_percept(implant).data.squeeze().T > 0.2)
     npt.assert_almost_equal(regionprops(percept)[0].orientation, 0, decimal=1)
+
+
+def test_ProsthesisSystem_deactivate():
+    implant = ProsthesisSystem(ElectrodeGrid((10, 10), 30))
+    implant.stim = np.ones(implant.n_electrodes)
+    electrode = 'A3'
+    npt.assert_equal(electrode in implant.stim.electrodes, True)
+    implant.deactivate(electrode)
+    npt.assert_equal(implant[electrode].activated, False)
+    npt.assert_equal(electrode in implant.stim.electrodes, False)

--- a/pulse2percept/stimuli/base.py
+++ b/pulse2percept/stimuli/base.py
@@ -442,21 +442,23 @@ class Stimulus(PrettyPrint):
                 'time': self.time
             }
             return
+        # Start with a list of True and set the removed electrodes to False:
         keep_el = np.ones(len(self.electrodes), dtype=bool)
         for electrode in np.array([electrodes]).ravel():
             try:
+                # Check if `electrode` is an index into the electrodes array:
                 self.electrodes[electrode]
                 keep_el[electrode] = False
             except (IndexError, KeyError):
+                # Another possibility is that a string with the electrode name
+                # was passed. In this case, find the corresponding list index:
                 try:
                     keep_el[list(self.electrodes).index(electrode)] = False
                 except ValueError:
-                    raise ValueError(f'Electrode {electrode} not found.')
-        data = self.data[keep_el]
-        electrodes = self.electrodes[keep_el]
+                    raise ValueError(f'Electrode "{electrode}" not found.')
         self._stim = {
-            'data': data,
-            'electrodes': electrodes,
+            'data': self.data[keep_el],
+            'electrodes': self.electrodes[keep_el],
             'time': self.time,
         }
 

--- a/pulse2percept/stimuli/base.py
+++ b/pulse2percept/stimuli/base.py
@@ -227,7 +227,8 @@ class Stimulus(PrettyPrint):
             _time = source.time
             _electrodes = source.electrodes
             if 'electrodes' not in source.metadata.keys():
-                self.metadata['electrodes'][str(_electrodes[0])] = {'metadata' : source.metadata, 'type' : type(source)}
+                self.metadata['electrodes'][str(_electrodes[0])] = {
+                    'metadata': source.metadata, 'type': type(source)}
             else:
                 self.metadata = source.metadata
         elif isinstance(source, np.ndarray):
@@ -246,7 +247,9 @@ class Stimulus(PrettyPrint):
                                  "NumPy array. Must be < 2-D." % source.ndim)
             if len(self.metadata['electrodes']) != len(_electrodes):
                 for elec in _electrodes:
-                    self.metadata['electrodes'][str(elec)] = {'metadata' : '', 'type': np.ndarray}
+                    self.metadata['electrodes'][str(elec)] = {
+                        'metadata': '', 'type': np.ndarray
+                    }
         else:
             # Input is either a scalar or (more likely) a collection of source
             # types. Easiest to tream them all as a collection and iterate:
@@ -416,6 +419,46 @@ class Stimulus(PrettyPrint):
                       'electrodes': self.electrodes,
                       'time': time}
         return stim
+
+    def remove(self, electrodes):
+        """Remove electrode(s)
+
+        Removes the stimulus of a certain electrode or list of electrodes.
+
+        .. versionadded:: 0.8
+
+        Parameters
+        ----------
+        electrodes : int, string, or list of int/str
+            The item(s) to remove from the stimulus. Can either be an electrode
+            index, electrode name, or a list thereof.
+        """
+        if not electrodes:
+            return
+        if np.isscalar(electrodes) and electrodes == 'all':
+            self._stim = {
+                'data': self.data[[]],
+                'electrodes': [],
+                'time': self.time
+            }
+            return
+        keep_el = np.ones(len(self.electrodes), dtype=bool)
+        for electrode in np.array([electrodes]).ravel():
+            try:
+                self.electrodes[electrode]
+                keep_el[electrode] = False
+            except (IndexError, KeyError):
+                try:
+                    keep_el[list(self.electrodes).index(electrode)] = False
+                except ValueError:
+                    raise ValueError(f'Electrode {electrode} not found.')
+        data = self.data[keep_el]
+        electrodes = self.electrodes[keep_el]
+        self._stim = {
+            'data': data,
+            'electrodes': electrodes,
+            'time': self.time,
+        }
 
     def plot(self, electrodes=None, time=None, fmt='k-', ax=None):
         """Plot the stimulus

--- a/pulse2percept/stimuli/tests/test_base.py
+++ b/pulse2percept/stimuli/tests/test_base.py
@@ -546,3 +546,12 @@ def test_Stimulus_arithmetic(scalar):
         s = stim >> np.array([2, 3])
     with pytest.raises(TypeError):
         s = stim << np.array([2, 3])
+
+
+def test_Stimulus_remove():
+    stim = Stimulus([[0, 1, 2], [3, 4, 5]], electrodes=['A1', 'C3'])
+    npt.assert_equal('A1' in stim.electrodes, True)
+    npt.assert_equal('C3' in stim.electrodes, True)
+    stim.remove('A1')
+    npt.assert_equal('A1' in stim.electrodes, False)
+    npt.assert_equal('C3' in stim.electrodes, True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ cython>=0.28
 numpy>=1.11
 setuptools<50.0
 scipy>=1.0.1
-scikit_image>=0.14
+scikit_image>=0.14,<0.19.0
 matplotlib>=3.0.2
 imageio_ffmpeg>=0.4
 joblib>=0.11


### PR DESCRIPTION
A deactivated electrode should not be able to receive a stimulus. This works if the electrode is deactivated first, before a stimulus is assigned. But this doesn't work if the electrode is deactivated after a stimulus was assigned. This PR fixes that by providing a `Stimulus.remove(electrode)` method.