### PR TITLE
[FIX] Github wheels for mac

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,6 +17,9 @@ jobs:
       matrix:
         python-version: ["3.10", 3.9, 3.8, 3.7]
         os: [ubuntu-latest, ubuntu-20.04, windows-latest, macOS-latest]
+        exclude:
+          - os: macOS-latest
+            python-version: 3.7 
     
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -37,12 +37,13 @@ jobs:
           CIBW_SKIP: "*-manylinux_i686 cp38-win32 cp39-win32"
 
       - name: Build Py3.7 wheels
+        if: ${{ matrix.os != macos-12}}
         uses: pypa/cibuildwheel@v2.1.3
         env:
           CIBW_BEFORE_BUILD_LINUX: "yum install -y python-devel zlib-devel libjpeg-turbo-devel wget && python -m pip install pip==20.3 && python -m pip install Pillow==6.2.1 && python -m pip install -r requirements.txt && python -m pip install -e ."
           CIBW_BEFORE_BUILD: "python -m pip install pip==20.3 && python -m pip install Pillow==6.2.1 && python -m pip install -r requirements.txt && python -m pip install -e ."
           CIBW_BUILD: "cp37-*"
-          CIBW_SKIP: "*-manylinux_i686 cp37-win32 *macosx*"
+          CIBW_SKIP: "*-manylinux_i686 cp37-win32"
 
       - uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, windows-2019, macos-12]
+        os: [ubuntu-20.04, windows-2019, macos-10.15]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, windows-2019, macos-10.15]
+        os: [ubuntu-20.04, windows-2019, macos-12]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, windows-2019, macos-12 ]
+        os: [ubuntu-20.04, windows-2019, macos-12]
 
     steps:
       - uses: actions/checkout@v2
@@ -42,7 +42,7 @@ jobs:
           CIBW_BEFORE_BUILD_LINUX: "yum install -y python-devel zlib-devel libjpeg-turbo-devel wget && python -m pip install pip==20.3 && python -m pip install Pillow==6.2.1 && python -m pip install -r requirements.txt && python -m pip install -e ."
           CIBW_BEFORE_BUILD: "python -m pip install pip==20.3 && python -m pip install Pillow==6.2.1 && python -m pip install -r requirements.txt && python -m pip install -e ."
           CIBW_BUILD: "cp37-*"
-          CIBW_SKIP: "*-manylinux_i686 cp37-win32"
+          CIBW_SKIP: "*-manylinux_i686 cp37-win32 cp37-macosx_x86_64"
 
       - uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, windows-2019, macos-12]
+        os: [ubuntu-20.04, windows-2019, macos-12 ]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -37,7 +37,7 @@ jobs:
           CIBW_SKIP: "*-manylinux_i686 cp38-win32 cp39-win32"
 
       - name: Build Py3.7 wheels
-        if: ${{ matrix.os != macos-12}}
+        if: ${{ matrix.os != "macos-12"}}
         uses: pypa/cibuildwheel@v2.1.3
         env:
           CIBW_BEFORE_BUILD_LINUX: "yum install -y python-devel zlib-devel libjpeg-turbo-devel wget && python -m pip install pip==20.3 && python -m pip install Pillow==6.2.1 && python -m pip install -r requirements.txt && python -m pip install -e ."

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -42,7 +42,7 @@ jobs:
           CIBW_BEFORE_BUILD_LINUX: "yum install -y python-devel zlib-devel libjpeg-turbo-devel wget && python -m pip install pip==20.3 && python -m pip install Pillow==6.2.1 && python -m pip install -r requirements.txt && python -m pip install -e ."
           CIBW_BEFORE_BUILD: "python -m pip install pip==20.3 && python -m pip install Pillow==6.2.1 && python -m pip install -r requirements.txt && python -m pip install -e ."
           CIBW_BUILD: "cp37-*"
-          CIBW_SKIP: "*-manylinux_i686 cp37-win32 cp37-macosx_x86_64"
+          CIBW_SKIP: "*-manylinux_i686 cp37-win32 *macosx*"
 
       - uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -37,7 +37,6 @@ jobs:
           CIBW_SKIP: "*-manylinux_i686 cp38-win32 cp39-win32"
 
       - name: Build Py3.7 wheels
-        if: ${{ matrix.os != "macos-12"}}
         uses: pypa/cibuildwheel@v2.1.3
         env:
           CIBW_BEFORE_BUILD_LINUX: "yum install -y python-devel zlib-devel libjpeg-turbo-devel wget && python -m pip install pip==20.3 && python -m pip install Pillow==6.2.1 && python -m pip install -r requirements.txt && python -m pip install -e ."


### PR DESCRIPTION
Keeps Mac os runner updated (12), but removes build for python 3.7 on mac. 

There is some obscure installation error with libbz2 on mac that is preventing tests from passing for python 3.7 on mac targets. After some initial digging it does not seem like there is an obvious fix, and since python 3.7 is officially deprecated in a couple of days anyways, I am just removing this test. 