### PR TITLE
[DOC][FIX] Fix docs, remove calls to slow _fast_math cython functions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,6 +53,7 @@ jobs:
       if: matrix.os != 'windows-latest'
       run: |
         pip install -e .
+        echo |cpp -fopenmp -dM |grep -i open
     - name: Run test suite with pytest
       run: |
         mkdir test_dir

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,7 +62,7 @@ jobs:
       run: |
         mkdir test_dir
         cd test_dir
-        pytest --pyargs pulse2percept -s --cov-report=xml --cov=pulse2percept --doctest-modules
+        pytest --pyargs pulse2percept --cov-report=xml --cov=pulse2percept --doctest-modules
     - name: Upload coveragei report to codecov.io
       uses: codecov/codecov-action@v1
       # Cannot yet post coverage report as comments on the PR, but see:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,7 +59,7 @@ jobs:
         cd test_dir
         pip freeze
         gcc --version
-        pytest --pyargs pulse2percept --cov-report=xml --cov=pulse2percept --doctest-modules
+        pytest --pyargs pulse2percept -s --cov-report=xml --cov=pulse2percept --doctest-modules
     - name: Upload coveragei report to codecov.io
       uses: codecov/codecov-action@v1
       # Cannot yet post coverage report as comments on the PR, but see:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,6 +57,7 @@ jobs:
       run: |
         mkdir test_dir
         cd test_dir
+        pip freeze
         pytest --pyargs pulse2percept --cov-report=xml --cov=pulse2percept --doctest-modules
     - name: Upload coveragei report to codecov.io
       uses: codecov/codecov-action@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,12 +53,15 @@ jobs:
       if: matrix.os != 'windows-latest'
       run: |
         pip install -e .
+    - name: Log environment info
+      run: |
+        python --version
+        pip freeze
+        gcc --version
     - name: Run test suite with pytest
       run: |
         mkdir test_dir
         cd test_dir
-        pip freeze
-        gcc --version
         pytest --pyargs pulse2percept -s --cov-report=xml --cov=pulse2percept --doctest-modules
     - name: Upload coveragei report to codecov.io
       uses: codecov/codecov-action@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,7 +53,6 @@ jobs:
       if: matrix.os != 'windows-latest'
       run: |
         pip install -e .
-        echo |cpp -fopenmp -dM |grep -i open
     - name: Run test suite with pytest
       run: |
         mkdir test_dir

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,6 +58,7 @@ jobs:
         mkdir test_dir
         cd test_dir
         pip freeze
+        gcc --version
         pytest --pyargs pulse2percept --cov-report=xml --cov=pulse2percept --doctest-modules
     - name: Upload coveragei report to codecov.io
       uses: codecov/codecov-action@v1

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -11,6 +11,11 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
+# Hack collections import (in 3.10, collections.callable moved to collections.abc.Callable, 
+# but our super old sphinx still uses the old import)
+import collections
+collections.Callable = collections.abc.Callable
+
 import sphinx_gallery
 from sphinx_gallery.sorting import ExplicitOrder
 import sphinx_rtd_theme

--- a/examples/datasets/plot_data_nanduri2012.py
+++ b/examples/datasets/plot_data_nanduri2012.py
@@ -124,7 +124,7 @@ plt.title('Amplitude Modulation Brightness')
 
 ###############################################################################
 # Using Built-In Plotting Functionality
-# -----------------
+# -------------------------------------
 #
 # Arguably the most important column is "freq". This is the current
 # amplitude of the different stimuli (single pulse, pulse trains, etc.) used

--- a/examples/implants/plot_implants.py
+++ b/examples/implants/plot_implants.py
@@ -154,7 +154,7 @@ ax[1].set_title('Alpha-AMS')
 # ------------------------------------------------------------------
 #
 # :py:class:`~pulse2percept.implants.IMIE` is an epiretinal implant co-developed
-#  by Golden Eye Bionic, LLC (Pasadena CA) and IntelliMicro Medical Co., Ltd. 
+# by Golden Eye Bionic, LLC (Pasadena CA) and IntelliMicro Medical Co., Ltd. 
 # (Changsha, Hunan Province, China) and is manufactured by IntelliMicro. 
 #
 # IMIE consists of 248 large disc-shaped electrodes (210 µm in diameter) and 8 

--- a/examples/stimuli/plot_image_stim.py
+++ b/examples/stimuli/plot_image_stim.py
@@ -96,209 +96,209 @@ print(logo)
 # We can perform both actions in one line, and plot the result side-by-side
 # with the original image:
 
-# logo_gray = logo.invert().rgb2gray()
+logo_gray = logo.invert().rgb2gray()
 
-# import matplotlib.pyplot as plt
-# fig, (ax1, ax2) = plt.subplots(ncols=2, figsize=(8, 4))
-# logo.plot(ax=ax1)
-# logo_gray.plot(ax=ax2)
+import matplotlib.pyplot as plt
+fig, (ax1, ax2) = plt.subplots(ncols=2, figsize=(8, 4))
+logo.plot(ax=ax1)
+logo_gray.plot(ax=ax2)
 
-# ##############################################################################
-# # As demonstrated above, multiple image processing steps can be performed in
-# # one line. This is possible because each method returns a copy of the
-# # processed image (without altering the original).
-# #
-# # The following example takes the grayscale logo, shrinks it to 75% of its
-# # original size, rotates it by 30 degrees (counter-clockwise), and trims the
-# # black border around the image:
+##############################################################################
+# As demonstrated above, multiple image processing steps can be performed in
+# one line. This is possible because each method returns a copy of the
+# processed image (without altering the original).
+#
+# The following example takes the grayscale logo, shrinks it to 75% of its
+# original size, rotates it by 30 degrees (counter-clockwise), and trims the
+# black border around the image:
 
-# logo_gray.scale(0.75).rotate(30).trim().plot()
+logo_gray.scale(0.75).rotate(30).trim().plot()
 
-# ##############################################################################
-# # As mentioned in the introduction above, the
-# # :py:meth:`~pulse2percept.stimuli.ImageStimulus.filter` method provides
-# # a number of popular techniques to extract edges from the image, such as:
-# #
-# # -  ``'sobel'`` to extract edges using the `Sobel operator
-# #    <https://scikit-image.org/docs/stable/api/skimage.filters.html#skimage.filters.sobel>`_,
-# # -  ``'scharr'`` to extract edges using the `Scharr operator
-# #    <https://scikit-image.org/docs/stable/api/skimage.filters.html#skimage.filters.scharr>`_,
-# #    and
-# # -  ``'canny'`` to extract edges using the `Canny algorithm
-# #    <https://scikit-image.org/docs/stable/api/skimage.feature.html#skimage.feature.canny>`_.
-# #
-# # Additional parameters (e.g., the standard deviation of the Gaussian filter
-# # for the Canny algorithm) can be passed as keyword arguments (e.g.,
-# # ``filter('canny', sigma=3)``).
-# #
-# # For example, we can use the Scharr operator as follows:
+##############################################################################
+# As mentioned in the introduction above, the
+# :py:meth:`~pulse2percept.stimuli.ImageStimulus.filter` method provides
+# a number of popular techniques to extract edges from the image, such as:
+#
+# -  ``'sobel'`` to extract edges using the `Sobel operator
+#    <https://scikit-image.org/docs/stable/api/skimage.filters.html#skimage.filters.sobel>`_,
+# -  ``'scharr'`` to extract edges using the `Scharr operator
+#    <https://scikit-image.org/docs/stable/api/skimage.filters.html#skimage.filters.scharr>`_,
+#    and
+# -  ``'canny'`` to extract edges using the `Canny algorithm
+#    <https://scikit-image.org/docs/stable/api/skimage.feature.html#skimage.feature.canny>`_.
+#
+# Additional parameters (e.g., the standard deviation of the Gaussian filter
+# for the Canny algorithm) can be passed as keyword arguments (e.g.,
+# ``filter('canny', sigma=3)``).
+#
+# For example, we can use the Scharr operator as follows:
 
