### PR TITLE
[DOC] Update readthedocs.yml

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,21 +1,37 @@
-# .readthedocs.yml
-# Read the Docs configuration file
+# Read the Docs configuration file for Sphinx projects
 # See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
 
 # Required
 version: 2
 
-# Build documentation in the doc/ directory with Sphinx
+# Set the OS, Python version and other tools you might need
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.10"
+    # You can also specify other tool versions:
+    # nodejs: "20"
+    # rust: "1.70"
+    # golang: "1.20"
+
+# Build documentation in the "docs/" directory with Sphinx
 sphinx:
-  builder: html
-  configuration: doc/conf.py
+  configuration: docs/conf.py
+  # You can configure Sphinx to use a different builder, for instance use the dirhtml builder for simpler URLs
+  # builder: "dirhtml"
+  # Fail on all warnings to avoid broken references
+  # fail_on_warning: true
 
 # Optionally build your docs in additional formats such as PDF and ePub
-formats: []
+# formats:
+#   - pdf
+#   - epub
 
-# Optionally set the version of Python and requirements required to build your docs
+# Optional but recommended, declare the Python requirements required
+# to build your documentation
+# See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
 python:
-   version: 3.7
+   version: 3.10
    install:
       - requirements: requirements.txt
       - requirements: doc/requirements.txt

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -31,7 +31,6 @@ sphinx:
 # to build your documentation
 # See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
 python:
-   version: 3.10
    install:
       - requirements: requirements.txt
       - requirements: doc/requirements.txt


### PR DESCRIPTION
readthedocs.yml is out of date. Build currently fails because the build.os option is not set. Also bump to use python 3.10 for docs
