### PR TITLE
[DOC] [MNT] Use Python 3.12 for ReadTheDocs

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -3,7 +3,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.11"
+    python: "3.12"
 
 sphinx:
   configuration: doc/conf.py


### PR DESCRIPTION
There's no real reason to limit RTD to Python 3.11. Dependabot wants to bump Sphinx but can't. So bumping Python to 3.12 first