### PR TITLE
[DOC] Fix incorrect implant mention in Dynaphos docs

### DIFF
--- a/examples/models/plot_dynaphos.py
+++ b/examples/models/plot_dynaphos.py
@@ -98,10 +98,8 @@ model.build()
 # :py:mod:`~pulse2percept.implants` module.
 #
 # In the following, we will create an 
-# :py:class:`~pulse2percept.implants.EnsembleImplant` consisting 
-# of :py:class:`~pulse2percept.implants.cortex.Cortivis` implants. 
-# We will place these in a 3x3 grid centered at (18000, 0), which 
-# is 18000mm into the right hemisphere of the visual cortex.
+# :py:class:`~pulse2percept.implants.cortex.Orion` implant 
+# at the default location.
 
 implant = Orion()
 


### PR DESCRIPTION
## Description

Dynaphos docs incorrectly referenced an `EnsembleImplant` when the example uses an `Orion` implant, so this PR just fixes that sentence.

## Type of Change

Please delete options that are not relevant.

- [x] Documentation change
