### PR TITLE
[ENH] Add generic rectangle implant and remove codecov

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,4 +79,4 @@ jobs:
         flags: unittests
         name: codecov-umbrella
         yml: ./codecov.yml
-        commit_parent: e5289c3403d349b25111b358919b122815ac9b6c
+        commit_parent: e5289c3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,14 +69,15 @@ jobs:
         mkdir test_dir
         cd test_dir
         pytest --pyargs pulse2percept --cov-report=xml --cov=pulse2percept --doctest-modules
-    - name: Upload coveragei report to codecov.io
-      uses: codecov/codecov-action@v4
-      # Cannot yet post coverage report as comments on the PR, but see:
-      # https://github.com/codecov/codecov-python/pull/214
-      with:
-        token: ${{ secrets.CODECOV_TOKEN }}
-        file: ./test_dir/coverage.xml
-        flags: unittests
-        name: codecov-umbrella
-        yml: ./codecov.yml
-        commit_parent: e5289c3
+    # removed for now since it fails to compare to recent parent
+    # - name: Upload coveragei report to codecov.io
+    #   uses: codecov/codecov-action@v4
+    #   # Cannot yet post coverage report as comments on the PR, but see:
+    #   # https://github.com/codecov/codecov-python/pull/214
+    #   with:
+    #     token: ${{ secrets.CODECOV_TOKEN }}
+    #     file: ./test_dir/coverage.xml
+    #     flags: unittests
+    #     name: codecov-umbrella
+    #     yml: ./codecov.yml
+    #     commit_parent: e5289c3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,3 +79,4 @@ jobs:
         flags: unittests
         name: codecov-umbrella
         yml: ./codecov.yml
+        commit_parent: e5289c3403d349b25111b358919b122815ac9b6c

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,7 +70,7 @@ jobs:
         cd test_dir
         pytest --pyargs pulse2percept --cov-report=xml --cov=pulse2percept --doctest-modules
     - name: Upload coveragei report to codecov.io
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@v4
       # Cannot yet post coverage report as comments on the PR, but see:
       # https://github.com/codecov/codecov-python/pull/214
       with:

--- a/pulse2percept/implants/__init__.py
+++ b/pulse2percept/implants/__init__.py
@@ -23,7 +23,7 @@ Different prosthetic implants, such as Argus II, Alpha-IMS, BVT-24, PRIMA, Corti
 
     *  :ref:`Basic Concepts > Visual Prostheses <topics-implants>`
 """
-from .base import ProsthesisSystem
+from .base import ProsthesisSystem, RectangleImplant
 from .electrodes import (Electrode, PointSource, DiskElectrode,
                          SquareElectrode, HexElectrode)
 from .electrode_arrays import ElectrodeArray, ElectrodeGrid
@@ -56,6 +56,7 @@ __all__ = [
     'PRIMA55',
     'PRIMA40',
     'ProsthesisSystem',
+    'RectangleImplant',
     'SquareElectrode',
     'IMIE'
 ]


### PR DESCRIPTION
## Description
This adds a generic rectangle implant, which has been used previously in multiple papers.

Currently if you want to make a custom implant, you have to make a custom electrode grid, then create a prosthesis system subclass wrapping this earray, which is cumbersome, and lacks some of the basic functions that premade implants have.

This adds a generic `p2p.implants.RectangleImplant` which does all this for the user, so they can have an implant with a custom location, shape, spacing, electrode type, etc with one line.

It defaults to the 15x15 implant used in Granley et al 2022 and Granley et al 2023
![image](https://github.com/pulse2percept/pulse2percept/assets/25232557/11acc64e-f005-4e91-b77a-96e086459a7e)


This also removes codecov (see #632 )

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation change

