### PR TITLE
[ENH] Add methods to initialize an EnsembleImplant from a list of coordinates

### DIFF
--- a/pulse2percept/implants/ensemble.py
+++ b/pulse2percept/implants/ensemble.py
@@ -9,6 +9,49 @@ class EnsembleImplant(ProsthesisSystem):
     # Frozen class: User cannot add more class attributes
     __slots__ = ('_implants', '_earray', '_stim', 'safe_mode', 'preprocess')
 
+    @classmethod
+    def from_coords(cls, implant_type: type, x_coords, y_coords, z_coords = None, 
+                    stim=None, preprocess=False, safe_mode=False):
+        """
+        Create an ensemble of implants of type `implant_type`, with the
+        i-th implant being centered at (`x_coords[i]`, `y_coords[i]`) or
+        (`x_coords[i]`, `y_coords[i]`, `z_coords[i]`).
+
+        Parameters
+        ----------
+        implant_type : type
+            The type of implant to create for the ensemble.
+        x_coords : list
+            A list of the x-coordinates of the center of each implant.
+        y_coords : list
+            A list of the y-coordinates of the center of each implant.
+        z_coords : list, optional
+            An optional list of the z-coordinates of the center of each implant.
+            If this parameter is passed, a z-coordinate must be provided for each implant.
+        stim : :py:class:`~pulse2percept.stimuli.Stimulus` source type
+            A valid source type for the :py:class:`~pulse2percept.stimuli.Stimulus`
+            object (e.g., scalar, NumPy array, pulse train).
+        preprocess : bool or callable, optional
+            Either True/False to indicate whether to execute the implant's default
+            preprocessing method whenever a new stimulus is assigned, or a custom
+            function (callable).
+        safe_mode : bool, optional
+            If safe mode is enabled, only charge-balanced stimuli are allowed.
+        """
+
+        n = len(x_coords)
+        if len(y_coords) != n:
+            raise ValueError("y-coordinate list must be the same length as x-coordinate list")
+        if z_coords is not None and len(z_coords) != n:
+            raise ValueError("z-coordinate list must be the same length as x-coordinate list")
+        
+        if z_coords is not None:
+            implant_list = [implant_type(x=x, y=y, z=z) for x,y,z in zip(x_coords, y_coords, z_coords)]
+        else:
+            implant_list = [implant_type(x=x, y=y) for x,y in zip(x_coords, y_coords)]
+        
+        return cls(implant_list, stim=stim, preprocess=preprocess, safe_mode=safe_mode)
+
     def __init__(self, implants, stim=None, preprocess=False,safe_mode=False):
         """Ensemble implant
 

--- a/pulse2percept/implants/ensemble.py
+++ b/pulse2percept/implants/ensemble.py
@@ -1,4 +1,5 @@
 """`EnsembleImplant`"""
+import numpy as np
 from .base import ProsthesisSystem
 from .electrodes import Electrode
 from .electrode_arrays import ElectrodeArray
@@ -10,49 +11,105 @@ class EnsembleImplant(ProsthesisSystem):
     __slots__ = ('_implants', '_earray', '_stim', 'safe_mode', 'preprocess')
 
     @classmethod
-    def from_coords(cls, implant_type: type, x_coords, y_coords, z_coords = None, 
-                    stim=None, preprocess=False, safe_mode=False):
+    def from_cortical_map(cls, implant_type, vfmap, locs=None, xrange=None, yrange=None, xystep=None, 
+                        region='v1'):
         """
