### PR TITLE
[ENH] Add temporal torchmodel

### DIFF
--- a/pulse2percept/models/__init__.py
+++ b/pulse2percept/models/__init__.py
@@ -20,8 +20,8 @@ Computational models of the prosthetic vision, such as phosphene and neural resp
 
 """
 from .base import (BaseModel, Model, NotBuiltError, SpatialModel,
-                   TemporalModel)
-from .temporal import FadingTemporal
+                   TemporalModel, TorchSpatialModel, TorchTemporalModel)
+from .temporal import FadingTemporal, TorchFadingTemporal
 from .beyeler2019 import (ScoreboardModel, ScoreboardSpatial, AxonMapSpatial,
                           AxonMapModel)
 from .horsager2009 import Horsager2009Model, Horsager2009Temporal
@@ -50,6 +50,9 @@ __all__ = [
     'ScoreboardSpatial',
     'SpatialModel',
     'TemporalModel',
+    'TorchFadingTemporal',
+    'TorchSpatialModel',
+    'TorchTemporalModel',
     'Thompson2003Model',
     'Thompson2003Spatial',
 ]

--- a/pulse2percept/models/__init__.py
+++ b/pulse2percept/models/__init__.py
@@ -20,7 +20,7 @@ Computational models of the prosthetic vision, such as phosphene and neural resp
 
 """
 from .base import (BaseModel, Model, NotBuiltError, SpatialModel,
-                   TemporalModel, TorchSpatialModel, TorchTemporalModel)
+                   TemporalModel, TorchBaseModel)
 from .temporal import FadingTemporal, TorchFadingTemporal
 from .beyeler2019 import (ScoreboardModel, ScoreboardSpatial, AxonMapSpatial,
                           AxonMapModel)
@@ -50,9 +50,8 @@ __all__ = [
     'ScoreboardSpatial',
     'SpatialModel',
     'TemporalModel',
+    'TorchBaseModel',
     'TorchFadingTemporal',
-    'TorchSpatialModel',
-    'TorchTemporalModel',
     'Thompson2003Model',
     'Thompson2003Spatial',
 ]

--- a/pulse2percept/models/base.py
+++ b/pulse2percept/models/base.py
@@ -1053,7 +1053,7 @@ class Model(PrettyPrint):
         return _is_built
 
 
-class TorchSpatialModel(torch.nn.Module, metaclass=ABCMeta):
+class TorchBaseModel(torch.nn.Module, metaclass=ABCMeta):
     def __init__(self, p2pmodel):
         """
         Base class constructor for common logic
@@ -1100,56 +1100,6 @@ class TorchSpatialModel(torch.nn.Module, metaclass=ABCMeta):
         -------
         percept : torch.Tensor
             The predicted percept, with dimensions (n_time, n_pixels)
-
-        """
-        raise NotImplementedError
-
-class TorchTemporalModel(torch.nn.Module, metaclass=ABCMeta):
-    def __init__(self, p2pmodel):
-        """
-        Base class constructor for common logic
-
-        Subclasses should call this constructor and then should 
-        read in any relevant information from the p2pmodel (which is NOT stored),
-        including model parameters.
-
-        Parameters
-        ----------
-        p2pmodel : pulse2percept.models.Model
-            The pulse2percept model to wrap
-
-        """
-        super().__init__()
-        self.device = torch.device(p2pmodel.device)
-
-    @abstractmethod
-    def forward(self, stim, state=None, model_params=None):
-        """
-        Forward pass of the model
-
-        Parameters
-        ----------
-        stim : torch.Tensor
-            The stimulation tensor. 
-            Shape (n_pixels) or (n_pixels, 3) for biphasic models
-        state : torch.Tensor, optional
-            The model's state. If None, we assume this is the first frame.
-            The dimensions will vary from subclass to subclass.
-        model_params : torch.Tensor, optional
-            The model parameters to use. If None, will use the default parameters
-            Each subclass should use this, if provided, instead of parameters from the p2pmodel,
-            so that it is possible to differentiate wrt the parameters.
-
-            Only parameters that make sense to differentiate wrt and don't require
-            rebuild should go here.
-            For example, the fading temporal model would take in ([tau])
-
-        Returns
-        -------
-        percept : torch.Tensor
-            The predicted percept, with dimensions (n_pixels)
-        state : torch.Tensor
-            The model's state at the time of the predicted percept
 
         """
         raise NotImplementedError

--- a/pulse2percept/models/base.py
+++ b/pulse2percept/models/base.py
@@ -1078,7 +1078,7 @@ class TorchBaseModel(torch.nn.Module, metaclass=ABCMeta):
         self.device = torch.device(p2pmodel.device)
 
     @abstractmethod
