### PR TITLE
[ENH] Add Ensemble implant

### DIFF
--- a/pulse2percept/implants/__init__.py
+++ b/pulse2percept/implants/__init__.py
@@ -14,6 +14,7 @@ and PRIMA.
     bvt
     imie
     prima
+    ensemble
 
 .. seealso::
 
@@ -28,6 +29,7 @@ from .alpha import AlphaIMS, AlphaAMS
 from .bvt import BVT24, BVT44
 from .prima import PhotovoltaicPixel, PRIMA, PRIMA75, PRIMA55, PRIMA40
 from .imie import IMIE
+from .ensemble import EnsembleImplant
 from . import cortex
 
 __all__ = [
@@ -42,6 +44,7 @@ __all__ = [
     'Electrode',
     'ElectrodeArray',
     'ElectrodeGrid',
+    'EnsembleImplant',
     'HexElectrode',
     'PhotovoltaicPixel',
     'PointSource',

--- a/pulse2percept/implants/ensemble.py
+++ b/pulse2percept/implants/ensemble.py
@@ -7,12 +7,12 @@ class EnsembleImplant(ProsthesisSystem):
     """Ensemble implant
 
     An ensemble implant combines multiple implants into one larger electrode array
-    for the purpose of modelling implants used in tandem, e.g. CORTIVIS
+    for the purpose of modeling tandem implants, e.g. CORTIVIS, ICVP
     
     Parameters
     ----------
     implants : list or dict
-        The list of implants to be combined.
+        A list or dict of implants to be combined.
     stim : :py:class:`~pulse2percept.stimuli.Stimulus` source type
         A valid source type for the :py:class:`~pulse2percept.stimuli.Stimulus`
         object (e.g., scalar, NumPy array, pulse train).

--- a/pulse2percept/implants/ensemble.py
+++ b/pulse2percept/implants/ensemble.py
@@ -1,0 +1,68 @@
+"""`EnsembleImplant`"""
+from .base import ProsthesisSystem
+from .electrodes import Electrode
+from .electrode_arrays import ElectrodeArray
+
+class EnsembleImplant(ProsthesisSystem):
+    """Ensemble implant
+
+    An ensemble implant combines multiple implants into one larger electrode array
+    for the purpose of modelling implants used in tandem, e.g. CORTIVIS
+    
+    Parameters
+    ----------
+    implants : list or dict
+        The list of implants to be combined.
+    stim : :py:class:`~pulse2percept.stimuli.Stimulus` source type
+        A valid source type for the :py:class:`~pulse2percept.stimuli.Stimulus`
+        object (e.g., scalar, NumPy array, pulse train).
+    preprocess : bool or callable, optional
+        Either True/False to indicate whether to execute the implant's default
+        preprocessing method whenever a new stimulus is assigned, or a custom
+        function (callable).
+    safe_mode : bool, optional
+        If safe mode is enabled, only charge-balanced stimuli are allowed.
+    """
+
+    # Frozen class: User cannot add more class attributes
+    __slots__ = ('_implants', '_earray', '_stim', 'safe_mode', 'preprocess')
+
+    def __init__(self, implants, stim=None, preprocess=False,safe_mode=False):
+        self.implants = implants
+        self.safe_mode = safe_mode
+        self.preprocess = preprocess
+        self.stim = stim
+
+    def _pprint_params(self):
+        """Return dict of class attributes to pretty-print"""
+        return {'implants': self.implants, 'earray': self.earray, 'stim': self.stim,
+                'safe_mode': self.safe_mode, 'preprocess': self.preprocess}
+
+    @property
+    def implants(self):
+        """Dict of implants
+
+        """
+        return self._implants
+    
+    @implants.setter
+    def implants(self, implants):
+        """Implant dict setter (called upon ``self.implants = implants``)"""
+        # Assign the implant dict:
+        if isinstance(implants, list):
+            if not all(isinstance(implant, ProsthesisSystem) for implant in implants):
+                raise TypeError(f"All elements in 'implants' must be ProsthesisSystem objects.")
+            self._implants = {i:implant for i,implant in enumerate(implants)}
+        elif isinstance(implants, dict):
+            if not all(isinstance(implant, ProsthesisSystem) for implant in implants.values()):
+                raise TypeError(f"All elements in 'implants' must be ProsthesisSystem objects.")
+            self._implants = implants.copy()
+        else:
+            raise TypeError(f"'implants' must be a list or a dict object, not "
+                            f"{type(implants)}.")
+        # Create the electrode array
+        electrodes = {}
+        for i, implant in self._implants.items():
+            for name, electrode in implant.earray.electrodes.items():
+                electrodes[str(i) + "-" + str(name)] = electrode
+        self._earray = ElectrodeArray(electrodes)

--- a/pulse2percept/implants/tests/test_ensemble.py
+++ b/pulse2percept/implants/tests/test_ensemble.py
@@ -3,6 +3,7 @@ import numpy.testing as npt
 import pytest
 from pulse2percept.implants import (EnsembleImplant, PointSource, ProsthesisSystem)
 from pulse2percept.implants.cortex import Cortivis
+from pulse2percept.models.cortex.base import ScoreboardModel
 
 def test_EnsembleImplant():
     # Invalid instantiations:
@@ -24,6 +25,11 @@ def test_EnsembleImplant():
     npt.assert_equal(ensemble[0], p2[0])
     npt.assert_equal(ensemble[1], p1[0])
     npt.assert_equal(ensemble.electrode_names, ['A-0','B-0'])
+
+    # predict_percept smoke test
+    ensemble.stim = [1,1]
+    model = ScoreboardModel().build()
+    model.predict_percept(ensemble)
 
 # we essentially just need to make sure that electrode names are
 # set properly, the rest of the EnsembleImplant functionality 

--- a/pulse2percept/implants/tests/test_ensemble.py
+++ b/pulse2percept/implants/tests/test_ensemble.py
@@ -1,0 +1,43 @@
+import numpy as np
+import numpy.testing as npt
+import pytest
+from pulse2percept.implants import (EnsembleImplant, PointSource, ProsthesisSystem)
+from pulse2percept.implants.cortex import Cortivis
+
+def test_EnsembleImplant():
+    # Invalid instantiations:
+    with pytest.raises(TypeError):
+        EnsembleImplant(implants="this can't happen")
+
+    # Instantiate with list
+    p1 = ProsthesisSystem(PointSource(0,0,0))
+    p2 = ProsthesisSystem(PointSource(1,1,1))
+    ensemble = EnsembleImplant(implants=[p1,p2])
+    npt.assert_equal(ensemble.n_electrodes, 2)
+    npt.assert_equal(ensemble[0], p1[0])
+    npt.assert_equal(ensemble[1], p2[0])
+    npt.assert_equal(ensemble.electrode_names, ['0-0','1-0'])
+
+    # Instantiate with dict
+    ensemble = EnsembleImplant(implants={'A': p2, 'B': p1})
+    npt.assert_equal(ensemble.n_electrodes, 2)
+    npt.assert_equal(ensemble[0], p2[0])
+    npt.assert_equal(ensemble[1], p1[0])
+    npt.assert_equal(ensemble.electrode_names, ['A-0','B-0'])
+
+# we essentially just need to make sure that electrode names are
+# set properly, the rest of the EnsembleImplant functionality 
+# (electrode placement, etc) is determined by the implants passed in
+# and thus already tested
+# but we'll test it again just to make sure
+def test_ensemble_cortivis():
+    cortivis0 = Cortivis(0)
+    cortivis1 = Cortivis(x=10000)
+
+    ensemble = EnsembleImplant([cortivis0, cortivis1])
+
+    # check that positions are the same
+    npt.assert_equal(ensemble['0-1'].x, cortivis0['1'].x)
+    npt.assert_equal(ensemble['0-1'].y, cortivis0['1'].y)
+    npt.assert_equal(ensemble['1-1'].x, cortivis1['1'].x)
+    npt.assert_equal(ensemble['1-1'].y, cortivis1['1'].y)

--- a/pulse2percept/implants/tests/test_ensemble.py
+++ b/pulse2percept/implants/tests/test_ensemble.py
@@ -9,6 +9,10 @@ def test_EnsembleImplant():
     # Invalid instantiations:
     with pytest.raises(TypeError):
         EnsembleImplant(implants="this can't happen")
+    with pytest.raises(TypeError):
+        EnsembleImplant(implants=[3,Cortivis()])
+    with pytest.raises(TypeError):
+        EnsembleImplant(implants={'1': Cortivis(), '2': 'abcd'})
 
     # Instantiate with list
     p1 = ProsthesisSystem(PointSource(0,0,0))


### PR DESCRIPTION
## Description

Adds the `EnsembleImplant` which extends `ProsthesisSystem`. This class is meant for simulating multiple implants meant to be used in tandem, such as CORTIVIS, but can be used with any implant type. It takes a list or dict of `ProsthesisSystem` objects and combines their electrode arrays.

If the input is a list, the new electrodes are named in the form `idx`-`electrode_name` where `idx` is the index of the implant in the list.
If the input is a dict, the new electrodes are named in the form `key`-`electrode_name` where `key` is the key of the implant in the dict.

Closes #527 

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes