### PR TITLE
[FIX] Grid2D plot when step is a tuple

### DIFF
--- a/pulse2percept/utils/geometry.py
+++ b/pulse2percept/utils/geometry.py
@@ -169,6 +169,13 @@ class Grid2D(PrettyPrint):
             zorder = ZORDER['background']
 
         x, y = self.x, self.y
+        try:
+            # Step might be a tuple:
+            x_step, y_step = self.step
+        except TypeError:
+            x_step = self.step
+            y_step = self.step
+
         if style.lower() == 'cell':
             # Show a polygon for every grid cell that we are simulating:
             if self.type == 'hexagonal':
@@ -177,10 +184,10 @@ class Grid2D(PrettyPrint):
             for xret, yret in zip(x.ravel(), y.ravel()):
                 # Outlines of the cell are given by (x,y) and the step size:
                 vertices = np.array([
-                    [xret - self.step / 2, yret - self.step / 2],
-                    [xret - self.step / 2, yret + self.step / 2],
-                    [xret + self.step / 2, yret + self.step / 2],
-                    [xret + self.step / 2, yret - self.step / 2],
+                    [xret - x_step / 2, yret - y_step / 2],
+                    [xret - x_step / 2, yret + y_step / 2],
+                    [xret + x_step / 2, yret + y_step / 2],
+                    [xret + x_step / 2, yret - y_step / 2],
                 ])
                 if transform is not None:
                     vertices = np.array(transform(*vertices.T)).T

--- a/pulse2percept/utils/tests/test_geometry.py
+++ b/pulse2percept/utils/tests/test_geometry.py
@@ -97,6 +97,9 @@ def test_Grid2D_plot():
     ax = grid.plot(style='cell')
     ax = grid.plot(style='scatter')
 
+    # Step might be a tuple (smoke test):
+    Grid2D((-5, 5), (-5, 5), step=(0.5, 1)).plot(style='cell')
+
 
 class ValidCoordTransform(VisualFieldMap):
 


### PR DESCRIPTION
This PR fixes issue #442, when `step` of a `Grid2D` object is a tuple:

```
p2p.utils.Grid2D((-5, 5), (-5, 5), step=(0.5, 1)).plot(style='cell')
```
![image](https://user-images.githubusercontent.com/5214334/144913549-70219bc9-9976-47b0-b678-4b4a185b3873.png)