-    def forward(self, stim, e_locs, model_params=None):
+    def forward(self, stim, e_locs=None, state=None, model_params=None):
         """
         Forward pass of the model
 
@@ -1088,7 +1088,9 @@ class TorchBaseModel(torch.nn.Module, metaclass=ABCMeta):
             The stimulation tensor for each electrode. 
             Shape (n_time, n_elecs) or (n_time, n_elecs, 3) for biphasic models
         e_locs : torch.Tensor
-            The locations of the electrodes
+            The locations of the electrodes (for spatial models)
+        state : torch.Tensor
+            The state of the model (for temporal models)
         model_params : Tensor, optional
             The model parameters to use. If None, will use the default parameters
             Each subclass should use this, if provided, instead of parameters from the p2pmodel,

--- a/pulse2percept/models/base.py
+++ b/pulse2percept/models/base.py
@@ -1053,7 +1053,7 @@ class Model(PrettyPrint):
         return _is_built
 
 
-class TorchBaseModel(torch.nn.Module, metaclass=ABCMeta):
+class TorchSpatialModel(torch.nn.Module, metaclass=ABCMeta):
     def __init__(self, p2pmodel):
         """
         Base class constructor for common logic
@@ -1075,6 +1075,7 @@ class TorchBaseModel(torch.nn.Module, metaclass=ABCMeta):
             p2pmodel.build()
         self.device = torch.device(p2pmodel.device)
 
+    @abstractmethod
     def forward(self, stim, e_locs, model_params=None):
         """
         Forward pass of the model
@@ -1097,8 +1098,58 @@ class TorchBaseModel(torch.nn.Module, metaclass=ABCMeta):
 
         Returns
         -------
-        torch.Tensor
+        percept : torch.Tensor
             The predicted percept, with dimensions (n_time, n_pixels)
+
+        """
+        raise NotImplementedError
+
+class TorchTemporalModel(torch.nn.Module, metaclass=ABCMeta):
+    def __init__(self, p2pmodel):
+        """
+        Base class constructor for common logic
+
+        Subclasses should call this constructor and then should 
+        read in any relevant information from the p2pmodel (which is NOT stored),
+        including model parameters.
+
+        Parameters
+        ----------
+        p2pmodel : pulse2percept.models.Model
+            The pulse2percept model to wrap
+
+        """
+        super().__init__()
+        self.device = torch.device(p2pmodel.device)
+
+    @abstractmethod
+    def forward(self, stim, state=None, model_params=None):
+        """
+        Forward pass of the model
+
+        Parameters
+        ----------
+        stim : torch.Tensor
+            The stimulation tensor. 
+            Shape (n_pixels) or (n_pixels, 3) for biphasic models
+        state : torch.Tensor, optional
+            The model's state. If None, we assume this is the first frame.
+            The dimensions will vary from subclass to subclass.
+        model_params : torch.Tensor, optional
+            The model parameters to use. If None, will use the default parameters
+            Each subclass should use this, if provided, instead of parameters from the p2pmodel,
+            so that it is possible to differentiate wrt the parameters.
+
+            Only parameters that make sense to differentiate wrt and don't require
+            rebuild should go here.
+            For example, the fading temporal model would take in ([tau])
+
+        Returns
+        -------
+        percept : torch.Tensor
+            The predicted percept, with dimensions (n_pixels)
+        state : torch.Tensor
+            The model's state at the time of the predicted percept
 
         """
         raise NotImplementedError

--- a/pulse2percept/models/temporal.py
+++ b/pulse2percept/models/temporal.py
@@ -36,10 +36,8 @@ class TorchFadingTemporal(TorchBaseModel):
 
         """
 
-        if model_params is None:
-            tau = self.tau
-        else:
-            tau = model_params[0]
+        tau = self.tau if model_params is None else torch.Tensor(model_params[0], device=self.device)
+
 
         if state is None:
             state = torch.unsqueeze(torch.zeros_like(stim, device=self.device), 0)
@@ -53,6 +51,11 @@ class TorchFadingTemporal(TorchBaseModel):
         state[0] = bright
 
         return bright, state
+    
+    def offline_predict(self, stim, model_params=None):
+        tau = self.tau if model_params is None else torch.Tensor(model_params[0], device=self.device)
+
+
 
 
 class FadingTemporal(TemporalModel):

--- a/pulse2percept/models/temporal.py
+++ b/pulse2percept/models/temporal.py
@@ -141,7 +141,7 @@ class FadingTemporal(TemporalModel):
     def _predict_temporal(self, stim, t_percept):
         """Predict the temporal response"""
         # Pass the stimulus as a 2D NumPy array to the fast Cython function:
-        stim_data = stim.data.reshape((-1, len(stim.time)))
+        stim_data = stim.data.reshape((-1, len(stim.time))).copy(order='c')
         # Calculate at which simulation time steps we need to output a percept.
         # This is basically t_percept/self.dt, but we need to beware of
         # floating point rounding errors! 29.999 will be rounded down to 29 by

--- a/pulse2percept/models/temporal.py
+++ b/pulse2percept/models/temporal.py
@@ -20,9 +20,8 @@ class TorchFadingTemporal(TorchBaseModel):
         stim : torch.Tensor
             One frame of output from a spatial model. This frame will represent
             the stimulus at a given time point. Must have shape (n_pixels)
-        state : torch.Tensor, optional
+        state : torch.Tensor
             The internal state of the model. state[0] corresponds to ``bright``
-            Defaults to None. If None, the state is assumed to be zero.
         model_params : torch.Tensor, optional
             The model parameters to use when predicting the percept.
             model_params[0] is ``tau``.
@@ -38,9 +37,6 @@ class TorchFadingTemporal(TorchBaseModel):
         """
 
         tau = self.tau if model_params is None else torch.Tensor(model_params[0], device=self.device)
