### PR TITLE
[TST] [MNT] Fix failing tests

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -6,13 +6,10 @@ coverage:
       default:
         target: auto
         threshold: 5.0
-    ignore:
-      - "pulse2percept/datasets/tests/**/*"
-      - "pulse2percept/implants/tests/**/*"
-      - "pulse2percept/implants/cortex/tests/**/*"
-      - "pulse2percept/models/tests/**/*"
-      - "pulse2percept/models/cortex/tests/**/*"
-      - "pulse2percept/percepts/tests/**/*"
-      - "pulse2percept/stimuli/tests/**/*"
-      - "pulse2percept/utils/tests/**/*"
-      - "pulse2percept/viz/tests/**/*"
+
+# `ignore` is a top-level key: nested under `coverage.status` it is silently
+# dropped, which is how test modules ended up in the report. One glob covers
+# every tests/ directory, including ones added later.
+ignore:
+  - "pulse2percept/**/tests/**/*"
+  - "**/conftest.py"

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -63,6 +63,12 @@ jobs:
             lipo -info /tmp/omp/lib/libomp.dylib
           CIBW_BEFORE_BUILD_MACOS: |
             set -eux
+            # CIBW_ENVIRONMENT only keeps the *first* assignment when the
+            # value spans multiple lines, which silently dropped the
+            # deployment target for a long time. Fail with a clear message if
+            # that ever regresses:
+            : "${OMP_PREFIX:?not set - check CIBW_ENVIRONMENT_MACOS is one line}"
+            : "${MACOSX_DEPLOYMENT_TARGET:?not set - check CIBW_ENVIRONMENT_MACOS is one line}"
             ls -l "${OMP_PREFIX}/include/omp.h"
             # Fail loudly here rather than deep inside delocate if the OpenMP
             # runtime ever requires a newer macOS than the wheels target:
@@ -77,15 +83,19 @@ jobs:
               exit 1
             fi
             python -m pip install --upgrade pip setuptools wheel cython delocate oldest-supported-numpy
+          # NOTE: must stay a *folded* scalar (>-), i.e. a single line of
+          # space-separated assignments. With a literal block (|),
+          # cibuildwheel keeps only the first assignment and silently drops
+          # the rest -- which is how the deployment target below went missing
+          # for so long. setup.py derives the OpenMP compile/link flags from
+          # OMP_PREFIX, so nothing else needs setting here.
+          #
           # A fixed target for both arches, so the ABI floor is a decision we
           # make rather than a side effect of the runner image. macOS 11 is
           # the oldest release Apple silicon supports.
-          CIBW_ENVIRONMENT_MACOS: |
+          CIBW_ENVIRONMENT_MACOS: >-
             OMP_PREFIX=/tmp/omp
             MACOSX_DEPLOYMENT_TARGET=11.0
-            CFLAGS="-std=c99 -O3 -Xpreprocessor -fopenmp -I/tmp/omp/include"
-            CPPFLAGS="-I/tmp/omp/include"
-            LDFLAGS="-L/tmp/omp/lib -lomp"
           # No custom repair command: cibuildwheel's default delocate-wheel
           # invocation is correct once the deployment target and the vendored
           # libomp agree.

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -59,8 +59,15 @@ jobs:
             lipo -create /tmp/omp-osx-arm64/lib/libomp.dylib \
                          /tmp/omp-osx-64/lib/libomp.dylib \
                  -output /tmp/omp/lib/libomp.dylib
-            install_name_tool -id @rpath/libomp.dylib /tmp/omp/lib/libomp.dylib
+            # Give libomp an absolute install name. The extension records
+            # whatever LC_ID_DYLIB says, and conda-forge ships `@rpath/...`,
+            # which delocate cannot resolve because setup.py links without an
+            # -rpath. An absolute path is what Homebrew's libomp provides and
+            # what delocate expects; it is rewritten to @loader_path when the
+            # dylib is vendored into the wheel.
+            install_name_tool -id /tmp/omp/lib/libomp.dylib /tmp/omp/lib/libomp.dylib
             lipo -info /tmp/omp/lib/libomp.dylib
+            otool -D /tmp/omp/lib/libomp.dylib
           CIBW_BEFORE_BUILD_MACOS: |
             set -eux
             # CIBW_ENVIRONMENT only keeps the *first* assignment when the
@@ -96,9 +103,12 @@ jobs:
           CIBW_ENVIRONMENT_MACOS: >-
             OMP_PREFIX=/tmp/omp
             MACOSX_DEPLOYMENT_TARGET=11.0
-          # No custom repair command: cibuildwheel's default delocate-wheel
-          # invocation is correct once the deployment target and the vendored
-          # libomp agree.
+          # Same as cibuildwheel's default repair, but prints the dependency
+          # graph first: when delocate fails, cibuildwheel reports only the
+          # exit code, and `listdeps` shows which library went unresolved.
+          CIBW_REPAIR_WHEEL_COMMAND_MACOS: >-
+            delocate-listdeps --all --depending {wheel} &&
+            delocate-wheel --require-archs {delocate_archs} -w {dest_dir} -v {wheel}
 
           # ---------- Linux: enable OpenMP; OSN picks a compatible NumPy ----------
           CIBW_ENVIRONMENT_LINUX: "CFLAGS='-fopenmp'"

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -34,23 +34,61 @@ jobs:
       - name: Build wheels
         uses: pypa/cibuildwheel@7c619efba910c04005a835b110b057fc28fd6e93 # v3.2.0
         env:
-          # ---------- macOS: install libomp; compile & repair with macOS 15 target ----------
+          # ---------- macOS: OpenMP runtime independent of the runner image ----------
+          # Do NOT use Homebrew's libomp. Homebrew bottles are built for the
+          # runner's own macOS version, so the dylib's minimum-OS tracks
+          # whatever image GitHub happens to ship (`macos-latest` moved to the
+          # macOS 26 Apple-silicon image in June 2026). delocate then refuses
+          # to vendor it into a wheel tagged for an older macOS -- correctly,
+          # since that wheel would crash for anyone on an older system.
+          #
+          # conda-forge's llvm-openmp is built against an old deployment
+          # target, so it can be bundled into wheels that still install on
+          # macOS 11+. Both arch slices are merged into one universal binary
+          # so a single OMP_PREFIX serves the x86_64 and arm64 builds.
           CIBW_BEFORE_ALL_MACOS: |
-            brew update
-            brew install libomp || brew reinstall libomp
+            set -eux
+            curl -Ls https://micro.mamba.pm/api/micromamba/osx-arm64/latest \
+              | tar -xvj bin/micromamba
+            for arch in osx-arm64 osx-64; do
+              ./bin/micromamba create -y -p "/tmp/omp-${arch}" \
+                --platform "${arch}" -c conda-forge llvm-openmp
+            done
+            mkdir -p /tmp/omp/lib /tmp/omp/include
+            cp -R /tmp/omp-osx-arm64/include/. /tmp/omp/include/
+            lipo -create /tmp/omp-osx-arm64/lib/libomp.dylib \
+                         /tmp/omp-osx-64/lib/libomp.dylib \
+                 -output /tmp/omp/lib/libomp.dylib
+            install_name_tool -id @rpath/libomp.dylib /tmp/omp/lib/libomp.dylib
+            lipo -info /tmp/omp/lib/libomp.dylib
           CIBW_BEFORE_BUILD_MACOS: |
-            echo "libomp prefix: $(brew --prefix libomp)"
-            ls -l "$(brew --prefix libomp)/include/omp.h" || (echo "omp.h missing" && exit 1)
+            set -eux
+            ls -l "${OMP_PREFIX}/include/omp.h"
+            # Fail loudly here rather than deep inside delocate if the OpenMP
+            # runtime ever requires a newer macOS than the wheels target:
+            MINOS=$(otool -l "${OMP_PREFIX}/lib/libomp.dylib" \
+                    | awk '/LC_BUILD_VERSION/{f=1} f && /minos/{print $2; exit}')
+            echo "libomp minos='${MINOS}' deployment target=${MACOSX_DEPLOYMENT_TARGET}"
+            if [ -z "${MINOS}" ]; then
+              echo "note: no LC_BUILD_VERSION found, skipping the minimum-OS check"
+            elif [ "${MINOS%%.*}" -gt "${MACOSX_DEPLOYMENT_TARGET%%.*}" ]; then
+              echo "ERROR: libomp needs macOS ${MINOS}, wheels target ${MACOSX_DEPLOYMENT_TARGET}."
+              echo "delocate cannot vendor it; pick an OpenMP build with an older minimum."
+              exit 1
+            fi
             python -m pip install --upgrade pip setuptools wheel cython delocate oldest-supported-numpy
+          # A fixed target for both arches, so the ABI floor is a decision we
+          # make rather than a side effect of the runner image. macOS 11 is
+          # the oldest release Apple silicon supports.
           CIBW_ENVIRONMENT_MACOS: |
-            OMP_PREFIX="$(brew --prefix libomp)"
-            MACOSX_DEPLOYMENT_TARGET=15.0
-            CFLAGS="-std=c99 -O3 -Xpreprocessor -fopenmp -I${OMP_PREFIX}/include"
-            CPPFLAGS="-I${OMP_PREFIX}/include"
-            LDFLAGS="-L${OMP_PREFIX}/lib -lomp"
-          CIBW_REPAIR_WHEEL_COMMAND_MACOS: >
-            MACOSX_DEPLOYMENT_TARGET=15.0 delocate-listdeps {wheel} &&
-            MACOSX_DEPLOYMENT_TARGET=15.0 delocate-wheel -w {dest_dir} {wheel}
+            OMP_PREFIX=/tmp/omp
+            MACOSX_DEPLOYMENT_TARGET=11.0
+            CFLAGS="-std=c99 -O3 -Xpreprocessor -fopenmp -I/tmp/omp/include"
+            CPPFLAGS="-I/tmp/omp/include"
+            LDFLAGS="-L/tmp/omp/lib -lomp"
+          # No custom repair command: cibuildwheel's default delocate-wheel
+          # invocation is correct once the deployment target and the vendored
+          # libomp agree.
 
           # ---------- Linux: enable OpenMP; OSN picks a compatible NumPy ----------
           CIBW_ENVIRONMENT_LINUX: "CFLAGS='-fopenmp'"

