### PR TITLE
[FIX] SciPy breaks wheels

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 cython>=0.28
 numpy>=1.11
 setuptools<50.0
-scipy>=1.0.1,!=1.8.0
+scipy>=1.0.1,<=1.7.1
 scikit_image>=0.14,<0.19.0
 matplotlib>=3.0.2
 imageio_ffmpeg>=0.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 cython>=0.28
 numpy>=1.11
 setuptools<50.0
-scipy>=1.0.1,!1.8.0
+scipy>=1.0.1,!=1.8.0
 scikit_image>=0.14,<0.19.0
 matplotlib>=3.0.2
 imageio_ffmpeg>=0.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 cython>=0.28
 numpy>=1.11
 setuptools<50.0
-scipy>=1.0.1
+scipy>=1.0.1,!1.8.0
 scikit_image>=0.14,<0.19.0
 matplotlib>=3.0.2
 imageio_ffmpeg>=0.4


### PR DESCRIPTION
SciPy 1.7.2 applied some bug fix to the handling of BLAS/LAPACK that accidentally breaks our wheels. The issue is still present in 1.8.0. For now, we limit the allowed SciPy version