### PR TITLE
[FIX] Predict percept bug with single unique time point

### DIFF
--- a/pulse2percept/models/base.py
+++ b/pulse2percept/models/base.py
@@ -352,8 +352,11 @@ class SpatialModel(BaseModel, metaclass=ABCMeta):
                 # find unique stimulus points
                 _, t_unique, inverse = np.unique(stim.data.T, axis=0, 
                                                 return_index=True, return_inverse=True)
+                uniq_time = stim.time[t_unique]
+                if len(uniq_time) == 1:
+                    uniq_time = None
                 stim_unique = Stimulus(stim[:, stim.time[t_unique]], 
-                                       electrodes=stim.electrodes, time=stim.time[t_unique])
+                                       electrodes=stim.electrodes, time=uniq_time)
                 resp_unique = self._predict_spatial(implant.earray, stim_unique)
                 # reconstruct original time points, making sure to preserve C ordering
                 resp = resp_unique[..., inverse].copy(order='C')

--- a/pulse2percept/percepts/tests/test_base.py
+++ b/pulse2percept/percepts/tests/test_base.py
@@ -176,7 +176,7 @@ def test_Percept_save(dtype):
 
     # Cannot save multiple frames image:
     fname = 'test.jpg'
-    with pytest.raises(ValueError):
+    with pytest.raises(RuntimeError):
         percept.save(fname)
 
     # But, can save single frame as image:


### PR DESCRIPTION
## Description
Doesn't set `stim.time` if there is only 1 unique time point

Closes #503 

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

