### PR TITLE
[ENH] Smarter reshape_stim for implants

### DIFF
--- a/pulse2percept/implants/tests/test_prima.py
+++ b/pulse2percept/implants/tests/test_prima.py
@@ -7,7 +7,8 @@ from matplotlib.patches import Circle, RegularPolygon
 
 from pulse2percept.implants import (PhotovoltaicPixel, PRIMA, PRIMA75, PRIMA55,
                                     PRIMA40)
-
+from pulse2percept.stimuli import LogoBVL
+from pulse2percept.models import ScoreboardModel
 
 def test_PhotovoltaicPixel():
     electrode = PhotovoltaicPixel(0, 1, 2, 3, 4)
@@ -230,3 +231,10 @@ def test_PRIMA40(ztype, x, y, rot):
 
     with pytest.raises(ValueError):
         PRIMA40(0, 0, z=np.ones(16))
+
+
+def test_PRIMA40_reshape_stim():
+    # Smoke test a high-res hex implant with an ImageStimulus, where the
+    # old approach runs out of memory easily
+    PRIMA40(stim=LogoBVL())
+    


### PR DESCRIPTION
Automatically converting `ImageStimulus` objects for irregularly spaced electrode grids is tricky. The current approach is to build a higher-resolution stimulus with step size equal to the smallest $\Delta x$ separation of electrode locations. However, this quickly runs out of memory if electrode offsets are small.

A better approach is to use interpolation, where the image is assumed to span the whole range of `[min_x, max_x, min_y, max_y]` electrode locations and the value at `x,y` is interpolated.