### PR TITLE
[FIX] Add check for empty stimulus

### DIFF
--- a/pulse2percept/implants/base.py
+++ b/pulse2percept/implants/base.py
@@ -270,6 +270,8 @@ class ProsthesisSystem(PrettyPrint):
             self._stim = None
         elif isinstance(data, (list, tuple, dict)) and not data:
             self._stim = None
+        elif isinstance(data, np.ndarray) and data.size == 0:
+            self._stim = None
         else:
             # Preprocess can be a function (callable) or True/False:
             if callable(self.preprocess):

--- a/pulse2percept/implants/base.py
+++ b/pulse2percept/implants/base.py
@@ -265,7 +265,10 @@ class ProsthesisSystem(PrettyPrint):
     @stim.setter
     def stim(self, data):
         """Stimulus setter (called upon ``self.stim = data``)"""
+        # if stim is empty or None
         if data is None:
+            self._stim = None
+        elif isinstance(data, (list, tuple, dict)) and not data:
             self._stim = None
         else:
             # Preprocess can be a function (callable) or True/False:

--- a/pulse2percept/implants/tests/test_base.py
+++ b/pulse2percept/implants/tests/test_base.py
@@ -68,6 +68,12 @@ def test_ProsthesisSystem_stim():
     with pytest.raises(ValueError):
         implant.stim = stim
 
+    # make sure empty stimulus causes None stim
+    implant.stim = []
+    npt.assert_equal(implant.stim, None)
+    implant.stim = {}
+    npt.assert_equal(implant.stim, None)
+
     # color mapping
     stim = np.zeros((13*13, 5))
     stim[84, 0] = 1

--- a/pulse2percept/implants/tests/test_base.py
+++ b/pulse2percept/implants/tests/test_base.py
@@ -73,6 +73,8 @@ def test_ProsthesisSystem_stim():
     npt.assert_equal(implant.stim, None)
     implant.stim = {}
     npt.assert_equal(implant.stim, None)
+    implant.stim = np.array([])
+    npt.assert_equal(implant.stim, None)
 
     # color mapping
     stim = np.zeros((13*13, 5))


### PR DESCRIPTION
## Description

Adds a check in `ProsthesisSystem`'s `stim` setter. This causes empty inputs (e.g. `stim=[]` or `stim={}`) to set `ProsthesisSystem.stim` to `None`. Previously, the setter would try to create a `Stimulus` object which would cause various errors depending on the type (dict, list, etc.). With this change, passing an empty stimulus will now have the same effect as passing `stim=None`, which is that calling `model.predict_percept` on an implant with this stimulus will simply output `None` without throwing an error.

Closes #498 

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
