### PR TITLE
[MNT] Dual NumPy support (1.x & 2.x)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,20 +52,34 @@ jobs:
         run: |
           py="${{ matrix.python-version }}"
           if [[ "$py" == 3.10* || "$py" == 3.11* ]]; then
-            echo "NUMPY_SPEC=<2" >> "$GITHUB_ENV"         # NumPy 1.26.x ABI
-            echo "OSN_PIN=oldest-supported-numpy==2023.12.21" >> "$GITHUB_ENV"
+            echo "NUMPY_SPEC=<2" >> "$GITHUB_ENV"         # compile & run on NumPy 1.26.x ABI
           else
-            echo "NUMPY_SPEC=>=2,<3" >> "$GITHUB_ENV"     # NumPy 2.x ABI
-            echo "OSN_PIN=" >> "$GITHUB_ENV"
+            echo "NUMPY_SPEC=>=2,<3" >> "$GITHUB_ENV"     # compile & run on NumPy 2.x ABI
           fi
 
+      # Bootstrap build toolchain + the right NumPy headers for compilation
       - name: Upgrade pip and bootstrap build tools
         shell: bash
         run: |
           python -m pip install --upgrade pip
           python -m pip install "setuptools>=64" wheel "Cython>=3.0.8" "numpy${NUMPY_SPEC}"
-          if [[ -n "${OSN_PIN}" ]]; then python -m pip install "${OSN_PIN}"; fi
-          python -c "import numpy, sys; print('Using NumPy', numpy.__version__, 'on', sys.version)"
+          python -c "import numpy, sys; print('Build NumPy', numpy.__version__, 'on', sys.version)"
+
+      # For Py 3.10/3.11, constrain test-time deps so they don't upgrade NumPy to 2.x
+      - name: Write constraints
+        shell: bash
+        run: |
+          CFILE="$RUNNER_TEMP/constraints.txt"
+          py="${{ matrix.python-version }}"
+          if [[ "$py" == 3.10* || "$py" == 3.11* ]]; then
+            {
+              echo "numpy<2"
+              echo "scipy<1.16"
+            } > "$CFILE"
+          else
+            : > "$CFILE"
+          fi
+          echo "CONSTRAINTS_FILE=$CFILE" >> "$GITHUB_ENV"
 
       # ----- Lint -----
       - name: Lint with flake8
@@ -74,10 +88,11 @@ jobs:
           flake8 pulse2percept --ignore N802,N806,W504 --select W503 --count --show-source --statistics
 
       # ----- Install package (editable) with dev extras -----
-      # --no-build-isolation ensures Cython extensions use the preinstalled NumPy headers.
+      # --no-build-isolation ensures Cython uses the preinstalled NumPy headers.
+      # The constraints file prevents test deps (e.g. SciPy) from upgrading NumPy on 3.10/3.11.
       - name: Install package (editable + dev extras)
         run: |
-          python -m pip install -e ".[dev]" --no-build-isolation --force-reinstall
+          python -m pip install -e ".[dev]" --no-build-isolation -c "$CONSTRAINTS_FILE"
           python -c "import numpy, pulse2percept as p2p; print('Runtime NumPy', numpy.__version__); print('p2p version:', getattr(p2p, '__version__', 'unknown'))"
 
       # ----- Log env -----
@@ -85,6 +100,7 @@ jobs:
         run: |
           python --version
           pip show numpy
+          pip show scipy || true
           pip show pulse2percept
           pip freeze | sed -n '1,120p'
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,11 +2,9 @@ name: Build & Test
 
 on:
   push:
-    branches:
-      - '**'  # Trigger on all branches
+    branches: ["**"]
   pull_request:
-    branches:
-      - '**'  # Trigger on all branches involved in PRs
+    branches: ["**"]
 
 permissions:
   contents: read
@@ -16,126 +14,96 @@ jobs:
     name: Build ${{ matrix.os }} Py ${{ matrix.python-version }}
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         python-version: ["3.13", "3.12", "3.11", "3.10"]
         os: [ubuntu-latest, windows-latest, macos-latest]
-      fail-fast: false
 
     steps:
-      # Step 1: Check out the repository
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0
         with:
           egress-policy: audit
 
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - name: Checkout
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
-      # Step 2: Set up Python
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@8d9ed9ac5c53483de85588cdf95a591a75ab9f55 # v5.5.0
         with:
           python-version: ${{ matrix.python-version }}
 
-      # Step 3a: macOS system deps (OpenMP)
+      # ----- System deps for OpenMP / codecs -----
       - name: Install dependencies (macOS)
         if: runner.os == 'macOS'
         run: |
           brew install libomp
           echo "OMP_PREFIX=$(brew --prefix libomp)" >> "$GITHUB_ENV"
 
-      # Step 3b: Linux system deps
       - name: Install dependencies (Linux)
         if: runner.os == 'Linux'
         run: |
           sudo apt-get update
           sudo apt-get install -y libomp-dev zlib1g-dev libjpeg-turbo8-dev
 
-      # Step 4: Python tooling only (let build isolation pull NumPy/Cython via pyproject)
-      - name: Upgrade pip
+      # ----- Pin NumPy major BEFORE building to keep headers/runtime aligned -----
+      - name: Choose NumPy major
+        shell: bash
+        run: |
+          py="${{ matrix.python-version }}"
+          if [[ "$py" == 3.10* || "$py" == 3.11* ]]; then
+            echo "NUMPY_SPEC=<2" >> "$GITHUB_ENV"       # NumPy 1.26.x ABI
+            echo "OSN_PIN=oldest-supported-numpy==2023.12.21" >> "$GITHUB_ENV"
+          else
+            echo "NUMPY_SPEC=>=2,<3" >> "$GITHUB_ENV"   # NumPy 2.x ABI
+            echo "OSN_PIN=" >> "$GITHUB_ENV"
+          fi
+          echo "PYVER=$py" >> "$GITHUB_ENV"
+
+      - name: Upgrade pip and bootstrap build tools
         run: |
           python -m pip install --upgrade pip
+          # Install build tools and the chosen NumPy **in the runtime env**.
+          # Using --no-build-isolation later will ensure extensions see these headers.
+          python -m pip install "setuptools>=64" wheel "Cython>=3.0.8" "numpy${NUMPY_SPEC}"
+          if [[ -n "${OSN_PIN}" ]]; then python -m pip install "${OSN_PIN}"; fi
+          python -c "import numpy, sys; print('Using NumPy', numpy.__version__, 'on', sys.version)"
 
-      # Step 4.1 Clean any stale build artifacts (prevents cross-job ABI reuse)
-      - name: Clean working tree and build dirs
-        run: |
-          git clean -xdf
-          python - <<'PY'
-          import shutil, pathlib
-          for p in ("build", "dist", "pulse2percept.egg-info"):
-              shutil.rmtree(p, ignore_errors=True)
-          # also prune any in-tree compiled .so/.pyd just in case
-          for so in pathlib.Path(".").rglob("*.so"):
-              so.unlink()
-          for pyd in pathlib.Path(".").rglob("*.pyd"):
-              pyd.unlink()
-          PY
-
-      # Step 4.2 Pre-install the correct NumPy *runtime* major for this Python
-      - name: Preinstall NumPy matching ABI
-        run: |
-          case "${{ matrix.python-version }}" in
-            3.10|3.11)
-              python -m pip install "numpy<2"
-              ;;
-            3.12|3.13)
-              python -m pip install "numpy>=2,<3"
-              ;;
-          esac
-          python -c "import numpy,sys; print('Runtime NumPy:', numpy.__version__); sys.exit(0)"
-
-      # Step 5: Lint
+      # ----- Lint -----
       - name: Lint with flake8
         run: |
           python -m pip install flake8
           flake8 pulse2percept --ignore N802,N806,W504 --select W503 --count --show-source --statistics
 
-      # Ensure no stale build artifacts compiled against a different NumPy/Python
-      - name: Clean tree (no stale artifacts)
-        run: |
-          git clean -xdf || true
-
-      # Runtime NumPy must match the major your build will target:
-      # - Py 3.10/3.11 -> NumPy 1.x
-      # - Py 3.12/3.13 -> NumPy 2.x
-      - name: Pin runtime NumPy for 3.10/3.11
-        if: matrix.python-version == '3.10' || matrix.python-version == '3.11'
-        run: |
-          python -m pip install "numpy<2"
-
-      - name: Pin runtime NumPy for 3.12/3.13
-        if: matrix.python-version == '3.12' || matrix.python-version == '3.13'
-        run: |
-          python -m pip install "numpy>=2,<3"
-
-      # Step 6: Install package (editable) with dev extras
-      # Build isolation + oldest-supported-numpy (from pyproject) selects the right build-time NumPy.
+      # ----- Install package (editable) with dev extras -----
+      # IMPORTANT: --no-build-isolation so Cython extensions use the NUMPY_SPEC headers we just installed.
       - name: Install package (editable + dev extras)
         run: |
-          python -m pip install -e ".[dev]" --force-reinstall
+          python -m pip install -e ".[dev]" --no-build-isolation --force-reinstall
+          python -c "import numpy, pulse2percept as p2p; print('Runtime NumPy', numpy.__version__); print('p2p version:', getattr(p2p, '__version__', 'unknown'))"
 
-      # Step 7: Log env info
+      # ----- Log env -----
       - name: Log environment info
         run: |
           python --version
-          pip freeze
+          pip show numpy
           pip show pulse2percept
+          pip freeze | sed -n '1,120p'
 
-      # Step 8: Conditional Test Execution
+      # ----- Tests -----
       - name: Run default test suite for push
         if: github.event_name == 'push' && !github.event.pull_request
         run: |
-          mkdir -p test_dir
-          cd test_dir
+          mkdir -p test_dir && cd test_dir
           pytest --pyargs pulse2percept --cov=pulse2percept --cov-branch --cov-report=xml --doctest-modules
 
       - name: Run slow tests for pull requests
         if: github.event_name == 'pull_request'
         run: |
-          mkdir -p test_dir
-          cd test_dir
+          mkdir -p test_dir && cd test_dir
           pytest --pyargs pulse2percept --cov=pulse2percept --runslow --cov-branch --cov-report=xml --doctest-modules
 
-      # Step 9: Codecov
+      # ----- Coverage upload -----
       - name: Upload coverage report to codecov.io
         if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.12'
         uses: codecov/codecov-action@fdcc8476540edceab3de004e990f80d881c6cc00 # v5.5.0

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,6 +19,11 @@ jobs:
         python-version: ["3.13", "3.12", "3.11", "3.10"]
         os: [ubuntu-latest, windows-latest, macos-latest]
 
+    # Force bash on all OSes (avoids PowerShell var-expansion issues on Windows)
+    defaults:
+      run:
+        shell: bash
+
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0
@@ -33,7 +38,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      # ----- System deps -----
+      # ---- System deps ----
       - name: Install dependencies (macOS)
         if: runner.os == 'macOS'
         run: |
@@ -46,28 +51,25 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libomp-dev zlib1g-dev libjpeg-turbo8-dev
 
-      # ----- Decide NumPy major per Python (BASH even on Windows) -----
+      # ---- Decide NumPy major per Python ----
       - name: Choose NumPy major
-        shell: bash
         run: |
           py="${{ matrix.python-version }}"
           if [[ "$py" == 3.10* || "$py" == 3.11* ]]; then
-            echo "NUMPY_SPEC=<2" >> "$GITHUB_ENV"         # compile & run on NumPy 1.26.x ABI
+            echo "NUMPY_SPEC=<2" >> "$GITHUB_ENV"       # build+run on NumPy 1.26.x ABI
           else
-            echo "NUMPY_SPEC=>=2,<3" >> "$GITHUB_ENV"     # compile & run on NumPy 2.x ABI
+            echo "NUMPY_SPEC=>=2,<3" >> "$GITHUB_ENV"   # build+run on NumPy 2.x ABI
           fi
 
-      # Bootstrap build toolchain + the right NumPy headers for compilation
+      # ---- Bootstrap build toolchain + the right NumPy headers ----
       - name: Upgrade pip and bootstrap build tools
-        shell: bash
         run: |
           python -m pip install --upgrade pip
           python -m pip install "setuptools>=64" wheel "Cython>=3.0.8" "numpy${NUMPY_SPEC}"
           python -c "import numpy, sys; print('Build NumPy', numpy.__version__, 'on', sys.version)"
 
-      # For Py 3.10/3.11, constrain test-time deps so they don't upgrade NumPy to 2.x
+      # ---- Constraints to stop test deps from upgrading NumPy on 3.10/3.11 ----
       - name: Write constraints
-        shell: bash
         run: |
           CFILE="$RUNNER_TEMP/constraints.txt"
           py="${{ matrix.python-version }}"
@@ -77,25 +79,30 @@ jobs:
               echo "scipy<1.16"
             } > "$CFILE"
           else
+            # empty file
             : > "$CFILE"
           fi
           echo "CONSTRAINTS_FILE=$CFILE" >> "$GITHUB_ENV"
 
-      # ----- Lint -----
+      # ---- Lint ----
       - name: Lint with flake8
         run: |
           python -m pip install flake8
           flake8 pulse2percept --ignore N802,N806,W504 --select W503 --count --show-source --statistics
 
-      # ----- Install package (editable) with dev extras -----
-      # --no-build-isolation ensures Cython uses the preinstalled NumPy headers.
-      # The constraints file prevents test deps (e.g. SciPy) from upgrading NumPy on 3.10/3.11.
+      # ---- Install package (editable) with dev extras ----
+      # Use --no-build-isolation so Cython uses the preinstalled NumPy headers.
+      # Only pass -c if the constraints file is non-empty.
       - name: Install package (editable + dev extras)
         run: |
-          python -m pip install -e ".[dev]" --no-build-isolation -c "$CONSTRAINTS_FILE"
+          CONS_ARGS=()
+          if [[ -s "$CONSTRAINTS_FILE" ]]; then
+            CONS_ARGS=(-c "$CONSTRAINTS_FILE")
+          fi
+          python -m pip install -e ".[dev]" --no-build-isolation "${CONS_ARGS[@]}"
           python -c "import numpy, pulse2percept as p2p; print('Runtime NumPy', numpy.__version__); print('p2p version:', getattr(p2p, '__version__', 'unknown'))"
 
-      # ----- Log env -----
+      # ---- Log env ----
       - name: Log environment info
         run: |
           python --version
@@ -104,7 +111,7 @@ jobs:
           pip show pulse2percept
           pip freeze | sed -n '1,120p'
 
-      # ----- Tests -----
+      # ---- Tests ----
       - name: Run default test suite for push
         if: github.event_name == 'push' && !github.event.pull_request
         run: |
@@ -117,7 +124,7 @@ jobs:
           mkdir -p test_dir && cd test_dir
           pytest --pyargs pulse2percept --cov=pulse2percept --runslow --cov-branch --cov-report=xml --doctest-modules
 
-      # ----- Coverage upload -----
+      # ---- Coverage upload ----
       - name: Upload coverage report to codecov.io
         if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.12'
         uses: codecov/codecov-action@fdcc8476540edceab3de004e990f80d881c6cc00 # v5.5.0

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,6 +61,56 @@ jobs:
           python -m pip install flake8
           flake8 pulse2percept --ignore N802,N806,W504 --select W503 --count --show-source --statistics
 
-      # --- Hygiene inserted here ---
+      # Ensure no stale build artifacts compiled against a different NumPy/Python
+      - name: Clean tree (no stale artifacts)
+        run: |
+          git clean -xdf || true
 
