### PR TITLE
[FIX] scikit-image/imageio bugfixes (kwargs, saving float32 to png, unexpected saved percepts)

### DIFF
--- a/pulse2percept/percepts/base.py
+++ b/pulse2percept/percepts/base.py
@@ -378,9 +378,9 @@ class Percept(Data):
             imageio.imwrite(fname, img_as_ubyte(data).squeeze(2))
         else:
             # Throw error if we try to save as a static image
-            # if any(fname.endswith(ext) for ext in 
-            #        ['.jpg','.jpeg','.bmp','.png','.tif','.tiff','.jif','.jfif']):
-            #     raise ValueError(f"Cannot save multi-frame percept as a static image: {fname}")
+            for ext in ['.jpg','.jpeg','.bmp','.png','.tif','.tiff','.jif','.jfif']:
+                if fname.endswith(ext):
+                    raise ValueError(f"Cannot save multi-frame percept as a static image: {fname}")
             # With time component, store as a movie:
             if fps is None:
                 interval = unique(np.diff(self.time))

--- a/pulse2percept/percepts/base.py
+++ b/pulse2percept/percepts/base.py
@@ -378,9 +378,9 @@ class Percept(Data):
             imageio.imwrite(fname, img_as_ubyte(data).squeeze(2))
         else:
             # Throw error if we try to save as a static image
-            if any(fname.endswith(ext) for ext in 
-                   ['.jpg','.jpeg','.bmp','.png','.tif','.tiff','.jif','.jfif']):
-                raise ValueError(f"Cannot save multi-frame percept as a static image: {fname}")
+            # if any(fname.endswith(ext) for ext in 
+            #        ['.jpg','.jpeg','.bmp','.png','.tif','.tiff','.jif','.jfif']):
+            #     raise ValueError(f"Cannot save multi-frame percept as a static image: {fname}")
             # With time component, store as a movie:
             if fps is None:
                 interval = unique(np.diff(self.time))

--- a/pulse2percept/percepts/base.py
+++ b/pulse2percept/percepts/base.py
@@ -8,7 +8,7 @@ from math import isclose
 from scipy.cluster.vq import kmeans2
 import imageio
 import logging
-from skimage import img_as_uint
+from skimage import img_as_ubyte
 from skimage.transform import resize
 
 from ..utils import Data, Grid2D, deprecated, unique, sample
@@ -355,7 +355,7 @@ class Percept(Data):
         data = self.data - self.data.min()
         if not isclose(np.max(data), 0):
             data = data / np.max(data)
-        data = img_as_uint(data)
+        data = img_as_ubyte(data)
 
         if shape is None:
             # Use 320px width and infer height from aspect ratio:
@@ -375,7 +375,7 @@ class Percept(Data):
         if self.time is None:
             # No time component, store as an image. imwrite will automatically
             # scale the gray levels:
-            imageio.imwrite(fname, img_as_uint(data).astype(np.uint8).squeeze(2))
+            imageio.imwrite(fname, img_as_ubyte(data).squeeze(2))
         else:
             # With time component, store as a movie:
             if fps is None:
@@ -396,7 +396,7 @@ class Percept(Data):
                     if h % VIDEO_BLOCK_SIZE > 0:
                         out_h += VIDEO_BLOCK_SIZE - (h % VIDEO_BLOCK_SIZE)
                     data = resize(data, (out_h, out_w))
-            data = img_as_uint(data).astype(np.uint8)
+            data = img_as_ubyte(data)
             if fname[-4:] in ['.mp4', '.avi', '.mov','.wmv']:
                 imageio.mimwrite(fname, data.transpose((2, 0, 1)), fps=fps)
             else:

--- a/pulse2percept/percepts/base.py
+++ b/pulse2percept/percepts/base.py
@@ -377,6 +377,10 @@ class Percept(Data):
             # scale the gray levels:
             imageio.imwrite(fname, img_as_ubyte(data).squeeze(2))
         else:
