### PR TITLE
[FIX] Fix ImageStimulus crop safety checks + 2-channel indexing

### DIFF
--- a/pulse2percept/stimuli/images.py
+++ b/pulse2percept/stimuli/images.py
@@ -289,16 +289,23 @@ class ImageStimulus(Stimulus):
         if y0 < 0 or x0 < 0:
             raise ValueError(f"Top-left corner (y0,x0)=({y0},{x0}) lies "
                              f"outside the image.")
-        if y1 >= self.img_shape[0] or x1 >= self.img_shape[1]:
-            raise ValueError(f"Bottom-right corner (y1,x1)=({y1},{x1}) lies "
+        if y1 > self.img_shape[0] or x1 > self.img_shape[1]:
+            raise ValueError(f"Bottom-right corner (y1-1,x1-1)=({y1-1},{x1-1}) lies "
                              f"outside the image.")
         # Crop the image:
         img = self.data.reshape(self.img_shape)
-        cropped_img = img[y0:y1, x0:x1, :3]
+        # Check if we have color channels & index appropriately
+        if len(self.img_shape) == 3:
+            cropped_img = img[y0:y1, x0:x1, :3]
+        else:
+            cropped_img = img[y0:y1, x0:x1]
         electrodes = self.electrodes
         if electrodes is not None:
             electrodes = electrodes.reshape(self.img_shape)
-            electrodes = electrodes[y0:y1, x0:x1, :3].ravel()
+            if len(self.img_shape) == 3:
+                electrodes = electrodes[y0:y1, x0:x1, :3].ravel()
+            else:
+                electrodes = electrodes[y0:y1, x0:x1].ravel()
         return ImageStimulus(cropped_img, electrodes=electrodes,
                              metadata=self.metadata)
 

--- a/pulse2percept/stimuli/tests/test_images.py
+++ b/pulse2percept/stimuli/tests/test_images.py
@@ -86,8 +86,8 @@ def test_ImageStimulus_resize():
         stim.resize((-1, -1))
     os.remove(fname)
 
-
 def test_ImageStimulus_crop():
+    # test img with color channels
     fname = 'test.png'
     shape = (30, 50, 3)
     gray = create_dummy_img(fname, shape, 'rand')
@@ -102,6 +102,22 @@ def test_ImageStimulus_crop():
                      stim_cropped.electrodes.reshape(20, 30, 3)[3, 7, 0])
     npt.assert_equal(stim.electrodes.reshape(30, 50, 3)[15, 38, 2],
                      stim_cropped.electrodes.reshape(20, 30, 3)[10, 28, 2])
+
+    # test img with no color channels
+    fname_bw = 'test_bw.png'
+    shape_bw = (30, 50)
+    gray_bw = create_dummy_img(fname_bw, shape_bw, 'rand')
+    stim_bw = ImageStimulus(fname_bw)
+    stim_cropped_bw = stim_bw.crop(idx_rect=[5, 10, 25, 40])
+    npt.assert_equal(stim_cropped_bw.img_shape, (20, 30))
+    npt.assert_equal(stim_cropped_bw.data.reshape(stim_cropped_bw.img_shape)[3, 7],
+                     stim_bw.data.reshape(stim_bw.img_shape)[8, 17])
+    npt.assert_equal(stim_cropped_bw.data.reshape(stim_cropped_bw.img_shape)[10, 28],
+                     stim_bw.data.reshape(stim_bw.img_shape)[15, 38])
+    npt.assert_equal(stim_bw.electrodes.reshape(30, 50)[8, 17],
+                     stim_cropped_bw.electrodes.reshape(20, 30)[3, 7])
+    npt.assert_equal(stim_bw.electrodes.reshape(30, 50)[15, 38],
+                     stim_cropped_bw.electrodes.reshape(20, 30)[10, 28])
 
     stim_cropped2 = stim.crop(left=10, right=8, top=6, bottom=7)
     npt.assert_equal(stim_cropped2.img_shape, (17, 32, 3))
@@ -147,6 +163,9 @@ def test_ImageStimulus_crop():
         stim.crop([5, 10, 4, 40])
     with pytest.raises(ValueError):
         stim.crop([5, 10, 25, 9])
+    
+    os.remove(fname)
+    os.remove(fname_bw)
 
 
 def test_ImageStimulus_trim():


### PR DESCRIPTION
## Description

In ImageStimulus crop, we now check if y1 > img_shape[0] or x1 > img_shape[1], since x1,y1 are EXCLUSIVE bounds (specified in the docstring). Updates the error message to properly reflect the bottom-right coordinate (y1-1, x1-1).

We also check if the image has color channels so we can index appropriately for cropping.

Closes #564 

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