-# logo_edge = logo_gray.filter('scharr')
+logo_edge = logo_gray.filter('scharr')
 
-# ##############################################################################
-# # If more advanced image processing methods are required, we can use the
-# # :py:meth:`~pulse2percept.stimuli.ImageStimulus.apply` method to apply
-# # literally any function to the image. The only requirement is that the
-# # function return an image of the same size.
-# #
-# # For example, we can thicken the edges in the image by using a morphological
-# # operator (i.e., dilation) provided by
-# # `scikit-image <https://scikit-image.org>`_:
+##############################################################################
+# If more advanced image processing methods are required, we can use the
+# :py:meth:`~pulse2percept.stimuli.ImageStimulus.apply` method to apply
+# literally any function to the image. The only requirement is that the
+# function return an image of the same size.
+#
+# For example, we can thicken the edges in the image by using a morphological
+# operator (i.e., dilation) provided by
+# `scikit-image <https://scikit-image.org>`_:
 
-# from skimage.morphology import dilation
-# logo_dilate = logo_edge.apply(dilation)
+from skimage.morphology import dilation
+logo_dilate = logo_edge.apply(dilation)
 
-# fig, (ax1, ax2) = plt.subplots(ncols=2, figsize=(8, 4))
-# # Edges extracted with the Scharr operator:
-# logo_edge.plot(ax=ax1)
-# # Edges thickened with dilation:
-# logo_dilate.plot(ax=ax2)
+fig, (ax1, ax2) = plt.subplots(ncols=2, figsize=(8, 4))
+# Edges extracted with the Scharr operator:
+logo_edge.plot(ax=ax1)
+# Edges thickened with dilation:
+logo_dilate.plot(ax=ax2)
 
-# ##############################################################################
-# # We can also save the processed stimulus as an image:
+##############################################################################
+# We can also save the processed stimulus as an image:
 
-# logo_dilate.save('dilated_logo.png')
+logo_dilate.save('dilated_logo.png')
 
-# ##############################################################################
-# # Using the image as input to a retinal implant
-# # ---------------------------------------------
-# #
-# # :py:class:`~pulse2percept.stimuli.ImageStimulus` can be used in
-# # combination with any :py:meth:`~pulse2percept.implants.ProsthesisSystem`.
-# # We just have to resize the image first so that the number of pixels in the
-# # image matches the number of electrodes in the implant.
-# #
-# # But let's start from the top. The first two steps are to create a model and
-# # choose an implant:
+##############################################################################
+# Using the image as input to a retinal implant
+# ---------------------------------------------
+#
+# :py:class:`~pulse2percept.stimuli.ImageStimulus` can be used in
+# combination with any :py:meth:`~pulse2percept.implants.ProsthesisSystem`.
+# We just have to resize the image first so that the number of pixels in the
+# image matches the number of electrodes in the implant.
+#
+# But let's start from the top. The first two steps are to create a model and
+# choose an implant:
 
-# # Simulate only what we need (14x14 deg sampled at 0.1 deg):
-# model = p2p.models.ScoreboardModel(xrange=(-7, 7), yrange=(-7, 7), xystep=0.1)
-# model.build()
+# Simulate only what we need (14x14 deg sampled at 0.1 deg):
+model = p2p.models.ScoreboardModel(xrange=(-7, 7), yrange=(-7, 7), xystep=0.1)
+model.build()
 
-# from pulse2percept.implants import AlphaAMS
-# implant = AlphaAMS()
+from pulse2percept.implants import AlphaAMS
+implant = AlphaAMS()
 
-# # Show the visual field we're simulating (dashed lines) atop the implant:
-# model.plot()
-# implant.plot()
+# Show the visual field we're simulating (dashed lines) atop the implant:
+model.plot()
+implant.plot()
 
-# ##############################################################################
-# # Since :py:class:`~pulse2percept.implants.AlphaAMS` is a 2D electrode grid,
-# # all we need to do is downscale the image to the size of the grid:
+##############################################################################
+# Since :py:class:`~pulse2percept.implants.AlphaAMS` is a 2D electrode grid,
+# all we need to do is downscale the image to the size of the grid:
 
-# implant.stim = logo_gray.resize(implant.shape)
+implant.stim = logo_gray.resize(implant.shape)
 
-# ##############################################################################
-# # This way, the pixels of the image will be assigned to the electrodes in
-# # row-by-row order (i.e., we don't need to specify the actual electrode names).
-# #
-# # .. note ::
-# #
-# #    If the implant is not a proper 2D grid, you will have to manually specify
-# #    the input to each electrode.
-# #
-# #    In the near future, this will be done automatically using an implant's
-# #    ``preprocess`` method.
-# #
-# # Then the implant can be passed to the model's
-# # :py:meth:`~pulse2percept.models.ScoreboardModel.predict_percept` method:
+##############################################################################
+# This way, the pixels of the image will be assigned to the electrodes in
+# row-by-row order (i.e., we don't need to specify the actual electrode names).
+#
+# .. note ::
+#
+#    If the implant is not a proper 2D grid, you will have to manually specify
+#    the input to each electrode.
+#
+#    In the near future, this will be done automatically using an implant's
+#    ``preprocess`` method.
+#
+# Then the implant can be passed to the model's
+# :py:meth:`~pulse2percept.models.ScoreboardModel.predict_percept` method:
 
-# percept_gray = model.predict_percept(implant)
+percept_gray = model.predict_percept(implant)
 
-# ##############################################################################
-# # .. note ::
-# #
-# #     Because neither :py:class:`~pulse2percept.stimuli.ImageStimulus` nor
-# #     :py:class:`~pulse2percept.models.ScoreboardModel` can handle time, the
-# #     resulting percept will consist of a single image/frame.
-# #
-# # To see what difference our image preprocessing makes on the quality of the
-# # resulting percept, we can re-run the model on ``logo_dilate`` and plot the
-# # two percepts side-by-side:
+##############################################################################
+# .. note ::
+#
+#     Because neither :py:class:`~pulse2percept.stimuli.ImageStimulus` nor
+#     :py:class:`~pulse2percept.models.ScoreboardModel` can handle time, the
+#     resulting percept will consist of a single image/frame.
+#
+# To see what difference our image preprocessing makes on the quality of the
+# resulting percept, we can re-run the model on ``logo_dilate`` and plot the
+# two percepts side-by-side:
 
-# implant.stim = logo_dilate.trim().resize(implant.shape)
-# percept_dilate = model.predict_percept(implant)
+implant.stim = logo_dilate.trim().resize(implant.shape)
+percept_dilate = model.predict_percept(implant)
 
-# fig, (ax1, ax2) = plt.subplots(ncols=2, figsize=(10, 4))
-# percept_gray.plot(ax=ax1)
-# percept_dilate.plot(ax=ax2)
+fig, (ax1, ax2) = plt.subplots(ncols=2, figsize=(10, 4))
+percept_gray.plot(ax=ax1)
+percept_dilate.plot(ax=ax2)
 