-        Create an ensemble of implants of type `implant_type`, with the
-        i-th implant being centered at (`x_coords[i]`, `y_coords[i]`) or
-        (`x_coords[i]`, `y_coords[i]`, `z_coords[i]`).
+        Create an ensemble implant from a cortical visual field map.
+
+        The implant will be created by creating an implant of type `implant_type`
+        for each visual field location specified either by locs or by xrange, yrange, 
+        and xystep. Each implant will be centered at the given location.
+
+        Parameters
+        ----------
+        vfmap : p2p.topography.CorticalMap
+            Visual field map to create implant from.
+        implant_type : type
+            Type of implant to create for the ensemble. Must subclass 
+            p2p.implants.ProsthesisSystem
+        locs : np.ndarray with shape (n, 2), optional
+            Array of visual field locations to create implants at (dva). 
+            Not needed if using xrange, yrange, and xystep.
+        xrange, yrange: tuple of floats, optional
+            Range of x and y coordinates (dva) to create implants at.
+        xystep : float, optional
+            Spacing between implant centers. 
+        region : str, optional
+            Region of cortex to create implant in.
+
+        Returns
+        -------
+        ensemble : p2p.implants.EnsembleImplant
+            Ensemble implant created from the cortical visual field map.
+        """
+        from ..topography import CorticalMap, Grid2D
+        if not isinstance(vfmap, CorticalMap):
+            raise TypeError("vfmap must be a p2p.topography.CorticalMap")
+        if not issubclass(implant_type, ProsthesisSystem):
+            raise TypeError("implant_type must be a sub-type of ProsthesisSystem")
+
+        if locs is None:
+            if xrange is None:
+                xrange = (-3, 3)
+            if yrange is None:
+                yrange = (-3, 3)
+            if xystep is None:
+                xystep = 1
+            
+            # make a grid of points
+            grid = Grid2D(xrange, yrange, xystep)
+            xlocs = grid.x.flatten()
+            ylocs = grid.y.flatten()
+        else:
+            xlocs = locs[:, 0]
+            ylocs = locs[:, 1]
+
+        implant_locations = np.array(vfmap.from_dva()[region](xlocs, ylocs)).T
+
+        return cls.from_coords(implant_type=implant_type, locs=implant_locations)
+
+
+    @classmethod
+    def from_coords(cls, implant_type, locs=None, xrange=None, yrange=None, xystep=None):
+        """
+        Create an ensemble implant using physical (cortical or retinal) coordinates.
 
         Parameters
         ----------
         implant_type : type
             The type of implant to create for the ensemble.
-        x_coords : list
-            A list of the x-coordinates of the center of each implant.
-        y_coords : list
-            A list of the y-coordinates of the center of each implant.
-        z_coords : list, optional
-            An optional list of the z-coordinates of the center of each implant.
-            If this parameter is passed, a z-coordinate must be provided for each implant.
-        stim : :py:class:`~pulse2percept.stimuli.Stimulus` source type
-            A valid source type for the :py:class:`~pulse2percept.stimuli.Stimulus`
-            object (e.g., scalar, NumPy array, pulse train).
-        preprocess : bool or callable, optional
-            Either True/False to indicate whether to execute the implant's default
-            preprocessing method whenever a new stimulus is assigned, or a custom
-            function (callable).
-        safe_mode : bool, optional
-            If safe mode is enabled, only charge-balanced stimuli are allowed.
+        locs : np.ndarray with shape (n, 2), optional
+            Array of physical locations (um) to create implants at. Not
+            needed if using xrange, yrange, and xystep.
+        xrange, yrange: tuple of floats, optional
+            Range of x and y coordinates to create implants at.
+        xystep : float, optional
+            Spacing between implant centers. 
         """
+        from ..topography import Grid2D
 
         if not issubclass(implant_type, ProsthesisSystem):
             raise TypeError("implant_type must be a sub-type of ProsthesisSystem")
-        n = len(x_coords)
-        if len(y_coords) != n:
-            raise ValueError("y-coordinate list must be the same length as x-coordinate list")
-        if z_coords is not None and len(z_coords) != n:
-            raise ValueError("z-coordinate list must be the same length as x-coordinate list")
         
-        if z_coords is not None:
-            implant_list = [implant_type(x=x, y=y, z=z) for x,y,z in zip(x_coords, y_coords, z_coords)]
+        if locs is None:
+            if xrange is None:
+                xrange = (-3, 3)
+            if yrange is None:
+                yrange = (-3, 3)
+            if xystep is None:
+                xystep = 1
+            
+            # make a grid of points
+            grid = Grid2D(xrange, yrange, xystep)
+            xlocs = grid.x.flatten()
+            ylocs = grid.y.flatten()
         else:
-            implant_list = [implant_type(x=x, y=y) for x,y in zip(x_coords, y_coords)]
+            xlocs = locs[:, 0]
+            ylocs = locs[:, 1]
+
+        implant_list = [implant_type(x=x, y=y) for x,y in zip(xlocs, ylocs)]
         
-        return cls(implant_list, stim=stim, preprocess=preprocess, safe_mode=safe_mode)
+        return cls(implant_list)
 
     def __init__(self, implants, stim=None, preprocess=False,safe_mode=False):
         """Ensemble implant

