### PR TITLE
[FIX] Replace DataFrame.append with pd.concat

### DIFF
--- a/pulse2percept/datasets/perezfornos2012.py
+++ b/pulse2percept/datasets/perezfornos2012.py
@@ -90,12 +90,12 @@ def load_perezfornos2012(shuffle=False, subjects=None, figures=None,
         for time_step in time_steps:
             time_series = np.append(time_series, row[time_step])
 
-        raw_spec = {
+        raw_spec = pd.DataFrame([{
             'figure': row['Figure'],
             'subject': row['Subject'],
             'time_series': time_series
-        }
-        time_series_df = time_series_df.append(raw_spec, verify_integrity=False,
-                                               ignore_index=True)
+        }])
+        time_series_df = pd.concat([time_series_df, raw_spec], 
+                                   verify_integrity=False, ignore_index=True)
 
     return time_series_df.reset_index(drop=True)


### PR DESCRIPTION
## Description
`pandas.DataFrame.append` no longer exists in version 2.0, which causes our tests to fail. I changed it to use the recommended `pd.concat` instead.

https://pandas.pydata.org/pandas-docs/version/1.5/whatsnew/v1.4.0.html#whatsnew-140-deprecations-frame-series-append

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

