### PR TITLE
[ENH] Add Orion implant and Test

### DIFF
--- a/pulse2percept/implants/cortex/__init__.py
+++ b/pulse2percept/implants/cortex/__init__.py
@@ -9,5 +9,8 @@ Different cortical prosthetic implants such as TODO.
     *  :ref:`Basic Concepts > Visual Prostheses <topics-implants>`
 """
 
+from .orion import Orion
+
 __all__ = [
+    "Orion"
 ]

--- a/pulse2percept/implants/cortex/orion.py
+++ b/pulse2percept/implants/cortex/orion.py
@@ -1,0 +1,66 @@
+import numpy as np
+from pulse2percept.implants import ProsthesisSystem
+
+from .. import ProsthesisSystem
+from ..electrodes import DiskElectrode
+from ..electrode_arrays import ElectrodeGrid
+
+
+class Orion(ProsthesisSystem):
+    # Frozen class: User cannot add more class attributes
+    __slots__ = ('shape',)
+    # TODO: Get rid of eye arg?
+    def __init__(self, x=15000, y=0, z=0, rot=0, eye='RE', stim=None,
+                 preprocess=False, safe_mode=False):
+        """Orion I
+        Parameters
+        ----------
+        x/y/z : double
+            3D location (mm) of the center of the electrode array.
+            The coordinate system is centered over the fovea on the cortical
+            surface.
+            Positive ``x`` values move the electrode into the periphery
+            (azimuth), whereas positive ``y`` values move the electrode into
+            the upper visual field (elevation). ``z`` is ignored for now.
+        rot : float, optional
+            Rotation angle of the array (deg). Positive values denote
+            counter-clock-wise (CCW) rotations in the cortical coordinate
+            system.
+        eye : {'RE', 'LE'}, optional
+            Leftover from p2p. Now means cortical hemisphere
+        preprocess : bool or callable, optional
+            Either True/False to indicate whether to execute the implant's
+            default preprocessing method whenever a new stimulus is assigned, 
+            or a custom function (callable).
+        safe_mode : bool, optional
+            If safe mode is enabled, only charge-balanced stimuli are allowed.
+        """
+
+        self.eye = eye
+        if not np.isclose(z, 0):
+            raise NotImplementedError
+        self.preprocess = preprocess
+        self.safe_mode = safe_mode
+        self.shape = (10, 7)
+        spacing = (4200, np.sqrt(3**2-2.1**2)*1000)
+        self.earray = ElectrodeGrid(self.shape, spacing, x=x, y=y, z=z, rot=rot,
+                                    names=('A', '-1'), type='hex', r=1000,
+                                    etype=DiskElectrode)
+        for e in ['A1', 'F7', 'G7', 'H6', 'H7', 'I6', 'I7', 'J5', 'J6', 'J7']:
+            self.earray.remove_electrode(e)
+        # Hacking the naming scheme:
+        names = [f'{i:02}' for i in range(96, 36, -1)]
+        electrodes = {}
+        for ename, eobject in zip(names, self.earray.electrode_objects):
+            eobject.name = ename
+            electrodes.update({ename: eobject})
+        self._earray._electrodes = electrodes
+
+        # Beware of race condition: Stim must be set last, because it requires
+        # indexing into self.electrodes:
+        self.stim = stim
+
+    def plot(self, annotate=False, autoscale=True, ax=None, stim_cmap=False):
+        ax = super(Orion, self).plot(annotate=annotate, autoscale=autoscale,
+                                     ax=ax)
+        return ax

--- a/pulse2percept/implants/cortex/tests/test_orion.py
+++ b/pulse2percept/implants/cortex/tests/test_orion.py
@@ -1,0 +1,54 @@
+import numpy as np
+import pytest
+import numpy.testing as npt
+
+from pulse2percept.implants.cortex.orion import Orion
+
+
+@pytest.mark.parametrize('x', (-100, 200))
+@pytest.mark.parametrize('y', (-200, 400))
+@pytest.mark.parametrize('rot', (-45, 60))
+def test_orion(x, y, rot):
+    orion = Orion(x, y, rot=rot)
+    non_rot_orion = Orion(0)
+
+    n_elec = 60
+    spacing = (4200, np.sqrt(3**2-2.1**2)*1000)
+
+    # Slots:
+    npt.assert_equal(hasattr(orion, '__slots__'), True)
+    npt.assert_equal(hasattr(orion, '__dict__'), False)
+
+    # Make sure number of electrodes is correct
+    npt.assert_equal(orion.n_electrodes, n_elec)
+    npt.assert_equal(len(orion.earray.electrodes), n_elec)
+
+    # Coordinates of 55 when device is not rotated:
+    xy = np.array([non_rot_orion['55'].x, non_rot_orion['55'].y])
+    # Rotate
+    rot_rad = np.deg2rad(rot)
+    R = np.array([np.cos(rot_rad), -np.sin(rot_rad),
+                  np.sin(rot_rad), np.cos(rot_rad)]).reshape((2, 2))
+    xy = R @ xy
+    # Then off-set: Make sure first electrode is placed
+    # correctly
+    npt.assert_almost_equal(orion['55'].x, xy[0] + x, decimal=2)
+    npt.assert_almost_equal(orion['55'].y, xy[1] + y, decimal=2)
+
+    # Make sure the radius is correct
+    for electrode in orion.earray.electrode_objects:
+        npt.assert_almost_equal(electrode.r, 1000)
+
+    # Make sure the pitch is correct:
+    # distance between two electrodes that are one row apart and adjacent horizontally
+    diag_dist = np.sqrt((spacing[0] / 2) ** 2 + spacing[1] ** 2)
+    npt.assert_almost_equal(np.sqrt(
+        (orion['55'].x - orion['49'].x) ** 2 +
+        (orion['55'].y - orion['49'].y) ** 2),
+        diag_dist
+    )
+    npt.assert_almost_equal(np.sqrt(
+        (orion['55'].x - orion['60'].x) ** 2 +
+        (orion['55'].y - orion['60'].y) ** 2),
+        diag_dist
+    )


### PR DESCRIPTION
## Description

- Added the Orion cortical implant, which was previously [here](https://github.com/bionicvisionlab/p2pcortex/blob/master/p2pcortex/implants.py#L6)
- Simplified the code used to change the naming scheme to be numbers from 96 to 37 rather than the letter-number naming scheme ([before](https://github.com/bionicvisionlab/p2pcortex/blob/master/p2pcortex/implants.py#L46) and [after](https://github.com/pulse2percept/pulse2percept/compare/cortex...lukeyoffe:cortex?expand=1#diff-db6e7d60dc3bdc17f63ec99e497c63bddf0beffcb82d93e3daff91c932e00fe8R52))
- Added test for Orion implant
- Added Orion to the `__init__.py` for the cortex package

Closes #520 

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
