### PR TITLE
[FIX] Submodule import error

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: Build and Test
+name: Build & Test
 
 on:
   push:
@@ -10,7 +10,7 @@ on:
 
 jobs:
   build:
-    name: Build & Test on ${{ matrix.os }} with Python ${{ matrix.python-version }}
+    name: Build ${{ matrix.os }} Py ${{ matrix.python-version }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -60,20 +60,7 @@ jobs:
           pip install flake8
           flake8 pulse2percept --ignore N802,N806,W504 --select W503 --count --show-source --statistics
 
-      # Step 6: Debug OpenMP paths (macOS optional debugging step)
-      - name: Debug OpenMP paths
-        if: runner.os == 'macOS'
-        run: |
-          echo "Using Homebrew LLVM clang:"
-          which clang
-          which clang++
-          clang --version
-          echo "Include paths:"
-          ls -l $(brew --prefix libomp)/include
-          echo "Library paths:"
-          ls -l $(brew --prefix libomp)/lib
-
-      # Step 7a: Install the package (Windows)
+      # Step 6a: Install the package (Windows)
       - name: Install package (Windows)
         if: runner.os == 'windows-latest'
         run: |
@@ -85,7 +72,7 @@ jobs:
           $env:PATH += ';C:\Program Files (x86)\Windows Kits\10\bin\10.0.16299.0\x64'
           pip install .[dev]
             
-      # Step 7b: Install the package (Non-Windows)
+      # Step 6b: Install the package (Non-Windows)
       - name: Install package (Unix)
         if: runner.os != 'windows-latest'
         run: |
@@ -93,7 +80,7 @@ jobs:
           python setup.py build_ext --inplace
           python -m pip install ".[dev]"
       
-      # Step 8: Log
+      # Step 7: Log
       - name: Log environment info
         run: |
           python --version
@@ -101,22 +88,22 @@ jobs:
           gcc --version
           pip show pulse2percept
           
-      # Step 9: Conditional Test Execution
+      # Step 8: Conditional Test Execution
       - name: Run default test suite for push
         if: github.event_name == 'push' && !github.event.pull_request
         run: |
           mkdir test_dir
           cd test_dir
-          pytest --pyargs pulse2percept --doctest-modules --cov-report=xml --cov=pulse2percept --doctest-modules
+          pytest --pyargs pulse2percept --doctest-modules
 
       - name: Run slow tests for pull requests
         if: github.event_name == 'pull_request'
         run: |
           mkdir test_dir
           cd test_dir
-          pytest --pyargs pulse2percept --runslow --doctest-modules        
+          pytest --pyargs pulse2percept --runslow --cov-report=xml --cov=pulse2percept --doctest-modules        
           
-      # Step 10: Log
+      # Step 9: Codecov
       - name: Upload coverage report to codecov.io
         if: github.event_name == 'pull_request'
         uses: codecov/codecov-action@v1

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   build_wheels:
-    name: Build wheels on ${{ matrix.os }}
+    name: Wheels on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -32,7 +32,6 @@ sphinx:
 # See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
 python:
    install:
-      - requirements: requirements.txt
       - requirements: doc/requirements.txt
       - method: pip
         path: .

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -100,7 +100,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = 'pulse2percept'
-copyright = '2016 - 2020, pulse2percept developers (BSD License)'
+copyright = '2016 - 2025, pulse2percept developers (BSD License)'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,5 +1,4 @@
 jinja2<3.1
-setuptools>=42.0,<50.0
 sphinx==1.8.5
 alabaster<0.7.14
 sphinx_gallery>=0.7

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,10 +58,14 @@ dev = [
 
 [tool.setuptools]
 package-dir = {"" = "."}
-packages = ["pulse2percept"]
 include-package-data = true
 
 [tool.setuptools.package-data]
 "pulse2percept.stimuli" = ["data/*"]
 "pulse2percept.datasets" = ["data/*"]
 "pulse2percept.viz" = ["data/*"]
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["pulse2percept", "pulse2percept.*"]
+exclude = ["wheelhouse", "tests", "*/tests"]


### PR DESCRIPTION
Adds a few lines to pyproject.toml which fixes a bug where after `import pulse2percept as p2p` submodules were not found. Now it searches pulse2percept and pulse2percept/* for submodules (including the parent).

@mbeyeler This is a minimal fix just changing the toml, if you had other additions to pyproject.toml, setup.py, etc in the fix-data-docs branch feel free to add those in or in a separate PR after