### PR TITLE
[ENH] Only run predict percept on unique time points

### DIFF
--- a/pulse2percept/models/base.py
+++ b/pulse2percept/models/base.py
@@ -352,7 +352,7 @@ class SpatialModel(BaseModel, metaclass=ABCMeta):
                                 electrodes=stim.electrodes, time=t_percept,
                                 metadata=stim.metadata)
             # find unique stimulus points
-            amps, t_unique, inverse = np.unique(stim.data.T, axis=0, 
+            _, t_unique, inverse = np.unique(stim.data.T, axis=0, 
                                             return_index=True, return_inverse=True)
             stim_unique = Stimulus(stim[:, t_unique], electrodes=stim.electrodes,
                                    time=t_unique)

--- a/pulse2percept/models/base.py
+++ b/pulse2percept/models/base.py
@@ -351,14 +351,15 @@ class SpatialModel(BaseModel, metaclass=ABCMeta):
                 stim = Stimulus(stim[:, t_percept].reshape((-1, n_time)),
                                 electrodes=stim.electrodes, time=t_percept,
                                 metadata=stim.metadata)
-            # find unique stimulus points
-            _, t_unique, inverse = np.unique(stim.data.T, axis=0, 
-                                            return_index=True, return_inverse=True)
-            stim_unique = Stimulus(stim[:, t_unique], electrodes=stim.electrodes,
-                                   time=t_unique)
-            resp_unique = self._predict_spatial(implant.earray, stim_unique)
-            resp = resp_unique[..., inverse]
-            # resp = self._predict_spatial(implant.earray, stim)
+                # find unique stimulus points
+                _, t_unique, inverse = np.unique(stim.data.T, axis=0, 
+                                                return_index=True, return_inverse=True)
+                stim_unique = Stimulus(stim[:, t_unique], electrodes=stim.electrodes,
+                                    time=t_unique)
+                resp_unique = self._predict_spatial(implant.earray, stim_unique)
+                resp = resp_unique[..., inverse]
+            else:
+                resp = self._predict_spatial(implant.earray, stim)
         return Percept(resp.reshape(list(self.grid.x.shape) + [-1]),
                        space=self.grid, time=t_percept,
                        metadata={'stim': stim}, n_gray=self.n_gray, noise=self.noise)

--- a/pulse2percept/models/base.py
+++ b/pulse2percept/models/base.py
@@ -354,8 +354,8 @@ class SpatialModel(BaseModel, metaclass=ABCMeta):
                 # find unique stimulus points
                 _, t_unique, inverse = np.unique(stim.data.T, axis=0, 
                                                 return_index=True, return_inverse=True)
-                stim_unique = Stimulus(stim[:, t_unique], electrodes=stim.electrodes,
-                                    time=t_unique)
+                stim_unique = Stimulus(stim[:, stim.time[t_unique]], 
+                                       electrodes=stim.electrodes, time=t_unique)
                 resp_unique = self._predict_spatial(implant.earray, stim_unique)
                 resp = resp_unique[..., inverse]
             else:

--- a/pulse2percept/models/base.py
+++ b/pulse2percept/models/base.py
@@ -346,8 +346,6 @@ class SpatialModel(BaseModel, metaclass=ABCMeta):
             # Calculate the Stimulus at requested time points:
             if t_percept is not None:
                 # Save electrode parameters
-                if not isinstance(stim, Stimulus):
-                    stim = Stimulus(stim)  # make sure stimulus is in proper format
                 stim = Stimulus(stim[:, t_percept].reshape((-1, n_time)),
                                 electrodes=stim.electrodes, time=t_percept,
                                 metadata=stim.metadata)

--- a/pulse2percept/models/base.py
+++ b/pulse2percept/models/base.py
@@ -355,9 +355,10 @@ class SpatialModel(BaseModel, metaclass=ABCMeta):
                 _, t_unique, inverse = np.unique(stim.data.T, axis=0, 
                                                 return_index=True, return_inverse=True)
                 stim_unique = Stimulus(stim[:, stim.time[t_unique]], 
-                                       electrodes=stim.electrodes, time=t_unique)
+                                       electrodes=stim.electrodes, time=stim.time[t_unique])
                 resp_unique = self._predict_spatial(implant.earray, stim_unique)
-                resp = resp_unique[..., inverse]
+                # reconstruct original time points, making sure to preserve C ordering
+                resp = resp_unique[..., inverse].copy(order='C')
             else:
                 resp = self._predict_spatial(implant.earray, stim)
         return Percept(resp.reshape(list(self.grid.x.shape) + [-1]),


### PR DESCRIPTION
## Description
This changes `SpatialModel.predict_percept` to only call `_predict_spatial` for a compressed stimulus where the distribution of amplitudes across electrodes is unique. 


Performance improvement with default `AxonMapModel` on my laptop:

- With 20Hz `BiphasicPulseTrain`: 6.5ms vs 309ms, **~50x Speedup**
- With 250Hz `BiphasicPulseTrain`: 57ms vs 5s, **~90x Speedup**
- With random frequency `BiphasicPulseTrain` on 60 electrodes: 13.5min vs 4min , **~3.5xSpeedup**



Closes #456 

## Type of Change
- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