-      # Ensure no stale build artifacts compiled against a different Num
+      # Runtime NumPy must match the major your build will target:
+      # - Py 3.10/3.11 -> NumPy 1.x
+      # - Py 3.12/3.13 -> NumPy 2.x
+      - name: Pin runtime NumPy for 3.10/3.11
+        if: matrix.python-version == '3.10' || matrix.python-version == '3.11'
+        run: |
+          python -m pip install "numpy<2"
+
+      - name: Pin runtime NumPy for 3.12/3.13
+        if: matrix.python-version == '3.12' || matrix.python-version == '3.13'
+        run: |
+          python -m pip install "numpy>=2,<3"
+
+      # Step 6: Install package (editable) with dev extras
+      # Build isolation + oldest-supported-numpy (from pyproject) selects the right build-time NumPy.
+      - name: Install package (editable + dev extras)
+        run: |
+          python -m pip install -e ".[dev]" --force-reinstall
+
+      # Step 7: Log env info
+      - name: Log environment info
+        run: |
+          python --version
+          pip freeze
+          pip show pulse2percept
+
+      # Step 8: Conditional Test Execution
+      - name: Run default test suite for push
+        if: github.event_name == 'push' && !github.event.pull_request
+        run: |
+          mkdir -p test_dir
+          cd test_dir
+          pytest --pyargs pulse2percept --cov=pulse2percept --cov-branch --cov-report=xml --doctest-modules
+
+      - name: Run slow tests for pull requests
+        if: github.event_name == 'pull_request'
+        run: |
+          mkdir -p test_dir
+          cd test_dir
+          pytest --pyargs pulse2percept --cov=pulse2percept --runslow --cov-branch --cov-report=xml --doctest-modules
+
+      # Step 9: Codecov
+      - name: Upload coverage report to codecov.io
+        if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.12'
+        uses: codecov/codecov-action@fdcc8476540edceab3de004e990f80d881c6cc00 # v5.5.0
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          slug: pulse2percept/pulse2percept

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,6 +55,34 @@ jobs:
         run: |
           python -m pip install --upgrade pip
 
+      # Step 4.1 Clean any stale build artifacts (prevents cross-job ABI reuse)
+      - name: Clean working tree and build dirs
+        run: |
+          git clean -xdf
+          python - <<'PY'
+          import shutil, pathlib
+          for p in ("build", "dist", "pulse2percept.egg-info"):
+              shutil.rmtree(p, ignore_errors=True)
+          # also prune any in-tree compiled .so/.pyd just in case
+          for so in pathlib.Path(".").rglob("*.so"):
+              so.unlink()
+          for pyd in pathlib.Path(".").rglob("*.pyd"):
+              pyd.unlink()
+          PY
+
+      # Step 4.2 Pre-install the correct NumPy *runtime* major for this Python
+      - name: Preinstall NumPy matching ABI
+        run: |
+          case "${{ matrix.python-version }}" in
+            3.10|3.11)
+              python -m pip install "numpy<2"
+              ;;
+            3.12|3.13)
+              python -m pip install "numpy>=2,<3"
+              ;;
+          esac
+          python -c "import numpy,sys; print('Runtime NumPy:', numpy.__version__); sys.exit(0)"
+
       # Step 5: Lint
       - name: Lint with flake8
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,38 +61,6 @@ jobs:
           python -m pip install flake8
           flake8 pulse2percept --ignore N802,N806,W504 --select W503 --count --show-source --statistics
 
-      # Step 6: Install package (editable) with dev extras
-      # No manual numpy/cython; build isolation + oldest-supported-numpy will choose the right ABI
-      - name: Install package (editable + dev extras)
-        run: |
-          python -m pip install -e ".[dev]" --force-reinstall
+      # --- Hygiene inserted here ---
 
-      # Step 7: Log env info
-      - name: Log environment info
-        run: |
-          python --version
-          pip freeze
-          pip show pulse2percept
-
-      # Step 8: Conditional Test Execution
-      - name: Run default test suite for push
-        if: github.event_name == 'push' && !github.event.pull_request
-        run: |
-          mkdir -p test_dir
-          cd test_dir
-          pytest --pyargs pulse2percept --cov=pulse2percept --cov-branch --cov-report=xml --doctest-modules
-
-      - name: Run slow tests for pull requests
-        if: github.event_name == 'pull_request'
-        run: |
-          mkdir -p test_dir
-          cd test_dir
-          pytest --pyargs pulse2percept --cov=pulse2percept --runslow --cov-branch --cov-report=xml --doctest-modules
-
-      # Step 9: Codecov
-      - name: Upload coverage report to codecov.io
-        if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.12'
-        uses: codecov/codecov-action@fdcc8476540edceab3de004e990f80d881c6cc00 # v5.5.0
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          slug: pulse2percept/pulse2percept
+      # Ensure no stale build artifacts compiled against a different Num

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      # ----- System deps for OpenMP / codecs -----
+      # ----- System deps -----
       - name: Install dependencies (macOS)
         if: runner.os == 'macOS'
         run: |
@@ -46,25 +46,23 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libomp-dev zlib1g-dev libjpeg-turbo8-dev
 
-      # ----- Pin NumPy major BEFORE building to keep headers/runtime aligned -----
+      # ----- Decide NumPy major per Python (BASH even on Windows) -----
       - name: Choose NumPy major
         shell: bash
         run: |
           py="${{ matrix.python-version }}"
           if [[ "$py" == 3.10* || "$py" == 3.11* ]]; then
-            echo "NUMPY_SPEC=<2" >> "$GITHUB_ENV"       # NumPy 1.26.x ABI
+            echo "NUMPY_SPEC=<2" >> "$GITHUB_ENV"         # NumPy 1.26.x ABI
             echo "OSN_PIN=oldest-supported-numpy==2023.12.21" >> "$GITHUB_ENV"
           else
-            echo "NUMPY_SPEC=>=2,<3" >> "$GITHUB_ENV"   # NumPy 2.x ABI
+            echo "NUMPY_SPEC=>=2,<3" >> "$GITHUB_ENV"     # NumPy 2.x ABI
             echo "OSN_PIN=" >> "$GITHUB_ENV"
           fi
-          echo "PYVER=$py" >> "$GITHUB_ENV"
 
       - name: Upgrade pip and bootstrap build tools
+        shell: bash
         run: |
           python -m pip install --upgrade pip
-          # Install build tools and the chosen NumPy **in the runtime env**.
-          # Using --no-build-isolation later will ensure extensions see these headers.
           python -m pip install "setuptools>=64" wheel "Cython>=3.0.8" "numpy${NUMPY_SPEC}"
           if [[ -n "${OSN_PIN}" ]]; then python -m pip install "${OSN_PIN}"; fi
           python -c "import numpy, sys; print('Using NumPy', numpy.__version__, 'on', sys.version)"
@@ -76,7 +74,7 @@ jobs:
           flake8 pulse2percept --ignore N802,N806,W504 --select W503 --count --show-source --statistics
 
       # ----- Install package (editable) with dev extras -----
-      # IMPORTANT: --no-build-isolation so Cython extensions use the NUMPY_SPEC headers we just installed.
+      # --no-build-isolation ensures Cython extensions use the preinstalled NumPy headers.
       - name: Install package (editable + dev extras)
         run: |
           python -m pip install -e ".[dev]" --no-build-isolation --force-reinstall

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,65 +36,59 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      # Step 3a: Install dependencies (macOS only)
+      # Step 3a: macOS system deps (OpenMP)
       - name: Install dependencies (macOS)
         if: runner.os == 'macOS'
         run: |
-          brew install libomp llvm
-          export PATH="$(brew --prefix llvm)/bin:$PATH"
-          export CC="$(brew --prefix llvm)/bin/clang"
-          export CXX="$(brew --prefix llvm)/bin/clang++"
-          export CPPFLAGS="-I$(brew --prefix libomp)/include -I$(brew --prefix llvm)/include"
-          export LDFLAGS="-L$(brew --prefix libomp)/lib -L$(brew --prefix llvm)/lib -lomp"
+          brew install libomp
+          echo "OMP_PREFIX=$(brew --prefix libomp)" >> "$GITHUB_ENV"
 
-      # Step 3b: Install dependencies (Linux only)
+      # Step 3b: Linux system deps
       - name: Install dependencies (Linux)
         if: runner.os == 'Linux'
         run: |
           sudo apt-get update
           sudo apt-get install -y libomp-dev zlib1g-dev libjpeg-turbo8-dev
 
-      # Step 4: Install Python dependencies
-      - name: Install Python dependencies
+      # Step 4: Python tooling only (let build isolation pull NumPy/Cython via pyproject)
+      - name: Upgrade pip
         run: |
-          python -m pip install --upgrade pip setuptools wheel build numpy Cython
-          
-      # Step 5: lint
+          python -m pip install --upgrade pip
+
+      # Step 5: Lint
       - name: Lint with flake8
         run: |
-          pip install flake8
+          python -m pip install flake8
           flake8 pulse2percept --ignore N802,N806,W504 --select W503 --count --show-source --statistics
-            
-      # Step 6: Install the package (Non-Windows)
-      - name: Install package
+
+      # Step 6: Install package (editable) with dev extras
+      # No manual numpy/cython; build isolation + oldest-supported-numpy will choose the right ABI
+      - name: Install package (editable + dev extras)
         run: |
-          pip uninstall -y pulse2percept || true
-          python setup.py build_ext --inplace
-          python -m pip install ".[dev]"
-      
-      # Step 7: Log
+          python -m pip install -e ".[dev]" --force-reinstall
+
+      # Step 7: Log env info
       - name: Log environment info
         run: |
           python --version
           pip freeze
-          gcc --version
           pip show pulse2percept
-          
+
       # Step 8: Conditional Test Execution
       - name: Run default test suite for push
         if: github.event_name == 'push' && !github.event.pull_request
         run: |
-          mkdir test_dir
+          mkdir -p test_dir
           cd test_dir
           pytest --pyargs pulse2percept --cov=pulse2percept --cov-branch --cov-report=xml --doctest-modules
 
       - name: Run slow tests for pull requests
         if: github.event_name == 'pull_request'
         run: |
-          mkdir test_dir
+          mkdir -p test_dir
           cd test_dir
           pytest --pyargs pulse2percept --cov=pulse2percept --runslow --cov-branch --cov-report=xml --doctest-modules
-          
+
       # Step 9: Codecov
       - name: Upload coverage report to codecov.io
         if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.12'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -116,13 +116,13 @@ jobs:
         if: github.event_name == 'push' && !github.event.pull_request
         run: |
           mkdir -p test_dir && cd test_dir
-          pytest --pyargs pulse2percept --cov=pulse2percept --cov-branch --cov-report=xml --doctest-modules
+          pytest --pyargs pulse2percept --cov=pulse2percept --cov-branch --cov-report=xml --doctest-modules -x
 
       - name: Run slow tests for pull requests
         if: github.event_name == 'pull_request'
         run: |
           mkdir -p test_dir && cd test_dir
-          pytest --pyargs pulse2percept --cov=pulse2percept --runslow --cov-branch --cov-report=xml --doctest-modules
+          pytest --pyargs pulse2percept --cov=pulse2percept --runslow --cov-branch --cov-report=xml --doctest-modules -x
 
       # ---- Coverage upload ----
       - name: Upload coverage report to codecov.io

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -14,7 +14,6 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest, windows-latest, macos-latest ]
-      fail-fast: false
 
     steps:
       - name: Harden the runner (Audit all outbound calls)
@@ -35,43 +34,38 @@ jobs:
       - name: Build wheels
         uses: pypa/cibuildwheel@c923d83ad9c1bc00211c5041d0c3f73294ff88f6 # v3.1.4
         env:
-          # ---------- Build matrix ----------
-          CIBW_BUILD: "cp310-* cp311-* cp312-* cp313-*"
-          CIBW_SKIP: "*-manylinux_i686 *-win32 *musllinux*"
-          CIBW_BUILD_VERBOSITY: "1"
-
-          # ---------- macOS: libomp + deployment target 15.0 (matches Homebrew libomp) ----------
-          CIBW_ARCHS_MACOS: "x86_64 arm64"
+          # ---------- macOS: install libomp; compile & repair with macOS 15 target ----------
           CIBW_BEFORE_ALL_MACOS: |
             brew update
             brew install libomp || brew reinstall libomp
           CIBW_BEFORE_BUILD_MACOS: |
-            python -m pip install --upgrade pip setuptools wheel cython delocate
-            # Build against NumPy 2.0.* to get dual-ABI (works on NumPy 1.x and 2.x at runtime)
-            python -m pip install "numpy>=2.0,<2.1"
+            echo "libomp prefix: $(brew --prefix libomp)"
+            ls -l "$(brew --prefix libomp)/include/omp.h" || (echo "omp.h missing" && exit 1)
+            python -m pip install --upgrade pip setuptools wheel cython delocate oldest-supported-numpy
           CIBW_ENVIRONMENT_MACOS: |
             OMP_PREFIX="$(brew --prefix libomp)"
             MACOSX_DEPLOYMENT_TARGET=15.0
             CFLAGS="-std=c99 -O3 -Xpreprocessor -fopenmp -I${OMP_PREFIX}/include"
             CPPFLAGS="-I${OMP_PREFIX}/include"
             LDFLAGS="-L${OMP_PREFIX}/lib -lomp"
-          # Make wheel tag match the vendored libomp’s min version
-          CIBW_MACOSX_DEPLOYMENT_TARGET: "15.0"
           CIBW_REPAIR_WHEEL_COMMAND_MACOS: >
-            delocate-listdeps {wheel} &&
-            delocate-wheel -w {dest_dir} {wheel}
+            MACOSX_DEPLOYMENT_TARGET=15.0 delocate-listdeps {wheel} &&
+            MACOSX_DEPLOYMENT_TARGET=15.0 delocate-wheel -w {dest_dir} {wheel}
 
-          # ---------- Linux: OpenMP; build against NumPy 2.0.* ----------
-          CIBW_BEFORE_BUILD_LINUX: |
-            python -m pip install --upgrade pip setuptools wheel cython
-            python -m pip install "numpy>=2.0,<2.1"
+          # ---------- Linux: enable OpenMP; OSN picks a compatible NumPy ----------
           CIBW_ENVIRONMENT_LINUX: "CFLAGS='-fopenmp'"
+          CIBW_BEFORE_BUILD_LINUX: "python -m pip install --upgrade pip setuptools wheel cython oldest-supported-numpy"
 
-          # ---------- Windows: OpenMP; build against NumPy 2.0.* ----------
-          CIBW_BEFORE_BUILD_WINDOWS: |
-            python -m pip install --upgrade pip setuptools wheel cython
-            python -m pip install "numpy>=2.0,<2.1"
+          # ---------- Windows: enable OpenMP; OSN picks a compatible NumPy ----------
           CIBW_ENVIRONMENT_WINDOWS: "CFLAGS='/openmp'"
+          CIBW_BEFORE_BUILD_WINDOWS: "python -m pip install --upgrade pip setuptools wheel cython oldest-supported-numpy"
+
+          # ---------- Python versions / skips ----------
+          CIBW_BUILD: "cp310-* cp311-* cp312-* cp313-*"
+          CIBW_SKIP: "*-manylinux_i686 *-win32 *musllinux*"
+
+          # Build separate wheels for both Apple architectures
+          CIBW_ARCHS_MACOS: "x86_64 arm64"
 
       - name: Upload wheels
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -2,15 +2,10 @@ name: Wheels
 
 on:
   push:
-    branches:
-      - master
-      - torch
-    tags:
-      - v*
+    branches: [ master, torch ]
+    tags: [ v* ]
   pull_request:
-    branches:
-      - master
-      - torch
+    branches: [ master, torch ]
 
 jobs:
   build_wheels:
@@ -18,7 +13,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ ubuntu-latest, windows-latest, macos-latest ]
 
     steps:
       - name: Harden the runner (Audit all outbound calls)
@@ -39,33 +34,37 @@ jobs:
       - name: Build wheels
         uses: pypa/cibuildwheel@c923d83ad9c1bc00211c5041d0c3f73294ff88f6 # v3.1.4
         env:
-          # macOS: ensure libomp exists and wire up Apple clang for OpenMP
+          # ---------- macOS: ensure libomp exists; bundle it into wheels ----------
           CIBW_BEFORE_ALL_MACOS: |
             brew update
             brew install libomp || brew reinstall libomp
           CIBW_BEFORE_BUILD_MACOS: |
             echo "libomp prefix: $(brew --prefix libomp)"
             ls -l "$(brew --prefix libomp)/include/omp.h" || (echo "omp.h missing" && exit 1)
-            python -m pip install --upgrade pip setuptools wheel cython numpy
+            python -m pip install --upgrade pip setuptools wheel cython delocate oldest-supported-numpy
           CIBW_ENVIRONMENT_MACOS: |
             OMP_PREFIX="$(brew --prefix libomp)"
             MACOSX_DEPLOYMENT_TARGET=11.0
             CFLAGS="-std=c99 -O3 -Xpreprocessor -fopenmp -I${OMP_PREFIX}/include"
             CPPFLAGS="-I${OMP_PREFIX}/include"
             LDFLAGS="-L${OMP_PREFIX}/lib -lomp"
+          CIBW_REPAIR_WHEEL_COMMAND_MACOS: >
+            delocate-wheel -w {dest_dir} {wheel}
 
-          # Linux: enable OpenMP
+          # ---------- Linux: enable OpenMP; OSN installs the right NumPy ----------
           CIBW_ENVIRONMENT_LINUX: "CFLAGS='-fopenmp'"
+          CIBW_BEFORE_BUILD_LINUX: "python -m pip install --upgrade pip setuptools wheel cython oldest-supported-numpy"
 
-          # Windows: enable OpenMP
+          # ---------- Windows: enable OpenMP; OSN installs the right NumPy ----------
           CIBW_ENVIRONMENT_WINDOWS: "CFLAGS='/openmp'"
+          CIBW_BEFORE_BUILD_WINDOWS: "python -m pip install --upgrade pip setuptools wheel cython oldest-supported-numpy"
 
-          # Pre-build (non-macOS platforms)
-          CIBW_BEFORE_BUILD: "python -m pip install --upgrade pip setuptools wheel cython numpy"
-
-          # Python versions / skips
+          # ---------- Python versions / skips ----------
           CIBW_BUILD: "cp310-* cp311-* cp312-* cp313-*"
           CIBW_SKIP: "*-manylinux_i686 *-win32 *musllinux*"
+
+          # (Optional) Build for both Apple architectures as separate wheels
+          CIBW_ARCHS_MACOS: "x86_64 arm64"
 
       - name: Upload wheels
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -14,6 +14,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest, windows-latest, macos-latest ]
+      fail-fast: false
 
     steps:
       - name: Harden the runner (Audit all outbound calls)
@@ -24,7 +25,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
-      # Linux-only system deps
+      # Linux system deps
       - name: Install dependencies (Linux)
         if: runner.os == 'Linux'
         run: |
@@ -34,37 +35,43 @@ jobs:
       - name: Build wheels
         uses: pypa/cibuildwheel@c923d83ad9c1bc00211c5041d0c3f73294ff88f6 # v3.1.4
         env:
-          # ---------- macOS: ensure libomp exists; bundle it into wheels ----------
+          # ---------- Build matrix ----------
+          CIBW_BUILD: "cp310-* cp311-* cp312-* cp313-*"
+          CIBW_SKIP: "*-manylinux_i686 *-win32 *musllinux*"
+          CIBW_BUILD_VERBOSITY: "1"
+
+          # ---------- macOS: libomp + deployment target 15.0 (matches Homebrew libomp) ----------
+          CIBW_ARCHS_MACOS: "x86_64 arm64"
           CIBW_BEFORE_ALL_MACOS: |
             brew update
             brew install libomp || brew reinstall libomp
           CIBW_BEFORE_BUILD_MACOS: |
-            echo "libomp prefix: $(brew --prefix libomp)"
-            ls -l "$(brew --prefix libomp)/include/omp.h" || (echo "omp.h missing" && exit 1)
-            python -m pip install --upgrade pip setuptools wheel cython delocate oldest-supported-numpy
+            python -m pip install --upgrade pip setuptools wheel cython delocate
+            # Build against NumPy 2.0.* to get dual-ABI (works on NumPy 1.x and 2.x at runtime)
+            python -m pip install "numpy>=2.0,<2.1"
           CIBW_ENVIRONMENT_MACOS: |
             OMP_PREFIX="$(brew --prefix libomp)"
-            MACOSX_DEPLOYMENT_TARGET=11.0
+            MACOSX_DEPLOYMENT_TARGET=15.0
             CFLAGS="-std=c99 -O3 -Xpreprocessor -fopenmp -I${OMP_PREFIX}/include"
             CPPFLAGS="-I${OMP_PREFIX}/include"
             LDFLAGS="-L${OMP_PREFIX}/lib -lomp"
+          # Make wheel tag match the vendored libomp’s min version
+          CIBW_MACOSX_DEPLOYMENT_TARGET: "15.0"
           CIBW_REPAIR_WHEEL_COMMAND_MACOS: >
+            delocate-listdeps {wheel} &&
             delocate-wheel -w {dest_dir} {wheel}
 
-          # ---------- Linux: enable OpenMP; OSN installs the right NumPy ----------
+          # ---------- Linux: OpenMP; build against NumPy 2.0.* ----------
+          CIBW_BEFORE_BUILD_LINUX: |
+            python -m pip install --upgrade pip setuptools wheel cython
+            python -m pip install "numpy>=2.0,<2.1"
           CIBW_ENVIRONMENT_LINUX: "CFLAGS='-fopenmp'"
-          CIBW_BEFORE_BUILD_LINUX: "python -m pip install --upgrade pip setuptools wheel cython oldest-supported-numpy"
 
-          # ---------- Windows: enable OpenMP; OSN installs the right NumPy ----------
+          # ---------- Windows: OpenMP; build against NumPy 2.0.* ----------
+          CIBW_BEFORE_BUILD_WINDOWS: |
+            python -m pip install --upgrade pip setuptools wheel cython
+            python -m pip install "numpy>=2.0,<2.1"
           CIBW_ENVIRONMENT_WINDOWS: "CFLAGS='/openmp'"
-          CIBW_BEFORE_BUILD_WINDOWS: "python -m pip install --upgrade pip setuptools wheel cython oldest-supported-numpy"
-
-          # ---------- Python versions / skips ----------
-          CIBW_BUILD: "cp310-* cp311-* cp312-* cp313-*"
-          CIBW_SKIP: "*-manylinux_i686 *-win32 *musllinux*"
-
-          # (Optional) Build for both Apple architectures as separate wheels
-          CIBW_ARCHS_MACOS: "x86_64 arm64"
 
       - name: Upload wheels
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,17 +1,14 @@
 version: 2
 
 build:
-  os: "ubuntu-lts-latest"
+  os: ubuntu-22.04
   tools:
     python: "3.11"
-  environment:
-    P2P_PLOT_GALLERY: "0"
-    P2P_DOC_BUILD: "1"
 
 sphinx:
   configuration: doc/conf.py
   fail_on_warning: false
-  builder: "html"
+  builder: html
 
 python:
   install:

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -10,6 +10,6 @@ sphinx:
 
 python:
   install:
-    - requirements: doc/requirements-docs.txt
+    - requirements: doc/requirements.txt
     - method: pip
       path: .

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,12 +1,13 @@
 version: 2
+
 build:
   os: ubuntu-22.04
   tools:
     python: "3.11"
-  environment:
-    P2P_DISABLE_OPENMP: "1"   # let setup.py skip -fopenmp on RTD
+
 sphinx:
   configuration: doc/conf.py
+
 python:
   install:
     - requirements: doc/requirements-docs.txt

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -4,16 +4,14 @@ build:
   os: "ubuntu-lts-latest"
   tools:
     python: "3.11"
+  environment:
+    P2P_PLOT_GALLERY: "0"
+    P2P_DOC_BUILD: "1"
 
 sphinx:
   configuration: doc/conf.py
   fail_on_warning: false
   builder: "html"
-
-# Turn off example execution on RTD; keep a flag the code can read if needed
-environment:
-  P2P_PLOT_GALLERY: "0"
-  P2P_DOC_BUILD: "1"
 
 python:
   install:

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,6 +1,3 @@
-# Read the Docs configuration file for Sphinx projects
-# See https://docs.readthedocs.io/en/stable/config-file/v2.html
-
 version: 2
 
 build:
@@ -12,6 +9,11 @@ sphinx:
   configuration: doc/conf.py
   fail_on_warning: false
   builder: "html"
+
+# Turn off example execution on RTD; keep a flag the code can read if needed
+environment:
+  P2P_PLOT_GALLERY: "0"
+  P2P_DOC_BUILD: "1"
 
 python:
   install:

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,17 +1,14 @@
 version: 2
-
 build:
   os: ubuntu-22.04
   tools:
     python: "3.11"
-
+  environment:
+    P2P_DISABLE_OPENMP: "1"   # let setup.py skip -fopenmp on RTD
 sphinx:
   configuration: doc/conf.py
-  fail_on_warning: false
-  builder: html
-
 python:
   install:
-    - requirements: doc/requirements.txt
+    - requirements: doc/requirements-docs.txt
     - method: pip
       path: .

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -1,177 +1,99 @@
 # -- stdlib / setup -----------------------------------------------------------
 import os
 import sys
-import types
+import importlib.metadata
 
-# Put _ext on path (for github_link.py)
+# Make local extensions importable first (e.g., github_link.py)
 sys.path.insert(0, os.path.abspath('_ext'))
 
-# Use a non-interactive backend for any plotting during doc builds
+# Use a non-interactive backend for any plots
 import matplotlib
-matplotlib.use('Agg')
-
-# -- tiny helpers for stubbing modules on RTD --------------------------------
-def _stub_module(qualname: str, **attrs):
-    """Create a minimal module and register in sys.modules."""
-    m = types.ModuleType(qualname)
-    for k, v in attrs.items():
-        setattr(m, v.__name__ if callable(v) else k, v)
-    sys.modules[qualname] = m
-    return m
-
-def _stub_package(qualname: str):
-    """Create a minimal *package* (has __path__) and register it."""
-    m = types.ModuleType(qualname)
-    m.__path__ = []  # mark as a package
-    sys.modules[qualname] = m
-    return m
-
-def _stub_func(return_value=None):
-    def _f(*args, **kwargs):
-        return return_value
-    return _f
+matplotlib.use("Agg")
 
 ON_RTD = os.environ.get("READTHEDOCS") == "True"
 
-if ON_RTD:
-    # --- Stub JAX/JAXLIB to prevent importing heavy binary wheels on RTD ----
-    import numpy as _np
-    jax_pkg = _stub_package("jax")
-    # common jax APIs that might be referenced (no-ops)
-    jax_pkg.jit = lambda f=None, *a, **k: (f if f is not None else (lambda x: x))
-    jax_pkg.grad = _stub_func(None)
-    jax_pkg.device_put = _stub_func(None)
-    jax_pkg.random = types.SimpleNamespace(PRNGKey=_stub_func(0), normal=_stub_func(_np.array([])))
-    # jax.numpy as a separate importable module; alias to numpy for basic ops
-    _stub_package("jax.numpy")
-    sys.modules["jax.numpy"].__dict__.update(_np.__dict__)
-
-    jaxlib_pkg = _stub_package("jaxlib")
-    _stub_module("jaxlib.xla_client")
-    _stub_module("jaxlib.xla_extension")
-
-    # --- Stub your Cython extensions that showed up in RTD logs -------------
-    _stub_module("pulse2percept.utils._fast_array",
-                 fast_is_strictly_increasing=_stub_func(True))
-    _stub_module("pulse2percept.stimuli._base",
-                 fast_compress_space=_stub_func(None),
-                 fast_compress_time=_stub_func(None))
-    _stub_module("pulse2percept.models._temporal", fading_fast=_stub_func(None))
-    _stub_module("pulse2percept.models._beyeler2019",
-                 fast_scoreboard=_stub_func(None),
-                 fast_axon_map=_stub_func(None),
-                 fast_jansonius=_stub_func(None),
-                 fast_find_closest_axon=_stub_func(None))
-    _stub_module("pulse2percept.models._horsager2009", temporal_fast=_stub_func(None))
-    _stub_module("pulse2percept.models._nanduri2012",
-                 spatial_fast=_stub_func(None),
-                 temporal_fast=_stub_func(None))
-    _stub_module("pulse2percept.models._granley2021",
-                 fast_biphasic_axon_map=_stub_func(None))
-
-# -- Sphinx basics ------------------------------------------------------------
-import sphinx_gallery
-from sphinx_gallery.sorting import ExplicitOrder
-import sphinx_rtd_theme
+# -- Sphinx config ------------------------------------------------------------
 from github_link import make_linkcode_resolve
+import sphinx_rtd_theme
+from sphinx_gallery.sorting import ExplicitOrder
 
-# Project metadata
-project = 'pulse2percept'
-copyright = '2016 - 2025, pulse2percept developers (BSD License)'
+project = "pulse2percept"
+copyright = "2016 - 2025, pulse2percept developers"
 
-# Version: NEVER import the package on RTD (avoids JAX/NumPy ABI crashes)
-if ON_RTD:
-    # Prefer RTD-provided version strings if available; otherwise a safe fallback
+# Never import the package here; use package metadata if present
+try:
+    release = importlib.metadata.version("pulse2percept")
+    version = release
+except importlib.metadata.PackageNotFoundError:
+    # During first phase of RTD build, the package may not yet be installed
     version = release = os.environ.get("READTHEDOCS_VERSION", "0.0.dev")
-else:
-    try:
-        from pulse2percept import __version__
-        version = release = __version__
-    except Exception:
-        version = release = os.environ.get("P2P_DOC_VERSION", "0.0.dev")
 
-# Sphinx extensions
 extensions = [
-    'sphinx.ext.autodoc',
-    'sphinx.ext.autosummary',
-    'sphinx.ext.napoleon',
-    'sphinx.ext.intersphinx',
-    'sphinx.ext.linkcode',
-    'sphinx.ext.todo',
-    'sphinx_gallery.gen_gallery',
-    'versionwarning.extension',
-    'IPython.sphinxext.ipython_directive',
-    'IPython.sphinxext.ipython_console_highlighting',
-    'sphinx.ext.extlinks',
-    'sphinx.ext.mathjax',
+    "sphinx.ext.autodoc",
+    "sphinx.ext.autosummary",
+    "sphinx.ext.napoleon",
+    "sphinx.ext.intersphinx",
+    "sphinx.ext.linkcode",
+    "sphinx.ext.todo",
+    "sphinx_gallery.gen_gallery",
+    "versionwarning.extension",
+    "IPython.sphinxext.ipython_directive",
+    "IPython.sphinxext.ipython_console_highlighting",
+    "sphinx.ext.extlinks",
+    "sphinx.ext.mathjax",
 ]
 
