### PR TITLE
[FIX] Ensemble Implant with multiple stimuli

### DIFF
--- a/pulse2percept/implants/ensemble.py
+++ b/pulse2percept/implants/ensemble.py
@@ -223,7 +223,9 @@ class EnsembleImplant(ProsthesisSystem):
                     # Interpolate the stim data to new_times
                     new_stim = np.zeros((n_electrodes, len(new_times)))
                     for j in range(stim.data.shape[0]):  # Interpolate each electrode separately
-                        new_stim[j, :] = np.interp(new_times, t, stim.data[j, :])
+                        # if the stim ends, make it 0 instead of repeating the last value. Only interpolate
+                        # for the times that are in the original stim
+                        new_stim[j] = np.interp(new_times, t, stim.data[j], left=0, right=0)
                 
                 new_stims.append(new_stim)
             

--- a/pulse2percept/implants/ensemble.py
+++ b/pulse2percept/implants/ensemble.py
@@ -131,10 +131,13 @@ class EnsembleImplant(ProsthesisSystem):
         safe_mode : bool, optional
             If safe mode is enabled, only charge-balanced stimuli are allowed.
         """
-        self.implants = implants
-        self.safe_mode = safe_mode
         self.preprocess = preprocess
-        self.stim = stim
+        self.safe_mode = safe_mode
+        self.implants = implants
+        # self.stim might be set in self.implants = implants, so don't override it 
+        # unless the user actually passes a stimulus
+        if stim is not None or not hasattr(self, 'stim'):
+            self.stim = stim
 
     def _pprint_params(self):
         """Return dict of class attributes to pretty-print"""
@@ -168,4 +171,78 @@ class EnsembleImplant(ProsthesisSystem):
         for i, implant in self._implants.items():
             for name, electrode in implant.earray.electrodes.items():
                 electrodes[str(i) + "-" + str(name)] = electrode
+            
         self._earray = ElectrodeArray(electrodes)
+        self.merge_stimuli()
+        
+    def merge_stimuli(self):
+        """Constructs the combined stimulus for all implants in self._implants"""
+        if any([i.stim for i in self._implants.values()]):
+            # Need to combine all stimuli
+            # The ith stim is a np array of shape (implant[i].n_electrodes, len(times[i]))
+            # i.e. the amplitude of each electrode at each time point in times[i]
+            # HOWEVER, the times are not necessarily the same across implants
+            # So we need to create a new times array that is the union of all times
+            # and then interpolate the stimuli for each implant to this new time array
+            # Also, times[i] can be None if the stim is not temporal; in this case, we
+            # just line it up with the first time point. Finally, if the
+            # stim is none, then we just set it to all 0's, for all the time points
+            stims = []
+            times = []
+            for i, implant in self._implants.items():
+                if implant.stim is not None:
+                    stims.append(implant.stim)
+                    times.append(implant.stim.time)
+                else:
+                    stims.append(None)
+                    times.append(None)
+
+            # Collect all time points, ignoring None
+            valid_times = [t for t in times if t is not None]
+            
+            if valid_times:
+                # Get the union of all time points
+                new_times = np.unique(np.concatenate(valid_times))
+            else:
+                new_times = None  # No time-dependent stimulation
+            
+            # Create a new list to hold interpolated stimuli
+            new_stims = []
+            num_timepoints = len(new_times) if new_times is not None else 1
+            for i, (stim, t) in enumerate(zip(stims, times)):
+                n_electrodes = len(self._implants[list(self._implants.keys())[i]].electrode_names)
+                if stim is None:
+                    # If stim is None, create a zero array of shape (n_electrodes, len(new_times))
+                    new_stim = np.zeros((n_electrodes, num_timepoints))
+                elif t is None:
+                    # If stim exists but has no time information, assume all values correspond to first time point
+                    # fill the rest with 0s
+                    new_stim = np.zeros((n_electrodes, num_timepoints))
+                    new_stim[:, 0] = stim.data[:, 0]
+                else:
+                    # Interpolate the stim data to new_times
+                    new_stim = np.zeros((n_electrodes, len(new_times)))
+                    for j in range(stim.data.shape[0]):  # Interpolate each electrode separately
+                        new_stim[j, :] = np.interp(new_times, t, stim.data[j, :])
+                
+                new_stims.append(new_stim)
+            
+            # The metadata for each implant is stored in implant.metadata, and has 'electrodes' and 'user' keys
+            # We need to merge the 'electrodes' key across all implants, and simply concatenate the 'user' keys
+            metadata = {}
+            electrode_metadata = {}
+            user_metadata = {}
+            for i_name, implant in self._implants.items():
+                if implant.stim is None:
+                    continue
+                # in the new implant, the the electrode names are i_name + "-" + electrode_name
+                for e_name, e_metadata in implant.stim.metadata['electrodes'].items():
+                    electrode_metadata[str(i_name) + "-" + e_name] = e_metadata
+                user_metadata[str(i_name)] = implant.stim.metadata['user']
+            metadata['electrodes'] = electrode_metadata
+            metadata['user'] = user_metadata
+
+            # Combine all new_stims into a final array (stack along a new axis if needed)
+            # runtime import to avoid circular import
+            from ..stimuli import Stimulus
+            self.stim = Stimulus(np.concatenate(new_stims), time=new_times, electrodes=self.electrode_names, metadata=metadata)

--- a/pulse2percept/implants/tests/test_ensemble.py
+++ b/pulse2percept/implants/tests/test_ensemble.py
@@ -135,13 +135,15 @@ def test_merge_stimuli():
 
     # biphasic pulse trains
     implant1 = Orion()
-    implant1.stim = {e : BiphasicPulseTrain(330, 1, .45) for e in implant1.electrode_names}
+    implant1.stim = {e : BiphasicPulseTrain(50, 1, .45) for e in implant1.electrode_names}
     implant2 = Orion(x=-35000)
     implant2.stim = {e : BiphasicPulseTrain(20, 2, .85) for e in implant2.electrode_names}
     implant = EnsembleImplant([implant1, implant2])
     npt.assert_equal(implant.stim.data.shape, (120, 471))
     # make sure that implant.metadata['electrodes'] is also merged
-    npt.assert_equal(list(implant.metadata['electrodes'].keys()), implant.electrode_names)
+    npt.assert_equal(list(implant.stim.metadata['electrodes'].keys()), implant.electrode_names)
+    npt.assert_equal(implant.stim.metadata['electrodes']['0-96'], implant1.stim.metadata['electrodes']['96'])
+    npt.assert_equal(implant.stim.metadata['electrodes']['1-96'], implant2.stim.metadata['electrodes']['96'])
 
     # with cortivis and orion
     implant = EnsembleImplant([Orion(stim=np.ones(60)),
@@ -150,6 +152,6 @@ def test_merge_stimuli():
 
     # make sure supplying stim still overrides individual implants
     implant = EnsembleImplant([Orion(stim=np.ones(60)*2),
-                               Orion(x=-35000, stim=np.ones(60)*2)], stim=np.ones(60)*3)
+                               Orion(x=-35000, stim=np.ones(60)*2)], stim=np.ones(120)*3)
     npt.assert_equal(implant.stim.data.shape, (120, 1))
     npt.assert_equal(implant.stim.data, 3)

--- a/pulse2percept/implants/tests/test_ensemble.py
+++ b/pulse2percept/implants/tests/test_ensemble.py
@@ -2,9 +2,10 @@ import numpy as np
 import numpy.testing as npt
 import pytest
 from pulse2percept.implants import (EnsembleImplant, PointSource, ProsthesisSystem)
-from pulse2percept.implants.cortex import Cortivis
+from pulse2percept.implants.cortex import Cortivis, Orion
 from pulse2percept.topography import Polimeni2006Map
 from pulse2percept.models.cortex.base import ScoreboardModel
+from pulse2percept.stimuli import BiphasicPulseTrain
 
 def test_EnsembleImplant():
     # Invalid instantiations:
@@ -107,3 +108,48 @@ def test_from_cortical_map():
     npt.assert_approx_equal(ensemble['2-1'].x, c2['1'].x, 5)
     npt.assert_approx_equal(ensemble['2-1'].y, c2['1'].y, 5)
     npt.assert_approx_equal(ensemble['2-1'].z, c2['1'].z, 5)
+
+
+def test_merge_stimuli():
+    implant = EnsembleImplant([Orion(),
+                               Orion(x=-35000)])
+    npt.assert_equal(implant.stim is None, True)
+    implant = EnsembleImplant([Orion(stim=np.ones(60)),
+                               Orion(x=-35000)])
+    npt.assert_equal(implant.stim.data.shape, (120, 1))
+    npt.assert_equal(implant.stim.electrodes, implant.electrode_names)
+    implant = EnsembleImplant([Orion(stim=np.ones(60)),
+                               Orion(x=-35000, stim=np.ones(60)*2)])
+    npt.assert_equal(implant.stim.data.shape, (120, 1))
+    npt.assert_equal(implant.stim.electrodes, implant.electrode_names)
+    npt.assert_equal(implant.stim.data[:60], 1)
+    npt.assert_equal(implant.stim.data[60:], 2)
+
+    # with time 
+    implant = EnsembleImplant([Orion(stim=np.ones((60, 5))),
+                               Orion(x=-35000, stim=np.ones((60, 2))*2)])
+    npt.assert_equal(implant.stim.data.shape, (120, 5))
+    npt.assert_equal(implant.stim.data[:60], 1)  
+    npt.assert_equal(implant.stim.data[60:, :2], 2)
+    npt.assert_equal(implant.stim.data[60:, 2:], 0)
+
+    # biphasic pulse trains
+    implant1 = Orion()
+    implant1.stim = {e : BiphasicPulseTrain(330, 1, .45) for e in implant1.electrode_names}
+    implant2 = Orion(x=-35000)
+    implant2.stim = {e : BiphasicPulseTrain(20, 2, .85) for e in implant2.electrode_names}
+    implant = EnsembleImplant([implant1, implant2])
+    npt.assert_equal(implant.stim.data.shape, (120, 471))
+    # make sure that implant.metadata['electrodes'] is also merged
+    npt.assert_equal(list(implant.metadata['electrodes'].keys()), implant.electrode_names)
+
+    # with cortivis and orion
+    implant = EnsembleImplant([Orion(stim=np.ones(60)),
+                                 Cortivis(x=10000, stim=np.ones(96)*2)])
+    npt.assert_equal(implant.stim.data.shape, (156, 1))
+
+    # make sure supplying stim still overrides individual implants
+    implant = EnsembleImplant([Orion(stim=np.ones(60)*2),
+                               Orion(x=-35000, stim=np.ones(60)*2)], stim=np.ones(60)*3)
+    npt.assert_equal(implant.stim.data.shape, (120, 1))
+    npt.assert_equal(implant.stim.data, 3)


### PR DESCRIPTION
Fixes a bug where preset stimuli are ignored for each individual implant during ensemble implant creation. Now, it attempts to merge the stimuli, even if they have different times or electrodes. Also merges metatdata to support e.g. BiphasicAxonMapModel

Could consider putting merge_stimuli in the Stimulus class and perfect it at some point.

Also adds tests.

Closes #650
## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation change


