### PR TITLE
[ENH] [FIX] [REF] Overhaul Stimulus: faster construction and indexing

### DIFF
--- a/pulse2percept/models/beyeler2019.py
+++ b/pulse2percept/models/beyeler2019.py
@@ -20,8 +20,6 @@ from ._beyeler2019 import (fast_scoreboard, fast_axon_map, fast_jansonius,
 
 # Log all warnings.warn() at the WARNING level:
 import warnings
-import logging
-logging.captureWarnings(True)
 
 
 class ScoreboardSpatial(SpatialModel):

--- a/pulse2percept/models/granley2021.py
+++ b/pulse2percept/models/granley2021.py
@@ -11,6 +11,17 @@ from ..utils import FreezeError, deprecate_parameter
 from .base import NotBuiltError, BaseModel
 from ._granley2021 import fast_biphasic_axon_map
 
+# `find_threshold` bisects on a scaled copy of the stimulus *data*. This model
+# reads amplitude from the stimulus metadata instead, where it means a
+# multiple of threshold rather than a current, so scaling the data leaves the
+# prediction untouched and the search cannot converge:
+_FIND_THRESHOLD_MSG = (
+    "{cls} does not support find_threshold. It takes amplitude as a multiple "
+    "of threshold and reads it from the stimulus metadata, not from the "
+    "stimulus data, so scaling the data leaves the percept unchanged. Vary "
+    "`amp` when building the BiphasicPulseTrain instead."
+)
+
 
 class DefaultBrightModel(BaseModel):
     """
@@ -206,7 +217,8 @@ class BiphasicAxonMapSpatial(AxonMapSpatial):
     individually customized by setting the bright_model, size_model, or streak_model
     to any python callable with signature f(freq, amp, pdur)
 
-    .. note::
+    .. important::
+    
         Using this model in combination with a temporal model is not currently
         supported and will give unexpected results
 
@@ -506,12 +518,23 @@ class BiphasicAxonMapSpatial(AxonMapSpatial):
         return Percept(resp, space=self.grid, time=t_percept,
                        metadata={'stim': stim.metadata})
 
+    def find_threshold(self, implant, bright_th, amp_range=(0, 999), amp_tol=1,
+                       bright_tol=0.1, max_iter=100):
+        """Not supported by this model
+
+        Raises
+        ------
+        NotImplementedError
+        """
+        raise NotImplementedError(_FIND_THRESHOLD_MSG.format(
+            cls=type(self).__name__))
+
 
 class BiphasicAxonMapModel(Model):
     """ BiphasicAxonMapModel of [Granley2021]_ (standalone model)
 
     An AxonMapModel where phosphene brightness, size, and streak length scale
-    according to amplitude, frequency, and pulse duration
+    according to amplitude, frequency, and pulse duration.
 
     All stimuli must be BiphasicPulseTrains.
 
@@ -522,11 +545,17 @@ class BiphasicAxonMapModel(Model):
     bright_model, size_model, and streak model respectively. By default, these are
     set to classes that implement Eqs 3-6 from Granley 2021. These models can be
     individually customized by setting the bright_model, size_model, or streak_model
-    to any python callable with signature f(freq, amp, pdur)
+    to any python callable with signature f(freq, amp, pdur).
 
-    .. note::
-        Using this model in combination with a temporal model is not currently
-        supported and will give unexpected results
+    .. important::
+
+        Stimuli should pass amplitude as a factor of threshold, NOT as raw
+        amplitude in microamps.
+
+        This model interacts with `Stimulus` objects by reading the intended
+        amplitude, frequency, and pulse duration from their metadata.
+        Scaling, shifting, or otherwise manipulating the raw stimulus data
+        will not change the predicted percept.
 
     Parameters
     ----------
@@ -622,12 +651,19 @@ class BiphasicAxonMapModel(Model):
 
         Overrides base predict percept to keep desired time axes
 
-        .. important::
+        .. note::
 
             You must call ``build`` before calling ``predict_percept``.
 
-        Note: The stimuli should use amplitude as a factor of threshold,
-        NOT raw amplitude in microamps
+        .. important::
+
+            Stimuli should pass amplitude as a factor of threshold,
+            NOT as raw amplitude in microamps.
+
+            The model interacts with `Stimulus` objects by reading the
+            intended amplitude, frequency, and pulse duration from their 
+            metadata. Manipulating the raw stimulus data will not change
+            the predicted percept.
 
         Parameters
         ----------
@@ -654,3 +690,14 @@ class BiphasicAxonMapModel(Model):
             return None
         resp = self.spatial.predict_percept(implant, t_percept=t_percept)
         return resp
+
+    def find_threshold(self, implant, bright_th, amp_range=(0, 999), amp_tol=1,
+                       bright_tol=0.1, max_iter=100, t_percept=None):
+        """Not supported by this model
+
+        Raises
+        ------
+        NotImplementedError
+        """
+        raise NotImplementedError(_FIND_THRESHOLD_MSG.format(
+            cls=type(self).__name__))

--- a/pulse2percept/models/tests/test_granley2021.py
+++ b/pulse2percept/models/tests/test_granley2021.py
@@ -354,3 +354,22 @@ def test_biphasicAxonMapModel():
     # Lambda cannot be too small:
     with pytest.raises(ValueError):
         BiphasicAxonMapModel(axlambda=9).build()
+
+
+@pytest.mark.parametrize('model_cls', [BiphasicAxonMapModel,
+                                       BiphasicAxonMapSpatial])
+def test_find_threshold_not_supported(model_cls):
+    # This model takes amplitude as a multiple of threshold and reads it from
+    # the stimulus metadata, so the inherited `find_threshold` - which bisects
+    # on a scaled copy of the stimulus data - cannot converge. It has to say
+    # so rather than fail somewhere deeper with a confusing message.
+    model = model_cls(xrange=(-3, 3), yrange=(-2, 2), xystep=1,
+                      n_ax_segments=30).build()
+    implant = ArgusII(stim={'A1': BiphasicPulseTrain(20, 1, 0.45,
+                                                     stim_dur=100)})
+    with pytest.raises(NotImplementedError) as excinfo:
+        model.find_threshold(implant, 0.5)
+    npt.assert_equal(model_cls.__name__ in str(excinfo.value), True)
+    npt.assert_equal('metadata' in str(excinfo.value), True)
+    # predict_percept is unaffected:
+    npt.assert_equal(model.predict_percept(implant) is not None, True)

--- a/pulse2percept/models/thompson2003.py
+++ b/pulse2percept/models/thompson2003.py
@@ -10,8 +10,6 @@ from ._thompson2003 import fast_thompson2003
 
 # Log all warnings.warn() at the WARNING level:
 import warnings
-import logging
-logging.captureWarnings(True)
 
 
 class Thompson2003Spatial(SpatialModel):

--- a/pulse2percept/stimuli/_base.pyx
+++ b/pulse2percept/stimuli/_base.pyx
@@ -12,7 +12,11 @@ ctypedef Py_ssize_t index_t
 
 cpdef bool[::1] fast_compress_space(float32[:, ::1] data):
     """Compress a stimulus in space"""
-    # In space, we only keep electrodes with nonzero activation values
+    # In space, we only keep electrodes with nonzero activation values.
+    # Note that `c_isclose(x, 0)` is an exact test, not a tolerant one: its
+    # abs_tol is 0, so the comparison reduces to |x| <= 1e-9 * |x|, which
+    # holds only for x == 0. Electrodes carrying a tiny but nonzero amplitude
+    # are therefore kept, which is what "all-zero" above promises.
     cdef:
         index_t e, n_elec, t, n_time
         bool[::1] idx_space
@@ -29,7 +33,7 @@ cpdef bool[::1] fast_compress_space(float32[:, ::1] data):
 
     return np.asarray(idx_space)
 
-cpdef bool[::1] fast_compress_time(float32[:, ::1] data, float32[::1] time):
+cpdef bool[::1] fast_compress_time(float32[:, ::1] data):
     """Compress a stimulus in time"""
     # In time, we can't just remove empty columns. We need to walk
     # through each column and save all the "state transitions" along
@@ -41,6 +45,13 @@ cpdef bool[::1] fast_compress_time(float32[:, ::1] data, float32[::1] time):
     # You always need the first and last element. You also need the
     # high and low value (along with the time stamps) for every signal
     # edge.
+    # Only the column indices matter here, so the time axis itself is not
+    # needed: the caller applies the returned mask to it.
+    # `c_isclose`'s rel_tol (1e-9) sits far below float32 eps (~1.2e-7), so
+    # for float32 input this is exact equality for any pair of finite values.
+    # It is not interchangeable with `!=` at the extremes, though:
+    # c_isclose(inf, inf) is False, so a constant infinite signal registers an
+    # edge at every column.
     cdef:
         index_t e, n_elec, t, n_time
         bool[::1] idx_time

--- a/pulse2percept/stimuli/base.py
+++ b/pulse2percept/stimuli/base.py
@@ -303,101 +303,87 @@ class Stimulus(PrettyPrint):
                 'is_charge_balanced': self.is_charge_balanced,
                 'metadata': self.metadata}
 
-    def _from_source(self, source):
-        """Extract the data container and time information from source data
+    def _parse_source(self, source, nested=False):
+        """Extract data, time and electrode names from a single source
 
         This private method converts input data from allowable source types
-        into a 2D NumPy array, where the first dimension denotes electrodes
+        into a 2-D NumPy array, where the first dimension denotes electrodes
         and the second dimension denotes points in time.
 