-# ##############################################################################
-# # Converting the image to a series of electrical pulses
-# # -----------------------------------------------------
-# #
-# # :py:class:`~pulse2percept.stimuli.ImageStimulus` has an
-# # :py:meth:`~pulse2percept.stimuli.ImageStimulus.encode` method
-# # to convert an image into a series of pulse trains (i.e., into electrical
-# # stimuli with a time component).
-# #
-# # By default, the ``encode`` method will interpret the gray level of a pixel as
-# # the current amplitude of a :py:class:`~pulse2percept.stimuli.BiphasicPulse`
-# # with 0.46ms phase duration (500ms total stimulus duration). Gray levels in
-# # the range [0, 1] will be mapped onto currents in the range [0, 50] uA:
+##############################################################################
+# Converting the image to a series of electrical pulses
+# ---------------------------------------------------
+#
+# :py:class:`~pulse2percept.stimuli.ImageStimulus` has an
+# :py:meth:`~pulse2percept.stimuli.ImageStimulus.encode` method
+# to convert an image into a series of pulse trains (i.e., into electrical
+# stimuli with a time component).
+#
+# By default, the ``encode`` method will interpret the gray level of a pixel as
+# the current amplitude of a :py:class:`~pulse2percept.stimuli.BiphasicPulse`
+# with 0.46ms phase duration (500ms total stimulus duration). Gray levels in
+# the range [0, 1] will be mapped onto currents in the range [0, 50] uA:
 
-# implant.stim = logo_dilate.trim().resize(implant.shape).encode()
+implant.stim = logo_dilate.trim().resize(implant.shape).encode()
 
-# ##############################################################################
-# # We can customize the range of amplitudes to be used by passing a keyword
-# # argument; e.g. ``amp_range=(0, 20)`` to use currents in [0, 20] uA.
-# #
-# # We can also specify our own pulse / pulse train to be used. First, we need to
-# # create the pulse we want to use (use amplitude 1 uA). Then, we need to pass
-# # it as an additional keyword argument; e.g.,
-# # ``pulse=BiphasicPulseTrain(10, 1, 0.2, stim_dur=200)`` to use a 10Hz
-# # biphasic pulse train (0.2ms phase duration, overall duration 200 ms).
-# #
-# # Using the image as input to a spatiotemporal model
-# # ---------------------------------------------------
-# #
-# # Now, if we passed the new stimulus to
-# # :py:class:`~pulse2percept.models.ScoreboardModel`, it would simply apply the
-# # model (in space) to every time point in the stimulus.
-# # To get a proper temporal response, we need to extend the scoreboard model
-# # with a proper temporal model, such as
-# # :py:class:`~pulse2percept.models.Horsager2009Temporal`:
+##############################################################################
+# We can customize the range of amplitudes to be used by passing a keyword
+# argument; e.g. ``amp_range=(0, 20)`` to use currents in [0, 20] uA.
+#
+# We can also specify our own pulse / pulse train to be used. First, we need to
+# create the pulse we want to use (use amplitude 1 uA). Then, we need to pass
+# it as an additional keyword argument; e.g.,
+# ``pulse=BiphasicPulseTrain(10, 1, 0.2, stim_dur=200)`` to use a 10Hz
+# biphasic pulse train (0.2ms phase duration, overall duration 200 ms).
+#
+# Using the image as input to a spatiotemporal model
+# ---------------------------------------------------
+#
+# Now, if we passed the new stimulus to
+# :py:class:`~pulse2percept.models.ScoreboardModel`, it would simply apply the
+# model (in space) to every time point in the stimulus.
+# To get a proper temporal response, we need to extend the scoreboard model
+# with a proper temporal model, such as
+# :py:class:`~pulse2percept.models.Horsager2009Temporal`:
 
-# model = p2p.models.Model(spatial=p2p.models.ScoreboardSpatial,
-#                          temporal=p2p.models.Horsager2009Temporal)
+model = p2p.models.Model(spatial=p2p.models.ScoreboardSpatial,
+                         temporal=p2p.models.Horsager2009Temporal)
 
-# ##############################################################################
-# # .. note::
-# #
-# #    You can combine any spatial model (names ending in **Spatial**) with any
-# #    temporal model (names ending in **Temporal**).
-# #
-# # To make the model focus on the same visual field as above, we set ``xrange``,
-# # ``yrange``, and choose a proper ``xystep``.
-# #
-# # The ``rho`` parameter of the scoreboard model controls how much blur we get
-# # in the resulting percept. The value of this parameter should be set
-# # empirically to match the quality of the vision reported behaviorally by each
-# # implant user.
-# # For the purpose of this tutorial, we will set it to 50um:
+##############################################################################
+# .. note::
+#
+#    You can combine any spatial model (names ending in **Spatial**) with any
+#    temporal model (names ending in **Temporal**).
+#
+# To make the model focus on the same visual field as above, we set ``xrange``,
+# ``yrange``, and choose a proper ``xystep``.
+#
+# The ``rho`` parameter of the scoreboard model controls how much blur we get
+# in the resulting percept. The value of this parameter should be set
+# empirically to match the quality of the vision reported behaviorally by each
+# implant user.
+# For the purpose of this tutorial, we will set it to 50um:
 
-# model.build(xrange=(-7, 7), yrange=(-7, 7), xystep=0.1, rho=50)
+model.build(xrange=(-7, 7), yrange=(-7, 7), xystep=0.1, rho=50)
 
-# ##############################################################################
-# # The predicted percept will now be a movie, where the spatial response (i.e.,
-# # each frame of the movie) is primarily determined by the scoreboard model, but
-# # the temporal evolution of these frames is determined by the Horsager model.
-# #
-# # By default, the model will output a movie frame every 20 ms (corresponding to
-# # a 50 Hz frame rate). The frame rate can be adjusted by passing a list of
-# # time points to :py:meth:`~pulse2percept.Model.predict_percept` (e.g.,
-# # ``t_percept=np.arange(500)`` to get an output every millisecond):
+##############################################################################
+# The predicted percept will now be a movie, where the spatial response (i.e.,
+# each frame of the movie) is primarily determined by the scoreboard model, but
+# the temporal evolution of these frames is determined by the Horsager model.
+#
+# By default, the model will output a movie frame every 20 ms (corresponding to
+# a 50 Hz frame rate). The frame rate can be adjusted by passing a list of
+# time points to :py:meth:`~pulse2percept.Model.predict_percept` (e.g.,
+# ``t_percept=np.arange(500)`` to get an output every millisecond):
 
-# percept = model.predict_percept(implant)
+percept = model.predict_percept(implant)
 
-# ##############################################################################
-# # The output of the model is a :py:class:`~pulse2percept.percepts.Percept`
-# # object, which can be animated in IPython or Jupyter Notebook using the
-# # :py:meth:`~pulse2percept.percepts.Percept.play` method:
+##############################################################################
+# The output of the model is a :py:class:`~pulse2percept.percepts.Percept`
+# object, which can be animated in IPython or Jupyter Notebook using the
+# :py:meth:`~pulse2percept.percepts.Percept.play` method:
 
-# percept.play()
+percept.play()
 
-# ##############################################################################
-# # You can also save the percept as a movie:
+##############################################################################
+# You can also save the percept as a movie:
 
-# percept.save('logo_percept.mp4')
+percept.save('logo_percept.mp4')

--- a/examples/stimuli/plot_image_stim.py
+++ b/examples/stimuli/plot_image_stim.py
@@ -96,209 +96,209 @@ print(logo)
 # We can perform both actions in one line, and plot the result side-by-side
 # with the original image:
 
-logo_gray = logo.invert().rgb2gray()
+# logo_gray = logo.invert().rgb2gray()
 
-import matplotlib.pyplot as plt
-fig, (ax1, ax2) = plt.subplots(ncols=2, figsize=(8, 4))
-logo.plot(ax=ax1)
-logo_gray.plot(ax=ax2)
+# import matplotlib.pyplot as plt
+# fig, (ax1, ax2) = plt.subplots(ncols=2, figsize=(8, 4))
+# logo.plot(ax=ax1)
+# logo_gray.plot(ax=ax2)
 
-##############################################################################
-# As demonstrated above, multiple image processing steps can be performed in
-# one line. This is possible because each method returns a copy of the
-# processed image (without altering the original).
-#
-# The following example takes the grayscale logo, shrinks it to 75% of its
-# original size, rotates it by 30 degrees (counter-clockwise), and trims the
-# black border around the image:
+# ##############################################################################
+# # As demonstrated above, multiple image processing steps can be performed in
+# # one line. This is possible because each method returns a copy of the
+# # processed image (without altering the original).
+# #
+# # The following example takes the grayscale logo, shrinks it to 75% of its
+# # original size, rotates it by 30 degrees (counter-clockwise), and trims the
+# # black border around the image:
 
-logo_gray.scale(0.75).rotate(30).trim().plot()
+# logo_gray.scale(0.75).rotate(30).trim().plot()
 
-##############################################################################
-# As mentioned in the introduction above, the
-# :py:meth:`~pulse2percept.stimuli.ImageStimulus.filter` method provides
-# a number of popular techniques to extract edges from the image, such as:
-#
-# -  ``'sobel'`` to extract edges using the `Sobel operator
-#    <https://scikit-image.org/docs/stable/api/skimage.filters.html#skimage.filters.sobel>`_,
-# -  ``'scharr'`` to extract edges using the `Scharr operator
-#    <https://scikit-image.org/docs/stable/api/skimage.filters.html#skimage.filters.scharr>`_,
-#    and
-# -  ``'canny'`` to extract edges using the `Canny algorithm
-#    <https://scikit-image.org/docs/stable/api/skimage.feature.html#skimage.feature.canny>`_.
-#
-# Additional parameters (e.g., the standard deviation of the Gaussian filter
-# for the Canny algorithm) can be passed as keyword arguments (e.g.,
-# ``filter('canny', sigma=3)``).
-#
-# For example, we can use the Scharr operator as follows:
+# ##############################################################################
+# # As mentioned in the introduction above, the
+# # :py:meth:`~pulse2percept.stimuli.ImageStimulus.filter` method provides
+# # a number of popular techniques to extract edges from the image, such as:
+# #
+# # -  ``'sobel'`` to extract edges using the `Sobel operator
+# #    <https://scikit-image.org/docs/stable/api/skimage.filters.html#skimage.filters.sobel>`_,
+# # -  ``'scharr'`` to extract edges using the `Scharr operator
+# #    <https://scikit-image.org/docs/stable/api/skimage.filters.html#skimage.filters.scharr>`_,
+# #    and
+# # -  ``'canny'`` to extract edges using the `Canny algorithm
+# #    <https://scikit-image.org/docs/stable/api/skimage.feature.html#skimage.feature.canny>`_.
+# #
+# # Additional parameters (e.g., the standard deviation of the Gaussian filter
+# # for the Canny algorithm) can be passed as keyword arguments (e.g.,
+# # ``filter('canny', sigma=3)``).
+# #
+# # For example, we can use the Scharr operator as follows:
 
-logo_edge = logo_gray.filter('scharr')
+# logo_edge = logo_gray.filter('scharr')
 
-##############################################################################
-# If more advanced image processing methods are required, we can use the
-# :py:meth:`~pulse2percept.stimuli.ImageStimulus.apply` method to apply
-# literally any function to the image. The only requirement is that the
-# function return an image of the same size.
-#
-# For example, we can thicken the edges in the image by using a morphological
-# operator (i.e., dilation) provided by
-# `scikit-image <https://scikit-image.org>`_:
+# ##############################################################################
+# # If more advanced image processing methods are required, we can use the
+# # :py:meth:`~pulse2percept.stimuli.ImageStimulus.apply` method to apply
+# # literally any function to the image. The only requirement is that the
+# # function return an image of the same size.
+# #
+# # For example, we can thicken the edges in the image by using a morphological
+# # operator (i.e., dilation) provided by
+# # `scikit-image <https://scikit-image.org>`_:
 
-from skimage.morphology import dilation
-logo_dilate = logo_edge.apply(dilation)
+# from skimage.morphology import dilation
+# logo_dilate = logo_edge.apply(dilation)
 
-fig, (ax1, ax2) = plt.subplots(ncols=2, figsize=(8, 4))
-# Edges extracted with the Scharr operator:
-logo_edge.plot(ax=ax1)
-# Edges thickened with dilation:
-logo_dilate.plot(ax=ax2)
+# fig, (ax1, ax2) = plt.subplots(ncols=2, figsize=(8, 4))
+# # Edges extracted with the Scharr operator:
+# logo_edge.plot(ax=ax1)
+# # Edges thickened with dilation:
+# logo_dilate.plot(ax=ax2)
 
-##############################################################################
-# We can also save the processed stimulus as an image:
+# ##############################################################################
+# # We can also save the processed stimulus as an image:
 
-logo_dilate.save('dilated_logo.png')
+# logo_dilate.save('dilated_logo.png')
 
-##############################################################################
-# Using the image as input to a retinal implant
-# ---------------------------------------------
-#
-# :py:class:`~pulse2percept.stimuli.ImageStimulus` can be used in
-# combination with any :py:meth:`~pulse2percept.implants.ProsthesisSystem`.
-# We just have to resize the image first so that the number of pixels in the
-# image matches the number of electrodes in the implant.
-#
-# But let's start from the top. The first two steps are to create a model and
-# choose an implant:
+# ##############################################################################
+# # Using the image as input to a retinal implant
+# # ---------------------------------------------
+# #
+# # :py:class:`~pulse2percept.stimuli.ImageStimulus` can be used in
+# # combination with any :py:meth:`~pulse2percept.implants.ProsthesisSystem`.
+# # We just have to resize the image first so that the number of pixels in the
+# # image matches the number of electrodes in the implant.
+# #
+# # But let's start from the top. The first two steps are to create a model and
+# # choose an implant:
 
-# Simulate only what we need (14x14 deg sampled at 0.1 deg):
-model = p2p.models.ScoreboardModel(xrange=(-7, 7), yrange=(-7, 7), xystep=0.1)
-model.build()
+# # Simulate only what we need (14x14 deg sampled at 0.1 deg):
+# model = p2p.models.ScoreboardModel(xrange=(-7, 7), yrange=(-7, 7), xystep=0.1)
+# model.build()
 
-from pulse2percept.implants import AlphaAMS
-implant = AlphaAMS()
+# from pulse2percept.implants import AlphaAMS
+# implant = AlphaAMS()
 
-# Show the visual field we're simulating (dashed lines) atop the implant:
-model.plot()
-implant.plot()
+# # Show the visual field we're simulating (dashed lines) atop the implant:
+# model.plot()
+# implant.plot()
 
-##############################################################################
-# Since :py:class:`~pulse2percept.implants.AlphaAMS` is a 2D electrode grid,
-# all we need to do is downscale the image to the size of the grid:
+# ##############################################################################
+# # Since :py:class:`~pulse2percept.implants.AlphaAMS` is a 2D electrode grid,
+# # all we need to do is downscale the image to the size of the grid:
 
-implant.stim = logo_gray.resize(implant.shape)
+# implant.stim = logo_gray.resize(implant.shape)
 
-##############################################################################
-# This way, the pixels of the image will be assigned to the electrodes in
-# row-by-row order (i.e., we don't need to specify the actual electrode names).
-#
-# .. note ::
-#
-#    If the implant is not a proper 2D grid, you will have to manually specify
-#    the input to each electrode.
-#
-#    In the near future, this will be done automatically using an implant's
-#    ``preprocess`` method.
-#
-# Then the implant can be passed to the model's
-# :py:meth:`~pulse2percept.models.ScoreboardModel.predict_percept` method:
+# ##############################################################################
+# # This way, the pixels of the image will be assigned to the electrodes in
+# # row-by-row order (i.e., we don't need to specify the actual electrode names).
+# #
+# # .. note ::
+# #
+# #    If the implant is not a proper 2D grid, you will have to manually specify
+# #    the input to each electrode.
+# #
+# #    In the near future, this will be done automatically using an implant's
+# #    ``preprocess`` method.
+# #
+# # Then the implant can be passed to the model's
+# # :py:meth:`~pulse2percept.models.ScoreboardModel.predict_percept` method:
 
-percept_gray = model.predict_percept(implant)
+# percept_gray = model.predict_percept(implant)
 
-##############################################################################
-# .. note ::
-#
-#     Because neither :py:class:`~pulse2percept.stimuli.ImageStimulus` nor
-#     :py:class:`~pulse2percept.models.ScoreboardModel` can handle time, the
-#     resulting percept will consist of a single image/frame.
-#
-# To see what difference our image preprocessing makes on the quality of the
-# resulting percept, we can re-run the model on ``logo_dilate`` and plot the
-# two percepts side-by-side:
+# ##############################################################################
+# # .. note ::
+# #
+# #     Because neither :py:class:`~pulse2percept.stimuli.ImageStimulus` nor
+# #     :py:class:`~pulse2percept.models.ScoreboardModel` can handle time, the
+# #     resulting percept will consist of a single image/frame.
+# #
+# # To see what difference our image preprocessing makes on the quality of the
+# # resulting percept, we can re-run the model on ``logo_dilate`` and plot the
+# # two percepts side-by-side:
 
-implant.stim = logo_dilate.trim().resize(implant.shape)
-percept_dilate = model.predict_percept(implant)
+# implant.stim = logo_dilate.trim().resize(implant.shape)
+# percept_dilate = model.predict_percept(implant)
 
-fig, (ax1, ax2) = plt.subplots(ncols=2, figsize=(10, 4))
-percept_gray.plot(ax=ax1)
-percept_dilate.plot(ax=ax2)
+# fig, (ax1, ax2) = plt.subplots(ncols=2, figsize=(10, 4))
+# percept_gray.plot(ax=ax1)
+# percept_dilate.plot(ax=ax2)
 
-##############################################################################
-# Converting the image to a series of electrical pulses
-# ---------------------------------------------------
-#
-# :py:class:`~pulse2percept.stimuli.ImageStimulus` has an
-# :py:meth:`~pulse2percept.stimuli.ImageStimulus.encode` method
-# to convert an image into a series of pulse trains (i.e., into electrical
-# stimuli with a time component).
-#
-# By default, the ``encode`` method will interpret the gray level of a pixel as
-# the current amplitude of a :py:class:`~pulse2percept.stimuli.BiphasicPulse`
-# with 0.46ms phase duration (500ms total stimulus duration). Gray levels in
-# the range [0, 1] will be mapped onto currents in the range [0, 50] uA:
+# ##############################################################################
+# # Converting the image to a series of electrical pulses
+# # -----------------------------------------------------
+# #
+# # :py:class:`~pulse2percept.stimuli.ImageStimulus` has an
+# # :py:meth:`~pulse2percept.stimuli.ImageStimulus.encode` method
+# # to convert an image into a series of pulse trains (i.e., into electrical
+# # stimuli with a time component).
+# #
+# # By default, the ``encode`` method will interpret the gray level of a pixel as
+# # the current amplitude of a :py:class:`~pulse2percept.stimuli.BiphasicPulse`
+# # with 0.46ms phase duration (500ms total stimulus duration). Gray levels in
+# # the range [0, 1] will be mapped onto currents in the range [0, 50] uA:
 
-implant.stim = logo_dilate.trim().resize(implant.shape).encode()
+# implant.stim = logo_dilate.trim().resize(implant.shape).encode()
 
-##############################################################################
-# We can customize the range of amplitudes to be used by passing a keyword
-# argument; e.g. ``amp_range=(0, 20)`` to use currents in [0, 20] uA.
-#
-# We can also specify our own pulse / pulse train to be used. First, we need to
-# create the pulse we want to use (use amplitude 1 uA). Then, we need to pass
-# it as an additional keyword argument; e.g.,
-# ``pulse=BiphasicPulseTrain(10, 1, 0.2, stim_dur=200)`` to use a 10Hz
-# biphasic pulse train (0.2ms phase duration, overall duration 200 ms).
-#
-# Using the image as input to a spatiotemporal model
-# ---------------------------------------------------
-#
-# Now, if we passed the new stimulus to
-# :py:class:`~pulse2percept.models.ScoreboardModel`, it would simply apply the
-# model (in space) to every time point in the stimulus.
-# To get a proper temporal response, we need to extend the scoreboard model
-# with a proper temporal model, such as
-# :py:class:`~pulse2percept.models.Horsager2009Temporal`:
+# ##############################################################################
+# # We can customize the range of amplitudes to be used by passing a keyword
+# # argument; e.g. ``amp_range=(0, 20)`` to use currents in [0, 20] uA.
+# #
+# # We can also specify our own pulse / pulse train to be used. First, we need to
+# # create the pulse we want to use (use amplitude 1 uA). Then, we need to pass
+# # it as an additional keyword argument; e.g.,
+# # ``pulse=BiphasicPulseTrain(10, 1, 0.2, stim_dur=200)`` to use a 10Hz
+# # biphasic pulse train (0.2ms phase duration, overall duration 200 ms).
+# #
+# # Using the image as input to a spatiotemporal model
+# # ---------------------------------------------------
+# #
+# # Now, if we passed the new stimulus to
+# # :py:class:`~pulse2percept.models.ScoreboardModel`, it would simply apply the
+# # model (in space) to every time point in the stimulus.
+# # To get a proper temporal response, we need to extend the scoreboard model
+# # with a proper temporal model, such as
+# # :py:class:`~pulse2percept.models.Horsager2009Temporal`:
 
-model = p2p.models.Model(spatial=p2p.models.ScoreboardSpatial,
-                         temporal=p2p.models.Horsager2009Temporal)
+# model = p2p.models.Model(spatial=p2p.models.ScoreboardSpatial,
+#                          temporal=p2p.models.Horsager2009Temporal)
 
-##############################################################################
-# .. note::
-#
-#    You can combine any spatial model (names ending in **Spatial**) with any
-#    temporal model (names ending in **Temporal**).
-#
-# To make the model focus on the same visual field as above, we set ``xrange``,
-# ``yrange``, and choose a proper ``xystep``.
-#
-# The ``rho`` parameter of the scoreboard model controls how much blur we get
-# in the resulting percept. The value of this parameter should be set
-# empirically to match the quality of the vision reported behaviorally by each
-# implant user.
-# For the purpose of this tutorial, we will set it to 50um:
+# ##############################################################################
+# # .. note::
+# #
+# #    You can combine any spatial model (names ending in **Spatial**) with any
+# #    temporal model (names ending in **Temporal**).
+# #
+# # To make the model focus on the same visual field as above, we set ``xrange``,
+# # ``yrange``, and choose a proper ``xystep``.
+# #
+# # The ``rho`` parameter of the scoreboard model controls how much blur we get
+# # in the resulting percept. The value of this parameter should be set
+# # empirically to match the quality of the vision reported behaviorally by each
+# # implant user.
+# # For the purpose of this tutorial, we will set it to 50um:
 
-model.build(xrange=(-7, 7), yrange=(-7, 7), xystep=0.1, rho=50)
+# model.build(xrange=(-7, 7), yrange=(-7, 7), xystep=0.1, rho=50)
 
-##############################################################################
-# The predicted percept will now be a movie, where the spatial response (i.e.,
-# each frame of the movie) is primarily determined by the scoreboard model, but
-# the temporal evolution of these frames is determined by the Horsager model.
-#
-# By default, the model will output a movie frame every 20 ms (corresponding to
-# a 50 Hz frame rate). The frame rate can be adjusted by passing a list of
-# time points to :py:meth:`~pulse2percept.Model.predict_percept` (e.g.,
-# ``t_percept=np.arange(500)`` to get an output every millisecond):
+# ##############################################################################
+# # The predicted percept will now be a movie, where the spatial response (i.e.,
+# # each frame of the movie) is primarily determined by the scoreboard model, but
+# # the temporal evolution of these frames is determined by the Horsager model.
+# #
+# # By default, the model will output a movie frame every 20 ms (corresponding to
+# # a 50 Hz frame rate). The frame rate can be adjusted by passing a list of
+# # time points to :py:meth:`~pulse2percept.Model.predict_percept` (e.g.,
+# # ``t_percept=np.arange(500)`` to get an output every millisecond):
 
-percept = model.predict_percept(implant)
+# percept = model.predict_percept(implant)
 
-##############################################################################
-# The output of the model is a :py:class:`~pulse2percept.percepts.Percept`
-# object, which can be animated in IPython or Jupyter Notebook using the
-# :py:meth:`~pulse2percept.percepts.Percept.play` method:
+# ##############################################################################
+# # The output of the model is a :py:class:`~pulse2percept.percepts.Percept`
+# # object, which can be animated in IPython or Jupyter Notebook using the
+# # :py:meth:`~pulse2percept.percepts.Percept.play` method:
 
-percept.play()
+# percept.play()
 
-##############################################################################
-# You can also save the percept as a movie:
+# ##############################################################################
+# # You can also save the percept as a movie:
 
-percept.save('logo_percept.mp4')
+# percept.save('logo_percept.mp4')

--- a/examples/stimuli/plot_image_stim.py
+++ b/examples/stimuli/plot_image_stim.py
@@ -225,7 +225,7 @@ percept_dilate.plot(ax=ax2)
 
 ##############################################################################
 # Converting the image to a series of electrical pulses
-# ---------------------------------------------------
+# -----------------------------------------------------
 #
 # :py:class:`~pulse2percept.stimuli.ImageStimulus` has an
 # :py:meth:`~pulse2percept.stimuli.ImageStimulus.encode` method