--- a/pulse2percept/implants/ensemble.py
+++ b/pulse2percept/implants/ensemble.py
@@ -39,6 +39,8 @@ class EnsembleImplant(ProsthesisSystem):
             If safe mode is enabled, only charge-balanced stimuli are allowed.
         """
 
+        if not issubclass(implant_type, ProsthesisSystem):
+            raise TypeError("implant_type must be a sub-type of ProsthesisSystem")
         n = len(x_coords)
         if len(y_coords) != n:
             raise ValueError("y-coordinate list must be the same length as x-coordinate list")

--- a/pulse2percept/implants/tests/test_ensemble.py
+++ b/pulse2percept/implants/tests/test_ensemble.py
@@ -2,7 +2,8 @@ import numpy as np
 import numpy.testing as npt
 import pytest
 from pulse2percept.implants import (EnsembleImplant, PointSource, ProsthesisSystem)
-from pulse2percept.implants.cortex import Cortivis, LinearEdgeThread
+from pulse2percept.implants.cortex import Cortivis
+from pulse2percept.topography import Polimeni2006Map
 from pulse2percept.models.cortex.base import ScoreboardModel
 
 def test_EnsembleImplant():
@@ -52,35 +53,57 @@ def test_ensemble_cortivis():
     npt.assert_equal(ensemble['1-1'].x, cortivis1['1'].x)
     npt.assert_equal(ensemble['1-1'].y, cortivis1['1'].y)
 
-# test from_coords initialization
+# test from_coords initialization (physical coords in um)
 def test_from_coords():
-    x_coords = [0, 10000]
-    y_coords = [0, 0]
+    locs = np.array([(0,0), (10000,0)])
 
-    # no z-coords
-    c0 = LinearEdgeThread(x=0,y=0)
-    c1 = LinearEdgeThread(x=10000,y=0)
-    ensemble1 = EnsembleImplant.from_coords(LinearEdgeThread, x_coords=x_coords, y_coords=y_coords)
+    # check invalid instantiations
+    with pytest.raises(TypeError):
+        EnsembleImplant.from_coords(Cortivis(0), locs=locs)
 
-    # check that positions are the same
-    npt.assert_equal(ensemble1['0-1'].x, c0['1'].x)
-    npt.assert_equal(ensemble1['0-1'].y, c0['1'].y)
-    npt.assert_equal(ensemble1['0-1'].z, c0['1'].z)
-    npt.assert_equal(ensemble1['1-1'].x, c1['1'].x)
-    npt.assert_equal(ensemble1['1-1'].y, c1['1'].y)
-    npt.assert_equal(ensemble1['1-1'].z, c1['1'].z)
+    locs = np.array([(0,0), (10000,0), (0, 10000)])
 
-    # yes z-coords
-    z_coords = [-5, -10]
-    c2 = LinearEdgeThread(x=0,y=0,z=-5)
-    c3 = LinearEdgeThread(x=10000,y=0,z=-10)
-    ensemble2 = EnsembleImplant.from_coords(LinearEdgeThread, x_coords=x_coords, y_coords=y_coords, z_coords=z_coords)
+    c0 = Cortivis(x=0,y=0)
+    c1 = Cortivis(x=10000,y=0)
+    c2 = Cortivis(x=0, y=10000)
+    ensemble = EnsembleImplant.from_coords(Cortivis, locs=locs)
 
     # check that positions are the same
-    npt.assert_equal(ensemble2['0-1'].x, c2['1'].x)
-    npt.assert_equal(ensemble2['0-1'].y, c2['1'].y)
-    npt.assert_equal(ensemble2['0-1'].z, c2['1'].z)
-    npt.assert_equal(ensemble2['1-1'].x, c3['1'].x)
-    npt.assert_equal(ensemble2['1-1'].y, c3['1'].y)
-    npt.assert_equal(ensemble2['1-1'].z, c3['1'].z)
-    
+    npt.assert_equal(ensemble['0-1'].x, c0['1'].x)
+    npt.assert_equal(ensemble['0-1'].y, c0['1'].y)
+    npt.assert_equal(ensemble['0-1'].z, c0['1'].z)
+    npt.assert_equal(ensemble['1-1'].x, c1['1'].x)
+    npt.assert_equal(ensemble['1-1'].y, c1['1'].y)
+    npt.assert_equal(ensemble['1-1'].z, c1['1'].z)
+    npt.assert_equal(ensemble['2-1'].x, c2['1'].x)
+    npt.assert_equal(ensemble['2-1'].y, c2['1'].y)
+    npt.assert_equal(ensemble['2-1'].z, c2['1'].z)
+
+# test from_cortical_map initialization (vf coords in dva)
+def test_from_cortical_map():
+    vfmap = Polimeni2006Map()
+
+    locs = np.array([(2000,2000), (10000,0), (5000, 5000)]).astype(np.float64)
+
+    # find locations in dva
+    dva_x, dva_y = vfmap.to_dva()['v1'](locs[:,0], locs[:,1])
+    dva_list = [(x,y) for x,y in zip(dva_x, dva_y)]
+    dva_locs = np.array(dva_list)
+
+    c0 = Cortivis(x=2000, y=2000)
+    c1 = Cortivis(x=10000, y=0)
+    c2 = Cortivis(x=5000, y=5000)
+
+    # use dva coords to create ensemble
+    ensemble = EnsembleImplant.from_cortical_map(Cortivis, vfmap, dva_locs)
+
+    # check that positions are approx. the same
+    npt.assert_approx_equal(ensemble['0-1'].x, c0['1'].x, 5)
+    npt.assert_approx_equal(ensemble['0-1'].y, c0['1'].y, 5)
+    npt.assert_approx_equal(ensemble['0-1'].z, c0['1'].z, 5)
+    npt.assert_approx_equal(ensemble['1-1'].x, c1['1'].x, 5)
+    npt.assert_approx_equal(ensemble['1-1'].y, c1['1'].y, 5)
+    npt.assert_approx_equal(ensemble['1-1'].z, c1['1'].z, 5)
+    npt.assert_approx_equal(ensemble['2-1'].x, c2['1'].x, 5)
+    npt.assert_approx_equal(ensemble['2-1'].y, c2['1'].y, 5)
+    npt.assert_approx_equal(ensemble['2-1'].z, c2['1'].z, 5)

--- a/pulse2percept/implants/tests/test_ensemble.py
+++ b/pulse2percept/implants/tests/test_ensemble.py
@@ -2,7 +2,7 @@ import numpy as np
 import numpy.testing as npt
 import pytest
 from pulse2percept.implants import (EnsembleImplant, PointSource, ProsthesisSystem)
-from pulse2percept.implants.cortex import Cortivis
+from pulse2percept.implants.cortex import Cortivis, LinearEdgeThread
 from pulse2percept.models.cortex.base import ScoreboardModel
 
 def test_EnsembleImplant():
@@ -51,3 +51,36 @@ def test_ensemble_cortivis():
     npt.assert_equal(ensemble['0-1'].y, cortivis0['1'].y)
     npt.assert_equal(ensemble['1-1'].x, cortivis1['1'].x)
     npt.assert_equal(ensemble['1-1'].y, cortivis1['1'].y)
+
+# test from_coords initialization
+def test_from_coords():
+    x_coords = [0, 10000]
+    y_coords = [0, 0]
+
+    # no z-coords
+    c0 = LinearEdgeThread(x=0,y=0)
+    c1 = LinearEdgeThread(x=10000,y=0)
+    ensemble1 = EnsembleImplant.from_coords(LinearEdgeThread, x_coords=x_coords, y_coords=y_coords)
+
+    # check that positions are the same
+    npt.assert_equal(ensemble1['0-1'].x, c0['1'].x)
+    npt.assert_equal(ensemble1['0-1'].y, c0['1'].y)
+    npt.assert_equal(ensemble1['0-1'].z, c0['1'].z)
+    npt.assert_equal(ensemble1['1-1'].x, c1['1'].x)
+    npt.assert_equal(ensemble1['1-1'].y, c1['1'].y)
+    npt.assert_equal(ensemble1['1-1'].z, c1['1'].z)
+
+    # yes z-coords
+    z_coords = [-5, -10]
+    c2 = LinearEdgeThread(x=0,y=0,z=-5)
+    c3 = LinearEdgeThread(x=10000,y=0,z=-10)
+    ensemble2 = EnsembleImplant.from_coords(LinearEdgeThread, x_coords=x_coords, y_coords=y_coords, z_coords=z_coords)
+
+    # check that positions are the same
+    npt.assert_equal(ensemble2['0-1'].x, c2['1'].x)
+    npt.assert_equal(ensemble2['0-1'].y, c2['1'].y)
+    npt.assert_equal(ensemble2['0-1'].z, c2['1'].z)
+    npt.assert_equal(ensemble2['1-1'].x, c3['1'].x)
+    npt.assert_equal(ensemble2['1-1'].y, c3['1'].y)
+    npt.assert_equal(ensemble2['1-1'].z, c3['1'].z)
+    


### PR DESCRIPTION
## Description

Adds two methods to initialize an `EnsembleImplant` from a set of coordinates. This should generally match the format of `Neuralink.from_neuropythy()`.

`EnsembleImplant.from_coords()` allows the user to pass an implant type (must subclass `ProsthesisSystem`) & a set of locations on the cortex/retina (in µm), or an xrange/yrange/xystep in µm. We then automatically create a set of implants of the given type at the desired locations.

`EnsembleImplant.from_cortical_map()` takes the same parameters as `from_coords()` in addition to a `vfmap` (must be a `CorticalMap` instance and implement `from_dva()`) and `region` (defaults to v1). Locations/coordinates are passed to this function in dva, and internally converted to µm (in the given region).

Possible expansion: `from_retinal_map()`. Not implemented currently due to lack of use-cases as retinal implants are generally stand-alone. Would take an `eye` parameter instead of `region`?

## Type of Change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