--- a/pulse2percept/datasets/beyeler2019.py
+++ b/pulse2percept/datasets/beyeler2019.py
@@ -191,7 +191,7 @@ def fetch_beyeler2019(subjects=None, electrodes=None, data_path=None,
     # Combine 'img_shape_x' and 'img_shape_y' into 'img_shape' tuple
     df['img_shape'] = df.apply(lambda x: (x['img_shape_x'], x['img_shape_y']),
                                axis=1)
-    df.drop(columns=['img_shape_x', 'img_shape_y'], inplace=True)
+    df = df.drop(columns=['img_shape_x', 'img_shape_y'])
 
     # Verify integrity of the dataset:
     if len(df) != 400:
@@ -226,30 +226,17 @@ def fetch_beyeler2019(subjects=None, electrodes=None, data_path=None,
         idx &= idx_electrode
     df = df[idx]
 
-    # Augment with implant type & location data:
-    df['implant_type_str'] = ''
-    df['implant_x'] = 0
-    df['implant_y'] = 0
-    df['implant_rot'] = 0
-    df['xrange'] = None
-    df['yrange'] = None
-    for subject in df.subject.unique():
-        df.loc[df.subject == subject,
-               'implant_type_str'] = subject_params[subject]['implant_type_str']
-        df.loc[df.subject == subject,
-               'implant_x'] = subject_params[subject]['implant_x']
-        df.loc[df.subject == subject,
-               'implant_y'] = subject_params[subject]['implant_y']
-        df.loc[df.subject == subject,
-               'implant_rot'] = subject_params[subject]['implant_rot']
-        df.loc[df.subject == subject, 'xrange'] = df.loc[df.subject == subject].apply(
-            lambda row: (subject_params[subject]['xmin'], 
-                         subject_params[subject]['xmax']), axis=1
-        )
-        df.loc[df.subject == subject, 'yrange'] = df.loc[df.subject == subject].apply(
-            lambda row: (subject_params[subject]['ymin'], 
-                         subject_params[subject]['ymax']), axis=1
-        )
+    # Augment with implant type & location data. Build each column in one go
+    # rather than pre-initializing it and then writing into it per subject:
+    # writing a float (e.g. `implant_rot`) into a column created as int is an
+    # incompatible-dtype setitem, which pandas will turn into an error.
+    params = df.subject.map(subject_params)
+    df['implant_type_str'] = params.map(lambda p: p['implant_type_str'])
+    df['implant_x'] = params.map(lambda p: p['implant_x'])
+    df['implant_y'] = params.map(lambda p: p['implant_y'])
+    df['implant_rot'] = params.map(lambda p: p['implant_rot'])
+    df['xrange'] = params.map(lambda p: (p['xmin'], p['xmax']))
+    df['yrange'] = params.map(lambda p: (p['ymin'], p['ymax']))
 
     if shuffle:
         df = df.sample(n=len(df), random_state=random_state)

--- a/pulse2percept/datasets/tests/test_beyeler2019.py
+++ b/pulse2percept/datasets/tests/test_beyeler2019.py
@@ -76,3 +76,20 @@ def test_fetch_beyeler2019():
         with pytest.raises(ImportError):
             reload(datasets)
             datasets.fetch_beyeler2019()
+
+
+def test_fetch_beyeler2019_missing_dependencies():
+    """The loader must explain which optional dependency is missing.
+
+    These guards run before any download, so they are testable without the
+    dataset being present.
+    """
+    from pulse2percept.datasets import beyeler2019 as mod
+
+    with mock.patch.object(mod, 'has_h5py', False):
+        with pytest.raises(ImportError):
+            mod.fetch_beyeler2019()
+
+    with mock.patch.object(mod, 'has_pandas', False):
+        with pytest.raises(ImportError):
+            mod.fetch_beyeler2019()

--- a/pulse2percept/datasets/tests/test_greenwald2009.py
+++ b/pulse2percept/datasets/tests/test_greenwald2009.py
@@ -16,7 +16,7 @@ def test_load_greenwald2009():
         npt.assert_equal(expected_col in data.columns, True)
 
     npt.assert_equal(data.shape, (83, 12))
-    npt.assert_equal(data.subject.unique(), ['S05', 'S06'])
+    npt.assert_equal(list(data.subject.unique()), ['S05', 'S06'])
 
     # Shuffle dataset
     data = load_greenwald2009(shuffle=True, random_state=5)
@@ -28,19 +28,19 @@ def test_load_greenwald2009():
     # Select electrodes
     data = load_greenwald2009(electrodes=['B2', 'C3'])
     npt.assert_equal(data.shape, (56, 12))
-    npt.assert_equal(data.electrode.unique(), ['B2', 'C3'])
+    npt.assert_equal(list(data.electrode.unique()), ['B2', 'C3'])
 
     # Load electrode that doesn't exist
     data = load_greenwald2009(electrodes=['C4', 'Z1'])
     npt.assert_equal(data.shape, (27, 12))
-    npt.assert_equal(data.electrode.unique(), 'C4')
+    npt.assert_equal(list(data.electrode.unique()), ['C4'])
 
     # Select by subject
     data = load_greenwald2009(subjects='S05')
     npt.assert_equal(data.shape, (48, 12))
-    npt.assert_equal(data.subject.unique(), 'S05')
+    npt.assert_equal(list(data.subject.unique()), ['S05'])
 
     # Select by subject with non-existent subject
     data = load_greenwald2009(subjects=['S06', 'X1'])
     npt.assert_equal(data.shape, (35, 12))
-    npt.assert_equal(data.subject.unique(), 'S06')
+    npt.assert_equal(list(data.subject.unique()), ['S06'])

--- a/pulse2percept/datasets/tests/test_horsager2009.py
+++ b/pulse2percept/datasets/tests/test_horsager2009.py
@@ -18,7 +18,7 @@ def test_load_horsager2009():
         npt.assert_equal(expected_col in data.columns, True)
 
     npt.assert_equal(data.shape, (608, 21))
-    npt.assert_equal(data.subject.unique(), ['S05', 'S06'])
+    npt.assert_equal(list(data.subject.unique()), ['S05', 'S06'])
 
     # Shuffle dataset (index will always be range(608), but rows are shuffled):
     data = load_horsager2009(shuffle=True, random_state=42)
@@ -32,30 +32,30 @@ def test_load_horsager2009():
     # Select subjects:
     data = load_horsager2009(subjects='S05')
     npt.assert_equal(data.shape, (296, 21))
-    npt.assert_equal(data.subject.unique(), 'S05')
+    npt.assert_equal(list(data.subject.unique()), ['S05'])
     data = load_horsager2009(subjects=['S05', 'S07'])  # 'S07' doesnt' exist
     npt.assert_equal(data.shape, (296, 21))
-    npt.assert_equal(data.subject.unique(), 'S05')
+    npt.assert_equal(list(data.subject.unique()), ['S05'])
     data = load_horsager2009(subjects=['S05', 'S06'])  # same as None
     npt.assert_equal(data.shape, (608, 21))
     data = load_horsager2009(subjects='S6')  # 'S6' doesn't exist
     npt.assert_equal(data.shape, (0, 21))
-    npt.assert_equal(data.subject.unique(), [])
+    npt.assert_equal(list(data.subject.unique()), [])
 
     # Select electrodes:
     data = load_horsager2009(electrodes='A1')
     npt.assert_equal(data.shape, (114, 21))
-    npt.assert_equal(data.electrode.unique(), 'A1')
-    npt.assert_equal(data.subject.unique(), ['S06', 'S05'])
+    npt.assert_equal(list(data.electrode.unique()), ['A1'])
+    npt.assert_equal(list(data.subject.unique()), ['S06', 'S05'])
     data = load_horsager2009(electrodes=['A1', 'A9'])  # 'A9' doesn't exist
     npt.assert_equal(data.shape, (114, 21))
-    npt.assert_equal(data.electrode.unique(), 'A1')
-    npt.assert_equal(data.subject.unique(), ['S06', 'S05'])
+    npt.assert_equal(list(data.electrode.unique()), ['A1'])
+    npt.assert_equal(list(data.subject.unique()), ['S06', 'S05'])
 
     # Select stimulus types:
     data = load_horsager2009(stim_types='single_pulse')
     npt.assert_equal(data.shape, (80, 21))
-    npt.assert_equal(data.stim_type.unique(), 'single_pulse')
+    npt.assert_equal(list(data.stim_type.unique()), ['single_pulse'])
     npt.assert_equal(list(data.subject.unique()), ['S05', 'S06'])
     data = load_horsager2009(stim_types=['single_pulse', 'fixed_duration'])
     npt.assert_equal(data.shape, (200, 21))
@@ -67,6 +67,6 @@ def test_load_horsager2009():
     data = load_horsager2009(subjects='S05', electrodes=['A1', 'C3'],
                              stim_types='single_pulse')
     npt.assert_equal(data.shape, (16, 21))
-    npt.assert_equal(data.subject.unique(), 'S05')
+    npt.assert_equal(list(data.subject.unique()), ['S05'])
     npt.assert_equal(list(data.electrode.unique()), ['C3', 'A1'])
-    npt.assert_equal(data.stim_type.unique(), 'single_pulse')
+    npt.assert_equal(list(data.stim_type.unique()), ['single_pulse'])

--- a/pulse2percept/datasets/tests/test_nanduri2012.py
+++ b/pulse2percept/datasets/tests/test_nanduri2012.py
@@ -16,7 +16,7 @@ def test_load_nanduri2012():
         npt.assert_equal(expected_col in data.columns, True)
 
     npt.assert_equal(data.shape, (128, 17))
-    npt.assert_equal(data.subject.unique(), ['S06'])
+    npt.assert_equal(list(data.subject.unique()), ['S06'])
 
     # Shuffle dataset (index will always be range(552), but rows are shuffled):
     data = load_nanduri2012(shuffle=True, random_state=42)
@@ -28,17 +28,18 @@ def test_load_nanduri2012():
     # Select electrodes:
     data = load_nanduri2012(electrodes='A2')
     npt.assert_equal(data.shape, (16, 17))
-    npt.assert_equal(data.electrode.unique(), 'A2')
-    npt.assert_equal(data.subject.unique(), 'S06')
-    data = load_nanduri2012(electrodes=['A1', 'A9'])  # 'A9' doesn't exist
+    npt.assert_equal(list(data.electrode.unique()), ['A2'])
+    npt.assert_equal(list(data.subject.unique()), ['S06'])
+    # neither 'A1' nor 'A9' exists, so the selection comes back empty:
+    data = load_nanduri2012(electrodes=['A1', 'A9'])
     npt.assert_equal(data.shape, (0, 17))
-    npt.assert_equal(data.electrode.unique(), 'A1')
-    npt.assert_equal(data.subject.unique(), 'S06')
+    npt.assert_equal(list(data.electrode.unique()), [])
+    npt.assert_equal(list(data.subject.unique()), [])
 
     # Select task
     data = load_nanduri2012(task='rate')
     npt.assert_equal(data.shape, (88, 17))
-    npt.assert_equal(data.task.unique(), 'rate')
+    npt.assert_equal(list(data.task.unique()), ['rate'])
     data = load_nanduri2012(task='size')
     npt.assert_equal(data.shape, (40, 17))
-    npt.assert_equal(data.task.unique(), 'size')
+    npt.assert_equal(list(data.task.unique()), ['size'])

--- a/pulse2percept/datasets/tests/test_perezfornos2012.py
+++ b/pulse2percept/datasets/tests/test_perezfornos2012.py
@@ -36,15 +36,15 @@ def test_load_perezfornos2012():
     # Test selecting by subjects
     data = load_perezfornos2012(subjects='S2')
     npt.assert_equal(data.shape, (5, 3))
-    npt.assert_equal(data.subject.unique(), 'S2')
+    npt.assert_equal(list(data.subject.unique()), ['S2'])
     data = load_perezfornos2012(subjects=['S2', 'S3'])
     npt.assert_equal(data.shape, (10, 3))
-    npt.assert_equal(data.subject.unique(), ['S2', 'S3'])
+    npt.assert_equal(list(data.subject.unique()), ['S2', 'S3'])
 
     # Test selecting by figure
     data = load_perezfornos2012(figures='fig3_S7')
     npt.assert_equal(data.shape, (1, 3))
-    npt.assert_equal(data.figure.unique(), 'fig3_S7')
+    npt.assert_equal(list(data.figure.unique()), ['fig3_S7'])
     data = load_perezfornos2012(figures=['fig3_S7', 'fig4_S3'])
     npt.assert_equal(data.shape, (2, 3))
-    npt.assert_equal(data.figure.unique(), ['fig3_S7', 'fig4_S3'])
+    npt.assert_equal(list(data.figure.unique()), ['fig3_S7', 'fig4_S3'])

--- a/pulse2percept/implants/cortex/tests/test_neuralink.py
+++ b/pulse2percept/implants/cortex/tests/test_neuralink.py
@@ -74,3 +74,49 @@ def test_Neuralink():
     
 
 
+
+
+def _ax3d():
+    fig = plt.figure()
+    return fig.add_subplot(111, projection='3d')
+
+
+@pytest.mark.parametrize('make_obj', [
+    pytest.param(lambda: EllipsoidElectrode(0, 1, 2, 3, 4, 5, name='A001'),
+                 id='EllipsoidElectrode'),
+    pytest.param(lambda: LinearEdgeThread(0, 0, 0), id='LinearEdgeThread'),
+    pytest.param(lambda: Neuralink([LinearEdgeThread(0, 0, 0),
+                                    LinearEdgeThread(100, 0, 0)]),
+                 id='Neuralink'),
+])
+def test_plot3D(make_obj):
+    obj = make_obj()
+
+    # Plots onto a given 3D axis:
+    plt.close('all')
+    ax = _ax3d()
+    npt.assert_equal(obj.plot3D(ax=ax) is not None, True)
+
+    # Creates its own 3D axis when none is given:
+    plt.close('all')
+    npt.assert_equal(obj.plot3D() is not None, True)
+
+    # ... and honors `figsize` when it does:
+    plt.close('all')
+    ax = obj.plot3D(figsize=(8, 6))
+    npt.assert_almost_equal(ax.figure.get_size_inches(), (8, 6))
+
+    # A 2D axis is rejected:
+    plt.close('all')
+    _, ax2d = plt.subplots()
+    with pytest.raises(ValueError):
+        obj.plot3D(ax=ax2d)
+    plt.close('all')
+
+
+def test_Neuralink_from_neuropythy_requires_neuropythy_map():
+    # The vfmap must be a NeuropythyMap; this guard runs before any dataset
+    # is touched, so it is testable without neuropythy installed:
+    from pulse2percept.topography import Watson2014Map
+    with pytest.raises(TypeError):
+        Neuralink.from_neuropythy(Watson2014Map())

--- a/pulse2percept/implants/tests/test_alpha.py
+++ b/pulse2percept/implants/tests/test_alpha.py
@@ -50,6 +50,11 @@ def test_AlphaIMS(ztype, x, y, rot):
     for e in ['A1', 'B2', 'C3']:
         npt.assert_equal(alpha[e].a, 50)
 
+
+# The checks below don't depend on x/y/rot/ztype, so they live outside the
+# parametrized test above: running them once covers the same code as running
+# them for all 16 parameter combinations.
+def test_AlphaIMS_indexing():
     # `h` must have the right dimensions
     with pytest.raises(ValueError):
         AlphaIMS(x=-100, y=10, z=np.arange(28))
@@ -63,6 +68,8 @@ def test_AlphaIMS(ztype, x, y, rot):
         npt.assert_equal(electrode, alpha[name])
         npt.assert_equal(alpha["unlikely name for an electrode"], None)
 
+
+def test_AlphaIMS_eye():
     # Right-eye implant:
     xc, yc = 1600, -1600
     alpha_re = AlphaIMS(eye='RE', x=xc, y=yc)
@@ -129,6 +136,9 @@ def test_AlphaAMS(ztype, x, y, rot):
     for e in ['A1', 'B2', 'C3']:
         npt.assert_equal(alpha[e].r, 15)
 
+
+# As above: independent of x/y/rot/ztype, so run once rather than 16 times.
+def test_AlphaAMS_indexing():
     # `h` must have the right dimensions
     with pytest.raises(ValueError):
         AlphaAMS(x=-100, y=10, z=np.arange(12))
@@ -142,6 +152,8 @@ def test_AlphaAMS(ztype, x, y, rot):
         npt.assert_equal(electrode, alpha[name])
         npt.assert_equal(alpha["unlikely name for an electrode"], None)
 
+
+def test_AlphaAMS_eye():
     # Right-eye implant:
     xc, yc = 1600, -1600
     alpha_re = AlphaAMS(eye='RE', x=xc, y=yc)
@@ -163,6 +175,6 @@ def test_AlphaAMS(ztype, x, y, rot):
 
     # Invalid eye string:
     with pytest.raises(TypeError):
-        AlphaIMS(eye=[1, 2])
+        AlphaAMS(eye=[1, 2])
     with pytest.raises(ValueError):
-        AlphaIMS(eye='left eye')
+        AlphaAMS(eye='left eye')

--- a/pulse2percept/models/base.py
+++ b/pulse2percept/models/base.py
@@ -128,12 +128,18 @@ class BaseModel(Frozen, PrettyPrint, metaclass=ABCMeta):
                      f"constructor or in ``build``, not in ``{f_caller_2}``.")
             raise AttributeError(err_s)
 
-    def __deepcopy__(self, memodict={}):
+    def __deepcopy__(self, memodict=None):
+        if memodict is None:
+            memodict = {}
         if id(self) in memodict:
             return memodict[id(self)]
         copied = copy(self)
+        # Register before recursing, and pass `memodict` down, so that shared
+        # references are copied once and reference cycles terminate:
+        memodict[id(self)] = copied
         for attr in self.__dict__:
-            copied.__setattr__(attr, deepcopy(self.__getattribute__(attr)))
+            copied.__setattr__(attr,
+                               deepcopy(self.__getattribute__(attr), memodict))
         if self.is_built:
             copied.build()
         return copied
@@ -820,7 +826,7 @@ class Model(PrettyPrint):
                        f"{self.__class__.__name__} outside the constructor.")
             raise FreezeError(err_str)
 