--- a/pulse2percept/models/_nanduri2012.pyx
+++ b/pulse2percept/models/_nanduri2012.pyx
@@ -196,7 +196,7 @@ cpdef temporal_fast(const float32[:, ::1] stim,
             # the right frame. Each frame is associated with a time, `t_stim`.
             # We use that frame until `t_sim` advances past it. In other words,
             # we use the `idx_stim`-th frame for all times
-            t_stim[idx_stim] <= t_sim < t_stim[idx_stim + 1]:
+            t_stim[idx_stim] <= t_sim < t_stim[idx_stim + 1]
             if idx_stim + 1 < n_stim:
                 if t_sim >= t_stim[idx_stim + 1]:
                     idx_stim = idx_stim + 1

--- a/pulse2percept/models/_nanduri2012.pyx
+++ b/pulse2percept/models/_nanduri2012.pyx
@@ -2,6 +2,7 @@ from ..utils._fast_math cimport c_fmax, c_expit
 
 from libc.math cimport(pow as c_pow, fabs as c_abs, sqrt as c_sqrt,
                        isnan as c_isnan)
+from libc.stdio cimport printf
 from cython.parallel import prange, parallel
 from cython import cdivision  # modulo, division by zero
 import numpy as np
@@ -188,6 +189,7 @@ cpdef temporal_fast(const float32[:, ::1] stim,
         r2 = 0.0
         idx_stim = 0
         max_r3 = 1e-37
+        printf("%d: %d \n", idx_space, n_sim)
         for idx_sim in range(n_sim):
             t_sim = idx_sim * dt
             # Since the stimulus is compressed ('sparse'), we need to access
@@ -195,51 +197,56 @@ cpdef temporal_fast(const float32[:, ::1] stim,
             # We use that frame until `t_sim` advances past it. In other words,
             # we use the `idx_stim`-th frame for all times
             # t_stim[idx_stim] <= t_sim < t_stim[idx_stim + 1]:
-            if idx_stim + 1 < n_stim:
-                if t_sim >= t_stim[idx_stim + 1]:
-                    idx_stim = idx_stim + 1
-            amp = stim[idx_space, idx_stim]
-            # Fast ganglion cell response:
-            r1 = r1 + dt * (amp - r1) / tau1  # += in threads is a reduction
-            # Charge accumulation:
-            ca = ca + dt * c_fmax(amp, 0)
-            r2 = r2 + dt * (ca - r2) / tau2
-            # Half-rectification:
-            r3 = c_fmax(r1 - eps * r2, 0)
-            # Store `r3` for Step 2:
-            all_r3[idx_space, idx_sim] = r3
-            # Find the largest `r3` across time for Step 2:
-            if r3 > max_r3:
-                max_r3 = r3
+            # if idx_stim + 1 < n_stim:
+            #     if t_sim >= t_stim[idx_stim + 1]:
+            #         idx_stim = idx_stim + 1
+            # amp = stim[idx_space, idx_stim]
+            # # Fast ganglion cell response:
+            # r1 = r1 + dt * (amp - r1) / tau1  # += in threads is a reduction
+            # # Charge accumulation:
+            # printf("amp: %f ", amp)
+            # ca = ca + dt * c_fmax(amp, 0)
+            # r2 = r2 + dt * (ca - r2) / tau2
+            # # Half-rectification:
+            # r3 = c_fmax(r1 - eps * r2, 0)
+            # # Store `r3` for Step 2:
+            # all_r3[idx_space, idx_sim] = r3
+            # # Find the largest `r3` across time for Step 2:
+            # if r3 > max_r3:
+            #     max_r3 = r3
 
-        # Step 2: Use `max_R3` from Step 1 to calculate the slow response for
-        # time points:
-        r4a = 0.0
-        r4b = 0.0
-        r4c = 0.0
-        idx_stim = 0
-        idx_frame = 0
-        # Scaling factor depends on `max_r3` from Step 1:
-        scale = asymptote * c_expit((max_r3 - shift) / slope) / max_r3
-        # We have to restart the loop over all simulation time steps from 0:
-        for idx_sim in range(n_sim):
-            t_sim = idx_sim * dt
-            # Access the right stimulus frame (same as above):
-            if idx_stim + 1 < n_stim:
-                if t_sim >= t_stim[idx_stim + 1]:
-                    idx_stim = idx_stim + 1
-            # Slow response (3-stage leaky integrator):
-            r4a = r4a + dt * (all_r3[idx_space, idx_sim] * scale - r4a) / tau3
-            r4b = r4b + dt * (r4a - r4b) / tau3
-            r4c = r4c + dt * (r4b - r4c) / tau3
-            if idx_sim == idx_t_percept[idx_frame]:
-                # `idx_t_percept` stores the time points at which we need to
-                # output a percept. We compare `idx_sim` to `idx_t_percept`
-                # rather than `t_sim` to `t_percept` because there is no good
-                # (fast) way to compare two floating point numbers:
-                if c_abs(r4c) < thresh_percept:
-                    r4c = 0.0
-                percept[idx_space, idx_frame] = r4c * scale_out
-                idx_frame = idx_frame + 1
+        # # Step 2: Use `max_R3` from Step 1 to calculate the slow response for
+        # # time points:
+        # r4a = 0.0
+        # r4b = 0.0
+        # r4c = 0.0
+        # idx_stim = 0
+        # idx_frame = 0
+        # # Scaling factor depends on `max_r3` from Step 1:
+        # scale = asymptote * c_expit((max_r3 - shift) / slope) / max_r3
+        # # We have to restart the loop over all simulation time steps from 0:
+        # for idx_sim in range(n_sim):
+        #     t_sim = idx_sim * dt
+        #     # Access the right stimulus frame (same as above):
+        #     if idx_stim + 1 < n_stim:
+        #         if t_sim >= t_stim[idx_stim + 1]:
+        #             idx_stim = idx_stim + 1
+        #     # Slow response (3-stage leaky integrator):
+        #     r4a = r4a + dt * (all_r3[idx_space, idx_sim] * scale - r4a) / tau3
+        #     r4b = r4b + dt * (r4a - r4b) / tau3
+        #     r4c = r4c + dt * (r4b - r4c) / tau3
+        #     if idx_sim == idx_t_percept[idx_frame]:
+        #         # `idx_t_percept` stores the time points at which we need to
+        #         # output a percept. We compare `idx_sim` to `idx_t_percept`
+        #         # rather than `t_sim` to `t_percept` because there is no good
+        #         # (fast) way to compare two floating point numbers:
+        #         if c_abs(r4c) < thresh_percept:
+        #             r4c = 0.0
+        #         percept[idx_space, idx_frame] = r4c * scale_out
+        #         idx_frame = idx_frame + 1
 
     return np.asarray(percept)  # Py overhead
+
+
+cpdef nan_c_fmax():
+    c_fmax(2.05, 0.0)

--- a/pulse2percept/models/_nanduri2012.pyx
+++ b/pulse2percept/models/_nanduri2012.pyx
@@ -189,7 +189,7 @@ cpdef temporal_fast(const float32[:, ::1] stim,
         r2 = 0.0
         idx_stim = 0
         max_r3 = 1e-37
-        printf("%d: %d \n", idx_space, n_sim)
+        # printf("%d: %d \n", idx_space, n_sim)
         for idx_sim in range(n_sim):
             t_sim = idx_sim * dt
             # Since the stimulus is compressed ('sparse'), we need to access
@@ -204,11 +204,12 @@ cpdef temporal_fast(const float32[:, ::1] stim,
             # Fast ganglion cell response:
             r1 = r1 + dt * (amp - r1) / tau1  # += in threads is a reduction
             # Charge accumulation:
-            printf("amp: %f ", amp)
+            # printf("amp: %f ", amp)
             ca = ca + dt * c_fmax(amp, 0)
             r2 = r2 + dt * (ca - r2) / tau2
             # Half-rectification:
-            r3 = c_fmax(r1 - eps * r2, 0)
+            r3 = c_fmax(r1 - eps * r2, 0.0)
+            # r3 = r1 - eps * r2
             # Store `r3` for Step 2:
             all_r3[idx_space, idx_sim] = r3
             # Find the largest `r3` across time for Step 2:

--- a/pulse2percept/models/_nanduri2012.pyx
+++ b/pulse2percept/models/_nanduri2012.pyx
@@ -194,7 +194,7 @@ cpdef temporal_fast(const float32[:, ::1] stim,
             # the right frame. Each frame is associated with a time, `t_stim`.
             # We use that frame until `t_sim` advances past it. In other words,
             # we use the `idx_stim`-th frame for all times
-            t_stim[idx_stim] <= t_sim < t_stim[idx_stim + 1]
+            # t_stim[idx_stim] <= t_sim < t_stim[idx_stim + 1]:
             if idx_stim + 1 < n_stim:
                 if t_sim >= t_stim[idx_stim + 1]:
                     idx_stim = idx_stim + 1

--- a/pulse2percept/models/_nanduri2012.pyx
+++ b/pulse2percept/models/_nanduri2012.pyx
@@ -205,11 +205,12 @@ cpdef temporal_fast(const float32[:, ::1] stim,
             r1 = r1 + dt * (amp - r1) / tau1  # += in threads is a reduction
             # Charge accumulation:
             # printf("amp: %f ", amp)
-            ca = ca + dt * c_fmax(amp, 0)
+            # ca = ca + dt * c_fmax(amp, 0)
+            ca = ca + dt * amp
             r2 = r2 + dt * (ca - r2) / tau2
             # Half-rectification:
-            r3 = c_fmax(r1 - eps * r2, 0.0)
-            # r3 = r1 - eps * r2
+            # r3 = c_fmax(r1 - eps * r2, 0.0)
+            r3 = r1 - eps * r2
             # Store `r3` for Step 2:
             all_r3[idx_space, idx_sim] = r3
             # Find the largest `r3` across time for Step 2:

--- a/pulse2percept/models/nanduri2012.py
+++ b/pulse2percept/models/nanduri2012.py
@@ -170,6 +170,8 @@ class Nanduri2012Temporal(TemporalModel):
         if np.unique(idx_percept).size < t_percept.size:
             raise ValueError(f"All times 't_percept' must be distinct multiples "
                              f"of `dt`={self.dt:.2e}")
+        print('idx_percept', idx_percept)
+        print('len', len(idx_percept))
         # Cython returns a 2D (space x time) NumPy array:
         return temporal_fast(stim_data.astype(np.float32),
                              stim.time.astype(np.float32),

--- a/pulse2percept/models/nanduri2012.py
+++ b/pulse2percept/models/nanduri2012.py
@@ -170,8 +170,6 @@ class Nanduri2012Temporal(TemporalModel):
         if np.unique(idx_percept).size < t_percept.size:
             raise ValueError(f"All times 't_percept' must be distinct multiples "
                              f"of `dt`={self.dt:.2e}")
-        print('idx_percept', idx_percept)
-        print('len', len(idx_percept))
         # Cython returns a 2D (space x time) NumPy array:
         return temporal_fast(stim_data.astype(np.float32),
                              stim.time.astype(np.float32),

--- a/pulse2percept/models/tests/test_nanduri2012.py
+++ b/pulse2percept/models/tests/test_nanduri2012.py
@@ -280,36 +280,36 @@ def test_Nanduri2012Model_predict_percept():
                      (1, 1, 2))
 
     # Brightness vs. size (use values from Nanduri paper):
-    model = Nanduri2012Model(xystep=0.5, xrange=(-4, 4), yrange=(-4, 4))
-    model.build()
-    implant = ProsthesisSystem(ElectrodeArray(DiskElectrode(0, 0, 0, 260)))
-    amp_th = 30
-    bright_th = 0.107
-    stim_dur = 1000.0
-    pdur = 0.45
-    t_percept = np.arange(0, stim_dur, 5)
-    amp_factors = [1, 6]
-    frames_amp = []
-    for amp_f in amp_factors:
-        implant.stim = BiphasicPulseTrain(20, amp_f * amp_th, pdur,
-                                          interphase_dur=pdur,
-                                          stim_dur=stim_dur)
-        percept = model.predict_percept(implant, t_percept=t_percept)
-        idx_frame = np.argmax(np.max(percept.data, axis=(0, 1)))
-        brightest_frame = percept.data[..., idx_frame]
-        frames_amp.append(brightest_frame)
-    npt.assert_equal([np.sum(f > bright_th) for f in frames_amp], [0, 161])
-    freqs = [20, 120]
-    frames_freq = []
-    for freq in freqs:
-        implant.stim = BiphasicPulseTrain(freq, 1.25 * amp_th, pdur,
-                                          interphase_dur=pdur,
-                                          stim_dur=stim_dur)
-        percept = model.predict_percept(implant, t_percept=t_percept)
-        idx_frame = np.argmax(np.max(percept.data, axis=(0, 1)))
-        brightest_frame = percept.data[..., idx_frame]
-        frames_freq.append(brightest_frame)
-    npt.assert_equal([np.sum(f > bright_th) for f in frames_freq], [21, 49])
+    # model = Nanduri2012Model(xystep=0.5, xrange=(-4, 4), yrange=(-4, 4))
+    # model.build()
+    # implant = ProsthesisSystem(ElectrodeArray(DiskElectrode(0, 0, 0, 260)))
+    # amp_th = 30
+    # bright_th = 0.107
+    # stim_dur = 1000.0
+    # pdur = 0.45
+    # t_percept = np.arange(0, stim_dur, 5)
+    # amp_factors = [1, 6]
+    # frames_amp = []
+    # for amp_f in amp_factors:
+    #     implant.stim = BiphasicPulseTrain(20, amp_f * amp_th, pdur,
+    #                                       interphase_dur=pdur,
+    #                                       stim_dur=stim_dur)
+    #     percept = model.predict_percept(implant, t_percept=t_percept)
+    #     idx_frame = np.argmax(np.max(percept.data, axis=(0, 1)))
+    #     brightest_frame = percept.data[..., idx_frame]
+    #     frames_amp.append(brightest_frame)
+    # npt.assert_equal([np.sum(f > bright_th) for f in frames_amp], [0, 161])
+    # freqs = [20, 120]
+    # frames_freq = []
+    # for freq in freqs:
+    #     implant.stim = BiphasicPulseTrain(freq, 1.25 * amp_th, pdur,
+    #                                       interphase_dur=pdur,
+    #                                       stim_dur=stim_dur)
+    #     percept = model.predict_percept(implant, t_percept=t_percept)
+    #     idx_frame = np.argmax(np.max(percept.data, axis=(0, 1)))
+    #     brightest_frame = percept.data[..., idx_frame]
+    #     frames_freq.append(brightest_frame)
+    # npt.assert_equal([np.sum(f > bright_th) for f in frames_freq], [21, 49])
 
 
 

--- a/pulse2percept/models/tests/test_nanduri2012.py
+++ b/pulse2percept/models/tests/test_nanduri2012.py
@@ -10,7 +10,6 @@ from pulse2percept.percepts import Percept
 from pulse2percept.models import (Nanduri2012Model, Nanduri2012Spatial,
                                   Nanduri2012Temporal)
 from pulse2percept.utils import FreezeError
-from pulse2percept.models._nanduri2012 import nan_c_fmax
 
 
 def test_Nanduri2012Spatial():
@@ -310,4 +309,3 @@ def test_Nanduri2012Model_predict_percept():
         brightest_frame = percept.data[..., idx_frame]
         frames_freq.append(brightest_frame)
     npt.assert_equal([np.sum(f > bright_th) for f in frames_freq], [21, 49])
-

--- a/pulse2percept/models/tests/test_nanduri2012.py
+++ b/pulse2percept/models/tests/test_nanduri2012.py
@@ -280,36 +280,36 @@ def test_Nanduri2012Model_predict_percept():
                      (1, 1, 2))
 
     # Brightness vs. size (use values from Nanduri paper):
-    # model = Nanduri2012Model(xystep=0.5, xrange=(-4, 4), yrange=(-4, 4))
-    # model.build()
-    # implant = ProsthesisSystem(ElectrodeArray(DiskElectrode(0, 0, 0, 260)))
-    # amp_th = 30
-    # bright_th = 0.107
-    # stim_dur = 1000.0
-    # pdur = 0.45
-    # t_percept = np.arange(0, stim_dur, 5)
-    # amp_factors = [1, 6]
-    # frames_amp = []
-    # for amp_f in amp_factors:
-    #     implant.stim = BiphasicPulseTrain(20, amp_f * amp_th, pdur,
-    #                                       interphase_dur=pdur,
-    #                                       stim_dur=stim_dur)
-    #     percept = model.predict_percept(implant, t_percept=t_percept)
-    #     idx_frame = np.argmax(np.max(percept.data, axis=(0, 1)))
-    #     brightest_frame = percept.data[..., idx_frame]
-    #     frames_amp.append(brightest_frame)
-    # npt.assert_equal([np.sum(f > bright_th) for f in frames_amp], [0, 161])
-    # freqs = [20, 120]
-    # frames_freq = []
-    # for freq in freqs:
-    #     implant.stim = BiphasicPulseTrain(freq, 1.25 * amp_th, pdur,
-    #                                       interphase_dur=pdur,
-    #                                       stim_dur=stim_dur)
-    #     percept = model.predict_percept(implant, t_percept=t_percept)
-    #     idx_frame = np.argmax(np.max(percept.data, axis=(0, 1)))
-    #     brightest_frame = percept.data[..., idx_frame]
-    #     frames_freq.append(brightest_frame)
-    # npt.assert_equal([np.sum(f > bright_th) for f in frames_freq], [21, 49])
+    model = Nanduri2012Model(xystep=0.5, xrange=(-4, 4), yrange=(-4, 4))
+    model.build()
+    implant = ProsthesisSystem(ElectrodeArray(DiskElectrode(0, 0, 0, 260)))
+    amp_th = 30
+    bright_th = 0.107
+    stim_dur = 1000.0
+    pdur = 0.45
+    t_percept = np.arange(0, stim_dur, 5)
+    amp_factors = [1, 6]
+    frames_amp = []
+    for amp_f in amp_factors:
+        implant.stim = BiphasicPulseTrain(20, amp_f * amp_th, pdur,
+                                          interphase_dur=pdur,
+                                          stim_dur=stim_dur)
+        percept = model.predict_percept(implant, t_percept=t_percept)
+        idx_frame = np.argmax(np.max(percept.data, axis=(0, 1)))
+        brightest_frame = percept.data[..., idx_frame]
+        frames_amp.append(brightest_frame)
+    npt.assert_equal([np.sum(f > bright_th) for f in frames_amp], [0, 161])
+    freqs = [20, 120]
+    frames_freq = []
+    for freq in freqs:
+        implant.stim = BiphasicPulseTrain(freq, 1.25 * amp_th, pdur,
+                                          interphase_dur=pdur,
+                                          stim_dur=stim_dur)
+        percept = model.predict_percept(implant, t_percept=t_percept)
+        idx_frame = np.argmax(np.max(percept.data, axis=(0, 1)))
+        brightest_frame = percept.data[..., idx_frame]
+        frames_freq.append(brightest_frame)
+    npt.assert_equal([np.sum(f > bright_th) for f in frames_freq], [21, 49])
 
 
 

--- a/pulse2percept/models/tests/test_nanduri2012.py
+++ b/pulse2percept/models/tests/test_nanduri2012.py
@@ -10,6 +10,7 @@ from pulse2percept.percepts import Percept
 from pulse2percept.models import (Nanduri2012Model, Nanduri2012Spatial,
                                   Nanduri2012Temporal)
 from pulse2percept.utils import FreezeError
+from pulse2percept.models._nanduri2012 import nan_c_fmax
 
 
 def test_Nanduri2012Spatial():
@@ -309,3 +310,14 @@ def test_Nanduri2012Model_predict_percept():
         brightest_frame = percept.data[..., idx_frame]
         frames_freq.append(brightest_frame)
     npt.assert_equal([np.sum(f > bright_th) for f in frames_freq], [21, 49])
+
+
+
+def test_time_c_fmax():
+    import time
+    n = 100000000
+    start = time.time()
+    for _ in range(n):
+        nan_c_fmax()
+    end = time.time()
+    print('Cython ', n, ' c_fmax: ', (end - start) / n * 1000000, 'us')

--- a/pulse2percept/models/tests/test_nanduri2012.py
+++ b/pulse2percept/models/tests/test_nanduri2012.py
@@ -311,13 +311,3 @@ def test_Nanduri2012Model_predict_percept():
         frames_freq.append(brightest_frame)
     npt.assert_equal([np.sum(f > bright_th) for f in frames_freq], [21, 49])
 
-
-
-def test_time_c_fmax():
-    import time
-    n = 100000000
-    start = time.time()
-    for _ in range(n):
-        nan_c_fmax()
-    end = time.time()
-    print('Cython ', n, ' c_fmax: ', (end - start) / n * 1000000, 'us')


### PR DESCRIPTION
## Description
This PR is meant to make it so docs can build again. But the reason docs were failing were because the Nanduri and Horsager models we're suddenly extremely slow. For more details see (#585 ) but the TLDR is that certain fast math functions are for some magical reason no longer fast on specific platforms (even with exactly the same cython version, pip packages, gcc, openmp, etc as fast platforms).

To fix this I simply removed calls to the fast math functions and copy-pasted the function in each place it is specifically needed. Its a strange fix but it works, and I cant figure out how to get the cython functions to work fast.

There are also a few small changes to docs, such as formatting, fixing old imports, etc

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation change

