### PR TITLE
[ENH] [FIX] Robust file downloads & OSF endpoints

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -67,6 +67,7 @@ intersphinx_mapping = {"python": ("https://docs.python.org/3", None)}
 from sphinx_gallery.sorting import ExplicitOrder
 sphinx_gallery_conf = {
     "examples_dirs": ["../examples"],
+    "abort_on_example_error": False,
     "gallery_dirs": ["examples"],
     "reference_url": {"pulse2percept": None},
     "thumbnail_size": (320, 224),

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -67,7 +67,6 @@ intersphinx_mapping = {"python": ("https://docs.python.org/3", None)}
 from sphinx_gallery.sorting import ExplicitOrder
 sphinx_gallery_conf = {
     "examples_dirs": ["../examples"],
-    "abort_on_example_error": False,
     "gallery_dirs": ["examples"],
     "reference_url": {"pulse2percept": None},
     "thumbnail_size": (320, 224),

--- a/doc/topics/cortical.rst
+++ b/doc/topics/cortical.rst
@@ -197,11 +197,10 @@ consists of 32 electrodes.
 
 
 Neuralink works well with the :py:class:`~pulse2percept.topography.NeuropythyMap`,
-which is a 3D patient-specific MRI based retinotopy. You can easily create
+which is a 3D patient-specific MRI based retinotopy. You can create
 a Neuralink implant with multiple threads using the NeuropythyMap as follows:
 
-.. ipython:: python
-    :okwarning:
+.. code-block:: python
 
     from pulse2percept.implants.cortex import Neuralink
     from pulse2percept.topography import NeuropythyMap

--- a/examples/implants/plot_implants_cortical.py
+++ b/examples/implants/plot_implants_cortical.py
@@ -7,7 +7,8 @@ pulse2percept supports the following cortical implants:
 
 Orion Prosthesis System (Cortigent Inc.)
 ----------------------------------------
-:py:class:`~pulse2percept.implants.cortex.Orion` contains 60 electrodes in a hex shaped grid inspired by Argus II.
+:py:class:`~pulse2percept.implants.cortex.Orion` contains 60 electrodes in a 
+hex shaped grid inspired by Argus II.
 """
 
 import matplotlib.pyplot as plt
@@ -74,50 +75,22 @@ plt.axis('equal')
 plt.show()
 
 ###############################################################################
-# Neuralink implants can be easily created from a NeuropythyMap
+# Neuralink implants can be created from a NeuropythyMap
 # enabling easy placement of implants across the cortical surface.
-
-import os
-from pulse2percept.datasets.base import has_network, osf_is_reachable
-
-def _placeholder(msg):
-    fig = plt.figure(figsize=(8, 2))
-    ax = fig.add_subplot(111)
-    ax.text(0.5, 0.5, msg, ha='center', va='center', wrap=True)
-    ax.axis('off')
-    plt.show()
-
-# Hard skip on RTD to avoid flaky external downloads:
-if os.environ.get("READTHEDOCS") == "True":
-    _placeholder("Skipping Neuropythy demo on ReadTheDocs.")
-else:
-    msg = None
-    try:
-        import neuropythy  # noqa: F401
-    except Exception as e:
-        msg = f"Neuropythy not installed: {e}"
-    if msg is None and not has_network():
-        msg = "No internet connection; skipping Neuropythy demo."
-    if msg is None and not osf_is_reachable():
-        msg = "OSF is unreachable; skipping Neuropythy demo."
-
-    try:
-        if msg is None:
-            nmap = p2p.topography.NeuropythyMap(subject='fsaverage', regions=['v1'])
-            model = p2p.models.cortex.ScoreboardModel(
-                rho=500, xrange=(-6, 0), yrange=(-5, 5), xystep=.25, vfmap=nmap
-            ).build()
-            nlink = Neuralink.from_neuropythy(
-                nmap, xrange=model.xrange, yrange=model.yrange, xystep=2, rand_insertion_angle=0
-            )
-            print(len(nlink.implants), " total threads")
-            fig = plt.figure(figsize=(10, 4))
-            ax1 = fig.add_subplot(121, projection='3d')
-            model.plot3D(ax=ax1, style='cell'); nlink.plot3D(ax=ax1)
-            ax2 = fig.add_subplot(122)
-            model.plot(style='cell', ax=ax2); nlink.plot(ax=ax2)
-            plt.show()
-        else:
-            _placeholder(msg)
-    except Exception as e:
-        _placeholder(f"Neuropythy demo failed: {e}\n(Continuing without this figure.)")
+#
+# .. code-block:: python
+#
+#     nmap = p2p.topography.NeuropythyMap(subject='fsaverage', regions=['v1'])
+#     model = p2p.models.cortex.ScoreboardModel(
+#         rho=500, xrange=(-6, 0), yrange=(-5, 5), xystep=.25, vfmap=nmap
+#     ).build()
+#     nlink = Neuralink.from_neuropythy(
+#         nmap, xrange=model.xrange, yrange=model.yrange, xystep=2, rand_insertion_angle=0
+#     )
+#     print(len(nlink.implants), " total threads")
+#     fig = plt.figure(figsize=(10, 4))
+#     ax1 = fig.add_subplot(121, projection='3d')
+#     model.plot3D(ax=ax1, style='cell'); nlink.plot3D(ax=ax1)
+#     ax2 = fig.add_subplot(122)
+#     model.plot(style='cell', ax=ax2); nlink.plot(ax=ax2)
+#     plt.show()

--- a/examples/implants/plot_implants_cortical.py
+++ b/examples/implants/plot_implants_cortical.py
@@ -76,57 +76,48 @@ plt.show()
 ###############################################################################
 # Neuralink implants can be easily created from a NeuropythyMap
 # enabling easy placement of implants across the cortical surface.
-# See the neuropythy example for more details.
 
 import os
 from pulse2percept.datasets.base import has_network, osf_is_reachable
 
-msg = None
-try:
-    import neuropythy  # noqa: F401  # probe presence only
-except Exception as e:
-    msg = f"Neuropythy not installed: {e}"
-
-if msg is None and not has_network():
-    msg = "No internet connection; skipping Neuropythy demo."
-if msg is None and not osf_is_reachable():
-    msg = "OSF is unreachable; skipping Neuropythy demo."
-
-try:
-    if msg is None:
-        # --- Normal (happy) path ---
-        nmap = p2p.topography.NeuropythyMap(subject='fsaverage', regions=['v1'])
-        model = p2p.models.cortex.ScoreboardModel(
-            rho=500, xrange=(-6, 0), yrange=(-5, 5), xystep=.25, vfmap=nmap
-        ).build()
-        nlink = Neuralink.from_neuropythy(
-            nmap, xrange=model.xrange, yrange=model.yrange,
-            xystep=2, rand_insertion_angle=0
-        )
-        print(len(nlink.implants), " total threads")
-        fig = plt.figure(figsize=(10, 4))
-        ax1 = fig.add_subplot(121, projection='3d')
-        model.plot3D(ax=ax1, style='cell')
-        nlink.plot3D(ax=ax1)
-        ax2 = fig.add_subplot(122)
-        model.plot(style='cell', ax=ax2)
-        nlink.plot(ax=ax2)
-        plt.show()
-    else:
-        # --- Friendly placeholder so docs still build ---
-        fig = plt.figure(figsize=(8, 2))
-        ax = fig.add_subplot(111)
-        ax.text(0.5, 0.5, msg, ha='center', va='center', wrap=True)
-        ax.axis('off')
-        plt.show()
-except Exception as e:
-    # Any unexpected runtime error -> placeholder but keep the build alive
+def _placeholder(msg):
     fig = plt.figure(figsize=(8, 2))
     ax = fig.add_subplot(111)
-    ax.text(
-        0.5, 0.5,
-        f"Neuropythy demo failed: {e}\n(Continuing without this figure.)",
-        ha='center', va='center', wrap=True
-    )
+    ax.text(0.5, 0.5, msg, ha='center', va='center', wrap=True)
     ax.axis('off')
     plt.show()
+
+# Hard skip on RTD to avoid flaky external downloads:
+if os.environ.get("READTHEDOCS") == "True":
+    _placeholder("Skipping Neuropythy demo on ReadTheDocs.")
+else:
+    msg = None
+    try:
+        import neuropythy  # noqa: F401
+    except Exception as e:
+        msg = f"Neuropythy not installed: {e}"
+    if msg is None and not has_network():
+        msg = "No internet connection; skipping Neuropythy demo."
+    if msg is None and not osf_is_reachable():
+        msg = "OSF is unreachable; skipping Neuropythy demo."
+
+    try:
+        if msg is None:
+            nmap = p2p.topography.NeuropythyMap(subject='fsaverage', regions=['v1'])
+            model = p2p.models.cortex.ScoreboardModel(
+                rho=500, xrange=(-6, 0), yrange=(-5, 5), xystep=.25, vfmap=nmap
+            ).build()
+            nlink = Neuralink.from_neuropythy(
+                nmap, xrange=model.xrange, yrange=model.yrange, xystep=2, rand_insertion_angle=0
+            )
+            print(len(nlink.implants), " total threads")
+            fig = plt.figure(figsize=(10, 4))
+            ax1 = fig.add_subplot(121, projection='3d')
+            model.plot3D(ax=ax1, style='cell'); nlink.plot3D(ax=ax1)
+            ax2 = fig.add_subplot(122)
+            model.plot(style='cell', ax=ax2); nlink.plot(ax=ax2)
+            plt.show()
+        else:
+            _placeholder(msg)
+    except Exception as e:
+        _placeholder(f"Neuropythy demo failed: {e}\n(Continuing without this figure.)")

--- a/examples/implants/plot_implants_cortical.py
+++ b/examples/implants/plot_implants_cortical.py
@@ -77,15 +77,56 @@ plt.show()
 # Neuralink implants can be easily created from a NeuropythyMap
 # enabling easy placement of implants across the cortical surface.
 # See the neuropythy example for more details.
-nmap = p2p.topography.NeuropythyMap(subject='fsaverage', regions=['v1'])
-model = p2p.models.cortex.ScoreboardModel(rho=500, xrange=(-6, 0), yrange=(-5, 5), xystep=.25, vfmap=nmap).build()
-nlink = Neuralink.from_neuropythy(nmap, xrange=model.xrange, yrange=model.yrange, 
-                                                      xystep=2, rand_insertion_angle=0)
-print(len(nlink.implants), " total threads")
-fig = plt.figure(figsize=(10, 4))
-ax1 = fig.add_subplot(121, projection='3d')
-model.plot3D(ax=ax1, style='cell')
-nlink.plot3D(ax=ax1)
-ax2 = fig.add_subplot(122)
-model.plot(style='cell', ax=ax2)
-nlink.plot(ax=ax2)
+
+import os
+from pulse2percept.datasets.base import has_network, osf_is_reachable
+
+msg = None
+try:
+    import neuropythy  # noqa: F401  # probe presence only
+except Exception as e:
+    msg = f"Neuropythy not installed: {e}"
+
+if msg is None and not has_network():
+    msg = "No internet connection; skipping Neuropythy demo."
+if msg is None and not osf_is_reachable():
+    msg = "OSF is unreachable; skipping Neuropythy demo."
+
+try:
+    if msg is None:
+        # --- Normal (happy) path ---
+        nmap = p2p.topography.NeuropythyMap(subject='fsaverage', regions=['v1'])
+        model = p2p.models.cortex.ScoreboardModel(
+            rho=500, xrange=(-6, 0), yrange=(-5, 5), xystep=.25, vfmap=nmap
+        ).build()
+        nlink = Neuralink.from_neuropythy(
+            nmap, xrange=model.xrange, yrange=model.yrange,
+            xystep=2, rand_insertion_angle=0
+        )
+        print(len(nlink.implants), " total threads")
+        fig = plt.figure(figsize=(10, 4))
+        ax1 = fig.add_subplot(121, projection='3d')
+        model.plot3D(ax=ax1, style='cell')
+        nlink.plot3D(ax=ax1)
+        ax2 = fig.add_subplot(122)
+        model.plot(style='cell', ax=ax2)
+        nlink.plot(ax=ax2)
+        plt.show()
+    else:
+        # --- Friendly placeholder so docs still build ---
+        fig = plt.figure(figsize=(8, 2))
+        ax = fig.add_subplot(111)
+        ax.text(0.5, 0.5, msg, ha='center', va='center', wrap=True)
+        ax.axis('off')
+        plt.show()
+except Exception as e:
+    # Any unexpected runtime error -> placeholder but keep the build alive
+    fig = plt.figure(figsize=(8, 2))
+    ax = fig.add_subplot(111)
+    ax.text(
+        0.5, 0.5,
+        f"Neuropythy demo failed: {e}\n(Continuing without this figure.)",
+        ha='center', va='center', wrap=True
+    )
+    ax.axis('off')
+    plt.show()

--- a/examples/models/plot_neuropythy.py
+++ b/examples/models/plot_neuropythy.py
@@ -35,6 +35,37 @@ import pulse2percept as p2p
 import matplotlib.pyplot as plt
 import warnings
 warnings.filterwarnings("ignore") # ignore matplotlib warnings
+import os
+import matplotlib.pyplot as plt
+from pulse2percept.datasets.base import has_network, osf_is_reachable
+
+def _placeholder(msg):
+    fig = plt.figure(figsize=(8, 2))
+    ax = fig.add_subplot(111)
+    ax.text(0.5, 0.5, msg, ha='center', va='center', wrap=True)
+    ax.axis('off')
+    plt.show()
+
+# Hard skip on RTD (avoid large external downloads)
+if os.environ.get("READTHEDOCS") == "True":
+    _placeholder("Skipping Neuropythy example on ReadTheDocs.")
+    raise SystemExit
+
+# Require neuropythy + network + OSF before proceeding
+try:
+    import neuropythy  # noqa: F401
+except Exception as e:
+    _placeholder(f"Neuropythy not installed: {e}\nSkipping example.")
+    raise SystemExit
+
+if not has_network():
+    _placeholder("No internet connection; skipping Neuropythy example.")
+    raise SystemExit
+
+if not osf_is_reachable():
+    _placeholder("OSF unreachable (cannot fetch Benson & Winawer data); skipping.")
+    raise SystemExit
+
 
 # this could take a while if you haven't already downloaded the dataset
 nmap = p2p.topography.NeuropythyMap(subject='fsaverage', regions=['v1'])

--- a/examples/models/plot_neuropythy.py
+++ b/examples/models/plot_neuropythy.py
@@ -1,183 +1,151 @@
-# -*- coding: utf-8 -*-
+-*- coding: utf-8 -*-
 """
 ===============================================================================
 Neuropythy and Neuralink: Patient specific visual field maps based on MRI
 ===============================================================================
 
-Neuropythy [Benson2018]_ is a Python package that predicts patient-specific 
-visuotopies based on MRI scans of the human visual cortex. It is possible to use 
+Neuropythy [Benson2018]_ is a python package that predicts patient-specific
+visuotopies based on MRI scans of the human visual cortex. It is possible to use
 Neuropythy within pulse2percept as the visual field map for cortical models.
 
 First, make sure neuropythy is installed, which can be done with
-`pip install neuropythy`.
+``pip install neuropythy``.
 
+.. warning::
+   Running this example may download large datasets and can take several minutes.
+   On hosted doc builds, the code may be shown but not executed.
 
 Creating a Neuropythy visual field map
 --------------------------------------
+
 :py:class:`~pulse2percept.topography.NeuropythyMap` requires a subject parameter,
 which can be either:
-1) 'fsaverage' (the average of freesurfer subjects)
-2) a string with a subject from the Benson Winawer 2018 dataset ('S1201'-'S1208')
-3) the path to a freesurfer subject directory in a format neuropythy can load
-4) the name of a subject in any directory specified by `ny.config['freesurfer_subject_paths']` or
-5) an instantiated `neuropythy.mri.core.Subject`
+
+*  'fsaverage' (the average of freesurfer subjects)
+*  a string with a subject from the Benson Winawer 2018 dataset ('S1201'-'S1208')
+*  the path to a freesurfer subject directory in a format neuropythy can load
+*  the name of a subject in any directory specified by ``ny.config['freesurfer_subject_paths']`` or
+*  an instantiated ``neuropythy.mri.core.Subject``
 
 If you do not have it downloaded already, the Benson Winawer 2018 dataset will
-be automatically downloaded and cached to the provided `cache_dir` parameter,
-which defaults to `~/.neuropythy_p2p`. If you have already downloaded the dataset,
-elsewhere, just add the subjects folder of the dataset to `ny.config['freesurfer_subject_paths']` and p2p
-will be able to load subjects from your predownloaded directory.
+be automatically downloaded and cached to the provided ``cache_dir`` parameter,
+which defaults to ``~/.neuropythy_p2p``. If you have already downloaded the dataset
+elsewhere, just add the subjects folder of the dataset to
+``ny.config['freesurfer_subject_paths']`` and p2p will be able to load subjects
+from your predownloaded directory.
+
+.. warning::
+
+    This could take a while if you haven't already downloaded the dataset.
+
+.. code-block:: python
+
+    nmap = p2p.topography.NeuropythyMap(subject='fsaverage', regions=['v1'])
+
+NeuropythyMap provides a number of methods to transform visual field coordinates
+into cortical coordinates:
+
+*  :py:meth:`~pulse2percept.topography.NeuropythyMap.dva_to_v1`
+*  :py:meth:`~pulse2percept.topography.NeuropythyMap.dva_to_v2`
+*  :py:meth:`~pulse2percept.topography.NeuropythyMap.dva_to_v3`
+
+In contrast to other visual field maps, you may also specify a cortical surface
+that the visual field coordinates should be mapped to. By default, the cortical
+surface is set to 'midgray', but you can also specify 'white' or 'pial', or other
+surfaces accepted by neuropythy.
+
+Lets use our map in a model and visualize the transform
+
+.. code-block:: python
+
+    model = p2p.models.cortex.ScoreboardModel(vfmap=nmap, regions=['v1'])
+    model.build()
+    fig, axes = plt.subplots(ncols=2, figsize=(10, 4))
+    model.plot(style='cell', ax=axes[0])
+    model.plot(style='scatter', ax=axes[1])
+
+.. note::
+
+    If we call the usual plot() method, it will be plotting a 2D
+    projection of the points. This can look quite strange sometimes, since the
+    points are inherently 3D. To plot the points in 3D, we can use the
+    plot3D() method.
+
+.. code-block:: python
+
+    fig = plt.figure(figsize=(10, 4))
+    ax1 = fig.add_subplot(121, projection='3d')
+    model.plot3D(ax=ax1, style='cell')
+    ax2 = fig.add_subplot(122, projection='3d')
+    model.plot3D(ax=ax2, style='scatter')
+
+Neuropythy can use up to 'v1', 'v2', 'v3'. If you want to use all three regions,
+you can specify them as a list.
+
+Lets use all three regions and plot the result (note it can get a little messy):
+
+.. code-block:: python
+
+    nmap = p2p.topography.NeuropythyMap(subject='fsaverage', regions=['v1', 'v2', 'v3'])
+    model = p2p.models.cortex.ScoreboardModel(xrange=(-20, 20), yrange=(-20, 20), xystep=0.5,
+                                              vfmap=nmap, regions=['v1', 'v2', 'v3'])
+    fig = plt.figure(figsize=(10, 4))
+    ax1 = fig.add_subplot(121, projection='3d')
+    model.plot3D(ax=ax1, style='cell')
+    ax2 = fig.add_subplot(122, projection='3d')
+    model.plot3D(ax=ax2, style='scatter')
+
+Note that the regions are not necessarily
+contiguous, and the map will likely be discontinuous at the boundaries between
+visual areas. To combat this, you can set the ``jitter_boundary`` to True
+to add a small amount of noise to the boundary to make it less noticeable.
+This is turned off by default.
+
+Placing implants with neuropythy maps
+-------------------------------------
+
+When using a cortical map, it is important to place your implant in the correct
+3D location; the default z value of 0 will likely not be on a cortical surface.
+
+For the Neuralink implant, there exists a helper function,
+:py:meth:`~pulse2percept.implants.NeuralinkImplant.from_neuropythy`, which will
+automatically place neuralink threads at specified visual field locations across
+the cortical surface. Threads will be inserted perpendicular to the cortical surface
+up to ``rand_insertion_angle``. Similar helper functions are under development
+for other cortical implants.
+
+Lets place a Neuralink implant across the right hemisphere of the cortex:
+
+.. code-block:: python
+
+    nmap = p2p.topography.NeuropythyMap(subject='fsaverage', regions=['v1'])
+    model = p2p.models.cortex.ScoreboardModel(vfmap=nmap, xrange=(-4, 0), yrange=(-4, 4), xystep=.25).build()
+    nlink = p2p.implants.cortex.Neuralink.from_neuropythy(
+        nmap, xrange=model.xrange, yrange=model.yrange, xystep=1, rand_insertion_angle=0
+    )
+    print(len(nlink.implants), " total threads")
+
+    fig = plt.figure(figsize=(10, 4))
+    ax1 = fig.add_subplot(121, projection='3d')
+    model.plot3D(ax=ax1, style='cell')
+    nlink.plot3D(ax=ax1)
+    ax2 = fig.add_subplot(122)
+    model.plot(style='cell', ax=ax2)
+    nlink.plot(ax=ax2)
+
+Finally, let's predict what a percept would look like if we stimulated one
+electrode on each thread, using the scoreboard model:
+
+.. code-block:: python
+
+    nmap = p2p.topography.NeuropythyMap(subject='fsaverage', regions=['v1'], jitter_boundary=True)
+    model = p2p.models.cortex.ScoreboardModel(rho=800, xrange=(-15, 15), yrange=(-15, 15),
+                                              xystep=.25, vfmap=nmap).build()
+    nlink = p2p.implants.cortex.Neuralink.from_neuropythy(
+        nmap, xrange=model.xrange, yrange=model.yrange, xystep=3, rand_insertion_angle=0
+    )
+    nlink.stim = {e: 1 for e in [i for i in nlink.electrode_names if i[-1] == '1']}
+    percept = model.predict_percept(nlink)
+    percept.plot()
 
 """
-# sphinx_gallery_thumbnail_number = 5
-
-import pulse2percept as p2p
-import matplotlib.pyplot as plt
-import warnings
-warnings.filterwarnings("ignore") # ignore matplotlib warnings
-import os
-import matplotlib.pyplot as plt
-from pulse2percept.datasets.base import has_network, osf_is_reachable
-
-def _placeholder(msg):
-    fig = plt.figure(figsize=(8, 2))
-    ax = fig.add_subplot(111)
-    ax.text(0.5, 0.5, msg, ha='center', va='center', wrap=True)
-    ax.axis('off')
-    plt.show()
-
-# Hard skip on RTD (avoid large external downloads)
-if os.environ.get("READTHEDOCS") == "True":
-    _placeholder("Skipping Neuropythy example on ReadTheDocs.")
-    raise SystemExit
-
-# Require neuropythy + network + OSF before proceeding
-try:
-    import neuropythy  # noqa: F401
-except Exception as e:
-    _placeholder(f"Neuropythy not installed: {e}\nSkipping example.")
-    raise SystemExit
-
-if not has_network():
-    _placeholder("No internet connection; skipping Neuropythy example.")
-    raise SystemExit
-
-if not osf_is_reachable():
-    _placeholder("OSF unreachable (cannot fetch Benson & Winawer data); skipping.")
-    raise SystemExit
-
-
-# this could take a while if you haven't already downloaded the dataset
-nmap = p2p.topography.NeuropythyMap(subject='fsaverage', regions=['v1'])
-nmap
-
-##################################################################################
-# NeuropythyMap provides a number of methods to transform visual field coordinates
-# into cortical coordinates:
-#
-# * :py:meth:`~pulse2percept.topography.NeuropythyMap.dva_to_v1`
-# * :py:meth:`~pulse2percept.topography.NeuropythyMap.dva_to_v2`
-# * :py:meth:`~pulse2percept.topography.NeuropythyMap.dva_to_v3`
-#
-# In contrast to other visual field maps, you may also specify a cortical surface
-# that the visual field coordinates should be mapped to. By default, the cortical
-# surface is set to 'midgray', but you can also specify 'white' or 'pial', or other
-# surfaces accepted by neuropythy.
-#
-#
-# Lets use our map in a model and visualize the transform
-
-model = p2p.models.cortex.ScoreboardModel(vfmap=nmap, regions=['v1'])
-model.build()
-fig, axes = plt.subplots(ncols=2, figsize=(10, 4))
-model.plot(style='cell', ax=axes[0])
-model.plot(style='scatter', ax=axes[1])
-
-##################################################################################
-# Note, if we call the usual plot() method, it will be plotting a 2D
-# projection of the points. This can look quite strange sometimes, since the
-# points are inherently 3D. To plot the points in 3D, we can use the
-# plot3D() method.
-
-fig = plt.figure(figsize=(10, 4))
-ax1 = fig.add_subplot(121, projection='3d')
-model.plot3D(ax=ax1, style='cell')
-ax2 = fig.add_subplot(122, projection='3d')
-model.plot3D(ax=ax2, style='scatter')
-
-##################################################################################
-# Neuropythy can use up to 'v1', 'v2', 'v3'. If you want to use all three regions,
-# you can specify them as a list. 
-#
-# Lets use all three regions and plot the result (note it can get a little messy):
-nmap = p2p.topography.NeuropythyMap(subject='fsaverage', regions=['v1', 'v2', 'v3'])
-model = p2p.models.cortex.ScoreboardModel(xrange=(-20, 20), yrange=(-20, 20), xystep=0.5,
-                                          vfmap=nmap, regions=['v1', 'v2', 'v3'])
-fig = plt.figure(figsize=(10, 4))
-ax1 = fig.add_subplot(121, projection='3d')
-model.plot3D(ax=ax1, style='cell')
-ax2 = fig.add_subplot(122, projection='3d')
-model.plot3D(ax=ax2, style='scatter')
-
-
-##################################################################################
-# 
-# Note that the regions are not necessarily
-# contiguous, and the map will likely be discontinuous at the boundaries between
-# visual areas. To combat this, you can set the `jitter_boundary` to True
-# to add a small amount of noise to the boundary to make it less noticeable.
-# This is turned off by default.
-#
-# Placing implants with neuropythy maps
-# -------------------------------------
-# When using a cortical map, it is important to place your implant in the correct
-# 3D location; the default z value of 0 will likely not be on a cortical surface.
-# 
-# 
-# For the Neuralink implant, there exists a helper function, 
-# :py:meth:`~pulse2percept.implants.NeuralinkImplant.from_neuropythy`, which will
-# automatically place neuralink threads at specified visual field locations across 
-# the cortical surface. Threads will be inserted perpendicular to the cortical surface
-# up to `rand_insertion_angle`. Similar helper functions are under development
-# for other cortical implants.
-#
-# Lets place a Neuralink implant across the right hemisphere of the cortex:
-nmap = p2p.topography.NeuropythyMap(subject='fsaverage', regions=['v1'])
-model = p2p.models.cortex.ScoreboardModel(vfmap=nmap, 
-                                          xrange=(-4, 0), yrange=(-4, 4), 
-                                          xystep=.25).build()
-nlink = p2p.implants.cortex.Neuralink.from_neuropythy(nmap, 
-                                                      xrange=model.xrange, 
-                                                      yrange=model.yrange, 
-                                                      xystep=1,
-                                                      rand_insertion_angle=0)
-print(len(nlink.implants), " total threads")
-fig = plt.figure(figsize=(10, 4))
-ax1 = fig.add_subplot(121, projection='3d')
-model.plot3D(ax=ax1, style='cell')
-nlink.plot3D(ax=ax1)
-ax2 = fig.add_subplot(122)
-model.plot(style='cell', ax=ax2)
-nlink.plot(ax=ax2)
-
-##################################################################################
-# Finally, lets predict what a percept would look like if we stimulated one 
-# electrode on each thread, using the scoreboard model:
-nmap = p2p.topography.NeuropythyMap(subject='fsaverage', regions=['v1'], 
-                                    jitter_boundary=True)
-model = p2p.models.cortex.ScoreboardModel(rho=800, 
-                                          xrange=(-15, 15), 
-                                          yrange=(-15, 15), 
-                                          xystep=.25, 
-                                          vfmap=nmap).build()
-nlink = p2p.implants.cortex.Neuralink.from_neuropythy(nmap, 
-                                                      xrange=model.xrange, 
-                                                      yrange=model.yrange, 
-                                                      xystep=3,
-                                                      rand_insertion_angle=0)
-nlink.stim = {e : 1 for e in [i for i in nlink.electrode_names if i[-1] == '1']}
-percept = model.predict_percept(nlink)
-percept.plot()
-
-
-

--- a/examples/models/plot_neuropythy.py
+++ b/examples/models/plot_neuropythy.py
@@ -1,4 +1,4 @@
--*- coding: utf-8 -*-
+# -*- coding: utf-8 -*-
 """
 ===============================================================================
 Neuropythy and Neuralink: Patient specific visual field maps based on MRI