-    def __deepcopy__(self, memodict={}):
+    def __deepcopy__(self, memodict=None):
         """
         Perform a deep copy of the Model object.
 
@@ -834,9 +840,11 @@ class Model(PrettyPrint):
         -------
 
         """
+        if memodict is None:
+            memodict = {}
         if id(self) in memodict:
             return memodict[id(self)]
-        attributes = deepcopy(self.__dict__)
+        attributes = deepcopy(self.__dict__, memodict)
         # Remove Spatial and Temporal Model attributes, they are created internally.
         attributes.pop('spatial')
         attributes.pop('temporal')

--- a/pulse2percept/models/base.py
+++ b/pulse2percept/models/base.py
@@ -371,7 +371,10 @@ class SpatialModel(BaseModel, metaclass=ABCMeta):
             # Calculate the Stimulus at requested time points:
             if t_percept is not None:
                 # Save electrode parameters
-                stim = Stimulus(stim[:, t_percept].reshape((-1, n_time)),
+                # np.asarray: indexing a single-electrode stimulus returns a
+                # scalar, which has no `reshape`:
+                stim = Stimulus(np.asarray(stim[:, t_percept]).reshape((-1,
+                                                                       n_time)),
                                 electrodes=stim.electrodes, time=t_percept,
                                 metadata=stim.metadata)
                 # find unique stimulus points
@@ -845,10 +848,22 @@ class Model(PrettyPrint):
         if id(self) in memodict:
             return memodict[id(self)]
         attributes = deepcopy(self.__dict__, memodict)
-        # Remove Spatial and Temporal Model attributes, they are created internally.
-        attributes.pop('spatial')
-        attributes.pop('temporal')
+        # Most Model subclasses create their spatial and temporal models in
+        # the constructor, so those cannot be passed in as parameters:
+        spatial = attributes.pop('spatial', None)
+        temporal = attributes.pop('temporal', None)
         result = self.__class__(**attributes)
+        # Whatever the constructor made, replace it with our copies. Model
+        # parameters (e.g. `rho`) are forwarded to the sub-models by
+        # `__setattr__`, so they live in `spatial`/`temporal`, not in
+        # `self.__dict__` -- reconstructing from the constructor alone would
+        # silently reset them to their defaults. This bypasses
+        # `Model.__setattr__`, which outside the constructor forwards
+        # attributes to the sub-models; it is the assignment __init__ makes.
+        if spatial is not None:
+            object.__setattr__(result, 'spatial', spatial)
+        if temporal is not None:
+            object.__setattr__(result, 'temporal', temporal)
         if self.is_built:
             result.build()
         memodict[id(self)] = result

--- a/pulse2percept/models/tests/test_base.py
+++ b/pulse2percept/models/tests/test_base.py
@@ -488,3 +488,146 @@ def test_Model_predict_percept_correctly_parallelizes():
 
     # we expect roughly a linear decrease in time as thread count increases
     npt.assert_almost_equal(actual=two_thread_temporal_predict_time, desired=one_thread_temporal_predict_time / 2, decimal=1e-5)
+
+
+class ScalingSpatialModel(ValidSpatialModel):
+    """Spatial model whose brightness equals the stimulus amplitude.
+
+    `find_threshold` bisects on amplitude, so a model with a known,
+    monotonic amplitude-to-brightness mapping gives a predictable threshold.
+    """
+
+    def _predict_spatial(self, earray, stim):
+        if not self.is_built:
+            raise NotBuiltError
+        n_time = 1 if stim.time is None else stim.time.size
+        out = np.zeros((self.grid.x.size, n_time), dtype=np.float32)
+        out[:] = np.abs(stim.data).max()
+        return out
+
+
+class ScalingTemporalModel(ValidTemporalModel):
+    """Temporal model whose brightness equals the stimulus amplitude."""
+
+    def _predict_temporal(self, stim, t_percept):
+        if not self.is_built:
+            raise NotBuiltError
+        out = np.zeros((stim.data.shape[0], len(t_percept)), dtype=np.float32)
+        out[:] = np.abs(stim.data).max()
+        return out
+
+
+def test_SpatialModel_find_threshold():
+    model = ScalingSpatialModel(xystep=5).build()
+    implant = ArgusI(stim={'A1': 1})
+
+    # Brightness equals amplitude, so the threshold is the target brightness:
+    npt.assert_almost_equal(model.find_threshold(implant, 20), 20, decimal=0)
+    npt.assert_almost_equal(model.find_threshold(implant, 55), 55, decimal=0)
+
+    # `implant` must be a ProsthesisSystem:
+    with pytest.raises(TypeError):
+        model.find_threshold(Stimulus({'A1': 1}), 20)
+
+
+def test_TemporalModel_find_threshold():
+    model = ScalingTemporalModel().build()
+    stim = Stimulus({'A1': 1})
+
+    npt.assert_almost_equal(model.find_threshold(stim, 20), 20, decimal=0)
+
+    # `stim` must be a Stimulus:
+    with pytest.raises(TypeError):
+        model.find_threshold(ArgusI(stim={'A1': 1}), 20)
+
+
+def test_Model_find_threshold():
+    model = Model(spatial=ScalingSpatialModel(xystep=5)).build()
+    implant = ArgusI(stim={'A1': 1})
+
+    npt.assert_almost_equal(model.find_threshold(implant, 20), 20, decimal=0)
+
+    # `implant` must be a ProsthesisSystem:
+    with pytest.raises(TypeError):
+        model.find_threshold(Stimulus({'A1': 1}), 20)
+
+
+def test_Model_deepcopy_memo():
+    model = Model(spatial=ValidSpatialModel())
+
+    # Called directly, without a memo dict:
+    copied = model.__deepcopy__()
+    npt.assert_equal(isinstance(copied, Model), True)
+    npt.assert_equal(id(copied) != id(model), True)
+
+    # An object already in the memo is returned as-is, not re-copied:
+    sentinel = 'already copied'
+    npt.assert_equal(model.__deepcopy__({id(model): sentinel}), sentinel)
+
+    # Shared references are copied once, not duplicated:
+    shared = ValidSpatialModel()
+    pair = copy.deepcopy({'a': shared, 'b': shared})
+    npt.assert_equal(pair['a'] is pair['b'], True)
+
+
+def test_SpatialModel_deepcopy_memo():
+    model = ValidSpatialModel()
+    npt.assert_equal(model.__deepcopy__() == model, True)
+    sentinel = 'already copied'
+    npt.assert_equal(model.__deepcopy__({id(model): sentinel}), sentinel)
+
+
+def test_Model_eq_and_hash():
+    model = Model(spatial=ValidSpatialModel())
+
+    # Identity short-circuit:
+    npt.assert_equal(model == model, True)
+    # Different type:
+    npt.assert_equal(model == 'not a model', False)
+    npt.assert_equal(model == ValidSpatialModel(), False)
+
+    # Hashable, so models can go in sets/dicts:
+    npt.assert_equal(isinstance(hash(model), int), True)
+    npt.assert_equal(len({model, model}), 1)
+
+
+def test_Model_pprint_params():
+    # Covers both the spatial and the temporal branch of _pprint_params:
+    both = Model(spatial=ValidSpatialModel(), temporal=ValidTemporalModel())
+    params = both._pprint_params()
+    npt.assert_equal('spatial' in params, True)
+    npt.assert_equal('temporal' in params, True)
+    # Parameters of the sub-models are pulled up:
+    npt.assert_equal('xystep' in params, True)
+    npt.assert_equal('dt' in params, True)
+    npt.assert_equal(isinstance(str(both), str), True)
+
+
+def test_Model_deepcopy_preserves_submodels_and_params():
+    # A plain Model takes spatial/temporal as constructor arguments and does
+    # not recreate them, so they must survive the copy:
+    model = Model(spatial=ValidSpatialModel(), temporal=ValidTemporalModel())
+    copied = copy.deepcopy(model)
+    npt.assert_equal(isinstance(copied.spatial, ValidSpatialModel), True)
+    npt.assert_equal(isinstance(copied.temporal, ValidTemporalModel), True)
+    npt.assert_equal(copied == model, True)
+    # ... as real copies, not as shared references:
+    npt.assert_equal(id(copied.spatial) != id(model.spatial), True)
+    npt.assert_equal(id(copied.temporal) != id(model.temporal), True)
+
+    # Model parameters are forwarded to the sub-models, so they live in
+    # `spatial`/`temporal` rather than in `Model.__dict__`. Rebuilding the
+    # copy from the constructor alone would silently reset them to defaults:
+    model = Model(spatial=ValidSpatialModel(xystep=5, thresh_percept=0.5))
+    copied = copy.deepcopy(model)
+    npt.assert_almost_equal(copied.xystep, 5)
+    npt.assert_almost_equal(copied.thresh_percept, 0.5)
+    npt.assert_equal(copied == model, True)
+
+    # The copy is independent of the original:
+    copied.xystep = 3
+    npt.assert_almost_equal(model.xystep, 5)
+
+    # A built model stays built:
+    built = Model(spatial=ValidSpatialModel(xystep=5)).build()
+    npt.assert_equal(copy.deepcopy(built).is_built, True)

--- a/pulse2percept/models/tests/test_beyeler2019.py
+++ b/pulse2percept/models/tests/test_beyeler2019.py
@@ -324,8 +324,15 @@ def test_AxonMapModel(engine):
     with pytest.raises(ValueError):
         AxonMapModel(axlambda=9).build()
 
-@pytest.mark.parametrize('original', [AxonMapModel(), AxonMapModel().build()])
-def test_deepcopy_AxonMapModel(original):
+# Build the model inside the test, not in the decorator: arguments to
+# `parametrize` are evaluated at import time, so building here would run on
+# every pytest invocation (even `--collect-only`, even when this test is
+# deselected) and would surface any failure as a collection error.
+@pytest.mark.parametrize('build', (False, True))
+def test_deepcopy_AxonMapModel(build):
+    original = AxonMapModel()
+    if build:
+        original.build()
     copied = copy.deepcopy(original)
 
     # Assert these are two different objects

--- a/pulse2percept/stimuli/base.py
+++ b/pulse2percept/stimuli/base.py
@@ -12,6 +12,7 @@ import matplotlib.pyplot as plt
 from copy import deepcopy
 import operator as ops
 from math import isclose
+from scipy.integrate import trapezoid
 import numpy as np
 np.set_printoptions(precision=2, threshold=5, edgeitems=2)
 
@@ -912,7 +913,7 @@ class Stimulus(PrettyPrint):
         """
         if self.time is None:
             return np.allclose(self.data, 0, atol=MIN_AMP)
-        return np.allclose(np.trapz(self.data, x=self.time), 0, atol=MIN_AMP)
+        return np.allclose(trapezoid(self.data, x=self.time), 0, atol=MIN_AMP)
 
     @property
     def duration(self):

--- a/pulse2percept/stimuli/tests/test_pulse_trains.py
+++ b/pulse2percept/stimuli/tests/test_pulse_trains.py
@@ -1,6 +1,7 @@
 import numpy as np
 import pytest
 import numpy.testing as npt
+from scipy.integrate import trapezoid
 
 from pulse2percept.stimuli import (Stimulus, PulseTrain, BiphasicPulseTrain,
                                    BiphasicTripletTrain,
@@ -75,7 +76,7 @@ def test_BiphasicPulseTrain(amp, interphase_dur, delay_dur, cathodic_first):
     npt.assert_almost_equal(pt.time[-1], stim_dur, decimal=2)
     npt.assert_equal(pt.cathodic_first, cathodic_first)
     npt.assert_equal(pt.is_charge_balanced,
-                     np.isclose(np.trapz(pt.data, pt.time)[0], 0, atol=1e-5))
+                     np.isclose(trapezoid(pt.data, pt.time)[0], 0, atol=1e-5))
 
     # Zero frequency:
     pt = BiphasicPulseTrain(0, amp, phase_dur)
@@ -88,7 +89,7 @@ def test_BiphasicPulseTrain(amp, interphase_dur, delay_dur, cathodic_first):
     # Pulse can fill the entire window (no "unique time points" error):
     pt = BiphasicPulseTrain(10, 20, 50, stim_dur=500)
     npt.assert_almost_equal(pt.time[-1], 500)
-    npt.assert_equal(np.round(np.trapz(np.abs(pt.data), pt.time)[0]), 10000)
+    npt.assert_equal(np.round(trapezoid(np.abs(pt.data), pt.time)[0]), 10000)
 
     # Specific number of pulses
     for n_pulses in [2, 4, 5]:
@@ -132,7 +133,7 @@ def test_AsymmetricBiphasicPulseTrain(amp1, amp2, interphase_dur, delay_dur,
     npt.assert_almost_equal(pt.time[-1], stim_dur, decimal=2)
     npt.assert_equal(pt.cathodic_first, cathodic_first)
     npt.assert_equal(pt.is_charge_balanced,
-                     np.isclose(np.trapz(pt.data, pt.time)[0], 0, atol=1e-5))
+                     np.isclose(trapezoid(pt.data, pt.time)[0], 0, atol=1e-5))
 
     # Zero frequency:
     pt = AsymmetricBiphasicPulseTrain(0, amp1, amp2, phase_dur1, phase_dur2)
@@ -145,7 +146,7 @@ def test_AsymmetricBiphasicPulseTrain(amp1, amp2, interphase_dur, delay_dur,
     # Pulse can fill the entire window (no "unique time points" error):
     pt = AsymmetricBiphasicPulseTrain(10, 40, 10, 20, 80, stim_dur=500)
     npt.assert_almost_equal(pt.time[-1], 500)
-    npt.assert_equal(np.round(np.trapz(np.abs(pt.data), pt.time)[0]), 8000)
+    npt.assert_equal(np.round(trapezoid(np.abs(pt.data), pt.time)[0]), 8000)
 
     # Specific number of pulses
     for n_pulses in [2, 4, 5]:
@@ -193,7 +194,7 @@ def test_BiphasicTripletTrain(amp, interphase_dur, interpulse_dur, delay_dur, ca
     npt.assert_almost_equal(pt.time[-1], stim_dur, decimal=2)
     npt.assert_equal(pt.cathodic_first, cathodic_first)
     npt.assert_equal(pt.is_charge_balanced,
-                     np.isclose(np.trapz(pt.data, pt.time)[0], 0, atol=1e-5))
+                     np.isclose(trapezoid(pt.data, pt.time)[0], 0, atol=1e-5))
 
     # Zero frequency:
     pt = BiphasicPulseTrain(0, amp, phase_dur)
@@ -206,7 +207,7 @@ def test_BiphasicTripletTrain(amp, interphase_dur, interpulse_dur, delay_dur, ca
     # Pulse can fill the entire window (no "unique time points" error):
     pt = BiphasicTripletTrain(10, 20, 100 / 6.001, stim_dur=500)
     npt.assert_almost_equal(pt.time[-1], 500)
-    npt.assert_equal(np.round(np.trapz(np.abs(pt.data), pt.time)[0]), 9998)
+    npt.assert_equal(np.round(trapezoid(np.abs(pt.data), pt.time)[0]), 9998)
 
     # Specific number of pulses
     for n_pulses in [2, 4, 5]:

--- a/pulse2percept/stimuli/tests/test_pulses.py
+++ b/pulse2percept/stimuli/tests/test_pulses.py
@@ -1,6 +1,7 @@
 import numpy as np
 import numpy.testing as npt
 import pytest
+from scipy.integrate import trapezoid
 
 from pulse2percept.stimuli import (AsymmetricBiphasicPulse, BiphasicPulse,
                                    MonophasicPulse, Stimulus)
@@ -187,7 +188,7 @@ def test_AsymmetricBiphasicPulse(amp1, amp2, interphase_dur, delay_dur,
     npt.assert_almost_equal(pulse.time[-1], min_dur, decimal=3)
     npt.assert_equal(pulse.cathodic_first, cathodic_first)
     npt.assert_equal(pulse.is_charge_balanced,
-                     np.isclose(np.trapz(pulse.data, pulse.time)[0], 0))
+                     np.isclose(trapezoid(pulse.data, pulse.time)[0], 0))
 
     # Custom stim dur:
     pulse = AsymmetricBiphasicPulse(amp1, amp2, phase_dur1, phase_dur2,
@@ -222,7 +223,7 @@ def test_AsymmetricBiphasicPulse(amp1, amp2, interphase_dur, delay_dur,
     npt.assert_almost_equal(pulse.time[0], 0)
     npt.assert_almost_equal(pulse.time[-1], min_dur, decimal=3)
     npt.assert_equal(pulse.is_charge_balanced,
-                     np.isclose(np.trapz(pulse.data, pulse.time)[0], 0))
+                     np.isclose(trapezoid(pulse.data, pulse.time)[0], 0))
 
     # If both phases have the same values, it's basically a symmetric biphasic
     # pulse:

--- a/pulse2percept/topography/base.py
+++ b/pulse2percept/topography/base.py
@@ -39,10 +39,14 @@ class CoordinateGrid:
             if self.__dict__.keys() != other.__dict__.keys():
                 return False
             for key in self.__dict__.keys():
-                if isinstance(self.__dict__[key], np.ndarray):
-                    if not np.array_equal(self.__dict__[key], other.__dict__[key]):
+                mine, theirs = self.__dict__[key], other.__dict__[key]
+                # If either side is an array, compare as arrays: `!=` between
+                # None and an array is elementwise, not a bool (this is how a
+                # 2D grid, whose z is None, compares against a 3D one).
+                if isinstance(mine, np.ndarray) or isinstance(theirs, np.ndarray):
+                    if not np.array_equal(mine, theirs):
                         return False
-                elif self.__dict__[key] != other.__dict__[key]:
+                elif mine != theirs:
                     return False
             return True
         def __hash__(self):
@@ -453,7 +457,9 @@ class Grid2D(PrettyPrint):
         """
         # avoid circular import
         from .neuropythy import NeuropythyMap
-        fig_kwargs = ['figsize']
+        # 'c' is passed to the plotting call explicitly (as `color`), so it
+        # must not also be forwarded through **kwargs:
+        fig_kwargs = ['figsize', 'c']
         if ax is None:
             ax = plt.gca()
             if ax.name != '3d':

--- a/pulse2percept/topography/base.py
+++ b/pulse2percept/topography/base.py
@@ -545,12 +545,18 @@ class Grid2D(PrettyPrint):
 
 
     
-    def __deepcopy__(self, memodict={}):
+    def __deepcopy__(self, memodict=None):
+        if memodict is None:
+            memodict = {}
         if id(self) in memodict:
             return memodict[id(self)]
         copied = copy(self)
+        # Register before recursing, and pass `memodict` down, so that shared
+        # references are copied once and reference cycles terminate:
+        memodict[id(self)] = copied
         for attr in self.__dict__:
-            copied.__setattr__(attr, deepcopy(self.__getattribute__(attr)))
+            copied.__setattr__(attr,
+                               deepcopy(self.__getattribute__(attr), memodict))
         return copied
 
     def __eq__(self, other):

--- a/pulse2percept/topography/base.py
+++ b/pulse2percept/topography/base.py
@@ -206,10 +206,12 @@ class Grid2D(PrettyPrint):
         # Build the grid from `x_range`, `y_range`. If the range is 0, make
         # sure that the number of steps is 1, because linspace(0, 0, num=5)
         # will return a 1x5 array:
-        xdiff = np.abs(np.diff(x_range))
+        # `np.diff` returns a 1-element array, so pull out the scalar: NumPy
+        # does not allow converting an array with ndim > 0 to a Python scalar.
+        xdiff = np.abs(np.diff(x_range)).item()
         nx = int(np.round(xdiff / x_step) + 1) if xdiff != 0 else 1
         self._xflat = np.linspace(*x_range, num=nx, dtype=np.float32)
-        ydiff = np.abs(np.diff(y_range))
+        ydiff = np.abs(np.diff(y_range)).item()
         ny = int(np.round(ydiff / y_step) + 1) if ydiff != 0 else 1
         self._yflat = np.linspace(*y_range, num=ny, dtype=np.float32)
         # Create the grid, flip y axis so that it increases from bottom to top:

--- a/pulse2percept/topography/tests/conftest.py
+++ b/pulse2percept/topography/tests/conftest.py
@@ -5,14 +5,14 @@ def pytest_addoption(parser):
         parser.addoption(
             "--runslow", action="store_true", default=False, help="run slow tests"
         )
-    except:
+    except Exception:
         # already added it
         pass
 
 def pytest_configure(config):
     try:
         config.addinivalue_line("markers", "slow: mark test as slow to run")
-    except:
+    except Exception:
         pass
 
 
@@ -21,7 +21,7 @@ def pytest_collection_modifyitems(config, items):
         if config.getoption("--runslow"):
             # --runslow given in cli: do not skip slow tests
             return
-    except:
+    except Exception:
         pass
     skip_slow = pytest.mark.skip(reason="need --runslow option to run")
     for item in items:

--- a/pulse2percept/topography/tests/test_base.py
+++ b/pulse2percept/topography/tests/test_base.py
@@ -81,8 +81,16 @@ class TestMapDouble(VisualFieldMap):
             "double": lambda x, y: (2*x, 2*y)
         }
 
