### PR TITLE
[TST] Download & precache Benson map data

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,27 +55,68 @@ jobs:
           BASE="$HOME/.neuropythy_p2p/benson_winawer_2018"
           mkdir -p "$BASE"
 
-          # Dir -> OSF URL (from Neuropythy)
+          # Dir -> base OSF url (as in Neuropythy)
           declare -A URLS=(
-            [analyses]="https://osf.io/cpfa8/download?direct=1"
-            [retinotopy]="https://osf.io/m4k8q/download?direct=1"
-            [freesurfer_subjects]="https://osf.io/pu9js/download?direct=1"
+            [analyses]="https://osf.io/cpfa8/download"
+            [retinotopy]="https://osf.io/m4k8q/download"
+            [freesurfer_subjects]="https://osf.io/pu9js/download"
           )
 
           UA="neuropythy-ci/1.0 (+https://github.com/pulse2percept/pulse2percept)"
+          CURL="curl -fL --retry 5 --retry-delay 2 -A \"$UA\""
+
+          # Given an OSF download url, try several direct-download flavors until tar -tzf succeeds.
+          fetch_targz() {
+            local url="$1" out="$2"
+            # Build candidate variants
+            local base="${url%%\?*}" qs="${url#*$base}"
+            local qprefix="?"
+            [[ "$qs" == "$url" ]] || qprefix="&"
+
+            # 1) original
+            # 2) ?direct=1
+            # 3) ?download=1
+            # 4) /?action=download (replace trailing /download)
+            # 5) /download?direct=1 (explicit)
+            local cand=()
+            cand+=("$url")
+            cand+=("$base${qprefix}direct=1")
+            cand+=("$base${qprefix}download=1")
+            if [[ "$base" == */download ]]; then
+              cand+=("${base%/download}/?action=download")
+              cand+=("$base?direct=1")
+            fi
+
+            for u in "${cand[@]}"; do
+              echo "Attempting: $u"
+              # Download
+              bash -lc "$CURL -o \"$out\" \"$u\"" || true
+              # Validate it's a gzip'd tar (quick and reliable)
+              if tar -tzf "$out" >/dev/null 2>&1; then
+                echo "Valid tar.gz from: $u"
+                return 0
+              else
+                echo "Not a valid tar.gz from: $u"
+                echo "First 200 bytes (UTF-8 guess):"
+                head -c 200 "$out" | tr -dc '[:print:]\n' || true
+                echo
+              fi
+            done
+            return 1
+          }
 
           for d in "${!URLS[@]}"; do
             TARBALL="$BASE/$d.tar.gz"
             echo "Downloading $d -> $TARBALL"
-            curl -fL --retry 5 --retry-delay 2 -A "$UA" -o "$TARBALL" "${URLS[$d]}"
-
-            echo "Verifying $TARBALL is a valid tar.gz"
-            tar -tzf "$TARBALL" >/dev/null
+            fetch_targz "${URLS[$d]}" "$TARBALL" || {
+              echo "ERROR: Could not obtain a valid tar.gz for $d from OSF."
+              exit 2
+            }
 
             echo "Extracting $TARBALL into $BASE"
             tar -xzf "$TARBALL" -C "$BASE"
 
-            # Ensure $BASE/$d exists even if archive created a different top-level dir
+            # Ensure $BASE/$d exists even if archive used a wrapper dir
             if [[ ! -d "$BASE/$d" ]]; then
               TOPDIR="$(tar -tzf "$TARBALL" | head -1 | cut -d/ -f1 || true)"
               if [[ -n "$TOPDIR" && -d "$BASE/$TOPDIR" ]]; then
@@ -90,6 +131,9 @@ jobs:
 
             rm -f "$TARBALL"
           done
+
+          echo "Dataset warmed at $BASE"
+
 
       - name: Verify Neuropythy dataset layout
         shell: bash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,6 +38,71 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
+      # ---- Preseed Neuropythy dataset & cache it ----
+      - name: Cache Neuropythy Benson-Winawer dataset
+        uses: actions/cache@v4
+        id: npy_cache
+        with:
+          path: ~/.neuropythy_p2p/benson_winawer_2018
+          # Per-OS cache (tar/extract behavior differs slightly); bump suffix to bust cache
+          key: neuropythy-bw2018-${{ runner.os }}-v1
+
+      - name: Warm Neuropythy dataset (first run only)
+        if: steps.npy_cache.outputs.cache-hit != 'true'
+        shell: bash
+        run: |
+          set -euxo pipefail
+          BASE="$HOME/.neuropythy_p2p/benson_winawer_2018"
+          mkdir -p "$BASE"
+
+          # Dir -> OSF URL (from Neuropythy)
+          declare -A URLS=(
+            [analyses]="https://osf.io/cpfa8/download?direct=1"
+            [retinotopy]="https://osf.io/m4k8q/download?direct=1"
+            [freesurfer_subjects]="https://osf.io/pu9js/download?direct=1"
+          )
+
+          UA="neuropythy-ci/1.0 (+https://github.com/pulse2percept/pulse2percept)"
+
+          for d in "${!URLS[@]}"; do
+            TARBALL="$BASE/$d.tar.gz"
+            echo "Downloading $d -> $TARBALL"
+            curl -fL --retry 5 --retry-delay 2 -A "$UA" -o "$TARBALL" "${URLS[$d]}"
+
+            echo "Verifying $TARBALL is a valid tar.gz"
+            tar -tzf "$TARBALL" >/dev/null
+
+            echo "Extracting $TARBALL into $BASE"
+            tar -xzf "$TARBALL" -C "$BASE"
+
+            # Ensure $BASE/$d exists even if archive created a different top-level dir
+            if [[ ! -d "$BASE/$d" ]]; then
+              TOPDIR="$(tar -tzf "$TARBALL" | head -1 | cut -d/ -f1 || true)"
+              if [[ -n "$TOPDIR" && -d "$BASE/$TOPDIR" ]]; then
+                mkdir -p "$BASE/$d"
+                shopt -s dotglob nullglob
+                mv "$BASE/$TOPDIR"/* "$BASE/$d" || true
+                rmdir "$BASE/$TOPDIR" || true
+              else
+                mkdir -p "$BASE/$d"
+              fi
+            fi
+
+            rm -f "$TARBALL"
+          done
+
+      - name: Verify Neuropythy dataset layout
+        shell: bash
+        run: |
+          set -euo pipefail
+          BASE="$HOME/.neuropythy_p2p/benson_winawer_2018"
+          for d in analyses retinotopy freesurfer_subjects; do
+            [[ -d "$BASE/$d" ]] || { echo "Missing $BASE/$d"; exit 1; }
+          done
+          echo "Dataset ready at $BASE"
+          # Optional: quick tree for debugging
+          find "$BASE" -maxdepth 2 -type d | sort
+
       # ---- System deps ----
       - name: Install dependencies (macOS)
         if: runner.os == 'macOS'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,43 +63,39 @@ jobs:
           )
 
           UA="neuropythy-ci/1.0 (+https://github.com/pulse2percept/pulse2percept)"
-          CURL="curl -fL --retry 5 --retry-delay 2 -A \"$UA\""
+          CURL_BASE=(curl -fL --retry 5 --retry-delay 2 -A "$UA" -H "Referer: https://osf.io/")
 
-          # Given an OSF download url, try several direct-download flavors until tar -tzf succeeds.
           fetch_targz() {
             local url="$1" out="$2"
-            # Build candidate variants
-            local base="${url%%\?*}" qs="${url#*$base}"
-            local qprefix="?"
-            [[ "$qs" == "$url" ]] || qprefix="&"
+            # Build candidate variants WITHOUT referencing unset vars
+            local base
+            base="${url%%\?*}"
 
-            # 1) original
-            # 2) ?direct=1
-            # 3) ?download=1
-            # 4) /?action=download (replace trailing /download)
-            # 5) /download?direct=1 (explicit)
-            local cand=()
-            cand+=("$url")
-            cand+=("$base${qprefix}direct=1")
-            cand+=("$base${qprefix}download=1")
+            # Try a few common direct-download patterns
+            local cand=(
+              "$url"
+              "${base}?direct=1"
+              "${base}?download=1"
+              "${base}?action=download"
+            )
+            # If the URL ends with /download, also try the parent action form
             if [[ "$base" == */download ]]; then
               cand+=("${base%/download}/?action=download")
+              cand+=("${base%/download}?action=download")
               cand+=("$base?direct=1")
             fi
 
             for u in "${cand[@]}"; do
               echo "Attempting: $u"
-              # Download
-              bash -lc "$CURL -o \"$out\" \"$u\"" || true
-              # Validate it's a gzip'd tar (quick and reliable)
-              if tar -tzf "$out" >/dev/null 2>&1; then
-                echo "Valid tar.gz from: $u"
-                return 0
-              else
-                echo "Not a valid tar.gz from: $u"
-                echo "First 200 bytes (UTF-8 guess):"
-                head -c 200 "$out" | tr -dc '[:print:]\n' || true
-                echo
+              if "${CURL_BASE[@]}" -o "$out" "$u"; then
+                if tar -tzf "$out" >/dev/null 2>&1; then
+                  echo "Valid tar.gz from: $u"
+                  return 0
+                else
+                  echo "Not a valid tar.gz from: $u"
+                  head -c 200 "$out" | tr -dc '[:print:]\n' || true
+                  echo
+                fi
               fi
             done
             return 1
@@ -133,7 +129,6 @@ jobs:
           done
 
           echo "Dataset warmed at $BASE"
-
 
       - name: Verify Neuropythy dataset layout
         shell: bash


### PR DESCRIPTION
Addresses a download issue encountered on macos-latest with Python 3.13. Downloads the neuropythy dataset using curl and pre-caches it for all runners