### PR TITLE
[FIX] Y axis treatment in retinotopy, visual field, and Grid2D. Fix AxonMapModel OD location

### DIFF
--- a/pulse2percept/models/beyeler2019.py
+++ b/pulse2percept/models/beyeler2019.py
@@ -454,7 +454,8 @@ class AxonMapSpatial(SpatialModel):
             # Keep only reasonably sized axon bundles:
             bundles = list(filter(lambda x: len(x) > 10, bundles))
         # Convert to um:
-        bundles = [np.array(self.retinotopy.dva_to_ret(b[:, 0], b[:, 1])).T
+        # Use negative y coord: Want slope in DVA not ret (compat)
+        bundles = [np.array(self.retinotopy.dva_to_ret(b[:, 0], -b[:, 1])).T
                    for b in bundles]
         return bundles
 

--- a/pulse2percept/models/beyeler2019.py
+++ b/pulse2percept/models/beyeler2019.py
@@ -454,8 +454,7 @@ class AxonMapSpatial(SpatialModel):
             # Keep only reasonably sized axon bundles:
             bundles = list(filter(lambda x: len(x) > 10, bundles))
         # Convert to um:
-        # Use negative y coord: Want slope in DVA not ret (compat)
-        bundles = [np.array(self.retinotopy.dva_to_ret(b[:, 0], -b[:, 1])).T
+        bundles = [np.array(self.retinotopy.dva_to_ret(b[:, 0], b[:, 1])).T
                    for b in bundles]
         return bundles
 

--- a/pulse2percept/models/beyeler2019.py
+++ b/pulse2percept/models/beyeler2019.py
@@ -843,9 +843,9 @@ class AxonMapSpatial(SpatialModel):
             od_xy = self.loc_od
             od_w = 6.44
             od_h = 6.85
-            # Flip y upside down for dva:
+            # Convert axon bundles to dva:
             axon_bundles = [np.array(self.retinotopy.ret_to_dva(bundle[:, 0],
-                                                             -bundle[:, 1])).T
+                                                             bundle[:, 1])).T
                             for bundle in axon_bundles]
             labels = ['upper', 'lower', 'left', 'right']
         else:

--- a/pulse2percept/models/cortex/tests/test_base.py
+++ b/pulse2percept/models/cortex/tests/test_base.py
@@ -10,6 +10,7 @@ from pulse2percept.topography import Polimeni2006Map
 from pulse2percept.percepts import Percept
 from pulse2percept.topography import Watson2014Map
 
+
 @pytest.mark.parametrize('ModelClass', [ScoreboardModel, ScoreboardSpatial])
 @pytest.mark.parametrize('jitter_boundary', [True, False])
 @pytest.mark.parametrize('regions', 
@@ -81,12 +82,21 @@ def test_predict_spatial(ModelClass, regions):
     npt.assert_equal(percept.shape, list(model.grid.x.shape) + [2])
     npt.assert_equal(np.all(percept.data[:, :, 1] == 0), True)
     pmax = percept.data.max()
-    npt.assert_almost_equal(percept.data[27, 18, 0], pmax)
+    npt.assert_almost_equal(percept.data[33, 18, 0], pmax)
     npt.assert_almost_equal(percept.data[30, 13, 0], 1.96066, 5)
-    npt.assert_almost_equal(percept.data[32, 8, 0], 0.013483, 5)
+    npt.assert_almost_equal(percept.data[32, 8, 0], 0.013312, 5)
     npt.assert_equal(np.sum(percept.data > 0.75), 122)
     npt.assert_equal(np.sum(percept.data > 1), 105)
     npt.assert_almost_equal(percept.time, [0, 1])
+
+    if 'v1' in regions:
+        # make sure cortical representation is flipped
+        vfmap = Polimeni2006Map(k=15, a=0.5, b=90)
+        model = ModelClass(xrange=(-5, 0), yrange=(-3, 3), xystep=0.1, rho=400, retinotopy=vfmap).build()
+        implant = Orion(x=30000, y=0, rot=0, stim={'40' : 1,  '94' :5})
+        percept = model.predict_percept(implant)
+        half = model.grid.shape[0] // 2
+        npt.assert_equal(np.sum(percept.data[:half, :, :]) >  np.sum(percept.data[half:, :, :]), True)
 
 
 @pytest.mark.parametrize('ModelClass', [ScoreboardModel, ScoreboardSpatial])

--- a/pulse2percept/models/tests/test_beyeler2019.py
+++ b/pulse2percept/models/tests/test_beyeler2019.py
@@ -534,7 +534,7 @@ def test_AxonMapModel_predict_percept(engine):
     npt.assert_equal(np.sum(percept.data > 0.8), 1)
     npt.assert_equal(np.sum(percept.data > 0.6), 2)
     npt.assert_equal(np.sum(percept.data > 0.1), 7)
-    npt.assert_equal(np.sum(percept.data > 0.0001), 31)
+    npt.assert_equal(np.sum(percept.data > 0.0001), 32)
     # Overall only a few bright pixels:
     npt.assert_almost_equal(np.sum(percept.data), 3.3087, decimal=3)
     # Brightest pixel is in lower right:

--- a/pulse2percept/models/tests/test_beyeler2019.py
+++ b/pulse2percept/models/tests/test_beyeler2019.py
@@ -536,7 +536,7 @@ def test_AxonMapModel_predict_percept(engine):
     npt.assert_equal(np.sum(percept.data > 0.1), 7)
     npt.assert_equal(np.sum(percept.data > 0.0001), 32)
     # Overall only a few bright pixels:
-    npt.assert_almost_equal(np.sum(percept.data), 3.3087, decimal=3)
+    npt.assert_almost_equal(np.sum(percept.data), 3.406, decimal=3)
     # Brightest pixel is in lower right:
     npt.assert_almost_equal(percept.data[33, 46, 0], np.max(percept.data))
     # Top half is empty:

--- a/pulse2percept/models/tests/test_beyeler2019.py
+++ b/pulse2percept/models/tests/test_beyeler2019.py
@@ -534,9 +534,9 @@ def test_AxonMapModel_predict_percept(engine):
     npt.assert_equal(np.sum(percept.data > 0.8), 1)
     npt.assert_equal(np.sum(percept.data > 0.6), 2)
     npt.assert_equal(np.sum(percept.data > 0.1), 7)
-    npt.assert_equal(np.sum(percept.data > 0.0001), 32)
+    npt.assert_equal(np.sum(percept.data > 0.0001), 31)
     # Overall only a few bright pixels:
-    npt.assert_almost_equal(np.sum(percept.data), 3.406, decimal=3)
+    npt.assert_almost_equal(np.sum(percept.data), 3.3087, decimal=3)
     # Brightest pixel is in lower right:
     npt.assert_almost_equal(percept.data[33, 46, 0], np.max(percept.data))
     # Top half is empty:

--- a/pulse2percept/models/tests/test_beyeler2019.py
+++ b/pulse2percept/models/tests/test_beyeler2019.py
@@ -488,10 +488,10 @@ def test_AxonMapModel_calc_bundle_tangent(engine):
                          xrange=(-20, 20), yrange=(-15, 15),
                          n_ax_segments=500, axons_range=(-180, 180),
                          ax_segments_range=(3, 50))
-    npt.assert_almost_equal(model.spatial.calc_bundle_tangent(0, 0), 0.4819,
+    npt.assert_almost_equal(model.spatial.calc_bundle_tangent(0, 0), -0.4819,
                             decimal=3)
     npt.assert_almost_equal(model.spatial.calc_bundle_tangent(0, 1000),
-                            -0.5514, decimal=3)
+                            -0.268, decimal=3)
     with pytest.raises(TypeError):
         model.spatial.calc_bundle_tangent([0], 1000)
     with pytest.raises(TypeError):
@@ -504,13 +504,13 @@ def test_AxonMapModel_calc_bundle_tangent_fast(engine):
                          xrange=(-20, 20), yrange=(-15, 15),
                          n_ax_segments=500, axons_range=(-180, 180),
                          ax_segments_range=(3, 50))