-# Autodoc
 autosummary_generate = True
 autodoc_default_options = {
-    'members': None,
-    'member-order': 'bysource',
-    'inherited-members': None,
+    "members": True,
+    "member-order": "bysource",
+    "inherited-members": True,
 }
-
-# Napoleon
-napoleon_google_docstring = False
-napoleon_numpy_docstring = True
-napoleon_include_init_with_doc = False
-napoleon_include_private_with_doc = False
-napoleon_include_special_with_doc = False
-napoleon_use_admonition_for_examples = False
-napoleon_use_admonition_for_notes = False
-napoleon_use_admonition_for_references = False
-napoleon_use_ivar = False
-napoleon_use_param = True
-napoleon_use_rtype = False
 todo_include_todos = True
 
-# MathJax
-mathjax_path = 'https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS_SVG'
+source_suffix = ".rst"
+master_doc = "index"
+templates_path = ["_templates"]
+exclude_patterns = ["_build", "**/.ipynb_checkpoints"]
 
-# Source files and paths
-templates_path = ['_templates']
-exclude_patterns = ['_build', '**/.ipynb_checkpoints']
-source_suffix = '.rst'
-master_doc = 'index'
+html_theme = "sphinx_rtd_theme"
+html_static_path = ["_static"]
+html_css_files = ["css/custom.css"]
 
-# HTML output
-html_theme = 'sphinx_rtd_theme'
-html_static_path = ['_static']
-html_css_files = ['css/custom.css']
-html_last_updated_fmt = '%b %d, %Y'
+intersphinx_mapping = {"python": ("https://docs.python.org/3", None)}
 