-@pytest.mark.parametrize('vfmap', [Watson2014Map(), Polimeni2006Map(regions=['v1', 'v2', 'v3'])])
-def test_Grid2D_plot(vfmap):
+# Parametrize over a factory, not over instances: arguments to `parametrize`
+# are built at import time (on every pytest run, even when this test is
+# deselected) and are shared across invocations.
+@pytest.mark.parametrize('make_vfmap', [
+    pytest.param(Watson2014Map, id='Watson2014Map'),
+    pytest.param(lambda: Polimeni2006Map(regions=['v1', 'v2', 'v3']),
+                 id='Polimeni2006Map'),
+])
+def test_Grid2D_plot(make_vfmap):
+    vfmap = make_vfmap()
     plt.figure()
     # This test is slow
     grid = Grid2D((-20, 20), (-40, 40), step=1)

--- a/pulse2percept/topography/tests/test_base.py
+++ b/pulse2percept/topography/tests/test_base.py
@@ -218,3 +218,132 @@ def test_3D_transform():
     npt.assert_equal(grid.ret.x[-1, -1], 2)
     npt.assert_equal(grid.ret.y[-1, -1], -2)
     npt.assert_equal(grid.ret.z[-1, -1], 1)
+
+def test_Grid2D_deepcopy_memo():
+    import copy
+    grid = Grid2D((-2, 2), (-2, 2), step=1)
+
+    # Called directly, without a memo dict:
+    copied = grid.__deepcopy__()
+    npt.assert_equal(copied == grid, True)
+    npt.assert_equal(id(copied) != id(grid), True)
+
+    # The default memo must not persist between calls (a shared mutable
+    # default would leak copies from one call into the next):
+    other = Grid2D((-1, 1), (-1, 1), step=1)
+    npt.assert_equal(other.__deepcopy__() == other, True)
+
+    # An object already in the memo is returned as-is, not re-copied:
+    sentinel = 'already copied'
+    npt.assert_equal(grid.__deepcopy__({id(grid): sentinel}), sentinel)
+
+    # Copies are independent of the original:
+    copied = copy.deepcopy(grid)
+    copied.x_range = (-9, 9)
+    npt.assert_equal(grid.x_range != copied.x_range, True)
+
+
+def test_Grid2D_plot3D_validation():
+    grid = Grid2D((-2, 2), (-2, 2), step=1)
+    grid.build(Watson2014Map())
+
+    # A 2D axis cannot be used for a 3D plot:
+    _, ax2d = plt.subplots()
+    with pytest.raises(ValueError):
+        grid.plot3D(ax=ax2d)
+
+    # A 2D visual field map has nothing to plot in 3D:
+    fig = plt.figure()
+    ax3d = fig.add_subplot(111, projection='3d')
+    with pytest.raises(ValueError):
+        grid.plot3D(ax=ax3d)
+
+    # A 3D map gets past the ndim check, so style and surface are validated:
+    grid3d = Grid2D((-2, 2), (-2, 2), step=1)
+    grid3d.build(Valid3DTransform())
+    with pytest.raises(ValueError):
+        grid3d.plot3D(style='invalid', ax=ax3d)
+    with pytest.raises(ValueError):
+        grid3d.plot3D(surface='invalid', ax=ax3d)
+    plt.close('all')
+
+
+def test_CoordinateGrid():
+    from pulse2percept.topography.base import CoordinateGrid
+    x, y = np.arange(4.0), np.arange(4.0) * 2
+    grid = CoordinateGrid(x, y)
+
+    # 2D grid has no z:
+    npt.assert_equal(grid.z, None)
+    npt.assert_equal('CoordinateGrid(x=' in repr(grid), True)
+    npt.assert_equal('z=' in repr(grid), False)
+    npt.assert_equal(str(grid), repr(grid))
+
+    # 3D grid reports z:
+    grid3d = CoordinateGrid(x, y, np.ones(4))
+    npt.assert_equal('z=' in repr(grid3d), True)
+    npt.assert_equal('z=' in str(grid3d), True)
+
+    # Equality: identity, equal values, different values, different type,
+    # and a differing set of attributes:
+    npt.assert_equal(grid == grid, True)
+    npt.assert_equal(grid == CoordinateGrid(x.copy(), y.copy()), True)
+    npt.assert_equal(grid == CoordinateGrid(x, y + 1), False)
+    npt.assert_equal(grid == 'not a grid', False)
+    npt.assert_equal(grid == grid3d, False)
+
+    # Non-array attributes are compared directly:
+    npt.assert_equal(CoordinateGrid(1, 2) == CoordinateGrid(1, 2), True)
+    npt.assert_equal(CoordinateGrid(1, 2) == CoordinateGrid(1, 3), False)
+
+    # Hashable, so grids can go in sets/dicts:
+    npt.assert_equal(isinstance(hash(grid), int), True)
+    npt.assert_equal(len({grid, grid}), 1)
+
+
+class Valid3DMap(RetinalMap):
+    """A 3D retinal map, so `plot3D` can be exercised without neuropythy."""
+
+    def get_default_params(self):
+        params = super().get_default_params()
+        params.update({'ndim': 3, 'jitter_boundary': False})
+        return params
+
+    def dva_to_ret(self, x_dva, y_dva):
+        x = np.asarray(x_dva, dtype=float)
+        return x_dva, y_dva, np.ones_like(x)
+
+    def ret_to_dva(self, x_ret, y_ret, z_ret=None):
+        return x_ret, y_ret
+
+
+def test_Grid2D_plot3D():
+    grid = Grid2D((-2, 2), (-2, 2), step=1)
+    grid.build(Valid3DMap())
+
+    def new_ax():
+        fig = plt.figure()
+        return fig.add_subplot(111, projection='3d')
+
+    # Both styles (smoke tests):
+    for style in ['scatter', 'cell']:
+        npt.assert_equal(grid.plot3D(style=style, ax=new_ax()) is not None, True)
+
+    # All colorings:
+    for color_by in ['region', 'eccentricity', 'angle']:
+        npt.assert_equal(
+            grid.plot3D(color_by=color_by, ax=new_ax()) is not None, True)
+    with pytest.raises(ValueError):
+        grid.plot3D(color_by='unknown', ax=new_ax())
+
+    # An explicit color overrides `color_by`:
+    npt.assert_equal(grid.plot3D(ax=new_ax(), c='blue') is not None, True)
+
+    # Without an `ax`, a 3D axis is created. Close any open figures first:
+    # if a 3D axis is already current, `plot3D` reuses it as-is.
+    plt.close('all')
+    npt.assert_equal(grid.plot3D() is not None, True)
+    plt.close('all')
+    ax = grid.plot3D(figsize=(9, 7))
+    npt.assert_almost_equal(ax.figure.get_size_inches(), (9, 7))
+    plt.close('all')