--- a/examples/models/plot_neuropythy.py
+++ b/examples/models/plot_neuropythy.py
@@ -4,7 +4,7 @@
 Neuropythy and Neuralink: Patient specific visual field maps based on MRI
 ===============================================================================
 
-Neuropythy [Benson2018]_ is a python package that predicts patient-specific 
+Neuropythy [Benson2018]_ is a Python package that predicts patient-specific 
 visuotopies based on MRI scans of the human visual cortex. It is possible to use 
 Neuropythy within pulse2percept as the visual field map for cortical models.
 
@@ -143,9 +143,14 @@ model.plot3D(ax=ax2, style='scatter')
 #
 # Lets place a Neuralink implant across the right hemisphere of the cortex:
 nmap = p2p.topography.NeuropythyMap(subject='fsaverage', regions=['v1'])
-model = p2p.models.cortex.ScoreboardModel(vfmap=nmap, xrange=(-4, 0), yrange=(-4, 4), xystep=.25).build()
-nlink = p2p.implants.cortex.Neuralink.from_neuropythy(nmap, xrange=model.xrange, yrange=model.yrange, 
-                                                      xystep=1,rand_insertion_angle=0)
+model = p2p.models.cortex.ScoreboardModel(vfmap=nmap, 
+                                          xrange=(-4, 0), yrange=(-4, 4), 
+                                          xystep=.25).build()
+nlink = p2p.implants.cortex.Neuralink.from_neuropythy(nmap, 
+                                                      xrange=model.xrange, 
+                                                      yrange=model.yrange, 
+                                                      xystep=1,
+                                                      rand_insertion_angle=0)
 print(len(nlink.implants), " total threads")
 fig = plt.figure(figsize=(10, 4))
 ax1 = fig.add_subplot(121, projection='3d')
