### PR TITLE
[FIX] Hotfix for numpy 2.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 cython>=0.28
-numpy>=1.11
+numpy>=1.11,<=1.26
 setuptools<50.0
 scipy<=1.7.1; python_version < '3.10'
 scipy>=1.0.1; python_version >= '3.10'


### PR DESCRIPTION
This limits numpy to be <= 1.26. Another PR (#635) is ready for numpy 2 support, but tests wont pass until neuropythy/pimms is made [np2 compatible ](https://github.com/noahbenson/pimms/pull/6)