-        Some stimuli don't have a time component (such as a stimulus created
-        from a scalar or 1D NumPy array. In this case, times=None.
+        The same source is read in one of two ways, depending on where it
+        appears:
+
+        * At the top level, a flat sequence of N values means N electrodes
+          stimulated once each, with no time component.
+        * As an element of a collection (a list entry or a dict value), that
+          same sequence means a *single* electrode sampled at N points in
+          time.
+
+        ``nested`` selects between the two readings. Only a collection can
+        contain a nested source, so only a collection passes ``nested=True``.
+
+        Returns ``electrodes=None`` when the source does not name its own
+        electrodes; it is then up to the caller to number them. Likewise,
+        ``time=None`` means the source has no time component (e.g. a scalar).
         """
+        if isinstance(source, Stimulus):
+            # e.g. a Stimulus being renamed, or a dict of Stimulus objects.
+            # Brings along its own electrode names and time axis:
+            return source.data, source.time, source.electrodes
         if np.isscalar(source) and not isinstance(source, str):
-            # Scalar: 1 electrode, no time component
-            data = np.array([source], dtype=np.float32).reshape((1, -1))
-            time = None
-            electrodes = None
-        elif isinstance(source, (list, tuple)):
-            # List or touple with N elements: 1 electrode, N time points
+            # Scalar: 1 electrode, no time component - either way round
+            return np.array([source], dtype=np.float32).reshape((1, -1)), \
+                None, None
+        if isinstance(source, np.ndarray):
+            if nested:
+                if source.ndim > 1:
+                    raise ValueError(f"Cannot create Stimulus object from a "
+                                     f"{source.ndim}-D NumPy array. Must be "
+                                     f"1-D.")
+                # 1-D NumPy array with N elements: 1 electrode, N time points
+                data = source.astype(np.float32).reshape((1, -1))
+                return data, np.arange(data.shape[-1], dtype=np.float32), None
+            if source.ndim == 1:
+                # N electrodes, no time component
+                return source.reshape((-1, 1)), None, None
+            if source.ndim == 2:
+                # N electrodes x M time points
+                return source, np.arange(source.shape[-1],
+                                         dtype=np.float32), None
+            raise ValueError(f"Cannot create Stimulus object from a "
+                             f"{source.ndim}-D NumPy array. Must be < 2-D.")
+        if nested and isinstance(source, (list, tuple)):
+            # List or tuple with N elements: 1 electrode, N time points.
+            # At the top level these are collections, handled by `_factory`:
             data = np.array(source, dtype=np.float32).reshape((1, -1))
-            time = np.arange(data.shape[-1], dtype=np.float32)
-            electrodes = None
-        elif isinstance(source, np.ndarray):
-            if source.ndim > 1:
-                raise ValueError(f"Cannot create Stimulus object from a "
-                                 f"{source.ndim}-D NumPy array. Must be 1-D.")
-            # 1D NumPy array with N elements: 1 electrode, N time points
-            data = source.astype(np.float32).reshape((1, -1))
-            time = np.arange(data.shape[-1], dtype=np.float32)
-            electrodes = None
-        elif isinstance(source, Stimulus):
-            # e.g. from a dictionary of Stimulus objects
-            data = source.data
-            time = source.time
-            electrodes = source.electrodes
-        else:
-            raise TypeError(f"Cannot create Stimulus object from {type(source)}. Choose "
-                            f"from: scalar, tuple, list, NumPy array, or "
-                            f"Stimulus.")
-        return time, data, electrodes
+            return data, np.arange(data.shape[-1], dtype=np.float32), None
+        raise TypeError(f"Cannot create Stimulus object from {type(source)}. Choose "
+                        f"from: scalar, tuple, list, NumPy array, or "
+                        f"Stimulus.")
 
     def _factory(self, source, electrodes, time, compress):
         """Build the Stimulus object from the specified source type"""
         # Whether we numbered the electrodes ourselves (0..N-1), in which case
         # they cannot possibly contain duplicates:
         _auto_electrodes = False
-        if isinstance(source, self.__class__):
-            # Stimulus: We're done. This might happen in ProsthesisSystem if
-            # the user builds the stimulus themselves. It can also be used to
-            # overwrite the time axis or provide new electrode names:
-            _data = source.data
-            _time = source.time
-            _electrodes = source.electrodes
-            if 'electrodes' not in source.metadata.keys():
-                self.metadata['electrodes'][str(_electrodes[0])] = {
-                    'metadata': source.metadata, 'type': type(source)}
-            else:
-                self.metadata = source.metadata
-        elif isinstance(source, np.ndarray):
-            # A NumPy array is either 1-D (list of electrodes, time=None) or
-            # 2-D (electrodes x time points):
-            if source.ndim == 1:
-                _data = source.reshape((-1, 1))
-                _time = None
-                _electrodes = np.arange(_data.shape[0])
-                _auto_electrodes = True
-            elif source.ndim == 2:
-                _data = source
-                _time = np.arange(_data.shape[-1], dtype=np.float32)
-                _electrodes = np.arange(_data.shape[0])
-                _auto_electrodes = True
-            else:
-                raise ValueError(f"Cannot create Stimulus object from a "
-                                 f"{source.ndim}-D NumPy array. Must be < 2-D.")
-        elif (_flat := _as_scalar_column(source)) is not None:
+        if (_flat := _as_scalar_column(source)) is not None:
             # A flat sequence of scalars is one electrode per element, with no
-            # time component. The generic path below would build a separate
+            # time component. The collection path below would build a separate
             # 1x1 array (and time axis) for every single electrode:
-            _data = _flat
-            _time = None
-            _electrodes = np.arange(_data.shape[0])
-            _auto_electrodes = True
-        else:
-            # Input is either a scalar or (more likely) a collection of source
-            # types. Easiest to tream them all as a collection and iterate:
+            _data, _time, _electrodes = _flat, None, None
+        elif isinstance(source, (dict, list, tuple)):
+            # A collection: every entry is itself a source, contributing one
+            # electrode (or, for a Stimulus, however many it already has):
             if isinstance(source, dict):
                 iterator = source.items()
-            elif isinstance(source, (list, tuple)):
-                iterator = enumerate(source)
             else:
-                iterator = enumerate([source])
+                iterator = enumerate(source)
             _time = []
             _electrodes = []
             _data = []
             for ele, src in iterator:
                 # Extract times and data from source:
-                t, d, e = self._from_source(src)
+                d, t, e = self._parse_source(src, nested=True)
                 _time.append(t)
                 _data.append(d)
                 if isinstance(source, dict):
@@ -426,6 +412,24 @@ class Stimulus(PrettyPrint):
             # and `_time` as columns (except sometimes `_time` is None).
             _data = np.vstack(_data) if _data else np.array([])
             _time = _time[0] if _time else None
+        else:
+            # A single source: a scalar, a NumPy array, or a Stimulus. The
+            # latter might be handed to us by ProsthesisSystem if the user
+            # built the stimulus themselves, and is also how a stimulus gets
+            # new electrode names or a new time axis:
+            _data, _time, _electrodes = self._parse_source(source)
+            if isinstance(source, Stimulus):
+                if 'electrodes' not in source.metadata.keys():
+                    self.metadata['electrodes'][str(_electrodes[0])] = {
+                        'metadata': source.metadata, 'type': type(source)}
+                else:
+                    self.metadata = source.metadata
+
+        if _electrodes is None:
+            # The source did not name its electrodes, so number them 0..N-1.
+            # Those are unique by construction:
+            _electrodes = np.arange(_data.shape[0])
+            _auto_electrodes = True
 
         # User can overwrite the names of the electrodes:
         if electrodes is not None:

--- a/pulse2percept/stimuli/base.py
+++ b/pulse2percept/stimuli/base.py
@@ -8,7 +8,7 @@ from ._base import fast_compress_space, fast_compress_time
 from sys import _getframe
 from matplotlib.axes import Subplot
 import matplotlib.pyplot as plt
-from copy import deepcopy
+from copy import copy, deepcopy
 import operator as ops
 from math import isclose
 from scipy.integrate import trapezoid
@@ -353,6 +353,23 @@ class Stimulus(PrettyPrint):
         if compress:
             self.compress()
 
+    def _shallow_copy(self):
+        """Copy the object without duplicating the data container
+
+        Methods that return a new stimulus (``append``, the arithmetic
+        operators) replace ``_stim`` wholesale, so there is no point in
+        deep-copying the (potentially large) data arrays first. Everything
+        else is preserved as it would be by ``deepcopy``: the subclass, its
+        additional attributes, and an independent copy of ``metadata``.
+
+        Note that the returned object shares its ``_stim`` dict with ``self``
+        until the caller assigns a new one, which the ``_stim`` setter always
+        does (it never mutates the dict in place).
+        """
+        stim = copy(self)
+        stim.metadata = deepcopy(self.metadata)
+        return stim
+
     def compress(self):
         """Compress the source data
 
@@ -411,7 +428,7 @@ class Stimulus(PrettyPrint):
         if other.time[0] < 0:
             raise NotImplementedError("Appending a stimulus with a negative "
                                       "time axis is currently not supported.")
-        stim = deepcopy(self)
+        stim = self._shallow_copy()
         # Last time point of `self` can be merged with first point of `other`
         # but only if they have the same amplitude(s):
         if isclose(other.time[0], 0, abs_tol=DT):
@@ -762,11 +779,19 @@ class Stimulus(PrettyPrint):
         if not a_supported and not b_supported:
             raise TypeError(f"Unsupported operand for types {(type(a))} and "
                             f"{type(b)}")
-        # Return a copy of the current object with the new data:
-        stim = deepcopy(self)
-        stim._stim = {'data': op(a, b) if field == 'data' else stim.data,
-                      'electrodes': stim.electrodes,
-                      'time': op(a, b) if field == 'time' else stim.time}
+        # Return a copy of the current object with the new data. The operator
+        # produces a new array for `field`; the other fields must be copied
+        # explicitly, so that the returned stimulus shares no buffer with the
+        # original (`_shallow_copy` does not duplicate the data container):
+        stim = self._shallow_copy()
+        time = stim.time
+        if field == 'time':
+            time = op(a, b)
+        elif time is not None:
+            time = time.copy()
+        stim._stim = {'data': op(a, b) if field == 'data' else stim.data.copy(),
+                      'electrodes': stim.electrodes.copy(),
+                      'time': time}
         return stim
 
     def __add__(self, scalar):

--- a/pulse2percept/stimuli/base.py
+++ b/pulse2percept/stimuli/base.py
@@ -518,7 +518,7 @@ class Stimulus(PrettyPrint):
         electrodes = electrodes[keep_el]
 
         if time is not None:
-            idx_time = fast_compress_time(data, time)
+            idx_time = fast_compress_time(data)
             data = data[:, idx_time]
             time = time[idx_time]
 

--- a/pulse2percept/stimuli/base.py
+++ b/pulse2percept/stimuli/base.py
@@ -22,9 +22,16 @@ def _interp_rows(x, xp, fp):
     electrodes.
 
     The arithmetic is deliberately carried out in double precision and in the
-    same order as ``np.interp``'s C loop, so that the result is identical down
-    to the last bit: temporal models resolve stimulus edges on a fixed
-    simulation grid, where a one-ulp difference can change the output.
+    same order as ``np.interp``'s C loop, because temporal models resolve
+    stimulus edges on a fixed simulation grid.
+
+    Agreement with ``np.interp`` is exact wherever no arithmetic is needed:
+    on a knot, or beyond the end points, where the stored value is assigned
+    verbatim. For interior points it is exact to within one rounding - a C
+    compiler may contract ``slope * dx + y0`` into a single fused
+    multiply-add (it does on arm64), whereas the NumPy expression below
+    always rounds twice. That is at most a few ULP of float64, well below the
+    float32 that the caller ends up storing.
 
     Parameters
     ----------

--- a/pulse2percept/stimuli/base.py
+++ b/pulse2percept/stimuli/base.py
@@ -5,8 +5,7 @@ from ..utils import PrettyPrint, unique, is_strictly_increasing
 from ..utils.constants import DT, MIN_AMP
 from ._base import fast_compress_space, fast_compress_time
 
-from sys import _getframe
-from matplotlib.axes import Subplot
+from matplotlib.axes import Axes
 import matplotlib.pyplot as plt
 from copy import copy, deepcopy
 import operator as ops
@@ -292,7 +291,7 @@ class Stimulus(PrettyPrint):
         else:
             self.metadata = {'electrodes': {}, 'user': metadata}
         # Flag will be flipped in the compress method:
-        self.is_compressed = False
+        self._is_compressed = False
         # Extract the data and coordinates (electrodes, time) from the source:
         self._factory(source, electrodes, time, compress)
 
@@ -531,7 +530,7 @@ class Stimulus(PrettyPrint):
             'electrodes': electrodes,
             'time': time,
         }