-    npt.assert_almost_equal(model.spatial.calc_bundle_tangent_fast(0, 0), 0.4819,
+    npt.assert_almost_equal(model.spatial.calc_bundle_tangent_fast(0, 0), -0.4819,
                             decimal=3)
     npt.assert_almost_equal(model.spatial.calc_bundle_tangent_fast(0, 1000),
-                            -0.5514, decimal=3)
+                            -0.268, decimal=3)
     
     npt.assert_almost_equal(model.spatial.calc_bundle_tangent_fast(np.array([0, 0.]), np.array([0, 1000.])),
-                            np.array([0.4819, -0.5514]), decimal=3)
+                            np.array([-0.4819, -0.268]), decimal=3)
 
 
 
@@ -534,9 +534,9 @@ def test_AxonMapModel_predict_percept(engine):
     npt.assert_equal(np.sum(percept.data > 0.8), 1)
     npt.assert_equal(np.sum(percept.data > 0.6), 2)
     npt.assert_equal(np.sum(percept.data > 0.1), 7)
-    npt.assert_equal(np.sum(percept.data > 0.0001), 31)
+    npt.assert_equal(np.sum(percept.data > 0.0001), 32)
     # Overall only a few bright pixels:
-    npt.assert_almost_equal(np.sum(percept.data), 3.3087, decimal=3)
+    npt.assert_almost_equal(np.sum(percept.data), 3.4062, decimal=3)
     # Brightest pixel is in lower right:
     npt.assert_almost_equal(percept.data[33, 46, 0], np.max(percept.data))
     # Top half is empty:

--- a/pulse2percept/models/tests/test_granley2021.py
+++ b/pulse2percept/models/tests/test_granley2021.py
@@ -236,10 +236,10 @@ def test_biphasicAxonMapSpatial(engine):
     implant = ArgusII()
     implant.stim = Stimulus({'A4': BiphasicPulseTrain(20, 1, 1)})
     percept = model.predict_percept(implant)
-    npt.assert_equal(np.sum(percept.data > 0.0813), 70)
-    npt.assert_equal(np.sum(percept.data > 0.1626), 50)
-    npt.assert_equal(np.sum(percept.data > 0.2439), 33)
-    npt.assert_equal(np.sum(percept.data > 0.4065), 16)
+    npt.assert_equal(np.sum(percept.data > 0.0813), 69)
+    npt.assert_equal(np.sum(percept.data > 0.1626), 46)
+    npt.assert_equal(np.sum(percept.data > 0.2439), 32)
+    npt.assert_equal(np.sum(percept.data > 0.4065), 14)
     npt.assert_equal(np.sum(percept.data > 0.5691), 4)
 
 

--- a/pulse2percept/models/tests/test_granley2021.py
+++ b/pulse2percept/models/tests/test_granley2021.py
@@ -237,9 +237,9 @@ def test_biphasicAxonMapSpatial(engine):
     implant.stim = Stimulus({'A4': BiphasicPulseTrain(20, 1, 1)})
     percept = model.predict_percept(implant)
     npt.assert_equal(np.sum(percept.data > 0.0813), 70)
-    npt.assert_equal(np.sum(percept.data > 0.1626), 46)
-    npt.assert_equal(np.sum(percept.data > 0.2439), 32)
-    npt.assert_equal(np.sum(percept.data > 0.4065), 14)
+    npt.assert_equal(np.sum(percept.data > 0.1626), 50)
+    npt.assert_equal(np.sum(percept.data > 0.2439), 33)
+    npt.assert_equal(np.sum(percept.data > 0.4065), 16)
     npt.assert_equal(np.sum(percept.data > 0.5691), 4)
 
 

--- a/pulse2percept/models/tests/test_granley2021.py
+++ b/pulse2percept/models/tests/test_granley2021.py
@@ -236,10 +236,10 @@ def test_biphasicAxonMapSpatial(engine):
     implant = ArgusII()
     implant.stim = Stimulus({'A4': BiphasicPulseTrain(20, 1, 1)})
     percept = model.predict_percept(implant)
-    npt.assert_equal(np.sum(percept.data > 0.0813), 69)
-    npt.assert_equal(np.sum(percept.data > 0.1626), 46)
-    npt.assert_equal(np.sum(percept.data > 0.2439), 32)
-    npt.assert_equal(np.sum(percept.data > 0.4065), 14)
+    npt.assert_equal(np.sum(percept.data > 0.0813), 70)
+    npt.assert_equal(np.sum(percept.data > 0.1626), 50)
+    npt.assert_equal(np.sum(percept.data > 0.2439), 33)
+    npt.assert_equal(np.sum(percept.data > 0.4065), 16)
     npt.assert_equal(np.sum(percept.data > 0.5691), 4)
 
 