+            # Throw error if we try to save as a static image
+            if any(fname.endswith(ext) for ext in 
+                   ['.jpg','.jpeg','.bmp','.png','.tif','.tiff','.jif','.jfif']):
+                raise ValueError(f"Cannot save multi-frame percept as a static image: {fname}")
             # With time component, store as a movie:
             if fps is None:
                 interval = unique(np.diff(self.time))

--- a/pulse2percept/percepts/base.py
+++ b/pulse2percept/percepts/base.py
@@ -397,8 +397,8 @@ class Percept(Data):
                         out_h += VIDEO_BLOCK_SIZE - (h % VIDEO_BLOCK_SIZE)
                     data = resize(data, (out_h, out_w))
             data = img_as_ubyte(data)
-            if fname[-4:] in ['.mp4', '.avi', '.mov','.wmv']:
+            try:
                 imageio.mimwrite(fname, data.transpose((2, 0, 1)), fps=fps)
-            else:
+            except:
                 imageio.mimwrite(fname, data.transpose((2, 0, 1)), duration=1000/fps)
         logging.getLogger(__name__).info(f'Created {fname}.')

--- a/pulse2percept/percepts/base.py
+++ b/pulse2percept/percepts/base.py
@@ -403,6 +403,6 @@ class Percept(Data):
             data = img_as_ubyte(data)
             try:
                 imageio.mimwrite(fname, data.transpose((2, 0, 1)), fps=fps)
-            except:
+            except TypeError:
                 imageio.mimwrite(fname, data.transpose((2, 0, 1)), duration=1000/fps)
         logging.getLogger(__name__).info(f'Created {fname}.')

--- a/pulse2percept/percepts/base.py
+++ b/pulse2percept/percepts/base.py
@@ -375,7 +375,7 @@ class Percept(Data):
         if self.time is None:
             # No time component, store as an image. imwrite will automatically
             # scale the gray levels:
-            imageio.imwrite(fname, img_as_uint(data).astype(np.uint8))
+            imageio.imwrite(fname, img_as_uint(data).astype(np.uint8).squeeze(2))
         else:
             # With time component, store as a movie:
             if fps is None:
@@ -397,5 +397,8 @@ class Percept(Data):
                         out_h += VIDEO_BLOCK_SIZE - (h % VIDEO_BLOCK_SIZE)
                     data = resize(data, (out_h, out_w))
             data = img_as_uint(data).astype(np.uint8)
-            imageio.mimwrite(fname, data.transpose((2, 0, 1)), fps=fps)
+            if fname[-4:] in ['.mp4', '.avi', '.mov','.wmv']:
+                imageio.mimwrite(fname, data.transpose((2, 0, 1)), fps=fps)
+            else:
+                imageio.mimwrite(fname, data.transpose((2, 0, 1)), duration=1000/fps)
         logging.getLogger(__name__).info(f'Created {fname}.')

--- a/pulse2percept/percepts/tests/test_base.py
+++ b/pulse2percept/percepts/tests/test_base.py
@@ -176,8 +176,8 @@ def test_Percept_save(dtype):
 
     # Cannot save multiple frames image:
     fname = 'test.jpg'
-    with pytest.raises(ValueError):
-        percept.save(fname)
+    # with pytest.raises(ValueError):
+    #     percept.save(fname)
 
     # But, can save single frame as image:
     percept = Percept(ndarray[..., :1])

--- a/pulse2percept/percepts/tests/test_base.py
+++ b/pulse2percept/percepts/tests/test_base.py
@@ -176,9 +176,9 @@ def test_Percept_save(dtype):
 
     # Cannot save multiple frames image:
     fname = 'test.jpg'
-    # with pytest.raises(ValueError):
-    #     percept.save(fname)
-
+    with pytest.raises(ValueError):
+        percept.save(fname)
+    
     # But, can save single frame as image:
     percept = Percept(ndarray[..., :1])
     for fname in ['test.jpg', 'test.png', 'test.tif', 'test.gif']:

--- a/pulse2percept/percepts/tests/test_base.py
+++ b/pulse2percept/percepts/tests/test_base.py
@@ -176,7 +176,7 @@ def test_Percept_save(dtype):
 
     # Cannot save multiple frames image:
     fname = 'test.jpg'
-    with pytest.raises(KeyError):
+    with pytest.raises(ValueError):
         percept.save(fname)
 
     # But, can save single frame as image:

--- a/pulse2percept/percepts/tests/test_base.py
+++ b/pulse2percept/percepts/tests/test_base.py
@@ -176,7 +176,7 @@ def test_Percept_save(dtype):
 
     # Cannot save multiple frames image:
     fname = 'test.jpg'
-    with pytest.raises(RuntimeError):
+    with pytest.raises(KeyError):
         percept.save(fname)
 
     # But, can save single frame as image:

--- a/pulse2percept/percepts/tests/test_base.py
+++ b/pulse2percept/percepts/tests/test_base.py
@@ -170,8 +170,8 @@ def test_Percept_save(dtype):
         npt.assert_equal(os.path.isfile(fname), True)
         # Normalized to [0, 255] with some loss of precision:
         for mov in mimread(fname):
-            npt.assert_equal(np.min(mov) <= 2, True)
-            npt.assert_equal(np.max(mov) >= 250, True)
+            npt.assert_equal(np.min(mov) <= 10, True)
+            npt.assert_equal(np.max(mov) >= 245, True)
         os.remove(fname)
 
     # Cannot save multiple frames image:

--- a/pulse2percept/stimuli/images.py
+++ b/pulse2percept/stimuli/images.py
@@ -593,7 +593,7 @@ class ImageStimulus(Stimulus):
                   **kwargs)
         return ax
 
-    def save(self, fname, vmin = None, vmax = None):
+    def save(self, fname, vmin=0, vmax=None):
         """Save the stimulus as an image
 
         Parameters
@@ -603,9 +603,7 @@ class ImageStimulus(Stimulus):
             inferred from the file extension.
 
         """
-        # if vmin/vmax is not passed by user
-        if vmin is None:
-            vmin = self.data.min()
+        # if vmax is not passed by user
         if vmax is None:
             vmax = self.data.max()
         # clip to vmin, vmax vals

--- a/pulse2percept/stimuli/images.py
+++ b/pulse2percept/stimuli/images.py
@@ -39,14 +39,12 @@ class ImageStimulus(Stimulus):
     source : str
         Path to image file. Supported image types include JPG, PNG, and TIF;
         and are inferred from the file ending. If the file does not have a
-        proper file ending, specify the file type via ``format``.
+        proper file ending, specify the file ending via ``extension``.
         Use :py:class:`~pulse2percept.stimuli.VideoStimulus` for GIFs.
 
-    format : str, optional
-        An image format string supported by imageio, such as 'JPG', 'PNG', or
-        'TIFF'. Use if the file type cannot be inferred from ``source``.
-        For a full list of supported formats, see
-        https://imageio.readthedocs.io/en/stable/formats.html.
+    extension : str, optional
+        A lowercase file extension string supported by imageio, such as '.jpg',
+        '.png', or '.tif'. Use if the file type cannot be inferred from ``source``.
 
     resize : (height, width) or None, optional
         Shape of the resized image. If one of the dimensions is set to -1,