-        self.is_compressed = True
+        self._is_compressed = True
 
     def append(self, other):
         """Append another stimulus
@@ -701,7 +700,7 @@ class Stimulus(PrettyPrint):
             # Convert to list so w can iterate over it:
             axes = [axes]
         for i, ax in enumerate(axes):
-            if not isinstance(ax, Subplot):
+            if not isinstance(ax, Axes):
                 raise TypeError(f"'axes' must be a list of subplots, but "
                                 f"axes[{i}] is {type(ax)}.")
         if len(axes) != len(electrodes):
@@ -767,11 +766,10 @@ class Stimulus(PrettyPrint):
                     start = self.time[0] if time.start is None else time.start
                     stop = self.time[-1] if time.stop is None else time.stop
                     time = np.arange(start, stop, time.step, dtype=np.float32)
-            else:
-                if not np.any(time == Ellipsis):
-                    # Convert to float so time is not mistaken for column index
-                    if np.array(time).dtype != bool:
-                        time = np.float32(time)
+            elif time is not Ellipsis:
+                # Convert to float so time is not mistaken for column index
+                if np.array(time).dtype != bool:
+                    time = np.float32(time)
         else:
             electrodes = item
             time = None
@@ -1047,21 +1045,12 @@ class Stimulus(PrettyPrint):
 
     @property
     def is_compressed(self):
-        """Flag indicating whether the stimulus has been compressed"""
-        return self._is_compressed
+        """Flag indicating whether the stimulus has been compressed
 
-    @is_compressed.setter
-    def is_compressed(self, val):
-        """This flag can only be set in ``compress``"""
-        # getframe(0) is 'is_compressed'
-        # getframe(1) is the one we are looking for:
-        f_caller = _getframe(1).f_code.co_name
-        if f_caller in ["__init__", "compress"]:
-            self._is_compressed = val
-        else:
-            err_s = (f"The attribute `is_compressed` can only be set in the "
-                     f"constructor or in `compress`, not in `{f_caller}`.")
-            raise AttributeError(err_s)
+        Read-only: the flag is maintained by ``compress``. Assigning to it
+        raises an ``AttributeError``.
+        """
+        return self._is_compressed
 
     @property
     def dt(self):

--- a/pulse2percept/stimuli/base.py
+++ b/pulse2percept/stimuli/base.py
@@ -439,9 +439,11 @@ class Stimulus(PrettyPrint):
 
         # User can overwrite the names of the electrodes:
         if electrodes is not None:
+            _renamed_from = _electrodes
             _electrodes = np.array([electrodes]).flatten()
             _auto_electrodes = False
         else:
+            _renamed_from = None
             if not isinstance(_electrodes, np.ndarray):
                 # Could be a list of NumPy arrays, need to flatten:
                 try:
@@ -471,6 +473,22 @@ class Stimulus(PrettyPrint):
                     _electrodes = _electrodes.astype(
                         np.result_type(_electrodes.dtype, f'U{n_digits}'))
                 _electrodes[idx] = idx
+
+        if _renamed_from is not None and len(_renamed_from) == len(_electrodes):
+            # Per-electrode metadata is addressed by electrode name (that is
+            # how BiphasicAxonMapModel finds its stimulus parameters), so
+            # renaming the electrodes has to rename those keys too. Keys that
+            # do not belong to any electrode are left alone, and `metadata`
+            # may be shared with the source stimulus, so never rename in
+            # place:
+            elec_meta = self.metadata.get('electrodes')
+            rename = {str(old): str(new)
+                      for old, new in zip(_renamed_from, _electrodes)
+                      if str(old) != str(new)}
+            if elec_meta and rename:
+                self.metadata = dict(self.metadata)
+                self.metadata['electrodes'] = {rename.get(k, k): v
+                                               for k, v in elec_meta.items()}
 
         # User can overwrite time:
         if time is not None:

--- a/pulse2percept/stimuli/base.py
+++ b/pulse2percept/stimuli/base.py
@@ -5,7 +5,6 @@ from ..utils import PrettyPrint, unique, is_strictly_increasing
 from ..utils.constants import DT, MIN_AMP
 from ._base import fast_compress_space, fast_compress_time
 
-import logging
 from sys import _getframe
 from matplotlib.axes import Subplot
 import matplotlib.pyplot as plt
@@ -14,10 +13,6 @@ import operator as ops
 from math import isclose
 from scipy.integrate import trapezoid
 import numpy as np
-np.set_printoptions(precision=2, threshold=5, edgeitems=2)
-
-# Log all warnings.warn() at the WARNING level:
-logging.captureWarnings(True)
 
 
 def merge_time_axes(data, time, merge_tolerance=1e-6):
@@ -326,6 +321,13 @@ class Stimulus(PrettyPrint):
             msg = (f"Duplicate electrode names detected {_electrodes[idx]}, "
                    f"and replaced with integer values")
             warnings.warn(msg)
+            if _electrodes.dtype.kind in 'US':
+                # A fixed-width string array may be too narrow to hold the
+                # integer replacements, which would truncate them silently
+                # (and could even reintroduce duplicates), so widen it first:
+                n_digits = len(str(len(_electrodes) - 1))
+                _electrodes = _electrodes.astype(
+                    np.result_type(_electrodes.dtype, f'U{n_digits}'))
             _electrodes[idx] = idx
 
         # User can overwrite time:
@@ -444,12 +446,16 @@ class Stimulus(PrettyPrint):
             The item(s) to remove from the stimulus. Can either be an electrode
             index, electrode name, or a list thereof.
         """
-        if not electrodes:
+        # Nothing to remove. Note that ``electrodes`` must not be tested for
+        # falsiness here, because 0 is a perfectly valid electrode index:
+        if electrodes is None or np.size(electrodes) == 0:
             return
         if np.isscalar(electrodes) and electrodes == 'all':
             self._stim = {
                 'data': self.data[[]],
-                'electrodes': [],
+                # Keep `electrodes` an array (of the same dtype) so that it can
+                # still be indexed with a boolean mask afterwards:
+                'electrodes': self.electrodes[[]],
                 'time': self.time
             }
             return
@@ -797,6 +803,8 @@ class Stimulus(PrettyPrint):
 
     def __rshift__(self, scalar):
         """Shift every time point in the stimulus some ms into the future"""
+        if self.time is None:
+            raise ValueError("Cannot shift a stimulus in time if time=None.")
         return self._apply_operator(self.time, ops.add, scalar, field='time')
 
     def __lshift__(self, scalar):

--- a/pulse2percept/stimuli/base.py
+++ b/pulse2percept/stimuli/base.py
@@ -15,6 +15,87 @@ from scipy.integrate import trapezoid
 import numpy as np
 
 
+def _interp_rows(x, xp, fp):
+    """Linearly interpolate every row of ``fp`` at the time points ``x``
+
+    Vectorized equivalent of ``[np.interp(x, xp, row) for row in fp]``, which
+    is otherwise a Python-level loop over (potentially many thousands of)
+    electrodes.
+
+    The arithmetic is deliberately carried out in double precision and in the
+    same order as ``np.interp``'s C loop, so that the result is identical down
+    to the last bit: temporal models resolve stimulus edges on a fixed
+    simulation grid, where a one-ulp difference can change the output.
+
+    Parameters
+    ----------
+    x : 1-D array
+        Time points at which to interpolate.
+    xp : 1-D array
+        The stimulus time axis.
+    fp : 2-D array
+        The stimulus data, one row per electrode.
+
+    Returns
+    -------
+    data : 2-D array
+        Interpolated data, of shape ``(len(fp), len(x))``.
+    """
+    x = np.asarray(x, dtype=np.float64)
+    xp = np.asarray(xp, dtype=np.float64)
+    fp = np.asarray(fp)
+    # np.interp's C loop is hard to beat per element; what the vectorized path
+    # saves is one Python-level call per electrode. That only pays off with
+    # enough electrodes to amortize its setup, and only while the result stays
+    # small enough that the extra passes over it are cheaper than those calls.
+    # Outside that regime (and for a non-monotonic time axis, where
+    # np.interp's guess-based bracket search cannot be reproduced in a
+    # vectorized way because its result depends on the preceding query point),
+    # defer to np.interp itself:
+    if (fp.shape[0] < 32 or x.size > 256 or xp.size < 2
+            or not np.all(np.diff(xp) > 0)):
+        return np.array([np.interp(x, xp, row)
+                         for row in fp]).reshape((-1, x.size))
+    # Bracket index j such that xp[j] <= x < xp[j+1], as np.interp does. Note
+    # that `j`, `x0` and `x1` are all 1-D (one entry per requested time point):
+    j = np.clip(np.searchsorted(xp, x, side='right') - 1, 0, xp.size - 2)
+    x0, x1 = xp[j], xp[j + 1]
+    # Gather first and widen afterwards: upcasting all of `fp` would touch the
+    # whole (potentially large) data container instead of just two columns
+    # per requested time point:
+    y0 = fp[:, j].astype(np.float64)
+    y1 = fp[:, j + 1].astype(np.float64)
+    with np.errstate(invalid='ignore', divide='ignore'):
+        out = (y1 - y0) / (x1 - x0)     # slope; reused in place below
+        out *= x - x0
+        out += y0
+        # np.interp retries from the right end of the interval if that gave a
+        # NaN (which happens for infinite slopes), then gives up:
+        nan = np.isnan(out)
+        if nan.any():
+            slope = (y1 - y0) / (x1 - x0)
+            out = np.where(nan, slope * (x - x1) + y1, out)
+            out = np.where(np.isnan(out) & (y0 == y1), y0, out)
+    # The remaining corrections all select whole columns, so build the masks
+    # on the 1-D time axis and write in place rather than allocating another
+    # full-size array per correction:
+    exact = x == x0
+    if exact.any():
+        # Exact hits on a knot return the stored value verbatim:
+        out[:, exact] = y0[:, exact]
+    # Beyond the end points, the value of the closest end point is returned:
+    below = x <= xp[0]
+    if below.any():
+        out[:, below] = fp[:, :1]
+    above = x >= xp[-1]
+    if above.any():
+        out[:, above] = fp[:, -1:]
+    undefined = np.isnan(x)
+    if undefined.any():
+        out[:, undefined] = x[undefined]
+    return out
+
+
 def merge_time_axes(data, time, merge_tolerance=1e-6):
     """
     Merge time axes
@@ -690,8 +771,7 @@ class Stimulus(PrettyPrint):
             data = self.data
         else:
             data = self.data[electrodes, :].reshape(-1, len(self.time))
-        data = [np.interp(time, self.time, row) for row in data]
-        data = np.array(data).reshape((-1, len(time))).astype(np.float32)
+        data = _interp_rows(time, self.time, data).astype(np.float32)
         # Return a single element as scalar:
         if data.size == 1:
             data = data.ravel()[0].item()

--- a/pulse2percept/stimuli/base.py
+++ b/pulse2percept/stimuli/base.py
@@ -52,8 +52,8 @@ def _interp_rows(x, xp, fp):
     # np.interp's guess-based bracket search cannot be reproduced in a
     # vectorized way because its result depends on the preceding query point),
     # defer to np.interp itself:
-    if (fp.shape[0] < 32 or x.size > 256 or xp.size < 2
-            or not np.all(np.diff(xp) > 0)):
+    if (fp.shape[0] < 32 or x.size > 256 or xp.size < 2 or
+            not np.all(np.diff(xp) > 0)):
         return np.array([np.interp(x, xp, row)
                          for row in fp]).reshape((-1, x.size))
     # Bracket index j such that xp[j] <= x < xp[j+1], as np.interp does. Note
@@ -96,6 +96,33 @@ def _interp_rows(x, xp, fp):
     return out
 
 
+def _as_scalar_column(source):
+    """Convert a flat sequence of scalars into an (N, 1) data container
+
+    Returns None if ``source`` is not a non-empty list or tuple of scalars, in
+    which case the caller has to fall back to the generic per-element path.
+    An empty sequence is excluded on purpose: it must keep producing a 1-D
+    (empty) data container.
+    """
+    if not isinstance(source, (list, tuple)) or not source:
+        return None
+    if not np.isscalar(source[0]) or isinstance(source[0], str):
+        return None
+    try:
+        flat = np.asarray(source)
+    except (TypeError, ValueError):
+        # Ragged (e.g. [1, [2, 3]]): let the generic path run, so that it
+        # raises the error it has always raised:
+        return None
+    # Let the dtype NumPy infers decide. Forcing float32 here would quietly
+    # accept sequences the generic path rejects: `[1, None]` would become
+    # `[1.0, nan]` rather than a TypeError. Strings, None and complex values
+    # all infer to a non-numeric dtype and so fall through:
+    if flat.ndim != 1 or flat.dtype.kind not in 'biuf':
+        return None
+    return flat.astype(np.float32).reshape((-1, 1))
+
+
 def merge_time_axes(data, time, merge_tolerance=1e-6):
     """
     Merge time axes