@@ -158,10 +163,18 @@ nlink.plot(ax=ax2)
 ##################################################################################
 # Finally, lets predict what a percept would look like if we stimulated one 
 # electrode on each thread, using the scoreboard model:
-nmap = p2p.topography.NeuropythyMap(subject='fsaverage', regions=['v1'], jitter_boundary=True)
-model = p2p.models.cortex.ScoreboardModel(rho=800, xrange=(-15, 15), yrange=(-15, 15), xystep=.25, vfmap=nmap).build()
-nlink = p2p.implants.cortex.Neuralink.from_neuropythy(nmap, xrange=model.xrange, yrange=model.yrange, 
-                                                      xystep=3,rand_insertion_angle=0)
+nmap = p2p.topography.NeuropythyMap(subject='fsaverage', regions=['v1'], 
+                                    jitter_boundary=True)
+model = p2p.models.cortex.ScoreboardModel(rho=800, 
+                                          xrange=(-15, 15), 
+                                          yrange=(-15, 15), 
+                                          xystep=.25, 
+                                          vfmap=nmap).build()
+nlink = p2p.implants.cortex.Neuralink.from_neuropythy(nmap, 
+                                                      xrange=model.xrange, 
+                                                      yrange=model.yrange, 
+                                                      xystep=3,
+                                                      rand_insertion_angle=0)
 nlink.stim = {e : 1 for e in [i for i in nlink.electrode_names if i[-1] == '1']}
 percept = model.predict_percept(nlink)
 percept.plot()