--- a/pulse2percept/topography/tests/test_neuropythy.py
+++ b/pulse2percept/topography/tests/test_neuropythy.py
@@ -9,25 +9,57 @@ from pulse2percept.topography import NeuropythyMap
 import time
 import os
 
-@pytest.fixture(scope='session')
-def neuropythy_available():
-    """Skip the test unless the Neuropythy 'fsaverage' subject can be loaded.
+def load_fsaverage_or_skip():
+    """Load the Neuropythy 'fsaverage' subject, or skip the calling test.
 
     Loading a subject may download the Benson & Winawer (2018) dataset, which
     can fail for any number of reasons outside our control (neuropythy not
     installed, no network, moved download endpoints, no disk space, ...). All
     of them should skip the test rather than error it out.
-
-    This is a fixture rather than a ``skipif`` condition on purpose: conditions
-    are evaluated at collection time, so a ``skipif`` would hit the network on
-    every test run, including runs where these tests are all skipped anyway.
     """
     try:
-        NeuropythyMap('fsaverage')
+        return NeuropythyMap('fsaverage')
     except Exception as err:
         pytest.skip(f"Could not load the Neuropythy 'fsaverage' subject "
                     f"({type(err).__name__}: {err}). Download the Benson & "
                     f"Winawer 2018 dataset to run this test.")
+
+
+@pytest.fixture(scope='session')
+def neuropythy_available():
+    """Skip the test unless the 'fsaverage' subject can be loaded.
+
+    This is a fixture rather than a ``skipif`` condition on purpose:
+    conditions are evaluated at collection time, so a ``skipif`` would hit the
+    network on every test run, including runs where these tests are all
+    skipped anyway.
+    """
+    return load_fsaverage_or_skip()
+
+
+def test_load_fsaverage_or_skip_swallows_any_error():
+    """Any failure to load the subject must skip, not error out.
+
+    This runs without neuropythy installed and without touching the network,
+    so it guards the fixture that gates every other test in this module.
+    """
+    import pulse2percept.topography.tests.test_neuropythy as mod
+
+    for err in (ImportError('no neuropythy'), ValueError('no such subject'),
+                OSError('network is down'), RuntimeError('something else')):
+        def boom(*args, _err=err, **kwargs):
+            raise _err
+
+        orig = mod.NeuropythyMap
+        mod.NeuropythyMap = boom
+        try:
+            with pytest.raises(pytest.skip.Exception) as excinfo:
+                load_fsaverage_or_skip()
+            # The skip reason names the underlying error, so a future
+            # breakage is diagnosable straight from the CI log:
+            npt.assert_equal(type(err).__name__ in str(excinfo.value), True)
+        finally:
+            mod.NeuropythyMap = orig
 
 
 # use pytest.mark.slow because all neuropythy tests

--- a/pulse2percept/topography/tests/test_neuropythy.py
+++ b/pulse2percept/topography/tests/test_neuropythy.py
@@ -9,12 +9,26 @@ from pulse2percept.topography import NeuropythyMap
 import time
 import os
 
-def _is_neuropythy_not_available():
+@pytest.fixture(scope='session')
+def neuropythy_available():
+    """Skip the test unless the Neuropythy 'fsaverage' subject can be loaded.
+
+    Loading a subject may download the Benson & Winawer (2018) dataset, which
+    can fail for any number of reasons outside our control (neuropythy not
+    installed, no network, moved download endpoints, no disk space, ...). All
+    of them should skip the test rather than error it out.
+
+    This is a fixture rather than a ``skipif`` condition on purpose: conditions
+    are evaluated at collection time, so a ``skipif`` would hit the network on
+    every test run, including runs where these tests are all skipped anyway.
+    """
     try:
         NeuropythyMap('fsaverage')
-        return False
-    except ValueError:
-        return True
+    except Exception as err:
+        pytest.skip(f"Could not load the Neuropythy 'fsaverage' subject "
+                    f"({type(err).__name__}: {err}). Download the Benson & "
+                    f"Winawer 2018 dataset to run this test.")
+
 
 # use pytest.mark.slow because all neuropythy tests
 # take a long time to run. This way, they will be skipped
@@ -22,11 +36,7 @@ def _is_neuropythy_not_available():
 # done either from the root p2p directory or from this tests
 # folder.
 @pytest.mark.slow
-@pytest.mark.skipif(
-    _is_neuropythy_not_available(),
-    reason='Download Neuropythy Benson & Winawer dataset to run this test'
-)
-def test_subject_parsing():
+def test_subject_parsing(neuropythy_available):
     import neuropythy as ny
     # random subject shouldn't download 
     start = time.time()
@@ -59,11 +69,7 @@ def test_subject_parsing():
 @pytest.mark.slow()
 @pytest.mark.parametrize('regions', [['v1'], ['v1', 'v3'], ['v1', 'v2', 'v3']])
 @pytest.mark.parametrize('jitter_boundary', [True, False])
-@pytest.mark.skipif(
-    _is_neuropythy_not_available(),
-    reason='Download Neuropythy Benson & Winawer dataset to run this test'
-)
-def test_dva_to_cortex(regions, jitter_boundary):
+def test_dva_to_cortex(regions, jitter_boundary, neuropythy_available):
     nmap = NeuropythyMap('fsaverage', regions=regions, jitter_boundary=jitter_boundary)
     npt.assert_equal(nmap.predicted_retinotopy is not None, True)
     npt.assert_equal(nmap.region_meshes is not None, True)
@@ -144,11 +150,7 @@ def test_dva_to_cortex(regions, jitter_boundary):
 
 
 @pytest.mark.slow
-@pytest.mark.skipif(
-    _is_neuropythy_not_available(),
-    reason='Download Neuropythy Benson & Winawer dataset to run this test'
-)
-def test_Neuralink_from_neuropythy():
+def test_Neuralink_from_neuropythy(neuropythy_available):
     nmap = NeuropythyMap('fsaverage', regions=['v1'], jitter_boundary=False)
     nlink = Neuralink.from_neuropythy(nmap, locs=np.array([[0, 0], [3, 3], [-2, -2]]))
     # 0, 0 should be nan so it wont make one
@@ -198,11 +200,7 @@ def test_Neuralink_from_neuropythy():
             
 
 @pytest.mark.slow
-@pytest.mark.skipif(
-    _is_neuropythy_not_available(),
-    reason='Download Neuropythy Benson & Winawer dataset to run this test'
-)
-def test_ndim_mixup():
+def test_ndim_mixup(neuropythy_available):
     nmap = NeuropythyMap('fsaverage')
     model = BeyelerScoreboard(vfmap=nmap)
     npt.assert_equal(2 in model.ndim, True)
@@ -212,11 +210,7 @@ def test_ndim_mixup():
 
 
 @pytest.mark.slow
-@pytest.mark.skipif(
-    _is_neuropythy_not_available(),
-    reason='Download Neuropythy Benson & Winawer dataset to run this test'
-)
-def test_neuropythy_scoreboard():
+def test_neuropythy_scoreboard(neuropythy_available):
     nmap = NeuropythyMap('fsaverage')
     model = ScoreboardModel(rho=800, xystep=.25, vfmap=nmap).build()
     implant = Neuralink.from_neuropythy(nmap, xrange=(-3, 3), yrange=(-3, 3))
@@ -248,11 +242,7 @@ def test_neuropythy_scoreboard():
 
 @pytest.mark.slow()
 @pytest.mark.parametrize('regions', [['v1'], ['v1', 'v3'], ['v1', 'v2', 'v3']])
-@pytest.mark.skipif(
-    _is_neuropythy_not_available(),
-    reason='Download Neuropythy Benson & Winawer dataset to run this test'
-)
-def test_cortex_to_dva(regions):
+def test_cortex_to_dva(regions, neuropythy_available):
     nmap = NeuropythyMap('fsaverage', regions=regions, jitter_boundary=True)
     npt.assert_equal(nmap.predicted_retinotopy is not None, True)
     npt.assert_equal(nmap.region_meshes is not None, True)

--- a/pulse2percept/utils/base.py
+++ b/pulse2percept/utils/base.py
@@ -8,6 +8,7 @@
 import numpy as np
 import sys
 import abc
+from scipy.integrate import trapezoid
 from scipy.special import factorial
 from collections import OrderedDict as ODict
 from functools import wraps
@@ -47,8 +48,6 @@ class PrettyPrint(object, metaclass=abc.ABCMeta):
 
     def __repr__(self):
         """Pretty print class as: ClassName(arg1=val1, arg2=val2)"""
-        # Shorten NumPy array output:
-        np.set_printoptions(precision=3, threshold=7, edgeitems=3)
         # Line width:
         lwidth = 60
         # Sort list of parameters alphabetically:
@@ -66,8 +65,12 @@ class PrettyPrint(object, metaclass=abc.ABCMeta):
                 sparam = key + '=\'' + str(val) + '\', '
             else:
                 if isinstance(val, np.ndarray):
-                    # Print NumPy arrays without line breaks:
-                    strobj = np.array2string(val).replace('\n', ',')
+                    # Print NumPy arrays without line breaks. Pass the
+                    # shortening options to `array2string` rather than calling
+                    # `np.set_printoptions`, which would change how arrays
+                    # print globally for anyone who reprs a p2p object.
+                    strobj = np.array2string(val, precision=3, threshold=7,
+                                             edgeitems=3).replace('\n', ',')
                     # If still too long, show shape:
                     if len(strobj) > lwidth - lindent:
                         strobj = f'<{str(val.shape)} np.ndarray>'
@@ -305,7 +308,7 @@ def gamma(n, tau, tsample, tol=0.01):
     y /= (tau * factorial(n - 1))
 
     # Normalize to unit area
-    y /= np.trapz(np.abs(y), dx=tsample)
+    y /= trapezoid(np.abs(y), dx=tsample)
 
     # Cut off tail where values are smaller than `tol`.
     # Make sure to start search on the right-hand side of the peak.

--- a/pulse2percept/utils/deprecation.py
+++ b/pulse2percept/utils/deprecation.py
@@ -102,7 +102,9 @@ class deprecated:
             def deprecated_attribute_(self):
                 ...
         """