--- a/pulse2percept/models/tests/test_granley2021.py
+++ b/pulse2percept/models/tests/test_granley2021.py
@@ -236,7 +236,7 @@ def test_biphasicAxonMapSpatial(engine):
     implant = ArgusII()
     implant.stim = Stimulus({'A4': BiphasicPulseTrain(20, 1, 1)})
     percept = model.predict_percept(implant)
-    npt.assert_equal(np.sum(percept.data > 0.0813), 69)
+    npt.assert_equal(np.sum(percept.data > 0.0813), 70)
     npt.assert_equal(np.sum(percept.data > 0.1626), 46)
     npt.assert_equal(np.sum(percept.data > 0.2439), 32)
     npt.assert_equal(np.sum(percept.data > 0.4065), 14)

--- a/pulse2percept/models/tests/test_nanduri2012.py
+++ b/pulse2percept/models/tests/test_nanduri2012.py
@@ -56,10 +56,10 @@ def test_Nanduri2012Spatial():
     # Nanduri model uses a linear dva_to_ret conversion factor:
     for factor in [0.0, 1.0, 2.0]:
         npt.assert_almost_equal(model.retinotopy.dva_to_ret(factor, factor),
-                                (280.0 * factor, 280.0 * factor))
+                                (280.0 * factor, -280.0 * factor))
     for factor in [0.0, 1.0, 2.0]:
         npt.assert_almost_equal(model.retinotopy.ret_to_dva(280.0 * factor,
-                                                         280.0 * factor),
+                                                         -280.0 * factor),
                                 (factor, factor))
 
 

--- a/pulse2percept/topography/base.py
+++ b/pulse2percept/topography/base.py
@@ -174,7 +174,7 @@ class Grid2D(PrettyPrint):
         self._xflat = np.linspace(*x_range, num=nx, dtype=np.float32)
         ydiff = np.abs(np.diff(y_range))
         ny = int(np.round(ydiff / y_step) + 1) if ydiff != 0 else 1
-        self._yflat = np.linspace(*y_range, num=ny, dtype=np.float32)
+        self._yflat = np.linspace(*y_range, num=ny, dtype=np.float32)[::-1]
         self._grid['dva'] = self.CoordinateGrid(
             *np.meshgrid(self._xflat, self._yflat, indexing='xy'))
         self.shape = self.x.shape

--- a/pulse2percept/topography/base.py
+++ b/pulse2percept/topography/base.py
@@ -174,9 +174,10 @@ class Grid2D(PrettyPrint):
         self._xflat = np.linspace(*x_range, num=nx, dtype=np.float32)
         ydiff = np.abs(np.diff(y_range))
         ny = int(np.round(ydiff / y_step) + 1) if ydiff != 0 else 1
-        self._yflat = np.linspace(*y_range, num=ny, dtype=np.float32)[::-1]
+        self._yflat = np.linspace(*y_range, num=ny, dtype=np.float32)
+        # Create the grid, flip y axis so that it increases from bottom to top:
         self._grid['dva'] = self.CoordinateGrid(
-            *np.meshgrid(self._xflat, self._yflat, indexing='xy'))
+            *np.meshgrid(self._xflat, self._yflat[::-1], indexing='xy'))
         self.shape = self.x.shape
         self.reset()
 

--- a/pulse2percept/topography/base.py
+++ b/pulse2percept/topography/base.py
@@ -50,15 +50,17 @@ class Grid2D(PrettyPrint):
 
     Examples
     --------
-    You can iterate through a grid as if it were a list:
+    You can iterate through a grid as if it were a list.
+    Notice, the grid is indexed in (x, y) order, starting in the upper 
+    left of the grid (following image convention)
 
     >>> grid = Grid2D((0, 1), (2, 3))
     >>> for x, y in grid:
     ...     print(x, y)
-    0.0 2.0
-    1.0 2.0
     0.0 3.0
     1.0 3.0
