### PR TITLE
[DOC] Add plot_argus.py example

### DIFF
--- a/doc/users/references.rst
+++ b/doc/users/references.rst
@@ -29,13 +29,16 @@ Studies referenced throughout the Documentation:
                 *Journal of Comparative Neurophysiology* 292:497-523,
                 doi:`10.1002/cne.902920402
                 <https://doi.org/10.1002/cne.902920402>`_.
+.. [EricksonDavis2021] C Erickson-Davis, H Korzybska (2021). What do blind people 
+                       "see" with retinal prostheses? Observations and qualitative
+                       reports of epiretinal implant users. *PLOS ONE* 16(2), doi:`10.1371/journal.pone.0229189 <https://doi.org/10.1371/journal.pone.0229189>`_.
 .. [Han2021] N Han, S Srivastava, A Xu, D Klein, M Beyeler (2021). Deep Learning–Based
              Scene Simplification for Bionic Vision. *Augmented Humans Conference* 2021,
              45–54. <https://doi.org/10.1145/3458709.3458982>`_.
 .. [Granley2021] Granley, J., & Beyeler, M. (2021). A Computational Model of 
                  Phosphene Appearance for Epiretinal Prostheses. *International
                  Conference of the IEEE Engineering in Medicine and Biology
-                 Society*.
+                 Society*, doi:`10.1109/EMBC46164.2021.9629663 <https://doi.org/10.1109/EMBC46164.2021.9629663>`_.
 .. [Greenwald2009] Greenwald, S., Horsager A., Humayun M, Greenberg R.,
                    McMahon M., Fine I. (2009).
                    Brightness as a Function of Current Amplitude in Human
@@ -68,6 +71,10 @@ Studies referenced throughout the Documentation:
                 K Mathieson, P Huie, J Harris, A Sher, D Palanker (2015).
                 Photovoltaic restoration of sight with high visual acuity.
                 *Nature Medicine* 21(5):476-482
+.. [Luo2016] YH Luo, JJ Zhong, M Clemo, L da Cruz (2016). Long-term Repeatability and 
+             Reproducibility of Phosphene Characteristics in Chronically Implanted
+             Argus(R) II Retinal Prosthesis Subjects. *Am J Ophthalmol*, 
+             doi:`10.1016/j.ajo.2016.07.021 <https://doi.org/10.1016/j.ajo.2016.07.021>`_.
 .. [Nanduri2012] D Nanduri, I Fine, A Horsager, GM Boynton, MS Humayun,
                  RJ Greenberg, JD Weiland (2012), Frequency and amplitude
                  modulation have different effects on the percepts elicited

