### PR TITLE
[BUG] Fix Corrupted Multi-Stimuli

### DIFF
--- a/pulse2percept/stimuli/base.py
+++ b/pulse2percept/stimuli/base.py
@@ -37,7 +37,7 @@ def merge_time_axes(data, time):
         return data, [time[0]]
     # Otherwise, we need to interpolate. Keep only the unique time points
     # across stimuli:
-    new_time = unique(np.concatenate(time), tol=DT)
+    new_time = unique(np.concatenate(time), tol=1e-6)
     # Now we need to interpolate the data values at each of these
     # new time points.
     new_data = []
@@ -814,7 +814,7 @@ class Stimulus(PrettyPrint):
                                  f"number of columns in the data array "
                                  f"({data_shape[1]}).")
             if not is_strictly_increasing(stim['time'], tol=0.95*DT):
-                msg = (f"Time points must be strictly monotonically ",
+                msg = (f"Time points must be strictly monotonically "
                        f"increasing: {list(stim['time'])}")
                 warnings.warn(msg)
         elif data_shape[0] > 0:

--- a/pulse2percept/stimuli/base.py
+++ b/pulse2percept/stimuli/base.py
@@ -36,7 +36,7 @@ def merge_time_axes(data, time):
     if identical:
         return data, [time[0]]
     # Otherwise, we need to interpolate. Keep only the unique time points
-    # across stimuli:
+    # across stimuli. We need a higher tolerance to ensure interpolation is correct.
     new_time = unique(np.concatenate(time), tol=1e-6)
     # Now we need to interpolate the data values at each of these
     # new time points.

--- a/pulse2percept/stimuli/base.py
+++ b/pulse2percept/stimuli/base.py
@@ -18,13 +18,27 @@ np.set_printoptions(precision=2, threshold=5, edgeitems=2)
 logging.captureWarnings(True)
 
 
-def merge_time_axes(data, time):
-    """Merge time axes
+def merge_time_axes(data, time, merge_tolerance=1e-6):
+    """
+    Merge time axes
 
     When a collection of source types is passed, it is possible that they
     have different time axes (e.g., different time steps, or a different
     stimulus duration). In this case, we need to merge all time axes into a
     single, coherent one. This is expensive, because of interpolation.
+
+    Parameters
+    ----------
+    data: list
+        List of numpy.ndarray's containing data points associated with time axes.
+    time: list
+        List of numpy.ndarray's containing time points to merge
+    merge_tolerance: float
+        Float representing the tolerance used when collecting unique time points from the time axes.
+    Returns
+        Tuple of: list of new data points (linearly interpolated from merged time axis), list of new merged time axis.
+    -------
+
     """
     # We can skip the costly interpolation if all `time` vectors are
     # identical:
@@ -37,7 +51,7 @@ def merge_time_axes(data, time):
         return data, [time[0]]
     # Otherwise, we need to interpolate. Keep only the unique time points
     # across stimuli. We need a higher tolerance to ensure interpolation is correct.
-    new_time = unique(np.concatenate(time), tol=1e-6)
+    new_time = unique(np.concatenate(time), tol=merge_tolerance)
     # Now we need to interpolate the data values at each of these
     # new time points.
     new_data = []


### PR DESCRIPTION
## Description
This PR addresses the issue where Stimuli would become corrupted when created from multiple Stimuli. The issue was in the merging of time axes, where not enough unique points were collected, leading to corrupted Stimuli when interpolated.

Closes #392 

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes

For detailed information on these and other aspects, see the contribution guidelines: https://pulse2percept.readthedocs.io/en/latest/developers/contributing.html