@@ -120,13 +147,19 @@ def merge_time_axes(data, time, merge_tolerance=1e-6):
     """
     # We can skip the costly interpolation if all `time` vectors are
     # identical:
+    t0 = time[0]
     identical = True
     for t in time:
-        if len(t) != len(time[0]) or not np.allclose(t, time[0]):
+        # np.array_equal is a lot cheaper than np.allclose (which builds
+        # several full-size temporaries) and, whenever it succeeds, implies
+        # it. Use it as a fast path for the common case where all stimuli
+        # share the very same time axis:
+        if len(t) != len(t0) or not (np.array_equal(t, t0) or
+                                     np.allclose(t, t0)):
             identical = False
             break
     if identical:
-        return data, [time[0]]
+        return data, [t0]
     # Otherwise, we need to interpolate. Keep only the unique time points
     # across stimuli. We need a higher tolerance to ensure interpolation is correct.
     new_time = unique(np.concatenate(time), tol=merge_tolerance)
@@ -311,6 +344,9 @@ class Stimulus(PrettyPrint):
 
     def _factory(self, source, electrodes, time, compress):
         """Build the Stimulus object from the specified source type"""
+        # Whether we numbered the electrodes ourselves (0..N-1), in which case
+        # they cannot possibly contain duplicates:
+        _auto_electrodes = False
         if isinstance(source, self.__class__):
             # Stimulus: We're done. This might happen in ProsthesisSystem if
             # the user builds the stimulus themselves. It can also be used to
@@ -330,13 +366,23 @@ class Stimulus(PrettyPrint):
                 _data = source.reshape((-1, 1))
                 _time = None
                 _electrodes = np.arange(_data.shape[0])
+                _auto_electrodes = True
             elif source.ndim == 2:
                 _data = source
                 _time = np.arange(_data.shape[-1], dtype=np.float32)
                 _electrodes = np.arange(_data.shape[0])
+                _auto_electrodes = True
             else:
                 raise ValueError(f"Cannot create Stimulus object from a "
                                  f"{source.ndim}-D NumPy array. Must be < 2-D.")
+        elif (_flat := _as_scalar_column(source)) is not None:
+            # A flat sequence of scalars is one electrode per element, with no
+            # time component. The generic path below would build a separate
+            # 1x1 array (and time axis) for every single electrode:
+            _data = _flat
+            _time = None
+            _electrodes = np.arange(_data.shape[0])
+            _auto_electrodes = True
         else:
             # Input is either a scalar or (more likely) a collection of source
             # types. Easiest to tream them all as a collection and iterate:
@@ -384,6 +430,7 @@ class Stimulus(PrettyPrint):
         # User can overwrite the names of the electrodes:
         if electrodes is not None:
             _electrodes = np.array([electrodes]).flatten()
+            _auto_electrodes = False
         else:
             if not isinstance(_electrodes, np.ndarray):
                 # Could be a list of NumPy arrays, need to flatten:
@@ -395,21 +442,25 @@ class Stimulus(PrettyPrint):
             raise ValueError(f"Number of electrodes provided ({len(_electrodes)}) does "
                              f"not match the number of electrodes in the data "
                              f"({_data.shape[0]}).")
-        unq, nunq = np.unique(_electrodes, return_index=True)
-        if len(unq) != _data.shape[0]:
-            # We found duplicate names: replace them by integer index
-            idx = np.delete(np.arange(len(_electrodes)), nunq)
-            msg = (f"Duplicate electrode names detected {_electrodes[idx]}, "
-                   f"and replaced with integer values")
-            warnings.warn(msg)
-            if _electrodes.dtype.kind in 'US':
-                # A fixed-width string array may be too narrow to hold the
-                # integer replacements, which would truncate them silently
-                # (and could even reintroduce duplicates), so widen it first:
-                n_digits = len(str(len(_electrodes) - 1))
-                _electrodes = _electrodes.astype(
-                    np.result_type(_electrodes.dtype, f'U{n_digits}'))
-            _electrodes[idx] = idx
+        # Electrodes we numbered ourselves are 0..N-1 and therefore unique by
+        # construction, so the sort that np.unique performs can be skipped
+        # (it dominates the cost of building an image or video stimulus):
+        if not _auto_electrodes:
+            unq, nunq = np.unique(_electrodes, return_index=True)
+            if len(unq) != _data.shape[0]:
+                # We found duplicate names: replace them by integer index
+                idx = np.delete(np.arange(len(_electrodes)), nunq)
+                msg = (f"Duplicate electrode names detected "
+                       f"{_electrodes[idx]}, and replaced with integer values")
+                warnings.warn(msg)
+                if _electrodes.dtype.kind in 'US':
+                    # A fixed-width string array may be too narrow to hold the
+                    # integer replacements, which would truncate them silently
+                    # (and could even reintroduce duplicates), so widen first:
+                    n_digits = len(str(len(_electrodes) - 1))
+                    _electrodes = _electrodes.astype(
+                        np.result_type(_electrodes.dtype, f'U{n_digits}'))
+                _electrodes[idx] = idx
 
         # User can overwrite time:
         if time is not None:
@@ -822,7 +873,11 @@ class Stimulus(PrettyPrint):
             return False
         if self.shape != other.shape:
             return False
-        if not np.allclose(self.data, other.data):
+        # np.allclose builds several full-size temporaries. np.array_equal is
+        # much cheaper and, whenever it succeeds, implies it - so use it as a
+        # fast path for the common case of comparing identical stimuli:
+        if not (np.array_equal(self.data, other.data) or
+                np.allclose(self.data, other.data)):
             return False
         return True
 

--- a/pulse2percept/stimuli/images.py
+++ b/pulse2percept/stimuli/images.py
@@ -115,14 +115,14 @@ class ImageStimulus(Stimulus):
         # Store the original image shape for resizing and color conversion:
         self.img_shape = img.shape
         # Convert to float array in [0, 1] and call the Stimulus constructor:
-        super(ImageStimulus, self).__init__(img_as_float32(img).ravel(),
+        super().__init__(img_as_float32(img).ravel(),
                                             time=None, electrodes=electrodes,
                                             metadata=metadata,
                                             compress=compress)
         self.metadata = metadata
 
     def _pprint_params(self):
-        params = super(ImageStimulus, self)._pprint_params()
+        params = super()._pprint_params()
         params.update({'img_shape': self.img_shape})
         return params
 
@@ -662,6 +662,7 @@ class SnellenChart(ImageStimulus):
         Additional stimulus metadata can be stored in a dictionary.
 
     """
+    __slots__ = ()
 
     def __init__(self, resize=None, show_annotations=True, row=None,
                  electrodes=None, metadata=None):
@@ -701,7 +702,7 @@ class SnellenChart(ImageStimulus):
                     raise ValueError(f'Invalid value for "row": {row}. Choose '
                                      f'an int between 1 and 11.')
         # Call ImageStimulus constructor:
-        super(SnellenChart, self).__init__(source,
+        super().__init__(source,
                                            resize=resize,
                                            as_gray=True,
                                            electrodes=electrodes,
@@ -734,6 +735,7 @@ class LogoBVL(ImageStimulus):
         Additional stimulus metadata can be stored in a dictionary.
 
     """
+    __slots__ = ()
 
     def __init__(self, resize=None, electrodes=None, metadata=None,
                  as_gray=False):
@@ -741,7 +743,7 @@ class LogoBVL(ImageStimulus):
         module_path = dirname(__file__)
         source = join(module_path, 'data', 'bionic-vision-lab.png')
         # Call ImageStimulus constructor:
-        super(LogoBVL, self).__init__(source,
+        super().__init__(source,
                                       resize=resize,
                                       as_gray=as_gray,
                                       electrodes=electrodes,
@@ -775,13 +777,14 @@ class LogoUCSB(ImageStimulus):
         Additional stimulus metadata can be stored in a dictionary.
 
     """
+    __slots__ = ()
 
     def __init__(self, resize=None, electrodes=None, metadata=None):
         # Load logo from data dir:
         module_path = dirname(__file__)
         source = join(module_path, 'data', 'ucsb.png')
         # Call ImageStimulus constructor:
-        super(LogoUCSB, self).__init__(source,
+        super().__init__(source,
                                        resize=resize,
                                        as_gray=True,
                                        electrodes=electrodes,

--- a/pulse2percept/stimuli/psychophysics.py
+++ b/pulse2percept/stimuli/psychophysics.py
@@ -61,6 +61,7 @@ class GratingStimulus(VideoStimulus):
         Additional stimulus metadata can be stored in a dictionary.
 
     """
+    __slots__ = ()
 
     def __init__(self, shape, direction=0, spatial_freq=0.1,
                  temporal_freq=0.001, phase=0, contrast=1, time=None,
@@ -91,7 +92,7 @@ class GratingStimulus(VideoStimulus):
         channel = contrast * channel / 2.0 + 0.5
 
         # Call VideoStimulus constructor:
-        super(GratingStimulus, self).__init__(channel, as_gray=True,
+        super().__init__(channel, as_gray=True,
                                               time=time,
                                               electrodes=electrodes,
                                               metadata=metadata,
@@ -162,6 +163,7 @@ class BarStimulus(VideoStimulus):
         Additional stimulus metadata can be stored in a dictionary.
 
     """
+    __slots__ = ()
 
     def __init__(self, shape, direction=0, speed=0.1, bar_width=1,
                  edge_width=3, px_btw_bars=None, start_pos=0, contrast=1,
@@ -217,7 +219,7 @@ class BarStimulus(VideoStimulus):
         bar = contrast * bar / 2.0 + 0.5
 
         # Call VideoStimulus constructor:
-        super(BarStimulus, self).__init__(bar, as_gray=True,
+        super().__init__(bar, as_gray=True,
                                           time=grating.time,
                                           electrodes=electrodes,
                                           metadata=metadata,

--- a/pulse2percept/stimuli/pulse_trains.py
+++ b/pulse2percept/stimuli/pulse_trains.py
@@ -223,7 +223,8 @@ class BiphasicPulseTrain(Stimulus):
                               electrode=electrode)
         # Concatenate the pulses:
         pt = PulseTrain(freq, pulse, n_pulses=n_pulses, stim_dur=stim_dur)
-        super().__init__(pt.data, time=pt.time, compress=False)
+        super().__init__(pt.data, time=pt.time, electrodes=electrode,
+                         compress=False)
         self.freq = freq
         self.cathodic_first = cathodic_first
 
@@ -296,7 +297,8 @@ class AsymmetricBiphasicPulseTrain(Stimulus):
                                         electrode=electrode)
         # Concatenate the pulses:
         pt = PulseTrain(freq, pulse, n_pulses=n_pulses, stim_dur=stim_dur)
-        super().__init__(pt.data, time=pt.time, compress=False)
+        super().__init__(pt.data, time=pt.time, electrodes=electrode,
+                         compress=False)
         self.freq = freq
         self.cathodic_first = cathodic_first
         self.metadata = {'user': metadata}
@@ -370,16 +372,17 @@ class BiphasicTripletTrain(Stimulus):
                               cathodic_first=cathodic_first,
                               electrode=electrode)
         if interpulse_dur != 0:
-            # Create an interpulse 'delay' pulse:
-            delay_pulse = MonophasicPulse(0, interpulse_dur)
+            # Create an interpulse 'delay' pulse. It has to sit on the same
+            # electrode as `pulse`, or the two cannot be appended:
+            delay_pulse = MonophasicPulse(0, interpulse_dur, electrode=electrode)
             pulse = pulse.append(delay_pulse)
         # Create the pulse triplet:
         triplet = pulse.append(pulse).append(pulse)
         # Create the triplet train:
         pt = PulseTrain(freq, triplet, n_pulses=n_pulses, stim_dur=stim_dur)
         # Set up the Stimulus object through the constructor:
-        super().__init__(pt.data, time=pt.time,
-                                                   compress=False)
+        super().__init__(pt.data, time=pt.time, electrodes=electrode,
+                         compress=False)
         self.freq = freq
         self.cathodic_first = cathodic_first
         self.metadata = {'user': metadata}

--- a/pulse2percept/stimuli/pulse_trains.py
+++ b/pulse2percept/stimuli/pulse_trains.py
@@ -2,7 +2,6 @@
    :py:class:`~pulse2percept.stimuli.BiphasicPulseTrain`, 
    :py:class:`~pulse2percept.stimuli.AsymmetricBiphasicPulseTrain`"""
 import numpy as np
-import logging
 
 # DT: Sampling time step (ms); defines the duration of the signal edge
 # transitions:

--- a/pulse2percept/stimuli/pulse_trains.py
+++ b/pulse2percept/stimuli/pulse_trains.py
@@ -2,12 +2,66 @@
    :py:class:`~pulse2percept.stimuli.BiphasicPulseTrain`, 
    :py:class:`~pulse2percept.stimuli.AsymmetricBiphasicPulseTrain`"""
 import numpy as np
+from math import isclose
 
 # DT: Sampling time step (ms); defines the duration of the signal edge
 # transitions:
 from .base import Stimulus
 from .pulses import BiphasicPulse, AsymmetricBiphasicPulse, MonophasicPulse
 from ..utils.constants import DT
+
+
+def _tile_pulse(pulse, shift, n_pulses):
+    """Concatenate ``n_pulses`` copies of ``pulse``, spaced by ``shift`` ms
+
+    Vectorized equivalent of repeatedly calling
+    ``pt = pt.append(pulse >> shift)``, which copies the ever-growing data
+    container once per pulse (and is therefore quadratic in ``n_pulses``).
+
+    Parameters
+    ----------
+    pulse : :py:class:`~pulse2percept.stimuli.Stimulus`
+        A stimulus containing a single pulse, with a time component.
+    shift : float
+        Time (ms) by which each copy is shifted with respect to the previous
+        one, in addition to the duration of the pulse itself.
+    n_pulses : int
+        Number of copies to concatenate.
+
+    Returns
+    -------
+    data, time : np.ndarray
+        The data container and time axis of the concatenated pulse train.
+    """
+    time, data = pulse.time, pulse.data
+    # The time axis of each appended copy, i.e. of ``pulse >> shift``:
+    shifted = time + shift
+    if shifted[0] < 0:
+        raise NotImplementedError("Appending a stimulus with a negative "
+                                  "time axis is currently not supported.")
+    # ``append`` offsets copy k by the last time point of copy k-1, so the
+    # offsets follow the recurrence last[k] = shifted[-1] + last[k-1], seeded
+    # with last[0] = time[-1]. A float32 cumsum accumulates in exactly the
+    # same order (and therefore rounds identically), which matters because
+    # temporal models resolve stimulus edges on a fixed simulation grid:
+    steps = np.full(n_pulses, shifted[-1], dtype=np.float32)
+    steps[0] = time[-1]
+    offsets = np.cumsum(steps, dtype=np.float32)[:-1, np.newaxis]
+    if isclose(shifted[0], 0, abs_tol=DT):
+        # The last time point of one copy coincides with the first time point
+        # of the next, so the two are merged into one - but only if they carry
+        # the same amplitude(s):
+        if not np.allclose(data[:, 0], data[:, -1]):
+            raise ValueError(f"Data mismatch: Cannot append other stimulus "
+                             f"because other[t=0] != this[t={time[-1]}ms]. "
+                             f"You may need to shift the other stimulus in "
+                             f"time by at least {DT:.1e} ms.")
+        new_time = np.concatenate((time, (shifted[1:] + offsets).ravel()))
+        new_data = np.hstack((data, np.tile(data[:, 1:], n_pulses - 1)))
+    else:
+        new_time = np.concatenate((time, (shifted + offsets).ravel()))
+        new_data = np.tile(data, n_pulses)
+    return new_data, new_time
 
 
 class PulseTrain(Stimulus):
@@ -82,11 +136,7 @@ class PulseTrain(Stimulus):
                                  f"pulse train window (dur={window_dur:.2f} "
                                  f"ms)")
             shift = np.maximum(0, window_dur - pulse.time[-1])
-            pt = pulse
-            for i in range(1, n_pulses):
-                pt = pt.append(pulse >> shift)
-            data = pt.data
-            time = pt.time
+            data, time = _tile_pulse(pulse, shift, n_pulses)
         if time[-1] > stim_dur + DT:
             # If stimulus is longer than the requested `stim_dur`, trim it.
             # Make sure to interpolate the end point:

--- a/pulse2percept/stimuli/pulse_trains.py
+++ b/pulse2percept/stimuli/pulse_trains.py
@@ -100,6 +100,7 @@ class PulseTrain(Stimulus):
        a 11 Hz pulse train into a 100 ms window, there will be 9 pulses.
 
     """
+    __slots__ = ('freq', 'pulse_type')
 
     def __init__(self, freq, pulse, n_pulses=None, stim_dur=1000.0,
                  electrode=None, metadata=None):
@@ -157,7 +158,7 @@ class PulseTrain(Stimulus):
 
     def _pprint_params(self):
         """Return a dict of class arguments to pretty-print"""
-        params = super(PulseTrain, self)._pprint_params()
+        params = super()._pprint_params()
         params.update({'freq': self.freq,
                        'pulse_type': self.pulse_type})
         return params
@@ -210,6 +211,7 @@ class BiphasicPulseTrain(Stimulus):
        smaller than 10 picoamps.
 
     """
+    __slots__ = ('freq', 'cathodic_first')
 
     def __init__(self, freq, amp, phase_dur, interphase_dur=0, delay_dur=0,
                  n_pulses=None, stim_dur=1000.0, cathodic_first=True,
@@ -234,7 +236,7 @@ class BiphasicPulseTrain(Stimulus):
 
     def _pprint_params(self):
         """Return a dict of class arguments to pretty-print"""
-        params = super(BiphasicPulseTrain, self)._pprint_params()
+        params = super()._pprint_params()
         params.update({'cathodic_first': self.cathodic_first,
                        'freq': self.freq})
         return params
@@ -281,6 +283,7 @@ class AsymmetricBiphasicPulseTrain(Stimulus):
         A dictionary of meta-data
 
     """
+    __slots__ = ('freq', 'cathodic_first')
 
     def __init__(self, freq, amp1, amp2, phase_dur1, phase_dur2,
                  interphase_dur=0, delay_dur=0, n_pulses=None, stim_dur=1000.0,
@@ -300,7 +303,7 @@ class AsymmetricBiphasicPulseTrain(Stimulus):
 
     def _pprint_params(self):
         """Return a dict of class arguments to pretty-print"""
-        params = super(AsymmetricBiphasicPulseTrain, self)._pprint_params()
+        params = super()._pprint_params()
         params.update({'cathodic_first': self.cathodic_first,
                        'freq': self.freq})
         return params
@@ -356,6 +359,7 @@ class BiphasicTripletTrain(Stimulus):
        smaller than 10 picoamps.
 
     """
+    __slots__ = ('freq', 'cathodic_first')
 
     def __init__(self, freq, amp, phase_dur, interphase_dur=0, interpulse_dur=0,
                  delay_dur=0, n_pulses=None, stim_dur=1000.0, cathodic_first=True,
@@ -374,7 +378,7 @@ class BiphasicTripletTrain(Stimulus):
         # Create the triplet train:
         pt = PulseTrain(freq, triplet, n_pulses=n_pulses, stim_dur=stim_dur)
         # Set up the Stimulus object through the constructor:
-        super(BiphasicTripletTrain, self).__init__(pt.data, time=pt.time,
+        super().__init__(pt.data, time=pt.time,
                                                    compress=False)
         self.freq = freq
         self.cathodic_first = cathodic_first
@@ -382,7 +386,7 @@ class BiphasicTripletTrain(Stimulus):
 
     def _pprint_params(self):
         """Return a dict of class arguments to pretty-print"""
-        params = super(BiphasicTripletTrain, self)._pprint_params()
+        params = super()._pprint_params()
         params.update({'cathodic_first': self.cathodic_first,
                        'freq': self.freq})
         return params

--- a/pulse2percept/stimuli/pulses.py
+++ b/pulse2percept/stimuli/pulses.py
@@ -49,6 +49,7 @@ class MonophasicPulse(Stimulus):
     >>> pulse = MonophasicPulse(-20, 1, delay_dur=2, stim_dur=10)
 
     """
+    __slots__ = ('cathodic',)
 
     def __init__(self, amp, phase_dur, delay_dur=0, stim_dur=None,
                  electrode=None):
@@ -91,7 +92,7 @@ class MonophasicPulse(Stimulus):
 
     def _pprint_params(self):
         """Return a dict of class arguments to pretty-print"""
-        params = super(MonophasicPulse, self)._pprint_params()
+        params = super()._pprint_params()
         params.update({'cathodic': self.cathodic})
         return params
 
@@ -142,6 +143,7 @@ class BiphasicPulse(Stimulus):
     >>> pulse = BiphasicPulse(-20, 1, delay_dur=2, stim_dur=10)
 
     """
+    __slots__ = ('cathodic_first',)
 
     def __init__(self, amp, phase_dur, interphase_dur=0, delay_dur=0,
                  stim_dur=None, cathodic_first=True, electrode=None):
@@ -194,7 +196,7 @@ class BiphasicPulse(Stimulus):
 
     def _pprint_params(self):
         """Return a dict of class arguments to pretty-print"""
-        params = super(BiphasicPulse, self)._pprint_params()
+        params = super()._pprint_params()
         params.update({'cathodic_first': self.cathodic_first})
         return params
 
@@ -251,6 +253,7 @@ class AsymmetricBiphasicPulse(Stimulus):
     ...                                 delay_dur=2, stim_dur=15)
 
     """
+    __slots__ = ('cathodic_first',)
 
     def __init__(self, amp1, amp2, phase_dur1, phase_dur2, interphase_dur=0,
                  delay_dur=0, stim_dur=None, cathodic_first=True,
@@ -311,6 +314,6 @@ class AsymmetricBiphasicPulse(Stimulus):
 
     def _pprint_params(self):
         """Return a dict of class arguments to pretty-print"""
-        params = super(AsymmetricBiphasicPulse, self)._pprint_params()
+        params = super()._pprint_params()
         params.update({'cathodic_first': self.cathodic_first})
         return params

--- a/pulse2percept/stimuli/tests/test_base.py
+++ b/pulse2percept/stimuli/tests/test_base.py
@@ -709,8 +709,13 @@ def test_Stimulus_shallow_copy():
 def test_interp_rows(n_el, n_t, n_q):
     # `_interp_rows` replaces a per-electrode np.interp loop, and switches
     # between a vectorized and a looped implementation depending on the shape.
-    # Both must agree with np.interp down to the last bit, because temporal
-    # models resolve stimulus edges on a fixed simulation grid.
+    # Both must agree with np.interp, because temporal models resolve stimulus
+    # edges on a fixed simulation grid.
+    #
+    # Interior points are allowed to differ by a rounding: a C compiler may
+    # contract `slope * dx + y0` into a single fused multiply-add inside
+    # np.interp (it does on arm64), where the NumPy expression rounds twice.
+    # Points that need no arithmetic must match exactly on every platform.
     rng = np.random.default_rng(n_el * 1000 + n_t * 10 + n_q)
     xp = np.unique(np.sort(rng.random(n_t).astype(np.float32) * 100))
     fp = ((rng.random((n_el, xp.size)) - 0.5) * 200).astype(np.float32)
@@ -720,7 +725,17 @@ def test_interp_rows(n_el, n_t, n_q):
               np.full(n_q, xp[-1], dtype=np.float32)):         # right end point
         expected = np.array([np.interp(x, xp, row) for row in fp])
         expected = expected.reshape((-1, x.size))
-        npt.assert_array_equal(_interp_rows(x, xp, fp), expected)
+        actual = _interp_rows(x, xp, fp)
+        # Scale the tolerance by the size of the data, not of the result: the
+        # rounding happens on the intermediate product, which stays the size
+        # of the inputs even where the result is near zero (any interpolation
+        # across a zero crossing, which biphasic pulses do all the time).
+        npt.assert_allclose(actual, expected, rtol=1e-12,
+                            atol=1e-10 * np.abs(fp).max())
+        # End points and exact knots are assigned verbatim, never computed,
+        # so those must agree exactly on every platform:
+        verbatim = (x <= xp[0]) | (x >= xp[-1]) | np.isin(x, xp)
+        npt.assert_array_equal(actual[:, verbatim], expected[:, verbatim])
 
 
 def test_interp_rows_edge_cases():
@@ -744,7 +759,9 @@ def test_interp_rows_edge_cases():
 
 def test_Stimulus_getitem_many_electrodes():
     # Interpolating a stimulus with many electrodes takes the vectorized path;
-    # the result must be identical to interpolating each electrode by itself.
+    # the result must match interpolating each electrode by itself, to within
+    # the one float32 ULP that a fused multiply-add inside np.interp can cost
+    # (see `test_interp_rows`):
     rng = np.random.default_rng(0)
     data = rng.random((200, 25)).astype(np.float32)
     stim = Stimulus(data)
@@ -753,8 +770,8 @@ def test_Stimulus_getitem_many_electrodes():
         t32 = np.float32(np.atleast_1d(t))
         expected = np.array([np.interp(t32, stim.time, row)
                              for row in data]).astype(np.float32)
-        npt.assert_array_equal(np.asarray(stim[:, t]).reshape(expected.shape),
-                               expected)
+        actual = np.asarray(stim[:, t]).reshape(expected.shape)
+        npt.assert_almost_equal(actual, expected, decimal=6)
     # A single electrode of that stimulus must give the same values:
     npt.assert_almost_equal(stim[7, 3.7], stim[:, 3.7][7, 0])
 

--- a/pulse2percept/stimuli/tests/test_base.py
+++ b/pulse2percept/stimuli/tests/test_base.py
@@ -13,6 +13,7 @@ import matplotlib.pyplot as plt
 from pulse2percept.stimuli import Stimulus
 from pulse2percept.stimuli import BiphasicPulseTrain
 from pulse2percept.stimuli import ImageStimulus
+from pulse2percept.stimuli.base import _interp_rows
 from pulse2percept.utils.constants import DT
 from pulse2percept.utils.testing import assert_warns_msg
 
@@ -700,3 +701,59 @@ def test_Stimulus_shallow_copy():
     npt.assert_equal(type(img * 2), ImageStimulus)
     npt.assert_equal((img * 2).img_shape, img.img_shape)
     npt.assert_almost_equal((img * 2).data, 2 * img.data)
+
+
+@pytest.mark.parametrize('n_el, n_t, n_q', [(1, 5, 3), (2, 12, 40), (40, 8, 5),
+                                            (40, 8, 400), (64, 300, 64),
+                                            (33, 4, 257)])
+def test_interp_rows(n_el, n_t, n_q):
+    # `_interp_rows` replaces a per-electrode np.interp loop, and switches
+    # between a vectorized and a looped implementation depending on the shape.
+    # Both must agree with np.interp down to the last bit, because temporal
+    # models resolve stimulus edges on a fixed simulation grid.
+    rng = np.random.default_rng(n_el * 1000 + n_t * 10 + n_q)
+    xp = np.unique(np.sort(rng.random(n_t).astype(np.float32) * 100))
+    fp = ((rng.random((n_el, xp.size)) - 0.5) * 200).astype(np.float32)
+    for x in (rng.random(n_q).astype(np.float32) * 140 - 20,   # incl. outside
+              np.resize(xp, n_q),                              # exactly on knots
+              np.full(n_q, xp[0], dtype=np.float32),           # left end point
+              np.full(n_q, xp[-1], dtype=np.float32)):         # right end point
+        expected = np.array([np.interp(x, xp, row) for row in fp])
+        expected = expected.reshape((-1, x.size))
+        npt.assert_array_equal(_interp_rows(x, xp, fp), expected)
+
+
+def test_interp_rows_edge_cases():
+    # A single time point: np.interp returns it everywhere
+    fp = np.array([[3.0], [4.0]], dtype=np.float32)
+    xp = np.array([2.5], dtype=np.float32)
+    x = np.array([-1.0, 2.5, 99.0], dtype=np.float32)
+    npt.assert_array_equal(_interp_rows(x, xp, fp),
+                           np.array([[3, 3, 3], [4, 4, 4]], dtype=np.float64))
+    # No electrodes at all:
+    npt.assert_equal(_interp_rows(x, np.array([0., 1.], np.float32),
+                                  np.zeros((0, 2), np.float32)).shape, (0, 3))
+    # A non-monotonic time axis is allowed (it only warns), but np.interp's
+    # bracket search is guess-based there, so we must defer to it verbatim:
+    xp = np.array([0., 1., 1., 2., 2.], dtype=np.float32)
+    fp = np.array([[1., 0., 1., 0., 2.]] * 40, dtype=np.float32)
+    x = np.array([0.0, 0.5, 1.0, 1.5, 2.0, 3.0], dtype=np.float32)
+    expected = np.array([np.interp(x, xp, row) for row in fp])
+    npt.assert_array_equal(_interp_rows(x, xp, fp), expected)
+
+
+def test_Stimulus_getitem_many_electrodes():
+    # Interpolating a stimulus with many electrodes takes the vectorized path;
+    # the result must be identical to interpolating each electrode by itself.
+    rng = np.random.default_rng(0)
+    data = rng.random((200, 25)).astype(np.float32)
+    stim = Stimulus(data)
+    for t in (3.7, [3.7], np.linspace(-2, 26, 37), np.asarray(stim.time)):
+        # __getitem__ casts the requested time points to float32 first:
+        t32 = np.float32(np.atleast_1d(t))
+        expected = np.array([np.interp(t32, stim.time, row)
+                             for row in data]).astype(np.float32)
+        npt.assert_array_equal(np.asarray(stim[:, t]).reshape(expected.shape),
+                               expected)
+    # A single electrode of that stimulus must give the same values:
+    npt.assert_almost_equal(stim[7, 3.7], stim[:, 3.7][7, 0])

--- a/pulse2percept/stimuli/tests/test_base.py
+++ b/pulse2percept/stimuli/tests/test_base.py
@@ -1,3 +1,6 @@
+import subprocess
+import sys
+
 import numpy as np
 import numpy.testing as npt
 import pytest
@@ -556,6 +559,100 @@ def test_Stimulus_remove():
     stim.remove('A1')
     npt.assert_equal('A1' in stim.electrodes, False)
     npt.assert_equal('C3' in stim.electrodes, True)
+
+    # Electrode 0 must be removable: `0` is falsy, but it is a valid index:
+    stim = Stimulus([[0, 1, 2], [3, 4, 5]])
+    stim.remove(0)
+    npt.assert_equal(stim.shape, (1, 3))
+    npt.assert_equal(stim.electrodes, [1])
+    npt.assert_almost_equal(stim.data, [[3, 4, 5]])
+    # Removing index 0 by index or by name gives the same result:
+    stim = Stimulus([[0, 1, 2], [3, 4, 5]], electrodes=['A1', 'C3'])
+    stim.remove(0)
+    npt.assert_equal(stim.electrodes, ['C3'])
+
+    # Removing a list of electrodes:
+    stim = Stimulus([[0, 1, 2], [3, 4, 5]], electrodes=['A1', 'C3'])
+    stim.remove(['A1', 'C3'])
+    npt.assert_equal(stim.shape, (0, 3))
+
+    # Removing "nothing" is a no-op. ProsthesisSystem relies on this when none
+    # of its electrodes are deactivated:
+    for nothing in (None, [], (), np.array([])):
+        stim = Stimulus([[0, 1, 2], [3, 4, 5]])
+        stim.remove(nothing)
+        npt.assert_equal(stim.shape, (2, 3))
+        npt.assert_equal(stim.electrodes, [0, 1])
+
+    # After 'all', `electrodes` must stay an array of the same dtype, so that
+    # it can still be indexed with a boolean mask:
+    stim = Stimulus([[0, 1, 2], [3, 4, 5]], electrodes=['A1', 'C3'])
+    dtype = stim.electrodes.dtype
+    stim.remove('all')
+    npt.assert_equal(isinstance(stim.electrodes, np.ndarray), True)
+    npt.assert_equal(stim.electrodes.dtype, dtype)
+    npt.assert_equal(stim.shape, (0, 3))
+    npt.assert_equal(stim.electrodes[np.zeros(0, dtype=bool)].size, 0)
+
+    # Unknown electrodes are an error:
+    stim = Stimulus([[0, 1, 2], [3, 4, 5]], electrodes=['A1', 'C3'])
+    with pytest.raises(ValueError):
+        stim.remove('B2')
+
+
+def test_Stimulus_duplicate_electrodes():
+    # Duplicate names are replaced with their integer index:
+    with pytest.warns(UserWarning, match='Duplicate electrode names'):
+        stim = Stimulus(np.ones((3, 2)), electrodes=['AA', 'AA', 'BB'])
+    npt.assert_equal(stim.electrodes, ['AA', '1', 'BB'])
+    # Integer names stay integers:
+    with pytest.warns(UserWarning, match='Duplicate electrode names'):
+        stim = Stimulus([Stimulus(1), Stimulus(2)])
+    npt.assert_equal(stim.electrodes, [0, 1])
+    # The integer replacements must not be truncated by a string dtype that is
+    # too narrow to hold them - the "fixed" names would be duplicates again:
+    n_el = 200
+    with pytest.warns(UserWarning, match='Duplicate electrode names'):
+        stim = Stimulus(np.ones((n_el, 2)), electrodes=['A'] * n_el)
+    npt.assert_equal(len(np.unique(stim.electrodes)), n_el)
+    npt.assert_equal(stim.electrodes[0], 'A')
+    npt.assert_equal(stim.electrodes[-1], str(n_el - 1))
+
+
+def test_Stimulus_shift_without_time():
+    # Shifting a stimulus that has no time component must be reported as such,
+    # not as a TypeError from adding a scalar to None:
+    stim = Stimulus(3)
+    npt.assert_equal(stim.time, None)
+    with pytest.raises(ValueError):
+        stim >> 1.0
+    with pytest.raises(ValueError):
+        stim << 1.0
+    # Stimuli that do have a time axis are unaffected:
+    stim = Stimulus([[0, 1, 2]], time=[0, 1, 2])
+    npt.assert_almost_equal((stim >> 1.5).time, [1.5, 2.5, 3.5])
+    npt.assert_almost_equal((stim << 1.5).time, [-1.5, -0.5, 0.5])
+
+
+def test_Stimulus_no_global_side_effects():
+    # Importing the module must not change NumPy's print options for the rest
+    # of the user's session (`Stimulus` used to call `np.set_printoptions` at
+    # module level). This has to run in a subprocess, because by the time this
+    # test executes the module has long been imported.
+    code = ("import numpy as np;"
+            "before = np.get_printoptions();"
+            "import pulse2percept.stimuli.base;"
+            "after = np.get_printoptions();"
+            "print('UNCHANGED' if before == after "
+            "else f'CHANGED: {before} -> {after}')")
+    out = subprocess.run([sys.executable, '-c', code], capture_output=True,
+                         text=True, check=True)
+    npt.assert_equal(out.stdout.strip().splitlines()[-1], 'UNCHANGED')
+    # Long arrays are still abbreviated in the repr, which is what the global
+    # print options used to (redundantly) take care of:
+    stim = Stimulus(np.arange(1000).reshape((10, 100)))
+    npt.assert_equal('...' in repr(stim), True)
+    npt.assert_equal('\n'.join(repr(stim).split()).count('electrodes='), 1)
 
 
 def test_merge_time_axes_merge_tolerance():

--- a/pulse2percept/stimuli/tests/test_base.py
+++ b/pulse2percept/stimuli/tests/test_base.py
@@ -842,3 +842,34 @@ def test_Stimulus___eq___tolerance():
                      False)
     npt.assert_equal(Stimulus([[np.inf, 1.0]]) == Stimulus([[np.inf, 1.0]]),
                      True)
+
+
+def test_Stimulus_rename_electrodes_metadata():
+    # Per-electrode metadata is keyed by electrode name (BiphasicAxonMapModel
+    # reads its stimulus parameters from there), so renaming the electrodes
+    # has to rename those keys as well.
+    stim = Stimulus({'A1': BiphasicPulseTrain(20, 30, 0.45, stim_dur=100),
+                     'B3': BiphasicPulseTrain(40, 20, 0.45, stim_dur=100)})
+    npt.assert_equal(sorted(stim.metadata['electrodes'].keys()), ['A1', 'B3'])
+
+    renamed = Stimulus(stim, electrodes=['Z9', 'Y8'])
+    npt.assert_equal(sorted(renamed.metadata['electrodes'].keys()), ['Y8', 'Z9'])
+    for old, new in [('A1', 'Z9'), ('B3', 'Y8')]:
+        npt.assert_equal(renamed.metadata['electrodes'][new],
+                         stim.metadata['electrodes'][old])
+    # The source must not be touched (its metadata may be shared):
+    npt.assert_equal(sorted(stim.metadata['electrodes'].keys()), ['A1', 'B3'])
+
+    # Swapping two names is a simultaneous remap, not two sequential ones:
+    swapped = Stimulus(stim, electrodes=['B3', 'A1'])
+    npt.assert_equal(swapped.metadata['electrodes']['B3'],
+                     stim.metadata['electrodes']['A1'])
+    npt.assert_equal(swapped.metadata['electrodes']['A1'],
+                     stim.metadata['electrodes']['B3'])
+
+    # Renaming a stimulus that has no per-electrode metadata is a no-op:
+    plain = Stimulus(np.ones((2, 3)))
+    npt.assert_equal(Stimulus(plain, electrodes=['P1', 'P2']).electrodes,
+                     ['P1', 'P2'])
+    npt.assert_equal(Stimulus(plain, electrodes=['P1', 'P2'])
+                     .metadata['electrodes'], {})

--- a/pulse2percept/stimuli/tests/test_base.py
+++ b/pulse2percept/stimuli/tests/test_base.py
@@ -757,3 +757,71 @@ def test_Stimulus_getitem_many_electrodes():
                                expected)
     # A single electrode of that stimulus must give the same values:
     npt.assert_almost_equal(stim[7, 3.7], stim[:, 3.7][7, 0])
+
+
+def test_Stimulus_scalar_sequence():
+    # A flat sequence of scalars takes a fast path in the constructor, which
+    # must agree with the generic per-element path in every respect:
+    for source in ([3, 5], (3, 5), [7], [3.5, -2.25, 0.0], [True, False],
+                   [np.float32(3), np.float64(5), np.int32(7)]):
+        stim = Stimulus(source)
+        npt.assert_equal(stim.shape, (len(source), 1))
+        npt.assert_equal(stim.time, None)
+        npt.assert_equal(stim.electrodes, np.arange(len(source)))
+        npt.assert_equal(stim.data.dtype, np.float32)
+        npt.assert_almost_equal(stim.data.ravel(),
+                                np.asarray(source, dtype=np.float32))
+    # Electrode names, metadata and compression still work:
+    stim = Stimulus([3, 5], electrodes=['A1', 'B2'], metadata={'x': 1})
+    npt.assert_equal(stim.electrodes, ['A1', 'B2'])
+    npt.assert_equal(stim.metadata['user'], {'x': 1})
+    npt.assert_equal(Stimulus([0, 3, 0, 5], compress=True).shape, (2, 1))
+
+    # An empty sequence still yields a 1-D (empty) data container:
+    for source in ([], ()):
+        npt.assert_equal(Stimulus(source).shape, (0,))
+        npt.assert_equal(Stimulus(source).time, None)
+
+    # Sequences that are not flat scalars must keep their old meaning: a
+    # nested sequence is a single electrode in time, not several electrodes
+    npt.assert_equal(Stimulus([[1, 5, 7, 2, 4]]).shape, (1, 5))
+    npt.assert_equal(Stimulus([[1, 1], [1, 1]]).shape, (2, 2))
+    npt.assert_equal(Stimulus(((1, 1), (1, 1))).shape, (2, 2))
+    # ...and invalid elements must still raise, not be coerced. `None` in
+    # particular converts to NaN if handed straight to np.asarray:
+    for source in (['a', 'b'], [1, 'a'], [1, None], [1, [2, 3]]):
+        with pytest.raises((TypeError, ValueError)):
+            Stimulus(source)
+
+
+def test_Stimulus_near_identical_time_axes():
+    # Merging is skipped when all time axes are *close*, not just equal - the
+    # fast path added for the common case must not tighten that tolerance.
+    t1 = np.array([0., 1., 2.], dtype=np.float32)
+    t2 = np.array([0., 1. + 3e-7, 2.], dtype=np.float32)
+    npt.assert_equal(np.array_equal(t1, t2), False)   # differ in float32...
+    npt.assert_equal(np.allclose(t1, t2), True)       # ...but within tolerance
+    stim1 = Stimulus([[0., 5., 0.]], time=t1)
+    stim2 = Stimulus([[0., 7., 0.]], time=t2)
+    merged = Stimulus([stim1, stim2])
+    # No interpolation: the first time axis is adopted verbatim
+    npt.assert_array_equal(np.asarray(merged.time), t1)
+    npt.assert_array_equal(merged.data, np.vstack((stim1.data, stim2.data)))
+    # Genuinely different axes are still merged by interpolation:
+    stim3 = Stimulus([[0., 9., 0.]], time=[0., 1.5, 2.])
+    merged = Stimulus([stim1, stim3])
+    npt.assert_equal(len(merged.time) > 3, True)
+
+
+def test_Stimulus___eq___tolerance():
+    # __eq__ compares with a tolerance; the exact-equality fast path must not
+    # change that:
+    npt.assert_equal(Stimulus([[1.0, 2.0]]) == Stimulus([[1.0, 2.0]]), True)
+    npt.assert_equal(Stimulus([[1.0, 2.0]]) == Stimulus([[1.0, 2.0 + 1e-9]]),
+                     True)
+    npt.assert_equal(Stimulus([[1.0, 2.0]]) == Stimulus([[1.0, 2.5]]), False)
+    # NaN never compares equal, with or without the fast path:
+    npt.assert_equal(Stimulus([[np.nan, 1.0]]) == Stimulus([[np.nan, 1.0]]),
+                     False)
+    npt.assert_equal(Stimulus([[np.inf, 1.0]]) == Stimulus([[np.inf, 1.0]]),
+                     True)

--- a/pulse2percept/stimuli/tests/test_base.py
+++ b/pulse2percept/stimuli/tests/test_base.py
@@ -12,6 +12,7 @@ import matplotlib.pyplot as plt
 
 from pulse2percept.stimuli import Stimulus
 from pulse2percept.stimuli import BiphasicPulseTrain
+from pulse2percept.stimuli import ImageStimulus
 from pulse2percept.utils.constants import DT
 from pulse2percept.utils.testing import assert_warns_msg
 
@@ -668,3 +669,34 @@ def test_merge_time_axes_merge_tolerance():
     # Assert no value goes close to 1/3 or -1/3, i.e. a corrupted data point
     npt.assert_equal(np.isclose(1/3, unique_points, atol=0.1).any(), False)
     npt.assert_equal(np.isclose(-1/3, unique_points, atol=0.1).any(), False)
+
+
+def test_Stimulus_shallow_copy():
+    # `append` and the arithmetic operators return a copy that shares nothing
+    # mutable with the original, even though the data container is no longer
+    # deep-copied first.
+    stim = BiphasicPulseTrain(20, 20, 0.45, stim_dur=100)
+    for derive in (lambda s: s * 2, lambda s: s + 1, lambda s: -s,
+                   lambda s: s >> 1.0, lambda s: s.append(s >> 1.0)):
+        copied = derive(stim)
+        # Same class and extra attributes:
+        npt.assert_equal(type(copied), type(stim))
+        npt.assert_equal(copied.freq, stim.freq)
+        npt.assert_equal(copied.cathodic_first, stim.cathodic_first)
+        npt.assert_equal(copied.is_compressed, stim.is_compressed)
+        # Metadata is equal but independent:
+        npt.assert_equal(copied.metadata, stim.metadata)
+        npt.assert_equal(copied.metadata is stim.metadata, False)
+        copied.metadata['user'] = 'changed'
+        npt.assert_equal(stim.metadata['user'], None)
+        # The data container is independent, too:
+        npt.assert_equal(copied._stim is stim._stim, False)
+        before = stim.data.copy()
+        copied.data[:] = 0
+        npt.assert_array_equal(stim.data, before)
+
+    # Subclass-specific attributes survive as well:
+    img = ImageStimulus(np.ones((4, 5), dtype=np.float32))
+    npt.assert_equal(type(img * 2), ImageStimulus)
+    npt.assert_equal((img * 2).img_shape, img.img_shape)
+    npt.assert_almost_equal((img * 2).data, 2 * img.data)

--- a/pulse2percept/stimuli/tests/test_pulse_trains.py
+++ b/pulse2percept/stimuli/tests/test_pulse_trains.py
@@ -281,3 +281,26 @@ def test_PulseTrain_tiling_errors():
     # A negative time axis is not supported:
     with pytest.raises(NotImplementedError):
         _tile_pulse(Stimulus([[0, 5, 0]], time=[-2.0, 0.0, 4.0]), 0.0, 3)
+
+
+@pytest.mark.parametrize('cls, args, kwargs', [
+    (PulseTrain, (20, BiphasicPulse(30, 0.45)), {}),
+    (BiphasicPulseTrain, (20, 30, 0.45), {}),
+    (AsymmetricBiphasicPulseTrain, (20, -40, 10, 1, 4), {}),
+    (BiphasicTripletTrain, (20, 30, 0.45), {}),
+    (BiphasicTripletTrain, (20, 30, 0.45), {'interpulse_dur': 0.5}),
+])
+def test_PulseTrain_electrode_name(cls, args, kwargs):
+    # The `electrode` argument is documented on every pulse train, so it must
+    # actually reach the Stimulus constructor. It also decides the key under
+    # which per-electrode metadata is filed, which is how BiphasicAxonMapModel
+    # looks up freq/amp/phase_dur.
+    stim = cls(*args, stim_dur=100, electrode='A1', **kwargs)
+    npt.assert_equal(stim.electrodes, ['A1'])
+    # Without a name, electrodes are still numbered from 0:
+    stim = cls(*args, stim_dur=100, **kwargs)
+    npt.assert_equal(stim.electrodes, [0])
+    # And the name has to survive the trip through Stimulus():
+    stim = Stimulus(cls(*args, stim_dur=100, electrode='A1', **kwargs))
+    npt.assert_equal(stim.electrodes, ['A1'])
+    npt.assert_equal('A1' in stim.metadata['electrodes'], True)

--- a/pulse2percept/stimuli/tests/test_pulse_trains.py
+++ b/pulse2percept/stimuli/tests/test_pulse_trains.py
@@ -3,9 +3,11 @@ import pytest
 import numpy.testing as npt
 from scipy.integrate import trapezoid
 
-from pulse2percept.stimuli import (Stimulus, PulseTrain, BiphasicPulseTrain,
+from pulse2percept.stimuli import (Stimulus, PulseTrain, BiphasicPulse,
+                                   BiphasicPulseTrain,
                                    BiphasicTripletTrain,
                                    AsymmetricBiphasicPulseTrain)
+from pulse2percept.stimuli.pulse_trains import _tile_pulse
 from pulse2percept.utils.constants import DT
 
 
@@ -235,3 +237,47 @@ def test_metadata():
     npt.assert_equal(stim.metadata['electrodes']['B1']['metadata']['freq'], 11)
     npt.assert_equal(stim.metadata['electrodes']
                      ['C3']['metadata']['user'], 'userdataC3')
+
+
+@pytest.mark.parametrize('freq, phase_dur, interphase_dur',
+                         [(20, 0.45, 0), (100, 0.45, 0.2), (13, 0.1, 0),
+                          (225, 0.075, 0.075), (2000, 0.1, 0)])
+def test_PulseTrain_tiling(freq, phase_dur, interphase_dur):
+    # The pulse train is assembled by tiling rather than by repeatedly calling
+    # `append`. The two must agree bit-for-bit: temporal models resolve
+    # stimulus edges on a fixed simulation grid, so even a sub-nanosecond
+    # difference in the time axis can change model output.
+    pulse = BiphasicPulse(20, phase_dur, interphase_dur=interphase_dur)
+    n_pulses = 7
+    window_dur = 1000.0 / freq
+    shift = np.maximum(0, window_dur - pulse.time[-1])
+
+    # Reference: the original implementation
+    ref = pulse
+    for _ in range(1, n_pulses):
+        ref = ref.append(pulse >> shift)
+
+    data, time = _tile_pulse(pulse, shift, n_pulses)
+    npt.assert_array_equal(data, ref.data)
+    npt.assert_array_equal(time, ref.time)
+    npt.assert_equal(data.dtype, ref.data.dtype)
+    npt.assert_equal(time.dtype, ref.time.dtype)
+
+    # A single pulse must come out unchanged:
+    data, time = _tile_pulse(pulse, shift, 1)
+    npt.assert_array_equal(data, pulse.data)
+    npt.assert_array_equal(time, pulse.time)
+
+
+def test_PulseTrain_tiling_errors():
+    # A pulse whose first and last sample differ cannot be tiled without a gap
+    # between the copies (the junction points would have to be merged):
+    pulse = Stimulus([[1, 2, 3]], time=[0, 0.5, 1.0])
+    with pytest.raises(ValueError):
+        _tile_pulse(pulse, 0.0, 3)
+    # ...but with a gap it is fine:
+    data, time = _tile_pulse(pulse, 5.0, 3)
+    npt.assert_equal(data.shape, (1, 9))
+    # A negative time axis is not supported:
+    with pytest.raises(NotImplementedError):
+        _tile_pulse(Stimulus([[0, 5, 0]], time=[-2.0, 0.0, 4.0]), 0.0, 3)

--- a/pulse2percept/stimuli/videos.py
+++ b/pulse2percept/stimuli/videos.py
@@ -80,12 +80,13 @@ class VideoStimulus(Stimulus):
         * Retain only the time points at which the stimulus changes.
 
     """
+    __slots__ = ('vid_shape', '_next_frame')
 
     def __init__(self, source, format=None, resize=None, as_gray=False,
                  electrodes=None, time=None, metadata=None, compress=False):
         if metadata is None:
             metadata = {}
-        elif type(metadata) != dict:
+        elif not isinstance(metadata, dict):
             metadata = {'user': metadata}
         if isinstance(source, str):
             # Filename provided, read the video:
@@ -140,7 +141,7 @@ class VideoStimulus(Stimulus):
             vid = vid_resize(vid, (height, width, *vid.shape[2:]))
         # Store the original image shape for resizing and color conversion:
         self.vid_shape = vid.shape
-        super(VideoStimulus, self).__init__(vid.reshape((-1, vid.shape[-1])),
+        super().__init__(vid.reshape((-1, vid.shape[-1])),
                                             time=time, electrodes=electrodes,
                                             metadata=metadata,
                                             compress=compress)
@@ -148,7 +149,7 @@ class VideoStimulus(Stimulus):
         self.rewind()
 
     def _pprint_params(self):
-        params = super(VideoStimulus, self)._pprint_params()
+        params = super()._pprint_params()
         params.update({'vid_shape': self.vid_shape})
         return params
 
@@ -710,6 +711,7 @@ class BostonTrain(VideoStimulus):
         Additional stimulus metadata can be stored in a dictionary.
 
     """
+    __slots__ = ()
 
     def __init__(self, resize=None, electrodes=None, as_gray=False,
                  metadata=None):
@@ -717,7 +719,7 @@ class BostonTrain(VideoStimulus):
         module_path = dirname(__file__)
         source = join(module_path, 'data', 'boston-train.mp4')
         # Call VideoStimulus constructor:
-        super(BostonTrain, self).__init__(source, format="MP4",
+        super().__init__(source, format="MP4",
                                           resize=resize,
                                           as_gray=as_gray,
                                           electrodes=electrodes,
@@ -756,6 +758,7 @@ class GirlPool(VideoStimulus):
         Additional stimulus metadata can be stored in a dictionary.
 
     """
+    __slots__ = ()
 
     def __init__(self, resize=None, electrodes=None, as_gray=False,
                  metadata=None):
@@ -763,7 +766,7 @@ class GirlPool(VideoStimulus):
         module_path = dirname(__file__)
         source = join(module_path, 'data', 'girl-pool.mp4')
         # Call VideoStimulus constructor:
-        super(GirlPool, self).__init__(source, format="MP4",
+        super().__init__(source, format="MP4",
                                        resize=resize,
                                        as_gray=as_gray,
                                        electrodes=electrodes,

--- a/pulse2percept/topography/cortex.py
+++ b/pulse2percept/topography/cortex.py
@@ -269,7 +269,7 @@ class Polimeni2006Map(CorticalMap):
             ax.plot(x[i, :], y[i, :], 'gray', label='v1' if i == 0 else None)
             rad = f"{radius[i, 0] : .1f}" if radius[i, 0] < 5 else f"{radius[i, 0] : .0f}"
             x_val = x[i, np.argsort(np.abs(y[i]))[0]]
-            ax.annotate(f"{rad}$\degree$", (x_val + 2000, 500),
+            ax.annotate(rf"{rad}$\degree$", (x_val + 2000, 500),
                          ha='center')
         x, y = self.dva_to_v2(*pol2cart(theta, radius))
         for i in range(x.shape[0]):

--- a/pulse2percept/utils/testing.py
+++ b/pulse2percept/utils/testing.py
@@ -6,7 +6,7 @@ import warnings
 
 
 def assert_warns_msg(expected_warning, func, msg, *args, **kwargs):
-    """Assert a call leads to a warning with a specific message
+    r"""Assert a call leads to a warning with a specific message
 
     Test whether a function call leads to a warning of type
     ``expected_warning`` with a message that contains the string ``msg``.


### PR DESCRIPTION
Long-overdue audit and cleanup of the `Stimulus` object and its subclasses. It is by far the most complex object in the codebase. No API changes. Small behavioral fixes - rest is behind the curtains.

## Performance

Measured on Windows / Python 3.11 / NumPy 2; each figure is that change against the state immediately before it.

| | before | after | |
|---|---:|---:|---:|
| `BiphasicPulseTrain(2000 Hz, 1000 ms)` | 97.9 ms | 0.16 ms | **602x** |
| `BiphasicPulseTrain(500 Hz, 1000 ms)` | 21.7 ms | 0.14 ms | 158x |
| `stim[:, t]`, single time point, 10k electrodes | 48.3 ms | 0.28 ms | 172x |
| `Stimulus(list of 10k scalars)` | 19.7 ms | 0.24 ms | 82x |
| `Stimulus(1-D array, 60k electrodes)` | 1.00 ms | 0.02 ms | 62x |
| `stim1 == stim2` (2000x3000) | 50.0 ms | 3.0 ms | 16x |
| `ImageStimulus(300x300)` | 1.92 ms | 0.19 ms | 10x |

- [x] `PulseTrain` is now assembled by tiling instead of `append` in a deep-copy loop
- [x] `__getitem__`: vectorized interpolation instead of `np.interp` per electrode
- [x] Electrode numbering: added fast path for a flat sequence of scalar names
- [x] All subclasses now have `__slots__` as originally intended

## Fixes

- [x] Importing the package no longer mutates global state (dropped `np.set_printoptions`)
- [x]  `stim.remove(0)` was a silent no-op, because `0` is false-y
- [x] The `electrode` argument was silently ignored by `BiphasicPulseTrain` and others
- [x] Renaming electrodes did not actually update names in `metadata['electrodes']` 
- [x] `stim >> x` on a stimulus with `time=None` raised a confusing `TypeError`
- [x] `find_threshold` is incompatible with `BiphasicAxonMapModel`; now raises `NotImplementedError`
- [x] Fixed outdated subplot / axes logic

## Cleanup

- [x] Unified `_from_source` and `_factory` into one dispatcher
- [x] Replaced the `sys._getframe` logic with a (cleaner) read-only property
- [x]  `fast_compress_time` never used its `time` argument