### PR TITLE
[BUG] Fix implant plot coloring with multiple axes

### DIFF
--- a/pulse2percept/implants/electrode_arrays.py
+++ b/pulse2percept/implants/electrode_arrays.py
@@ -181,7 +181,7 @@ class ElectrodeArray(PrettyPrint):
         patch_collection = PatchCollection(patches, match_original=True,
                                           zorder=ZORDER['annotate'], cmap=cm, norm=norm)
         ax.add_collection(patch_collection)
-        plt.sci(patch_collection) # enables plt.colormap()
+        ax._sci(patch_collection) # enables plt.colormap()
         if autoscale:
             ax.autoscale(True)
         ax.set_xlabel('x (microns)')


### PR DESCRIPTION
## Description
Changes `plt.sci ` to `ax._sci` so the current image is set on the correct axis

## Type of Change


- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
