### PR TITLE
[FIX] Preserve NeuropythyMap shapes and exact vertices

### DIFF
--- a/pulse2percept/topography/neuropythy.py
+++ b/pulse2percept/topography/neuropythy.py
@@ -308,7 +308,7 @@ class NeuropythyMap(CorticalMap):
         Parameters
         ----------
         xc, yc, zc : float or array_like
-            The x, y, and z-coordinate(s) of the cortex point(s) to look up (in mm).
+            The x, y, and z-coordinate(s) of the cortex point(s) to look up (in um).
         
         Returns
         -------
@@ -322,20 +322,24 @@ class NeuropythyMap(CorticalMap):
             raise ValueError("x, y, and z must have the same shape")
         id_nan = np.isnan(xc) | np.isnan(yc) | np.isnan(zc)
         query = np.stack([np.ravel(xc[~id_nan]), np.ravel(yc[~id_nan]), np.ravel(zc[~id_nan])], axis=-1) / 1000 # convert to mm
+        out = np.ones((*np.shape(xc), 2)) * np.nan
         if np.size(query) == 0:
-            return np.ones((*np.shape(xc), 2)) * np.nan
+            return out[..., 0], out[..., 1]
         dist, idx = self.cortex_tree.query(query, k=5)#, distance_upper_bound=self.cort_nn_thresh / 1000)
         idx_nan = np.all(dist > self.cort_nn_thresh / 1000, axis=-1)
-        dist[dist > self.cort_nn_thresh / 1000] = 999999999 # make high so it doesn't contribute to geometric mean
+        dist[dist > self.cort_nn_thresh / 1000] = 999999999 # make high so it has negligible weight
         neighbors = np.array([[self.region_meshes[self.addr_idxs['region'][i]][self.addr_idxs['hemi'][i]].coordinates[:, self.addr_idxs['addr'][i]] 
                                for i in nb_pts] 
                               for nb_pts in idx])
-        # use geometric mean based on distance
-        pts = np.sum(neighbors * 1/dist[..., None], axis=1) / np.sum(1/dist, axis=1)[:, None]
+        # use inverse-distance weighting, or only exact matches at distance zero
+        exact = dist == 0
+        weights = 1 / np.where(exact, 1, dist)
+        has_exact = np.any(exact, axis=1)
+        weights[has_exact] = exact[has_exact]
+        pts = np.sum(neighbors * weights[..., None], axis=1) / np.sum(weights, axis=1)[:, None]
         pts[idx_nan] = [np.nan, np.nan]
-        out = np.ones((*np.shape(xc), 2)) * np.nan
         out[~id_nan] = pts
-        return pts[:, 0], pts[:, 1]
+        return out[..., 0], out[..., 1]
     
 
     def v1_to_dva(self, xv1, yv1, zv1):
@@ -348,7 +352,7 @@ class NeuropythyMap(CorticalMap):
         Parameters
         ----------
         xv1, yv1, zv1 : float or array_like
-            The x, y, and z-coordinate(s) of the v1 point(s) to look up (in mm).
+            The x, y, and z-coordinate(s) of the v1 point(s) to look up (in um).
 
         Returns
         -------
@@ -367,7 +371,7 @@ class NeuropythyMap(CorticalMap):
         Parameters
         ----------
         xv2, yv2, zv2 : float or array_like
-            The x, y, and z-coordinate(s) of the v2 point(s) to look up (in mm).
+            The x, y, and z-coordinate(s) of the v2 point(s) to look up (in um).
 
         Returns
         -------
@@ -386,7 +390,7 @@ class NeuropythyMap(CorticalMap):
         Parameters
         ----------
         xv3, yv3, zv3 : float or array_like
-            The x, y, and z-coordinate(s) of the v3 point(s) to look up (in mm).
+            The x, y, and z-coordinate(s) of the v3 point(s) to look up (in um).
 
         Returns
         -------

