### PR TITLE
[ENH][REF] Torch Scoreboard

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v1
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -13,3 +13,4 @@ docutils<0.18
 jax[cpu]<=0.4.3
 neuropythy
 pickleshare
+torch

--- a/pulse2percept/models/base.py
+++ b/pulse2percept/models/base.py
@@ -1076,14 +1076,15 @@ class TorchBaseModel(torch.nn.Module, metaclass=ABCMeta):
             device = 'cuda' if torch.cuda.is_available() else 'cpu'
         self.device = torch.device(device)
 
-    def forward(self, amps, e_locs, model_params=None):
+    def forward(self, stim, e_locs, model_params=None):
         """
         Forward pass of the model
 
         Parameters
         ----------
-        amps : torch.Tensor
-            The amplitudes of the electrodes
+        stim : torch.Tensor
+            The stimulation tensor for each electrode. 
+            Shape (n_time, n_elecs) or (n_time, n_elecs, 3) for biphasic models
         e_locs : torch.Tensor
             The locations of the electrodes
         model_params : Tensor, optional

--- a/pulse2percept/models/base.py
+++ b/pulse2percept/models/base.py
@@ -251,7 +251,9 @@ class SpatialModel(BaseModel, metaclass=ABCMeta):
             'verbose': True,
             # default to 2d model. 3d models should override this
             'ndim' : [2],
-            'n_threads': multiprocessing.cpu_count()
+            'n_threads': multiprocessing.cpu_count(),
+            # default to cpu, can force cuda if using torch on gpu
+            'device': 'cpu'
         }
         return params
 
@@ -530,7 +532,9 @@ class TemporalModel(BaseModel, metaclass=ABCMeta):
             'thresh_percept': 0,
             # True: print status messages, False: silent
             'verbose': True,
-            'n_threads': multiprocessing.cpu_count()
+            'n_threads': multiprocessing.cpu_count(),
+            # default to cpu, can force cuda if using torch on gpu
+            'device': 'cpu'
         }
         return params
 
@@ -1050,7 +1054,7 @@ class Model(PrettyPrint):
 
 
 class TorchBaseModel(torch.nn.Module, metaclass=ABCMeta):
-    def __init__(self, p2pmodel, device=None):
+    def __init__(self, p2pmodel):
         """
         Base class constructor for common logic
 
@@ -1064,17 +1068,12 @@ class TorchBaseModel(torch.nn.Module, metaclass=ABCMeta):
         ----------
         p2pmodel : pulse2percept.models.Model
             The pulse2percept model to wrap
-        device : str, torch.device, optional
-            The device on which to run the model. If None, will use 'cuda' if
-            available, else 'cpu'
 
         """
         super().__init__()
         if not p2pmodel.is_built:
             p2pmodel.build()
-        if device is None:
-            device = 'cuda' if torch.cuda.is_available() else 'cpu'
-        self.device = torch.device(device)
+        self.device = torch.device(p2pmodel.device)
 
     def forward(self, stim, e_locs, model_params=None):
         """

--- a/pulse2percept/models/base.py
+++ b/pulse2percept/models/base.py
@@ -288,8 +288,8 @@ class SpatialModel(BaseModel, metaclass=ABCMeta):
         self.grid = Grid2D(self.xrange, self.yrange, step=self.xystep,
                            grid_type=self.grid_type)
         self.grid.build(self.vfmap)
+        self.is_built = True # this is so that torch models don't need to manually set is_built in order to access the model grid
         self._build()
-        self.is_built = True
         return self
 
     @abstractmethod

--- a/pulse2percept/models/cortex/base.py
+++ b/pulse2percept/models/cortex/base.py
@@ -188,10 +188,10 @@ class TorchScoreboardSpatial(nn.Module):
             self.boundary = p2pmodel.vfmap.left_offset/2
         self.locs = {}
         for region in self.regions:
-            x = torch.tensor(p2pmodel.grid[region].x.ravel())
-            y = torch.tensor(p2pmodel.grid[region].y.ravel())
+            x = torch.tensor(p2pmodel.grid[region].x.ravel(),device=self.device)
+            y = torch.tensor(p2pmodel.grid[region].y.ravel(),device=self.device)
             if p2pmodel.grid[region].z is not None:
-                z = torch.tensor(p2pmodel.grid[region].z.ravel())
+                z = torch.tensor(p2pmodel.grid[region].z.ravel(),device=self.device)
                 self.locs[region] = torch.stack([x, y, z], axis=-1)
             else:
                 self.locs[region] = torch.stack([x, y], axis=-1)

--- a/pulse2percept/models/cortex/base.py
+++ b/pulse2percept/models/cortex/base.py
@@ -318,7 +318,7 @@ class ScoreboardSpatial(CortexSpatial):
             if self.vfmap.ndim == 2:
                 e_locs = torch.tensor([(x,y) for x,y in zip(x_el, y_el)]).to(self.torchmodel.device)
                 amps = torch.tensor(stim.data).to(self.torchmodel.device)
-                return self.torchmodel(amps=amps, e_locs=e_locs, separate=separate, boundary=boundary).T.numpy()
+                return self.torchmodel(amps=amps, e_locs=e_locs).T.numpy()
             else:
                 raise ValueError("Invalid dimensionality of visual field map")
         elif self.engine == "cython":