--- a/examples/implants/plot_argus.py
+++ b/examples/implants/plot_argus.py
@@ -35,12 +35,12 @@ The result is a rich repertoire of phosphene shape that includes blobs, arcs,
 wedges, and triangles [Beyeler2019]_:
 
 """
-# sphinx_gallery_thumbnail_number = 2
+# sphinx_gallery_thumbnail_number = 1
 
 import matplotlib.pyplot as plt
 import pulse2percept as p2p
 
-fig, axes = plt.subplots(ncols=3, figsize=(15, 5))
+fig, axes = plt.subplots(ncols=3, figsize=(10, 3))
 for ax, subject, scale in zip(axes, ['S2', 'S3', 'S4'], [1, 1, 0.5]):
     data = p2p.datasets.fetch_beyeler2019(subjects=subject)
     p2p.viz.plot_argus_phosphenes(data, ax=ax, scale=scale)
@@ -57,30 +57,48 @@ fig.tight_layout()
 # ---------------------
 #
 # To simulate the vision provided by Argus II, we first need to set up a new
-# axon map model.
+# axon map model. We can specify phosphene size (``rho``) and elongation
+# (``axlambda``) as well as the visual field we would like to simulate (given
+# in degrees of visual angle):
 
-model = p2p.models.AxonMapModel(rho=300, axlambda=100,
+model = p2p.models.AxonMapModel(rho=400, axlambda=200,
                                 xrange=(-12, 12), yrange=(-8, 8))
 model.build()
+
+###############################################################################
+# We can visualize where the implant sits on the axon map as follows:
+
 model.plot()
 p2p.implants.ArgusII().plot()
 
 ###############################################################################
-# Here's the video stim:
+# We then need to choose a stimulus to run through the model:
 
 p2p.stimuli.BostonTrain().play()
 
 ###############################################################################
-# We will load it, convert it to grayscale, downscale it, and assign each pixel
-# to an electrode:
+# In real life, the Argus II camera would capture a video just like the above,
+# convert it to grayscale, downscale it, and then assign each pixel to an
+# electrode in the implant.
+#
+# After feeding the resulting stimulus through the axon map model, we get a
+# pretty good idea of what this video would look like to an Argus II patient:
 
 implant = p2p.implants.ArgusII(stim=p2p.stimuli.BostonTrain())
 model.predict_percept(implant).play()
 
 ###############################################################################
-# more cowbell
+# The above simulation is basically equivalent to the scoreboard model, because
+# each electrode appears as a large blob.
+#
+# However, as mentioned above, every patient sees phosphenes differently.
+# To some they appear thin and elongated, to others they appear big and
+# arc-like.
+#
+# To increase the arc length of individual phosphenes, we can choose a larger
+# ``axlambda`` value:
 
-model.axlambda = 500
+model.axlambda = 600
 model.build()
 model.predict_percept(implant).play()
 
@@ -98,30 +116,41 @@ model.predict_percept(implant).play()
 ###############################################################################
 # Girl Pool sequence
 # ------------------
+#
+# Another video shows a girl jumping into a swimming pool:
 
 p2p.stimuli.GirlPool().play()
 
-
 ###############################################################################
-# We will load it, convert it to grayscale, downscale it, and assign each pixel
-# to an electrode:
+# Similar to the above video, we can convert it to grayscale and downscale it,
+# then feed it through the axon map model:
 
 implant = p2p.implants.ArgusII(stim=p2p.stimuli.GirlPool())
-model.axlambda = 100
+model.rho = 400
+model.axlambda = 200
 model.build()
 model.predict_percept(implant).play()
 
 ###############################################################################
-# more cowbell
+# Here is the same video with longer phosphenes:
 
-model.axlambda = 500
+model.axlambda = 600
 model.build()
 model.predict_percept(implant).play()
 
 ###############################################################################
-# On the other hand, a subject
+# Here is the same video with thin and long phosphenes:
 
 model.rho = 50
 model.axlambda = 1000
 model.build()
 model.predict_percept(implant).play()
+
+###############################################################################
+# In reality, the vision provided by Argus II may be even worse for several
+# reasons:
+#
+# 1. The above simulations do not consider temporal distortions (e.g., flicker,
+#    persistence, fading)
+# 2. For some patients, individual phosphenes do not assemble into more complex
+#    percepts, or do so in a highly unpredictable way.

--- a/examples/implants/plot_argus.py
+++ b/examples/implants/plot_argus.py
@@ -1,0 +1,65 @@
+"""
+===============================================================================
+Simulating Argus II
+===============================================================================
+
+Background
+----------
+
+:py:class:`~pulse2percept.implants.ArgusII` is an epiretinal implant developed
+by Second Sight Medical Products, Inc. (Sylmar, CA).
+Now discontinued, it was the first retinal implant to get FDA approval in the US
+and the CE mark in Europe, and has been implanted in close to 500 patients
+worldwide.
+
+A number of studies have documented the artificial vision provided by
+Argus II, which contains 60 electrodes of 225 um diameter arranged in a 6 x 10
+grid (575 um center-to-center separation) [Yue2020]_.
+Researchers often assume that the stimulation of a grid of
+electrodes on the retina would lead to the perception of a grid of luminous
+dots ("phosphenes").
+We refer to this as the :py:class:`~pulse2percept.models.ScoreboardModel`
+of prosthetic vision.
+However, a growing body of evidence has shown that retinal implant users often
+report seeing distorted phosphenes and require extensive rehabilitative training 
+to make use of their new vision [Beyeler2019]_, [EricksonDavis2021]_.
+
+Although single-electrode phosphenes are consistent from trial to trial, they 
+vary across electrodes and users [Luo2016]_, [Beyeler2019]_.
+Phosphene shape strongly depends on stimulation parameters [Nanduri2012]_
+as well as the retinal location of the stimulating electrode [Beyeler2019]_ 
+due to inadvertent activation of passing axon fibers in the retina.
+The result is a rich repertoire of phosphene shape that includes blobs, arcs,
+wedges, and triangles [Beyeler2019]_:
+
+"""
+# sphinx_gallery_thumbnail_number = 2
+
+import matplotlib.pyplot as plt
+import pulse2percept as p2p
+
+fig, axes = plt.subplots(ncols=3, figsize=(15, 5))
+for ax, subject in zip(axes, ['S2', 'S3', 'S4']):
+    data = p2p.datasets.fetch_beyeler2019(subjects=subject)
+    p2p.viz.plot_argus_phosphenes(data, ax=ax)
+
+###############################################################################
+# Simulating video
+# ----------------
+#
+
+model = p2p.models.AxonMapModel(rho=300, axlambda=100).build()
+implant = p2p.implants.ArgusII(stim=p2p.stimuli.BostonTrain())
+model.predict_percept(implant).play()
+
+###############################################################################
+# more cowbell
+
+model = p2p.models.AxonMapModel(rho=300, axlambda=500).build()
+model.predict_percept(implant).play()
+
+###############################################################################
+# more cowbell
+
+model = p2p.models.AxonMapModel(rho=300, axlambda=1000).build()
+model.predict_percept(implant).play()

--- a/examples/implants/plot_argus.py
+++ b/examples/implants/plot_argus.py
@@ -12,10 +12,12 @@ Now discontinued, it was the first retinal implant to get FDA approval in the US
 and the CE mark in Europe, and has been implanted in close to 500 patients
 worldwide.
 
-A number of studies have documented the artificial vision provided by
-Argus II, which contains 60 electrodes of 225 um diameter arranged in a 6 x 10
+A number of studies have documented how the artificial vision provided by
+:py:class:`~pulse2percept.implants.ArgusII` (Second Sight Medical Products, Inc.)
+differs from normal sight.
+Argus II contains 60 electrodes of 225 um diameter arranged in a 6 x 10
 grid (575 um center-to-center separation) [Yue2020]_.
-Researchers often assume that the stimulation of a grid of
+Some researchers therefore assumed that the stimulation of a grid of
 electrodes on the retina would lead to the perception of a grid of luminous
 dots ("phosphenes").
 We refer to this as the :py:class:`~pulse2percept.models.ScoreboardModel`
@@ -39,27 +41,87 @@ import matplotlib.pyplot as plt
 import pulse2percept as p2p
 
 fig, axes = plt.subplots(ncols=3, figsize=(15, 5))
-for ax, subject in zip(axes, ['S2', 'S3', 'S4']):
+for ax, subject, scale in zip(axes, ['S2', 'S3', 'S4'], [1, 1, 0.5]):
     data = p2p.datasets.fetch_beyeler2019(subjects=subject)
-    p2p.viz.plot_argus_phosphenes(data, ax=ax)
+    p2p.viz.plot_argus_phosphenes(data, ax=ax, scale=scale)
+    ax.axis('off')
+    ax.set_title(subject)
+fig.tight_layout()
 
 ###############################################################################
-# Simulating video
-# ----------------
+# These phosphene shapes can be simulated with the
+# :py:class:`~pulse2percept.models.AxonMapModel`, which was developed to fit
+# behavioral data (see [Beyeler2019]_ for details).
 #
+# Boston Train sequence
+# ---------------------
+#
+# To simulate the vision provided by Argus II, we first need to set up a new
+# axon map model.
 
-model = p2p.models.AxonMapModel(rho=300, axlambda=100).build()
+model = p2p.models.AxonMapModel(rho=300, axlambda=100,
+                                xrange=(-12, 12), yrange=(-8, 8))
+model.build()
+model.plot()
+p2p.implants.ArgusII().plot()
+
+###############################################################################
+# Here's the video stim:
+
+p2p.stimuli.BostonTrain().play()
+
+###############################################################################
+# We will load it, convert it to grayscale, downscale it, and assign each pixel
+# to an electrode:
+
 implant = p2p.implants.ArgusII(stim=p2p.stimuli.BostonTrain())
 model.predict_percept(implant).play()
 
 ###############################################################################
 # more cowbell
 
-model = p2p.models.AxonMapModel(rho=300, axlambda=500).build()
+model.axlambda = 500
+model.build()
+model.predict_percept(implant).play()
+
+###############################################################################
+# On the other hand, some retinal implant recipients (e.g., 51-009) report
+# seeing thin and elongated phosphenes. In this case, the same video may appear
+# very different to them:
+
+model.rho = 50
+model.axlambda = 1000
+model.build()
+model.predict_percept(implant).play()
+
+
+###############################################################################
+# Girl Pool sequence
+# ------------------
+
+p2p.stimuli.GirlPool().play()
+
+
+###############################################################################
+# We will load it, convert it to grayscale, downscale it, and assign each pixel
+# to an electrode:
+
+implant = p2p.implants.ArgusII(stim=p2p.stimuli.GirlPool())
+model.axlambda = 100
+model.build()
 model.predict_percept(implant).play()
 
 ###############################################################################
 # more cowbell
 
-model = p2p.models.AxonMapModel(rho=300, axlambda=1000).build()
+model.axlambda = 500
+model.build()
+model.predict_percept(implant).play()
+
+###############################################################################
+# On the other hand, a subject
+
+model.rho = 50
+model.axlambda = 1000
+model.build()
 model.predict_percept(implant).play()

--- a/pulse2percept/datasets/beyeler2019.py
+++ b/pulse2percept/datasets/beyeler2019.py
@@ -1,4 +1,4 @@
-"""`fetch_beyeler2019`"""
+"""`fetch_beyeler2019`, `subject_params`"""
 from os.path import join, isfile
 import numpy as np
 
@@ -15,6 +15,66 @@ try:
     has_h5py = True
 except ImportError:
     has_h5py = False
+
+
+subject_params = {
+    'S1': {
+        'subject_id': 'S1',
+        'second_sight_id': 'TB',
+        'implant_type_str': 'ArgusI',
+        'implant_x': -1527,
+        'implant_y': -556,
+        'implant_rot': -64.74,
+        'loc_od_x': 13.6,
+        'loc_od_y': 0.0,
+        'xmin': -36.9,
+        'xmax': 36.9,
+        'ymin': -36.9,
+        'ymax': 36.9
+    },
+    'S2': {
+        'subject_id': 'S2',
+        'second_sight_id': '12-005',
+        'implant_type_str': 'ArgusII',
+        'implant_x': -1896,
+        'implant_y': -542,
+        'implant_rot': -44,
+        'loc_od_x': 15.8,
+        'loc_od_y': 1.4,
+        'xmin': -30,
+        'xmax': 30,
+        'ymin': -22.5,
+        'ymax': 22.5
+    },
+    'S3': {
+        'subject_id': 'S3',
+        'second_sight_id': '51-009',
+        'implant_type_str': 'ArgusII',
+        'implant_x': -1203,
+        'implant_y': 280,
+        'implant_rot': -35,
+        'loc_od_x': 15.4,
+        'loc_od_y': 1.57,
+        'xmin': -32.5,
+        'xmax': 32.5,
+        'ymin': -24.4,
+        'ymax': 24.4
+    },
+    'S4': {
+        'subject_id': 'S4',
+        'second_sight_id': '52-001',
+        'implant_type_str': 'ArgusII',
+        'implant_x': -1945,
+        'implant_y': 469,
+        'implant_rot': -34,
+        'loc_od_x': 15.8,
+        'loc_od_y': 1.51,
+        'xmin': -32,
+        'xmax': 32,
+        'ymin': -24,
+        'ymax': 24
+    }
+}
 
 
 def fetch_beyeler2019(subjects=None, electrodes=None, data_path=None,
@@ -170,6 +230,21 @@ def fetch_beyeler2019(subjects=None, electrodes=None, data_path=None,
             idx_electrode |= df.electrode == electrode
         idx &= idx_electrode
     df = df[idx]
+
+    # Augment with implant type & location data:
+    df['implant_type_str'] == ''
+    df['implant_x'] = 0
+    df['implant_y'] = 0
+    df['implant_rot'] = 0
+    for subject in df.subjects.unique():
+        df.loc[df.subject == subject,
+               'implant_type_str'] = subject_params[subject]['implant_type_str']
+        df.loc[df.subject == subject,
+               'implant_x'] = subject_params[subject]['implant_x']
+        df.loc[df.subject == subject,
+               'implant_y'] = subject_params[subject]['implant_y']
+        df.loc[df.subject == subject,
+               'implant_rot'] = subject_params[subject]['implant_rot']
 
     if shuffle:
         df = df.sample(n=len(df), random_state=random_state)

--- a/pulse2percept/datasets/beyeler2019.py
+++ b/pulse2percept/datasets/beyeler2019.py
@@ -236,7 +236,7 @@ def fetch_beyeler2019(subjects=None, electrodes=None, data_path=None,
     df['implant_x'] = 0
     df['implant_y'] = 0
     df['implant_rot'] = 0
-    for subject in df.subjects.unique():
+    for subject in df.subject.unique():
         df.loc[df.subject == subject,
                'implant_type_str'] = subject_params[subject]['implant_type_str']
         df.loc[df.subject == subject,

--- a/pulse2percept/datasets/beyeler2019.py
+++ b/pulse2percept/datasets/beyeler2019.py
@@ -232,7 +232,7 @@ def fetch_beyeler2019(subjects=None, electrodes=None, data_path=None,
     df = df[idx]
 
     # Augment with implant type & location data:
-    df['implant_type_str'] == ''
+    df['implant_type_str'] = ''
     df['implant_x'] = 0
     df['implant_y'] = 0
     df['implant_rot'] = 0

--- a/pulse2percept/datasets/tests/test_beyeler2019.py
+++ b/pulse2percept/datasets/tests/test_beyeler2019.py
@@ -26,7 +26,8 @@ def test_fetch_beyeler2019():
     columns = ['subject', 'amp', 'area', 'compactness', 'date', 'eccentricity',
                'electrode', 'filename', 'freq', 'image', 'orientation', 'pdur',
                'stim_class', 'x_center', 'y_center', 'img_shape',
-               'xrange', 'yrange']
+               'xrange', 'yrange', 'implant_type_str', 'implant_x', 'implant_y',
+               'implant_rot']
     for expected_col in columns:
         npt.assert_equal(expected_col in data.columns, True)
 

--- a/pulse2percept/datasets/tests/test_beyeler2019.py
+++ b/pulse2percept/datasets/tests/test_beyeler2019.py
@@ -31,7 +31,7 @@ def test_fetch_beyeler2019():
     for expected_col in columns:
         npt.assert_equal(expected_col in data.columns, True)
 
-    npt.assert_equal(data.shape, (400, 18))
+    npt.assert_equal(data.shape, (400, 22))
     npt.assert_equal(data.subject.unique(), ['S1', 'S2', 'S3', 'S4'])
     npt.assert_equal(list(data[data.subject == 'S1'].img_shape.unique()[0]),
                      [192, 192])
@@ -40,17 +40,17 @@ def test_fetch_beyeler2019():
 
     # Subset selection:
     subset = datasets.fetch_beyeler2019(subjects='S2')
-    npt.assert_equal(subset.shape, (110, 18))
+    npt.assert_equal(subset.shape, (110, 22))
     subset = datasets.fetch_beyeler2019(subjects=['S2', 'S3'])
-    npt.assert_equal(subset.shape, (200, 18))
+    npt.assert_equal(subset.shape, (200, 22))
     subset = datasets.fetch_beyeler2019(subjects='invalid')
-    npt.assert_equal(subset.shape, (0, 18))
+    npt.assert_equal(subset.shape, (0, 22))
     subset = datasets.fetch_beyeler2019(electrodes=['A1'])
-    npt.assert_equal(subset.shape, (10, 18))
+    npt.assert_equal(subset.shape, (10, 22))
     subset = datasets.fetch_beyeler2019(electrodes=['A1', 'C3'])
-    npt.assert_equal(subset.shape, (20, 18))
+    npt.assert_equal(subset.shape, (20, 22))
     subset = datasets.fetch_beyeler2019(electrodes='invalid')
-    npt.assert_equal(subset.shape, (0, 18))
+    npt.assert_equal(subset.shape, (0, 22))
 
     # Shuffle dataset (index will always be range(400), but rows are shuffled):
     data = datasets.fetch_beyeler2019(shuffle=True, random_state=42)

--- a/pulse2percept/percepts/base.py
+++ b/pulse2percept/percepts/base.py
@@ -246,7 +246,8 @@ class Percept(Data):
         ax.set_ylabel('y (degrees of visual angle)')
         return ax
 
-    def play(self, fps=None, repeat=True, annotate_time=True, ax=None):
+    def play(self, fps=None, repeat=True, annotate_time=True, ax=None,
+             colorbar=True):
         """Animate the percept as HTML with JavaScript
 
         The percept will be played in an interactive player in IPython or
