### PR TITLE
[ENH] Add benchmarking

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,6 +1,5 @@
 import pytest
 
-
 def pytest_addoption(parser):
     parser.addoption(
         "--runslow", action="store_true", default=False, help="run slow tests"

--- a/pulse2percept/models/beyeler2019.py
+++ b/pulse2percept/models/beyeler2019.py
@@ -296,8 +296,6 @@ class AxonMapSpatial(SpatialModel):
             'ignore_pickle': False,
             # Use the Watson transform for dva <=> ret:
             'vfmap': Watson2014Map(),
-            # whether or not to compile torch models
-            'compile': False
         }
         return {**base_params, **params}
 

--- a/pulse2percept/models/beyeler2019.py
+++ b/pulse2percept/models/beyeler2019.py
@@ -295,7 +295,9 @@ class AxonMapSpatial(SpatialModel):
             # You can force a build by ignoring pickles:
             'ignore_pickle': False,
             # Use the Watson transform for dva <=> ret:
-            'vfmap': Watson2014Map()
+            'vfmap': Watson2014Map(),
+            # whether or not to compile torch models
+            'compile': False
         }
         return {**base_params, **params}
 
@@ -757,6 +759,8 @@ class AxonMapSpatial(SpatialModel):
         elif self.engine == 'torch':
             self.axon_contrib = self.calc_axon_sensitivity(axons, pad=True).astype(np.float32)
             self.torchmodel = TorchAxonMapSpatial(self)
+            if self.compile:
+                self.torchmodel = torch.compile(self.torchmodel)
         else: 
             axon_contrib = self.calc_axon_sensitivity(axons)
             self.axon_contrib = np.concatenate(axon_contrib).astype(np.float32)
@@ -798,7 +802,7 @@ class AxonMapSpatial(SpatialModel):
                     np.array([earray[e].y for e in stim.electrodes], dtype=np.float32)), axis=-1),
                 device=self.device)
             amps = torch.tensor(stim.data, device=self.device)
-            return self.torchmodel(amps, e_locs).numpy()
+            return self.torchmodel(amps, e_locs).cpu().numpy()
         elif self.engine == 'jax':
             raise NotImplementedError("Jax will be supported in future release")
         else: 

--- a/pulse2percept/models/cortex/tests/test_dynaphos.py
+++ b/pulse2percept/models/cortex/tests/test_dynaphos.py
@@ -10,6 +10,7 @@ from pulse2percept.implants.cortex import Cortivis, Orion
 from pulse2percept.topography import Polimeni2006Map
 from pulse2percept.percepts import Percept
 from pulse2percept.stimuli import BiphasicPulseTrain
+from pulse2percept.utils.testing import get_bench_runspec, standard_model_benchmark
 
 def test_DynaphosModel():
     model = DynaphosModel(xrange=(-3, 3), yrange=(-3, 3), xystep=0.1).build()
@@ -112,3 +113,16 @@ def test_dynaphos_plot():
     m.build()
     m.plot()
     plt.close()
+
+@pytest.mark.benchmark(group='Dynaphos')
+@pytest.mark.parametrize('grid, elecs, times', get_bench_runspec())
+def test_bench_nanduri(benchmark, grid, elecs, times):
+    # if engine == 'torch' and device == 'cuda' and not torch.cuda.is_available():
+    #     pytest.skip("CUDA not available")
+    # if device == 'cpu' and engine == 'torch' and compile and sys.platform != 'linux':
+    #     pytest.skip("Torch on CPU only available on posix/ubuntu")
+    import warnings
+    warnings.filterwarnings("ignore", category=UserWarning)
+    model = DynaphosModel()
+    phosphene = benchmark(standard_model_benchmark(model, grid=grid, elecs=elecs, times=times))
+    npt.assert_equal(phosphene.data.shape[0] * phosphene.data.shape[1], grid)

--- a/pulse2percept/models/horsager2009.py
+++ b/pulse2percept/models/horsager2009.py
@@ -75,8 +75,8 @@ class Horsager2009Temporal(TemporalModel):
             raise ValueError(f"All times 't_percept' must be distinct multiples "
                              f"of `dt`={self.dt:.2e}")
         # Cython returns a 2D (space x time) NumPy array:
-        return temporal_fast(stim_data.astype(np.float32),
-                             stim.time.astype(np.float32),
+        return temporal_fast(stim_data.astype(np.float32).copy(order='C'),
+                             stim.time.astype(np.float32).copy(order='C'),
                              idx_percept,
                              self.dt, self.tau1, self.tau2, self.tau3,
                              self.eps, self.beta, self.thresh_percept, self.n_threads)

--- a/pulse2percept/models/temporal.py
+++ b/pulse2percept/models/temporal.py
@@ -72,6 +72,6 @@ class FadingTemporal(TemporalModel):
             raise ValueError(f"All times 't_percept' must be distinct multiples "
                              f"of `dt`={self.dt:.2e}")
         # Cython returns a 2D (space x time) NumPy array:
-        return fading_fast(stim_data.astype(np.float32),
+        return fading_fast(stim_data.astype(np.float32).copy(order='C'),
                            stim.time.astype(np.float32),
                            idx_percept, self.dt, self.tau, self.thresh_percept, self.n_threads)

--- a/pulse2percept/models/tests/test_horsager2009.py
+++ b/pulse2percept/models/tests/test_horsager2009.py
@@ -9,7 +9,7 @@ from pulse2percept.stimuli import BiphasicPulse, BiphasicPulseTrain
 from pulse2percept.percepts import Percept
 from pulse2percept.models import Horsager2009Model, Horsager2009Temporal
 from pulse2percept.utils import FreezeError
-
+from pulse2percept.utils.testing import get_bench_runspec, standard_model_benchmark
 
 def test_Horsager2009Temporal():
     model = Horsager2009Temporal()
@@ -118,3 +118,16 @@ def test_deepcopy_Horsager2009Model():
     # Assert changing the original doesn't affect the copied
     original.verbose = False
     npt.assert_equal(original != copied, True)
+
+@pytest.mark.benchmark(group='Horsager')
+@pytest.mark.parametrize('grid, elecs, times', get_bench_runspec(grids=None))
+def test_bench_horsager(benchmark, grid, elecs, times):
+    # if engine == 'torch' and device == 'cuda' and not torch.cuda.is_available():
+    #     pytest.skip("CUDA not available")
+    # if device == 'cpu' and engine == 'torch' and compile and sys.platform != 'linux':
+    #     pytest.skip("Torch on CPU only available on posix/ubuntu")
+    import warnings
+    warnings.filterwarnings("ignore", category=UserWarning)
+    model = Horsager2009Model()
+    phosphene = benchmark(standard_model_benchmark(model, grid=grid, elecs=elecs, times=times))
+    npt.assert_equal(phosphene.data.shape[0] * phosphene.data.shape[1], elecs)

--- a/pulse2percept/models/tests/test_nanduri2012.py
+++ b/pulse2percept/models/tests/test_nanduri2012.py
@@ -10,6 +10,7 @@ from pulse2percept.percepts import Percept
 from pulse2percept.models import (Nanduri2012Model, Nanduri2012Spatial,
                                   Nanduri2012Temporal)
 from pulse2percept.utils import FreezeError
+from pulse2percept.utils.testing import get_bench_runspec, standard_model_benchmark
 
 
 def test_Nanduri2012Spatial():
@@ -309,3 +310,17 @@ def test_Nanduri2012Model_predict_percept():
         brightest_frame = percept.data[..., idx_frame]
         frames_freq.append(brightest_frame)
     npt.assert_equal([np.sum(f > bright_th) for f in frames_freq], [21, 49])
+
+
+@pytest.mark.benchmark(group='Nanduri')
+@pytest.mark.parametrize('grid, elecs, times', get_bench_runspec())
+def test_bench_nanduri(benchmark, grid, elecs, times):
+    # if engine == 'torch' and device == 'cuda' and not torch.cuda.is_available():
+    #     pytest.skip("CUDA not available")
+    # if device == 'cpu' and engine == 'torch' and compile and sys.platform != 'linux':
+    #     pytest.skip("Torch on CPU only available on posix/ubuntu")
+    import warnings
+    warnings.filterwarnings("ignore", category=UserWarning)
+    model = Nanduri2012Model()
+    phosphene = benchmark(standard_model_benchmark(model, grid=grid, elecs=elecs, times=times))
+    npt.assert_equal(phosphene.data.shape[0] * phosphene.data.shape[1], grid)

--- a/pulse2percept/models/tests/test_temporal.py
+++ b/pulse2percept/models/tests/test_temporal.py
@@ -3,10 +3,11 @@ import copy
 import numpy.testing as npt
 import pytest
 
-from pulse2percept.models import FadingTemporal
+from pulse2percept.models import FadingTemporal, Model
 from pulse2percept.stimuli import Stimulus, MonophasicPulse, BiphasicPulse
 from pulse2percept.percepts import Percept
 from pulse2percept.utils import FreezeError
+from pulse2percept.utils.testing import get_bench_runspec, standard_model_benchmark
 
 
 def test_FadingTemporal():
@@ -79,3 +80,17 @@ def test_deepcopy_FadingTemporal():
     # Assert "destroying" the original doesn't affect the copied
     original = None
     npt.assert_equal(copied is not None, True)
+
+
+@pytest.mark.benchmark(group='FadingTemporal')
+@pytest.mark.parametrize('grid, elecs, times', get_bench_runspec(grids=None))
+def test_bench_fading_temporal(benchmark, grid, elecs, times):
+    # if engine == 'torch' and device == 'cuda' and not torch.cuda.is_available():
+    #     pytest.skip("CUDA not available")
+    # if device == 'cpu' and engine == 'torch' and compile and sys.platform != 'linux':
+    #     pytest.skip("Torch on CPU only available on posix/ubuntu")
+    import warnings
+    warnings.filterwarnings("ignore", category=UserWarning)
+    model = Model(spatial=None, temporal=FadingTemporal())
+    phosphene = benchmark(standard_model_benchmark(model, grid=grid, elecs=elecs, times=times))
+    npt.assert_equal(phosphene.data.shape[0] * phosphene.data.shape[1], elecs)

--- a/pulse2percept/models/tests/test_thompson2003.py
+++ b/pulse2percept/models/tests/test_thompson2003.py
@@ -12,7 +12,7 @@ from pulse2percept.implants import ArgusI, ArgusII
 from pulse2percept.percepts import Percept
 from pulse2percept.models import (Thompson2003Spatial, Thompson2003Model)
 from pulse2percept.topography import Curcio1990Map, Watson2014DisplaceMap
-from pulse2percept.utils.testing import assert_warns_msg
+from pulse2percept.utils.testing import assert_warns_msg, standard_model_benchmark, get_bench_runspec
 
 
 def test_Thompson2003Spatial():
@@ -181,3 +181,18 @@ def test_deepcopy_Thompson2003Model():
     # Assert "destroying" the original doesn't affect the copied
     original = None
     npt.assert_equal(copied is not None, True)
+
+
+
+@pytest.mark.benchmark(group='Thompson')
+@pytest.mark.parametrize('grid, elecs, times', get_bench_runspec())
+def test_bench_thompson(benchmark, grid, elecs, times):
+    # if engine == 'torch' and device == 'cuda' and not torch.cuda.is_available():
+    #     pytest.skip("CUDA not available")
+    # if device == 'cpu' and engine == 'torch' and compile and sys.platform != 'linux':
+    #     pytest.skip("Torch on CPU only available on posix/ubuntu")
+    import warnings
+    warnings.filterwarnings("ignore", category=UserWarning)
+    model = Thompson2003Model()
+    phosphene = benchmark(standard_model_benchmark(model, grid=grid, elecs=elecs, times=times))
+    npt.assert_equal(phosphene.data.shape[0] * phosphene.data.shape[1], grid)

--- a/pulse2percept/utils/__init__.py
+++ b/pulse2percept/utils/__init__.py
@@ -14,6 +14,7 @@
     parallel
     deprecation
     three_dim
+    testing
 
 """
 from .base import (PrettyPrint, FreezeError, Frozen, Data, bijective26_name,

--- a/pulse2percept/utils/testing.py
+++ b/pulse2percept/utils/testing.py
@@ -3,6 +3,7 @@
 import pytest
 import numpy.testing as npt
 import warnings
+import numpy as np
 
 
 def assert_warns_msg(expected_warning, func, msg, *args, **kwargs):
@@ -43,57 +44,171 @@ def assert_warns_msg(expected_warning, func, msg, *args, **kwargs):
 
 
 
-def generate_standard_benchmark(ModelClass, grid=True, elecs=True, time=True, **kwargs):
-    """Generates a standard benchmark for a model class
-    
-    Note that this does not do any checks for correctness, but simply
-    runs the model with different parameters and records the time it takes.
+def standard_model_benchmark(model, grid=None, elecs=None, times=None, 
+                               implant=None, **kwargs):
+    """
+    Generates a benchmark function that can be used to test the performance
+    of a model for a standard benchmark test.
+
+    Example usage:
+    ```
+    def test_standard_benchmark(benchmark):
+        model = AxonMapModel()
+        percept = benchmark(standard_benchmark_factory(model)())
+    ```
+
+    It is useful when combined with get_runspec() to run a standard benchmark
+    test with multiple parameters.
 
     Parameters
     ----------
-    ModelClass : p2p.model.Model
-        The model class to be tested.
-    grid : bool, optional
-        Whether to parametrize the test with different pixel grid sizes
-    elecs : bool, optional
-        Whether to parametrize the test with different electrode grid sizes
-    time : bool, optional
-        Whether to parametrize the test with different numbers of time points.
-    **kwargs : dict
-        Additional keyword arguments to be passed to the model class.
-    
+    model : object
+        The model to be tested.
+    grids : int or None
+        The grid size. If None, the default grid size of 100 pixels will be used.
+        Options: 100, 500, 1000, 5000, 10000.
+    elecs : int or None
+        The number of electrodes. If None, 20 electrodes will be used.
+        Options: 1, 20, 100, 225, 1000, 5000.
+    times : int, None or 'biphasic'
+        The time. If None, 1 time point will be used. If 'biphasic', a biphasic
+        pulse train will be used. Any other integer value can be used.
+    implant : object or None
+        The implant to be used. If None, a RectangleImplant will be used.
+
     Returns
     -------
-    benchmark : function
-        A function that runs the benchmark test, returning
+    function
+        A benchmark function just containing predict_percept for the specified setup.
     """
+    from ..models import BiphasicAxonMapModel, BiphasicAxonMapSpatial
+    from ..models.cortex import DynaphosModel
+    from ..implants import RectangleImplant
+    from ..stimuli import BiphasicPulseTrain
+    if grid is None:
+        grid = 100
+    if isinstance(grid, tuple):
+        if len(grid) == 2:
+            raise ValueError('grids must be a single integer or a tuple of 3 integers')
+        gridspec = grid
+    elif int(grid) == 100:
+        gridspec = ((-4, 5), (-4, 5), 1)
+    elif int(grid) == 500:
+        gridspec = ((-6, 6), (-4.5, 5), 0.5)
+    elif int(grid) == 1000:
+        gridspec = ((-6, 6), (-9.5, 10), 0.5)
+    elif int(grid) == 5000:
+        gridspec = ((-4.8, 5), (-9.8, 10), 0.2)
+    elif int(grid) == 10000:
+        gridspec = ((-4.9, 5), (-4.9, 5), 0.1)
 
-    def benchmark(benchmark, grid=None, elecs=None, time=None):
-        """
+    model_kwargs = {
+        'xrange': gridspec[0],
+        'yrange': gridspec[1],
+        'xystep': gridspec[2],
+    }
+    # replace defaults with user-provided values
+    model_kwargs = {**model_kwargs, **kwargs} 
+    model.build(**model_kwargs)
+    if not isinstance(grid, tuple):
+        npt.assert_equal(model.grid.shape[0] * model.grid.shape[1], int(grid))
+
+    if elecs is None:
+        elecs = 100
+    if int(elecs) == 20:
+        # (shape1, shape2, spacing)
+        shapespec = (4, 5, 400)
+    elif int(elecs) == 1:
+        shapespec = (1, 1, 400)
+    elif int(elecs) == 100:
+        shapespec = (10, 10, 250)
+    elif int(elecs) == 225:
+        shapespec = (15, 15, 200)
+    elif int(elecs) == 1000:
+        shapespec = (25, 40, 50)
+    elif int(elecs) == 5000:
+        shapespec = (50, 100, 20)
+
+    if implant is None:
+        implant = RectangleImplant(shape=shapespec[0:2], spacing=shapespec[2])
+    
+    npt.assert_equal(len(implant.electrodes), int(elecs))
+    if times is None:
+        times = 1
+        biphasic_classes = [BiphasicAxonMapModel, BiphasicAxonMapSpatial, DynaphosModel]
+        if np.any([isinstance(model, b) for b in biphasic_classes]):
+            times = 'biphasic'
+    if times == 'biphasic':
+        implant.stim = {e : BiphasicPulseTrain(20., np.random.rand(1).item(), .45) for e in implant.electrode_names}
+    else:
+        implant.stim = np.random.rand(len(implant.electrodes), int(times)).astype(np.float32)
+    def bench_fn():
+        return model.predict_percept(implant)
+    print(model.grid.shape, len(implant.electrodes), implant.stim.shape)
+    return bench_fn
         
-        """
-        if grid is None or int(grid) == 100:
-            gridspec = ((-4, 5), (-4, 5), 1)
-        elif int(grid) == 500:
-            gridspec = ((-6, 6), (-4.5, 5), 0.5)
-        elif int(grid) == 1000:
-            gridspec = ((-3, 3), (-4.75, 5), 0.25)
-        elif int(grid) == 5000:
-            gridspec = ((-2.9, 3), (-4.9, 5), 0.1)
-        elif int(grid) == 10000:
-            gridspec = ((-4.9, 5), (-4.9, 5), 0.1)
+    
+def get_bench_runspec(grids=True, elecs=True, times=True, biphasic=False):
+    """
+    Generates a list of tuples that can be used in combination with
+    pytest.mark.parameterize to run a standard benchmark test.
 
-        model_kwargs = {
-            'xrange': gridspec[0],
-            'yrange': gridspec[1],
-            'xystep': gridspec[2],
-        }
-        # replace defaults with user-provided values
-        model_kwargs = {**model_kwargs, **kwargs} 
-        model = ModelClass(**model_kwargs)
-        model.build()
+    Example usage:
+    ```
+    @pytest.mark.parametrize('grid, elecs, time', get_runspec())
+    def test_standard_benchmark(benchmark, grid, elecs, time):
+        model = AxonMapModel()
+        percept = benchmark(standard_benchmark_factory(model, grid, elecs, time)())
+    ```
 
-        
+    Parameters
+    ----------
+    grids : bool or list
+        If True, the grid size will be varied. If a list is provided, the
+        grid sizes will be taken from the list. They must be one of the valid
+        sizes for the standard benchmark: 100, 500, 1000, 5000, 10000.
+    elecs : bool
+        If True, the number of electrodes will be varied. If a list is provided,
+        the number of electrodes will be taken from the list. They must be one
+        of the valid sizes for the standard benchmark: 1, 20, 100, 225, 1000, 5000.
+    times : bool
+        If True, the time will be varied. If a list is provided, the time will
+        be taken from the list. Any time can be used.
+
+    Returns
+    -------
+    list
+        A list of tuples that can be used in combination with
+        pytest.mark.parameterize to run a standard benchmark test.
+    
+    """
+    if biphasic == True:
+        times = 'biphasic'
+    default_times = 'biphasic' if times == 'biphasic' else 1
+    default_elecs = 20
+    default_grids = 100
+    runspecs = []
+    if grids == True:
+        for g in [100, 500, 1000, 5000, 10000]:
+            runspecs.append((g, default_elecs, default_times))
+    elif isinstance(grids, list):
+        for g in grids:
+            runspecs.append((g, default_elecs, default_times))
+    if elecs == True:
+        for e in [1, 20, 100, 225, 1000, 5000]:
+            runspecs.append((default_grids, e, default_times))
+    elif isinstance(elecs, list):
+        for e in elecs:
+            runspecs.append((default_grids, e, default_times))
+    if times == True:
+        for times in [1, 10, 100, 1000]:
+            runspecs.append((default_grids, default_elecs, times))
+    elif isinstance(times, list):
+        for t in times:
+            runspecs.append((default_grids, default_elecs, t))
+    if grids == False and elecs == False and times == False:
+        runspecs.append((default_grids, default_elecs, default_times))
+    return list(set(runspecs))
 
         
     

--- a/pulse2percept/utils/testing.py
+++ b/pulse2percept/utils/testing.py
@@ -106,11 +106,11 @@ def standard_model_benchmark(model, grid=None, elecs=None, times=None,
         'xrange': gridspec[0],
         'yrange': gridspec[1],
         'xystep': gridspec[2],
-    }
+    } if hasattr(model, 'xrange') else {}
     # replace defaults with user-provided values
     model_kwargs = {**model_kwargs, **kwargs} 
     model.build(**model_kwargs)
-    if not isinstance(grid, tuple):
+    if not isinstance(grid, tuple) and hasattr(model, 'grid'):
         npt.assert_equal(model.grid.shape[0] * model.grid.shape[1], int(grid))
 
     if elecs is None:
@@ -144,7 +144,7 @@ def standard_model_benchmark(model, grid=None, elecs=None, times=None,
         implant.stim = np.random.rand(len(implant.electrodes), int(times)).astype(np.float32)
     def bench_fn():
         return model.predict_percept(implant)
-    print(model.grid.shape, len(implant.electrodes), implant.stim.shape)
+    # print(model.grid.shape, len(implant.electrodes), implant.stim.shape)
     return bench_fn
         
     

--- a/pulse2percept/utils/testing.py
+++ b/pulse2percept/utils/testing.py
@@ -40,3 +40,60 @@ def assert_warns_msg(expected_warning, func, msg, *args, **kwargs):
         npt.assert_equal(msg in ''.join(record[0].message.args[0]), True)
     # Remove generated warnings from registry:
     warnings.resetwarnings()
+
+
+
+def generate_standard_benchmark(ModelClass, grid=True, elecs=True, time=True, **kwargs):
+    """Generates a standard benchmark for a model class
+    
+    Note that this does not do any checks for correctness, but simply
+    runs the model with different parameters and records the time it takes.
+
+    Parameters
+    ----------
+    ModelClass : p2p.model.Model
+        The model class to be tested.
+    grid : bool, optional
+        Whether to parametrize the test with different pixel grid sizes
+    elecs : bool, optional
+        Whether to parametrize the test with different electrode grid sizes
+    time : bool, optional
+        Whether to parametrize the test with different numbers of time points.
+    **kwargs : dict
+        Additional keyword arguments to be passed to the model class.
+    
+    Returns
+    -------
+    benchmark : function
+        A function that runs the benchmark test, returning
+    """
+
+    def benchmark(benchmark, grid=None, elecs=None, time=None):
+        """
+        
+        """
+        if grid is None or int(grid) == 100:
+            gridspec = ((-4, 5), (-4, 5), 1)
+        elif int(grid) == 500:
+            gridspec = ((-6, 6), (-4.5, 5), 0.5)
+        elif int(grid) == 1000:
+            gridspec = ((-3, 3), (-4.75, 5), 0.25)
+        elif int(grid) == 5000:
+            gridspec = ((-2.9, 3), (-4.9, 5), 0.1)
+        elif int(grid) == 10000:
+            gridspec = ((-4.9, 5), (-4.9, 5), 0.1)
+
+        model_kwargs = {
+            'xrange': gridspec[0],
+            'yrange': gridspec[1],
+            'xystep': gridspec[2],
+        }
+        # replace defaults with user-provided values
+        model_kwargs = {**model_kwargs, **kwargs} 
+        model = ModelClass(**model_kwargs)
+        model.build()
+
+        
+
+        
+    

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,0 @@
-[tool.pytest.ini_options]
-addopts = "--benchmark-disable --benchmark-sort=mean --benchmark-warmup=on --benchmark-warmup-iterations=2 --benchmark-max-time=0.5"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools <= 50.0", "numpy<=1.26", "cython>0.28"]
+requires = ["setuptools <= 50.0", "numpy==1.26.4", "cython>0.28"]
 build-backend = "setuptools.build_meta"
 [tool.pytest.ini_options]
 addopts = "--benchmark-disable --benchmark-sort=mean --benchmark-warmup=on --benchmark-warmup-iterations=2 --benchmark-max-time=0.5"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools <= 50.0","cython<=3.0", "numpy>1.11"]
+requires = ["setuptools <= 50.0","cython>=0.28", "numpy>1.11"]
 build-backend = "setuptools.build_meta"
 [tool.pytest.ini_options]
 addopts = "--benchmark-disable --benchmark-sort=mean --benchmark-warmup=on --benchmark-warmup-iterations=2 --benchmark-max-time=0.5"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools <= 50.0","cython<=3.0"]
+requires = ["setuptools <= 50.0","cython<=3.0", "numpy>1.11"]
 build-backend = "setuptools.build_meta"
 [tool.pytest.ini_options]
 addopts = "--benchmark-disable --benchmark-sort=mean --benchmark-warmup=on --benchmark-warmup-iterations=2 --benchmark-max-time=0.5"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,5 @@
+[build-system]
+requires = ["setuptools <= 50.0", "numpy<=1.26", "cython>0.28"]
+build-backend = "setuptools.build_meta"
 [tool.pytest.ini_options]
 addopts = "--benchmark-disable --benchmark-sort=mean --benchmark-warmup=on --benchmark-warmup-iterations=2 --benchmark-max-time=0.5"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools <= 50.0", "numpy==1.26.4", "cython>0.28"]
+requires = ["setuptools <= 50.0", "numpy>=1.24", "cython>0.28"]
 build-backend = "setuptools.build_meta"
 [tool.pytest.ini_options]
 addopts = "--benchmark-disable --benchmark-sort=mean --benchmark-warmup=on --benchmark-warmup-iterations=2 --benchmark-max-time=0.5"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[tool.pytest.ini_options]
+addopts = "--benchmark-disable --benchmark-sort=mean --benchmark-warmup=on --benchmark-warmup-iterations=2 --benchmark-max-time=0.5"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools <= 50.0", "numpy>=1.11", "cython<=3.0"]
+requires = ["setuptools <= 50.0","cython<=3.0"]
 build-backend = "setuptools.build_meta"
 [tool.pytest.ini_options]
 addopts = "--benchmark-disable --benchmark-sort=mean --benchmark-warmup=on --benchmark-warmup-iterations=2 --benchmark-max-time=0.5"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools <= 50.0", "numpy>=1.24", "cython>0.28"]
+requires = ["setuptools <= 50.0", "numpy>=1.24", "cython<=3.0"]
 build-backend = "setuptools.build_meta"
 [tool.pytest.ini_options]
 addopts = "--benchmark-disable --benchmark-sort=mean --benchmark-warmup=on --benchmark-warmup-iterations=2 --benchmark-max-time=0.5"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools <= 50.0", "numpy>=1.24", "cython<=3.0"]
+requires = ["setuptools <= 50.0", "numpy>=1.11", "cython<=3.0"]
 build-backend = "setuptools.build_meta"
 [tool.pytest.ini_options]
 addopts = "--benchmark-disable --benchmark-sort=mean --benchmark-warmup=on --benchmark-warmup-iterations=2 --benchmark-max-time=0.5"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,7 @@
 dask
 h5py
 pytest>=5
+pytest-benchmark
 pytest-cov
 coveralls
 flake8

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,9 @@
 cython>=0.28
 numpy>=1.11,<=1.26
 setuptools<50.0
-scipy<=1.7.1; python_version < '3.10'
-scipy>=1.0.1; python_version >= '3.10'
+# scipy<=1.7.1; python_version < '3.10'
+# scipy>=1.0.1; python_version >= '3.10'
+scipy>=1.0.1
 scikit_image>=0.14
 matplotlib>=3.0.2
 imageio_ffmpeg>=0.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,6 @@
 cython>=0.28
 numpy>=1.11,<=1.26
 setuptools<50.0
-# scipy<=1.7.1; python_version < '3.10'
-# scipy>=1.0.1; python_version >= '3.10'
 scipy>=1.0.1
 scikit_image>=0.14
 matplotlib>=3.0.2


### PR DESCRIPTION
Adds timing benchmarking using pytest-benchmark for all models.

This is disabled by default, but can be enabled by passing `--benchmark-enable` to pytest.

Some options could be removed eventually. Right now every model is benchmarked with all engines (serial, cython, and torch), as well as torch on cpu and gpu, and torch with and without compilation. 

Closes #627 

This also adds a barebones pyproject.toml. Eventually we should migrate more setup, installation, and configuration to here (#571)