+    0.0 2.0
+    1.0 2.0
 
     """
 

--- a/pulse2percept/topography/base.py
+++ b/pulse2percept/topography/base.py
@@ -181,6 +181,7 @@ class Grid2D(PrettyPrint):
         self._grid['dva'] = self.CoordinateGrid(
             *np.meshgrid(self._xflat, self._yflat[::-1], indexing='xy'))
         self.shape = self.x.shape
+        self.size = self.x.size
         self.reset()
 
     def _make_hexagonal_grid(self, x_range, y_range, step):

--- a/pulse2percept/topography/retina.py
+++ b/pulse2percept/topography/retina.py
@@ -41,7 +41,7 @@ class Curcio1990Map(RetinalMap):
         Assumes that one degree of visual angle is equal to 280 um on the
         retina [Curcio1990]_.
         """
-        return 280.0 * xdva, 280.0 * ydva
+        return 280.0 * xdva, -280.0 * ydva
 
     def ret_to_dva(self, xret, yret):
         """Convert retinal eccentricity (um) to degrees of visual angle (dva)
@@ -49,7 +49,7 @@ class Curcio1990Map(RetinalMap):
         Assumes that one degree of visual angle is equal to 280 um on the
         retina [Curcio1990]_
         """
-        return xret / 280.0, yret / 280.0
+        return xret / 280.0, -yret / 280.0
 
     def __eq__(self, other):
         """
@@ -101,6 +101,10 @@ class Watson2014Map(RetinalMap):
         r_deg = 3.556 * r_mm + 0.05993 * r_mm ** 2 - 0.007358 * r_mm ** 3
         r_deg += 3.027e-4 * r_mm ** 4
         r_deg *= sign
+
+        # flip y axis
+        phi_um *= -1
+
         if coords.lower() == 'cart':
             return pol2cart(phi_um, r_deg)
         elif coords.lower() == 'polar':
@@ -131,6 +135,10 @@ class Watson2014Map(RetinalMap):
         r_deg = np.abs(r_deg)
         r_mm = 0.268 * r_deg + 3.427e-4 * r_deg ** 2 - 8.3309e-6 * r_deg ** 3
         r_um = 1e3 * r_mm * sign
+
+        # flip y axis
+        phi_deg *= -1
+
         if coords.lower() == 'cart':
             return pol2cart(phi_deg, r_um)
         elif coords.lower() == 'polar':

--- a/pulse2percept/topography/tests/test_base.py
+++ b/pulse2percept/topography/tests/test_base.py
@@ -27,10 +27,10 @@ def test_Grid2D(x_range, y_range):
     npt.assert_almost_equal(grid.x[0, -1], x_range[1])
     npt.assert_almost_equal(grid.x[-1, 0], x_range[0])
     npt.assert_almost_equal(grid.x[-1, -1], x_range[1])
-    npt.assert_almost_equal(grid.y[0, 0], y_range[0])
-    npt.assert_almost_equal(grid.y[0, -1], y_range[0])
-    npt.assert_almost_equal(grid.y[-1, 0], y_range[1])
-    npt.assert_almost_equal(grid.y[-1, -1], y_range[1])
+    npt.assert_almost_equal(grid.y[0, 0], y_range[1])
+    npt.assert_almost_equal(grid.y[0, -1], y_range[1])
+    npt.assert_almost_equal(grid.y[-1, 0], y_range[0])
+    npt.assert_almost_equal(grid.y[-1, -1], y_range[0])
 
 
 def test_Grid2D_make_rectangular_grid():
@@ -43,7 +43,7 @@ def test_Grid2D_make_rectangular_grid():
                       step=5 * mlt)
         npt.assert_almost_equal(grid.x[0], mlt * np.array([-10, -5, 0, 5, 10]))
         npt.assert_almost_equal(grid.y[:, 0],
-                                mlt * np.array([-10, -5, 0, 5, 10]))
+                                mlt * np.array([-10, -5, 0, 5, 10])[::-1])
 
     # Another way to verify this is to manually check the step size:
     for step in [0.25, 0.5, 1, 2]:
@@ -51,7 +51,7 @@ def test_Grid2D_make_rectangular_grid():
         npt.assert_equal(len(np.unique(np.diff(grid.x[0, :]))), 1)
         npt.assert_equal(len(np.unique(np.diff(grid.y[:, 0]))), 1)
         npt.assert_almost_equal(np.unique(np.diff(grid.x[0, :]))[0], step)
-        npt.assert_almost_equal(np.unique(np.diff(grid.y[:, 0]))[0], step)
+        npt.assert_almost_equal(np.unique(np.diff(grid.y[:, 0]))[0], -step)
 
     # Step size just a little too small/big to fit into range. In this case,
     # the step size gets adjusted so that the range is as specified by the
@@ -69,7 +69,7 @@ def test_Grid2D_make_rectangular_grid():
     npt.assert_almost_equal(grid.y, [[0, 0, 0, 0, 0]])
     grid = Grid2D((0, 0), (-1, 1), step=(2, 0.5))
     npt.assert_almost_equal(grid.x, [[0], [0], [0], [0], [0]])
-    npt.assert_almost_equal(grid.y[:, 0], [-1, -0.5, 0, 0.5, 1])
+    npt.assert_almost_equal(grid.y[:, 0], [-1, -0.5, 0, 0.5, 1][::-1])
 
     # Same step size, but given explicitly:
     npt.assert_almost_equal(Grid2D((-3, 3), (8, 12), step=0.123).x,

--- a/pulse2percept/topography/tests/test_retina.py
+++ b/pulse2percept/topography/tests/test_retina.py
@@ -11,10 +11,10 @@ def test_Curcio1990Map():
     # Curcio1990 uses a linear dva_to_ret conversion factor:
     for factor in [0.0, 1.0, 2.0]:
         npt.assert_almost_equal(Curcio1990Map().dva_to_ret(factor, factor),
-                                (280.0 * factor, 280.0 * factor))
+                                (280.0 * factor, -280.0 * factor))
     for factor in [0.0, 1.0, 2.0]:
         npt.assert_almost_equal(Curcio1990Map().ret_to_dva(280.0 * factor,
-                                                      280.0 * factor),
+                                                      -280.0 * factor),
                                 (factor, factor))
 
 
@@ -48,19 +48,19 @@ def test_Watson2014Map():
         trafo.dva_to_ret(0, 0, coords='invalid')
 
     # Below 15mm eccentricity, relationship is linear with slope 3.731
-    npt.assert_equal(trafo.ret_to_dva(0.0, 0.0), (0.0, 0.0))
+    npt.assert_almost_equal(trafo.ret_to_dva(0.0, 0.0), (0.0, 0.0))
     for sign in [-1, 1]:
         for exp in [2, 3, 4]:
             ret = sign * 10 ** exp  # mm
-            dva = 3.731 * sign * 10 ** (exp - 3)  # dva
+            dva = -3.731 * sign * 10 ** (exp - 3)  # dva
             npt.assert_almost_equal(trafo.ret_to_dva(0, ret)[1], dva,
                                     decimal=3 - exp)  # adjust precision
     # Below 50deg eccentricity, relationship is linear with slope 0.268
-    npt.assert_equal(trafo.dva_to_ret(0.0, 0.0), (0.0, 0.0))
+    npt.assert_almost_equal(trafo.dva_to_ret(0.0, 0.0), (0.0, 0.0))
     for sign in [-1, 1]:
         for exp in [-2, -1, 0]:
             dva = sign * 10 ** exp  # deg
-            ret = 0.268 * sign * 10 ** (exp + 3)  # mm
+            ret = -0.268 * sign * 10 ** (exp + 3)  # mm
             npt.assert_almost_equal(trafo.dva_to_ret(0, dva)[1], ret,
                                     decimal=-exp)  # adjust precision
 


### PR DESCRIPTION
## Description
### The issue

This issue originated from a bug report (#559 ) showing `AxonMapModel` axons not plotting correctly for `use_dva`:
```
model = p2p.models.AxonMapModel(
    loc_od=(10.5, 4.5),
    xrange=(-15, 5),  # dva
    yrange=(-2, 10),  # dva
    xystep=0.25,)

model.build()

fig, axs = plt.subplots(1,2)
model.plot(use_dva=False, ax=axs[0])
model.plot(use_dva=True, ax=axs[1])
fig.set_constrained_layout(True)
```
![image](https://github.com/pulse2percept/pulse2percept/assets/25232557/16d06ffa-01e1-447c-8b87-669a24bf325b)

However, the following issues with the plot revealed some deeper implementation details and a AxonMapModel bug

- The plotted simulated grid (y from [-2, 10]) is correct ONLY in dva, and is not correct in the retinal plot.
- The optic disc location (y_od = 4.5) is ONLY correct in dva, and not correct in the retinal plot.
- The axon locations look correct in the retinal plot, but only because the optic disc location is wrong. Really, the optic disc should be in the lower half in the retinal plot. Thus, the axons should be coming out of the optic disc, and are incorrect in BOTH plots.

The simulated grid is a plotting bug, but the OD location and axon trajectories appear to be flipped everywhere.

This all stems from one small implementation detail: Currently, dva2ret does NOT flip the y coordinate. 
`AxonMapModel().build().retinotopy.dva2ret(0, 5)` gives `(8.251217855283856e-14, 1347.5261375)`.
The formulas from Watson2014 and Curcio do not include the top/bottom hemisphere flip. 

Percepts always showed up in the correct hemisphere despite this. However, the model's aren't flipping the image vertically either. Instead, they rely on the fact that Grid2D's internal grid representation is inherently flipped
![image](https://github.com/pulse2percept/pulse2percept/assets/25232557/962c0763-ac1c-451a-aa21-3601ca6fd5a6)

Notice the `[0, 0]` entry, corresponding to the upper left pixel in the output image, has y (dva) coordinate of -15, and also a negative retinal coordinate.

**All retinal models currently implicitly rely on this assumption: that `model.grid` is storing 2 reversed versions of the grid (dva and ret).** 

However, this creates issues when models call `dva2ret` themselves. For example, the AxonMapModel calls this to calculate the location of the optic disc in retinal coordinates (from the VF coordinates passed in the constructor). But the vertical flip never happens because of this.

As a result, it seems that the axon map model has been using inverted axons (e.g. the axon used is the axon across the raphe from the point, not the nearest one)
However, since the axon map is _almost_ symmetric, this doesn't actually produce that different of results, especially if the optic disc is near 0. 


### Proposed Fix
The Grid2D representations being reversed does not generalize well to cortical models, where the cortical representation is not necessarily always inverted from the visual field representation (e.g. v2), and makes implementing retinal models difficult for anyone that doesn't know this feature of `ret2dva`.

This pull request does 4 things:

1. Changes all retinotopy objects to include the flip (if present) in y coordinate between visual field and anatomical coordinates. This way, the retinotopy fully specifies the transform, and models do not have to rely on other knowledge to perform correctly.
2. Reverses the y DVA representation so that the [0, 0] location of `grid.dva.y` actually corresponds to the [0, 0] pixel in the output percept, and to the [0, 0] coordinate in every other grid region present (e.g. ret, v1)
3. Fix various functions that relied on the `Grid2D` representation being reversed (e.g. `percept.space`, `AxonMapModel.plot()`)
4. **Breaking**: Fix the optic disc location in `AxonMapModel` to be flipped from the visual field location (plus update various tests)

### Screenshots showing some behavior after the change:
The original plotting error is fixed:
![image](https://github.com/pulse2percept/pulse2percept/assets/25232557/0b878aec-ee98-4587-a889-7f3df0cb2242)

Cortical and retinal models have the correct inverted retinotopy representation:
```
model = p2p.models.AxonMapModel()
model.build()
implant = p2p.implants.ArgusII(stim={'A4' : 5})
fig, axs = plt.subplots(1,2, figsize=(10, 5))
implant.plot(annotate=True, ax=axs[0])
model.plot(ax=axs[0])
model.predict_percept(implant).plot(ax=axs[1])
```
![image](https://github.com/pulse2percept/pulse2percept/assets/25232557/fbde797d-b001-48df-a14e-549c27c94181)

```
model = p2p.models.cortex.ScoreboardModel(xrange=(-5, 0), yrange=(-3, 3), rho=400).build()
implant = p2p.implants.cortex.Orion(x=25000, y=0, rot=0, stim={ '94' :5})
fig, axs = plt.subplots(1,2, figsize=(10, 5))
implant.plot(annotate=True, ax=axs[0])
model.plot(ax=axs[0])
model.predict_percept(implant).plot(ax=axs[1])
```
![image](https://github.com/pulse2percept/pulse2percept/assets/25232557/e5cac3f5-cbd8-4f7f-8faa-46fa2ce25fc5)





## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