@@ -265,6 +266,8 @@ class Percept(Data):
             title of the panel.
         ax : matplotlib.axes.AxesSubplot, optional
             A Matplotlib axes object. If None, will create a new Axes object
+        colorbar : {True, False}
+            Whether to show the colorbar
 
         Returns
         -------
@@ -275,7 +278,7 @@ class Percept(Data):
         """
         def update(data):
             if annotate_time:
-                mat.axes.set_title(f't = {self.time[self._next_frame - 1]} ms')
+                mat.axes.set_title(f't = {self.time[self._next_frame - 1]:.2f} ms')
             mat.set_data(data)
             return mat
 
@@ -306,9 +309,10 @@ class Percept(Data):
         self.rewind()
         mat = ax.imshow(np.zeros_like(self.data[..., 0]), cmap='gray',
                         vmax=self.data.max())
-        cbar = fig.colorbar(mat)
-        cbar.ax.set_ylabel('Phosphene brightness (a.u.)', rotation=-90,
-                           va='center')
+        if colorbar:
+            cbar = fig.colorbar(mat)
+            cbar.ax.set_ylabel('Phosphene brightness (a.u.)', rotation=-90,
+                               va='center')
         plt.close(fig)
         if fps is None:
             interval = unique(np.diff(self.time))

--- a/pulse2percept/stimuli/__init__.py
+++ b/pulse2percept/stimuli/__init__.py
@@ -21,7 +21,7 @@ from .pulses import AsymmetricBiphasicPulse, BiphasicPulse, MonophasicPulse
 from .pulse_trains import (PulseTrain, BiphasicPulseTrain,
                            BiphasicTripletTrain, AsymmetricBiphasicPulseTrain)
 from .images import ImageStimulus, LogoBVL, LogoUCSB, SnellenChart
-from .videos import VideoStimulus, BostonTrain
+from .videos import VideoStimulus, BostonTrain, GirlPool
 from .psychophysics import BarStimulus, GratingStimulus
 
 __all__ = [
@@ -32,6 +32,7 @@ __all__ = [
     'BiphasicPulseTrain',
     'BiphasicTripletTrain',
     'BostonTrain',
+    'GirlPool',
     'GratingStimulus',
     'ImageStimulus',
     'LogoBVL',

--- a/pulse2percept/stimuli/videos.py
+++ b/pulse2percept/stimuli/videos.py
@@ -1,4 +1,4 @@
-"""`VideoStimulus`, `BostonTrain`"""
+"""`VideoStimulus`, `BostonTrain`, `GirlPool`"""
 from os.path import dirname, join
 import numpy as np
 from math import isclose
@@ -607,15 +607,15 @@ class VideoStimulus(Stimulus):
         self._next_frame = 0
 
     def play(self, fps=None, repeat=True, annotate_time=True, ax=None):
-        """Animate the percept as HTML with JavaScript
+        """Animate the video as HTML with JavaScript
 
-        The percept will be played in an interactive player in IPython or
+        The video will be played in an interactive player in IPython or
         Jupyter Notebook.
 
         Parameters
         ----------
         fps : float or None
-            If None, uses the percept's time axis. Not supported for
+            If None, uses the video's time axis. Not supported for
             non-homogeneous time axis.
         repeat : bool, optional
             Whether the animation should repeat when the sequence of frames is
@@ -629,12 +629,12 @@ class VideoStimulus(Stimulus):
         Returns
         -------
         ani : matplotlib.animation.FuncAnimation
-            A Matplotlib animation object that will play the percept
+            A Matplotlib animation object that will play the video
             frame-by-frame.
         """
         def update(data):
             if annotate_time:
-                mat.axes.set_title(f't = {self.time[self._next_frame - 1]} ms')
+                mat.axes.set_title(f't = {self.time[self._next_frame - 1]:.2f} ms')
             mat.set_data(data.reshape(self.vid_shape[:-1]))
             return mat
 
@@ -664,8 +664,6 @@ class VideoStimulus(Stimulus):
         self.rewind()
         mat = ax.imshow(np.zeros(self.vid_shape[:-1]), cmap='gray',
                         vmax=self.data.max())
-        cbar = fig.colorbar(mat)
-        cbar.ax.set_ylabel('Brightness (a.u.)', rotation=-90, va='center')
         plt.close(fig)
         if fps is None:
             interval = unique(np.diff(self.time), tol=1e-2)
@@ -723,3 +721,49 @@ class BostonTrain(VideoStimulus):
                                           electrodes=electrodes,
                                           metadata=metadata,
                                           compress=False)
+
+
+class GirlPool(VideoStimulus):
+    """A girl jumping into a swimming pool
+
+    Load the "girl jumping in a pool" sequence, consisting of 91 frames of
+    240x426x3 pixels each.
+
+    .. versionadded:: 0.9
+
+    Parameters
+    ----------
+    resize : (height, width) or None
+        A tuple specifying the desired height and the width of the video
+        stimulus.
+
+    electrodes : int, string or list thereof; optional, default: None
+        Optionally, you can provide your own electrode names. If none are
+        given, electrode names will be numbered 0..N.
+
+        .. note::
+           The number of electrode names provided must match the number of
+           pixels in the (resized) video frame.
+
+    as_gray : bool, optional
+        Flag whether to convert the image to grayscale.
+        A four-channel image is interpreted as RGBA (e.g., a PNG), and the
+        alpha channel will be blended with the color black.
+
+    metadata : dict, optional, default: None
+        Additional stimulus metadata can be stored in a dictionary.
+
+    """
+
+    def __init__(self, resize=None, electrodes=None, as_gray=False,
+                 metadata=None):
+        # Load logo from data dir:
+        module_path = dirname(__file__)
+        source = join(module_path, 'data', 'girl-pool.mp4')
+        # Call VideoStimulus constructor:
+        super(GirlPool, self).__init__(source, format="MP4",
+                                       resize=resize,
+                                       as_gray=as_gray,
+                                       electrodes=electrodes,
+                                       metadata=metadata,
+                                       compress=False)

