### PR TITLE
[TST] Update percept.save tests

### DIFF
--- a/pulse2percept/percepts/tests/test_base.py
+++ b/pulse2percept/percepts/tests/test_base.py
@@ -176,7 +176,7 @@ def test_Percept_save(dtype):
 
     # Cannot save multiple frames image:
     fname = 'test.jpg'
-    with pytest.raises(ValueError):
+    with pytest.raises(RuntimeError):
         percept.save(fname)
 
     # But, can save single frame as image:


### PR DESCRIPTION
## Description
`percept.save()` tests currently fail locally and on github. I think imagio-ffmpeg changed slightly. Now, attempting to save a multi-frame percept as a image (e.g. '.jpg') raises a `RuntimeError`, not the `ValueError` that was previously expected.

To fix I just changed the tests to expect a `RuntimeError`

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
