### PR TITLE
[TST] Test p2p install in real Colab runtime

### DIFF
--- a/.github/scripts/check_install.py
+++ b/.github/scripts/check_install.py
@@ -1,0 +1,222 @@
+#!/usr/bin/env python3
+"""Verify an *installed* pulse2percept, beyond what `import pulse2percept` proves.
+
+Run this from a directory that is not the repo root. It answers four things a
+plain import does not:
+
+1. Are we testing the installed package, or did a source checkout on sys.path
+   shadow it? (Running a smoke test from the repo root silently tests the
+   checkout, which has no compiled extensions in it.)
+2. Did every C extension load as a real binary, or did something quietly fall
+   back to pure Python? A broken extension that degrades silently is worse
+   than one that raises, because the install looks healthy.
+3. Do the installed dependencies satisfy the versions the distribution
+   metadata asks for?
+4. Does a model actually build?
+
+Usage:
+    python check_install.py [--source-root /path/to/repo]
+
+--source-root is optional. When given, the set of C extensions to expect is
+derived from the .pyx files in that checkout, so adding a new .pyx extends
+this check automatically rather than needing a hardcoded list updated.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib
+import importlib.util
+import sys
+from importlib import metadata
+from importlib.machinery import EXTENSION_SUFFIXES
+from pathlib import Path
+
+PKG = "pulse2percept"
+
+# PyPI name -> import name, for the few that differ.
+IMPORT_NAME_OVERRIDES = {
+    "scikit-image": "skimage",
+    "pillow": "PIL",
+}
+
+
+def import_name(dist_name: str) -> str:
+    return IMPORT_NAME_OVERRIDES.get(dist_name, dist_name.replace("-", "_"))
+
+
+def check_not_shadowed(source_root: Path | None) -> list[str]:
+    """Confirm we resolved the installed package, not a source checkout."""
+    spec = importlib.util.find_spec(PKG)
+    if spec is None or not spec.origin:
+        return [f"{PKG} is not importable at all"]
+
+    origin = Path(spec.origin).resolve()
+    print(f"{PKG} resolves to: {origin}")
+
+    if source_root is not None:
+        root = Path(source_root).resolve()
+        if root in origin.parents:
+            return [
+                f"{PKG} resolved to the source checkout at {origin}, not the "
+                f"installed package. Run this from outside {root} -- as "
+                "written the test never touches what was installed."
+            ]
+
+    if not any(part in ("site-packages", "dist-packages") for part in origin.parts):
+        # Not fatal on its own: an editable install legitimately resolves
+        # outside site-packages. The source-root check above is the one that
+        # catches the real mistake.
+        print(f"note: {origin} is outside site-packages (editable install?)")
+    return []
+
+
+def expected_extensions(source_root: Path | None) -> list[str]:
+    """Module names for every Cython extension, derived from the .pyx files."""
+    if source_root is None:
+        return []
+    root = Path(source_root).resolve()
+    modules = []
+    for pyx in sorted(root.glob(f"{PKG}/**/*.pyx")):
+        modules.append(".".join(pyx.relative_to(root).with_suffix("").parts))
+    return modules
+
+
+def check_extensions(modules: list[str]) -> list[str]:
+    """Every extension must load, and must load from a compiled binary."""
+    failures = []
+    if not modules:
+        print("\nNo .pyx sources given, skipping the compiled-extension check.")
+        return failures
+
+    print(f"\nChecking {len(modules)} compiled extension(s):")
+    for name in modules:
+        try:
+            mod = importlib.import_module(name)
+        except Exception as exc:  # noqa: BLE001 - want the reason in the log
+            failures.append(f"{name}: failed to import ({exc.__class__.__name__}: {exc})")
+            print(f"  {name}: FAILED to import")
+            continue
+
+        origin = getattr(mod, "__file__", "") or ""
+        if not origin.endswith(tuple(EXTENSION_SUFFIXES)):
+            failures.append(
+                f"{name}: loaded from {origin!r}, which is not a compiled "
+                "extension. A pure-Python fallback is masking a broken build."
+            )
+            print(f"  {name}: NOT COMPILED ({origin})")
+        else:
+            print(f"  {name}: ok ({Path(origin).name})")
+    return failures
+
+
+def check_dependencies() -> list[str]:
+    """Every declared runtime dep must be importable and satisfy its specifier."""
+    from packaging.requirements import Requirement
+    from packaging.version import InvalidVersion, Version
+
+    try:
+        dist = metadata.distribution(PKG)
+    except metadata.PackageNotFoundError:
+        return [f"{PKG} is not installed in this environment"]
+
+    failures = []
+    print("\nRuntime dependencies:")
+    for line in dist.requires or []:
+        req = Requirement(line)
+        # Extras are not runtime requirements of the base install.
+        if req.marker and not req.marker.evaluate({"extra": ""}):
+            continue
+
+        module = import_name(req.name)
+        try:
+            importlib.import_module(module)
+        except Exception as exc:  # noqa: BLE001
+            failures.append(f"{req.name}: import {module!r} failed ({exc})")
+            print(f"  {req.name}: IMPORT FAILED")
+            continue
+
+        # Trust installed metadata over a module's __version__ attribute; the
+        # two can disagree, and metadata is what pip resolved against.
+        try:
+            version = metadata.version(req.name)
+        except metadata.PackageNotFoundError:
+            print(f"  {req.name}: imported, no distribution metadata to check")
+            continue
+
+        if not req.specifier:
+            print(f"  {req.name} == {version}")
+            continue
+
+        try:
+            ok = Version(version) in req.specifier
+        except InvalidVersion:
+            print(f"  {req.name} == {version} (unparseable, not checked)")
+            continue
+
+        print(f"  {req.name} == {version} {'ok' if ok else 'VIOLATES'} {req.specifier}")
+        if not ok:
+            failures.append(f"{req.name}=={version} does not satisfy {req.specifier}")
+    return failures
+
+
+def check_model_builds() -> list[str]:
+    """The install is only useful if a model actually builds."""
+    print("\nBuilding a model:")
+    try:
+        from pulse2percept.implants import ArgusII
+        from pulse2percept.models import ScoreboardModel
+
+        model = ScoreboardModel(xrange=(-4, 4), yrange=(-4, 4), xystep=1).build()
+        implant = ArgusII()
+        implant.stim = {e: 1 for e in ("A1", "F10")}
+        percept = model.predict_percept(implant)
+        if percept is None or percept.data.size == 0:
+            return ["ScoreboardModel produced an empty percept"]
+        print(f"  ScoreboardModel -> percept {percept.data.shape}, ok")
+    except Exception as exc:  # noqa: BLE001
+        return [f"model build failed ({exc.__class__.__name__}: {exc})"]
+    return []
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--source-root",
+        default=None,
+        help="repo checkout, used to detect shadowing and to find .pyx files",
+    )
+    args = parser.parse_args()
+    source_root = Path(args.source_root) if args.source_root else None
+
+    print(f"Python: {sys.version}")
+    print(f"cwd   : {Path.cwd()}")
+
+    failures = check_not_shadowed(source_root)
+    if failures:
+        # Everything downstream would be testing the wrong package.
+        print("\nFAILED:")
+        for failure in failures:
+            print(f"  - {failure}")
+        return 1
+
+    import pulse2percept
+
+    print(f"{PKG} version: {getattr(pulse2percept, '__version__', 'unknown')}")
+
+    failures += check_extensions(expected_extensions(source_root))
+    failures += check_dependencies()
+    failures += check_model_builds()
+
+    if failures:
+        print("\nFAILED:")
+        for failure in failures:
+            print(f"  - {failure}")
+        return 1
+
+    print("\nAll install checks passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/colab_smoke.py
+++ b/.github/scripts/colab_smoke.py
@@ -1,0 +1,223 @@
+#!/usr/bin/env python3
+"""Install pulse2percept inside the real Colab runtime and check what it broke.
+
+This runs *inside* Google's published Colab image (see colab.yml). It is
+Python rather than shell so it can be run and debugged locally against the
+very same image a user gets in a notebook:
+
+    docker run --rm -v "$PWD:/repo:ro" -w /tmp \
+        us-docker.pkg.dev/colab-images/public/cpu-runtime:latest \
+        python3 /repo/.github/scripts/colab_smoke.py pulse2percept \
+            --source-root /repo
+
+The working directory must not be the checkout: from there a source tree
+shadows the installed package on sys.path and the whole run tests the wrong
+thing (quietly).
+
+Why this exists
+---------------
+An install that fails outright is the easy case, and the regular test matrix
+already catches it. The failure users actually hit in Colab is quieter: pip
+resolves a dependency, upgrades numpy or scipy, and the TensorFlow / JAX /
+PyTorch that Colab preinstalled against the old ABI stops importing -- or the
+notebook starts demanding a runtime restart. A clean virtualenv has nothing
+preinstalled, so it structurally cannot reproduce that. So we install into the
+real thing and compare `pip freeze` either side.
+
+Packages that appear are fine. Packages that *change version* are not.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+
+def canonicalize(name: str) -> str:
+    """Normalize a distribution name (PEP 503)."""
+    return re.sub(r"[-_.]+", "-", name).strip().lower()
+
+
+def run(cmd: list[str], *, check: bool = True) -> subprocess.CompletedProcess:
+    """Run a command, echoing it so CI logs show exactly what happened."""
+    print(f"\n$ {' '.join(cmd)}", flush=True)
+    return subprocess.run(cmd, check=check, text=True)
+
+
+def pip(*args: str, capture: bool = False) -> str:
+    """Invoke pip for the interpreter running this script."""
+    cmd = [sys.executable, "-m", "pip", *args]
+    if capture:
+        out = subprocess.run(cmd, check=True, text=True, capture_output=True)
+        return out.stdout
+    run(cmd)
+    return ""
+
+
+def freeze() -> dict[str, str]:
+    """Snapshot the environment as {canonical name: version}."""
+    installed: dict[str, str] = {}
+    for line in pip("freeze", "--all", capture=True).splitlines():
+        line = line.strip()
+        # Skip blanks, comments, editable installs and bare VCS/URL entries
+        # that carry no comparable version.
+        if not line or line.startswith(("#", "-e ", "-")):
+            continue
+        if "==" in line:
+            name, _, version = line.partition("==")
+        elif " @ " in line:
+            name, _, version = line.partition(" @ ")
+        else:
+            continue
+        installed[canonicalize(name)] = version.strip()
+    return installed
+
+
+def pip_check() -> set[str]:
+    """Whatever `pip check` complains about, as a set of lines.
+
+    Colab's image routinely ships with dependency conflicts of its own, so an
+    absolute `pip check` result is not a signal. Only conflicts that appear
+    *because of* our install are.
+    """
+    out = subprocess.run(
+        [sys.executable, "-m", "pip", "check"], text=True, capture_output=True
+    )
+    if out.returncode == 0:
+        # Exit 0 means no conflicts; the stdout is a success message, not a
+        # finding, and must not end up in the diff as a phantom conflict.
+        return set()
+    return {line.strip() for line in out.stdout.splitlines() if line.strip()}
+
+
+def report(title: str, rows: list[str]) -> None:
+    print(f"\n{title}")
+    print("-" * len(title))
+    for row in rows:
+        print(f"  {row}")
+    if not rows:
+        print("  (none)")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "spec",
+        help='what to hand pip, e.g. "pulse2percept" or "git+https://…@<sha>"',
+    )
+    parser.add_argument(
+        "--allow-change",
+        action="append",
+        default=[],
+        metavar="NAME",
+        help="tolerate a version change in this package (repeatable)",
+    )
+    parser.add_argument(
+        "--source-root",
+        default=None,
+        help="repo checkout, used to work out which C extensions to expect",
+    )
+    parser.add_argument(
+        "--require-wheel",
+        action="store_true",
+        help="fail unless a prebuilt wheel exists for this interpreter",
+    )
+    args = parser.parse_args()
+    tolerated = {canonicalize(n) for n in args.allow_change}
+
+    print(f"Python     : {sys.version}")
+    print(f"Executable : {sys.executable}")
+
+    before = freeze()
+    conflicts_before = pip_check()
+    print(f"\nColab ships {len(before)} packages before we touch anything.")
+    if conflicts_before:
+        print(f"({len(conflicts_before)} pre-existing pip conflicts, not ours)")
+
+    # No wheel for Colab's interpreter means every user pays for a source
+    # build: minutes of compiling, and a hard failure if the image ever stops
+    # shipping a compiler. Asking pip resolves this against Colab's *actual*
+    # Python and platform, so nothing here needs updating when Colab moves.
+    if args.require_wheel:
+        probe = run(
+            [
+                sys.executable, "-m", "pip", "install",
+                "--only-binary=:all:", "--dry-run", "--quiet", args.spec,
+            ],
+            check=False,
+        )
+        if probe.returncode != 0:
+            print(
+                f"\nFAILED:\n  - no prebuilt wheel for {args.spec} on this "
+                f"interpreter ({sys.implementation.cache_tag}). Colab users "
+                "would fall back to building from source."
+            )
+            return 1
+        print("A prebuilt wheel is available for Colab's interpreter.")
+
+    # Install exactly the way a notebook user would: plain pip, build
+    # isolation left on. Deliberately *not* --no-build-isolation, which would
+    # test a path no Colab user is on.
+    install = run(
+        [sys.executable, "-m", "pip", "install", "--root-user-action=ignore", args.spec],
+        check=False,
+    )
+    if install.returncode != 0:
+        print(
+            f"\nFAILED:\n  - `pip install {args.spec}` failed in the Colab "
+            "runtime (pip's own error is above). This is what a notebook user "
+            "would see."
+        )
+        return 1
+
+    after = freeze()
+
+    changed = [
+        f"{name}: {before[name]} -> {after[name]}"
+        for name in sorted(before.keys() & after.keys())
+        if before[name] != after[name] and name not in tolerated
+    ]
+    removed = sorted(before.keys() - after.keys() - tolerated)
+    added = sorted(after.keys() - before.keys())
+
+    report("Added by the install (expected)", added)
+    report("Changed versions (must be empty)", changed)
+    report("Removed (must be empty)", removed)
+
+    # Only conflicts we introduced count; Colab's own are not our problem.
+    new_conflicts = sorted(pip_check() - conflicts_before)
+    report("New dependency conflicts (must be empty)", new_conflicts)
+
+    problems = []
+    if changed:
+        problems.append(
+            f"{len(changed)} package(s) Colab preinstalled changed version. "
+            "This is what breaks TensorFlow/JAX/PyTorch in a notebook."
+        )
+    if removed:
+        problems.append(f"{len(removed)} package(s) were removed: {removed}")
+    if new_conflicts:
+        problems.append(f"{len(new_conflicts)} new dependency conflict(s).")
+
+    if problems:
+        print("\nFAILED:")
+        for problem in problems:
+            print(f"  - {problem}")
+        return 1
+
+    print("\nInstall left Colab's preinstalled packages untouched.")
+
+    # Hand off to the installed-package verifier, found next to this file so
+    # the mount point is not baked in. It is invoked as a script path (not
+    # `python -c`), which keeps the current directory off sys.path.
+    verify = [sys.executable, str(Path(__file__).resolve().parent / "check_install.py")]
+    if args.source_root:
+        verify += ["--source-root", args.source_root]
+    return run(verify, check=False).returncode
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/colab.yml
+++ b/.github/workflows/colab.yml
@@ -37,6 +37,10 @@ jobs:
   colab:
     name: Colab runtime (${{ matrix.source }})
     runs-on: ubuntu-latest
+    # The image is ~7 GB to pull and the install is quick; anything past this
+    # means something is wedged. The default is 6 hours, which leaves a PR
+    # showing "checks haven't completed yet" for most of a day.
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
@@ -97,10 +101,16 @@ jobs:
         run: |
           set -euo pipefail
           docker pull "$COLAB_IMAGE"
+          # Every `docker run` here must override the entrypoint. The image
+          # ships ENTRYPOINT ["/datalab/run.sh"], which boots the Colab
+          # Jupyter server and ignores whatever command follows it -- so
+          # without --entrypoint the container serves notebooks until the job
+          # times out and no step ever runs.
+          #
           # Record which Colab build this was, so a failure months from now is
           # still traceable to a specific runtime.
-          docker run --rm "$COLAB_IMAGE" \
-            bash -lc 'echo "$COLAB_RELEASE_TAG"; python3 --version'
+          docker run --rm --entrypoint bash "$COLAB_IMAGE" \
+            -lc 'echo "$COLAB_RELEASE_TAG"; python3 --version'
 
       - name: Install into Colab and check what moved
         # The repo is mounted read-only somewhere that is not the working
@@ -111,10 +121,11 @@ jobs:
         run: |
           set -euo pipefail
           docker run --rm \
+            --entrypoint python3 \
             -v "$GITHUB_WORKSPACE:/repo:ro" \
             -w /tmp \
             "$COLAB_IMAGE" \
-            python3 /repo/.github/scripts/colab_smoke.py \
+            /repo/.github/scripts/colab_smoke.py \
               "${{ steps.spec.outputs.spec }}" \
               --source-root /repo \
               ${{ matrix.source == 'pypi' && '--require-wheel' || '' }}
@@ -128,6 +139,7 @@ jobs:
     # never exercises this.
     name: NumPy ABI py${{ matrix.py }} on NumPy ${{ matrix.numpy }}
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/colab.yml
+++ b/.github/workflows/colab.yml
@@ -1,0 +1,190 @@
+name: Colab
+
+# Colab is where most people first run pulse2percept, and it is the one
+# environment we do not control: it arrives with numpy, scipy, pandas,
+# TensorFlow, JAX and PyTorch already installed, and `!pip install
+# pulse2percept` has to slot into that without disturbing any of it.
+#
+# Rather than approximate that with a pinned requirements file that nobody
+# will remember to refresh, this runs against the runtime image Google
+# publishes for the "connect to a local runtime" flow. It is public, needs no
+# authentication, costs nothing beyond a normal ubuntu runner, and Google
+# rebuilds it as Colab changes -- so the environment under test tracks Colab
+# on its own.
+
+on:
+  push:
+    branches: [ master, torch ]
+  pull_request:
+    branches: [ master, torch ]
+  schedule:
+    # Daily drift check: catches upstream releases breaking us even when
+    # nothing here changed.
+    - cron: '0 6 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: colab-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  COLAB_IMAGE: us-docker.pkg.dev/colab-images/public/cpu-runtime:latest
+
+jobs:
+  colab:
+    name: Colab runtime (${{ matrix.source }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # On a PR, test the code under review. On a schedule, also test the
+        # released package, since `!pip install pulse2percept` is what most
+        # notebooks actually run and it can break without anyone pushing.
+        source: ${{ (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && fromJSON('["ref","pypi"]') || fromJSON('["ref"]') }}
+
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a # v2.13.1
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+
+      - name: Free up disk space
+        # The image is ~6.8 GB compressed and ~15 GB unpacked; an
+        # ubuntu-latest runner starts with roughly 14 GB free. Dropping the
+        # preinstalled toolchains we never use buys about 20 GB more, which
+        # is comfortably enough. Done inline rather than with a third-party
+        # action to avoid widening the supply chain this repo scans.
+        run: |
+          set -euo pipefail
+          echo "Before:"
+          df -h /
+          sudo rm -rf \
+            /usr/share/dotnet \
+            /usr/local/lib/android \
+            /opt/ghc \
+            /usr/local/.ghcup \
+            /opt/hostedtoolcache/CodeQL
+          sudo docker image prune --all --force
+          echo "After:"
+          df -h /
+
+      - name: Work out what to install
+        id: spec
+        env:
+          SOURCE: ${{ matrix.source }}
+          # On a pull request these point at the PR head; everywhere else
+          # (push, schedule) they fall back to this repo at the current sha,
+          # which on a scheduled run is master.
+          REPO: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
+          SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: |
+          set -euo pipefail
+          if [ "$SOURCE" = "pypi" ]; then
+            spec="pulse2percept"
+          else
+            spec="git+https://github.com/${REPO}@${SHA}"
+          fi
+          echo "spec=${spec}" >> "$GITHUB_OUTPUT"
+          echo "Will install: ${spec}"
+
+      - name: Pull the Colab runtime image
+        run: |
+          set -euo pipefail
+          docker pull "$COLAB_IMAGE"
+          # Record which Colab build this was, so a failure months from now is
+          # still traceable to a specific runtime.
+          docker run --rm "$COLAB_IMAGE" \
+            bash -lc 'echo "$COLAB_RELEASE_TAG"; python3 --version'
+
+      - name: Install into Colab and check what moved
+        # The repo is mounted read-only somewhere that is not the working
+        # directory: the scripts need it to find the .pyx files, but it must
+        # never end up shadowing the installed package on sys.path. Working
+        # directory is /tmp, which is writable (importing pulse2percept drops
+        # a debug.log next to wherever you are).
+        run: |
+          set -euo pipefail
+          docker run --rm \
+            -v "$GITHUB_WORKSPACE:/repo:ro" \
+            -w /tmp \
+            "$COLAB_IMAGE" \
+            python3 /repo/.github/scripts/colab_smoke.py \
+              "${{ steps.spec.outputs.spec }}" \
+              --source-root /repo \
+              ${{ matrix.source == 'pypi' && '--require-wheel' || '' }}
+
+  numpy-abi:
+    # An extension compiled against numpy 1.x cannot be imported under numpy
+    # 2.x -- users hit "A module that was compiled using NumPy 1.x cannot be
+    # run in NumPy 2.x" and the install looks broken. Building against 2.x is
+    # what makes a wheel work on both, so every wheel we ship must import
+    # under either. The regular test matrix pins 3.10/3.11 to numpy 1.x and so
+    # never exercises this.
+    name: NumPy ABI py${{ matrix.py }} on ${{ matrix.numpy }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        py: [ "3.10", "3.11", "3.12", "3.13" ]
+        numpy: [ "numpy>=2,<3", "numpy==1.26.4" ]
+        exclude:
+          # numpy 1.26 has no 3.13 wheels.
+          - py: "3.13"
+            numpy: "numpy==1.26.4"
+
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a # v2.13.1
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+
+      - name: Set up Python ${{ matrix.py }}
+        uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
+        with:
+          python-version: ${{ matrix.py }}
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libomp-dev zlib1g-dev libjpeg-turbo8-dev
+
+      - name: Build a wheel
+        # Build isolation on, so this uses the build requirements declared in
+        # pyproject.toml -- the thing under test.
+        env:
+          CFLAGS: -fopenmp
+        run: |
+          set -euo pipefail
+          python -m pip install --upgrade pip build
+          python -m build --wheel --outdir dist
+          ls -l dist
+
+      - name: Install the wheel, then force ${{ matrix.numpy }}
+        run: |
+          set -euo pipefail
+          python -m venv "$RUNNER_TEMP/venv"
+          "$RUNNER_TEMP/venv/bin/python" -m pip install --upgrade pip
+          "$RUNNER_TEMP/venv/bin/python" -m pip install dist/*.whl
+          # Install the wheel first and move numpy afterwards, so this tests
+          # the ABI rather than whatever the resolver happened to prefer.
+          "$RUNNER_TEMP/venv/bin/python" -m pip install "${{ matrix.numpy }}"
+          "$RUNNER_TEMP/venv/bin/python" -c "import numpy; print('numpy', numpy.__version__)"
+
+      - name: Import against ${{ matrix.numpy }}
+        # Run from a directory that is not the checkout: from the repo root
+        # the source tree shadows the wheel and this would quietly test the
+        # wrong thing.
+        working-directory: ${{ runner.temp }}
+        run: |
+          "$RUNNER_TEMP/venv/bin/python" \
+            "$GITHUB_WORKSPACE/.github/scripts/check_install.py" \
+            --source-root "$GITHUB_WORKSPACE"

--- a/.github/workflows/colab.yml
+++ b/.github/workflows/colab.yml
@@ -126,17 +126,17 @@ jobs:
     # what makes a wheel work on both, so every wheel we ship must import
     # under either. The regular test matrix pins 3.10/3.11 to numpy 1.x and so
     # never exercises this.
-    name: NumPy ABI py${{ matrix.py }} on ${{ matrix.numpy }}
+    name: NumPy ABI py${{ matrix.py }} on NumPy ${{ matrix.numpy }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         py: [ "3.10", "3.11", "3.12", "3.13" ]
-        numpy: [ "numpy>=2,<3", "numpy==1.26.4" ]
+        numpy: [ "2.x", "1.x" ]
         exclude:
-          # numpy 1.26 has no 3.13 wheels.
+          # NumPy 1.26 is the last 1.x release and has no 3.13 wheels.
           - py: "3.13"
-            numpy: "numpy==1.26.4"
+            numpy: "1.x"
 
     steps:
       - name: Harden the runner (Audit all outbound calls)
@@ -168,18 +168,43 @@ jobs:
           python -m build --wheel --outdir dist
           ls -l dist
 
-      - name: Install the wheel, then force ${{ matrix.numpy }}
+      - name: Install the wheel under NumPy ${{ matrix.numpy }}
         run: |
           set -euo pipefail
+          CFILE="$RUNNER_TEMP/constraints.txt"
+
+          # Resolve the whole environment against the NumPy under test.
+          #
+          # Installing and *then* downgrading NumPy does not work: it leaves
+          # SciPy built against one major running against the other, which is
+          # a combination no user could have. SciPy also has to be pinned
+          # explicitly rather than left to the resolver -- scipy 1.16 declares
+          # "numpy>=1.25.2,<2.6", so a numpy<2 constraint alone happily keeps
+          # it, but its wheels are built against NumPy 2 and die on import
+          # under 1.26 with "module 'numpy' has no attribute 'long'". pip
+          # cannot see that from the metadata. This mirrors the constraints in
+          # build.yml, which exist for the same reason.
+          case "${{ matrix.numpy }}" in
+            2.x)
+              printf 'numpy>=2,<3\n' > "$CFILE"
+              ;;
+            1.x)
+              printf 'numpy<2\nscipy<1.16\n' > "$CFILE"
+              ;;
+            *)
+              echo "unknown NumPy profile: ${{ matrix.numpy }}" >&2
+              exit 1
+              ;;
+          esac
+          echo "Constraints:"; cat "$CFILE"
+
           python -m venv "$RUNNER_TEMP/venv"
           "$RUNNER_TEMP/venv/bin/python" -m pip install --upgrade pip
-          "$RUNNER_TEMP/venv/bin/python" -m pip install dist/*.whl
-          # Install the wheel first and move numpy afterwards, so this tests
-          # the ABI rather than whatever the resolver happened to prefer.
-          "$RUNNER_TEMP/venv/bin/python" -m pip install "${{ matrix.numpy }}"
-          "$RUNNER_TEMP/venv/bin/python" -c "import numpy; print('numpy', numpy.__version__)"
+          "$RUNNER_TEMP/venv/bin/python" -m pip install -c "$CFILE" dist/*.whl
+          "$RUNNER_TEMP/venv/bin/python" -c \
+            "import numpy, scipy; print('numpy', numpy.__version__, '/ scipy', scipy.__version__)"
 
-      - name: Import against ${{ matrix.numpy }}
+      - name: Import against NumPy ${{ matrix.numpy }}
         # Run from a directory that is not the checkout: from the repo root
         # the source tree shadows the wheel and this would quietly test the
         # wrong thing.

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -89,7 +89,7 @@ jobs:
               echo "delocate cannot vendor it; pick an OpenMP build with an older minimum."
               exit 1
             fi
-            python -m pip install --upgrade pip setuptools wheel cython delocate oldest-supported-numpy
+            python -m pip install --upgrade pip setuptools wheel cython delocate "numpy>=2.0"
           # NOTE: must stay a *folded* scalar (>-), i.e. a single line of
           # space-separated assignments. With a literal block (|),
           # cibuildwheel keeps only the first assignment and silently drops
@@ -110,13 +110,15 @@ jobs:
             delocate-listdeps --all --depending {wheel} &&
             delocate-wheel --require-archs {delocate_archs} -w {dest_dir} -v {wheel}
 
-          # ---------- Linux: enable OpenMP; OSN picks a compatible NumPy ----------
+          # ---------- Linux: enable OpenMP ----------
+          # NumPy comes from the build requirements in pyproject.toml, which
+          # pin 2.x so the wheels import under both NumPy 1.x and 2.x.
           CIBW_ENVIRONMENT_LINUX: "CFLAGS='-fopenmp'"
-          CIBW_BEFORE_BUILD_LINUX: "python -m pip install --upgrade pip setuptools wheel cython oldest-supported-numpy"
+          CIBW_BEFORE_BUILD_LINUX: "python -m pip install --upgrade pip setuptools wheel cython 'numpy>=2.0'"
 
-          # ---------- Windows: enable OpenMP; OSN picks a compatible NumPy ----------
+          # ---------- Windows: enable OpenMP ----------
           CIBW_ENVIRONMENT_WINDOWS: "CFLAGS='/openmp'"
-          CIBW_BEFORE_BUILD_WINDOWS: "python -m pip install --upgrade pip setuptools wheel cython oldest-supported-numpy"
+          CIBW_BEFORE_BUILD_WINDOWS: "python -m pip install --upgrade pip setuptools wheel cython \"numpy>=2.0\""
 
           # ---------- Python versions / skips ----------
           CIBW_BUILD: "cp310-* cp311-* cp312-* cp313-*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,8 +3,18 @@ requires = [
   "setuptools>=64",
   "wheel",
   "Cython>=3.0.8",
-  'oldest-supported-numpy==2023.12.21; python_version < "3.12"',
-  'numpy>=2.0; python_version >= "3.12"',
+  # Build against NumPy 2.x on every supported Python, not just 3.12+.
+  #
+  # An extension compiled against 2.x imports fine under both 1.x (>=1.19)
+  # and 2.x, because building against 2.x targets the older C API by default.
+  # One compiled against 1.x does *not* work under 2.x -- it raises "A module
+  # that was compiled using NumPy 1.x cannot be run in NumPy 2.x". Since the
+  # runtime requirement below allows numpy>=1.21,<3, the 3.10/3.11 wheels
+  # built against oldest-supported-numpy broke for anyone who had numpy 2
+  # installed, which is now the default nearly everywhere.
+  #
+  # oldest-supported-numpy is deprecated and documents this as the migration.
+  "numpy>=2.0",
 ]
 build-backend = "setuptools.build_meta"
 


### PR DESCRIPTION
Colab is where most people first install p2p, and it is the environment we don't control: it comes with NumPy, SciPy, pandas, TensorFlow, JAX, and PyTorch all pre-installed - and as these versions drift, `!pip install pulse2percept` sometimes works and sometimes doesn't.

The solution: `.github/workflows/colab.yml` runs against Google's published Colab runtime image, so the environment under test tracks Colab without anyone remembering to refresh a pinned versions file. But it's ~6.8GB compressed / 15 GB unpacked... so it needs a disk-reclaim step first, which is why we now have an explicit `docker run` (rather than a job-level) container.

On PRs it installs the branch under `test`. On the daily schedule it also installs from PyPi and makes sure the prebuilt wheels exist for Colab's interpreter. `numpy-abi` builds a wheel per `pyproject.toml` and imports it under both NumPy 1.x and 2.x across all supported Python versions.

New scripts:
- `.github/scripts/colab_smoke.py`: runs inside the container, installs and `pip check`s
- `.github/scripts/check_install.py`: verifies the installed package

Supersedes #738. Closes #643 