### PR TITLE
[MNT] Update sklearn in requirements

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,6 +8,6 @@ coveralls
 flake8
 mock
 seaborn
-sklearn
+scikit-learn
 pyswarm
 -r doc/requirements.txt


### PR DESCRIPTION
## Description

Using `sklearn` with pip is deprecated and is now an error, change to `scikit-learn`

## Type of Change

Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)
