### PR TITLE
[MNT][FIX] Update cibuildwheel

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -4,11 +4,13 @@ on:
   push:
     branches:
       - master
+      - cortex
     tags:
       - v*
   pull_request:
     branches:
       - master
+      - cortex
 
 jobs:
   build_wheels:
@@ -16,33 +18,34 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, windows-2019, macos-12]
+        os: [ubuntu-22.04, windows-2019, macos-12]
+
 
     steps:
       - uses: actions/checkout@v2
 
       - name: Build Py3.10 wheels
-        uses: pypa/cibuildwheel@v2.1.3
+        uses: pypa/cibuildwheel@v2.16.2
         env:
-          CIBW_BEFORE_BUILD_LINUX: "yum install -y python-devel zlib-devel libjpeg-turbo-devel wget && python -m pip install -U pip numpy pillow && wget https://github.com/scipy/scipy/releases/download/v1.8.0/scipy-1.8.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl && mv scipy-1.8.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl scipy-1.8.0-cp310-none-any.whl && python -m pip install scipy-1.8.0-cp310-none-any.whl && python -m pip install -r requirements.txt && python -m pip install -e ."
+          CIBW_BEFORE_BUILD_LINUX: "yum install -y python-devel zlib-devel libjpeg-turbo-devel wget && python -m pip install -U pip pillow numpy && python -m pip install -r requirements.txt && python -m pip install -e ."
           CIBW_BEFORE_BUILD: "python -m pip install -U pip numpy pillow && python -m pip install -r requirements.txt && python -m pip install -e ."
           CIBW_BUILD: "cp310-*"
-          CIBW_SKIP: "*-manylinux_i686 cp310-win32"
+          CIBW_SKIP: "*-manylinux_i686 cp310-win32 *musllinux*"
 
       - name: Build Py3.8-3.9 wheels
-        uses: pypa/cibuildwheel@v2.1.3
+        uses: pypa/cibuildwheel@v2.16.2
         env:
           CIBW_BEFORE_BUILD: "python -m pip install -U pip numpy && python -m pip install Pillow==8.3.2 && python -m pip install -r requirements.txt && python -m pip install -e ."
           CIBW_BUILD: "cp39-* cp38-*"
-          CIBW_SKIP: "*-manylinux_i686 cp38-win32 cp39-win32"
+          CIBW_SKIP: "*-manylinux_i686 cp38-win32 cp39-win32 *musllinux*"
 
       - name: Build Py3.7 wheels
-        uses: pypa/cibuildwheel@v2.1.3
+        uses: pypa/cibuildwheel@v2.16.2
         env:
           CIBW_BEFORE_BUILD_LINUX: "yum install -y python-devel zlib-devel libjpeg-turbo-devel wget && python -m pip install pip==20.3 && python -m pip install Pillow==6.2.1 && python -m pip install -r requirements.txt && python -m pip install -e ."
           CIBW_BEFORE_BUILD: "python -m pip install pip==20.3 && python -m pip install Pillow==6.2.1 && python -m pip install -r requirements.txt && python -m pip install -e ."
           CIBW_BUILD: "cp37-*"
-          CIBW_SKIP: "*-manylinux_i686 cp37-win32"
+          CIBW_SKIP: "*-manylinux_i686 cp37-win32 *musllinux*"
 
       - uses: actions/upload-artifact@v2
         with:


### PR DESCRIPTION
cibuildwheel currently fails to build all python versions for ubuntu. After a long and painstaking search for a `cibw_before_build_linux` that worked, I ended up just updating the cibuildwheel to use the current 2.16.2 (instead of long outdated 2.1.3) cibuildwheel release. 

Also updates to use ubuntu22.04

Replaces PR #569 