### PR TITLE
[FIX] mimread and circ_r2_score due to external dependency updates

### DIFF
--- a/pulse2percept/percepts/tests/test_base.py
+++ b/pulse2percept/percepts/tests/test_base.py
@@ -157,9 +157,9 @@ def test_Percept_save(dtype):
         percept.save(fname)
         npt.assert_equal(os.path.isfile(fname), True)
         # Normalized to [0, 255] with some loss of precision:
-        mov = mimread(fname)
-        npt.assert_equal(np.min(mov) <= 2, True)
-        npt.assert_equal(np.max(mov) >= 250, True)
+        for mov in mimread(fname):
+            npt.assert_equal(np.min(mov) <= 2, True)
+            npt.assert_equal(np.max(mov) >= 250, True)
         os.remove(fname)
 
     # Cannot save multiple frames image:

--- a/pulse2percept/utils/constants.py
+++ b/pulse2percept/utils/constants.py
@@ -1,4 +1,4 @@
-"""`DT`, `MIN_AMP`, `ZORDER`"""
+"""`DT`, `MIN_AMP`, `VIDEO_BLOCK_SIZE`, `ZORDER`"""
 
 #: Pulses with net currents smaller than 10 picoamps are considered
 #: charge-balanced (here expressed in microamps).
@@ -8,6 +8,9 @@ MIN_AMP = 1e-5
 #: transitions.
 DT = 1e-3
 
+# Block size for saving videos: width/height must be divisible by 16 for most
+# codecs to work
+VIDEO_BLOCK_SIZE = 16
 
 #: An enum specifying the zorder values to use in Matplotlib plots, ensuring
 #: that foreground items (like implants) always appear on top of background

--- a/pulse2percept/utils/stats.py
+++ b/pulse2percept/utils/stats.py
@@ -63,7 +63,7 @@ def r2_score(y_true, y_pred):
     ss_res = np.sum((y_true - y_pred) ** 2, dtype=np.float32)
     # Total sum of squares:
     ss_tot = np.sum((y_true - np.mean(y_true)) ** 2, dtype=np.float32)
-    if isclose(ss_tot, 0):
+    if isclose(ss_tot, 0, abs_tol=1e-9):
         return 0.0  # zero variance in the ground-truth data
     return 1 - ss_res / ss_tot
 
@@ -108,7 +108,6 @@ def circ_r2_score(y_true, y_pred):
     ss_res = np.mean(err ** 2, dtype=np.float32)
     ss_tot = np.asarray(circvar(y_true, low=-np.pi / 2, high=np.pi / 2),
                         dtype=np.float32)
-    print(f"debug: res={ss_res}, tot={ss_tot} isclose={isclose(ss_tot, 0.0)}")
-    if isclose(ss_tot, 0.0):
+    if isclose(ss_tot, 0.0, abs_tol=1e-9):
         return 0.0  # zero variance in the ground-truth data
     return 1 - ss_res / ss_tot

--- a/pulse2percept/utils/stats.py
+++ b/pulse2percept/utils/stats.py
@@ -108,6 +108,7 @@ def circ_r2_score(y_true, y_pred):
     ss_res = np.mean(err ** 2, dtype=np.float32)
     ss_tot = np.asarray(circvar(y_true, low=-np.pi / 2, high=np.pi / 2),
                         dtype=np.float32)
-    if isclose(ss_tot, 0):
+    print(f"debug: res={ss_res}, tot={ss_tot} isclose={isclose(ss_tot, 0.0)}")
+    if isclose(ss_tot, 0.0):
         return 0.0  # zero variance in the ground-truth data
     return 1 - ss_res / ss_tot

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,3 @@ scikit_image>=0.14,<0.19.0
 matplotlib>=3.0.2
 imageio_ffmpeg>=0.4
 joblib>=0.11
-pillow!=7.1.0,!=7.1.1,>=4.3.0,<9.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ scikit_image>=0.14,<0.19.0
 matplotlib>=3.0.2
 imageio_ffmpeg>=0.4
 joblib>=0.11
-pillow!=7.1.0,!=7.1.1,>=4.3.0,<=9.0.0
+pillow!=7.1.0,!=7.1.1,>=4.3.0,<9.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ scikit_image>=0.14,<0.19.0
 matplotlib>=3.0.2
 imageio_ffmpeg>=0.4
 joblib>=0.11
+pillow!=7.1.0,!=7.1.1,>=4.3.0,<=9.0.0


### PR DESCRIPTION
Through a combination of updates from our software dependencies, two tests are now breaking:
- [x] `mimread` in `percepts/tests/test_base.py`: Most recent imageio/pillow version returns a list of NumPy arrays for `mimread`, not all of which necessarily have the same shape. This may be caused by a lossy conversion from `float32` to `uint8`, especially when the percept has a shape does not divisible by 16 (`macro_block_size`). This is now fixed by adjusting the video shape before saving, manually converting to uint8, and updating the test accordingly.
- [x] `circ_r2_score` in `utils/tests/test_stats.py`: On some platforms, `isclose(ss_tot, 0)` does not return `True` for extremely small values (e.g., 1e-17), leading to an absurdly large R2 score. This is now fixed by specifying an `abs_tol`.