-        msg = self._get_message(f"Property {prop.__name__}")
+        # Use the getter's name, not `prop.__name__`: properties only grew a
+        # `__name__` attribute in Python 3.13.
+        msg = self._get_message(f"Property {prop.fget.__name__}")
 
         @property
         def wrapped(*args, **kwargs):

--- a/pulse2percept/utils/tests/test_base.py
+++ b/pulse2percept/utils/tests/test_base.py
@@ -2,6 +2,7 @@ import numpy as np
 import copy
 import pytest
 import numpy.testing as npt
+from scipy.integrate import trapezoid
 
 from pulse2percept.utils import (Frozen, FreezeError, PrettyPrint, Data,
                                  bijective26_name, cached, gamma)
@@ -157,7 +158,7 @@ def test_gamma():
                 npt.assert_equal(g[0], 0.0)
 
             # Make sure area under the curve is normalized
-            npt.assert_almost_equal(np.trapz(np.abs(g), dx=tsample), 1.0,
+            npt.assert_almost_equal(trapezoid(np.abs(g), dx=tsample), 1.0,
                                     decimal=2)
 
             # Make sure peak sits correctly

--- a/pulse2percept/utils/tests/test_convolution.py
+++ b/pulse2percept/utils/tests/test_convolution.py
@@ -11,12 +11,16 @@ from importlib import reload
 @pytest.mark.parametrize('method', ('sparse', 'fft'))
 def test_conv(mode, method):
     reload(convolution)
-    # time vector for stimulus (long)
+    # Time vector for stimulus. `np.convolve` below is a direct O(n*m)
+    # convolution and dominates the runtime of this test, so keep the sampling
+    # coarse: this still exercises every code path (long, sparse data with a
+    # much shorter kernel), it just doesn't spend 11 billion multiply-adds
+    # computing the expected value.
     stim_dur = 0.5  # seconds
-    tsample = 0.001 / 1000
+    tsample = 0.01 / 1000
     t = np.arange(0, stim_dur, tsample)
 
-    # stimulus (10 Hz anondic and cathodic pulse train)
+    # stimulus (100 Hz anodic and cathodic pulse train)
     stim = np.zeros_like(t)
     stim[::1000] = 1
     stim[100::1000] = -1

--- a/pulse2percept/utils/tests/test_deprecation.py
+++ b/pulse2percept/utils/tests/test_deprecation.py
@@ -47,3 +47,41 @@ def test_is_deprecated():
     npt.assert_equal(is_deprecated(MockClass3.__init__), True)
     npt.assert_equal(is_deprecated(MockClass4.__init__), False)
     npt.assert_equal(is_deprecated(mock_function), True)
+
+
+class MockClassProperty:
+
+    @deprecated(deprecated_version=0.5, alt_func='new_attribute')
+    @property
+    def deprecated_attribute(self):
+        """Original docstring."""
+        return 42
+
+
+def test_deprecated_property():
+    # A deprecated property warns on access, but still returns its value:
+    obj = MockClassProperty()
+    assert_warns_msg(DeprecationWarning, lambda: obj.deprecated_attribute,
+                     'since version 0.5')
+    npt.assert_equal(obj.deprecated_attribute, 42)
+
+    # The deprecation directive is prepended to the original docstring:
+    doc = MockClassProperty.deprecated_attribute.__doc__
+    npt.assert_equal('.. deprecated:: 0.5' in doc, True)
+    npt.assert_equal('Use ``new_attribute`` instead' in doc, True)
+    npt.assert_equal('Original docstring.' in doc, True)
+
+
+def test_deprecated_update_doc():
+    # Without an explicit message, a generic one is generated:
+    doc = deprecated(deprecated_version=0.6)._update_doc('Original.')
+    npt.assert_equal('.. deprecated:: 0.6' in doc, True)
+    npt.assert_equal('This feature is deprecated' in doc, True)
+    npt.assert_equal('Original.' in doc, True)
+    # An empty original docstring is fine:
+    npt.assert_equal('Original.' in deprecated()._update_doc(''), False)
+
+
+def test_is_deprecated_without_closure():
+    # A function with no closure cells at all (`__closure__` is None):
+    npt.assert_equal(is_deprecated(lambda: None), False)

--- a/pulse2percept/utils/tests/test_deprecation.py
+++ b/pulse2percept/utils/tests/test_deprecation.py
@@ -65,6 +65,11 @@ def test_deprecated_property():
                      'since version 0.5')
     npt.assert_equal(obj.deprecated_attribute, 42)
 