--- a/pulse2percept/models/cortex/base.py
+++ b/pulse2percept/models/cortex/base.py
@@ -200,7 +200,7 @@ class TorchScoreboardSpatial(nn.Module):
         """Predicts the percept
         Parameters
         ----------
-        amps: (n_elecs) shaped tensor
+        amps: (t, n_elecs) shaped tensor
             Amplitude for each electrode in the implant
         e_locs: (n_elecs, dim) shaped tensor
             electrode location (x, y, [z optional]) for each electrode
@@ -210,7 +210,7 @@ class TorchScoreboardSpatial(nn.Module):
         tot_intensities = 0
         for region in self.regions:
             d2_el = torch.sum((self.locs[region][:, None, :] - e_locs[None, :, :] )**2, axis=-1)
-            intensities = amps.T[:, None, :] * torch.exp(-d2_el / (2 * self.rho**2)) # generate gaussian blobs for each electrode
+            intensities = amps[:, None, :] * torch.exp(-d2_el / (2 * self.rho**2)) # generate gaussian blobs for each electrode
             if self.separate:
                 intensities *= torch.where((e_locs[None,:,0] < self.boundary) == (self.locs[region][:,None,0] < self.boundary), 1, 0) # ensure current cannot spread between hemispheres
             intensities = torch.sum(intensities, axis=-1) # add up all gaussian blobs
@@ -318,7 +318,7 @@ class ScoreboardSpatial(CortexSpatial):
             if self.vfmap.ndim == 2:
                 e_locs = torch.tensor([(x,y) for x,y in zip(x_el, y_el)]).to(self.torchmodel.device)
                 amps = torch.tensor(stim.data).to(self.torchmodel.device)
-                return self.torchmodel(amps=amps, e_locs=e_locs).T.numpy()
+                return self.torchmodel(amps=amps.T, e_locs=e_locs).T.numpy()
             else:
                 raise ValueError("Invalid dimensionality of visual field map")
         elif self.engine == "cython":

--- a/pulse2percept/models/cortex/base.py
+++ b/pulse2percept/models/cortex/base.py
@@ -301,7 +301,6 @@ class ScoreboardSpatial(CortexSpatial):
             if self.vfmap.ndim == 2:
                 e_locs = torch.tensor([(x,y) for x,y in zip(x_el, y_el)])
                 amps = torch.tensor(stim.data)
-                print(amps)
                 return self.torchmodel(amps=amps, e_locs=e_locs).T.numpy()
             else:
                 raise ValueError("Invalid dimensionality of visual field map")

--- a/pulse2percept/models/cortex/base.py
+++ b/pulse2percept/models/cortex/base.py
@@ -6,7 +6,6 @@ from .._beyeler2019 import fast_scoreboard, fast_scoreboard_3d
 from ...utils.constants import ZORDER
 import numpy as np
 import torch
-import torch.nn as nn
 
 class CortexSpatial(SpatialModel):
     """Abstract base class for cortical models

--- a/pulse2percept/models/cortex/base.py
+++ b/pulse2percept/models/cortex/base.py
@@ -205,7 +205,8 @@ class TorchScoreboardSpatial(nn.Module):
         for region in self.regions:
             d2_el = torch.sum((self.locs[region][:, None, :] - e_locs[None, :, :] )**2, axis=-1)
             intensities = amps.T[:, None, :] * torch.exp(-d2_el / (2 * self.rho**2)) # generate gaussian blobs for each electrode
-            intensities *= separate * torch.where((e_locs[None,:,0] < boundary) == (self.locs[region][:,None,0] < boundary), 1, 0) # ensure current cannot spread between hemispheres
+            if separate:
+                intensities *= torch.where((e_locs[None,:,0] < boundary) == (self.locs[region][:,None,0] < boundary), 1, 0) # ensure current cannot spread between hemispheres
             intensities = torch.sum(intensities, axis=-1) # add up all gaussian blobs
             tot_intensities += intensities
         return tot_intensities

--- a/pulse2percept/models/cortex/base.py
+++ b/pulse2percept/models/cortex/base.py
@@ -286,7 +286,6 @@ class ScoreboardSpatial(CortexSpatial):
 
     def _build(self):
         if self.engine == 'torch':
-            self.is_built = True
             self.torchmodel = TorchScoreboardSpatial(self)
 
     def get_default_params(self):

--- a/pulse2percept/models/cortex/base.py
+++ b/pulse2percept/models/cortex/base.py
@@ -170,8 +170,8 @@ class CortexSpatial(SpatialModel):
         return ax
 
 class TorchScoreboardSpatial(TorchBaseModel):
-    def __init__(self, p2pmodel, device=None):
-        super().__init__(p2pmodel, device=device)
+    def __init__(self, p2pmodel):
+        super().__init__(p2pmodel)
         self.rho = torch.tensor(p2pmodel.rho, device=self.device)
         self.shape = p2pmodel.grid.shape
         self.regions = p2pmodel.regions
@@ -317,8 +317,8 @@ class ScoreboardSpatial(CortexSpatial):
             boundary = self.vfmap.left_offset/2
         if self.engine == "torch":
             if self.vfmap.ndim == 2:
-                e_locs = torch.tensor([(x,y) for x,y in zip(x_el, y_el)]).to(self.torchmodel.device)
-                amps = torch.tensor(stim.data).to(self.torchmodel.device)
+                e_locs = torch.tensor([(x,y) for x,y in zip(x_el, y_el)]).to(self.device)
+                amps = torch.tensor(stim.data).to(self.device)
                 return self.torchmodel(amps=amps.T, e_locs=e_locs).T.numpy()
             else:
                 raise ValueError("Invalid dimensionality of visual field map")


### PR DESCRIPTION
## Description

Adds a PyTorch backend/engine for the cortex ScoreboardModel. This backend can be selected by passing the argument `engine='torch'` during model initialization.

This also adds the `TorchBaseModel` abstract class which all torch models will subclass.

Closes #611 

## Type of Change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