--- a/pulse2percept/topography/tests/test_neuropythy_nodata.py
+++ b/pulse2percept/topography/tests/test_neuropythy_nodata.py
@@ -1,0 +1,79 @@
+from types import SimpleNamespace
+import warnings
+
+import numpy as np
+import numpy.testing as npt
+import pytest
+from scipy.spatial import cKDTree
+
+from pulse2percept.topography import NeuropythyMap
+
+
+def _make_neuropythy_map():
+    nmap = NeuropythyMap.__new__(NeuropythyMap)
+    cortex_points = np.array([
+        [0, 0, 0],
+        [1, 0, 0],
+        [0, 1, 0],
+        [0, 0, 1],
+        [1, 1, 1],
+    ], dtype='float32')
+    mesh = SimpleNamespace(coordinates=np.array([
+        [10, 20, 30, 40, 50],
+        [1, 2, 3, 4, 5],
+    ], dtype='float32'))
+    object.__setattr__(nmap, 'cortex_tree', cKDTree(cortex_points))
+    object.__setattr__(nmap, 'cort_nn_thresh', 2000)
+    object.__setattr__(nmap, 'region_meshes', {'v1': (mesh,)})
+    object.__setattr__(nmap, 'addr_idxs', {
+        'addr': np.arange(5),
+        'region': np.array(['v1'] * 5),
+        'hemi': np.zeros(5, dtype=int),
+    })
+    return nmap
+
+
+@pytest.mark.parametrize('shape', [(3,), (2, 2)])
+def test_cortex_to_dva_preserves_input_shape_and_nans(shape):
+    nmap = _make_neuropythy_map()
+    xc = np.full(shape, 100, dtype='float32')
+    yc = np.full(shape, 100, dtype='float32')
+    zc = np.full(shape, 100, dtype='float32')
+    xc.flat[1] = np.nan
+    yc.flat[-1] = np.nan
+    id_nan = np.isnan(xc) | np.isnan(yc) | np.isnan(zc)
+
+    xdva, ydva = nmap.cortex_to_dva(xc, yc, zc)
+
+    assert xdva.shape == shape
+    assert ydva.shape == shape
+    npt.assert_array_equal(np.isnan(xdva), id_nan)
+    npt.assert_array_equal(np.isnan(ydva), id_nan)
+    assert np.all(np.isfinite(xdva[~id_nan]))
+    assert np.all(np.isfinite(ydva[~id_nan]))
+
+
+def test_cortex_to_dva_exact_vertex_is_finite_without_warnings():
+    nmap = _make_neuropythy_map()
+
+    with warnings.catch_warnings():
+        warnings.simplefilter('error', RuntimeWarning)
+        xdva, ydva = nmap.cortex_to_dva(0, 0, 0)
+
+    assert np.shape(xdva) == ()
+    assert np.shape(ydva) == ()
+    npt.assert_equal([xdva, ydva], [10, 1])
+
+
+def test_cortex_to_dva_all_nan_returns_two_same_shape_arrays():
+    nmap = _make_neuropythy_map()
+    shape = (2, 3)
+    nan_coords = np.full(shape, np.nan, dtype='float32')
+
+    result = nmap.cortex_to_dva(nan_coords, nan_coords, nan_coords)
+
+    assert isinstance(result, tuple)
+    assert len(result) == 2
+    for values in result:
+        assert values.shape == shape
+        assert np.all(np.isnan(values))


### PR DESCRIPTION
## Description

`NeuropythyMap.cortex_to_dva` currently flattens outputs when NaNs are present, returns a single array for all-NaN input, and can divide by zero at exact cortical vertices. This change preserves the input shape and NaN mask, uses only exact matches when zero-distance neighbors exist, and corrects the documented cortical units from mm to um.

Closes #774

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation change

## Checklist

- [ ] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Validation

- Current-base focused regression: 0 passed, 4 failed
- Patched focused regression: 4 passed, 0 failed
- Adjacent synthetic checks: 12 passed, 0 failed
- AST parsing and `git diff --check`: passed
- Environment: Python 3.12.10, NumPy 2.4.1, SciPy 1.17.0

The full repository suite was not run locally because the existing environment lacks the optional Matplotlib/Neuropythy stack; no dependencies were installed. The focused checks load the exact module source and exercise the reported shape, NaN, exact-vertex, duplicate-vertex, threshold, wrapper, and unit behavior. Repository CI remains authoritative.

## Automation disclosure

OpenAI Codex selected the issue, applied and independently reviewed the minimal patch, ran the checks above, and opened this Draft PR through an isolated contributor account. No issue comment or claim was posted, and human self-review is not claimed.