### PR TITLE
[DOC] Fix gallery thumbnail images

### DIFF
--- a/doc/_static/css/custom.css
+++ b/doc/_static/css/custom.css
@@ -33,20 +33,3 @@ h3 {
 p {
 	margin-bottom: 4px;
 }
-
-/* Change thumbnail size */
-.sphx-glr-thumbcontainer {
-    min-height: 270px !important;
-    margin: 20px !important;
-}
-.sphx-glr-thumbcontainer .figure {
-    width: 280px !important;
-}
-.sphx-glr-thumbcontainer img {
-    max-height: 250px !important;
-    max-width: 300px !important;
-    width: 250px !important;
-}
-.sphx-glr-thumbcontainer a.internal {
-    padding: 220px 10px 0 !important;
-}


### PR DESCRIPTION
## Description
Sphinx-gallery updated and it treats `_static/custom.css` slightly differently, causing the issue where thumbnails overflow their boxes. 

**E.G.:**
![image](https://user-images.githubusercontent.com/25232557/213805777-e7853abc-0e5c-45a5-b8e1-0e4b8ca63e64.png)

Just removing the custom thumbnail sizing in `custom.css` fixes the issue. The thumbnails are smaller than before, but after ~20 minutes I couldnt figure out how to make them bigger without overlapping, and I think it currently looks fine, so I just left it.

**New Version:**
![image](https://user-images.githubusercontent.com/25232557/213805968-7c086c74-e298-4057-ae21-3c65508051d2.png)

## Type of Change

- [x] Documentation change

