### PR TITLE
[DOC] Pin jinja version to <3.1

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,3 +1,4 @@
+jinja2<3.1
 setuptools>=42.0,<50.0
 sphinx==1.8.5
 sphinx_gallery>=0.7


### PR DESCRIPTION
With a fresh install of p2p and `doc/requirements.txt`, building docs currently fails:
`sphinx.errors.ExtensionError: Could not import extension sphinx.builders.latex (exception: cannot import name 'contextfunction' from 'jinja2'`


Jinja is imported by sphinx, and our sphinx version does not allow for the newest jinja update. 

We could alternatively upgrade to the newest version of sphinx, but that creates a whole other group of issues. This is an easier fix for now atleast.