### PR TITLE
[ENH][FIX][DOC] Add Dynaphos activation threshold

### DIFF
--- a/doc/topics/cortical.rst
+++ b/doc/topics/cortical.rst
@@ -51,7 +51,8 @@ If we want to plot the model in the visual field, we can do so by setting
 the points in the visual field.  The points in the visual field are evenly
 spaced, and are represented by `+` symbols.
 
-.. ipython:: python
+.. ipython:: python 
+    :okwarning:
 
     @savefig score.png align=center
     model.plot(style="scatter", use_dva=True)

--- a/examples/models/plot_dynaphos.py
+++ b/examples/models/plot_dynaphos.py
@@ -23,7 +23,7 @@ The first step is to instantiate the
 :py:class:`~pulse2percept.models.cortex.DynaphosModel` class by calling its
 constructor method.
 """
-# sphinx_gallery_thumbnail_number = 1
+# sphinx_gallery_thumbnail_number = 4
 
 import numpy as np
 import matplotlib as mpl
@@ -62,7 +62,10 @@ print(model)
 # * ``tau_trace``: The trace decay constant, in ms.
 # * ``kappa_trace``: The stimulus effect modifier
 # * ``tau_act``: The activation decay constant, in ms.
-# * ``a_thr``: The tissue activation threshold, under which a percept is not generated.
+# * ``a_thr``: The tissue activation threshold, under which a phosphene is not
+#   generated. Note that this is a threshold for the internal activation value, 
+#   unlike other models' ``thresh_percept`` which is a threshold for the final
+#   percept brightness.
 # * ``sig_slope``, ``a50``: The slope of the sigmoidal brightness curve and
 #   activation value for which the brightness reaches half of its maximum.
 #
@@ -119,13 +122,13 @@ implant.plot()
 #
 # Note that all stimuli passed to Dynaphos must have a time component.
 #
-# For example, the following sends 30 microamps to all electrodes of the
+# For example, the following sends 100 microamps to all electrodes of the
 # implant, at 300Hz with a phase duration of 0.17ms:
 
 stim_freq = 300  # stimulus frequency (Hz)
 phase_dur = 0.17  # duration of the cathodic/anodic phase (ms)
 stim_dur = 1000  # stimulus duration (ms)
-stim_amp = 30  # stimulus current (uA)
+stim_amp = 100  # stimulus current (uA)
 implant.stim = {e: BiphasicPulseTrain(amp=stim_amp, freq=stim_freq, 
                                       phase_dur=phase_dur, stim_dur=stim_dur) 
                 for e in implant.electrode_names}
@@ -162,7 +165,7 @@ ax.plot([0, stim_dur], [0, 0], 'k')
 
 ax.set_xlabel('time (s)')
 ax.set_ylabel('predicted brightness (a.u.)')
-ax.set_yticks(np.arange(0, 0.2, 0.02))
+ax.set_yticks(np.arange(0, 1.01, 0.1))
 ax.set_xlim(0, stim_dur)
 fig.legend(loc='center')
 fig.tight_layout()
@@ -173,11 +176,6 @@ fig.tight_layout()
 #
 # The paper reports that phosphene brightness is affected
 # by amplitude modulation.
-
-# Use the frequency, pulse duration, and stim duration from the paper:
-stim_freq = 300
-pulse_dur = 0.17
-stim_dur = 166
 
 # Use the amplitude values from the paper:
 amps = [10, 20, 30, 40, 50, 60, 70, 80, 90, 100]
@@ -194,8 +192,7 @@ for amp in amps:
     # 1. Generate a pulse train with amplitude `amp`, frequency 300Hz,
     #    166ms duration, and pulse duration 0.17ms
     implant.stim = { e: BiphasicPulseTrain(freq=300, amp=amp, phase_dur=0.17,
-                                      stim_dur=166).append(
-                        BiphasicPulseTrain(300,0,0.17,stim_dur=700-166))
+                                      stim_dur=166)
                     for e in implant.electrode_names }
     # 2. Run the model:
     percept = model.predict_percept(implant, t_percept=t_percept)
@@ -203,7 +200,7 @@ for amp in amps:
     bright_over_time.append(np.max(np.max(percept.data, axis=1), axis=0))
 
 ###############################################################################
-# We can also reproduce the percept brightness plot in Fig. 3b: 
+# This allows us to reproduce the brightness-over-time plot in Fig. 3: 
 
 fig, ax = plt.subplots(1, figsize=(7.5,3))
 

--- a/pulse2percept/models/cortex/dynaphos.py
+++ b/pulse2percept/models/cortex/dynaphos.py
@@ -36,6 +36,8 @@ class DynaphosModel(BaseModel):
         Activation decay constant (ms)
     sig_slope : float, optional
         Slope of the sigmoidal brightness curve
+    a_thr : float, optional
+        Activation threshold value, under which a phosphene is not generated
     a50 : float, optional
         Activation value for which a phosphene reaches half of its maximum brightness
     freq : float, optional

--- a/pulse2percept/models/cortex/dynaphos.py
+++ b/pulse2percept/models/cortex/dynaphos.py
@@ -128,6 +128,8 @@ class DynaphosModel(BaseModel):
                 'sig_slope': 19152642.500946816,
                 # A50 - activation for which a phosphene reaches half of its maximum brightness
                 'a50': 1.057631326853325e-07,
+                # A_Thr - activation threshold under which a phosphene is not generated
+                'a_thr': 9.141886000943878e-08,
                 # Default stimulus frequency (Hz)
                 'freq': 300,
                 # Default stimulus pulse duration (ms)
@@ -293,7 +295,7 @@ class DynaphosModel(BaseModel):
                 # (fast) way to compare two floating point numbers:
                 for el_idx in range(stim.data.shape[0]):
                     gauss = np.zeros(self.grid['dva'].x.shape)
-                    if A[el_idx] != 0:
+                    if A[el_idx] >= self.a_thr:
                         gauss = create_gaussian(phosphene_locations['v1'][0][el_idx], 
                                                 phosphene_locations['v1'][1][el_idx], 
                                                 sigma[el_idx], x_el[el_idx])

--- a/pulse2percept/models/cortex/tests/test_dynaphos.py
+++ b/pulse2percept/models/cortex/tests/test_dynaphos.py
@@ -73,15 +73,15 @@ def test_temporal_predict():
                                           stim_dur=sdur)
         percept = model.predict_percept(implant, t_percept=t_percept)
         bright_amp.append(percept.data.max())
-    bright_amp_ref = np.array([0.0, 0.208, 0.416, 0.66, 0.841])
+    bright_amp_ref = np.array([0.0, 0.0, 0.0, 0.66, 0.841])
     npt.assert_almost_equal(bright_amp, bright_amp_ref, decimal=3)
 
     # Test that default models give expected values
     implant = Orion(x=15000, stim={'55': BiphasicPulseTrain(freq=300, amp=100, phase_dur=0.17)})
     percept = model.predict_percept(implant)
-    npt.assert_equal(np.sum(percept.data > 0.0122), 149)
-    npt.assert_equal(np.sum(percept.data > 0.0375), 97)
-    npt.assert_equal(np.sum(percept.data > 0.3305), 50)
+    npt.assert_equal(np.sum(percept.data > 0.0122), 147)
+    npt.assert_equal(np.sum(percept.data > 0.0375), 96)
+    npt.assert_equal(np.sum(percept.data > 0.3305), 49)
     npt.assert_equal(np.sum(percept.data > 0.8451), 39)
     npt.assert_equal(np.sum(percept.data > 0.8883), 9)
 


### PR DESCRIPTION
## Description

Adds a cortical tissue activation threshold to the Dynaphos model, to better match the paper. This is a settable parameter (a_thr) and limits when percepts are generated. This also prevents the currently observed behavior where, if a stimulus goes from high amplitude to 0, the generated phosphenes never fully fade.

Updates Dynaphos documentation to match, and adds an example allowing us to reproduce a figure from the paper (with limitations).

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation change

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
