### PR TITLE
[DOC][ENH] Add Neuralink to doc and override from_cortical_map for Neuralink

### DIFF
--- a/doc/topics/implants.rst
+++ b/doc/topics/implants.rst
@@ -46,6 +46,7 @@ pulse2percept provides the following prosthesis systems (aka *'implants', 'bioni
 `Orion`      cortical        60                  Cortigent Inc
 `Cortivis`   cortical        96                  Biomedical Technologies
 `ICVP`       cortical        16                  Sigenics Inc
+`Neuralink`  cortical        32 / thread         Neuralink Corp
 ===========  ==============  ==================  =================================
 
 Stimuli can be assigned to the various electrodes in the electrode array,
@@ -55,7 +56,7 @@ A mathematical model is then used to compute the neural stimulus response and
 predict the resulting visual percept
 (see :ref:`Computational Models <topics-models>`).
 
-Understanding the coordinate system
+Understanding the coordinate system (Retina)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The easiest way to understand the coordinate system is to look at the

--- a/pulse2percept/implants/cortex/neuralink.py
+++ b/pulse2percept/implants/cortex/neuralink.py
@@ -329,6 +329,45 @@ class Neuralink(EnsembleImplant):
                                             orient=direction, orient_mode='direction')
         return cls(threads)
     
+    @classmethod
+    def from_cortical_map(cls, implant_type, vfmap, locs=None, xrange=None, 
+                          yrange=None, xystep=None, region='v1'):
+        """
+        Override of parent class from cortical map method.
+        Uses from_neuropythy instead of from_cortical_map if the provided
+        vfmap is a NeuropythyMap.
+
+        Parameters
+        ----------
+        implant_type : p2p.implants.ProsthesisSystem
+            Type of implant to create. Currently only NeuralinkThread is supported.
+        vfmap : p2p.topography.CorticalMap
+            Cortical map to create implant from.
+        locs : np.ndarray with shape (n, 2), optional
+            Array of visual field locations to create threads at. Not
+            needed if using xrange, yrange, and xystep.
+        xrange, yrange: tuple of floats, optional
+            Range of x and y coordinates to create threads at.
+        xystep : float, optional
+            Spacing between threads.
+        region : str, optional
+            Region of cortex to create implant in.
+
+        Returns
+        -------
+        Neuralink : p2p.implants.Neuralink
+            Neuralink ensemble implant created from the visual field map.
+        """
+        if not issubclass(implant_type, NeuralinkThread):
+            raise TypeError("implant_type must be a subclass of NeuralinkThread")
+        from ...topography import NeuropythyMap
+        if not isinstance(vfmap, NeuropythyMap):
+            return super().from_cortical_map(implant_type, vfmap, locs=locs, xrange=xrange, 
+                                             yrange=yrange, xystep=xystep, region=region)
+        return cls.from_neuropythy(vfmap, locs=locs, xrange=xrange, yrange=yrange, 
+                                    xystep=xystep, region=region, Thread=implant_type)
+
+    
 
     def __init__(self, threads, stim=None, preprocess=False, safe_mode=False):
         """


### PR DESCRIPTION
Adds neuralink to the implants documentation basic concepts and overrides from_cortical_map for neuralink to choose whether to use from_neuropythy or not depending on type of vfmap passed