--- a/pulse2percept/datasets/base.py
+++ b/pulse2percept/datasets/base.py
@@ -67,10 +67,21 @@ def clear_data_dir(data_dir=None):
 
 
 def has_network(timeout=3.0):
-    """Return True if we appear to have general network connectivity.
+    """Check for general network connectivity
 
-    Tries a few common endpoints; success on ANY is considered 'online'.
-    Keeps it simple and fast; no DNS resolution required for the IP checks.
+    Attempts TCP connections to a small set of well-known hosts (e.g., DNS and OSF).
+    If any connection succeeds within the timeout, the host is considered online.
+    This is a fast pre-flight check that avoids unnecessary download attempts.
+
+    Parameters
+    ----------
+    timeout : float, optional
+        Timeout in seconds for each connectivity attempt. Default is 3.0.
+
+    Returns
+    -------
+    bool
+        True if at least one probe succeeds; False otherwise.
     """
     checks = [
         ("1.1.1.1", 53),     # Cloudflare DNS (TCP)
@@ -166,6 +177,25 @@ def _normalize_osf_download(osf_id_or_url):
 
 
 def osf_is_reachable(test_url="https://osf.io/rduj4", timeout=5.0):
+    """Check whether OSF downloads are reachable
+
+    Probes OSF by normalizing the given URL or GUID to the direct download
+    form (``https://osf.io/download/<GUID>``) and issuing a quick HEAD request.
+    If HEAD is not supported, falls back to fetching a few bytes with GET.
+    No files are written to disk.
+
+    Parameters
+    ----------
+    test_url : str, optional
+        An OSF GUID or URL used for the probe (defaults to a tiny file you own).
+    timeout : float, optional
+        Request timeout in seconds. Default is 5.0.
+
+    Returns
+    -------
+    bool
+        True if OSF responds successfully; False otherwise.
+    """
     url = _normalize_osf_download(test_url)
     try:
         req = Request(url, method="HEAD")
@@ -185,7 +215,42 @@ def osf_is_reachable(test_url="https://osf.io/rduj4", timeout=5.0):
 def download_from_osf(osf_id_or_url, filename, checksum=None,
                       data_path=None, download_if_missing=True,
                       progress_bar=_report_hook):
-    """Download once from OSF into the data dir, via fetch_url."""
+    """Download a file from OSF into the data directory (once)
+
+    Normalizes an OSF GUID or URL to the direct download endpoint
+    (``https://osf.io/download/<GUID>``), performs quick pre-flight checks
+    (general network + OSF reachability), and downloads the file via
+    :py:func:`~pulse2percept.datasets.fetch_url`. If the file already exists,
+    it is not downloaded again.
+
+    Parameters
+    ----------
+    osf_id_or_url : str
+        OSF GUID (e.g., ``'pf2ja'``) or OSF URL (with or without ``/download``).
+    filename : str
+        Local filename to save under the data directory (e.g., ``'han2021.zip'``).
+    checksum : str or None, optional
+        Expected SHA-256 hex digest. If provided, integrity is verified.
+    data_path : str or None, optional
+        Custom data directory. Defaults to :py:func:`~pulse2percept.datasets.get_data_dir`.
+    download_if_missing : bool, optional
+        If False and the file is missing locally, raises an IOError instead of downloading.
+        Default is True.
+    progress_bar : callable, optional
+        Progress callback with signature ``func(count, block_size, total_size)``.
+        Defaults to :py:func:`~pulse2percept.datasets._report_hook`.
+
+    Returns
+    -------
+    str
+        Absolute path to the downloaded (or already present) local file.
+
+    Raises
+    ------
+    IOError
+        If the file is missing and ``download_if_missing`` is False; if there is no
+        network connectivity; if OSF is unreachable; or if the checksum verification fails.
+    """
     data_path = get_data_dir(data_path)
     file_path = join(data_path, filename)
 

--- a/pulse2percept/datasets/base.py
+++ b/pulse2percept/datasets/base.py
@@ -8,11 +8,12 @@ import sys
 from os import environ, makedirs
 from os.path import exists, expanduser, join
 from shutil import rmtree
+import socket
+import re
 import hashlib
 import ssl
 from urllib.request import urlretrieve, urlopen, Request
-import socket
-import re
+from urllib.error import URLError, HTTPError
 
 
 def get_data_dir(data_dir=None):
@@ -140,38 +141,45 @@ def fetch_url(url, file_path, progress_bar=_report_hook, remote_checksum=None):
                       f"file may be corrupted.")
 
 
-def osf_is_reachable(test_url="https://osf.io/rduj4", timeout=5.0):
-    # Convert bare GUID to /download if needed
-    m = re.match(r"^https?://(?:www\.)?osf\.io/([a-z0-9]+)/?$", test_url, flags=re.I)
-    if m:
-        test_url = "https://osf.io/%s/download" % m.group(1)
+def _normalize_osf_download(osf_id_or_url):
+    """Return a direct OSF download URL in the new form: https://osf.io/download/<GUID>.
 
+    Accepts:
+      - bare GUID:          pf2ja
+      - old forms:          https://osf.io/pf2ja  or  https://osf.io/pf2ja/download
+      - new form already:   https://osf.io/download/pf2ja
+    """
+    # Bare GUID?
+    if re.fullmatch(r"[a-z0-9]{5}", osf_id_or_url, flags=re.I):
+        return "https://osf.io/download/%s" % osf_id_or_url
+
+    # URL forms -> extract GUID (handles old/new)
+    m = re.match(
+        r"^https?://(?:www\.)?osf\.io/(?:(?:download/)?([a-z0-9]{5})(?:/download)?)\/?$",
+        osf_id_or_url, flags=re.I
+    )
+    if m:
+        return "https://osf.io/download/%s" % m.group(1)
+
+    # If it's some other OSF URL (e.g., already has query params), just return as-is
+    return osf_id_or_url
+
+
+def osf_is_reachable(test_url="https://osf.io/rduj4", timeout=5.0):
+    url = _normalize_osf_download(test_url)
     try:
-        # HEAD first
-        req = Request(test_url, method="HEAD")
+        req = Request(url, method="HEAD")
         with urlopen(req, timeout=timeout) as resp:
             code = getattr(resp, "status", 200)
             if 200 <= code < 400:
                 return True
     except Exception:
         pass
-
-    # Fallback: GET a few bytes
     try:
-        with urlopen(test_url, timeout=timeout) as resp:
+        with urlopen(url, timeout=timeout) as resp:
             return len(resp.read(64)) > 0
-    except Exception:
+    except (HTTPError, URLError, OSError):
         return False
-
-
-def _normalize_osf_download(osf_id_or_url):
-    """Return a direct OSF download URL from a GUID or URL."""
-    if re.match(r"^https?://", osf_id_or_url, flags=re.I):
-        m = re.match(r"^(https?://(?:www\.)?osf\.io/[a-z0-9]+)/?$", osf_id_or_url, flags=re.I)
-        if m:
-            return m.group(1) + "/download"
-        return osf_id_or_url  # may already include /download
-    return f"https://osf.io/{osf_id_or_url}/download"
 
 
 def download_from_osf(osf_id_or_url, filename, checksum=None,

--- a/pulse2percept/datasets/base.py
+++ b/pulse2percept/datasets/base.py
@@ -1,5 +1,8 @@
 """:py:class:`~pulse2percept.datasets.get_data_dir`, 
    :py:class:`~pulse2percept.datasets.clear_data_dir`, 
+   :py:class:`~pulse2percept.datasets.has_network`, 
+   :py:class:`~pulse2percept.datasets.osf_is_reachable`,
+   :py:class:`~pulse2percept.datasets.download_from_osf`,
    :py:class:`~pulse2percept.datasets.fetch_url`"""
 import sys
 from os import environ, makedirs
@@ -7,7 +10,9 @@ from os.path import exists, expanduser, join
 from shutil import rmtree
 import hashlib
 import ssl
-from urllib.request import urlretrieve
+from urllib.request import urlretrieve, urlopen, Request
+import socket
+import re
 
 
 def get_data_dir(data_dir=None):
@@ -58,6 +63,28 @@ def clear_data_dir(data_dir=None):
     """
     data_dir = get_data_dir(data_dir)
     rmtree(data_dir)
+
+
+def has_network(timeout=3.0):
+    """Return True if we appear to have general network connectivity.
+
+    Tries a few common endpoints; success on ANY is considered 'online'.
+    Keeps it simple and fast; no DNS resolution required for the IP checks.
+    """
+    checks = [
+        ("1.1.1.1", 53),     # Cloudflare DNS (TCP)
+        ("8.8.8.8", 53),     # Google DNS (TCP)
+        ("example.com", 80), # Plain HTTP
+        ("osf.io", 443),     # OSF over HTTPS
+    ]
+    for host, port in checks:
+        try:
+            sock = socket.create_connection((host, port), timeout=timeout)
+            sock.close()
+            return True
+        except OSError:
+            continue
+    return False
 
 
 def _sha256(path):
@@ -111,3 +138,60 @@ def fetch_url(url, file_path, progress_bar=_report_hook, remote_checksum=None):
         raise IOError(f"{file_path} has an SHA256 checksum ({checksum}) "
                       f"differing from expected ({remote_checksum}), "
                       f"file may be corrupted.")
+
+
+def osf_is_reachable(test_url="https://osf.io/rduj4", timeout=5.0):
+    # Convert bare GUID to /download if needed
+    m = re.match(r"^https?://(?:www\.)?osf\.io/([a-z0-9]+)/?$", test_url, flags=re.I)
+    if m:
+        test_url = "https://osf.io/%s/download" % m.group(1)
+
+    try:
+        # HEAD first
+        req = Request(test_url, method="HEAD")
+        with urlopen(req, timeout=timeout) as resp:
+            code = getattr(resp, "status", 200)
+            if 200 <= code < 400:
+                return True
+    except Exception:
+        pass
+
+    # Fallback: GET a few bytes
+    try:
+        with urlopen(test_url, timeout=timeout) as resp:
+            return len(resp.read(64)) > 0
+    except Exception:
+        return False
+
+
+def _normalize_osf_download(osf_id_or_url):
+    """Return a direct OSF download URL from a GUID or URL."""
+    if re.match(r"^https?://", osf_id_or_url, flags=re.I):
+        m = re.match(r"^(https?://(?:www\.)?osf\.io/[a-z0-9]+)/?$", osf_id_or_url, flags=re.I)
+        if m:
+            return m.group(1) + "/download"
+        return osf_id_or_url  # may already include /download
+    return f"https://osf.io/{osf_id_or_url}/download"
+
+
+def download_from_osf(osf_id_or_url, filename, checksum=None,
+                      data_path=None, download_if_missing=True,
+                      progress_bar=_report_hook):
+    """Download once from OSF into the data dir, via fetch_url."""
+    data_path = get_data_dir(data_path)
+    file_path = join(data_path, filename)
+
+    if exists(file_path):
+        return file_path
+    if not download_if_missing:
+        raise IOError(f"No local file {file_path} found")
+
+    # quick preflight checks (fast + minimal)
+    if not has_network():
+        raise IOError("No internet connection.")
+    if not osf_is_reachable():  # probes your tiny OSF file
+        raise IOError("OSF downloads appear unavailable right now.")
+
+    url = _normalize_osf_download(osf_id_or_url)
+    fetch_url(url, file_path, progress_bar=progress_bar, remote_checksum=checksum)
+    return file_path

--- a/pulse2percept/datasets/beyeler2019.py
+++ b/pulse2percept/datasets/beyeler2019.py
@@ -3,7 +3,7 @@
 from os.path import join, isfile
 import numpy as np
 
-from .base import get_data_dir, fetch_url
+from .base import get_data_dir, download_from_osf
 
 try:
     import pandas as pd
@@ -156,14 +156,11 @@ def fetch_beyeler2019(subjects=None, electrodes=None, data_path=None,
     data_path = get_data_dir(data_path)
 
     # Download the dataset if it doesn't already exist:
-    file_path = join(data_path, 'beyeler2019.h5')
-    if not isfile(file_path):
-        if download_if_missing:
-            url = 'https://osf.io/28uqg/download'
-            checksum = '19817990a615d289cdc93b928c138f71977ea2cab54fd1b35d186f3b5a3c4ff5'
-            fetch_url(url, file_path, remote_checksum=checksum)
-        else:
-            raise IOError(f"No local file {file_path} found")
+    file_path = download_from_osf(
+        "28uqg", "beyeler2019.h5",
+        checksum="19817990a615d289cdc93b928c138f71977ea2cab54fd1b35d186f3b5a3c4ff5",
+        data_path=data_path, download_if_missing=download_if_missing
+    )
 
     # Open the HDF5 file:
     f = h5py.File(file_path, 'r')

--- a/pulse2percept/datasets/han2021.py
+++ b/pulse2percept/datasets/han2021.py
@@ -2,7 +2,7 @@
 from os.path import join, isfile
 import numpy as np
 
-from .base import get_data_dir, fetch_url
+from .base import get_data_dir, download_from_osf
 from pulse2percept.stimuli import VideoStimulus
 
 try:
@@ -89,14 +89,11 @@ def fetch_han2021(videos=None, resize=None, as_gray=None, data_path=None,
     data_path = get_data_dir(data_path)
 
     # Download the dataset if it doesn't already exist:
-    file_path = join(data_path, 'han2021.zip')
-    if not isfile(file_path):
-        if download_if_missing:
-            url = 'https://osf.io/pf2ja/download'
-            checksum = 'e31a74a6ac9decfa8d8b9eccd0c71da868f8dfa9f0475a4caca82085307d67b1'
-            fetch_url(url, file_path, remote_checksum=checksum)
-        else:
-            raise IOError(f"No local file {file_path} found")
+    file_path = download_from_osf(
+        "pf2ja", "han2021.zip",
+        checksum="e31a74a6ac9decfa8d8b9eccd0c71da868f8dfa9f0475a4caca82085307d67b1",
+        data_path=data_path, download_if_missing=download_if_missing
+    )
 
     # Open the HDF5 file:
     hf = h5py.File(file_path, 'r')

--- a/pulse2percept/datasets/tests/test_base.py
+++ b/pulse2percept/datasets/tests/test_base.py
@@ -2,8 +2,15 @@ import numpy.testing as npt
 import os
 from shutil import rmtree
 import pytest
-
-from pulse2percept.datasets import get_data_dir, clear_data_dir, fetch_url
+import socket
+import io
+from urllib.error import URLError
+from urllib.request import Request
+import tempfile, os, hashlib
+from pulse2percept.datasets.base import (
+    has_network, osf_is_reachable, download_from_osf,
+    _normalize_osf_download, _sha256, _report_hook, fetch_url
+)
 
 
 def _remove_dir(path):
@@ -33,6 +40,35 @@ def test_data_dir(tmp_data_dir):
     npt.assert_equal(os.path.exists(data_dir), True)
 
 
+def test_has_network_online_monkeypatch(monkeypatch):
+    def _ok(addr, timeout=None):
+        class _Sock:
+            def close(self): pass
+        return _Sock()
+    monkeypatch.setattr("socket.create_connection", _ok)
+    assert has_network() is True
+
+
+def test_sha256_roundtrip():
+    fd, p = tempfile.mkstemp()
+    os.close(fd)
+    try:
+        data = b"abc123"
+        with open(p, "wb") as f:
+            f.write(data)
+        h = hashlib.sha256(); h.update(data)
+        assert _sha256(p) == h.hexdigest()
+    finally:
+        os.remove(p)
+
+
+def test_report_hook_prints(monkeypatch, capsys):
+    # total_size must be > 0 to avoid div by zero
+    _report_hook(count=5, block_size=1024, total_size=10*1024)
+    out = capsys.readouterr().out
+    assert "Downloading" in out and "%" in out
+
+
 def test_fetch_url(tmp_data_dir):
     url = 'https://bionicvisionlab.org/publications/2017-pulse2percept/2017-pulse2percept.pdf'
     file_path = os.path.join(tmp_data_dir, 'paper2.pdf')
@@ -43,3 +79,101 @@ def test_fetch_url(tmp_data_dir):
     # Use correct checksum:
     fetch_url(url, file_path, remote_checksum=paper_checksum)
     npt.assert_equal(os.path.exists(file_path), True)
+
+
+def test_normalize_osf_download_variants():
+    assert _normalize_osf_download("pf2ja").endswith("/pf2ja/download")
+    assert _normalize_osf_download("https://osf.io/pf2ja").endswith("/pf2ja/download")
+    assert _normalize_osf_download("https://osf.io/pf2ja/").endswith("/pf2ja/download")
+    assert _normalize_osf_download("https://osf.io/pf2ja/download").endswith("/pf2ja/download")
+
+
+def test_osf_is_reachable_head_success(monkeypatch):
+    class _Resp:
+        status = 200
+        def __enter__(self): return self
+        def __exit__(self, *a): pass
+    def _urlopen(req, timeout=None):
+        assert isinstance(req, Request)
+        return _Resp()
+    monkeypatch.setattr("pulse2percept.datasets.base.urlopen", _urlopen)
+    assert osf_is_reachable("https://osf.io/rduj4") is True
+
+
+def test_osf_is_reachable_head_fail_get_success(monkeypatch):
+    class _HeadErr(Exception): pass
+    def _urlopen_head(req, timeout=None):
+        # Simulate HEAD raising
+        raise URLError("HEAD not supported")
+    class _GetResp:
+        def __enter__(self): return self
+        def __exit__(self, *a): pass
+        def read(self, n): return b"ok"
+    calls = {"n": 0}
+    def _urlopen(req, timeout=None):
+        calls["n"] += 1
+        if calls["n"] == 1:  # first call is HEAD
+            raise URLError("HEAD not supported")
+        return _GetResp()
+    monkeypatch.setattr("pulse2percept.datasets.base.urlopen", _urlopen)
+    assert osf_is_reachable("https://osf.io/rduj4") is True
+
+
+def test_osf_is_reachable_total_fail(monkeypatch):
+    def _urlopen(req, timeout=None):
+        raise URLError("down")
+    monkeypatch.setattr("pulse2percept.datasets.base.urlopen", _urlopen)
+    assert osf_is_reachable("https://osf.io/rduj4") is False
+
+
+def test_download_from_osf_returns_when_exists(tmp_path, monkeypatch):
+    # Create existing file
+    p = tmp_path / "han2021.zip"
+    p.write_bytes(b"already here")
+    # Make get_data_dir return tmp_path
+    monkeypatch.setattr("pulse2percept.datasets.base.get_data_dir", lambda d=None: str(tmp_path))
+    from pulse2percept.datasets.base import download_from_osf
+    out = download_from_osf("pf2ja", "han2021.zip", checksum=None, data_path=str(tmp_path))
+    assert out == str(p)
+
+
+def test_download_from_osf_raises_when_not_allowed(tmp_path, monkeypatch):
+    monkeypatch.setattr("pulse2percept.datasets.base.get_data_dir", lambda d=None: str(tmp_path))
+    with pytest.raises(IOError):
+        download_from_osf("pf2ja", "han2021.zip", download_if_missing=False, data_path=str(tmp_path))
+
+
+def test_download_from_osf_offline(tmp_path, monkeypatch):
+    monkeypatch.setattr("pulse2percept.datasets.base.get_data_dir", lambda d=None: str(tmp_path))
+    monkeypatch.setattr("pulse2percept.datasets.base.has_network", lambda: False)
+    with pytest.raises(IOError):
+        download_from_osf("pf2ja", "han2021.zip", data_path=str(tmp_path))
+
+
+def test_download_from_osf_osf_down(tmp_path, monkeypatch):
+    monkeypatch.setattr("pulse2percept.datasets.base.get_data_dir", lambda d=None: str(tmp_path))
+    monkeypatch.setattr("pulse2percept.datasets.base.has_network", lambda: True)
+    monkeypatch.setattr("pulse2percept.datasets.base.osf_is_reachable", lambda : False)
+    with pytest.raises(IOError):
+        download_from_osf("pf2ja", "han2021.zip", data_path=str(tmp_path))
+
+
+def test_download_from_osf_calls_fetch_url(tmp_path, monkeypatch):
+    monkeypatch.setattr("pulse2percept.datasets.base.get_data_dir", lambda d=None: str(tmp_path))
+    monkeypatch.setattr("pulse2percept.datasets.base.has_network", lambda: True)
+    monkeypatch.setattr("pulse2percept.datasets.base.osf_is_reachable", lambda : True)
+
+    called = {}
+    def _fake_fetch(url, file_path, progress_bar=None, remote_checksum=None):
+        # Normalize expectation: ends with /download
+        assert url.startswith("https://osf.io/28uqg") and url.endswith("/download")
+        # Create the file to satisfy subsequent existence checks
+        with open(file_path, "wb") as f:
+            f.write(b"ok")
+        called["args"] = (url, file_path, remote_checksum)
+    monkeypatch.setattr("pulse2percept.datasets.base.fetch_url", _fake_fetch)
+
+    out = download_from_osf("https://osf.io/28uqg", "beyeler2019.h5",
+                            checksum="deadbeef", data_path=str(tmp_path))
+    assert os.path.exists(out)
+    assert called["args"][2] == "deadbeef"

--- a/pulse2percept/datasets/tests/test_base.py
+++ b/pulse2percept/datasets/tests/test_base.py
@@ -8,8 +8,9 @@ from urllib.error import URLError
 from urllib.request import Request
 import tempfile, os, hashlib
 from pulse2percept.datasets.base import (
-    has_network, osf_is_reachable, download_from_osf,
-    _normalize_osf_download, _sha256, _report_hook, fetch_url
+    get_data_dir, clear_data_dir, has_network, 
+    osf_is_reachable, download_from_osf, _normalize_osf_download, 
+    _sha256, _report_hook, fetch_url
 )
 
 

--- a/pulse2percept/datasets/tests/test_base.py
+++ b/pulse2percept/datasets/tests/test_base.py
@@ -83,10 +83,11 @@ def test_fetch_url(tmp_data_dir):
 
 
 def test_normalize_osf_download_variants():
-    assert _normalize_osf_download("pf2ja").endswith("/pf2ja/download")
-    assert _normalize_osf_download("https://osf.io/pf2ja").endswith("/pf2ja/download")
-    assert _normalize_osf_download("https://osf.io/pf2ja/").endswith("/pf2ja/download")
-    assert _normalize_osf_download("https://osf.io/pf2ja/download").endswith("/pf2ja/download")
+    assert _normalize_osf_download("pf2ja") == "https://osf.io/download/pf2ja"
+    assert _normalize_osf_download("https://osf.io/pf2ja") == "https://osf.io/download/pf2ja"
+    assert _normalize_osf_download("https://osf.io/pf2ja/") == "https://osf.io/download/pf2ja"
+    assert _normalize_osf_download("https://osf.io/pf2ja/download") == "https://osf.io/download/pf2ja"
+    assert _normalize_osf_download("https://osf.io/download/pf2ja") == "https://osf.io/download/pf2ja"
 
 
 def test_osf_is_reachable_head_success(monkeypatch):
@@ -166,8 +167,7 @@ def test_download_from_osf_calls_fetch_url(tmp_path, monkeypatch):
 
     called = {}
     def _fake_fetch(url, file_path, progress_bar=None, remote_checksum=None):
-        # Normalize expectation: ends with /download
-        assert url.startswith("https://osf.io/28uqg") and url.endswith("/download")
+        assert url == "https://osf.io/download/28uqg"
         # Create the file to satisfy subsequent existence checks
         with open(file_path, "wb") as f:
             f.write(b"ok")

--- a/pulse2percept/topography/tests/test_neuropythy.py
+++ b/pulse2percept/topography/tests/test_neuropythy.py
@@ -3,11 +3,18 @@ import numpy.testing as npt
 import pytest
 from pulse2percept.models.cortex import ScoreboardModel
 from pulse2percept.models import ScoreboardModel as BeyelerScoreboard
-from pulse2percept.topography import NeuropythyMap
-from pulse2percept.implants.cortex import Neuralink, LinearEdgeThread
+from pulse2percept.implants.cortex import Neuralink
 from pulse2percept.implants import EnsembleImplant
+from pulse2percept.topography import NeuropythyMap
 import time
 import os
+
+def _is_neuropythy_not_available():
+    try:
+        NeuropythyMap('fsaverage')
+        return False
+    except IOError:
+        return True
 
 # use pytest.mark.slow because all neuropythy tests
 # take a long time to run. This way, they will be skipped
@@ -15,6 +22,10 @@ import os
 # done either from the root p2p directory or from this tests
 # folder.
 @pytest.mark.slow
+@pytest.mark.skipif(
+    _is_neuropythy_not_available(),
+    reason='Download Neuropythy Benson & Winawer dataset to run this test'
+)
 def test_subject_parsing():
     import neuropythy as ny
     # random subject shouldn't download 
@@ -48,6 +59,10 @@ def test_subject_parsing():
 @pytest.mark.slow()
 @pytest.mark.parametrize('regions', [['v1'], ['v1', 'v3'], ['v1', 'v2', 'v3']])
 @pytest.mark.parametrize('jitter_boundary', [True, False])
+@pytest.mark.skipif(
+    _is_neuropythy_not_available(),
+    reason='Download Neuropythy Benson & Winawer dataset to run this test'
+)
 def test_dva_to_cortex(regions, jitter_boundary):
     nmap = NeuropythyMap('fsaverage', regions=regions, jitter_boundary=jitter_boundary)
     npt.assert_equal(nmap.predicted_retinotopy is not None, True)
@@ -129,6 +144,10 @@ def test_dva_to_cortex(regions, jitter_boundary):
 
 
 @pytest.mark.slow
+@pytest.mark.skipif(
+    _is_neuropythy_not_available(),
+    reason='Download Neuropythy Benson & Winawer dataset to run this test'
+)
 def test_Neuralink_from_neuropythy():
     nmap = NeuropythyMap('fsaverage', regions=['v1'], jitter_boundary=False)
     nlink = Neuralink.from_neuropythy(nmap, locs=np.array([[0, 0], [3, 3], [-2, -2]]))
@@ -178,8 +197,11 @@ def test_Neuralink_from_neuropythy():
             idx += 1
             
 
-
 @pytest.mark.slow
+@pytest.mark.skipif(
+    _is_neuropythy_not_available(),
+    reason='Download Neuropythy Benson & Winawer dataset to run this test'
+)
 def test_ndim_mixup():
     nmap = NeuropythyMap('fsaverage')
     model = BeyelerScoreboard(vfmap=nmap)
@@ -190,6 +212,10 @@ def test_ndim_mixup():
 
 
 @pytest.mark.slow
+@pytest.mark.skipif(
+    _is_neuropythy_not_available(),
+    reason='Download Neuropythy Benson & Winawer dataset to run this test'
+)
 def test_neuropythy_scoreboard():
     nmap = NeuropythyMap('fsaverage')
     model = ScoreboardModel(rho=800, xystep=.25, vfmap=nmap).build()
@@ -220,9 +246,12 @@ def test_neuropythy_scoreboard():
     npt.assert_almost_equal(np.max(percept.data), 86.4913, decimal=1)
 
 
-
 @pytest.mark.slow()
 @pytest.mark.parametrize('regions', [['v1'], ['v1', 'v3'], ['v1', 'v2', 'v3']])
+@pytest.mark.skipif(
+    _is_neuropythy_not_available(),
+    reason='Download Neuropythy Benson & Winawer dataset to run this test'
+)
 def test_cortex_to_dva(regions):
     nmap = NeuropythyMap('fsaverage', regions=regions, jitter_boundary=True)
     npt.assert_equal(nmap.predicted_retinotopy is not None, True)

--- a/pulse2percept/topography/tests/test_neuropythy.py
+++ b/pulse2percept/topography/tests/test_neuropythy.py
@@ -13,7 +13,7 @@ def _is_neuropythy_not_available():
     try:
         NeuropythyMap('fsaverage')
         return False
-    except IOError:
+    except ValueError:
         return True
 
 # use pytest.mark.slow because all neuropythy tests


### PR DESCRIPTION
OSF has redesigned their webpage and broken the direct download endpoints in the process. Direct links are now "osf.io/download/`id`" instead of "osf.io/`id`/download". This PR addresses the issue with a couple of forward-looking improvements:

- [x] `p2p.datasets.has_network` checks for general network connectivity
- [x] `p2p.datasets.osf_is_reachable` checks whether OSF downloads are reachable
- [x] `p2p.datasets.download_from_osf` wraps OSF download calls by normalizing an OSF GUID or URL to the direct download endpoint. Should they change the endpoint again, `_normalize_osf_download` is the central place to update it
- [x] Datasets now inform of the specific error (no network, OSF down, unreachable/malformatted OSF download link)
- [x] The Neuropythy imports are affected by this as well; tests will only run if Benson & Winawer data is available