### PR TITLE
[ENH] Upgrade neuropythy 3d mapping for rand rotation implants

### DIFF
--- a/pulse2percept/implants/cortex/neuralink.py
+++ b/pulse2percept/implants/cortex/neuralink.py
@@ -181,7 +181,7 @@ class LinearEdgeThread(NeuralinkThread):
         offset = parse_3d_orient([1, 0, 0], 'direction')[0] @ self.direction * (self.r + 7//2) 
         electrode_locs = [start + i*self.spacing*self.direction + offset for i in range(self.n_elecs)]
         for i, loc in enumerate(electrode_locs):
-            electrodes[str(i)] = self.electrode(loc[0], loc[1], loc[2], orient=self.rot)
+            electrodes[str(i)] = self.electrode(loc[0], loc[1], loc[2], orient=self.rot, orient_mode='rot')
         
         self.earray = ElectrodeArray(electrodes)
         self.safe_mode = safe_mode
@@ -316,7 +316,8 @@ class Neuralink(EnsembleImplant):
                 rho = np.random.uniform(-rand_insertion_angle, rand_insertion_angle)
                 theta = np.random.uniform(0, 360)
                 rot_rand, _, _ = parse_3d_orient([0, rho, theta], 'angle')
-                rot_direction, _, _= parse_3d_orient(direction, 'direction')
+                rot_direction, _, _ = parse_3d_orient(direction, 'direction')
+
                 direction = rot_direction @ rot_rand
 
             location = surface_points[:, i]
@@ -328,7 +329,7 @@ class Neuralink(EnsembleImplant):
             name = chr(65 + j) + name
 
             threads[name] = Thread(x=location[0], y=location[1], z=location[2],
-                                            orient=direction, orient_mode='direction')
+                                            orient=direction, orient_mode='rot')
         return cls(threads)
     
     @classmethod

--- a/pulse2percept/topography/neuropythy.py
+++ b/pulse2percept/topography/neuropythy.py
@@ -9,7 +9,7 @@ class NeuropythyMap(CorticalMap):
 
     split_map = False
 
-    def __init__(self, subject, cache_dir=None, **params):
+    def __init__(self, subject='fsaverage', cache_dir=None, **params):
         """
         Uses the visual field maps from the neuropythy package.
         Requires the neuropythy package to be installed (`pip install neuropythy`)

--- a/pulse2percept/utils/three_dim.py
+++ b/pulse2percept/utils/three_dim.py
@@ -92,6 +92,8 @@ def parse_3d_orient(orient, orient_mode='direction'):
             raise ValueError('orient_mode must be either "direction" or "angle".')
         
     elif orient.ndim == 2:
+        if orient_mode != 'rot':
+            raise ValueError('orient_mode must be "rot" if orient is a 3D rotation matrix.')
         try:
             cond = np.allclose(np.linalg.inv(orient), orient.T)
         except np.linalg.LinAlgError:


### PR DESCRIPTION
Although it wasn't really a bug, this creates a more consistent workflow when using rand_insertion_angle for constructing an Neuralink ensemble from a neuropythy vfmap.

Also changes default vfmap subject to be 'fsaverage'
