### PR TITLE
[FIX] Models are now hashable

### DIFF
--- a/pulse2percept/models/base.py
+++ b/pulse2percept/models/base.py
@@ -154,6 +154,10 @@ class BaseModel(Frozen, PrettyPrint, metaclass=ABCMeta):
             return True
         return self.__dict__ == other.__dict__
 
+    def __hash__(self):
+        # Default python 2.6+ implementation
+        return id(self) // 16
+
 
 class SpatialModel(BaseModel, metaclass=ABCMeta):
     """Abstract base class for all spatial models

--- a/pulse2percept/models/base.py
+++ b/pulse2percept/models/base.py
@@ -833,6 +833,10 @@ class Model(PrettyPrint):
             return True
         return self.temporal == other.temporal and self.spatial == other.spatial
 
+    def __hash__(self):
+        # Default python 2.6+ implementation
+        return id(self) // 16
+
     def _pprint_params(self):
         """Return a dictionary of parameters to pretty - print"""
         params = {'spatial': self.spatial, 'temporal': self.temporal}


### PR DESCRIPTION
## Description

Adds `__hash__` functions to `Model` and `BaseModel`, which allows Jax based models to work again. 

Closes #471 

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