--- a/pulse2percept/viz/argus.py
+++ b/pulse2percept/viz/argus.py
@@ -109,9 +109,9 @@ def plot_argus_phosphenes(data, argus=None, scale=1.0, axon_map=None,
         try:
             specs = data.iloc[0]
             implant_type = ArgusI if specs.implant_type_str == 'ArgusI' else ArgusII
-            argus = implant_type(x=specs.implant_x, y=specs.implant_y,
-                                 rot=specs.implant_rot)
-        except KeyError:
+            argus = implant_type(x=specs['implant_x'], y=specs['implant_y'],
+                                 rot=specs['implant_rot'])
+        except (KeyError, AttributeError):
             raise ValueError('If "argus" is not given, "data" must contain '
                              'columns "implant_type_str", "implant_x", '
                              '"implant_y", and "implant_rot".')

--- a/pulse2percept/viz/tests/test_argus.py
+++ b/pulse2percept/viz/tests/test_argus.py
@@ -42,9 +42,16 @@ def test_plot_argus_phosphenes():
     # Works only for axon maps:
     with pytest.raises(TypeError):
         plot_argus_phosphenes(df, ArgusI(), ax=ax, axon_map=ScoreboardModel())
-
     # Manual subject selection
     plot_argus_phosphenes(df[df.electrode == 'B2'], ArgusI(), ax=ax)
+    # If no implant given, dataframe must have additional columns:
+    with pytest.raises(ValueError):
+        plot_argus_phosphenes(df, ax=ax)
+    df['implant_type_str'] = 'ArgusII'
+    df['implant_x'] = 0
+    df['implant_y'] = 0
+    df['implant_rot'] = 0
+    plot_argus_phosphenes(df, ax=ax)
 
 
 @pytest.mark.parametrize('implant', (ArgusI(), ArgusII()))


### PR DESCRIPTION
Add a gallery example that simulates the vision provided by Argus II, along with some minor enhancements:
- [x] `p2p.datasets.fetch_beyeler2019` now includes subject-level parameters
- [x] `p2p.viz.plot_argus_phosphenes` can now be called without the `argus` argument, given that the data frame contains the necessary implant information