-# InterSphinx
-intersphinx_mapping = {'python': ('https://docs.python.org/3', None)}
-
-# Gallery configuration
+# Sphinx-Gallery: keep execution on (your examples produce images),
+# but never fail the build if an example hiccups.
+from sphinx_gallery.sorting import ExplicitOrder
 sphinx_gallery_conf = {
-    'examples_dirs': ['../examples'],
-    'gallery_dirs': ['examples'],
-    'reference_url': {'pulse2percept': None},
-    'thumbnail_size': (320, 224),
-    'remove_config_comments': True,
-    'subsection_order': ExplicitOrder([
-        '../examples/implants',
-        '../examples/stimuli',
-        '../examples/models',
-        '../examples/datasets',
-        '../examples/cortex',
-        '../examples/developers',
+    "examples_dirs": ["../examples"],
+    "gallery_dirs": ["examples"],
+    "reference_url": {"pulse2percept": None},
+    "thumbnail_size": (320, 224),
+    "remove_config_comments": True,
+    "subsection_order": ExplicitOrder([
+        "../examples/implants",
+        "../examples/stimuli",
+        "../examples/models",
+        "../examples/datasets",
+        "../examples/developers",
     ]),
+    "only_warn_on_example_error": True,
 }
 
-# GitHub linkcode resolver
-linkcode_resolve = make_linkcode_resolve(
-    'pulse2percept',
-    'https://github.com/pulse2percept/pulse2percept/blob/{revision}/{package}/{path}#L{lineno}'
+# linkcode_resolve must be a function (avoid partial warning)
+_resolver = make_linkcode_resolve(
+    "pulse2percept",
+    "https://github.com/pulse2percept/pulse2percept/blob/{revision}/{package}/{path}#L{lineno}",
 )
+def linkcode_resolve(domain, info):
+    return _resolver(domain, info)
 
-# External links
 extlinks = {
-    'pull':   ('https://github.com/pulse2percept/pulse2percept/pull/%s', 'PR #%s'),
-    'issue':  ('https://github.com/pulse2percept/pulse2percept/issues/%s', 'Issue #%s'),
-    'commit': ('https://github.com/pulse2percept/pulse2percept/commit/%s', 'Commit %s'),
+    "pull":   ("https://github.com/pulse2percept/pulse2percept/pull/%s", "PR #%s"),
+    "issue":  ("https://github.com/pulse2percept/pulse2percept/issues/%s", "Issue #%s"),
+    "commit": ("https://github.com/pulse2percept/pulse2percept/commit/%s", "Commit %s"),
 }
+
+# MathJax (older URL that loads reliably on RTD)
+mathjax_path = "https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS_SVG"

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -51,6 +51,15 @@ _mock('pulse2percept.models._beyeler2019', {
     'fast_jansonius':        lambda *a, **k: None,
     'fast_find_closest_axon':lambda *a, **k: (None, None),
 })
+_mock('pulse2percept.models._horsager2009', {
+    'temporal_fast': lambda *a, **k: None,
+})
+_mock('pulse2percept.models._nanduri2012', {
+    'temporal_fast': lambda *a, **k: None,
+})
+_mock('pulse2percept.models._granley2021', {
+    'biphasic_axonmap_fast': lambda *a, **k: None,
+})
 
 # Tell autodoc to treat them as mocked as well
 autodoc_mock_imports = [
@@ -58,6 +67,9 @@ autodoc_mock_imports = [
     'pulse2percept.stimuli._base',
     'pulse2percept.models._temporal',
     'pulse2percept.models._beyeler2019',
+    'pulse2percept.models._horsager2009',
+    'pulse2percept.models._nanduri2012',
+    'pulse2percept.models._granley2021',
 ]
 
 # ----------------------

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -1,31 +1,57 @@
 import os
 import sys
+import types
 import sphinx_gallery
 from sphinx_gallery.sorting import ExplicitOrder
 import sphinx_rtd_theme
 
-# Ensure paths are set correctly
+# Ensure _ext is importable (for github_link)
 sys.path.insert(0, os.path.abspath('_ext'))
 from github_link import make_linkcode_resolve
 
+# ----------------------
 # Project metadata
+# ----------------------
 project = 'pulse2percept'
 copyright = '2016 - 2025, pulse2percept developers (BSD License)'
 
-# --- DO NOT import the package here (avoids importing Cython during docs) ---
+# Get version WITHOUT importing the package (avoids compiled imports on RTD)
 try:
-    from importlib.metadata import version as _dist_version, PackageNotFoundError
+    from importlib.metadata import version as _dist_version
+    version = release = _dist_version("pulse2percept")
 except Exception:
-    from importlib_metadata import version as _dist_version, PackageNotFoundError  # py<3.8 backport
+    # Fallback for local builds / PR previews
+    version = release = os.environ.get("P2P_DOC_VERSION", "0.0.dev")
 
-try:
-    release = _dist_version("pulse2percept")
-except PackageNotFoundError:
-    # Fallback when building without an installed wheel
-    release = os.environ.get("READTHEDOCS_VERSION", "0.0.0")
-version = release
+# ----------------------
+# Mock compiled submodules early so imports succeed in docs
+# ----------------------
+def _mock(modname, attrs=None):
+    if modname in sys.modules:
+        return
+    m = types.ModuleType(modname)
+    for k, v in (attrs or {}).items():
+        setattr(m, k, v)
+    sys.modules[modname] = m
 
+# These are the ones tripping your build
+_mock('pulse2percept.utils._fast_array', {
+    'fast_is_strictly_increasing': lambda *a, **k: True,
+})
+_mock('pulse2percept.stimuli._base', {
+    'fast_compress_space': lambda *a, **k: None,
+    'fast_compress_time': lambda *a, **k: None,
+})
+
+# Tell autodoc to treat them as mocked as well
+autodoc_mock_imports = [
+    'pulse2percept.utils._fast_array',
+    'pulse2percept.stimuli._base',
+]
+
+# ----------------------
 # Sphinx extensions
+# ----------------------
 extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.autosummary',
@@ -41,21 +67,14 @@ extensions = [
     'sphinx.ext.mathjax',
 ]
 
-# Autodoc
+# Autodoc / Napoleon
 autosummary_generate = True
 autodoc_default_options = {
     'members': None,
     'member-order': 'bysource',
-    'inherited-members': None
+    'inherited-members': None,
 }
-
-# --- Mock the compiled Cython module so autodoc can import pure-Python modules ---
-autodoc_mock_imports = [
-    'pulse2percept.utils._fast_array',
-]
-
-# Napoleon settings
-napoleon_google_docstring = False  # force consistency
+napoleon_google_docstring = False
 napoleon_numpy_docstring = True
 napoleon_include_init_with_doc = False
 napoleon_include_private_with_doc = False
@@ -68,7 +87,7 @@ napoleon_use_param = True
 napoleon_use_rtype = False
 todo_include_todos = True
 
-# Math rendering
+# MathJax
 mathjax_path = 'https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS_SVG'
 
 # Source files and paths
@@ -83,36 +102,44 @@ html_static_path = ['_static']
 html_css_files = ['css/custom.css']
 html_last_updated_fmt = '%b %d, %Y'
 
-# InterSphinx mapping
+# InterSphinx
 intersphinx_mapping = {'python': ('https://docs.python.org/3', None)}
 
-# --- Gallery configuration (disable execution on RTD to avoid running imports/examples) ---
-PLOT_GALLERY = os.environ.get("P2P_PLOT_GALLERY", "0") == "1"  # off by default on RTD
+# Gallery configuration
 sphinx_gallery_conf = {
     'examples_dirs': ['../examples'],
     'gallery_dirs': ['examples'],
     'reference_url': {'pulse2percept': None},
     'thumbnail_size': (320, 224),
     'remove_config_comments': True,
-    'plot_gallery': PLOT_GALLERY,
     'subsection_order': ExplicitOrder([
         '../examples/implants',
         '../examples/stimuli',
         '../examples/models',
         '../examples/datasets',
         '../examples/cortex',
-        '../examples/developers'
-    ])
+        '../examples/developers',
+    ]),
+    # On RTD, avoid executing examples to reduce chances of runtime import/ABI issues
+    'plot_gallery': False if os.environ.get('READTHEDOCS') == 'True' else True,
 }
 
-# GitHub link code resolver
-linkcode_resolve = make_linkcode_resolve(
-    'pulse2percept',
-    'https://github.com/pulse2percept/pulse2percept/blob/{revision}/{package}/{path}#L{lineno}'
-)
+# IPython: make sure we use a non-interactive backend; pre-set any env you need
+ipython_execlines = [
+    "import os; os.environ.setdefault('MPLBACKEND', 'Agg')",
+]
 
+# GitHub link code resolver — wrap the partial so Sphinx sees a function
+_linkcode_partial = make_linkcode_resolve(
+    'pulse2percept',
+    'https://github.com/pulse2percept/pulse2percept/blob/{revision}/{package}/{path}#L{lineno}',
+)
+def linkcode_resolve(domain, info):
+    return _linkcode_partial(domain, info)
+
+# Short external links
 extlinks = {
-    'pull': ('https://github.com/pulse2percept/pulse2percept/pull/%s', 'PR #%s'),
-    'issue': ('https://github.com/pulse2percept/pulse2percept/issues/%s', 'Issue #%s'),
+    'pull':   ('https://github.com/pulse2percept/pulse2percept/pull/%s', 'PR #%s'),
+    'issue':  ('https://github.com/pulse2percept/pulse2percept/issues/%s', 'Issue #%s'),
     'commit': ('https://github.com/pulse2percept/pulse2percept/commit/%s', 'Commit %s'),
 }

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -55,10 +55,14 @@ _mock('pulse2percept.models._horsager2009', {
     'temporal_fast': lambda *a, **k: None,
 })
 _mock('pulse2percept.models._nanduri2012', {
+    'spatial_fast':  lambda *a, **k: None,
     'temporal_fast': lambda *a, **k: None,
 })
 _mock('pulse2percept.models._granley2021', {
     'biphasic_axonmap_fast': lambda *a, **k: None,
+})
+_mock('pulse2percept.models._thompson2003', {
+    'spatial_fast': lambda *a, **k: None,
 })
 
 # Tell autodoc to treat them as mocked as well
@@ -70,6 +74,7 @@ autodoc_mock_imports = [
     'pulse2percept.models._horsager2009',
     'pulse2percept.models._nanduri2012',
     'pulse2percept.models._granley2021',
+    'pulse2percept.models._thompson2003',
 ]
 
 # ----------------------

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -6,16 +6,24 @@ import sphinx_rtd_theme
 
 # Ensure paths are set correctly
 sys.path.insert(0, os.path.abspath('_ext'))
-
 from github_link import make_linkcode_resolve
 
 # Project metadata
 project = 'pulse2percept'
 copyright = '2016 - 2025, pulse2percept developers (BSD License)'
 
-# Retrieve version from package
-from pulse2percept import __version__
-version = release = __version__
+# --- DO NOT import the package here (avoids importing Cython during docs) ---
+try:
+    from importlib.metadata import version as _dist_version, PackageNotFoundError
+except Exception:
+    from importlib_metadata import version as _dist_version, PackageNotFoundError  # py<3.8 backport
+
+try:
+    release = _dist_version("pulse2percept")
+except PackageNotFoundError:
+    # Fallback when building without an installed wheel
+    release = os.environ.get("READTHEDOCS_VERSION", "0.0.0")
+version = release
 
 # Sphinx extensions
 extensions = [
@@ -29,7 +37,8 @@ extensions = [
     'versionwarning.extension',
     'IPython.sphinxext.ipython_directive',
     'IPython.sphinxext.ipython_console_highlighting',
-    'sphinx.ext.extlinks', 
+    'sphinx.ext.extlinks',
+    'sphinx.ext.mathjax',
 ]
 
 # Autodoc
@@ -39,6 +48,11 @@ autodoc_default_options = {
     'member-order': 'bysource',
     'inherited-members': None
 }
+
+# --- Mock the compiled Cython module so autodoc can import pure-Python modules ---
+autodoc_mock_imports = [
+    'pulse2percept.utils._fast_array',
+]
 
 # Napoleon settings
 napoleon_google_docstring = False  # force consistency
@@ -55,7 +69,6 @@ napoleon_use_rtype = False
 todo_include_todos = True
 
 # Math rendering
-extensions.append('sphinx.ext.mathjax')
 mathjax_path = 'https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS_SVG'
 
 # Source files and paths
@@ -65,7 +78,7 @@ source_suffix = '.rst'
 master_doc = 'index'
 
 # HTML output
-html_theme = 'sphinx_rtd_theme'  # Switch to 'furo' if preferred
+html_theme = 'sphinx_rtd_theme'
 html_static_path = ['_static']
 html_css_files = ['css/custom.css']
 html_last_updated_fmt = '%b %d, %Y'
@@ -73,13 +86,15 @@ html_last_updated_fmt = '%b %d, %Y'
 # InterSphinx mapping
 intersphinx_mapping = {'python': ('https://docs.python.org/3', None)}
 
-# Gallery configuration
+# --- Gallery configuration (disable execution on RTD to avoid running imports/examples) ---
+PLOT_GALLERY = os.environ.get("P2P_PLOT_GALLERY", "0") == "1"  # off by default on RTD
 sphinx_gallery_conf = {
     'examples_dirs': ['../examples'],
     'gallery_dirs': ['examples'],
     'reference_url': {'pulse2percept': None},
     'thumbnail_size': (320, 224),
     'remove_config_comments': True,
+    'plot_gallery': PLOT_GALLERY,
     'subsection_order': ExplicitOrder([
         '../examples/implants',
         '../examples/stimuli',
@@ -101,4 +116,3 @@ extlinks = {
     'issue': ('https://github.com/pulse2percept/pulse2percept/issues/%s', 'Issue #%s'),
     'commit': ('https://github.com/pulse2percept/pulse2percept/commit/%s', 'Commit %s'),
 }
-

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -45,12 +45,19 @@ _mock('pulse2percept.stimuli._base', {
 _mock('pulse2percept.models._temporal', {
     'fading_fast': lambda *a, **k: 0.0,
 })
+_mock('pulse2percept.models._beyeler2019', {
+    'fast_scoreboard':       lambda *a, **k: None,
+    'fast_axon_map':         lambda *a, **k: None,
+    'fast_jansonius':        lambda *a, **k: None,
+    'fast_find_closest_axon':lambda *a, **k: (None, None),
+})
 
 # Tell autodoc to treat them as mocked as well
 autodoc_mock_imports = [
     'pulse2percept.utils._fast_array',
     'pulse2percept.stimuli._base',
-    'pulse2percept.models._temporal'
+    'pulse2percept.models._temporal',
+    'pulse2percept.models._beyeler2019',
 ]
 
 # ----------------------

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -42,11 +42,15 @@ _mock('pulse2percept.stimuli._base', {
     'fast_compress_space': lambda *a, **k: None,
     'fast_compress_time': lambda *a, **k: None,
 })
+_mock('pulse2percept.models._temporal', {
+    'fading_fast': lambda *a, **k: 0.0,
+})
 
 # Tell autodoc to treat them as mocked as well
 autodoc_mock_imports = [
     'pulse2percept.utils._fast_array',
     'pulse2percept.stimuli._base',
+    'pulse2percept.models._temporal'
 ]
 
 # ----------------------

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -5,7 +5,7 @@ Cython>=3.0.8
 sphinx==8.2.3
 sphinx_rtd_theme
 sphinx_gallery==0.19.0
-versionwarning
+sphinx-version-warning==1.1.2
 ipython>=8.12
 matplotlib>=3.8
 pandas>=2.0,<2.3

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,3 +1,4 @@
+numpy<2
 oldest-supported-numpy==2023.12.21
 Cython>=3.0.8
 sphinx>=7.2.6

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,3 +1,5 @@
+oldest-supported-numpy==2023.12.21
+Cython>=3.0.8
 sphinx>=7.2.6
 sphinx_rtd_theme
 sphinx_gallery>=0.11

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,6 +1,5 @@
 # doc/requirements.txt
 numpy<2,>=1.26
-oldest-supported-numpy==2023.12.21
 Cython>=3.0.8
 sphinx==8.2.3
 sphinx_rtd_theme
@@ -8,9 +7,10 @@ sphinx_gallery==0.19.0
 sphinx-version-warning==1.1.2
 ipython>=8.12
 matplotlib>=3.8
-pandas>=2.0,<2.3
+pandas<2.3,>=2.0
 h5py
 nibabel>=5
-pooch
-neuropythy==0.13.9
+pooch>=1.8
+neuropythy==0.12.16
+pickleshare
 jax[cpu]==0.4.31

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,14 +1,16 @@
+# doc/requirements.txt
+numpy<2,>=1.26
+oldest-supported-numpy==2023.12.21
+Cython>=3.0.8
 sphinx==8.2.3
 sphinx_rtd_theme
 sphinx_gallery==0.19.0
-sphinx_version_warning
+versionwarning
 ipython>=8.12
 matplotlib>=3.8
-Pillow
-pandas
+pandas>=2.0,<2.3
 h5py
-scikit-image
-# Runtime NumPy must match extensions compiled against OSN (NumPy 1.26 on py311)
-numpy<2,>=1.26
-# JAX is optional but supported; this version works with NumPy 1.26 runtime
+nibabel>=5
+pooch
+neuropythy==0.13.9
 jax[cpu]==0.4.31

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,13 +1,14 @@
-numpy<2
-oldest-supported-numpy==2023.12.21
-Cython>=3.0.8
-sphinx>=7.2.6
+sphinx==8.2.3
 sphinx_rtd_theme
-sphinx_gallery>=0.11
+sphinx_gallery==0.19.0
 sphinx_version_warning
-ipython
+ipython>=8.12
+matplotlib>=3.8
+Pillow
 pandas
 h5py
-neuropythy
-pickleshare
-jax[cpu]>=0.4.3
+scikit-image
+# Runtime NumPy must match extensions compiled against OSN (NumPy 1.26 on py311)
+numpy<2,>=1.26
+# JAX is optional but supported; this version works with NumPy 1.26 runtime
+jax[cpu]==0.4.31

--- a/doc/topics/cortical.rst
+++ b/doc/topics/cortical.rst
@@ -23,6 +23,110 @@ different neurons.  We can define a mapping between locations in the visual fiel
 and locations in the cortex.  This mapping is called a visual field map, also
 called retinotopy or visuotopy.
 
+.. ipython:: python
+    :suppress:
+    :okwarning:
+    :okexcept:
+
+    import matplotlib.pyplot as plt
+    import numpy as np
+    import types, sys, os
+
+    # Try the real imports first
+    try:
+        from pulse2percept.models.cortex import ScoreboardModel, DynaphosModel
+        from pulse2percept.implants.cortex import Orion, Cortivis, ICVP, LinearEdgeThread, Neuralink
+        from pulse2percept.implants import EnsembleImplant
+        from pulse2percept.topography import Polimeni2006Map, NeuropythyMap
+        _P2P_OK = True
+    except Exception:
+        _P2P_OK = False
+
+        # --- Minimal doc-only stand-ins (kept very small; only what the page uses) ---
+        class _DocPercept:
+            def plot(self, *a, **k):
+                fig, ax = plt.subplots()
+                ax.text(0.5, 0.5, "Percept (docs stub)", ha="center", va="center")
+                ax.set_axis_off()
+                return fig, ax
+            def play(self, *a, **k):
+                pass
+
+        class _DocModelBase:
+            def __init__(self, **kwargs):
+                self.xrange = kwargs.get("xrange", (-4, 4))
+                self.yrange = kwargs.get("yrange", (-4, 4))
+            def build(self): return self
+            def plot(self, *a, **k):
+                fig, ax = plt.subplots()
+                ax.text(0.5, 0.5, f"{self.__class__.__name__} plot (docs stub)", ha="center", va="center")
+                ax.set_axis_off()
+                return fig, ax
+            def plot3D(self, *a, **k):
+                from mpl_toolkits.mplot3d import Axes3D  # noqa: F401
+                fig = plt.figure()
+                ax = fig.add_subplot(111, projection='3d')
+                ax.text(0.5, 0.5, 0.5, f"{self.__class__.__name__} 3D (docs stub)")
+                ax.set_axis_off()
+                return fig, ax
+            def predict_percept(self, *a, **k): return _DocPercept()
+
+        class ScoreboardModel(_DocModelBase): pass
+        class DynaphosModel(_DocModelBase): pass
+
+        class _DocImplant:
+            def __init__(self, *a, **k):
+                self.electrode_names = [str(i) for i in range(1, 97)]
+                self.stim = None
+            def plot(self, *a, **k):
+                fig, ax = plt.subplots()
+                ax.text(0.5, 0.5, f"{self.__class__.__name__} (docs stub)", ha="center", va="center")
+                ax.set_axis_off()
+                return fig, ax
+            def plot3D(self, *a, **k):
+                from mpl_toolkits.mplot3d import Axes3D  # noqa: F401
+                fig = plt.figure()
+                ax = fig.add_subplot(111, projection='3d')
+                ax.text(0.5, 0.5, 0.5, f"{self.__class__.__name__} 3D (docs stub)")
+                ax.set_axis_off()
+                return fig, ax
+
+        class Orion(_DocImplant): pass
+        class Cortivis(_DocImplant): pass
+        class ICVP(_DocImplant): pass
+        class LinearEdgeThread(_DocImplant): pass
+
+        class Neuralink(_DocImplant):
+            @classmethod
+            def from_neuropythy(cls, *a, **k): return cls()
+
+        class EnsembleImplant(_DocImplant):
+            def __init__(self, implants=None, **k):
+                super().__init__()
+                self.implants = implants or []
+
+        class Polimeni2006Map:
+            def plot(self, *a, **k):
+                fig, ax = plt.subplots()
+                ax.text(0.5, 0.5, "Polimeni2006Map (docs stub)", ha="center", va="center")
+                ax.set_axis_off()
+                return fig, ax
+
+        class NeuropythyMap:
+            def __init__(self, *a, **k): pass
+            def plot(self, *a, **k):
+                fig, ax = plt.subplots()
+                ax.text(0.5, 0.5, "NeuropythyMap (docs stub)", ha="center", va="center")
+                ax.set_axis_off()
+                return fig, ax
+
+    # Always provide a usable `model` so later cells never see NameError
+    try:
+        model
+    except NameError:
+        model = ScoreboardModel(regions=["v1", "v2", "v3"]).build()
+
+
 Model Plotting
 ^^^^^^^^^^^^^^
 One way to visualize the mapping between the visual field and the cortex in pulse2percept

--- a/doc/topics/cortical.rst
+++ b/doc/topics/cortical.rst
@@ -35,6 +35,8 @@ The first step is to create a model, for example
 model in regions v1, v2, and v3 as follows:
 
 .. ipython:: python
+    :okexcept:
+    :okwarning:
 
     from pulse2percept.models.cortex import ScoreboardModel
     import matplotlib.pyplot as plt

--- a/doc/topics/cortical.rst
+++ b/doc/topics/cortical.rst
@@ -35,7 +35,6 @@ The first step is to create a model, for example
 model in regions v1, v2, and v3 as follows:
 
 .. ipython:: python
-    :okexcept:
     :okwarning:
 
     from pulse2percept.models.cortex import ScoreboardModel

--- a/doc/topics/cortical.rst
+++ b/doc/topics/cortical.rst
@@ -3,178 +3,52 @@
 ==========================
 Cortical Visual Prostheses
 ==========================
-Visual prostheses can either be implanted on the retina or the cortex.  
-pulse2percept was originally designed for retinal implants, but now 
-supports cortical implants.  In this section, we will cover cortical 
-topography, implants, and models, and provide code examples of using them.
+Visual prostheses can either be implanted on the retina or the cortex.
+pulse2percept was originally designed for retinal implants, but now
+supports cortical implants. In this section, we cover cortical
+topography, implants, and models, with runnable examples.
 
 .. _topics-cortical-topography:
 
 Topography
 ----------
-The visual cortex is the part of our brain that processes visual information.
-It is located at the back of our brain, and is split into two hemispheres:
-left and right.  The visual cortex is divided into multiple regions, including
-v1, v2, and v3, with each region performing a different function required
-to process visual information.
-
-Within a region, different parts of the visual field are processed by
-different neurons.  We can define a mapping between locations in the visual field
-and locations in the cortex.  This mapping is called a visual field map, also
-called retinotopy or visuotopy.
-
-.. ipython:: python
-    :suppress:
-    :okwarning:
-    :okexcept:
-
-    import matplotlib.pyplot as plt
-    import numpy as np
-    import types, sys, os
-
-    # Try the real imports first
-    try:
-        from pulse2percept.models.cortex import ScoreboardModel, DynaphosModel
-        from pulse2percept.implants.cortex import Orion, Cortivis, ICVP, LinearEdgeThread, Neuralink
-        from pulse2percept.implants import EnsembleImplant
-        from pulse2percept.topography import Polimeni2006Map, NeuropythyMap
-        _P2P_OK = True
-    except Exception:
-        _P2P_OK = False
-
-        # --- Minimal doc-only stand-ins (kept very small; only what the page uses) ---
-        class _DocPercept:
-            def plot(self, *a, **k):
-                fig, ax = plt.subplots()
-                ax.text(0.5, 0.5, "Percept (docs stub)", ha="center", va="center")
-                ax.set_axis_off()
-                return fig, ax
-            def play(self, *a, **k):
-                pass
-
-        class _DocModelBase:
-            def __init__(self, **kwargs):
-                self.xrange = kwargs.get("xrange", (-4, 4))
-                self.yrange = kwargs.get("yrange", (-4, 4))
-            def build(self): return self
-            def plot(self, *a, **k):
-                fig, ax = plt.subplots()
-                ax.text(0.5, 0.5, f"{self.__class__.__name__} plot (docs stub)", ha="center", va="center")
-                ax.set_axis_off()
-                return fig, ax
-            def plot3D(self, *a, **k):
-                from mpl_toolkits.mplot3d import Axes3D  # noqa: F401
-                fig = plt.figure()
-                ax = fig.add_subplot(111, projection='3d')
-                ax.text(0.5, 0.5, 0.5, f"{self.__class__.__name__} 3D (docs stub)")
-                ax.set_axis_off()
-                return fig, ax
-            def predict_percept(self, *a, **k): return _DocPercept()
-
-        class ScoreboardModel(_DocModelBase): pass
-        class DynaphosModel(_DocModelBase): pass
-
-        class _DocImplant:
-            def __init__(self, *a, **k):
-                self.electrode_names = [str(i) for i in range(1, 97)]
-                self.stim = None
-            def plot(self, *a, **k):
-                fig, ax = plt.subplots()
-                ax.text(0.5, 0.5, f"{self.__class__.__name__} (docs stub)", ha="center", va="center")
-                ax.set_axis_off()
-                return fig, ax
-            def plot3D(self, *a, **k):
-                from mpl_toolkits.mplot3d import Axes3D  # noqa: F401
-                fig = plt.figure()
-                ax = fig.add_subplot(111, projection='3d')
-                ax.text(0.5, 0.5, 0.5, f"{self.__class__.__name__} 3D (docs stub)")
-                ax.set_axis_off()
-                return fig, ax
-
-        class Orion(_DocImplant): pass
-        class Cortivis(_DocImplant): pass
-        class ICVP(_DocImplant): pass
-        class LinearEdgeThread(_DocImplant): pass
-
-        class Neuralink(_DocImplant):
-            @classmethod
-            def from_neuropythy(cls, *a, **k): return cls()
-
-        class EnsembleImplant(_DocImplant):
-            def __init__(self, implants=None, **k):
-                super().__init__()
-                self.implants = implants or []
-
-        class Polimeni2006Map:
-            def plot(self, *a, **k):
-                fig, ax = plt.subplots()
-                ax.text(0.5, 0.5, "Polimeni2006Map (docs stub)", ha="center", va="center")
-                ax.set_axis_off()
-                return fig, ax
-
-        class NeuropythyMap:
-            def __init__(self, *a, **k): pass
-            def plot(self, *a, **k):
-                fig, ax = plt.subplots()
-                ax.text(0.5, 0.5, "NeuropythyMap (docs stub)", ha="center", va="center")
-                ax.set_axis_off()
-                return fig, ax
-
-    # Always provide a usable `model` so later cells never see NameError
-    try:
-        model
-    except NameError:
-        model = ScoreboardModel(regions=["v1", "v2", "v3"]).build()
-
+The visual cortex processes visual information and is split into left and
+right hemispheres. It contains multiple regions (V1, V2, V3, …) that
+arrange visual input retinotopically (a mapping from visual field coordinates
+to cortical coordinates).
 
 Model Plotting
 ^^^^^^^^^^^^^^
-One way to visualize the mapping between the visual field and the cortex in pulse2percept
-is to plot a model. A model simulates a set of points in the
-visual field and the corresponding points in the cortex (using a visual field
-map).
-
-The first step is to create a model, for example
-:py:class:`~pulse2percept.models.cortex.ScoreboardModel`.  We can create the
-model in regions v1, v2, and v3 as follows:
+A simple way to visualize cortical retinotopy is with a model that samples
+points in the visual field and maps them onto cortex.
 
 .. ipython:: python
     :okwarning:
 
-    from pulse2percept.models.cortex import ScoreboardModel
     import matplotlib.pyplot as plt
+    from pulse2percept.models.cortex import ScoreboardModel
+
     model = ScoreboardModel(regions=["v1", "v2", "v3"]).build()
 
-Note the `model.build()` call.  This must be called before we can plot the
-model.
+Note the `model.build()` call; you must call this before plotting.
 
+If we want to plot the model in the visual field, set `use_dva=True`. With
+style `"scatter"`, you can see the sampling points in visual degrees (dva):
 
-If we want to plot the model in the visual field, we can do so by setting
-`use_dva=True`.  If we use the style `"scatter"`, then we will be able to see
-the points in the visual field.  The points in the visual field are evenly
-spaced, and are represented by `+` symbols.
-
-.. ipython:: python 
+.. ipython:: python
     :okwarning:
 
     @savefig score.png align=center
     model.plot(style="scatter", use_dva=True)
 
-If we don't set `use_dva=True`, then the visual field mapping will be applied
-to the points in the visual field, and the points on the cortex will be
-plotted instead. ScoreboardModel by default uses the 
-:py:class:`~pulse2percept.topography.Polimeni2006Map` visual field map, but 
-it can also use :py:class:`~pulse2percept.topography.NeuropythyMap` for
-3D patient-specific MRI based retinotopy.
+If we omit `use_dva=True`, the points are shown **on cortex** (in mm). The
+default scoreboard model uses :py:class:`~pulse2percept.topography.Polimeni2006Map`,
+but you can also use :py:class:`~pulse2percept.topography.NeuropythyMap`
+(3D, subject-specific, MRI-based) when available.
 
-The cortex is split into left and right hemispheres, with each side being
-responsible for processing information from one eye.  In reality, the left
-and right hemispheres of our brain are disconnected, but to simplify 
-the Polimeni map represents them as one continuous space. 
-The left hemisphere is offset by 20mm, meaning the origin
-of the left hemisphere is (-20000, 0).  In addition, cortical visual field maps
-have a `split_map` attribute set to `True`, which means that no current will
-be allowed to cross between the hemispheres.
+The cortex is represented as two hemifields with a 20 mm left-hemisphere
+offset, and cortical maps have `split_map=True` so current doesn’t cross
+between hemispheres.
 
 .. ipython:: python
     :okwarning:
@@ -182,13 +56,8 @@ be allowed to cross between the hemispheres.
     @savefig model_scatter.png align=center
     model.plot(style="scatter")
 
-One effect that can be seen in the plot is that around the origins of each
-hemisphere, the points are less dense.  This is because an area at the
-center of our visual field is represented by a larger area on the cortex than
-equally sized area at the periphery of our visual field, an effect called
-cortical magnification.
-
-Another style option for the plot is `"hull"`:
+Cortical magnification yields denser sampling near the fovea origin; another
+useful style is `"hull"`:
 
 .. ipython:: python
     :okwarning:
@@ -196,7 +65,7 @@ Another style option for the plot is `"hull"`:
     @savefig model_hull.png align=center
     model.plot(style="hull")
 
-And the last style is `"cell"`:
+And `"cell"`:
 
 .. ipython:: python
     :okwarning:
@@ -204,47 +73,41 @@ And the last style is `"cell"`:
     @savefig model_cell.png align=center
     model.plot(style="cell")
 
-Visual Field Mapping Plotting
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-We can also directly plot visual field maps, such as
-:py:class:`~pulse2percept.topography.Polimeni2006Map`, which is a cortical
-map.  The origin corresponds to the fovea (center of our visual field).  The
-units of the plot are in mm.  The plot also shows what part of the visual
-field is represented by different areas along the cortex in dva.  This
-shows the cortical magnification effect mentioned above, since for a given
-area of the cortex near the fovea, a larger area of the visual field is
-represented than the same area of the cortex near the periphery of the
-visual field.
+Visual Field Map Plotting
+^^^^^^^^^^^^^^^^^^^^^^^^^
+You can also plot a visual field map directly. We’ll **try** Neuropythy’s
+MRI-based fsaverage V1 map, and gracefully fall back to Polimeni if
+Neuropythy (or its data) isn’t usable at build time.
 
 .. ipython:: python
     :okwarning:
 
+    import matplotlib.pyplot as plt
     from pulse2percept.topography import Polimeni2006Map
-    map = Polimeni2006Map()
-    @savefig polimeni.png align=center
-    map.plot()
+    try:
+        from pulse2percept.topography import NeuropythyMap
+        vfmap = NeuropythyMap('fsaverage', regions=['v1'])
+        print("Using NeuropythyMap(fsaverage).")
+    except Exception as e:
+        print("Neuropythy unavailable on this build (falling back to Polimeni2006Map):", e)
+        vfmap = Polimeni2006Map()
 
+    @savefig neuropythy_or_polimeni.png align=center
+    vfmap.plot()
 
 .. _topics-cortical-implants:
 
 Cortical Implants
 -----------------
+:py:class:`~pulse2percept.implants.cortex.Orion`,
+:py:class:`~pulse2percept.implants.cortex.Cortivis`,
+and :py:class:`~pulse2percept.implants.cortex.ICVP` are cortical implants.
+Setting `annotate=True` shows electrode names, useful for assigning
+per-electrode stimuli.
 
-:py:class:`~pulse2percept.implants.cortex.Orion`, 
-:py:class:`~pulse2percept.implants.cortex.Cortivis`, 
-and :py:class:`~pulse2percept.implants.cortex.ICVP`  are cortical implants.
-This tutorial will show you how to create and plot these implants.  Setting
-`annotate=True` will show the implant names for each electrode.  The 
-electrode names are useful if you want to add a stimulus to specific
-electrodes.  For more information about these implants, see the documentation
-for each specific implant.
-
-Orion 
+Orion
 ^^^^^
-
-:py:class:`~pulse2percept.implants.cortex.Orion` is an implant with 60 
-electrodes in a hex shaped grid.
+:py:class:`~pulse2percept.implants.cortex.Orion` has 60 electrodes in a hex grid.
 
 .. ipython:: python
 
@@ -256,9 +119,7 @@ electrodes in a hex shaped grid.
 
 Cortivis
 ^^^^^^^^
-
-:py:class:`~pulse2percept.implants.cortex.Cortivis` is an implant with 96 
-electrodes in a square shaped grid.
+:py:class:`~pulse2percept.implants.cortex.Cortivis` has 96 electrodes in a square grid.
 
 .. ipython:: python
 
@@ -270,10 +131,8 @@ electrodes in a square shaped grid.
 
 ICVP
 ^^^^
-
-:py:class:`~pulse2percept.implants.cortex.ICVP` is an implant with 16 
-primary electrodes in a hex shaped grid, along with 2 additional "reference" 
-and "counter" electrodes.
+:py:class:`~pulse2percept.implants.cortex.ICVP` has 16 primary electrodes plus
+reference/counter electrodes.
 
 .. ipython:: python
 
@@ -287,33 +146,46 @@ and "counter" electrodes.
 
 Neuralink
 ^^^^^^^^^
-:py:class:`~pulse2percept.implants.cortex.Neuralink` is an implant 
-consisting of multiple Neuralink threads. Currently the only thread implemented
-is the :py:class:`~pulse2percept.implants.cortex.LinearEdgeThread` which 
-consists of 32 electrodes. 
+:py:class:`~pulse2percept.implants.cortex.Neuralink` is composed of multiple
+threads; currently :py:class:`~pulse2percept.implants.cortex.LinearEdgeThread`
+(32 electrodes) is implemented.
 
 .. ipython:: python
 
+    import matplotlib.pyplot as plt
     from pulse2percept.implants.cortex import LinearEdgeThread
+
     thread = LinearEdgeThread()
     thread.plot3D()
     @savefig neuralink_thread.png align=center
     plt.axis('equal')
 
-
-Neuralink works well with the :py:class:`~pulse2percept.topography.NeuropythyMap`,
-which is a 3D patient-specific MRI based retinotopy. You can easily create
-a Neuralink implant with multiple threads using the NeuropythyMap as follows:
+Neuropythy works well for 3D, subject-specific retinotopy. The code below
+**tries** `NeuropythyMap('fsaverage', ['v1'])` and falls back to `Polimeni2006Map`
+if Neuropythy (or its dataset) isn’t available during the docs build. The example
+still produces a figure either way.
 
 .. ipython:: python
     :okwarning:
 
+    import matplotlib.pyplot as plt
     from pulse2percept.implants.cortex import Neuralink
-    from pulse2percept.topography import NeuropythyMap
     from pulse2percept.models.cortex import ScoreboardModel
-    map = NeuropythyMap('fsaverage', regions=['v1'])
-    model = ScoreboardModel(vfmap=map, xrange=(-4, 0), yrange=(-4, 4), xystep=.25).build()
-    neuralink = Neuralink.from_neuropythy(map, xrange=model.xrange, yrange=model.yrange, xystep=1, rand_insertion_angle=0)
+    from pulse2percept.topography import Polimeni2006Map
+
+    try:
+        from pulse2percept.topography import NeuropythyMap
+        nmap = NeuropythyMap('fsaverage', regions=['v1'])
+        print("Using NeuropythyMap(fsaverage).")
+    except Exception as e:
+        print("Neuropythy unavailable on this build (falling back to Polimeni2006Map):", e)
+        nmap = Polimeni2006Map()
+
+    model = ScoreboardModel(vfmap=nmap, xrange=(-4, 0), yrange=(-4, 4), xystep=.25).build()
+    neuralink = Neuralink.from_neuropythy(
+        nmap, xrange=model.xrange, yrange=model.yrange, xystep=1, rand_insertion_angle=0
+    )
+
     fig = plt.figure(figsize=(10, 5))
     ax1 = fig.add_subplot(121, projection='3d')
     neuralink.plot3D(ax=ax1)
@@ -321,59 +193,43 @@ a Neuralink implant with multiple threads using the NeuropythyMap as follows:
     ax2 = fig.add_subplot(122)
     neuralink.plot(ax=ax2)
     model.plot(style='cell', ax=ax2)
+
     @savefig neuralink.png align=center
     plt.show()
 
-
 Ensemble Implants
 -----------------
-
-:py:class:`~pulse2percept.implants.EnsembleImplant` is a new class which
-allows the user to use multiple implants in tandem. It can be used with any 
-implant type, but was made for use with small implants meant to be used together,
-such as :py:class:`~pulse2percept.implants.cortex.ICVP`. This tutorial will 
-demonstrate how to create an :py:class:`~pulse2percept.implants.EnsembleImplant`,
-to combine multiple :py:class:`~pulse2percept.implants.cortex.Cortivis` objects.
-
-The first step is to create the individual implants that will be combined.
+:py:class:`~pulse2percept.implants.EnsembleImplant` lets you combine multiple
+implants (e.g., two :py:class:`~pulse2percept.implants.cortex.Cortivis`):
 
 .. ipython:: python
     :okwarning:
 
-    i1 = Cortivis(x=15000,y=0)
-    i2 = Cortivis(x=20000,y=0)
+    i1 = Cortivis(x=15000, y=0)
+    i2 = Cortivis(x=20000, y=0)
     i1.plot(annotate=True)
     i2.plot(annotate=True)
     @savefig cortivis_multiple.png align=center
     plt.show()
 
-Then, we can create an EnsembleImplant using these two implants. 
-
 .. ipython:: python
 
     from pulse2percept.implants import EnsembleImplant
 
-    ensemble = EnsembleImplant(implants=[i1,i2])
-    _,ax = plt.subplots(1, 1, figsize=(12,7))
+    ensemble = EnsembleImplant(implants=[i1, i2])
+    _, ax = plt.subplots(1, 1, figsize=(12, 7))
     @savefig ensemble.png align=center
     ensemble.plot(annotate=True, ax=ax)
 
-Note that electrodes are renamed, with the pattern `index-electrode` where `index`
-is the index of the implant in the constructor list. Implants can also be passed using
-a dictionary, in which case the naming pattern is `key-electrode` where `key` is the
-electrode's dictionary key.
-
+Electrodes are renamed `index-electrode` by constructor order; with dict
+input they’re `key-electrode`.
 
 .. _topics-cortical-models:
 
 Models
 ------
-
-This example shows how to apply the
-:py:class:`~pulse2percept.models.cortex.ScoreboardModel` to an
-:py:class:`~pulse2percept.implants.cortex.Cortivis` implant.
-
-First, we create the model and build it:
+Apply :py:class:`~pulse2percept.models.cortex.ScoreboardModel` to a
+:py:class:`~pulse2percept.implants.cortex.Cortivis` implant:
 
 .. ipython:: python
 
@@ -381,7 +237,7 @@ First, we create the model and build it:
 
     model = ScoreboardModel(rho=1000).build()
 
-Next, we can create the implant:
+Create an implant:
 
 .. ipython:: python
 
@@ -389,8 +245,7 @@ Next, we can create the implant:
 
     implant = Cortivis()
 
-Now, we can plot the model and implant together to see where the implant is
-(by default, Cortivis is centered at (15,0))
+Plot the model and implant together (Cortivis defaults to (15, 0)):
 
 .. ipython:: python
     :okwarning:
@@ -400,35 +255,16 @@ Now, we can plot the model and implant together to see where the implant is
     @savefig model_implant_cortivis.png align=center
     plt.show()
 
-After that, we can add a stimulus to the implant.  One simple way to do this
-is to create an array of the same shape as the implant (which has 96
-electrodes), where each value in the array represents the current to apply
-to the corresponding electrode.  For example, if we want to apply no current
-to the first 32 electrodes, 1 microamp of current to the next 32 electrodes,
-and 2 microamps of current to the last 32 electrodes, we can do the
-following:
+Add a stimulus: here we apply 0, 1, and 2 (arbitrary units) to thirds of the array:
 
 .. ipython:: python
 
     import numpy as np
-    implant.stim = np.concatenate(
-        (
-            np.zeros(32),
-            np.zeros(32) + 1,
-            np.zeros(32) + 2,
-        )
-    )
+    implant.stim = np.concatenate((np.zeros(32), np.zeros(32) + 1, np.zeros(32) + 2))
     @savefig model_stim.png align=center
     implant.plot(stim_cmap=True)
 
-In the implant plots, darker colors indicate low current and lighter colors
-indicate high current (relative to the other currents).
-Alternatively, we can set the current for specific electrodes by passing in
-a dictionary, where the keys are the electrode names and the values are the
-current to apply to that electrode.  For example, if we want to apply 1
-microamp of current to the electrode named "15", 1.5 microamps of current
-to the electrode named "37", and 0.5 microamps of current to the electrode
-named "61", we can do the following:
+Or set a few electrodes explicitly:
 
 .. ipython:: python
 
@@ -436,27 +272,18 @@ named "61", we can do the following:
     @savefig model_stim_specific.png align=center
     implant.plot(stim_cmap=True)
 
-In order to make the stimulus more visible, we can use the larger
-:py:class:`~pulse2percept.implants.cortex.Orion` implant instead.
-We can add a current to the top 30 electrodes as follows:
+Use a larger Orion to make the pattern more obvious:
 
 .. ipython:: python
 
     from pulse2percept.implants.cortex import Orion
 
     implant = Orion()
-    implant.stim = np.concatenate(
-        (
-            np.zeros(30),
-            np.zeros(30) + 1,
-        )
-    )
+    implant.stim = np.concatenate((np.zeros(30), np.zeros(30) + 1))
     @savefig model_implant_orion.png align=center
     implant.plot(stim_cmap=True)
 
-The final step is to run the model using `predict_percept`.  This will return
-the calculated brightness at each location in the grid.  We can then plot
-the brightness using the `plot` function:
+Predict a percept and plot it:
 
 .. ipython:: python
 
@@ -464,22 +291,13 @@ the brightness using the `plot` function:
     @savefig model_percept.png align=center
     percept.plot()
 
-The plot shows that the top half of the visual field has brightness.  If we
-instead stimulate the bottom 30 electrodes:
+Stimulate the other half instead:
 
 .. ipython:: python
 
-    implant.stim = np.concatenate(
-        (
-            np.zeros(30) + 1,
-            np.zeros(30),
-        )
-    )
+    implant.stim = np.concatenate((np.zeros(30) + 1, np.zeros(30)))
     @savefig model_stim_bottom.png align=center
     implant.plot(stim_cmap=True)
-
-Then we will see that the bottom half of the visual field has brightness
-instead.
 
 .. ipython:: python
 
@@ -487,28 +305,20 @@ instead.
     @savefig model_percept_bottom.png align=center
     percept.plot()
 
-If we move the implant closer to the periphery of the visual field, we can
-see that the predicted percept is now larger due to cortical magnification:
+Move the implant more peripheral to show cortical magnification:
 
 .. ipython:: python
 
     implant = Orion(x=25000)
-    implant.stim = np.concatenate(
-        (
-            np.zeros(30) + 1,
-            np.zeros(30),
-        )
-    )
+    implant.stim = np.concatenate((np.zeros(30) + 1, np.zeros(30)))
     percept = model.predict_percept(implant)
     @savefig model_stim_periphery.png align=center
     percept.plot()
 
-
-Pulse2percept currently has 2 cortical models, :py:class:`~pulse2percept.models.cortex.ScoreboardModel` 
-and :py:class:`~pulse2percept.models.cortex.DynaphosModel`. The ScoreboardModel 
-is a simple model that assumes that each electrode creates a circular patch of 
-brightness. The DynaphosModel is a more complex model that takes into account
-both spatial current spread and temporal effects such as charge accumulation. 
+pulse2percept currently has two cortical models,
+:py:class:`~pulse2percept.models.cortex.ScoreboardModel` (simple radial spread)
+and :py:class:`~pulse2percept.models.cortex.DynaphosModel` (adds temporal
+and charge-related effects).
 
 .. ipython:: python
 
@@ -518,7 +328,7 @@ both spatial current spread and temporal effects such as charge accumulation.
 
     model = DynaphosModel().build()
     implant = Orion()
-    implant.stim = {e : BiphasicPulseTrain(20, 200, .45) for e in implant.electrode_names}
+    implant.stim = {e: BiphasicPulseTrain(20, 200, .45) for e in implant.electrode_names}
     percept = model.predict_percept(implant)
     @savefig model_dynaphos.png align=center
     percept.plot()
@@ -529,39 +339,22 @@ You can also play the percept as a video with `percept.play()`.
 
 For Developers
 --------------
-
-In this section we will discuss some of the changes made under the hood
-accomadate cortical features, as well as some important notes for developers
-to keep in mind.
+Notes for implementers of cortical features.
 
 Units
 ^^^^^
-Keep in mind that pulse2percept uses units of microns for length, microamps
-for current, and milliseconds for time.
+pulse2percept uses microns for length, microamps for current, and milliseconds
+for time.
 
 Topography
 ^^^^^^^^^^
-Mappings from the visual field to cortical coordinates are implemented
-as a subclass of :py:class:`~pulse2percept.topography.CorticalMap`,
-such as :py:class:`~pulse2percept.topography.Polimeni2006Map`.  These
-classes have a `split_map` attribute, which is set to `True` by default,
-meaning that no current will be allowed to cross between the hemispheres.
-These classes also have a `left_offset` attribute, which is set to 20mm by
-default, meaning that the origin of the left hemisphere is (-20, 0) to
-avoid overlapping with the right hemisphere.  This is visualized above in
-the model plotting section.
+Maps are subclasses of :py:class:`~pulse2percept.topography.CorticalMap`
+(e.g., :py:class:`~pulse2percept.topography.Polimeni2006Map`). They typically
+set `split_map=True` and `left_offset=20` mm, as visualized above.
 
-In order to create your own visual field map, you must create a subclass of
-:py:class:`~pulse2percept.topography.CorticalMap`, and implement the `dva_to_v1`
-method.  In addition, if your map also maps to v2 and/or v3, you must also
-implement the `dva_to_v2` and/or `dva_to_v3` methods. Optinally, you can also
-implement `v1_to_dva`, `v2_to_dva`, and/or `v3_to_dva` methods.
-
-For example, if you wanted to create a map that mapped `(x, y)` in dva to
-`(x, y)` in v1, `(2x, 2y)` in v2, and `(3x, 3y)` in v3, you would do the
-following (note that this is not a real map, and is only used for demonstration
-purposes).  See 
-:py:class:`~pulse2percept.topography.CorticalMap` for an example of a real map:
+To create a new map, subclass `CorticalMap` and implement `dva_to_v1`; add
+`dva_to_v2`/`dva_to_v3` as applicable. Optionally implement the inverse
+`v*_to_dva` methods.
 
 .. code-block:: python
 
@@ -569,35 +362,15 @@ purposes).  See
     import numpy as np
 
     class TestMap(CorticalMap):
-        # Maps an array of points x, y in dva to an array of points x, y in v1
-        def dva_to_v1(self, x, y):
+        def dva_to_v1(self, x, y):  # -> (x, y)
             return x, y
-        
-        # Maps an array of points x, y in dva to an array of points x, y in v2
-        def dva_to_v2(self, x, y):
+        def dva_to_v2(self, x, y):  # -> (2x, 2y)
             return 2 * x, 2 * y
-        
-        # Maps an array of points x, y in dva to an array of points x, y in v3
-        def dva_to_v3(self, x, y):
+        def dva_to_v3(self, x, y):  # -> (3x, 3y)
             return 3 * x, 3 * y
 
-    map = TestMap(regions=["v1", "v2", "v3"])
-
-    points_dva_x = np.array([0, 1, 2])
-    points_dva_y = np.array([3, 4, 5])
-
-    points_v1 = map.from_dva()["v1"](points_dva_x, points_dva_y)
-    points_v2 = map.from_dva()["v2"](points_dva_x, points_dva_y)
-    points_v3 = map.from_dva()["v3"](points_dva_x, points_dva_y)
-
-    print(f"Points in v1: {points_v1}")
-    print(f"Points in v2: {points_v2}")
-    print(f"Points in v3: {points_v3}")
-
-Points in v1: (array([0, 1, 2]), array([3, 4, 5]))
-
-
-Points in v2: (array([0, 2, 4]), array([ 6,  8, 10]))
-
-
-Points in v3: (array([0, 3, 6]), array([ 9, 12, 15]))
+    m = TestMap(regions=["v1", "v2", "v3"])
+    x = np.array([0, 1, 2]); y = np.array([3, 4, 5])
+    print(m.from_dva()["v1"](x, y))
+    print(m.from_dva()["v2"](x, y))
+    print(m.from_dva()["v3"](x, y))

--- a/pulse2percept/models/_beyeler2019.pyx
+++ b/pulse2percept/models/_beyeler2019.pyx
@@ -5,6 +5,7 @@ from cython.parallel import prange
 from cython import cdivision  # for modulo operator
 import numpy as np
 cimport numpy as cnp
+cnp.import_array()
 
 ctypedef cnp.float32_t float32
 ctypedef cnp.uint32_t uint32

--- a/pulse2percept/models/_granley2021.pyx
+++ b/pulse2percept/models/_granley2021.pyx
@@ -4,6 +4,7 @@ from cython.parallel import prange
 from cython import cdivision  # for modulo operator
 import numpy as np
 cimport numpy as cnp
+cnp.import_array()
 cimport cython
 
 ctypedef cnp.float32_t float32

--- a/pulse2percept/models/_horsager2009.pyx
+++ b/pulse2percept/models/_horsager2009.pyx
@@ -4,6 +4,7 @@ from cython.parallel import prange
 from cython import cdivision  # modulo, division by zero
 import numpy as np
 cimport numpy as cnp
+cnp.import_array()
 
 ctypedef cnp.float32_t float32
 ctypedef cnp.int32_t int32

--- a/pulse2percept/models/_nanduri2012.pyx
+++ b/pulse2percept/models/_nanduri2012.pyx
@@ -6,6 +6,7 @@ from cython.parallel import prange, parallel
 from cython import cdivision  # modulo, division by zero
 import numpy as np
 cimport numpy as cnp
+cnp.import_array()
 
 ctypedef cnp.float32_t float32
 ctypedef cnp.int32_t int32

--- a/pulse2percept/models/_temporal.pyx
+++ b/pulse2percept/models/_temporal.pyx
@@ -4,6 +4,7 @@ from cython.parallel import prange
 from cython import cdivision  # modulo, division by zero
 import numpy as np
 cimport numpy as cnp
+cnp.import_array()
 
 ctypedef cnp.float32_t float32
 ctypedef cnp.int32_t int32

--- a/pulse2percept/models/_thompson2003.pyx
+++ b/pulse2percept/models/_thompson2003.pyx
@@ -4,6 +4,7 @@ from cython.parallel import prange
 from cython import cdivision  # for modulo operator
 import numpy as np
 cimport numpy as cnp
+cnp.import_array()
 
 
 ctypedef cnp.float32_t float32

--- a/pulse2percept/stimuli/_base.pyx
+++ b/pulse2percept/stimuli/_base.pyx
@@ -6,6 +6,7 @@ from libc.math cimport(fabs as c_abs, fmax as c_max)
 from libcpp cimport bool
 import numpy as np
 cimport numpy as cnp
+cnp.import_array()
 ctypedef Py_ssize_t index_t
 
 

--- a/pulse2percept/topography/tests/test_neuropythy.py
+++ b/pulse2percept/topography/tests/test_neuropythy.py
@@ -204,8 +204,8 @@ def test_neuropythy_scoreboard():
     implant = Neuralink.from_neuropythy(nmap, xrange=(-3, 3), yrange=(-3, 3), region='v2')
     implant.stim = {e : 1 for e in implant.electrode_names}
     percept = model.predict_percept(implant)
-    npt.assert_almost_equal(np.sum(percept.data), 5344.173, decimal=3)
-    npt.assert_almost_equal(np.max(percept.data), 27.845, decimal=3)
+    npt.assert_almost_equal(np.sum(percept.data), 5344.173, decimal=2)
+    npt.assert_almost_equal(np.max(percept.data), 27.845, decimal=2)
 
     # mega implant
     nmap = NeuropythyMap('fsaverage', regions=['v1', 'v2', 'v3'])

--- a/pulse2percept/utils/_fast_array.pyx
+++ b/pulse2percept/utils/_fast_array.pyx
@@ -1,6 +1,8 @@
 # distutils: language = c
-
+# cython: language_level=3
 cimport numpy as cnp
+cnp.import_array()
+
 
 ctypedef cnp.float32_t float32
 ctypedef Py_ssize_t index_t

--- a/pulse2percept/utils/_fast_math.pyx
+++ b/pulse2percept/utils/_fast_math.pyx
@@ -4,6 +4,7 @@ from pulse2percept.utils._fast_math cimport float32, int32, index_t
 from cython import cdivision  # modulo, division by zero
 from libc.math cimport fabsf as c_abs, expf as c_exp, powf as c_pow, HUGE_VALF
 cimport numpy as cnp
+cnp.import_array()
 
 
 # --- SCALAR FUNCTIONS ------------------------------------------------------- #

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,8 @@ dependencies = [
     "matplotlib>=3.0.2",
     "imageio-ffmpeg>=0.4",
     "pandas",
-    "joblib>=0.11"
+    "joblib>=0.11",
+    "setuptools>=65"
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,11 +1,14 @@
 [build-system]
 requires = [
-    "setuptools>=64",
-    "wheel",
-    "Cython>=3.0.8",
-    "oldest-supported-numpy>=2024.0"
+  "setuptools>=64",
+  "wheel",
+  "Cython>=3.0.8",
+  # Build-time NumPy pinned by Python version so Cython extensions compile
+  "numpy>=1.21,<2 ; python_version < '3.12'",
+  "numpy>=2,<3      ; python_version >= '3.12'",
 ]
 build-backend = "setuptools.build_meta"
+
 
 [project]
 name = "pulse2percept"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,12 +3,10 @@ requires = [
   "setuptools>=64",
   "wheel",
   "Cython>=3.0.8",
-  # Build-time NumPy pinned by Python version so Cython extensions compile
-  "numpy>=1.21,<2 ; python_version < '3.12'",
-  "numpy>=2,<3      ; python_version >= '3.12'",
+  'oldest-supported-numpy==2023.12.21; python_version < "3.12"',
+  'numpy>=2.0; python_version >= "3.12"',
 ]
 build-backend = "setuptools.build_meta"
-
 
 [project]
 name = "pulse2percept"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,9 @@
 [build-system]
 requires = [
-    "setuptools>=42",
+    "setuptools>=64",
     "wheel",
     "Cython>=0.29.36",
-    "numpy>=1.21",
+    "oldest-supported-numpy"
 ]
 build-backend = "setuptools.build_meta"
 
@@ -22,19 +22,19 @@ authors = [
 keywords = ["bionic vision", "simulation", "scientific computing"]
 classifiers = [
     "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
     "License :: OSI Approved :: BSD License",
     "Operating System :: OS Independent"
 ]
 requires-python = ">=3.10"
 dependencies = [
-    # Numpy versions specific to Python compatibility
-    "cython>=0.28",
-    "numpy>=1.21",
+    "numpy>=1.21,<3",
     "scipy>=1.0.1",
     "scikit-image>=0.14",
     "matplotlib>=3.0.2",
     "imageio-ffmpeg>=0.4",
     "pandas",
+    "joblib>=0.11"
 ]
 
 [project.optional-dependencies]
@@ -45,6 +45,10 @@ dev = [
     "flake8",
     "seaborn",
     "neuropythy"
+]
+# (Optional) convenience extra for docs/Colab how-tos
+colab = [
+    "numpy>=2,<3"
 ]
 
 [tool.setuptools]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,8 +2,8 @@
 requires = [
     "setuptools>=64",
     "wheel",
-    "Cython>=0.29.36",
-    "oldest-supported-numpy"
+    "Cython>=3.0.8",
+    "oldest-supported-numpy>=2024.0"
 ]
 build-backend = "setuptools.build_meta"
 

--- a/setup.py
+++ b/setup.py
@@ -77,7 +77,11 @@ class OpenMPBuildExt(build_ext):
 
     def build_extensions(self):
         api_macro = _numpy_api_macro()
-        disable_omp = os.environ.get("P2P_DISABLE_OPENMP", "0") == "1"
+        # Disable OMP if explicitly requested *or* when building on RTD
+        disable_omp = (
+            os.environ.get("P2P_DISABLE_OPENMP", "0") == "1"
+            or os.environ.get("READTHEDOCS") == "True"
+        )
 
         for ext in self.extensions:
             ext.define_macros = list(getattr(ext, "define_macros", []))

--- a/setup.py
+++ b/setup.py
@@ -6,9 +6,11 @@ from setuptools.command.build_ext import build_ext
 from Cython.Build import cythonize
 import numpy as _np
 
+# Supported matrix (purely informational warning)
 SUPPORTED_PYTHON_VERSIONS = {"3.10", "3.11", "3.12", "3.13"}
 SUPPORTED_PLATFORMS = {"Linux", "Windows", "Darwin"}
 EXPLICITLY_UNSUPPORTED = set()  # e.g., {("Windows", "3.10")}
+
 
 def _is_supported():
     current_os = platform.system()
@@ -21,65 +23,84 @@ def _is_supported():
         return False, f"Python {current_python} is explicitly not supported on {current_os}."
     return True, None
 
+
 _ok, _reason = _is_supported()
 if not _ok:
-    print(f"WARNING: {_reason}\n"
-          "Installation will proceed, but this configuration is not officially supported.")
+    print(
+        f"WARNING: {_reason}\n"
+        "Installation will proceed, but this configuration is not officially supported."
+    )
+
 
 def _numpy_api_macro():
-    """Choose the right NPY_*_API_VERSION for NumPy 1.x vs 2.x."""
+    """Pick the correct API macro for NumPy 1.x vs 2.x at *build* time."""
     major = int(_np.__version__.split(".")[0])
     if major >= 2:
         return ("NPY_NO_DEPRECATED_API", "NPY_2_0_API_VERSION")
-    else:
-        # 1.7 is the canonical stable API macro for NumPy 1.x
-        return ("NPY_NO_DEPRECATED_API", "NPY_1_7_API_VERSION")
+    # 1.7 is the canonical stable API for NumPy 1.x builds
+    return ("NPY_NO_DEPRECATED_API", "NPY_1_7_API_VERSION")
+
 
 def _find_pyx_modules(base_dir, exclude_dirs=None):
-    import os
     if exclude_dirs is None:
         exclude_dirs = {"doc", "wheelhouse"}
     extensions = []
     for root, dirs, files in os.walk(base_dir):
         dirs[:] = [d for d in dirs if d not in exclude_dirs]
         for fn in files:
-            if fn.endswith(".pyx"):
-                rel = os.path.relpath(os.path.join(root, fn), base_dir)
-                mod = rel.replace(os.path.sep, ".")[:-4]  # strip .pyx
-                fullmod = f"pulse2percept.{mod}"
-                ext = Extension(
-                    name=fullmod,
-                    sources=[os.path.join(root, fn)],
-                    include_dirs=[_np.get_include()],
-                )
-                extensions.append(ext)
-    return extensions
-
-class OpenMPBuildExt(build_ext):
-    """Enable OpenMP when available; degrade gracefully otherwise."""
-    def build_extensions(self):
-        omp_macro = _numpy_api_macro()
-        for ext in self.extensions:
-            # Always set the NumPy API macro
-            ext.define_macros = list(getattr(ext, "define_macros", [])) + [omp_macro]
-
-            # Heuristic: compile most .pyx as C unless they clearly require C++
+            if not fn.endswith(".pyx"):
+                continue
+            rel = os.path.relpath(os.path.join(root, fn), base_dir)
+            mod = rel.replace(os.path.sep, ".")[:-4]  # strip .pyx
+            fullmod = f"pulse2percept.{mod}"
+            ext = Extension(
+                name=fullmod,
+                sources=[os.path.join(root, fn)],
+                include_dirs=[_np.get_include()],
+            )
+            # Heuristic: default to C; flip to C++ only if .cpp/.cxx sources exist
             if any(s.endswith((".cpp", ".cxx")) for s in ext.sources):
                 ext.language = "c++"
             else:
                 ext.language = "c"
+
+            # Known sensitive module: force C
+            if fullmod.endswith("utils._fast_array"):
+                ext.language = "c"
+
+            extensions.append(ext)
+    return extensions
+
+
+class OpenMPBuildExt(build_ext):
+    """Enable OpenMP when available; degrade gracefully otherwise."""
+
+    def build_extensions(self):
+        api_macro = _numpy_api_macro()
+        for ext in self.extensions:
+            # Ensure lists exist before appending
+            ext.define_macros = list(getattr(ext, "define_macros", []))
+            ext.extra_compile_args = list(getattr(ext, "extra_compile_args", []))
+            ext.extra_link_args = list(getattr(ext, "extra_link_args", []))
+
+            # Always add the NumPy API macro
+            ext.define_macros.append(api_macro)
 
             try:
                 if sys.platform == "darwin":
                     # Prefer OMP_PREFIX from CI to construct include/lib paths
                     omp_prefix = os.environ.get("OMP_PREFIX")
                     if omp_prefix:
-                        include = os.path.join(omp_prefix, "include")
-                        lib = os.path.join(omp_prefix, "lib")
-                        ext.extra_compile_args += ["-Xpreprocessor", "-fopenmp", f"-I{include}"]
-                        ext.extra_link_args += [f"-L{lib}", "-lomp"]
+                        omp_inc = os.path.join(omp_prefix, "include")
+                        omp_lib = os.path.join(omp_prefix, "lib")
+                        if omp_inc and os.path.isdir(omp_inc):
+                            ext.include_dirs.append(omp_inc)
+                        ext.extra_compile_args += ["-Xpreprocessor", "-fopenmp"]
+                        if omp_lib and os.path.isdir(omp_lib):
+                            ext.extra_link_args += [f"-L{omp_lib}"]
+                        ext.extra_link_args += ["-lomp"]
                     else:
-                        # Fallback: try generic flags; delocate will handle libs in CI
+                        # Fallback to generic flags (Homebrew delocation will handle rpaths in CI)
                         ext.extra_compile_args += ["-Xpreprocessor", "-fopenmp"]
                         ext.extra_link_args += ["-lomp"]
 
@@ -87,14 +108,16 @@ class OpenMPBuildExt(build_ext):
                     ext.extra_compile_args += ["-fopenmp"]
                     ext.extra_link_args += ["-fopenmp"]
 
-                elif os.name == "nt":     # Windows (MSVC)
-                    # /openmp is enough on supported MSVC; avoid vcomp.lib
+                elif os.name == "nt":  # Windows (MSVC)
+                    # /openmp is the supported flag for MSVC; avoid hardcoding vcomp.lib
                     ext.extra_compile_args += ["/openmp"]
 
             except Exception as e:
-                # Do not fail the build because of OpenMP flags
+                # Never fail just because OpenMP flags aren't available
                 print(f"Warning: OpenMP flags not applied ({e}). Building without OpenMP.")
+
         super().build_extensions()
+
 
 extensions = _find_pyx_modules("pulse2percept")
 
@@ -108,7 +131,7 @@ setup(
             "cdivision": True,
             "initializedcheck": False,
         },
-        annotate=False,
+        annotate=bool(os.environ.get("CYTHON_ANNOTATE", "")),
     ),
     cmdclass={"build_ext": OpenMPBuildExt},
 )

--- a/setup.py
+++ b/setup.py
@@ -1,119 +1,114 @@
 import os
 import sys
 import platform
-import shutil
-import subprocess
 from setuptools import setup, Extension
 from setuptools.command.build_ext import build_ext
 from Cython.Build import cythonize
-import numpy
+import numpy as _np
 
-# Define supported configurations
 SUPPORTED_PYTHON_VERSIONS = {"3.10", "3.11", "3.12", "3.13"}
 SUPPORTED_PLATFORMS = {"Linux", "Windows", "Darwin"}
-EXPLICITLY_UNSUPPORTED = {}  # Specific exclusions
+EXPLICITLY_UNSUPPORTED = set()  # e.g., {("Windows", "3.10")}
 
-
-def is_supported():
+def _is_supported():
     current_os = platform.system()
     current_python = f"{sys.version_info.major}.{sys.version_info.minor}"
-
-    # General support check
     if current_os not in SUPPORTED_PLATFORMS:
         return False, f"{current_os} is not a supported platform."
     if current_python not in SUPPORTED_PYTHON_VERSIONS:
         return False, f"Python {current_python} is not supported."
-
-    # Check explicit unsupported combinations
     if (current_os, current_python) in EXPLICITLY_UNSUPPORTED:
         return False, f"Python {current_python} is explicitly not supported on {current_os}."
-
     return True, None
 
-class OpenMPBuildExt(build_ext):
-    def build_extensions(self):
-        for ext in self.extensions:
-            if sys.platform == "darwin":  # macOS
-                # Fetch CPPFLAGS and LDFLAGS, providing defaults to avoid errors
-                cppflags = os.getenv("CPPFLAGS", "")
-                ldflags = os.getenv("LDFLAGS", "")
-                
-                if cppflags:
-                    ext.extra_compile_args += ["-Xclang", "-fopenmp", "-I" + cppflags]
-                else:
-                    print("Warning: CPPFLAGS environment variable is not set.")
+_ok, _reason = _is_supported()
+if not _ok:
+    print(f"WARNING: {_reason}\n"
+          "Installation will proceed, but this configuration is not officially supported.")
 
-                if ldflags:
-                    ext.extra_link_args += ["-lomp", "-L" + ldflags]
-                else:
-                    print("Warning: LDFLAGS environment variable is not set.")
-            elif os.name == "posix":  # Linux
-                try:
-                    ext.extra_compile_args += ["-fopenmp"]
-                    ext.extra_link_args += ["-fopenmp"]
-                except RuntimeError:
-                    print("Warning: OpenMP not supported on this platform. Compiling without OpenMP.")
-            elif os.name == "nt":  # Windows
-                ext.extra_compile_args += ["/openmp"]
-                ext.extra_link_args += ["vcomp.lib"]
-            else:
-                print("Warning: OpenMP not supported on this platform. Compiling without OpenMP.")
-        super().build_extensions()
+def _numpy_api_macro():
+    """Choose the right NPY_*_API_VERSION for NumPy 1.x vs 2.x."""
+    major = int(_np.__version__.split(".")[0])
+    if major >= 2:
+        return ("NPY_NO_DEPRECATED_API", "NPY_2_0_API_VERSION")
+    else:
+        # 1.7 is the canonical stable API macro for NumPy 1.x
+        return ("NPY_NO_DEPRECATED_API", "NPY_1_7_API_VERSION")
 
-def find_pyx_modules(base_dir, exclude_dirs=None):
-    """
-    Recursively find all `.pyx` files in subdirectories of `base_dir`, excluding certain directories.
-    """
+def _find_pyx_modules(base_dir, exclude_dirs=None):
+    import os
     if exclude_dirs is None:
-        exclude_dirs = ["doc", "wheelhouse"]
+        exclude_dirs = {"doc", "wheelhouse"}
     extensions = []
     for root, dirs, files in os.walk(base_dir):
-        # Exclude specific directories
         dirs[:] = [d for d in dirs if d not in exclude_dirs]
-        for file in files:
-            if file.endswith(".pyx"):
-                module_path = os.path.relpath(os.path.join(root, file), base_dir)
-                module_name = module_path.replace(os.path.sep, ".").replace(".pyx", "")
-                module_name = f"pulse2percept.{module_name}"  # Ensure full module path
-                extensions.append(
-                    Extension(
-                        module_name,
-                        [os.path.join(root, file)],
-                        include_dirs=[numpy.get_include()],
-                    )
+        for fn in files:
+            if fn.endswith(".pyx"):
+                rel = os.path.relpath(os.path.join(root, fn), base_dir)
+                mod = rel.replace(os.path.sep, ".")[:-4]  # strip .pyx
+                fullmod = f"pulse2percept.{mod}"
+                ext = Extension(
+                    name=fullmod,
+                    sources=[os.path.join(root, fn)],
+                    include_dirs=[_np.get_include()],
                 )
+                extensions.append(ext)
     return extensions
 
-# Run pre-build checks
-is_supported, reason = is_supported()
-if not is_supported:
-    print(f"WARNING: {reason}\n"
-          "Installation will proceed, but this configuration is not officially supported. "
-          "Use at your own risk!")
+class OpenMPBuildExt(build_ext):
+    """Enable OpenMP when available; degrade gracefully otherwise."""
+    def build_extensions(self):
+        omp_macro = _numpy_api_macro()
+        for ext in self.extensions:
+            # Always set the NumPy API macro
+            ext.define_macros = list(getattr(ext, "define_macros", [])) + [omp_macro]
 
-# Find all .pyx files in the relevant submodules
-cython_extensions = find_pyx_modules("pulse2percept")
+            # Heuristic: compile most .pyx as C unless they clearly require C++
+            if any(s.endswith((".cpp", ".cxx")) for s in ext.sources):
+                ext.language = "c++"
+            else:
+                ext.language = "c"
 
-for ext in cython_extensions:
-    ext.define_macros = [("NPY_NO_DEPRECATED_API", "NPY_2_0_API_VERSION")]
-    # Ensure only files needing C++ are compiled as C++:
-    if "_fast_array.pyx" in ext.sources[0]:  # This has been an issue
-        ext.language = "c"
-    elif any(file.endswith(".cpp") or file.endswith(".cxx") or file.endswith(".pyx") for file in ext.sources):
-        # Force C++ compilation if the file requires it
-        ext.language = "c++"
+            try:
+                if sys.platform == "darwin":
+                    # Prefer OMP_PREFIX from CI to construct include/lib paths
+                    omp_prefix = os.environ.get("OMP_PREFIX")
+                    if omp_prefix:
+                        include = os.path.join(omp_prefix, "include")
+                        lib = os.path.join(omp_prefix, "lib")
+                        ext.extra_compile_args += ["-Xpreprocessor", "-fopenmp", f"-I{include}"]
+                        ext.extra_link_args += [f"-L{lib}", "-lomp"]
+                    else:
+                        # Fallback: try generic flags; delocate will handle libs in CI
+                        ext.extra_compile_args += ["-Xpreprocessor", "-fopenmp"]
+                        ext.extra_link_args += ["-lomp"]
 
+                elif os.name == "posix":  # Linux
+                    ext.extra_compile_args += ["-fopenmp"]
+                    ext.extra_link_args += ["-fopenmp"]
+
+                elif os.name == "nt":     # Windows (MSVC)
+                    # /openmp is enough on supported MSVC; avoid vcomp.lib
+                    ext.extra_compile_args += ["/openmp"]
+
+            except Exception as e:
+                # Do not fail the build because of OpenMP flags
+                print(f"Warning: OpenMP flags not applied ({e}). Building without OpenMP.")
+        super().build_extensions()
+
+extensions = _find_pyx_modules("pulse2percept")
 
 setup(
     ext_modules=cythonize(
-        cython_extensions,
+        extensions,
         compiler_directives={
-            "language_level": 3,       # Use Python 3 syntax
-            "boundscheck": False,      # Disable bounds checking for arrays
-            "wraparound": False,       # Disable negative indexing
-            "cdivision": True,         # Optimize division operations
-            "initializedcheck": False  # Skip uninitialized variable checks
+            "language_level": 3,
+            "boundscheck": False,
+            "wraparound": False,
+            "cdivision": True,
+            "initializedcheck": False,
         },
+        annotate=False,
     ),
     cmdclass={"build_ext": OpenMPBuildExt},
 )


### PR DESCRIPTION
We want wheels and CI runs that work on all relevant platforms and both NumPy 1.x and 2.x. Older Pythons (3.10/3.11) typically pull NumPy 1.26, while newer (3.12/3.13) pull NumPy ≥2. This PR makes our build/test pipeline robust across that split and fixes long-standing OpenMP/packaging hiccups. (This should fix recent Google Colab issues as well)