### PR TITLE
[MNT][FIX] Remove outdated ubuntu workflows, add Jax version requirement

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ jobs:
   # Continuous integration: Run unit tests on all supported platforms whenever
   # someone pushes a new commit or creates a pull request. 
   build:
-    name: Building on ${{ matrix.os }} with Python-${{ matrix.python-version }}
+    name: Building on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       # Test on all supported platforms using all supported Python versions:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
       # Test on all supported platforms using all supported Python versions:
       matrix:
         python-version: ["3.10", 3.9, 3.8, 3.7]
-        os: [ubuntu-latest, ubuntu-18.04, windows-latest, macOS-latest]
+        os: [ubuntu-latest, ubuntu-20.04, windows-latest, macOS-latest]
     
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ jobs:
   # Continuous integration: Run unit tests on all supported platforms whenever
   # someone pushes a new commit or creates a pull request. 
   build:
-    name: Building on ${{ matrix.os }}
+    name: Building on ${{ matrix.os }} with Python-${{ matrix.python-version }}
     runs-on: ${{ matrix.os }}
     strategy:
       # Test on all supported platforms using all supported Python versions:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -42,7 +42,7 @@ jobs:
           CIBW_BEFORE_BUILD_LINUX: "yum install -y python-devel zlib-devel libjpeg-turbo-devel wget && python -m pip install pip==20.3 && python -m pip install Pillow==6.2.1 && python -m pip install -r requirements.txt && python -m pip install -e ."
           CIBW_BEFORE_BUILD: "python -m pip install pip==20.3 && python -m pip install Pillow==6.2.1 && python -m pip install -r requirements.txt && python -m pip install -e ."
           CIBW_BUILD: "cp37-*"
-          CIBW_SKIP: "*-manylinux_i686"
+          CIBW_SKIP: "*-manylinux_i686 cp37-win32"
 
       - uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -34,7 +34,7 @@ jobs:
         env:
           CIBW_BEFORE_BUILD: "python -m pip install -U pip numpy && python -m pip install Pillow==8.3.2 && python -m pip install -r requirements.txt && python -m pip install -e ."
           CIBW_BUILD: "cp39-* cp38-*"
-          CIBW_SKIP: "*-manylinux_i686 cp310-win32"
+          CIBW_SKIP: "*-manylinux_i686 cp38-win32 cp39-win32"
 
       - name: Build Py3.7 wheels
         uses: pypa/cibuildwheel@v2.1.3

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -8,4 +8,4 @@ joblib>=0.11
 pandas
 h5py
 docutils<0.18
-jax[cpu]
+jax[cpu]<=0.4.3

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -8,4 +8,4 @@ joblib>=0.11
 pandas
 h5py
 docutils<0.18
-jax[cpu]<=0.4
+jax[cpu]<=0.4.3

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -8,4 +8,4 @@ joblib>=0.11
 pandas
 h5py
 docutils<0.18
-jax[cpu]<=0.4.3
+jax[cpu]

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -8,4 +8,4 @@ joblib>=0.11
 pandas
 h5py
 docutils<0.18
-jax[cpu]
+jax[cpu]<=0.4


### PR DESCRIPTION
## Description
This PR fixes 2 things:

1. Ubuntu 18.04 is no longer supported and Github actions will no longer run it. Updated version uses only 20.04 and 22.04
2. A new Jax update causes tests to fail. Since jax is such a small part of p2p and will likely be removed soon, I didn't bother trying to figure out how to fix it, and just required the version to be <=0.4.3