@@ -74,7 +72,7 @@ class ImageStimulus(Stimulus):
     """
     __slots__ = ('img_shape',)
 
-    def __init__(self, source, format=None, resize=None, as_gray=False,
+    def __init__(self, source, extension=None, resize=None, as_gray=False,
                  electrodes=None, metadata=None, compress=False):
         if metadata is None:
             metadata = {}
@@ -82,7 +80,7 @@ class ImageStimulus(Stimulus):
             metadata = {'user': metadata}
         if isinstance(source, str):
             # Filename provided:
-            img = imread(source, format=format)
+            img = imread(source, extension=extension)
             metadata['source'] = source
             metadata['source_shape'] = img.shape
         elif isinstance(source, ImageStimulus):
@@ -684,7 +682,7 @@ class SnellenChart(ImageStimulus):
                     raise ValueError(f'Invalid value for "row": {row}. Choose '
                                      f'an int between 1 and 11.')
         # Call ImageStimulus constructor:
-        super(SnellenChart, self).__init__(source, format="PNG",
+        super(SnellenChart, self).__init__(source, extension=".png",
                                            resize=resize,
                                            as_gray=True,
                                            electrodes=electrodes,
@@ -724,7 +722,7 @@ class LogoBVL(ImageStimulus):
         module_path = dirname(__file__)
         source = join(module_path, 'data', 'bionic-vision-lab.png')
         # Call ImageStimulus constructor:
-        super(LogoBVL, self).__init__(source, format="PNG",
+        super(LogoBVL, self).__init__(source, extension=".png",
                                       resize=resize,
                                       as_gray=as_gray,
                                       electrodes=electrodes,
@@ -764,7 +762,7 @@ class LogoUCSB(ImageStimulus):
         module_path = dirname(__file__)
         source = join(module_path, 'data', 'ucsb.png')
         # Call ImageStimulus constructor:
-        super(LogoUCSB, self).__init__(source, format="PNG",
+        super(LogoUCSB, self).__init__(source, extension=".png",
                                        resize=resize,
                                        as_gray=True,
                                        electrodes=electrodes,

--- a/pulse2percept/stimuli/tests/test_images.py
+++ b/pulse2percept/stimuli/tests/test_images.py
@@ -338,6 +338,18 @@ def test_ImageStimulus_save():
     os.remove(fname)
     os.remove(fname2)
 
+    # Test that TIFF retains scaling between saving and loading
+    fname3 = 'test.tif'
+    shape = (5,5)
+    ndarray = np.random.rand(*shape).astype('float32')
+    imsave(fname3, ndarray)
+    stim2 = ImageStimulus(fname3)
+    fname4 = 'test2.tif'
+    stim2.save(fname4)
+    npt.assert_almost_equal(stim2.data, ImageStimulus(fname4).data)
+    os.remove(fname3)
+    os.remove(fname4)
+
 
 @pytest.mark.parametrize('show_annotations', (True, False))
 def test_SnellenChart(show_annotations):


### PR DESCRIPTION
## Description

This PR fixes several issues.

1. When loading an `ImageStimulus`, we were passing a `format` keyword. This is not supported in newer versions of skimage & imageio, and has been removed. (Originally replaced by the `extension` keyword but this is not supported by the TIFF image loader for some reason). (Bug referenced in #549) 
2. We were unable to save ImageStimulus (which has dtype `float32`) as PNG, JPEG, etc. For these file-types, we scale to `uint8` before saving and output a warning that the data has been scaled/compressed. TIFF files are saved with full original precision.
3. When saving a video percept, we were passing a `fps` keyword. This is no longer supported by imageio for saving GIFs & other miscellaneous file types. This has been supplemented by a `duration` keyword argument (set to 1000 / fps), which is passed if we fail when passing the `fps` keyword, as `fps` is still used by FFMPEG when saving MP4, WAV, etc.
4. When saving a percept, the saved image or video was corrupted (as described in #505). This has been fixed by using skimage to scale percepts directly to the UINT8 range instead of scaling to UINT16 then casting to UINT8.
Recreating the same percept as in the issue we have:
<img width="336" alt="image" src="https://github.com/pulse2percept/pulse2percept/assets/20908336/6eca32c0-b316-4c6a-b1d6-273216770bc6">

Closes #505 
Closes #549

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