+    # The warning names the property. `property` objects only have a
+    # `__name__` on Python 3.13+, so the name has to come from the getter:
+    assert_warns_msg(DeprecationWarning, lambda: obj.deprecated_attribute,
+                     'Property deprecated_attribute is deprecated')
+
     # The deprecation directive is prepended to the original docstring:
     doc = MockClassProperty.deprecated_attribute.__doc__
     npt.assert_equal('.. deprecated:: 0.5' in doc, True)

--- a/pulse2percept/viz/argus.py
+++ b/pulse2percept/viz/argus.py
@@ -2,6 +2,7 @@
    :py:class:`~pulse2percept.viz.plot_argus_simulated_phosphenes`"""
 import numpy as np
 import pandas as pd
+from os.path import dirname, join
 from skimage.io import imread
 from skimage.measure import moments as img_moments
 from skimage.transform import (estimate_transform as img_transform,
@@ -9,7 +10,6 @@ from skimage.transform import (estimate_transform as img_transform,
 
 import matplotlib.pyplot as plt
 from matplotlib import patches
-from pkg_resources import resource_filename
 
 from ..implants import ArgusI, ArgusII
 from ..models import AxonMapModel
@@ -17,8 +17,8 @@ from ..utils import scale_image, center_image
 from ..utils.constants import ZORDER
 from ..topography import Watson2014Map
 
-PATH_ARGUS1 = resource_filename('pulse2percept', 'viz/data/argus1.png')
-PATH_ARGUS2 = resource_filename('pulse2percept', 'viz/data/argus2.png')
+PATH_ARGUS1 = join(dirname(__file__), 'data', 'argus1.png')
+PATH_ARGUS2 = join(dirname(__file__), 'data', 'argus2.png')
 # Pixel locations of electrodes (Argus I: A1-4, B1-4, ...; Argus II: A1-10,
 # B1-10, ...) in the above images:
 PX_ARGUS1 = np.array([

--- a/pulse2percept/viz/base.py
+++ b/pulse2percept/viz/base.py
@@ -103,8 +103,8 @@ def correlation_matrix(X, cols=None, dropna=True, ax=None):
     # Calculate column-wise correlation:
     corr = X.corr()
     if dropna:
-        corr.dropna(how='all', axis=0, inplace=True)
-        corr.dropna(how='all', axis=1, inplace=True)
+        corr = corr.dropna(how='all', axis=0)
+        corr = corr.dropna(how='all', axis=1)
     if ax is None:
         ax = plt.gca()
     sns.heatmap(corr, mask=np.triu(np.ones(corr.shape), k=1).astype(bool),

--- a/pulse2percept/viz/tests/test_argus.py
+++ b/pulse2percept/viz/tests/test_argus.py
@@ -54,8 +54,12 @@ def test_plot_argus_phosphenes():
     plot_argus_phosphenes(df, ax=ax)
 
 
-@pytest.mark.parametrize('implant', (ArgusI(), ArgusII()))
-def test_plot_argus_simulated_phosphenes(implant):
+# Parametrize over the class, not over instances: arguments to `parametrize`
+# are built at import time and shared across invocations, so mutating one
+# (as this test does with `implant.stim`) would leak state between tests.
+@pytest.mark.parametrize('ImplantType', (ArgusI, ArgusII))
+def test_plot_argus_simulated_phosphenes(ImplantType):
+    implant = ImplantType()
     implant.stim = {'A1': [1, 0, 0], 'B2': [0, 1, 0], 'C3': [0, 0, 1]}
     percepts = ScoreboardModel().build().predict_percept(implant)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,8 +35,7 @@ dependencies = [
     "matplotlib>=3.0.2",
     "imageio-ffmpeg>=0.4",
     "pandas",
-    "joblib>=0.11",
-    "setuptools>=65"
+    "joblib>=0.11"
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ classifiers = [
 requires-python = ">=3.10"
 dependencies = [
     "numpy>=1.21,<3",
-    "scipy>=1.0.1",
+    "scipy>=1.6",
     "scikit-image>=0.14",
     "matplotlib>=3.0.2",
     "imageio-ffmpeg>=0.4",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,15 @@ colab = [
     "numpy>=2,<3"
 ]
 
+[tool.coverage.run]
+# Measure coverage of the library, not of the test suite itself: test modules
+# that are skipped (e.g. because an optional dataset isn't available) would
+# otherwise report as large blocks of uncovered code.
+omit = [
+    "*/tests/*",
+    "*/conftest.py",
+]
+
 [tool.setuptools]
 package-dir = {"" = "."}
 include-package-data = true


### PR DESCRIPTION
Restores a green CI after several dependencies moved underneath us, then fixes the latent bugs that surfaced along the way:
- [x] Pandas no longer likes `inplace=True`
- [x] Several NumPy issues: `np.trapz` is obsolete, arrays not converted to True/False, etc.
- [x] Several anti-patterns re:deepcopy, memodict, pkg_resouces
- [x] Neuropythy import fails with different HTTP code
- [x] Expensive allocations inside pytest's `parametrize` slowed down our tests
- [x] `Model.__deepcopy__` silently reset every customized parameter to its default
- [x] `find_threshold` crashed for any time-less stimulus
- [x] `Grid2D.plot3D(c=...)` always raised `TypeError`
- [x] `CoordinateGrid.__eq__` raised an error instead of returning `False` when comparing a 2D grid against a 3D one
- [x] Tests spent something like 78% of total runtime on `np.convolve`, repeated per parametrization
- [x] macOS wheel had a malformatted config var that pinned the wrong runner version