### PR TITLE
[ENH] Allow easy stimulus coloring in implant.plot()

### DIFF
--- a/pulse2percept/implants/base.py
+++ b/pulse2percept/implants/base.py
@@ -170,7 +170,7 @@ class ProsthesisSystem(PrettyPrint):
             raise ValueError(err_str)
         return stim
 
-    def plot(self, annotate=False, autoscale=True, ax=None, color_stim=False, cmap='OrRd'):
+    def plot(self, annotate=False, autoscale=True, ax=None, stim_cmap=False):
         """Plot
 
         Parameters
@@ -182,11 +182,10 @@ class ProsthesisSystem(PrettyPrint):
         ax : matplotlib.axes._subplots.AxesSubplot, optional
             A Matplotlib axes object. If None, will either use the current axes
             (if exists) or create a new Axes object.
-        color_stim : bool, optional
-            If true, the fill color of the plotted electrodes will vary based 
-            on maximum stimulus amplitude on each electrode
-        cmap : str
-            Matplotlib colormap to use for stimulus coloring.
+        stim_cmap : bool, str, or matplotlib colormap, optional
+            If not false, the fill color of the plotted electrodes will vary based 
+            on maximum stimulus amplitude on each electrode. The chosen colormap
+            will be used if provided
 
         Returns
         -------
@@ -194,11 +193,13 @@ class ProsthesisSystem(PrettyPrint):
             Returns the axis object of the plot
         """
         stim = None
-        if color_stim:
+        if stim_cmap:
             if self.stim is None:
                 raise ValueError("Must assign a stimulus in order to enable stimulus coloring")
             stim = self.stim
-        return self.earray.plot(annotate=annotate, autoscale=autoscale, ax=ax, color_stim=stim, cmap=cmap)
+            if stim_cmap == True:
+                stim_cmap = 'hot'
+        return self.earray.plot(annotate=annotate, autoscale=autoscale, ax=ax, color_stim=stim, cmap=stim_cmap)
 
     def activate(self, electrodes):
         self.earray.activate(electrodes)

--- a/pulse2percept/implants/base.py
+++ b/pulse2percept/implants/base.py
@@ -170,7 +170,7 @@ class ProsthesisSystem(PrettyPrint):
             raise ValueError(err_str)
         return stim
 
-    def plot(self, annotate=False, autoscale=True, ax=None):
+    def plot(self, annotate=False, autoscale=True, ax=None, color_stim=False, cmap='OrRd'):
         """Plot
 
         Parameters
@@ -182,13 +182,23 @@ class ProsthesisSystem(PrettyPrint):
         ax : matplotlib.axes._subplots.AxesSubplot, optional
             A Matplotlib axes object. If None, will either use the current axes
             (if exists) or create a new Axes object.
+        color_stim : bool, optional
+            If true, the fill color of the plotted electrodes will vary based 
+            on stimulus amplitude
+        cmap : str
+            Matplotlib colormap to use for stimulus coloring.
 
         Returns
         -------
         ax : ``matplotlib.axes.Axes``
             Returns the axis object of the plot
         """
-        return self.earray.plot(annotate=annotate, autoscale=autoscale, ax=ax)
+        stim = None
+        if color_stim:
+            if self.stim is None:
+                raise ValueError("Must assign a stimulus in order to enable stimulus coloring")
+            stim = self.stim
+        return self.earray.plot(annotate=annotate, autoscale=autoscale, ax=ax, color_stim=stim, cmap=cmap)
 
     def activate(self, electrodes):
         self.earray.activate(electrodes)

--- a/pulse2percept/implants/base.py
+++ b/pulse2percept/implants/base.py
@@ -184,7 +184,7 @@ class ProsthesisSystem(PrettyPrint):
             (if exists) or create a new Axes object.
         color_stim : bool, optional
             If true, the fill color of the plotted electrodes will vary based 
-            on stimulus amplitude
+            on maximum stimulus amplitude on each electrode
         cmap : str
             Matplotlib colormap to use for stimulus coloring.
 

--- a/pulse2percept/implants/electrode_arrays.py
+++ b/pulse2percept/implants/electrode_arrays.py
@@ -136,6 +136,8 @@ class ElectrodeArray(PrettyPrint):
             (if exists) or create a new Axes object.
         color_stim : ``pulse2percept.stimuli.Stimulus``, or None
             If provided, colors the earray based on the stimulus amplitudes
+        cmap : str
+            Matplotlib colormap to use for stimulus coloring.
 
         Returns
         -------

--- a/pulse2percept/implants/electrode_arrays.py
+++ b/pulse2percept/implants/electrode_arrays.py
@@ -162,7 +162,7 @@ class ElectrodeArray(PrettyPrint):
                     amp = np.max(color_stim[name])
                     if amp != 0:
                         kwargs['fc'] = cm(norm(amp), alpha=0.8)
-            if not electrode.activated:
+            else:
                 kwargs = electrode.plot_deactivated_kwargs
             if isinstance(electrode.plot_patch, list):
                 # Special case: draw multiple objects per electrode

--- a/pulse2percept/implants/electrode_arrays.py
+++ b/pulse2percept/implants/electrode_arrays.py
@@ -156,11 +156,12 @@ class ElectrodeArray(PrettyPrint):
         for name, electrode in self.electrodes.items():
             # Rather than calling electrode.plot(), generate all the patch
             # objects and add them to a collection:
-            kwargs = deepcopy(electrode.plot_kwargs)
-            if color_stim is not None and name in color_stim.electrodes:
-                amp = np.max(color_stim[name])
-                if amp != 0:
-                    kwargs['fc'] = cm(norm(amp), alpha=0.8)
+            if electrode.activated:
+                kwargs = deepcopy(electrode.plot_kwargs)
+                if color_stim is not None and name in color_stim.electrodes:
+                    amp = np.max(color_stim[name])
+                    if amp != 0:
+                        kwargs['fc'] = cm(norm(amp), alpha=0.8)
             if not electrode.activated:
                 kwargs = electrode.plot_deactivated_kwargs
             if isinstance(electrode.plot_patch, list):

--- a/pulse2percept/implants/tests/test_base.py
+++ b/pulse2percept/implants/tests/test_base.py
@@ -74,12 +74,20 @@ def test_ProsthesisSystem_stim():
     stim[98, 2] = 2
     implant.stim = stim
     plt.cla()
-    ax = implant.plot(color_stim=True, cmap='hsv')
+    ax = implant.plot(stim_cmap='hsv')
     plt.colorbar()
     npt.assert_equal(len(ax.collections), 1)
     npt.assert_equal(ax.collections[0].colorbar.vmax, 2)
     npt.assert_equal(ax.collections[0].cmap(ax.collections[0].norm(1)),
-                     (0.0, 1.0, 0.9647031631761764, 1)) 
+                     (0.0, 1.0, 0.9647031631761764, 1))
+    # make sure default behaviour unchanged
+    plt.cla()
+    ax = implant.plot()
+    plt.colorbar()
+    npt.assert_equal(len(ax.collections), 1)
+    npt.assert_equal(ax.collections[0].colorbar.vmax, 1)
+    npt.assert_equal(ax.collections[0].cmap(ax.collections[0].norm(1)),
+                     (0.993248, 0.906157, 0.143936, 1))  
 
     # Deactivated electrodes cannot receive stimuli:
     implant.deactivate('H4')

--- a/pulse2percept/implants/tests/test_base.py
+++ b/pulse2percept/implants/tests/test_base.py
@@ -3,6 +3,7 @@ import collections as coll
 import pytest
 import numpy.testing as npt
 from matplotlib.patches import Circle
+import matplotlib.pyplot as plt
 from skimage.measure import label, regionprops
 
 from pulse2percept.implants import (PointSource, ElectrodeArray, ElectrodeGrid,
@@ -35,6 +36,7 @@ def test_ProsthesisSystem():
     npt.assert_equal(implant.stim.time, None)
     npt.assert_equal(implant.stim.electrodes, [0])
 
+    plt.cla()
     ax = implant.plot()
     npt.assert_equal(len(ax.texts), 0)
     npt.assert_equal(len(ax.collections), 1)
@@ -65,6 +67,19 @@ def test_ProsthesisSystem_stim():
     stim = Stimulus(np.ones((13 * 13 + 1, 5)))
     with pytest.raises(ValueError):
         implant.stim = stim
+
+    # color mapping
+    stim = np.zeros((13*13, 5))
+    stim[84, 0] = 1
+    stim[98, 2] = 2
+    implant.stim = stim
+    plt.cla()
+    ax = implant.plot(color_stim=True, cmap='hsv')
+    plt.colorbar()
+    npt.assert_equal(len(ax.collections), 1)
+    npt.assert_equal(ax.collections[0].colorbar.vmax, 2)
+    npt.assert_equal(ax.collections[0].cmap(ax.collections[0].norm(1)),
+                     (0.0, 1.0, 0.9647031631761764, 1)) 
 
     # Deactivated electrodes cannot receive stimuli:
     implant.deactivate('H4')


### PR DESCRIPTION
## Description
This introduces an easy way to color the electrode array in `implant.plot()` based on the amplitude of the stimulating electrodes. 
`implant.plot()` now accepts a `color_stim` parameter, defaulting to False. If True, the amplitude of each electrode is mapped to the color of each active electrode in the plot. The color map can also be specified with the `cmap` parameter.

I'm currently not sure what the best default colormap to use is. 
**Example**: 
Default behavior unchanged
```
implant = ArgusII()
implant.stim = {'B4': BiphasicPulseTrain(5, 2, 1), 'C5': BiphasicPulseTrain(5, 3, 1), 'D6': BiphasicPulseTrain(5, 4, 1)} 
implant.plot()
```
![image](https://user-images.githubusercontent.com/25232557/175132666-99755804-ae44-43ec-9969-e927d2aea732.png)

A single monotonically increasing cmap (e.g. 'OrRd') could make sense:
```
implant.plot(color_stim=True, cmap='OrRd')
plt.colorbar()
```
![image](https://user-images.githubusercontent.com/25232557/175137515-15f6d604-c909-427d-9bab-7156f2963081.png)

Or having different colors for each unique amp also makes sense (e.g. 'gist_rainbow')
![image](https://user-images.githubusercontent.com/25232557/175143549-f8d27874-1d97-4b01-8993-9a178a31b07c.png)


Note: The colorbar is not added by default, only if the user calls `plt.colorbar`

## Type of Change

Please delete options that are not relevant.
- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
