### PR TITLE
[FIX][MNT] Fix cortex packages not importing as expected

### DIFF
--- a/pulse2percept/implants/__init__.py
+++ b/pulse2percept/implants/__init__.py
@@ -30,6 +30,7 @@ from .bvt import BVT24, BVT44
 from .prima import PhotovoltaicPixel, PRIMA, PRIMA75, PRIMA55, PRIMA40
 from .imie import IMIE
 from .ensemble import EnsembleImplant
+from . import cortex
 
 __all__ = [
     'AlphaAMS',

--- a/pulse2percept/models/__init__.py
+++ b/pulse2percept/models/__init__.py
@@ -32,6 +32,8 @@ from .nanduri2012 import (Nanduri2012Model, Nanduri2012Spatial,
 from .granley2021 import BiphasicAxonMapModel, BiphasicAxonMapSpatial
 from .thompson2003 import Thompson2003Model, Thompson2003Spatial
 
+from . import cortex
+
 __all__ = [
     'AxonMapModel',
     'AxonMapSpatial',


### PR DESCRIPTION
## Description

Looks like after updating `setup.py`, including cortex subpackages in the parent's `__init__.py` no longer causes a circular import error.

<img width="688" alt="image" src="https://github.com/pulse2percept/pulse2percept/assets/20908336/befef976-814f-4910-98d0-ea5423537fe9">

Cortex packages now import as expected.

Closes #581 

## Type of Change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes