### PR TITLE
[MNT] Cleanly remove the jax engine

### DIFF
--- a/.github/scripts/colab_smoke.py
+++ b/.github/scripts/colab_smoke.py
@@ -25,6 +25,10 @@ preinstalled, so it structurally cannot reproduce that. So we install into the
 real thing and compare `pip freeze` either side.
 
 Packages that appear are fine. Packages that *change version* are not.
+
+When something does move, the report also says *why*: pip states the
+requirement it was resolving and who asked for it, which is the difference
+between "numpy got downgraded" and "our own numpy ceiling downgraded it".
 """
 
 from __future__ import annotations
@@ -35,16 +39,94 @@ import subprocess
 import sys
 from pathlib import Path
 
+# The distribution under test. A version change traceable to a requirement
+# this package declares itself is the actionable kind: it is ours to fix.
+DIST_NAME = "pulse2percept"
+
+# `Collecting numpy<1.27,>=1.21 (from pulse2percept)`, or with a chain of
+# requirers: `(from scikit-image>=0.14->pulse2percept)`. This is the only
+# place pip states the *reason* it picked a version.
+COLLECTING = re.compile(
+    r"^\s*Collecting\s+(?P<req>[^\s(]+)"
+    r"(?:\s+\(from\s+(?P<chain>[^)]*)\))?\s*$"
+)
+# Leading distribution name of a requirement, e.g. `numpy` of `numpy<1.27`.
+REQ_NAME = re.compile(r"^[A-Za-z0-9._-]+")
+# Any version specifier. An unpinned requirement cannot move anything, so it
+# is never the thing to go fix. Both directions matter: an upper bound drags a
+# package down, a lower bound pushes it up.
+HAS_SPECIFIER = re.compile(r"[<>=!~]")
+
 
 def canonicalize(name: str) -> str:
     """Normalize a distribution name (PEP 503)."""
     return re.sub(r"[-_.]+", "-", name).strip().lower()
 
 
-def run(cmd: list[str], *, check: bool = True) -> subprocess.CompletedProcess:
-    """Run a command, echoing it so CI logs show exactly what happened."""
+def run(cmd: list[str], *, check: bool = True,
+        tee: bool = False) -> subprocess.CompletedProcess:
+    """Run a command, echoing it so CI logs show exactly what happened.
+
+    With ``tee``, the output is captured *and* printed: the CI log stays
+    complete, and the text remains available to attribute version changes to
+    the requirement that caused them.
+    """
     print(f"\n$ {' '.join(cmd)}", flush=True)
-    return subprocess.run(cmd, check=check, text=True)
+    if not tee:
+        return subprocess.run(cmd, check=check, text=True)
+    proc = subprocess.run(cmd, check=check, text=True,
+                          stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+    if proc.stdout:
+        print(proc.stdout, end="", flush=True)
+    return proc
+
+
+def parse_requirements(output: str) -> dict[str, list[tuple[str, str]]]:
+    """Map each package pip resolved to the requirement(s) it was satisfying.
+
+    Returns ``{canonical name: [(requirement, requirer chain), ...]}``, where
+    the chain is pip's own ``a->b`` rendering, nearest requirer first, and is
+    empty for a package asked for on the command line.
+    """
+    found: dict[str, list[tuple[str, str]]] = {}
+    for line in output.splitlines():
+        match = COLLECTING.match(line)
+        if not match:
+            continue
+        req = match.group("req")
+        name = REQ_NAME.match(req)
+        if not name:
+            continue
+        entry = (req, (match.group("chain") or "").strip())
+        bucket = found.setdefault(canonicalize(name.group(0)), [])
+        if entry not in bucket:
+            bucket.append(entry)
+    return found
+
+
+def explain(names: list[str],
+            requirements: dict[str, list[tuple[str, str]]]) -> list[str]:
+    """Say which requirement pip was resolving for each of ``names``."""
+    rows: list[str] = []
+    for name in names:
+        reqs = requirements.get(name)
+        if not reqs:
+            # pip only prints `Collecting` for packages it (re)installs by
+            # name; a version can also move as a side effect of backtracking.
+            rows.append(f"{name}: no requirement line from pip -- most likely "
+                        f"resolver backtracking to satisfy another pin")
+            continue
+        for req, chain in reqs:
+            who = chain.replace("->", " -> ") if chain else "the install target"
+            rows.append(f"{name}: required by {who} as `{req}`")
+            # Whoever asked for it first is the one holding the constraint.
+            immediate = REQ_NAME.match(chain.split("->")[0].strip()) if chain else None
+            specifier = req[len(REQ_NAME.match(req).group(0)):]
+            if (immediate and canonicalize(immediate.group(0)) == DIST_NAME
+                    and HAS_SPECIFIER.search(specifier)):
+                rows.append(f"    ^ that bound is declared by {DIST_NAME} "
+                            f"itself -- ours to fix, in pyproject.toml")
+    return rows
 
 
 def pip(*args: str, capture: bool = False) -> str:
@@ -164,6 +246,7 @@ def main() -> int:
     install = run(
         [sys.executable, "-m", "pip", "install", "--root-user-action=ignore", args.spec],
         check=False,
+        tee=True,
     )
     if install.returncode != 0:
         print(
@@ -175,11 +258,12 @@ def main() -> int:
 
     after = freeze()
 
-    changed = [
-        f"{name}: {before[name]} -> {after[name]}"
-        for name in sorted(before.keys() & after.keys())
+    changed_names = [
+        name for name in sorted(before.keys() & after.keys())
         if before[name] != after[name] and name not in tolerated
     ]
+    changed = [f"{name}: {before[name]} -> {after[name]}"
+               for name in changed_names]
     removed = sorted(before.keys() - after.keys() - tolerated)
     added = sorted(after.keys() - before.keys())
 
@@ -190,6 +274,15 @@ def main() -> int:
     # Only conflicts we introduced count; Colab's own are not our problem.
     new_conflicts = sorted(pip_check() - conflicts_before)
     report("New dependency conflicts (must be empty)", new_conflicts)
+
+    # A bare list of what moved sends the reader digging through pip's log for
+    # the requirement behind it -- and the conflicts above name whichever
+    # preinstalled packages happened to be caught in the blast, which reads
+    # like the cause and is not.
+    if changed_names or removed:
+        report("Why those versions moved",
+               explain(changed_names + removed,
+                       parse_requirements(install.stdout or "")))
 
     problems = []
     if changed:

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -13,4 +13,3 @@ nibabel>=5
 pooch>=1.8
 neuropythy==0.12.16
 pickleshare
-jax[cpu]==0.4.31

--- a/doc/users/release_notes.rst
+++ b/doc/users/release_notes.rst
@@ -4,6 +4,31 @@
 Release Notes
 =============
 
+v0.9.1 (unreleased)
+-------------------
+
+Highlights:
+
+*  NumPy 2.x support: wheels import under both NumPy 1.x and 2.x, so installing
+   pulse2percept no longer downgrades NumPy in environments that ship it, such
+   as Google Colab (:pull:`635`, :pull:`736`)
+*  Python 3.13 support; the minimum supported Python is now 3.10 (:pull:`649`)
+*  Removed the jax engine and ``predict_percept_batched`` from
+   :py:class:`~pulse2percept.models.BiphasicAxonMapModel`; the ``engine``
+   argument of the effect models and the ``pad`` argument of
+   :py:meth:`~pulse2percept.models.AxonMapSpatial.calc_axon_sensitivity` are
+   deprecated, and will be removed in v0.10.0 (:pull:`XXX`)
+*  Removed the ``model_selection`` module (:pull:`685`) and support for the
+   joblib and dask parallel backends (:pull:`686`); the ``engine`` and
+   ``scheduler`` model parameters are deprecated, and will be removed in
+   v0.10.0 (:pull:`XXX`)
+*  ``n_jobs`` is now an alias for ``n_threads``: either name sets the number
+   of OpenMP threads, and ``None`` or ``-1`` uses every core (:pull:`XXX`)
+*  More robust dataset downloads, with updated OSF endpoints (:pull:`754`)
+*  Smarter ``reshape_stim`` for implants (:pull:`680`)
+*  Installation is now tested inside the real Google Colab runtime (:pull:`777`)
+*  Various bug fixes (:pull:`682`, :pull:`700`, :pull:`732`, :pull:`776`)
+
 v0.9.0 Cortex (2025-02-17)
 --------------------------
 

--- a/examples/models/plot_granley2021_biphasic.py
+++ b/examples/models/plot_granley2021_biphasic.py
@@ -59,9 +59,8 @@ print(model)
 ##############################################################################
 # The most important parameters are ``rho`` and ``axlambda``, which control the 
 # radial and axonal current spread, respectively. The parameters ``a0``-``a9`` are 
-# coefficients for the size, streak, and bright models, which will be discussed 
-# later in this example. The biphasic axon map model supports both the default 
-# cython engine and a faster, gpu-enabled jax engine.
+# coefficients for the size, streak, and bright models, which will be discussed
+# later in this example.
 #
 # The rest of the parameters are shared with 
 # :py:class:`~pulse2percept.models.AxonMapModel`. For full details on these 
@@ -254,62 +253,4 @@ plt.show()
 # which can be shared with the overarching BiphasicAxonMapModel itself (e.g. an effect 
 # model can depend on ``rho``, and if ``model.rho`` is changed, ``rho`` will also be changed in
 # the effect model). For an example of this, 
-# see :py:class:`~pulse2percept.models.granley2021.DefaultSizeModel` 
-#
-#
-# If using custom effect models with jax, the effect models must be written for jax so they can
-# be JIT compiled (i.e. using jax.numpy instead of numpy)
-
-########################################################################################
-# JAX Engine
-# ============
-#
-# The default computational engine is cython, but an engine based on 
-# `jax <https://github.com/google/jax>`_ is also provided. The jax engine is slightly faster on CPU
-# and significantly faster on GPU, at the cost of increased memory usage. The jax-based model 
-# can be used identically to the cython engine, but it also has some additional features
-# and limitations. 
-# 
-# .. note ::
-#
-#     Jax functions are compiled the first time they are called. Thus, the first
-#     `predict_percept` will be slow. Subsequent calls reuse the compiled and
-#     optimized function, and are much faster
-#
-# One additional feature is the 
-# `_predict_spatial_jax` function,
-# which is a stripped, purely functional version of 
-# `predict_percept` that operates on
-# numpy arrays. This avoids the overhead of creating p2p stimulus and percept objects,
-# and if used correctly, provides an additional speedup. 
-#
-# `_predict_spatial_jax` takes in 
-# a (n_elecs, 3) numpy array specifying the frequency, amplitude, and pulse duration on
-# each electrode, and two (n_elec) shaped arrays specifying the x and y locations of each
-# electrode
-model = BiphasicAxonMapModel(engine='jax')
-model.build()
-implant = ArgusII()
-ex = np.array([implant[e].x for e in implant.electrodes])
-ey = np.array([implant[e].y for e in implant.electrodes]) 
-stim = np.zeros((60, 3))
-stim[3] = [20, 1, 0.45]
-percept = model._predict_spatial_jax(stim, ex, ey)
-percept = np.array(percept).reshape(model.grid.shape)
-plt.imshow(percept, cmap='gray')
-plt.show()
-##################################################################################################
-# One other useful feature is the 
-# `predict_percept_batched` function. This
-# applies predict_percept to batches of input stimuli, using optimized matrix operations. See also 
-# its faster, stripped version `_predict_spatial_batched`. This 
-# function is only intended to be used if you are repeatedly simulating batches of percepts. 
-# Since jax compiles each function the first time it is used, using this function only once
-# for a singular group of stimuli will be noticably slower than repeatedly applying 
-# `predict_percept`. However, splitting a very large set of stimuli into smaller batches and 
-# using `predict_percept_batched` will be significantly faster than `predict_percept` on each
-# individual stimuli.
-#
-# Note that this function consumes a large amount of memory, and may not run on systems or 
-# GPUs with limited memory. 
-
+# see :py:class:`~pulse2percept.models.granley2021.DefaultSizeModel`

--- a/pulse2percept/models/base.py
+++ b/pulse2percept/models/base.py
@@ -12,8 +12,38 @@ import multiprocessing
 from ..implants import ProsthesisSystem
 from ..stimuli import Stimulus
 from ..percepts import Percept
-from ..utils import (PrettyPrint, Frozen, FreezeError, bisect)
+from ..utils import (PrettyPrint, Frozen, FreezeError, bisect,
+                     deprecate_parameter, warn_deprecated_params)
 from ..utils.constants import ZORDER
+
+
+def _n_jobs_alias():
+    """Build the ``n_jobs`` property, an alias for ``n_threads``
+
+    Both names refer to the same OpenMP thread count, and both read and write
+    the same storage, so they can never drift apart. ``None`` and ``-1`` mean
+    "use every core", following the scikit-learn convention.
+    """
+    def getter(self):
+        return self.n_threads
+
+    def setter(self, val):
+        if val is None:
+            val = multiprocessing.cpu_count()
+        if isinstance(val, bool) or not isinstance(val, (int, np.integer)):
+            raise ValueError(f"n_jobs must be an integer, None, or -1 (all "
+                             f"cores), not {val!r}.")
+        if val == -1:
+            val = multiprocessing.cpu_count()
+        if val < 1:
+            raise ValueError(f"n_jobs must be >= 1, or -1 for all cores, "
+                             f"not {val}.")
+        self.n_threads = int(val)
+
+    return property(getter, setter,
+                    doc="Number of OpenMP threads to use during "
+                        "parallelization. An alias for ``n_threads``: both "
+                        "names read and write the same value.")
 
 
 class NotBuiltError(ValueError, AttributeError):
@@ -38,6 +68,11 @@ class BaseModel(Frozen, PrettyPrint, metaclass=ABCMeta):
 
     """
 
+    # Parameters that are still accepted, but that nothing reads any more.
+    # Maps a name to the ``deprecate_parameter`` describing it; subclasses
+    # override this (see ``SpatialModel``).
+    _deprecated_params = {}
+
     def __init__(self, **params):
         """BaseModel constructor
 
@@ -50,6 +85,10 @@ class BaseModel(Frozen, PrettyPrint, metaclass=ABCMeta):
         defaults = self.get_default_params()
         for key, val in defaults.items():
             setattr(self, key, val)
+        # Warn on the ones the user named explicitly, before they are set:
+        # applying a default must stay silent.
+        warn_deprecated_params(type(self).__name__, params,
+                               self._deprecated_params)
         # Then overwrite any arguments also given in `params`:
         for key, val in params.items():
             if key in defaults:
@@ -68,6 +107,8 @@ class BaseModel(Frozen, PrettyPrint, metaclass=ABCMeta):
 
     def set_params(self, **params):
         """Set the parameters of this model"""
+        warn_deprecated_params(type(self).__name__, params,
+                               self._deprecated_params)
         for key, value in params.items():
             setattr(self, key, value)
 
@@ -228,6 +269,25 @@ class SpatialModel(BaseModel, metaclass=ABCMeta):
            <topics-models-building-your-own>`
     """
 
+    # Parameters that are still accepted so existing code keeps running, but
+    # that nothing reads any more.
+    _deprecated_params = {
+        'engine': deprecate_parameter(
+            'engine', deprecated_version='0.9.1', removed_version='0.10.0',
+            addendum="It chose between the Cython and the pure-Python "
+                     "implementation of the Jansonius axon-growth model; the "
+                     "Cython one is now always used. Use ``n_threads`` (or "
+                     "its alias ``n_jobs``) to control parallelism."),
+        'scheduler': deprecate_parameter(
+            'scheduler', deprecated_version='0.9.1',
+            removed_version='0.10.0',
+            addendum="It selected the joblib or dask parallel backend, "
+                     "support for which was removed in v0.9.1."),
+    }
+
+    #: ``n_jobs`` is an alias for ``n_threads``; see ``_n_jobs_alias``.
+    n_jobs = _n_jobs_alias()
+
     def __init__(self, **params):
         super().__init__(**params)
         self.grid = None
@@ -252,15 +312,17 @@ class SpatialModel(BaseModel, metaclass=ABCMeta):
             'n_gray': None,
             # Salt-and-pepper noise on the output:
             'noise': None,
-            # Cython can be used to speed up computations:
+            # Deprecated in 0.9.1, removed in 0.10.0; see _deprecated_params:
             'engine': 'cython',
             'scheduler': 'threading',
-            'n_jobs': 1,
             # True: print status messages, 0: silent
             'verbose': True,
             # default to 2d model. 3d models should override this
             'ndim' : [2],
-            'n_threads': multiprocessing.cpu_count()
+            # Number of OpenMP threads. `n_jobs` is an alias that writes
+            # through to `n_threads`, so it has to be applied *after* it:
+            'n_threads': multiprocessing.cpu_count(),
+            'n_jobs': None,
         }
         return params
 
@@ -533,6 +595,9 @@ class TemporalModel(BaseModel, metaclass=ABCMeta):
            <topics-models-building-your-own>`
     """
 
+    #: ``n_jobs`` is an alias for ``n_threads``; see ``_n_jobs_alias``.
+    n_jobs = _n_jobs_alias()
+
     def get_default_params(self):
         """Return a dictionary of default values for all model parameters"""
         params = {
@@ -542,7 +607,10 @@ class TemporalModel(BaseModel, metaclass=ABCMeta):
             'thresh_percept': 0,
             # True: print status messages, False: silent
             'verbose': True,
-            'n_threads': multiprocessing.cpu_count()
+            # `n_jobs` is an alias that writes through to `n_threads`, so it
+            # has to be applied *after* it:
+            'n_threads': multiprocessing.cpu_count(),
+            'n_jobs': None,
         }
         return params
 
@@ -922,6 +990,14 @@ class Model(PrettyPrint):
         params: dict
             A dictionary of parameters to set.
         """
+        # A Model built from *instances* never routes through
+        # ``BaseModel.__init__``, so the deprecated names have to be caught
+        # here too. Collect both sides first so a parameter deprecated on the
+        # spatial *and* temporal model only warns once.
+        specs = {}
+        for model in (self.spatial, self.temporal):
+            specs.update(getattr(model, '_deprecated_params', {}))
+        warn_deprecated_params(type(self).__name__, params, specs)
         for key, val in params.items():
             setattr(self, key, val)
 

--- a/pulse2percept/models/base.py
+++ b/pulse2percept/models/base.py
@@ -252,7 +252,7 @@ class SpatialModel(BaseModel, metaclass=ABCMeta):
             'n_gray': None,
             # Salt-and-pepper noise on the output:
             'noise': None,
-            # Cython/Jax can be used to speed up computations:
+            # Cython can be used to speed up computations:
             'engine': 'cython',
             'scheduler': 'threading',
             'n_jobs': 1,

--- a/pulse2percept/models/beyeler2019.py
+++ b/pulse2percept/models/beyeler2019.py
@@ -237,10 +237,9 @@ class AxonMapSpatial(SpatialModel):
     min_ax_sensitivity : float, optional
         Axon segments whose contribution to brightness is smaller than this
         value will be pruned to improve computational efficiency. Set to a
-        value between 0 and 1. If engine is jax, all other axons will be padded
-        to the length enforced by this constraint.
+        value between 0 and 1.
     engine : string, optional
-        Engine to use for computation. Options are 'serial', 'cython', and 'jax'.
+        Engine to use for computation. Options are 'serial' and 'cython'.
         Defaults to 'cython'
     axon_pickle : str, optional
         File name in which to store precomputed axon maps.
@@ -518,7 +517,7 @@ class AxonMapSpatial(SpatialModel):
             return closest_axon, closest_idx
         return closest_axon
 
-    def calc_axon_sensitivity(self, bundles, pad=False):
+    def calc_axon_sensitivity(self, bundles, pad=None):
         """Calculate the sensitivity of each axon segment to electrical current
 
         This function combines the x,y coordinates of each bundle segment with
@@ -539,27 +538,39 @@ class AxonMapSpatial(SpatialModel):
         that the only work left to do during run time is to multiply the
         sensitivity value with the current applied to each segment.
 
-        If pad is True (set when engine is 'jax'), axons are padded to all have 
-        the same length as the longest axon
-
         Parameters
         ----------
         bundles : list of Nx2 arrays
             A list of bundles, where every bundle is an Nx2 array consisting of
-            the x,y coordinates of each axon segment (retinal coords, microns). 
+            the x,y coordinates of each axon segment (retinal coords, microns).
             Note that each bundle will most likely have a different N
+        pad : bool, optional
+            .. deprecated:: 0.10
+
+                Accepted but ignored, and will be removed in version 0.12.
+                ``pad=True`` used to pad all axons to the length of the longest
+                one and return a single (n_points, axon_length, 3) array, which
+                only the (now removed) jax backend consumed. This method now
+                always returns the unpadded list described below.
 
         Returns
         -------
-        axon_contrib : numpy array with shape (n_points, axon_length, 3)
-            An array of axon segments and sensitivity values. Each entry in the
-            array is a Nx3 array, where the first two columns contain the retinal
+        axon_contrib : list of Nx3 arrays
+            A list with one entry per point on ``self.grid``. Each entry is a
+            Nx3 array, where the first two columns contain the retinal
             coordinates of each axon segment (microns), and the third column
             contains the sensitivity of the segment to electrical current.
-            The latter depends on ``self.axlambda``. axon_length is set to the 
-            maximum length of any axon after being trimmed due to min_sensitivity 
+            The latter depends on ``self.axlambda``. Note that each axon will
+            most likely have a different N, since segments whose sensitivity
+            falls below ``min_ax_sensitivity`` are trimmed.
 
         """
+        if pad is not None:
+            warnings.warn("The 'pad' parameter of calc_axon_sensitivity is "
+                          "deprecated since version 0.10, and will be removed "
+                          "in version 0.12. It is ignored: an unpadded list of "
+                          "Nx3 arrays is always returned, even for pad=True.",
+                          DeprecationWarning, stacklevel=2)
         xyret = np.column_stack((self.grid.ret.x.ravel(),
                                  self.grid.ret.y.ravel()))
         # Only include axon segments that are < `max_d2` from the soma. These
@@ -584,22 +595,7 @@ class AxonMapSpatial(SpatialModel):
             contrib = np.column_stack((axon[idx_d2, :], sensitivity))
             axon_contrib.append(contrib)
 
-        if pad:
-            # pad to length of longest axon
-            axon_length = max([len(axon) for axon in axon_contrib])
-            axon_sensitivities = np.zeros((len(axon_contrib), axon_length, 3))
-            for i, axon in enumerate(axon_contrib):
-                original_len = len(axon)
-                if original_len >= axon_length:
-                    axon_sensitivities[i] = axon[:axon_length]
-                elif original_len != 0:
-                    axon_sensitivities[i, :original_len] = axon
-                    axon_sensitivities[i, original_len:] = axon[-1]
-
-            del axon_contrib
-            return axon_sensitivities
-        else:
-            return axon_contrib
+        return axon_contrib
 
     def calc_bundle_tangent(self, xc, yc):
         """Calculates orientation of fiber bundle tangent at (xc, yc)
@@ -735,24 +731,16 @@ class AxonMapSpatial(SpatialModel):
             axons = self.find_closest_axon(bundles)
             if type(axons) != list:
                 axons = [axons]
-        # Calculate axon contributions (depends on engine):
-        # If engine is cython or serial:
-        #   Axon contribution is a list of (differently shaped) NumPy arrays,
-        #   and a list cannot be accessed in parallel without the gil. Instead
-        #   we need to concatenate it into a really long Nx3 array, and pass the
-        #   start and end indices of each slice:
-        # If engine is jax:
-        #   All axons are the same length, so Axon contribution is an array with
-        #   shape (n, axon_length, 3)
-        if self.engine == 'jax':
-            self.axon_contrib = self.calc_axon_sensitivity(
-                axons, pad=True).astype(np.float32)
-        else:
-            axon_contrib = self.calc_axon_sensitivity(axons)
-            self.axon_contrib = np.concatenate(axon_contrib).astype(np.float32)
-            len_axons = [a.shape[0] for a in axon_contrib]
-            self.axon_idx_end = np.cumsum(len_axons)
-            self.axon_idx_start = self.axon_idx_end - np.array(len_axons)
+        # Calculate axon contributions. Axon contribution is a list of
+        # (differently shaped) NumPy arrays, and a list cannot be accessed in
+        # parallel without the gil. Instead we need to concatenate it into a
+        # really long Nx3 array, and pass the start and end indices of each
+        # slice:
+        axon_contrib = self.calc_axon_sensitivity(axons)
+        self.axon_contrib = np.concatenate(axon_contrib).astype(np.float32)
+        len_axons = [a.shape[0] for a in axon_contrib]
+        self.axon_idx_end = np.cumsum(len_axons)
+        self.axon_idx_start = self.axon_idx_end - np.array(len_axons)
         if need_axons:
             # Pickle axons along with all important parameters:
             params = {'loc_od': self.loc_od,
@@ -770,20 +758,17 @@ class AxonMapSpatial(SpatialModel):
             warnings.warn(msg)
         # This does the expansion of a compact stimulus and a list of
         # electrodes to activation values at X,Y grid locations:
-        if self.engine != 'jax':
-            return fast_axon_map(stim.data,
-                                 np.array([earray[e].x for e in stim.electrodes],
-                                          dtype=np.float32),
-                                 np.array([earray[e].y for e in stim.electrodes],
-                                          dtype=np.float32),
-                                 self.axon_contrib,
-                                 self.axon_idx_start.astype(np.uint32),
-                                 self.axon_idx_end.astype(np.uint32),
-                                 self.rho,
-                                 self.thresh_percept,
-                                 self.n_threads)
-        else:
-            raise NotImplementedError("Jax will be supported in future release")
+        return fast_axon_map(stim.data,
+                             np.array([earray[e].x for e in stim.electrodes],
+                                      dtype=np.float32),
+                             np.array([earray[e].y for e in stim.electrodes],
+                                      dtype=np.float32),
+                             self.axon_contrib,
+                             self.axon_idx_start.astype(np.uint32),
+                             self.axon_idx_end.astype(np.uint32),
+                             self.rho,
+                             self.thresh_percept,
+                             self.n_threads)
 
     def plot(self, use_dva=False, style='hull', annotate=True, autoscale=True,
              ax=None, figsize=None):
@@ -968,10 +953,9 @@ class AxonMapModel(Model):
     min_ax_sensitivity : float, optional
         Axon segments whose contribution to brightness is smaller than this
         value will be pruned to improve computational efficiency. Set to a
-        value between 0 and 1. If engine is jax, all other axons will be padded
-        to the length enforced by this constraint.
+        value between 0 and 1.
     engine : string, optional
-        Engine to use for computation. Options are 'serial', 'cython', and 'jax'.
+        Engine to use for computation. Options are 'serial' and 'cython'.
         Defaults to 'cython'
     axon_pickle : str, optional
         File name in which to store precomputed axon maps.

--- a/pulse2percept/models/beyeler2019.py
+++ b/pulse2percept/models/beyeler2019.py
@@ -11,6 +11,7 @@ from matplotlib.patches import Ellipse
 
 from ..utils.constants import ZORDER
 from ..topography import Watson2014Map
+from ..utils import deprecate_parameter
 from ..implants import ProsthesisSystem, ElectrodeArray
 from ..stimuli import Stimulus
 from ..models import Model, SpatialModel
@@ -517,6 +518,10 @@ class AxonMapSpatial(SpatialModel):
             return closest_axon, closest_idx
         return closest_axon
 
+    @deprecate_parameter('pad', deprecated_version='0.9.1',
+                         removed_version='0.10.0',
+                         addendum="An unpadded list of Nx3 arrays is always "
+                                  "returned, even for pad=True.")
     def calc_axon_sensitivity(self, bundles, pad=None):
         """Calculate the sensitivity of each axon segment to electrical current
 
@@ -545,9 +550,9 @@ class AxonMapSpatial(SpatialModel):
             the x,y coordinates of each axon segment (retinal coords, microns).
             Note that each bundle will most likely have a different N
         pad : bool, optional
-            .. deprecated:: 0.10
+            .. deprecated:: 0.9.1
 
-                Accepted but ignored, and will be removed in version 0.12.
+                Accepted but ignored, and will be removed in version 0.10.0.
                 ``pad=True`` used to pad all axons to the length of the longest
                 one and return a single (n_points, axon_length, 3) array, which
                 only the (now removed) jax backend consumed. This method now
@@ -565,12 +570,6 @@ class AxonMapSpatial(SpatialModel):
             falls below ``min_ax_sensitivity`` are trimmed.
 
         """
-        if pad is not None:
-            warnings.warn("The 'pad' parameter of calc_axon_sensitivity is "
-                          "deprecated since version 0.10, and will be removed "
-                          "in version 0.12. It is ignored: an unpadded list of "
-                          "Nx3 arrays is always returned, even for pad=True.",
-                          DeprecationWarning, stacklevel=2)
         xyret = np.column_stack((self.grid.ret.x.ravel(),
                                  self.grid.ret.y.ravel()))
         # Only include axon segments that are < `max_d2` from the soma. These

--- a/pulse2percept/models/beyeler2019.py
+++ b/pulse2percept/models/beyeler2019.py
@@ -72,8 +72,10 @@ class ScoreboardSpatial(SpatialModel):
         subject to noise in each frame.
 
     n_threads : int, optional
-        Number of CPU threads to use during parallelization using OpenMP. 
+        Number of CPU threads to use during parallelization using OpenMP.
         Defaults to max number of user CPU cores.
+    n_jobs : int, optional
+        Alias for ``n_threads``; ``None`` or ``-1`` uses every core.
 
     .. important ::
         If you change important model parameters outside the constructor (e.g.,
@@ -154,8 +156,10 @@ class ScoreboardModel(Model):
         A float between 0 and 1 will be interpreted as a ratio of pixels to
         subject to noise in each frame.
     n_threads : int, optional
-        Number of CPU threads to use during parallelization using OpenMP. 
+        Number of CPU threads to use during parallelization using OpenMP.
         Defaults to max number of user CPU cores.
+    n_jobs : int, optional
+        Alias for ``n_threads``; ``None`` or ``-1`` uses every core.
 
     .. important ::
         If you change important model parameters outside the constructor (e.g.,
@@ -240,16 +244,21 @@ class AxonMapSpatial(SpatialModel):
         value will be pruned to improve computational efficiency. Set to a
         value between 0 and 1.
     engine : string, optional
-        Engine to use for computation. Options are 'serial' and 'cython'.
-        Defaults to 'cython'
+        .. deprecated:: 0.9.1
+
+            Accepted but ignored, and will be removed in version 0.10.0. It
+            chose between the Cython and the pure-Python implementation of the
+            Jansonius axon-growth model; the Cython one is now always used.
     axon_pickle : str, optional
         File name in which to store precomputed axon maps.
     ignore_pickle : bool, optional
         A flag whether to ignore the pickle file in future calls to
         ``model.build()``.
     n_threads : int, optional
-        Number of CPU threads to use during parallelization using OpenMP. 
+        Number of CPU threads to use during parallelization using OpenMP.
         Defaults to max number of user CPU cores.
+    n_jobs : int, optional
+        Alias for ``n_threads``; ``None`` or ``-1`` uses every core.
 
     .. important ::
         If you change important model parameters outside the constructor (e.g.,
@@ -350,27 +359,7 @@ class AxonMapSpatial(SpatialModel):
         is_superior = phi0 > 0
         rho = np.linspace(*self.ax_segments_range, num=self.n_ax_segments,
                           dtype=np.float32)
-        if self.engine == 'cython':
-            xprime, yprime = fast_jansonius(rho, phi0, beta_sup, beta_inf)
-        else:
-            if is_superior:
-                # Axon is in superior retina, compute `b` (real number) from
-                # Eq. 5:
-                b = np.exp(beta_sup + 3.9 * np.tanh(-(phi0 - 121.0) / 14.0))
-                # Equation 3, `c` a positive real number:
-                c = 1.9 + 1.4 * np.tanh((phi0 - 121.0) / 14.0)
-            else:
-                # Axon is in inferior retina: compute `b` (real number) from
-                # Eq. 6:
-                b = -np.exp(beta_inf + 1.5 * np.tanh(-(-phi0 - 90.0) / 25.0))
-                # Equation 4, `c` a positive real number:
-                c = 1.0 + 0.5 * np.tanh((-phi0 - 90.0) / 25.0)
-
-            # Spiral as a function of `rho`:
-            phi = phi0 + b * (rho - rho.min()) ** c
-            # Convert to Cartesian coordinates:
-            xprime = rho * np.cos(np.deg2rad(phi))
-            yprime = rho * np.sin(np.deg2rad(phi))
+        xprime, yprime = fast_jansonius(rho, phi0, beta_sup, beta_inf)
         # Find the array elements where the axon crosses the meridian:
         if is_superior:
             # Find elements in inferior retina
@@ -954,16 +943,21 @@ class AxonMapModel(Model):
         value will be pruned to improve computational efficiency. Set to a
         value between 0 and 1.
     engine : string, optional
-        Engine to use for computation. Options are 'serial' and 'cython'.
-        Defaults to 'cython'
+        .. deprecated:: 0.9.1
+
+            Accepted but ignored, and will be removed in version 0.10.0. It
+            chose between the Cython and the pure-Python implementation of the
+            Jansonius axon-growth model; the Cython one is now always used.
     axon_pickle : str, optional
         File name in which to store precomputed axon maps.
     ignore_pickle : bool, optional
         A flag whether to ignore the pickle file in future calls to
         ``model.build()``.
     n_threads : int, optional
-        Number of CPU threads to use during parallelization using OpenMP. 
+        Number of CPU threads to use during parallelization using OpenMP.
         Defaults to max number of user CPU cores.
+    n_jobs : int, optional
+        Alias for ``n_threads``; ``None`` or ``-1`` uses every core.
 
     .. important ::
         If you change important model parameters outside the constructor (e.g.,

--- a/pulse2percept/models/cortex/base.py
+++ b/pulse2percept/models/cortex/base.py
@@ -56,8 +56,10 @@ class CortexSpatial(SpatialModel):
         A float between 0 and 1 will be interpreted as a ratio of pixels to
         subject to noise in each frame.
     n_threads : int, optional
-        Number of CPU threads to use during parallelization using OpenMP. 
+        Number of CPU threads to use during parallelization using OpenMP.
         Defaults to max number of user CPU cores.
+    n_jobs : int, optional
+        Alias for ``n_threads``; ``None`` or ``-1`` uses every core.
 
     .. important::
 
@@ -228,8 +230,10 @@ class ScoreboardSpatial(CortexSpatial):
         A float between 0 and 1 will be interpreted as a ratio of pixels to
         subject to noise in each frame.
     n_threads : int, optional
-        Number of CPU threads to use during parallelization using OpenMP. 
+        Number of CPU threads to use during parallelization using OpenMP.
         Defaults to max number of user CPU cores.
+    n_jobs : int, optional
+        Alias for ``n_threads``; ``None`` or ``-1`` uses every core.
 
     .. important ::
     
@@ -341,8 +345,10 @@ class ScoreboardModel(Model):
         A float between 0 and 1 will be interpreted as a ratio of pixels to
         subject to noise in each frame.
     n_threads : int, optional
-        Number of CPU threads to use during parallelization using OpenMP. 
+        Number of CPU threads to use during parallelization using OpenMP.
         Defaults to max number of user CPU cores.
+    n_jobs : int, optional
+        Alias for ``n_threads``; ``None`` or ``-1`` uses every core.
 
     .. important ::
         If you change important model parameters outside the constructor (e.g.,

--- a/pulse2percept/models/granley2021.py
+++ b/pulse2percept/models/granley2021.py
@@ -285,9 +285,11 @@ class BiphasicAxonMapSpatial(AxonMapSpatial):
         ignore_pickle: bool, optional
             A flag whether to ignore the pickle file in future calls to
             ``model.build()``.
-        n_threads: int, optional
-            Number of CPU threads to use during parallelization using OpenMP. 
+        n_threads : int, optional
+            Number of CPU threads to use during parallelization using OpenMP.
             Defaults to max number of user CPU cores.
+        n_jobs : int, optional
+            Alias for ``n_threads``; ``None`` or ``-1`` uses every core.
     """
 
     def __init__(self, **params):
@@ -603,9 +605,11 @@ class BiphasicAxonMapModel(Model):
         ignore_pickle: bool, optional
             A flag whether to ignore the pickle file in future calls to
             ``model.build()``.
-        n_threads: int, optional
-            Number of CPU threads to use during parallelization using OpenMP. 
+        n_threads : int, optional
+            Number of CPU threads to use during parallelization using OpenMP.
             Defaults to max number of user CPU cores.
+        n_jobs : int, optional
+            Alias for ``n_threads``; ``None`` or ``-1`` uses every core.
 
     """
 

--- a/pulse2percept/models/granley2021.py
+++ b/pulse2percept/models/granley2021.py
@@ -2,13 +2,12 @@
    :py:class:`~pulse2percept.models.BiphasicAxonMapSpatial` [Granley2021]_"""
 import numpy as np
 import sys
-import warnings
 
 from . import AxonMapSpatial, Model
 from ..implants import ProsthesisSystem, ElectrodeArray
 from ..stimuli import BiphasicPulseTrain, Stimulus
 from ..percepts import Percept
-from ..utils import FreezeError
+from ..utils import FreezeError, deprecate_parameter
 from .base import NotBuiltError, BaseModel
 from ._granley2021 import fast_biphasic_axon_map
 
@@ -91,18 +90,18 @@ class DefaultSizeModel(BaseModel):
         Linear regression coefficients for size vs amplitude (Eq 5)
         F_size = a5*scaled_amp + a6
     engine : string, optional
-        .. deprecated:: 0.10
+        .. deprecated:: 0.9.1
 
-            Accepted but ignored, and will be removed in version 0.12. It used
-            to select between the NumPy and the (now removed) jax backend.
+            Accepted but ignored, and will be removed in version 0.10.0. It
+            used to select between the NumPy and the (now removed) jax
+            backend.
     """
 
+    @deprecate_parameter('engine', deprecated_version='0.9.1',
+                         removed_version='0.10.0',
+                         addendum="It used to select between the NumPy and "
+                                  "the (now removed) jax backend.")
     def __init__(self, rho, engine=None, **params):
-        if engine is not None:
-            warnings.warn("The 'engine' parameter of DefaultSizeModel is "
-                          "deprecated since version 0.10, and will be removed "
-                          "in version 0.12. It is ignored.",
-                          DeprecationWarning, stacklevel=2)
         super(DefaultSizeModel, self).__init__(**params)
         self.rho = rho
         self.build()
@@ -153,18 +152,18 @@ class DefaultStreakModel(BaseModel):
         Regression coefficients for streak length vs pulse duration (Eq 6)
         F_streak = -a7*pdur^a8 + a9
     engine : string, optional
-        .. deprecated:: 0.10
+        .. deprecated:: 0.9.1
 
-            Accepted but ignored, and will be removed in version 0.12. It used
-            to select between the NumPy and the (now removed) jax backend.
+            Accepted but ignored, and will be removed in version 0.10.0. It
+            used to select between the NumPy and the (now removed) jax
+            backend.
     """
 
+    @deprecate_parameter('engine', deprecated_version='0.9.1',
+                         removed_version='0.10.0',
+                         addendum="It used to select between the NumPy and "
+                                  "the (now removed) jax backend.")
     def __init__(self, axlambda, engine=None, **params):
-        if engine is not None:
-            warnings.warn("The 'engine' parameter of DefaultStreakModel is "
-                          "deprecated since version 0.10, and will be removed "
-                          "in version 0.12. It is ignored.",
-                          DeprecationWarning, stacklevel=2)
         super(DefaultStreakModel, self).__init__(**params)
         self.axlambda = axlambda
         self.build()

--- a/pulse2percept/models/granley2021.py
+++ b/pulse2percept/models/granley2021.py
@@ -1,8 +1,8 @@
 """:py:class:`~pulse2percept.models.BiphasicAxonMapModel`,
    :py:class:`~pulse2percept.models.BiphasicAxonMapSpatial` [Granley2021]_"""
-from functools import partial
 import numpy as np
 import sys
+import warnings
 
 from . import AxonMapSpatial, Model
 from ..implants import ProsthesisSystem, ElectrodeArray
@@ -11,28 +11,6 @@ from ..percepts import Percept
 from ..utils import FreezeError
 from .base import NotBuiltError, BaseModel
 from ._granley2021 import fast_biphasic_axon_map
-
-
-try:
-    import os
-    os.environ['XLA_PYTHON_CLIENT_PREALLOCATE'] = '0'
-    import jax
-    import jax.numpy as jnp
-    from jax import jit, vmap, lax
-    has_jax = True
-except ImportError:
-    has_jax = False
-
-
-def cond_jit(fn, static_argnums=None):
-    """ Conditional decorator for jax jit"""
-    if has_jax:
-        if static_argnums is None:
-            return jit(fn)
-        else:
-            return jit(fn, static_argnums=static_argnums)
-    else:
-        return fn
 
 
 class DefaultBrightModel(BaseModel):
@@ -111,13 +89,22 @@ class DefaultSizeModel(BaseModel):
         a0*pdur + a1.
     a5, a6 : float, optional
         Linear regression coefficients for size vs amplitude (Eq 5)
-        F_size = a5*scaled_amp + a6 
+        F_size = a5*scaled_amp + a6
+    engine : string, optional
+        .. deprecated:: 0.10
+
+            Accepted but ignored, and will be removed in version 0.12. It used
+            to select between the NumPy and the (now removed) jax backend.
     """
 
-    def __init__(self, rho, engine="serial", **params):
+    def __init__(self, rho, engine=None, **params):
+        if engine is not None:
+            warnings.warn("The 'engine' parameter of DefaultSizeModel is "
+                          "deprecated since version 0.10, and will be removed "
+                          "in version 0.12. It is ignored.",
+                          DeprecationWarning, stacklevel=2)
         super(DefaultSizeModel, self).__init__(**params)
         self.rho = rho
-        self.engine = engine
         self.build()
 
     def get_default_params(self):
@@ -149,10 +136,7 @@ class DefaultSizeModel(BaseModel):
         """
         min_f_size = self.min_rho**2 / self.rho**2
         F_size = self.a5 * amp * self.scale_threshold(pdur) + self.a6
-        if self.engine == 'jax':
-            return jnp.maximum(F_size, min_f_size)
-        else:
-            return np.maximum(F_size, min_f_size)
+        return np.maximum(F_size, min_f_size)
 
 
 class DefaultStreakModel(BaseModel):
@@ -168,12 +152,21 @@ class DefaultStreakModel(BaseModel):
     a7, a8, a9: float, optional
         Regression coefficients for streak length vs pulse duration (Eq 6)
         F_streak = -a7*pdur^a8 + a9
+    engine : string, optional
+        .. deprecated:: 0.10
+
+            Accepted but ignored, and will be removed in version 0.12. It used
+            to select between the NumPy and the (now removed) jax backend.
     """
 
-    def __init__(self, axlambda, engine='serial', **params):
+    def __init__(self, axlambda, engine=None, **params):
+        if engine is not None:
+            warnings.warn("The 'engine' parameter of DefaultStreakModel is "
+                          "deprecated since version 0.10, and will be removed "
+                          "in version 0.12. It is ignored.",
+                          DeprecationWarning, stacklevel=2)
         super(DefaultStreakModel, self).__init__(**params)
         self.axlambda = axlambda
-        self.engine = engine
         self.build()
 
     def get_default_params(self):
@@ -194,10 +187,7 @@ class DefaultStreakModel(BaseModel):
         """
         min_f_streak = self.min_lambda**2 / self.axlambda ** 2
         F_streak = self.a9 - self.a7 * pdur ** self.a8
-        if self.engine == 'jax':
-            return jnp.maximum(F_streak, min_f_streak)
-        else:
-            return np.maximum(F_streak, min_f_streak)
+        return np.maximum(F_streak, min_f_streak)
 
 
 class BiphasicAxonMapSpatial(AxonMapSpatial):
@@ -306,9 +296,9 @@ class BiphasicAxonMapSpatial(AxonMapSpatial):
         if self.bright_model is None:
             self.bright_model = DefaultBrightModel()
         if self.size_model is None:
-            self.size_model = DefaultSizeModel(self.rho, self.engine)
+            self.size_model = DefaultSizeModel(self.rho)
         if self.streak_model is None:
-            self.streak_model = DefaultStreakModel(self.axlambda, self.engine)
+            self.streak_model = DefaultStreakModel(self.axlambda)
         for key, val in params.items():
             if key in ['bright_model', 'size_model', 'streak_model']:
                 continue
@@ -399,19 +389,8 @@ class BiphasicAxonMapSpatial(AxonMapSpatial):
             raise TypeError("size_model needs to be callable")
         if not callable(self.streak_model):
             raise TypeError("streak_model needs to be callable")
-        if self.engine == 'jax' and not has_jax:
-            raise ImportError("Engine was chosen as jax, but jax is not installed. "
-                              "You can install it with 'pip install \"jax[cpu]\"' for cpu "
-                              "or following https://github.com/google/jax#installation for gpu")
 
         super(BiphasicAxonMapSpatial, self)._build()
-        if self.engine == 'jax':
-            # Clear previously cached functions
-            self._predict_spatial_jax = jit(self._predict_spatial_jax)
-            self._predict_spatial_batched = jit(self._predict_spatial_batched)
-            # Cache axon_contrib for fast access later
-            self.axon_contrib = jax.device_put(
-                jnp.array(self.axon_contrib), jax.devices()[0])
 
     def _predict_spatial(self, earray, stim):
         """Predicts the percept"""
@@ -441,133 +420,24 @@ class BiphasicAxonMapSpatial(AxonMapSpatial):
         x = np.array(x, dtype=np.float32)
         y = np.array(y, dtype=np.float32)
 
-        if self.engine != 'jax':
-            bright_effects = np.array(self.bright_model(elec_params[:, 0], elec_params[:, 1], elec_params[:, 2]),
-                                      dtype=np.float32).reshape((-1))
-            size_effects = np.array(self.size_model(elec_params[:, 0], elec_params[:, 1], elec_params[:, 2]),
-                                    dtype=np.float32).reshape((-1))
-            streak_effects = np.array(self.streak_model(elec_params[:, 0], elec_params[:, 1], elec_params[:, 2]),
-                                      dtype=np.float32).reshape((-1))
-            amps = np.array(elec_params[:, 1], dtype=np.float32).reshape((-1))
-            return fast_biphasic_axon_map(
-                amps,
-                bright_effects,
-                size_effects,
-                streak_effects,
-                x, y,
-                self.axon_contrib,
-                self.axon_idx_start.astype(np.uint32),
-                self.axon_idx_end.astype(np.uint32),
-                self.rho, self.thresh_percept,
-                self.n_threads)
-        else:
-            return self._predict_spatial_jax(elec_params[:, :3], x, y)
-
-    def predict_one_point_jax(self, axon, eparams, x, y, rho):
-        """ Predicts the brightness contribution from each axon segment for each pixel"""
-        d2_el = (axon[:, 0, None] - x)**2 + (axon[:, 1, None] - y)**2
-        intensities = eparams[:, 0] * jnp.exp(-d2_el / (2. * rho**2 * eparams[:, 1])) * (
-            axon[:, 2, None] ** (1./eparams[:, 2]))
-        return jnp.sum(intensities, axis=1)
-
-    @partial(cond_jit, static_argnums=[0])
-    def biphasic_axon_map_jax(self, eparams, x, y, axon_segments, rho, thresh_percept):
-        """ Predicts the spatial response of BiphasicAxonMapModel using Jax
-
-        Parameters:
-        -------------
-        eparams : jnp.array with shape (n_elecs, 3)
-            Brightness, size, and streak length effect on each electrode
-        x, y : jnp.array with shape (n_elecs)
-            x and y coordinate of each electrode
-        axon_segments : jnp.array with shape (n_points, n_ax_segments, 3)
-            Closest axon segment to each simulated point, as returned by calc_axon_sensitivities
-        rho : float
-            The rho parameter of the axon map model: exponential decay constant
-            (microns) away from the axon.
-        axlambda : float
-            The lambda parameter of the axon map model: exponential decay constant
-            (microns) away from the cell body along the axon
-        thresh_percept : float
-            Spatial responses smaller than ``thresh_percept`` will be set to zero
-        """
-        I = jnp.max(jax.vmap(self.predict_one_point_jax, in_axes=[0, None, None, None, None])(
-            axon_segments,
-            eparams, x, y,
-            rho), axis=1)
-        I = (I > thresh_percept) * I
-        return I
-
-    @partial(cond_jit, static_argnums=[0])
-    def _predict_spatial_jax(self, elec_params, x, y):
-        """
-        A stripped version of _predict_spatial that takes only electrode parameters, 
-        and returns only a numpy array
-        This is a better function to use when the stimulus is guaranteed to be safe,
-        and the percept object isn't used, just the data in the percept (e.g. inside a neural network)
-
-        Parameters:
-        ------------
-        elec_params : np.array with shape (n_electrodes, 3)
-            Frequency, amplitude, and pulse duration for each electrode
-        x, y: np.array with shape (n_electrodes)
-            x and y coordinates of electrodes
-
-        Returns:
-        ------------
-        resp : flattened np.array() representing the resulting percept, shape (:, 1)
-        """
-        bright_effects = jnp.array(self.bright_model(elec_params[:, 0],
-                                                     elec_params[:, 1],
-                                                     elec_params[:, 2])).reshape((-1))
-        size_effects = jnp.array(self.size_model(elec_params[:, 0],
-                                                 elec_params[:, 1],
-                                                 elec_params[:, 2])).reshape((-1))
-        streak_effects = jnp.array(self.streak_model(elec_params[:, 0],
-                                                     elec_params[:, 1],
-                                                     elec_params[:, 2])).reshape((-1))
-        eparams = jnp.stack(
-            [bright_effects, size_effects, streak_effects], axis=1)
-
-        resp = self.biphasic_axon_map_jax(eparams, x, y,
-                                          self.axon_contrib,
-                                          self.rho,
-                                          self.thresh_percept)
-        return resp
-
-    @partial(cond_jit, static_argnums=[0])
-    def _predict_spatial_batched(self, elec_params, x, y):
-        """ A batched version of _predict_spatial_jax
-        Parameters:
-        -------------
-        elec_params : np.array with shape (batch_size, n_electrodes, 3)
-            The 3 columns are freq, amp, pdur for each electrode
-        x, y: np.array with shape (n_electrodes)
-            x and y coordinates of electrodes
-        Returns:
-        ------------
-        resp : np.array() representing the resulting percepts, shape (batch_size, :, 1)
-        """
-        bright_effects = self.bright_model(elec_params[:, :, 0],
-                                           elec_params[:, :, 1],
-                                           elec_params[:, :, 2])
-        size_effects = self.size_model(elec_params[:, :, 0],
-                                       elec_params[:, :, 1],
-                                       elec_params[:, :, 2])
-        streak_effects = self.streak_model(elec_params[:, :, 0],
-                                           elec_params[:, :, 1],
-                                           elec_params[:, :, 2])
-        eparams = jnp.stack(
-            [bright_effects, size_effects, streak_effects], axis=2)
-
-        def predict_one(e_params):
-            return self.biphasic_axon_map_jax(e_params, x, y,
-                                              self.axon_contrib,
-                                              self.rho,
-                                              self.thresh_percept)
-        resps = lax.map(predict_one, eparams)
-
-        return resps
+        bright_effects = np.array(self.bright_model(elec_params[:, 0], elec_params[:, 1], elec_params[:, 2]),
+                                  dtype=np.float32).reshape((-1))
+        size_effects = np.array(self.size_model(elec_params[:, 0], elec_params[:, 1], elec_params[:, 2]),
+                                dtype=np.float32).reshape((-1))
+        streak_effects = np.array(self.streak_model(elec_params[:, 0], elec_params[:, 1], elec_params[:, 2]),
+                                  dtype=np.float32).reshape((-1))
+        amps = np.array(elec_params[:, 1], dtype=np.float32).reshape((-1))
+        return fast_biphasic_axon_map(
+            amps,
+            bright_effects,
+            size_effects,
+            streak_effects,
+            x, y,
+            self.axon_contrib,
+            self.axon_idx_start.astype(np.uint32),
+            self.axon_idx_end.astype(np.uint32),
+            self.rho, self.thresh_percept,
+            self.n_threads)
 
     def predict_percept(self, implant, t_percept=None):
         """ Predicts the spatial response
@@ -634,93 +504,6 @@ class BiphasicAxonMapSpatial(AxonMapSpatial):
                 implant.earray, stim).reshape(self.grid.x.shape)
         return Percept(resp, space=self.grid, time=t_percept,
                        metadata={'stim': stim.metadata})
-
-    def predict_percept_batched(self, implant, stims, t_percept=None):
-        """
-        Batched version of predict_percept
-        Only supported with jax engine
-
-        This is significantly faster if you do not batch ALL of your percepts, but rather, split
-        them into chunks (128 - 256 percepts each) and repeatedly call that. 
-        This is because jax has to compile on the first call, so repeated calls 
-        is much faster.
-
-        Parameters
-        ----------
-            implant: :py:class:`~pulse2percept.implants.ProsthesisSystem`
-                A valid prosthesis system. 
-            stims : list of stimuli
-                A percept will be predicted for each stimulus. Each stimulus
-                must be a collection of :py:class:`~pulse2percept.stimuli.BiphasicPulseTrains'
-            t_percept: float or list of floats, optional
-                The time points at which to output a percept (ms).
-                If None, ``implant.stim.time`` is used.
-
-        Returns
-        -------
-            percepts: list of :py:class:`~pulse2percept.models.Percept`
-                A list of Percept objects whose ``data`` container has dimensions Y x X x 1.
-        """
-        if self.engine != 'jax':
-            raise ImportError(
-                "Batched predict percept is not supported unless engine is jax")
-
-        stims = [Stimulus(s) for s in stims]
-        # Make sure all stimuli are BiphasicPulseTrains
-        for stim in stims:
-            if not isinstance(stim, BiphasicPulseTrain):
-                # Could still be a stimulus where each electrode has a biphasic pulse train
-                # or a 0 stimulus
-                for i, (ele, params) in enumerate(stim.metadata
-                                                  ['electrodes'].items()):
-                    if (params['type'] != BiphasicPulseTrain or
-                            params['metadata']['delay_dur'] != 0) and \
-                            np.any(stim[i]):
-                        raise TypeError(
-                            f"All stimuli must be BiphasicPulseTrains with no "
-                            f"delay dur (Failing electrode: {ele})")
-
-        if not self.is_built:
-            raise NotBuiltError("Yout must call ``build`` first.")
-        if not isinstance(implant, ProsthesisSystem):
-            raise TypeError(f"'implant' must be a ProsthesisSystem object, "
-                            f"not {type(implant)}.")
-        if implant.eye != self.eye:
-            raise ValueError(f"The implant is in {implant.eye} but the model was "
-                             f"built for {self.eye}.")
-
-        # Currently all stimuli must have same electrodes
-        all_elecs = list(set().union(
-            *[s.metadata['electrodes'].keys() for s in stims]))
-        max_elecs = len(all_elecs)
-        # Compute stimulus parameters for all electrodes
-        eparams = np.zeros((len(stims), max_elecs, 3))
-        for idx_stim, stim in enumerate(stims):
-            if stim is None:
-                continue
-            for elec in stim.metadata['electrodes'].keys():
-                idx_elec = all_elecs.index(elec)
-                elec_metadata = stim.metadata['electrodes'][elec]['metadata']
-                eparams[idx_stim, idx_elec, 0] = elec_metadata['freq']
-                eparams[idx_stim, idx_elec, 1] = elec_metadata['amp']
-                eparams[idx_stim, idx_elec, 2] = elec_metadata['phase_dur']
-        x = np.array([implant.earray[elec].x for elec in all_elecs])
-        y = np.array([implant.earray[elec].y for elec in all_elecs])
-        # Predict percepts (returns only numpy array)
-        percepts_data = self._predict_spatial_batched(eparams, x, y)
-        # Convert into percepts
-        percepts = []
-        for idx_percept, pdata in enumerate(percepts_data):
-            if t_percept is None:
-                n_time = 1
-            else:
-                n_time = len(t_percept)
-            resp = np.zeros(list(self.grid.x.shape) + [n_time])
-            # Response goes in first frame
-            resp[:, :, 0] = pdata.reshape(self.grid.x.shape)
-            percepts.append(Percept(resp, space=self.grid, time=t_percept,
-                                    metadata={'stim': stims[idx_percept].metadata}))
-        return percepts
 
 
 class BiphasicAxonMapModel(Model):

--- a/pulse2percept/models/nanduri2012.py
+++ b/pulse2percept/models/nanduri2012.py
@@ -54,8 +54,10 @@ class Nanduri2012Spatial(SpatialModel):
         A float between 0 and 1 will be interpreted as a ratio of pixels to
         subject to noise in each frame.
     n_threads : int, optional
-        Number of CPU threads to use during parallelization using OpenMP. 
+        Number of CPU threads to use during parallelization using OpenMP.
         Defaults to max number of user CPU cores.
+    n_jobs : int, optional
+        Alias for ``n_threads``; ``None`` or ``-1`` uses every core.
 
     """
 
@@ -132,8 +134,10 @@ class Nanduri2012Temporal(TemporalModel):
     thresh_percept : float, optional
         Below threshold, the percept has brightness zero.
     n_threads : int, optional
-        Number of CPU threads to use during parallelization using OpenMP. 
+        Number of CPU threads to use during parallelization using OpenMP.
         Defaults to max number of user CPU cores.
+    n_jobs : int, optional
+        Alias for ``n_threads``; ``None`` or ``-1`` uses every core.
 
     """
 

--- a/pulse2percept/models/tests/test_base.py
+++ b/pulse2percept/models/tests/test_base.py
@@ -1,4 +1,6 @@
 import copy
+import multiprocessing
+import warnings
 
 import numpy as np
 import pytest
@@ -112,6 +114,49 @@ def test_SpatialModel():
     with pytest.raises(TypeError):
         # must pass an implant
         ValidSpatialModel().build().predict_percept(Stimulus(3))
+
+@pytest.mark.parametrize('param, value', [('engine', 'serial'),
+                                          ('scheduler', 'dask')])
+def test_SpatialModel_deprecated_params(param, value):
+    # `engine` chose the Cython vs pure-Python axon-growth path (Cython is now
+    # always used) and `scheduler` drove the joblib/dask backends, removed in
+    # 0.9.1. Both are still accepted, but ignored:
+    with pytest.deprecated_call():
+        model = ValidSpatialModel(**{param: value})
+    # Still stored and readable, just unused by anything:
+    npt.assert_equal(getattr(model, param), value)
+    # Naming it later warns as well:
+    with pytest.deprecated_call():
+        model.set_params(**{param: value})
+    # Falling back to the default must stay silent, as must reading the
+    # parameters back out -- the warning is for explicit use only:
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", DeprecationWarning)
+        silent = ValidSpatialModel()
+        repr(silent)
+        silent.set_params(xystep=0.5)
+        copy.deepcopy(silent)
+
+
+@pytest.mark.parametrize('param, value', [('engine', 'serial'),
+                                          ('scheduler', 'dask')])
+def test_Model_deprecated_params(param, value):
+    # A Model built from instances never reaches BaseModel.__init__, so this
+    # path needs catching separately, and should warn only once:
+    with pytest.deprecated_call() as record:
+        model = Model(spatial=ValidSpatialModel(), **{param: value})
+    deprecations = [w for w in record
+                    if issubclass(w.category, DeprecationWarning)]
+    npt.assert_equal(len(deprecations), 1)
+    # The warning names the model the user actually constructed:
+    npt.assert_equal('Model' in str(deprecations[0].message), True)
+    npt.assert_equal(getattr(model, param), value)
+    with pytest.deprecated_call():
+        model.set_params({param: value})
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", DeprecationWarning)
+        Model(spatial=ValidSpatialModel())
+
 
 def test_eq_SpatialModel():
     valid = ValidSpatialModel()
@@ -288,6 +333,49 @@ def test_deepcopy_TemporalModel():
     # Assert "destroying" the original doesn't affect the copied
     original = None
     npt.assert_equal(copied is not None, True)
+
+
+@pytest.mark.parametrize('cls', [ValidSpatialModel, ValidTemporalModel])
+def test_n_jobs_aliases_n_threads(cls):
+    # `n_jobs` and `n_threads` are two names for the OpenMP thread count, and
+    # must never disagree:
+    model = cls()
+    npt.assert_equal(model.n_jobs, model.n_threads)
+    # Setting either name moves both, whether in the constructor...
+    model = cls(n_jobs=3)
+    npt.assert_equal(model.n_threads, 3)
+    npt.assert_equal(model.n_jobs, 3)
+    # ...or afterwards, by attribute or by set_params:
+    model.n_jobs = 5
+    npt.assert_equal(model.n_threads, 5)
+    model.n_threads = 7
+    npt.assert_equal(model.n_jobs, 7)
+    model.set_params(n_jobs=2)
+    npt.assert_equal(model.n_threads, 2)
+    # The default must not quietly drop us to a single thread:
+    npt.assert_equal(cls().n_threads, multiprocessing.cpu_count())
+    # None and -1 both mean "every core", following scikit-learn:
+    npt.assert_equal(cls(n_jobs=None).n_threads, multiprocessing.cpu_count())
+    npt.assert_equal(cls(n_jobs=-1).n_threads, multiprocessing.cpu_count())
+    # Nonsense is rejected rather than silently ignored:
+    for bad in (0, -2, 2.5, 'many'):
+        with pytest.raises(ValueError):
+            cls(n_jobs=bad)
+    # It is an alias, not a deprecation -- it must not warn:
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", DeprecationWarning)
+        cls(n_jobs=4)
+
+
+def test_Model_n_jobs_aliases_n_threads():
+    # Through a Model, n_jobs has to reach both sub-models:
+    model = Model(spatial=ValidSpatialModel(), temporal=ValidTemporalModel(),
+                  n_jobs=3)
+    npt.assert_equal(model.spatial.n_threads, 3)
+    npt.assert_equal(model.temporal.n_threads, 3)
+    model.n_jobs = 6
+    npt.assert_equal(model.spatial.n_threads, 6)
+    npt.assert_equal(model.temporal.n_threads, 6)
 
 
 def test_Model():

--- a/pulse2percept/models/tests/test_beyeler2019.py
+++ b/pulse2percept/models/tests/test_beyeler2019.py
@@ -3,6 +3,7 @@ import numpy as np
 import pytest
 import numpy.testing as npt
 import copy
+import warnings
 
 from matplotlib.axes import Subplot
 import matplotlib.pyplot as plt
@@ -175,7 +176,7 @@ def test_ScoreboardModel_predict_percept():
     assert_warns_msg(UserWarning, model.predict_percept, msg, implant)
 
 
-@ pytest.mark.parametrize('engine', ('serial', 'cython', 'jax'))
+@ pytest.mark.parametrize('engine', ('serial', 'cython'))
 def test_AxonMapSpatial(engine):
     # AxonMapSpatial automatically sets `rho`, `axlambda`:
     model = AxonMapSpatial(engine=engine, xystep=5)
@@ -213,12 +214,6 @@ def test_AxonMapSpatial(engine):
     model = AxonMapSpatial(engine=engine, rho=200, axlambda=100, xystep=5,
                            xrange=(-20, 20), yrange=(-15, 15))
     model.build()
-    # Axon map jax predict_percept not implemented yet
-    if engine == 'jax':
-        with pytest.raises(NotImplementedError):
-            percept = model.predict_percept(
-                ArgusII(stim={'A1': [1, 0], 'B3': [0, 2]}))
-        return
     percept = model.predict_percept(ArgusI(stim={'A1': [1, 0], 'B3': [0, 2]}))
     npt.assert_equal(percept.shape, list(model.grid.x.shape) + [2])
     pmax = percept.data.max(axis=(0, 1))
@@ -278,7 +273,7 @@ def test_AxonMapSpatial_plot():
         plt.close(fig)
 
 
-@ pytest.mark.parametrize('engine', ('serial', 'cython', 'jax'))
+@ pytest.mark.parametrize('engine', ('serial', 'cython'))
 def test_AxonMapModel(engine):
     set_params = {'xystep': 2, 'engine': engine, 'rho': 432, 'axlambda': 20,
                   'n_axons': 9, 'n_ax_segments': 50,
@@ -356,7 +351,7 @@ def test_deepcopy_AxonMapModel(build):
 @ pytest.mark.parametrize('eye', ('LE', 'RE'))
 @ pytest.mark.parametrize('loc_od', ((15.5, 1.5), (7.0, 3.0), (-2.0, -2.0)))
 @ pytest.mark.parametrize('sign', (-1.0, 1.0))
-@ pytest.mark.parametrize('engine', ('serial', 'cython', 'jax'))
+@ pytest.mark.parametrize('engine', ('serial', 'cython'))
 def test_AxonMapModel__jansonius2009(eye, loc_od, sign, engine):
     # With `rho` starting at 0, all axons should originate in the optic disc
     # center
@@ -411,7 +406,7 @@ def test_AxonMapModel__jansonius2009(eye, loc_od, sign, engine):
         npt.assert_almost_equal(single_fiber[0], loc_od)
 
 
-@ pytest.mark.parametrize('engine', ('serial', 'cython', 'jax'))
+@ pytest.mark.parametrize('engine', ('serial', 'cython'))
 def test_AxonMapModel_grow_axon_bundles(engine):
     for n_axons in [1, 2, 3, 5, 10]:
         model = AxonMapModel(xystep=2, engine=engine, n_axons=n_axons,
@@ -421,7 +416,7 @@ def test_AxonMapModel_grow_axon_bundles(engine):
         npt.assert_equal(len(bundles), n_axons)
 
 
-@ pytest.mark.parametrize('engine', ('serial', 'cython', 'jax'))
+@ pytest.mark.parametrize('engine', ('serial', 'cython'))
 def test_AxonMapModel_find_closest_axon(engine):
     model = AxonMapModel(xystep=1, engine=engine, n_axons=5,
                          xrange=(-20, 20), yrange=(-15, 15),
@@ -453,7 +448,7 @@ def test_AxonMapModel_find_closest_axon(engine):
     npt.assert_equal(closest_idx, 0)
 
 
-@ pytest.mark.parametrize('engine', ('serial', 'cython', 'jax'))
+@ pytest.mark.parametrize('engine', ('serial', 'cython'))
 def test_AxonMapModel_calc_axon_sensitivity(engine):
     model = AxonMapModel(xystep=2, engine=engine, n_axons=10,
                          xrange=(-20, 20), yrange=(-15, 15),
@@ -463,32 +458,42 @@ def test_AxonMapModel_calc_axon_sensitivity(engine):
                              model.spatial.grid.ret.y.ravel()))
     bundles = model.spatial.grow_axon_bundles()
     axons = model.spatial.find_closest_axon(bundles)
-    # Need two separate contribs, one to get cut off axons from, and another
-    # to actually test against (with/without padding)
-    contrib = model.spatial.calc_axon_sensitivity(axons, pad=False)
-    pad = engine == 'jax'
-    axon_contrib = model.spatial.calc_axon_sensitivity(axons, pad=pad)
+    axon_contrib = model.spatial.calc_axon_sensitivity(axons)
 
     # Check lambda math:
-    max_axon_length = max([len(ax) for ax in contrib])
-    for ax, xy, model_ax in zip(contrib, xyret, axon_contrib):
-        axon = np.insert(ax, 0, list(xy) + [0], axis=0)
+    for model_ax, xy in zip(axon_contrib, xyret):
+        axon = np.insert(model_ax, 0, list(xy) + [0], axis=0)
         d2 = np.cumsum(np.sqrt(np.diff(axon[:, 0], axis=0) ** 2 +
                                np.diff(axon[:, 1], axis=0) ** 2))**2
         max_d2 = -2.0 * model.axlambda ** 2 * np.log(model.min_ax_sensitivity)
         idx_d2 = d2 < max_d2
         sensitivity = np.exp(-d2[idx_d2] / (2.0 * model.spatial.axlambda ** 2))
-        # Axons need to be padded for jax
-        if engine == 'jax':
-            s = np.zeros((max_axon_length))
-            s[:len(sensitivity)] = sensitivity
-            if len(sensitivity) > 0:
-                s[len(sensitivity):] = sensitivity[-1]
-            sensitivity = s.astype(np.float32)
         npt.assert_almost_equal(sensitivity, model_ax[:, 2])
 
 
-@ pytest.mark.parametrize('engine', ('serial', 'cython', 'jax'))
+@ pytest.mark.parametrize('pad', (True, False))
+def test_AxonMapModel_calc_axon_sensitivity_deprecated_pad(pad):
+    # 'pad' used to pad all axons to the length of the longest one for the
+    # (now removed) jax backend. It is still accepted, but ignored:
+    model = AxonMapModel(xystep=2, n_axons=10, xrange=(-20, 20),
+                         yrange=(-15, 15), axons_range=(-30, 30))
+    model.build()
+    axons = model.spatial.find_closest_axon(model.spatial.grow_axon_bundles())
+    with pytest.deprecated_call():
+        deprecated = model.spatial.calc_axon_sensitivity(axons, pad=pad)
+    # Always the unpadded list, even for pad=True:
+    expected = model.spatial.calc_axon_sensitivity(axons)
+    npt.assert_equal(isinstance(deprecated, list), True)
+    npt.assert_equal(len(deprecated), len(expected))
+    for ax_dep, ax_exp in zip(deprecated, expected):
+        npt.assert_almost_equal(ax_dep, ax_exp)
+    # Not passing it does not warn:
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", DeprecationWarning)
+        model.spatial.calc_axon_sensitivity(axons)
+
+
+@ pytest.mark.parametrize('engine', ('serial', 'cython'))
 def test_AxonMapModel_calc_bundle_tangent(engine):
     model = AxonMapModel(xystep=5, engine=engine, n_axons=500,
                          xrange=(-20, 20), yrange=(-15, 15),
@@ -504,7 +509,7 @@ def test_AxonMapModel_calc_bundle_tangent(engine):
         model.spatial.calc_bundle_tangent(0, [1000])
 
 
-@ pytest.mark.parametrize('engine', ('serial', 'cython', 'jax'))
+@ pytest.mark.parametrize('engine', ('serial', 'cython'))
 def test_AxonMapModel_calc_bundle_tangent_fast(engine):
     model = AxonMapModel(xystep=5, engine=engine, n_axons=500,
                          xrange=(-20, 20), yrange=(-15, 15),
@@ -520,7 +525,7 @@ def test_AxonMapModel_calc_bundle_tangent_fast(engine):
 
 
 
-@ pytest.mark.parametrize('engine', ('serial', 'cython', 'jax'))
+@ pytest.mark.parametrize('engine', ('serial', 'cython'))
 def test_AxonMapModel_predict_percept(engine):
     model = AxonMapModel(xystep=0.55, axlambda=100, rho=100,
                          thresh_percept=0, engine=engine,
@@ -530,11 +535,6 @@ def test_AxonMapModel_predict_percept(engine):
     # Single-electrode stim:
     img_stim = np.zeros(60)
     img_stim[47] = 1
-    # Axon map jax predict_percept not implemented yet
-    if engine == 'jax':
-        with pytest.raises(NotImplementedError):
-            percept = model.predict_percept(ArgusII(stim=img_stim))
-        return
     percept = model.predict_percept(ArgusII(stim=img_stim))
     # Single bright pixel, rest of arc is less bright:
     npt.assert_equal(np.sum(percept.data > 0.8), 1)

--- a/pulse2percept/models/tests/test_beyeler2019.py
+++ b/pulse2percept/models/tests/test_beyeler2019.py
@@ -19,7 +19,7 @@ from pulse2percept.utils.testing import assert_warns_msg
 
 def test_ScoreboardSpatial():
     # ScoreboardSpatial automatically sets `rho`:
-    model = ScoreboardSpatial(engine='serial', xystep=5)
+    model = ScoreboardSpatial(xystep=5)
 
     # User can set `rho`:
     model.rho = 123
@@ -46,7 +46,7 @@ def test_ScoreboardSpatial():
     npt.assert_almost_equal(percept.data, 0)
 
     # Multiple frames are processed independently:
-    model = ScoreboardSpatial(engine='serial', rho=200, xystep=5,
+    model = ScoreboardSpatial(rho=200, xystep=5,
                               xrange=(-20, 20), yrange=(-15, 15))
     model.build()
     percept = model.predict_percept(ArgusI(stim={'A1': [1, 0], 'B3': [0, 2]}))
@@ -80,7 +80,7 @@ def test_deepcopy_ScoreboardSpatial():
 
 def test_ScoreboardModel():
     # ScoreboardModel automatically sets `rho`:
-    model = ScoreboardModel(engine='serial', xystep=5)
+    model = ScoreboardModel(xystep=5)
     npt.assert_equal(model.has_space, True)
     npt.assert_equal(model.has_time, False)
     npt.assert_equal(hasattr(model.spatial, 'rho'), True)
@@ -108,7 +108,7 @@ def test_ScoreboardModel():
     npt.assert_almost_equal(model.predict_percept(implant).data, 0)
 
     # Multiple frames are processed independently:
-    model = ScoreboardModel(engine='serial', rho=200, xystep=5,
+    model = ScoreboardModel(rho=200, xystep=5,
                             xrange=(-20, 20), yrange=(-15, 15))
     model.build()
     percept = model.predict_percept(ArgusI(stim={'A1': [1, 2]}))
@@ -156,14 +156,14 @@ def test_ScoreboardModel_predict_percept():
     npt.assert_almost_equal(percept.data[33, 46, 0], np.max(percept.data))
 
     # Full Argus II: 60 bright spots
-    model = ScoreboardModel(engine='serial', xystep=0.55, rho=100)
+    model = ScoreboardModel(xystep=0.55, rho=100)
     model.build()
     percept = model.predict_percept(ArgusII(stim=np.ones(60)))
     npt.assert_equal(np.sum(np.isclose(percept.data, 0.8, rtol=0.1, atol=0.1)),
                      88)
 
     # Model gives same outcome as Spatial:
-    spatial = ScoreboardSpatial(engine='serial', xystep=1, rho=100)
+    spatial = ScoreboardSpatial(xystep=1, rho=100)
     spatial.build()
     spatial_percept = model.predict_percept(ArgusII(stim=np.ones(60)))
     npt.assert_almost_equal(percept.data, spatial_percept.data)
@@ -176,10 +176,9 @@ def test_ScoreboardModel_predict_percept():
     assert_warns_msg(UserWarning, model.predict_percept, msg, implant)
 
 
-@ pytest.mark.parametrize('engine', ('serial', 'cython'))
-def test_AxonMapSpatial(engine):
+def test_AxonMapSpatial():
     # AxonMapSpatial automatically sets `rho`, `axlambda`:
-    model = AxonMapSpatial(engine=engine, xystep=5)
+    model = AxonMapSpatial(xystep=5)
 
     # User can set `rho`:
     model.rho = 123
@@ -211,7 +210,7 @@ def test_AxonMapSpatial(engine):
         AxonMapSpatial(axlambda=9).build()
 
     # Multiple frames are processed independently:
-    model = AxonMapSpatial(engine=engine, rho=200, axlambda=100, xystep=5,
+    model = AxonMapSpatial(rho=200, axlambda=100, xystep=5,
                            xrange=(-20, 20), yrange=(-15, 15))
     model.build()
     percept = model.predict_percept(ArgusI(stim={'A1': [1, 0], 'B3': [0, 2]}))
@@ -273,9 +272,8 @@ def test_AxonMapSpatial_plot():
         plt.close(fig)
 
 
-@ pytest.mark.parametrize('engine', ('serial', 'cython'))
-def test_AxonMapModel(engine):
-    set_params = {'xystep': 2, 'engine': engine, 'rho': 432, 'axlambda': 20,
+def test_AxonMapModel():
+    set_params = {'xystep': 2, 'rho': 432, 'axlambda': 20,
                   'n_axons': 9, 'n_ax_segments': 50,
                   'xrange': (-30, 30), 'yrange': (-20, 20),
                   'loc_od': (5, 6)}
@@ -351,11 +349,10 @@ def test_deepcopy_AxonMapModel(build):
 @ pytest.mark.parametrize('eye', ('LE', 'RE'))
 @ pytest.mark.parametrize('loc_od', ((15.5, 1.5), (7.0, 3.0), (-2.0, -2.0)))
 @ pytest.mark.parametrize('sign', (-1.0, 1.0))
-@ pytest.mark.parametrize('engine', ('serial', 'cython'))
-def test_AxonMapModel__jansonius2009(eye, loc_od, sign, engine):
+def test_AxonMapModel__jansonius2009(eye, loc_od, sign):
     # With `rho` starting at 0, all axons should originate in the optic disc
     # center
-    model = AxonMapModel(loc_od=loc_od, xystep=2, engine=engine,
+    model = AxonMapModel(loc_od=loc_od, xystep=2,
                          ax_segments_range=(0, 45),
                          n_ax_segments=100)
     for phi0 in [-135.0, 66.0, 128.0]:
@@ -365,7 +362,7 @@ def test_AxonMapModel__jansonius2009(eye, loc_od, sign, engine):
 
     # These axons should all end at the meridian
     for phi0 in [110.0, 135.0, 160.0]:
-        model = AxonMapModel(loc_od=(15, 2), xystep=2, engine=engine,
+        model = AxonMapModel(loc_od=(15, 2), xystep=2,
                              n_ax_segments=801,
                              ax_segments_range=(0, 45))
         ax_pos = model.spatial._jansonius2009(sign * phi0)
@@ -374,31 +371,28 @@ def test_AxonMapModel__jansonius2009(eye, loc_od, sign, engine):
     # `phi0` must be within [-180, 180]
     for phi0 in [-200.0, 181.0]:
         with pytest.raises(ValueError):
-            failed = AxonMapModel(xystep=2, engine=engine)
+            failed = AxonMapModel(xystep=2)
             failed.spatial._jansonius2009(phi0)
 
     # `n_rho` must be >= 1
     for n_rho in [-1, 0]:
         with pytest.raises(ValueError):
-            model = AxonMapModel(n_ax_segments=n_rho, xystep=2,
-                                 engine=engine)
+            model = AxonMapModel(n_ax_segments=n_rho, xystep=2)
             model.spatial._jansonius2009(0.0)
 
     # `ax_segments_range` must have min <= max
     for lorho in [-200.0, 90.0]:
         with pytest.raises(ValueError):
-            model = AxonMapModel(ax_segments_range=(lorho, 45), xystep=2,
-                                 engine=engine)
+            model = AxonMapModel(ax_segments_range=(lorho, 45), xystep=2)
             model.spatial._jansonius2009(0)
     for hirho in [-200.0, 40.0]:
         with pytest.raises(ValueError):
-            model = AxonMapModel(ax_segments_range=(45, hirho), xystep=2,
-                                 engine=engine)
+            model = AxonMapModel(ax_segments_range=(45, hirho), xystep=2)
             model.spatial._jansonius2009(0)
 
     # A single axon fiber with `phi0`=0 should return a single pixel location
     # that corresponds to the optic disc
-        model = AxonMapModel(loc_od=loc_od, xystep=2, engine=engine, eye=eye,
+        model = AxonMapModel(loc_od=loc_od, xystep=2, eye=eye,
                              ax_segments_range=(0, 0),
                              n_ax_segments=1)
         single_fiber = model.spatial._jansonius2009(0)
@@ -406,19 +400,17 @@ def test_AxonMapModel__jansonius2009(eye, loc_od, sign, engine):
         npt.assert_almost_equal(single_fiber[0], loc_od)
 
 
-@ pytest.mark.parametrize('engine', ('serial', 'cython'))
-def test_AxonMapModel_grow_axon_bundles(engine):
+def test_AxonMapModel_grow_axon_bundles():
     for n_axons in [1, 2, 3, 5, 10]:
-        model = AxonMapModel(xystep=2, engine=engine, n_axons=n_axons,
+        model = AxonMapModel(xystep=2, n_axons=n_axons,
                              axons_range=(-20, 20), xrange=(-20, 20),
                              yrange=(-15, 15))
         bundles = model.spatial.grow_axon_bundles()
         npt.assert_equal(len(bundles), n_axons)
 
 
-@ pytest.mark.parametrize('engine', ('serial', 'cython'))
-def test_AxonMapModel_find_closest_axon(engine):
-    model = AxonMapModel(xystep=1, engine=engine, n_axons=5,
+def test_AxonMapModel_find_closest_axon():
+    model = AxonMapModel(xystep=1, n_axons=5,
                          xrange=(-20, 20), yrange=(-15, 15),
                          axons_range=(-45, 45))
     model.build()
@@ -448,9 +440,8 @@ def test_AxonMapModel_find_closest_axon(engine):
     npt.assert_equal(closest_idx, 0)
 
 
-@ pytest.mark.parametrize('engine', ('serial', 'cython'))
-def test_AxonMapModel_calc_axon_sensitivity(engine):
-    model = AxonMapModel(xystep=2, engine=engine, n_axons=10,
+def test_AxonMapModel_calc_axon_sensitivity():
+    model = AxonMapModel(xystep=2, n_axons=10,
                          xrange=(-20, 20), yrange=(-15, 15),
                          axons_range=(-30, 30))
     model.build()
@@ -493,9 +484,8 @@ def test_AxonMapModel_calc_axon_sensitivity_deprecated_pad(pad):
         model.spatial.calc_axon_sensitivity(axons)
 
 
-@ pytest.mark.parametrize('engine', ('serial', 'cython'))
-def test_AxonMapModel_calc_bundle_tangent(engine):
-    model = AxonMapModel(xystep=5, engine=engine, n_axons=500,
+def test_AxonMapModel_calc_bundle_tangent():
+    model = AxonMapModel(xystep=5, n_axons=500,
                          xrange=(-20, 20), yrange=(-15, 15),
                          n_ax_segments=500, axons_range=(-180, 180),
                          ax_segments_range=(3, 50))
@@ -509,9 +499,8 @@ def test_AxonMapModel_calc_bundle_tangent(engine):
         model.spatial.calc_bundle_tangent(0, [1000])
 
 
-@ pytest.mark.parametrize('engine', ('serial', 'cython'))
-def test_AxonMapModel_calc_bundle_tangent_fast(engine):
-    model = AxonMapModel(xystep=5, engine=engine, n_axons=500,
+def test_AxonMapModel_calc_bundle_tangent_fast():
+    model = AxonMapModel(xystep=5, n_axons=500,
                          xrange=(-20, 20), yrange=(-15, 15),
                          n_ax_segments=500, axons_range=(-180, 180),
                          ax_segments_range=(3, 50))
@@ -525,10 +514,9 @@ def test_AxonMapModel_calc_bundle_tangent_fast(engine):
 
 
 
-@ pytest.mark.parametrize('engine', ('serial', 'cython'))
-def test_AxonMapModel_predict_percept(engine):
+def test_AxonMapModel_predict_percept():
     model = AxonMapModel(xystep=0.55, axlambda=100, rho=100,
-                         thresh_percept=0, engine=engine,
+                         thresh_percept=0,
                          xrange=(-20, 20), yrange=(-15, 15),
                          n_axons=500)
     model.build()
@@ -551,7 +539,7 @@ def test_AxonMapModel_predict_percept(engine):
     npt.assert_almost_equal(np.sum(percept.data[39:, :, 0]), 0)
 
     # Full Argus II with small lambda: 60 bright spots
-    model = AxonMapModel(engine='serial', xystep=1, rho=100, axlambda=40,
+    model = AxonMapModel(xystep=1, rho=100, axlambda=40,
                          xrange=(-20, 20), yrange=(-15, 15), n_axons=500)
     model.build()
     percept = model.predict_percept(ArgusII(stim=np.ones(60)))
@@ -561,7 +549,7 @@ def test_AxonMapModel_predict_percept(engine):
     npt.assert_equal(np.sum(percept.data > 0.275), 56)
 
     # Model gives same outcome as Spatial:
-    spatial = AxonMapSpatial(engine='serial', xystep=1, rho=100, axlambda=40,
+    spatial = AxonMapSpatial(xystep=1, rho=100, axlambda=40,
                              xrange=(-20, 20), yrange=(-15, 15), n_axons=500)
     spatial.build()
     spatial_percept = spatial.predict_percept(ArgusII(stim=np.ones(60)))

--- a/pulse2percept/models/tests/test_granley2021.py
+++ b/pulse2percept/models/tests/test_granley2021.py
@@ -180,13 +180,12 @@ def test_effects_models_deprecated_engine(cls, arg):
         cls(arg)
 
 
-@pytest.mark.parametrize('engine', ('serial', 'cython'))
-def test_biphasicAxonMapSpatial(engine):
+def test_biphasicAxonMapSpatial():
     # Lambda cannot be too small:
     with pytest.raises(ValueError):
         BiphasicAxonMapSpatial(axlambda=9).build()
 
-    model = BiphasicAxonMapModel(engine=engine, xystep=2).build()
+    model = BiphasicAxonMapModel(xystep=2).build()
     # Only accepts biphasic pulse trains with no delay dur
     implant = ArgusI(stim=np.ones(16))
     with pytest.raises(TypeError):
@@ -204,7 +203,7 @@ def test_biphasicAxonMapSpatial(engine):
     npt.assert_equal(percept.time, None)
 
     # Should be equal to axon map model if effects models return 1
-    model = BiphasicAxonMapSpatial(engine=engine, xystep=2)
+    model = BiphasicAxonMapSpatial(xystep=2)
     def bright_model(freq, amp, pdur): return 1
     def size_model(freq, amp, pdur): return 1
     def streak_model(freq, amp, pdur): return 1
@@ -221,13 +220,13 @@ def test_biphasicAxonMapSpatial(engine):
         percept.data[:, :, 0], percept_axon.max(axis='frames'))
 
     # Effect models must be callable
-    model = BiphasicAxonMapSpatial(engine=engine, xystep=2)
+    model = BiphasicAxonMapSpatial(xystep=2)
     model.bright_model = 1.0
     with pytest.raises(TypeError):
         model.build()
 
     # If t_percept is not specified, there should only be one frame
-    model = BiphasicAxonMapSpatial(engine=engine, xystep=2)
+    model = BiphasicAxonMapSpatial(xystep=2)
     model.build()
     implant = ArgusII()
     implant.stim = Stimulus({'A5': BiphasicPulseTrain(20, 1, 0.45)})
@@ -241,7 +240,7 @@ def test_biphasicAxonMapSpatial(engine):
     npt.assert_equal(np.any(percept.data[:, :, 1:]), False)
 
     # Test that default models give expected values
-    model = BiphasicAxonMapSpatial(engine=engine, rho=400, axlambda=600,
+    model = BiphasicAxonMapSpatial(rho=400, axlambda=600,
                                    xystep=1, xrange=(-20, 20), yrange=(-15, 15))
     model.build()
     implant = ArgusII()
@@ -254,13 +253,12 @@ def test_biphasicAxonMapSpatial(engine):
     npt.assert_equal(np.sum(percept.data > 0.5691), 4)
 
 
-@pytest.mark.parametrize('engine', ('serial', 'cython'))
-def test_biphasicAxonMapModel(engine):
-    set_params = {'xystep': 2, 'engine': engine, 'rho': 432, 'axlambda': 20,
+def test_biphasicAxonMapModel():
+    set_params = {'xystep': 2, 'rho': 432, 'axlambda': 20,
                   'n_axons': 9, 'n_ax_segments': 50,
                   'xrange': (-30, 30), 'yrange': (-20, 20),
                   'loc_od': (5, 6)}
-    model = BiphasicAxonMapModel(engine=engine)
+    model = BiphasicAxonMapModel()
     for param in set_params:
         npt.assert_equal(hasattr(model.spatial, param), True)
 
@@ -285,7 +283,7 @@ def test_biphasicAxonMapModel(engine):
     npt.assert_equal(model.axlambda, 450)
 
     # Effect model parameters can be passed even in constructor
-    model = BiphasicAxonMapModel(engine=engine, a0=5, rho=432)
+    model = BiphasicAxonMapModel(a0=5, rho=432)
     npt.assert_equal(model.a0, 5)
     npt.assert_equal(model.spatial.bright_model.a0, 5)
     npt.assert_equal(model.rho, 432)
@@ -296,7 +294,7 @@ def test_biphasicAxonMapModel(engine):
         model.invalid_param = 5
 
     # Custom parameters also propogate to effects models
-    model = BiphasicAxonMapModel(engine=engine)
+    model = BiphasicAxonMapModel()
 
     class TestSizeModel():
         def __init__(self):
@@ -329,7 +327,7 @@ def test_biphasicAxonMapModel(engine):
         TestInitClassBad()
 
     # User can override default values
-    model = BiphasicAxonMapModel(engine=engine)
+    model = BiphasicAxonMapModel()
     for key, value in set_params.items():
         setattr(model.spatial, key, value)
         npt.assert_equal(getattr(model.spatial, key), value)

--- a/pulse2percept/models/tests/test_granley2021.py
+++ b/pulse2percept/models/tests/test_granley2021.py
@@ -1,4 +1,5 @@
 import copy
+import warnings
 
 import numpy as np
 import pytest
@@ -13,11 +14,6 @@ from pulse2percept.models.granley2021 import DefaultBrightModel, \
     DefaultSizeModel, DefaultStreakModel
 from pulse2percept.utils.base import FreezeError
 
-try:
-    import jax
-    has_jax = True
-except ImportError:
-    has_jax = False
 
 def test_deepcopy_DefaultBrightModel():
     original = DefaultBrightModel()
@@ -166,11 +162,26 @@ def test_effects_models():
     npt.assert_equal(hasattr(model, 'a9'), True)
 
 
-@pytest.mark.parametrize('engine', ('serial', 'cython', 'jax'))
-def test_biphasicAxonMapSpatial(engine):
-    if engine == 'jax' and not has_jax:
-        pytest.skip("Jax not installed")
+@pytest.mark.parametrize('cls, arg', [(DefaultSizeModel, 200),
+                                      (DefaultStreakModel, 200)])
+def test_effects_models_deprecated_engine(cls, arg):
+    # 'engine' used to switch between the numpy and the (now removed) jax
+    # backend. It is still accepted, but ignored:
+    with pytest.deprecated_call():
+        deprecated = cls(arg, engine='serial')
+    # Passing it changes nothing about the model's output:
+    npt.assert_almost_equal(deprecated(20, 1, 0.45), cls(arg)(20, 1, 0.45))
+    # Even a value that used to select a different backend is a no-op:
+    with pytest.deprecated_call():
+        cls(arg, engine='jax')
+    # Not passing it does not warn:
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", DeprecationWarning)
+        cls(arg)
 
+
+@pytest.mark.parametrize('engine', ('serial', 'cython'))
+def test_biphasicAxonMapSpatial(engine):
     # Lambda cannot be too small:
     with pytest.raises(ValueError):
         BiphasicAxonMapSpatial(axlambda=9).build()
@@ -243,65 +254,8 @@ def test_biphasicAxonMapSpatial(engine):
     npt.assert_equal(np.sum(percept.data > 0.5691), 4)
 
 
-def test_predict_spatial_jax():
-    # ensure jax predict spatial is equal to normal
-    if not has_jax:
-        pytest.skip("Jax not installed")
-    model1 = BiphasicAxonMapModel(engine='jax', xystep=2)
-    model2 = BiphasicAxonMapModel(engine='cython', xystep=2)
-    model1.build()
-    model2.build()
-    implant = ArgusII()
-    implant.stim = {'A5' : BiphasicPulseTrain(25, 4, 0.45),
-                    'C7' : BiphasicPulseTrain(50, 2.5, 0.75)}
-    p1 = model1.predict_percept(implant)
-    p2 = model2.predict_percept(implant)
-    npt.assert_almost_equal(p1.data, p2.data, decimal=4)
-
-    # test changing model parameters, make sure jax is clearing cache on build
-    model1.axlambda = 800
-    model2.axlambda = 800
-    model1.rho = 50
-    model2.rho = 50
-    model1.build()
-    model2.build()
-    p1 = model1.predict_percept(implant)
-    p2 = model2.predict_percept(implant)
-    npt.assert_almost_equal(p1.data, p2.data, decimal=4)
-
-@pytest.mark.parametrize('engine', ('serial', 'cython', 'jax'))
-def test_predict_batched(engine):
-    if not has_jax:
-        pytest.skip("Jax not installed")
-
-    # Allows mix of valid Stimulus types
-    stims = [{'A5' : BiphasicPulseTrain(25, 4, 0.45),
-              'C7' : BiphasicPulseTrain(50, 2.5, 0.75)},
-             {'B4' : BiphasicPulseTrain(3, 1, 0.32)},
-             Stimulus({'F3' : BiphasicPulseTrain(12, 3, 1.2)})]
-    implant = ArgusII()
-    model = BiphasicAxonMapModel(engine=engine, xystep=2)
-    model.build()
-    # Import error if we dont have jax
-    if engine != 'jax':
-        with pytest.raises(ImportError):
-            model.predict_percept_batched(implant, stims)
-        return
-    
-    percepts_batched = model.predict_percept_batched(implant, stims)
-    percepts_serial = []
-    for stim in stims:
-        implant.stim = stim
-        percepts_serial.append(model.predict_percept(implant))
-
-    npt.assert_equal(len(percepts_serial), len(percepts_batched))
-    for p1, p2 in zip(percepts_batched, percepts_serial):
-        npt.assert_almost_equal(p1.data, p2.data)
-
-@pytest.mark.parametrize('engine', ('serial', 'cython', 'jax'))
+@pytest.mark.parametrize('engine', ('serial', 'cython'))
 def test_biphasicAxonMapModel(engine):
-    if engine == 'jax' and not has_jax:
-        pytest.skip("Jax not installed")
     set_params = {'xystep': 2, 'engine': engine, 'rho': 432, 'axlambda': 20,
                   'n_axons': 9, 'n_ax_segments': 50,
                   'xrange': (-30, 30), 'yrange': (-20, 20),

--- a/pulse2percept/models/tests/test_nanduri2012.py
+++ b/pulse2percept/models/tests/test_nanduri2012.py
@@ -14,7 +14,7 @@ from pulse2percept.utils import FreezeError
 
 def test_Nanduri2012Spatial():
     # Nanduri2012Spatial automatically sets `atten_a`:
-    model = Nanduri2012Spatial(engine='serial', xystep=5)
+    model = Nanduri2012Spatial(xystep=5)
 
     # User can set `atten_a`:
     model.atten_a = 12345
@@ -44,7 +44,7 @@ def test_Nanduri2012Spatial():
         model.predict_percept(implant)
 
     # Multiple frames are processed independently:
-    model = Nanduri2012Spatial(engine='serial', atten_a=14000, xystep=5,
+    model = Nanduri2012Spatial(atten_a=14000, xystep=5,
                                xrange=(-20, 20), yrange=(-15, 15))
     model.build()
     percept = model.predict_percept(ArgusI(stim={'A1': [1, 2]}))
@@ -176,7 +176,7 @@ def test_deepcopy_Nanduri2012Temporal():
     npt.assert_equal(original != copied, True)
 
 def test_Nanduri2012Model():
-    model = Nanduri2012Model(engine='serial', xystep=5)
+    model = Nanduri2012Model(xystep=5)
     npt.assert_equal(hasattr(model, 'has_time'), True)
     npt.assert_equal(model.has_time, True)
 
@@ -220,7 +220,7 @@ def test_deepcopy_Nanduri2012Model():
 
 def test_Nanduri2012Model_predict_percept():
     # Nothing in = nothing out:
-    model = Nanduri2012Model(xrange=(0, 0), yrange=(0, 0), engine='serial')
+    model = Nanduri2012Model(xrange=(0, 0), yrange=(0, 0))
     model.build()
     implant = ArgusI(stim=None)
     npt.assert_equal(model.predict_percept(implant), None)

--- a/pulse2percept/models/tests/test_thompson2003.py
+++ b/pulse2percept/models/tests/test_thompson2003.py
@@ -17,7 +17,7 @@ from pulse2percept.utils.testing import assert_warns_msg
 
 def test_Thompson2003Spatial():
     # Thompson2003Spatial automatically sets `radius`:
-    model = Thompson2003Spatial(engine='serial', xystep=5)
+    model = Thompson2003Spatial(xystep=5)
     # User can set `radius`:
     model.radius = 123
     npt.assert_equal(model.radius, 123)
@@ -40,7 +40,7 @@ def test_Thompson2003Spatial():
     npt.assert_almost_equal(percept.data, 0)
 
     # Multiple frames are processed independently:
-    model = Thompson2003Spatial(engine='serial', radius=200, xystep=5,
+    model = Thompson2003Spatial(radius=200, xystep=5,
                                 xrange=(-20, 20), yrange=(-15, 15))
     model.build()
     percept = model.predict_percept(ArgusI(stim={'A1': [1, 0], 'B3': [0, 2]}))
@@ -81,7 +81,7 @@ def test_deepcopy_Thompson2003Spatial():
 
 
 def test_Thompson2003Model():
-    model = Thompson2003Model(engine='serial', xystep=5)
+    model = Thompson2003Model(xystep=5)
     npt.assert_equal(model.has_space, True)
     npt.assert_equal(model.has_time, False)
     npt.assert_equal(hasattr(model.spatial, 'radius'), True)
@@ -109,7 +109,7 @@ def test_Thompson2003Model():
     npt.assert_almost_equal(model.predict_percept(implant).data, 0)
 
     # Multiple frames are processed independently:
-    model = Thompson2003Model(engine='serial', radius=1000, xystep=5,
+    model = Thompson2003Model(radius=1000, xystep=5,
                               xrange=(-20, 20), yrange=(-15, 15))
     model.build()
     percept = model.predict_percept(ArgusI(stim={'A1': [1, 2]}))
@@ -136,14 +136,14 @@ def test_Thompson2003Model_predict_percept():
     npt.assert_almost_equal(percept.data[33, 46, 0], np.max(percept.data))
 
     # Full Argus II: 60 bright spots
-    model = Thompson2003Model(engine='serial', xystep=0.55, radius=100)
+    model = Thompson2003Model(xystep=0.55, radius=100)
     model.build()
     percept = model.predict_percept(ArgusII(stim=np.ones(60)))
     npt.assert_equal(np.sum(np.isclose(percept.data, 1.0, rtol=0.1, atol=0.1)),
                      84)
 
     # Model gives same outcome as Spatial:
-    spatial = Thompson2003Spatial(engine='serial', xystep=1, radius=100)
+    spatial = Thompson2003Spatial(xystep=1, radius=100)
     spatial.build()
     spatial_percept = model.predict_percept(ArgusII(stim=np.ones(60)))
     npt.assert_almost_equal(percept.data, spatial_percept.data)

--- a/pulse2percept/utils/__init__.py
+++ b/pulse2percept/utils/__init__.py
@@ -23,7 +23,8 @@ from .images import center_image, scale_image, shift_image, trim_image
 from .convolution import center_vector, conv
 from .optimize import bisect
 from .stats import r2_score, circ_r2_score
-from .deprecation import deprecated, deprecate_parameter
+from .deprecation import (deprecated, deprecate_parameter,
+                          warn_deprecated_params)
 from .three_dim import parse_3d_orient
 
 __all__ = [
@@ -53,4 +54,5 @@ __all__ = [
     'shift_image',
     'trim_image',
     'unique',
+    'warn_deprecated_params',
 ]

--- a/pulse2percept/utils/__init__.py
+++ b/pulse2percept/utils/__init__.py
@@ -23,7 +23,7 @@ from .images import center_image, scale_image, shift_image, trim_image
 from .convolution import center_vector, conv
 from .optimize import bisect
 from .stats import r2_score, circ_r2_score
-from .deprecation import deprecated
+from .deprecation import deprecated, deprecate_parameter
 from .three_dim import parse_3d_orient
 
 __all__ = [
@@ -37,6 +37,7 @@ __all__ = [
     'conv',
     'Data',
     'delta_angle',
+    'deprecate_parameter',
     'deprecated',
     'FreezeError',
     'Frozen',

--- a/pulse2percept/utils/deprecation.py
+++ b/pulse2percept/utils/deprecation.py
@@ -241,6 +241,40 @@ class deprecate_parameter:
         return wrapped
 
 
+def warn_deprecated_params(obj_name, supplied, specs, stacklevel=3):
+    """Warn about deprecated *model* parameters that were supplied by name
+
+    pulse2percept models take their parameters as ``**params``, validated
+    against ``get_default_params`` rather than declared in a signature, so
+    :py:class:`~pulse2percept.utils.deprecate_parameter` cannot see them. This
+    is the equivalent for that path: hand it the names the caller actually
+    supplied, and it warns for the deprecated ones.
+
+    .. versionadded:: 0.9.1
+
+    Parameters
+    ----------
+    obj_name : str
+        Name of the model, as it should appear in the warning.
+    supplied : iterable of str
+        Parameter names the caller passed explicitly. Names that are not
+        deprecated are skipped, so it is fine to pass all of them.
+    specs : dict
+        Maps a deprecated parameter name to the
+        :py:class:`~pulse2percept.utils.deprecate_parameter` describing it, so
+        that signature-level and model-level deprecations word alike.
+    stacklevel : int, optional
+        Passed to ``warnings.warn``. Exact attribution is not possible through
+        a chain of ``super().__init__`` calls of varying depth, so the message
+        names the parameter and the model rather than relying on it.
+    """
+    for name in supplied:
+        spec = specs.get(name)
+        if spec is not None:
+            warnings.warn(spec._get_message(obj_name),
+                          category=DeprecationWarning, stacklevel=stacklevel)
+
+
 def is_deprecated(func):
     """Helper to check if ``func`` is wrapped by the deprecated decorator"""
     if sys.version_info < (3, 5):

--- a/pulse2percept/utils/deprecation.py
+++ b/pulse2percept/utils/deprecation.py
@@ -1,9 +1,26 @@
-""":py:class:`~pulse2percept.utils.deprecated`, 
+""":py:class:`~pulse2percept.utils.deprecated`,
+   :py:class:`~pulse2percept.utils.deprecate_parameter`,
    :py:class:`~pulse2percept.utils.is_deprecated`"""
 
 import sys
+import inspect
 import warnings
 import functools
+
+
+def _version_clause(deprecated_version=None, removed_version=None):
+    """Build the " since version X, and will be removed in version Y" clause
+
+    Shared by :py:class:`deprecated` and :py:class:`deprecate_parameter` so
+    that all deprecation messages are worded the same way.
+    """
+    dep_msg = ""
+    if deprecated_version is not None:
+        dep_msg = f" since version {deprecated_version}"
+    rmv_msg = ""
+    if removed_version is not None:
+        rmv_msg = f", and will be removed in version {removed_version}"
+    return dep_msg + rmv_msg
 
 
 class deprecated:
@@ -53,13 +70,8 @@ class deprecated:
         alt_msg = ""
         if self.alt_func is not None:
             alt_msg = f"Use ``{self.alt_func}`` instead."
-        dep_msg = ""
-        if self.deprecated_version is not None:
-            dep_msg = f" since version {self.deprecated_version}"
-        rmv_msg = ""
-        if self.removed_version is not None:
-            rmv_msg = f", and will be removed in version {self.removed_version}"
-        return msg + dep_msg + rmv_msg + ". " + alt_msg
+        clause = _version_clause(self.deprecated_version, self.removed_version)
+        return msg + clause + ". " + alt_msg
 
     def _update_doc(self, old_doc, msg=None):
         """Updates the docstring"""
@@ -126,6 +138,108 @@ class deprecated:
         wrapped.__doc__ = self._update_doc(wrapped.__doc__, msg)
 
         return wrapped
+
+class deprecate_parameter:
+    """Decorator to mark a single function or method parameter as deprecated
+
+    The decorated callable keeps *accepting* the parameter, so that existing
+    code does not break, but the value is ignored. A ``DeprecationWarning`` is
+    raised whenever the parameter is passed explicitly, whether by keyword or
+    by position.
+
+    Use this when a parameter is going away but the callable itself stays. To
+    deprecate an entire function, class, or property, use
+    :py:class:`~pulse2percept.utils.deprecated` instead.
+
+    .. versionadded:: 0.9.1
+
+    .. note::
+
+        This decorator only produces the *warning*. Document the parameter
+        itself by adding a ``.. deprecated::`` directive to its entry in the
+        docstring's ``Parameters`` section, which is where numpydoc expects it.
+
+    .. seealso::
+
+        Modeled on matplotlib's ``matplotlib._api.delete_parameter``.
+
+    Parameters
+    ----------
+    name : str
+        Name of the deprecated parameter. Must appear in the signature of the
+        decorated callable, otherwise a ``ValueError`` is raised at decoration
+        time (which catches the parameter being renamed or dropped).
+    deprecated_version : float or str
+        The package version in which the parameter was first marked as
+        deprecated.
+    removed_version : float or str
+        The package version in which the parameter will be removed.
+    addendum : str, optional
+        Text appended to the warning, e.g. to spell out what the parameter
+        used to do or how the behavior differs now that it is ignored.
+
+    Examples
+    --------
+    >>> from pulse2percept.utils import deprecate_parameter
+    >>> @deprecate_parameter('engine', deprecated_version='0.9.1',
+    ...                      removed_version='0.10.0')
+    ... def predict(data, engine=None):
+    ...     return data
+    >>> predict([1, 2])  # no warning
+    [1, 2]
+
+    """
+
+    def __init__(self, name, deprecated_version=None, removed_version=None,
+                 addendum=None):
+        self.name = name
+        self.deprecated_version = deprecated_version
+        self.removed_version = removed_version
+        self.addendum = addendum
+
+    def _get_message(self, obj_name):
+        """Builds the message string"""
+        msg = (f"The '{self.name}' parameter of {obj_name} is deprecated"
+               f"{_version_clause(self.deprecated_version, self.removed_version)}"
+               f". It is ignored.")
+        if self.addendum is not None:
+            msg = f"{msg} {self.addendum}"
+        return msg
+
+    def _get_obj_name(self, func):
+        """Names the decorated callable the way a user would refer to it"""
+        obj_name = getattr(func, '__qualname__', None) or func.__name__
+        # A decorated constructor is really about the class, so report
+        # `MyClass`, not `MyClass.__init__`:
+        if obj_name.endswith('.__init__'):
+            obj_name = obj_name[:-len('.__init__')]
+        return obj_name
+
+    def __call__(self, func):
+        signature = inspect.signature(func)
+        obj_name = self._get_obj_name(func)
+        if self.name not in signature.parameters:
+            raise ValueError(f"'{self.name}' is not a parameter of "
+                             f"{obj_name}. Its signature is {signature}.")
+
+        @functools.wraps(func)
+        def wrapped(*args, **kwargs):
+            try:
+                passed = self.name in signature.bind(*args, **kwargs).arguments
+            except TypeError:
+                # The call does not match the signature. Don't preempt the
+                # error the wrapped callable is about to raise itself:
+                passed = False
+            if passed:
+                # Build the message here rather than capturing it in the
+                # closure: `is_deprecated` looks for the word "deprecated" in
+                # closure cells, and the callable itself is *not* deprecated.
+                warnings.warn(self._get_message(obj_name),
+                              category=DeprecationWarning, stacklevel=2)
+            return func(*args, **kwargs)
+
+        return wrapped
+
 
 def is_deprecated(func):
     """Helper to check if ``func`` is wrapped by the deprecated decorator"""

--- a/pulse2percept/utils/tests/test_deprecation.py
+++ b/pulse2percept/utils/tests/test_deprecation.py
@@ -1,5 +1,8 @@
+import warnings
 import numpy.testing as npt
-from pulse2percept.utils.deprecation import deprecated, is_deprecated
+import pytest
+from pulse2percept.utils.deprecation import (deprecated, deprecate_parameter,
+                                             is_deprecated)
 from pulse2percept.utils.testing import assert_warns_msg
 
 
@@ -90,3 +93,73 @@ def test_deprecated_update_doc():
 def test_is_deprecated_without_closure():
     # A function with no closure cells at all (`__closure__` is None):
     npt.assert_equal(is_deprecated(lambda: None), False)
+
+
+@deprecate_parameter('old', deprecated_version=0.1, removed_version=0.2)
+def mock_func_old_param(a, old=None, b=3):
+    return a + b
+
+
+class MockClassOldParam:
+
+    @deprecate_parameter('old', deprecated_version=0.1, removed_version=0.2,
+                         addendum='It used to do nothing.')
+    def __init__(self, a, old=None):
+        self.a = a
+
+
+def test_deprecate_parameter():
+    # Passing the parameter warns, by keyword or by position:
+    assert_warns_msg(DeprecationWarning, mock_func_old_param,
+                     "The 'old' parameter of mock_func_old_param is "
+                     "deprecated since version 0.1, and will be removed in "
+                     "version 0.2. It is ignored.", 1, old='x')
+    assert_warns_msg(DeprecationWarning, mock_func_old_param,
+                     "'old' parameter", 1, 'x')
+    # But the parameter is ignored: the return value is unaffected:
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        npt.assert_equal(mock_func_old_param(1, old='x'), 4)
+        npt.assert_equal(mock_func_old_param(1, 'x', 10), 11)
+    # Omitting the parameter does not warn:
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", DeprecationWarning)
+        npt.assert_equal(mock_func_old_param(1), 4)
+        npt.assert_equal(mock_func_old_param(1, b=10), 11)
+
+
+def test_deprecate_parameter_method():
+    # On a constructor, the warning names the class, not `__init__`:
+    assert_warns_msg(DeprecationWarning, MockClassOldParam,
+                     "parameter of MockClassOldParam is deprecated",
+                     1, old='x')
+    # The addendum is appended to the message:
+    assert_warns_msg(DeprecationWarning, MockClassOldParam,
+                     'It used to do nothing.', 1, old='x')
+    # The wrapped callable still works:
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        npt.assert_equal(MockClassOldParam(1, old='x').a, 1)
+    # Docstring and name survive the wrapping:
+    npt.assert_equal(mock_func_old_param.__name__, 'mock_func_old_param')
+
+
+def test_deprecate_parameter_is_not_is_deprecated():
+    # Deprecating a parameter does not deprecate the callable itself, so
+    # `is_deprecated` must keep reporting False for it:
+    npt.assert_equal(is_deprecated(mock_func_old_param), False)
+    npt.assert_equal(is_deprecated(MockClassOldParam.__init__), False)
+
+
+def test_deprecate_parameter_unknown_param():
+    # A typo'd or already-removed parameter fails loudly at decoration time,
+    # rather than silently never warning:
+    with pytest.raises(ValueError):
+        @deprecate_parameter('nonexistent')
+        def func(a, b=2):
+            return a
+
+    # An invalid call is left to raise its own error, not preempted by the
+    # decorator's signature binding:
+    with pytest.raises(TypeError):
+        mock_func_old_param()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pulse2percept"
-version = "0.10.0dev"
+version = "0.9.1dev"
 description = "A Python-based simulation framework for bionic vision"
 readme = "README.rst"
 license = { file = "LICENSE" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,6 @@ dependencies = [
     "matplotlib>=3.0.2",
     "imageio-ffmpeg>=0.4",
     "pandas",
-    "joblib>=0.11"
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Removes the jax engine from `BiphasicAxonMapSpatial` and `AxonMapSpatial`. It was
obsolete on four counts:

- Jax was stripped from the dependencies in `pyproject.toml`. Its only declaration was one pinned line in `doc/requirements.txt` for the docs gallery
- CI installed `.[dev]` (which has no jax), so every jax test skipped quietly
- Jax functionality was never completed (e.g. `AxonMapSpatial._predict_spatial` raises `NotImplementedError`
- plus we have been stuck on jax 0.4.31, which caused all sorts of dependabot issues

For backward compatibility:

- `predict_percept_batched` is gone
- model `engine` and axon sensititivy `pad` remain but give a deprecated warning