### PR TITLE
[FIX] Fix electrode numbering annotation in implant.plot()

### DIFF
--- a/pulse2percept/implants/electrode_arrays.py
+++ b/pulse2percept/implants/electrode_arrays.py
@@ -172,16 +172,18 @@ class ElectrodeArray(PrettyPrint):
                 # Regular use case: single object
                 patches.append(electrode.plot_patch((electrode.x, electrode.y),
                                                     **kwargs))
-            if annotate:
+            
+        patch_collection = PatchCollection(patches, match_original=True,
+                                          zorder=ZORDER['annotate'], cmap=cm, norm=norm)
+        ax.add_collection(patch_collection)
+        ax._sci(patch_collection) # enables plt.colormap()
+        if annotate:
+            for name, electrode in self.electrodes.items():
                 ax.text(electrode.x, electrode.y, name, ha='center',
                         va='center',  color='black', size='large',
                         bbox={'boxstyle': 'square,pad=-0.2', 'ec': 'none',
                               'fc': (1, 1, 1, 0.7)},
                         zorder=ZORDER['annotate'])
-        patch_collection = PatchCollection(patches, match_original=True,
-                                          zorder=ZORDER['annotate'], cmap=cm, norm=norm)
-        ax.add_collection(patch_collection)
-        ax._sci(patch_collection) # enables plt.colormap()
         if autoscale:
             ax.autoscale(True)
         ax.set_xlabel('x (microns)')

--- a/pulse2percept/implants/electrode_arrays.py
+++ b/pulse2percept/implants/electrode_arrays.py
@@ -172,18 +172,16 @@ class ElectrodeArray(PrettyPrint):
                 # Regular use case: single object
                 patches.append(electrode.plot_patch((electrode.x, electrode.y),
                                                     **kwargs))
-            
-        patch_collection = PatchCollection(patches, match_original=True,
-                                          zorder=ZORDER['annotate'], cmap=cm, norm=norm)
-        ax.add_collection(patch_collection)
-        ax._sci(patch_collection) # enables plt.colormap()
-        if annotate:
-            for name, electrode in self.electrodes.items():
+            if annotate:
                 ax.text(electrode.x, electrode.y, name, ha='center',
                         va='center',  color='black', size='large',
                         bbox={'boxstyle': 'square,pad=-0.2', 'ec': 'none',
                               'fc': (1, 1, 1, 0.7)},
                         zorder=ZORDER['annotate'])
+        patch_collection = PatchCollection(patches, match_original=True,
+                                          zorder=ZORDER['foreground'], cmap=cm, norm=norm)
+        ax.add_collection(patch_collection)
+        ax._sci(patch_collection) # enables plt.colormap()
         if autoscale:
             ax.autoscale(True)
         ax.set_xlabel('x (microns)')


### PR DESCRIPTION
## Description
Right now electrode numbers appear under the electrode patches, so you cant really ever see them unless the plot is huge enough that the full name fits inside the electrode. If a user is taking the time to specify `annotate=True`, then annotations should always be legible.

**Old**:
![image](https://user-images.githubusercontent.com/25232557/217720263-2389ae99-a09f-4f61-a13d-7f35e39bfe4c.png)

**New:**
![image](https://user-images.githubusercontent.com/25232557/217720322-63c05f91-cfed-462c-94c4-149f84369ee1.png)


## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