-
-        if state is None:
-            state = torch.unsqueeze(torch.zeros_like(stim, device=self.device), 0)
         
         # get brightness state out
         bright = state[0]
@@ -53,7 +49,7 @@ class TorchFadingTemporal(TorchBaseModel):
         return torch.where(bright > self.thresh_percept, bright, 0), state
     
     def offline_predict(self, stim, t_stim, idx_percept, model_params=None):
-        state = None
+        state = torch.unsqueeze(torch.zeros_like(stim[:,0], device=self.device), 0)
 
         # calculate the total number of time points to simulate
         n_sim = idx_percept[-1] + 1

--- a/pulse2percept/models/temporal.py
+++ b/pulse2percept/models/temporal.py
@@ -24,7 +24,7 @@ class TorchFadingTemporal(TorchBaseModel):
             Defaults to None. If None, the state is assumed to be zero.
         model_params : torch.Tensor, optional
             The model parameters to use when predicting the percept.
-            model_params[0] is ``dt``, model_params[1] is ``tau``.
+            model_params[0] is ``tau``.
 
         Returns
         -------
@@ -37,11 +37,9 @@ class TorchFadingTemporal(TorchBaseModel):
         """
 
         if model_params is None:
-            dt = self.dt
             tau = self.tau
         else:
-            dt = model_params[0]
-            tau = model_params[1]
+            tau = model_params[0]
 
         if state is None:
             state = torch.unsqueeze(torch.zeros_like(stim, device=self.device), 0)
@@ -49,7 +47,7 @@ class TorchFadingTemporal(TorchBaseModel):
         # get brightness state out
         bright = state[0]
 
-        bright = torch.relu(bright + dt * (-stim - bright) / tau)
+        bright = torch.relu(bright + self.dt * (-stim - bright) / tau)
 
         # put brightness state back in
         state[0] = bright

--- a/pulse2percept/models/tests/test_temporal.py
+++ b/pulse2percept/models/tests/test_temporal.py
@@ -8,9 +8,9 @@ from pulse2percept.stimuli import Stimulus, MonophasicPulse, BiphasicPulse
 from pulse2percept.percepts import Percept
 from pulse2percept.utils import FreezeError
 
-
-def test_FadingTemporal():
-    model = FadingTemporal()
+@pytest.mark.parametrize('engine', ['cython', 'torch'])
+def test_FadingTemporal(engine):
+    model = FadingTemporal(engine=engine)
     # User can set their own params:
     model.dt = 0.1
     npt.assert_equal(model.dt, 0.1)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,4 +2,4 @@
 requires = ["setuptools <= 50.0","cython>=0.28", "numpy>1.11"]
 build-backend = "setuptools.build_meta"
 [tool.pytest.ini_options]
-addopts = "--benchmark-disable --benchmark-sort=mean --benchmark-warmup=on --benchmark-warmup-iterations=2 --benchmark-max-time=0.5"
+addopts = "--benchmark-skip --benchmark-sort=mean --benchmark-warmup=on --benchmark-warmup-iterations=2 --benchmark-max-time=0.5"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,4 +2,4 @@
 requires = ["setuptools <= 50.0","cython>=0.28", "numpy>1.11"]
 build-backend = "setuptools.build_meta"
 [tool.pytest.ini_options]
-addopts = "--benchmark-skip --benchmark-sort=mean --benchmark-warmup=on --benchmark-warmup-iterations=2 --benchmark-max-time=0.5"
+addopts = "--benchmark-disable --benchmark-sort=mean --benchmark-warmup=on --benchmark-warmup-iterations=2 --benchmark-max-time=0.5"


### PR DESCRIPTION
## Description

Adds torch backend for FadingTemporal, `TorchFadingTemporal`.

Refactors the TorchBaseModel `forward` signature to add a `state` kwarg for temporal models & to make the `e_locs` argument optional in the parent. Subclasses can choose which kwargs to use in the `forward`.

## Type of Change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

For detailed information on these and other aspects, see the contribution guidelines: https://pulse2percept.readthedocs.io/en/latest/developers/contributing.html
