### PR TITLE
[OPT] Speed up the predict-percept pipeline by 20x

### DIFF
--- a/pulse2percept/implants/base.py
+++ b/pulse2percept/implants/base.py
@@ -141,12 +141,12 @@ class ProsthesisSystem(PrettyPrint):
             # Define image coordinate space
             if isinstance(stim, ImageStimulus):
                 img_h, img_w = img.img_shape
-                n_frames = 1
                 data = img.data.reshape(img_h, img_w)  # Ensure 2D format
             elif isinstance(stim, VideoStimulus):
                 img_h, img_w, n_frames = img.vid_shape
                 data = img.data.reshape(img_h, img_w, n_frames)  # 3D format
-            
+
+
             x_min, x_max = np.min(x), np.max(x)
             y_min, y_max = np.min(y), np.max(y)
 
@@ -154,22 +154,16 @@ class ProsthesisSystem(PrettyPrint):
             img_x = np.linspace(x_min, x_max, img_w)
             img_y = np.linspace(y_min, y_max, img_h)
 
-            # If single-frame image, interpolate directly
-            if n_frames == 1:
-                interpolator = RegularGridInterpolator(
-                    (img_y, img_x), data, method='linear', 
-                    bounds_error=False, fill_value=0
-                )
-                pixel_values = interpolator(np.vstack((y, x)).T)
-            else:
-                # Handle multiple frames by interpolating each frame separately
-                pixel_values = np.zeros((len(x), n_frames))
-                for f in range(n_frames):
-                    interpolator = RegularGridInterpolator(
-                        (img_y, img_x), data[..., f], method='linear', 
-                        bounds_error=False, fill_value=0
-                    )
-                    pixel_values[:, f] = interpolator(np.vstack((y, x)).T)
+            # One interpolator covers every frame: the grid is the leading two
+            # axes of `data`, and anything past them -- the frame axis of a
+            # video -- is carried along, so a video comes back as
+            # (n_electrodes, n_frames) from a single call. Building one per
+            # frame instead meant re-deriving the same grid for each of them.
+            interpolator = RegularGridInterpolator(
+                (img_y, img_x), data, method='linear',
+                bounds_error=False, fill_value=0
+            )
+            pixel_values = interpolator(np.vstack((y, x)).T)
 
             return Stimulus(pixel_values, electrodes=self.electrode_names,
                             time=stim.time, metadata=stim.metadata)

--- a/pulse2percept/implants/tests/test_base.py
+++ b/pulse2percept/implants/tests/test_base.py
@@ -260,3 +260,31 @@ def test_rectangle_implant(ztype, x, y, rot):
     for shape in [(6, 10), (5, 12), (15, 15)]:
         implant = RectangleImplant(shape=shape)
         npt.assert_equal(implant.earray.shape, shape)
+
+
+def test_ProsthesisSystem_reshape_stim_frames_independent():
+    """Downsampling a video must treat each frame on its own.
+
+    ``reshape_stim`` builds one interpolator for the whole video rather than
+    one per frame, so this checks that a frame lands on the electrodes the
+    same way whether it arrives alone or inside a sequence.
+    """
+    rng = np.random.default_rng(3)
+    n_frames = 5
+    vid = rng.random((24, 31, n_frames)).astype(np.float32)
+    implant = ProsthesisSystem(ElectrodeGrid((6, 8), 200))
+
+    implant.stim = VideoStimulus(vid, time=np.arange(n_frames))
+    joint = implant.stim.data
+    npt.assert_equal(joint.shape, (implant.n_electrodes, n_frames))
+
+    for f in range(n_frames):
+        implant.stim = ImageStimulus(vid[..., f])
+        npt.assert_allclose(implant.stim.data[:, 0], joint[:, f], rtol=1e-5,
+                            atol=1e-7)
+
+    # Pixels outside the electrode footprint are filled with zero, not
+    # extrapolated, so an all-zero frame stays all zero:
+    vid[..., 2] = 0
+    implant.stim = VideoStimulus(vid, time=np.arange(n_frames))
+    npt.assert_equal(np.all(implant.stim.data[:, 2] == 0), True)

--- a/pulse2percept/models/_beyeler2019.pyx
+++ b/pulse2percept/models/_beyeler2019.pyx
@@ -2,6 +2,7 @@ from libc.math cimport(powf as c_pow, expf as c_exp, tanhf as c_tanh,
                        sinf as c_sin, cosf as c_cos, fabsf as c_abs,
                        isnan as c_isnan)
 from cython.parallel import prange
+from cython.parallel cimport threadid
 from cython import cdivision  # for modulo operator
 import numpy as np
 cimport numpy as cnp
@@ -15,6 +16,30 @@ ctypedef Py_ssize_t index_t
 cdef float32 deg2rad = <float32>(3.14159265358979323846 / 180.0)
 
 
+cdef cnp.uint8_t[::1] _active_electrodes(const float32[:, ::1] stim):
+    """Flag the electrodes that carry a nonzero amplitude at any time point.
+
+    The spatial kernels loop over electrodes *outside* the loop over time, so
+    they cannot skip an electrode that happens to be zero at one time point
+    the way a time-innermost loop could. Electrodes that are zero for the
+    whole stimulus can still be skipped, and for a sparse stimulus that is
+    most of them -- hence this one-off pass.
+    """
+    cdef:
+        index_t idx_el, idx_time
+        index_t n_el = stim.shape[0]
+        index_t n_time = stim.shape[1]
+        cnp.uint8_t[::1] active = np.zeros(n_el, dtype=np.uint8)
+
+    with nogil:
+        for idx_el in range(n_el):
+            for idx_time in range(n_time):
+                if c_abs(stim[idx_el, idx_time]) > 0:
+                    active[idx_el] = 1
+                    break
+    return active
+
+
 @cdivision(True)
 cpdef fast_scoreboard(const float32[:, ::1] stim,
                       const float32[::1] xel,
@@ -23,10 +48,18 @@ cpdef fast_scoreboard(const float32[:, ::1] stim,
                       const float32[::1] ygrid,
                       float32 rho,
                       float32 thresh_percept,
+                      float32 cutoff_r2,
                       uint32 separate,
                       float32 offset,
                       uint32 n_threads):
     """Fast spatial response of the scoreboard model
+
+    The Gaussian current spread of an electrode at a grid point depends only
+    on the two of them, not on time, so it is computed once per
+    (grid point, electrode) pair and then applied to every time point. The
+    innermost loop is over time, which is the contiguous axis of both ``stim``
+    and the output, and whose iterations are independent -- so it vectorizes
+    without needing relaxed floating-point semantics.
 
     Parameters
     ----------
@@ -44,52 +77,58 @@ cpdef fast_scoreboard(const float32[:, ::1] stim,
         constant for the current spread
     thresh_percept : float32
         Spatial responses smaller than ``thresh_percept`` will be set to zero
-    n_threads: uint32
-        Number of CPU threads to use during parallelization using OpenMP.
-    separate: uint32 : 
+    cutoff_r2 : float32
+        Squared distance (microns^2) beyond which an electrode is treated as
+        contributing nothing to a grid point. Pass ``inf`` to sum over every
+        electrode. See ``min_current_spread`` on the model for how this is
+        derived.
+    separate: uint32 :
         If nonzero, then points on different side of x=offset than the electrode
         will not contribute to the percept (used for cortical models)
     offset : float32
          Boundary for separation
+    n_threads: uint32
+        Number of CPU threads to use during parallelization using OpenMP.
     """
     cdef:
-        index_t idx_el, idx_time, idx_space, idx_bright
-        index_t n_el, n_time, n_space, n_bright
+        index_t idx_el, idx_time, idx_space
+        index_t n_el, n_time, n_space
         float32[:, ::1] bright
-        float32 px_bright, dist2, gauss, amp
+        float32 xdiff, ydiff, r2, gauss
+        cnp.uint8_t[::1] active
 
     n_el = stim.shape[0]
     n_time = stim.shape[1]
     n_space = len(xgrid)
-    n_bright = n_time * n_space
+    if n_threads < 1:  # `num_threads(0)` is not conforming OpenMP
+        n_threads = 1
 
-    # A flattened array containing n_time x n_space entries:
-    bright = np.empty((n_space, n_time), dtype=np.float32)  # Py overhead
+    bright = np.zeros((n_space, n_time), dtype=np.float32)  # Py overhead
+    active = _active_electrodes(stim)  # Py overhead
 
-    for idx_bright in prange(n_bright, schedule='static', nogil=True, num_threads=n_threads):
-        # For each entry in the output matrix:
-        idx_space = idx_bright % n_space
-        idx_time = idx_bright // n_space
-
+    # Parallel loop over all pixels to be rendered:
+    for idx_space in prange(n_space, schedule='guided', nogil=True,
+                            num_threads=n_threads):
         if c_isnan(xgrid[idx_space]) or c_isnan(ygrid[idx_space]):
-            bright[idx_space, idx_time] = <float32>0.0
             continue
-
-        px_bright = <float32>0.0
         for idx_el in range(n_el):
-            amp = stim[idx_el, idx_time]
-            if c_abs(amp) > 0:
-                if separate != 0:
-                    if ((xel[idx_el] < offset)  !=  
-                        (xgrid[idx_space] < offset)):
-                        continue
-                dist2 = (c_pow(xgrid[idx_space] - xel[idx_el], 2) +
-                         c_pow(ygrid[idx_space] - yel[idx_el], 2))
-                gauss = c_exp(-dist2 / (<float32>2.0 * rho * rho))
-                px_bright = px_bright + amp * gauss
-        if c_abs(px_bright) < thresh_percept:
-            px_bright = <float32>0.0
-        bright[idx_space, idx_time] = px_bright  # Py overhead
+            if active[idx_el] == 0:
+                continue
+            if separate != 0:
+                if ((xel[idx_el] < offset) != (xgrid[idx_space] < offset)):
+                    continue
+            xdiff = xgrid[idx_space] - xel[idx_el]
+            ydiff = ygrid[idx_space] - yel[idx_el]
+            r2 = xdiff * xdiff + ydiff * ydiff
+            if r2 > cutoff_r2:
+                continue
+            gauss = c_exp(-r2 / (<float32>2.0 * rho * rho))
+            for idx_time in range(n_time):
+                bright[idx_space, idx_time] = (bright[idx_space, idx_time] +
+                                               gauss * stim[idx_el, idx_time])
+        for idx_time in range(n_time):
+            if c_abs(bright[idx_space, idx_time]) < thresh_percept:
+                bright[idx_space, idx_time] = <float32>0.0
     return np.asarray(bright)  # Py overhead
 
 
@@ -103,10 +142,14 @@ cpdef fast_scoreboard_3d(const float32[:, ::1] stim,
                       const float32[::1] zgrid,
                       float32 rho,
                       float32 thresh_percept,
+                      float32 cutoff_r2,
                       uint32 separate,
                       float32 offset,
                       uint32 n_threads):
     """Fast spatial response of the scoreboard model
+
+    The three-dimensional counterpart of :func:`fast_scoreboard`; see there
+    for why the loop nest is ordered the way it is.
 
     Parameters
     ----------
@@ -124,53 +167,59 @@ cpdef fast_scoreboard_3d(const float32[:, ::1] stim,
         constant for the current spread
     thresh_percept : float32
         Spatial responses smaller than ``thresh_percept`` will be set to zero
-    n_threads: uint32
-        Number of CPU threads to use during parallelization using OpenMP.
-    separate: uint32 : 
+    cutoff_r2 : float32
+        Squared distance (microns^2) beyond which an electrode is treated as
+        contributing nothing to a grid point. Pass ``inf`` to sum over every
+        electrode. See ``min_current_spread`` on the model for how this is
+        derived.
+    separate: uint32 :
         If nonzero, then points on different side of x=offset than the electrode
         will not contribute to the percept (used for cortical models)
     offset : float32
          Boundary for separation
+    n_threads: uint32
+        Number of CPU threads to use during parallelization using OpenMP.
     """
     cdef:
-        index_t idx_el, idx_time, idx_space, idx_bright
-        index_t n_el, n_time, n_space, n_bright
+        index_t idx_el, idx_time, idx_space
+        index_t n_el, n_time, n_space
         float32[:, ::1] bright
-        float32 px_bright, dist2, gauss, amp
+        float32 xdiff, ydiff, zdiff, r2, gauss
+        cnp.uint8_t[::1] active
 
     n_el = stim.shape[0]
     n_time = stim.shape[1]
     n_space = len(xgrid)
-    n_bright = n_time * n_space
+    if n_threads < 1:  # `num_threads(0)` is not conforming OpenMP
+        n_threads = 1
 
-    # A flattened array containing n_time x n_space entries:
-    bright = np.empty((n_space, n_time), dtype=np.float32)  # Py overhead
+    bright = np.zeros((n_space, n_time), dtype=np.float32)  # Py overhead
+    active = _active_electrodes(stim)  # Py overhead
 
-    for idx_bright in prange(n_bright, schedule='static', nogil=True, num_threads=n_threads):
-        # For each entry in the output matrix:
-        idx_space = idx_bright % n_space
-        idx_time = idx_bright // n_space
-
+    # Parallel loop over all pixels to be rendered:
+    for idx_space in prange(n_space, schedule='guided', nogil=True,
+                            num_threads=n_threads):
         if c_isnan(xgrid[idx_space]) or c_isnan(ygrid[idx_space]):
-            bright[idx_space, idx_time] = <float32>0.0
             continue
-
-        px_bright = <float32>0.0
         for idx_el in range(n_el):
-            amp = stim[idx_el, idx_time]
-            if c_abs(amp) > 0:
-                if separate != 0:
-                    if ((xel[idx_el] < offset)  !=  
-                        (xgrid[idx_space] < offset)):
-                        continue
-                dist2 = (c_pow(xgrid[idx_space] - xel[idx_el], 2) +
-                         c_pow(ygrid[idx_space] - yel[idx_el], 2) +
-                         c_pow(zgrid[idx_space] - zel[idx_el], 2))
-                gauss = c_exp(-dist2 / (<float32>2.0 * rho * rho))
-                px_bright = px_bright + amp * gauss
-        if c_abs(px_bright) < thresh_percept:
-            px_bright = <float32>0.0
-        bright[idx_space, idx_time] = px_bright  # Py overhead
+            if active[idx_el] == 0:
+                continue
+            if separate != 0:
+                if ((xel[idx_el] < offset) != (xgrid[idx_space] < offset)):
+                    continue
+            xdiff = xgrid[idx_space] - xel[idx_el]
+            ydiff = ygrid[idx_space] - yel[idx_el]
+            zdiff = zgrid[idx_space] - zel[idx_el]
+            r2 = xdiff * xdiff + ydiff * ydiff + zdiff * zdiff
+            if r2 > cutoff_r2:
+                continue
+            gauss = c_exp(-r2 / (<float32>2.0 * rho * rho))
+            for idx_time in range(n_time):
+                bright[idx_space, idx_time] = (bright[idx_space, idx_time] +
+                                               gauss * stim[idx_el, idx_time])
+        for idx_time in range(n_time):
+            if c_abs(bright[idx_space, idx_time]) < thresh_percept:
+                bright[idx_space, idx_time] = <float32>0.0
     return np.asarray(bright)  # Py overhead
 
 
@@ -207,15 +256,16 @@ cpdef fast_jansonius(float32[::1] rho, float32 phi0, float32 beta_s,
 
 cdef index_t argmin_segment(float32[:, :] flat_bundles, float32 x, float32 y):
     cdef:
-        float32 dist2, min_dist2
+        float32 dist2, min_dist2, xdiff, ydiff
         index_t seg, n_seg
         index_t min_seg
 
     min_dist2 = <float32>1e12
     n_seg = flat_bundles.shape[0]
     for seg in range(n_seg):
-        dist2 = (c_pow(flat_bundles[seg, 0] - x, 2) +
-                 c_pow(flat_bundles[seg, 1] - y, 2))
+        xdiff = flat_bundles[seg, 0] - x
+        ydiff = flat_bundles[seg, 1] - y
+        dist2 = xdiff * xdiff + ydiff * ydiff
         if dist2 < min_dist2:
             min_dist2 = dist2
             min_seg = seg
@@ -246,8 +296,22 @@ cpdef fast_axon_map(const float32[:, ::1] stim,
                     const uint32[::1] idx_end,
                     float32 rho,
                     float32 thresh_percept,
+                    float32 cutoff_r2,
                     uint32 n_threads):
     """Fast spatial response of the axon map model
+
+    The Gaussian falloff from an electrode to an axon segment depends only on
+    the two of them, not on time. The loop nest is therefore ordered
+    pixel -> segment -> electrode -> time, so that the ``exp`` is evaluated
+    once per (segment, electrode) pair and reused across every time point.
+    A time-innermost ordering would evaluate it ``n_time`` times over.
+
+    The innermost loop over time accumulates into independent slots of a
+    scratch buffer, so it vectorizes without relaxed floating-point
+    semantics. Nothing of size ``n_segments x n_electrodes`` or
+    ``n_segments x n_time`` is ever materialized: each thread holds two
+    buffers of ``n_time`` floats, and ``stim`` is small enough to stay in
+    cache while every pixel streams past it.
 
     Parameters
     ----------
@@ -274,69 +338,109 @@ cpdef fast_axon_map(const float32[:, ::1] stim,
         axon contribution (stored/passed in ``axon``).
     thresh_percept : float32
         Spatial responses smaller than ``thresh_percept`` will be set to zero
+    cutoff_r2 : float32
+        Squared distance (microns^2) beyond which an electrode is treated as
+        contributing nothing to an axon segment. Pass ``inf`` to sum over
+        every electrode. See ``min_current_spread`` on the model for how this
+        is derived.
     n_threads: uint32
         Number of CPU threads to use during parallelization using OpenMP.
-    
+
     """
     cdef:
-        index_t idx_el, idx_time, idx_space, idx_ax, idx_bright
-        index_t n_el, n_time, n_space, n_ax, n_bright
+        index_t idx_el, idx_time, idx_space, idx_ax, tid, row
+        index_t n_el, n_time, n_space, stride
         float32[:, ::1] bright
-        float32 px_bright, xdiff, ydiff, r2, gauss, sgm_bright, amp
+        float32[:, ::1] scratch
+        float32 xdiff, ydiff, r2, gauss, sens, ax_x, ax_y, sgm
+        cnp.uint8_t[::1] active
 
     n_el = stim.shape[0]
     n_time = stim.shape[1]
     n_space = len(idx_start)
-    n_bright = n_time * n_space
+    # `num_threads(0)` is not conforming OpenMP, and the scratch buffer below
+    # is sized on the assumption that no thread id can reach `n_threads`:
+    if n_threads < 1:
+        n_threads = 1
 
     # A flattened array containing n_space x n_time entries:
     bright = np.empty((n_space, n_time), dtype=np.float32)  # Py overhead
+    active = _active_electrodes(stim)  # Py overhead
 
-    # Parallel loop over all pixels to be rendered:
-    for idx_space in prange(n_space, schedule='static', nogil=True, num_threads=n_threads):
-        # Each frame in `stim` is treated independently, so we can have an
-        # inner loop over all points in time:
+    # Per-thread scratch: row `tid` holds this thread's running per-time-point
+    # segment brightness (first `n_time` entries) and pixel brightness (next
+    # `n_time`). OpenMP may give the team fewer threads than requested but
+    # never more, so `n_threads` rows always suffice. Rows are padded to a
+    # 64-byte boundary so that two threads never share a cache line, which for
+    # a single-frame stimulus they otherwise would. This is the only extra
+    # memory the kernel needs, and allocating it through NumPy means a failure
+    # raises MemoryError here rather than inside a nogil block.
+    stride = ((2 * n_time + 15) // 16) * 16
+    scratch = np.empty((n_threads, stride), dtype=np.float32)
+
+    # Parallel loop over all pixels to be rendered. `guided` rather than
+    # `static`: axons differ several-fold in how many segments they have, and
+    # how many electrodes fall inside `cutoff_r2` varies with where the pixel
+    # sits relative to the array, so equal-sized chunks are not equal-sized
+    # work.
+    for idx_space in prange(n_space, schedule='guided', nogil=True,
+                            num_threads=n_threads):
+        tid = threadid()
+        # Brightness of this pixel over time, built up by taking the strongest
+        # activated axon segment at each time point:
         for idx_time in range(n_time):
-            # Find the brightness value of each pixel (`px_bright`) by finding
-            # the strongest activated axon segment:
-            px_bright = <float32>0.0
-            # Slice `axon_contrib` (but don't assign the slice to a variable).
-            # `idx_start` and `idx_end` serve as indexes into `axon_segments`.
-            # For example, the axon belonging to the neuron sitting at pixel
-            # `idx_space` has segments
-            # `axon_segments[idx_start[idx_space]:idx_end[idx_space]]`:
-            for idx_ax in range(idx_start[idx_space], idx_end[idx_space]):
-                # Calculate the activation of each axon segment by adding up
-                # the contribution of each electrode:
-                sgm_bright = <float32>0.0
-                for idx_el in range(n_el):
-                    amp = stim[idx_el, idx_time]
-                    if c_abs(amp) > 0:
-                        if (c_isnan(axon_segments[idx_ax, 0]) or
-                                c_isnan(axon_segments[idx_ax, 1])):
-                            continue
-                        # Calculate the distance between this axon segment and
-                        # the center of the stimulating electrode:
-                        xdiff = axon_segments[idx_ax, 0] - xel[idx_el]
-                        ydiff = axon_segments[idx_ax, 1] - yel[idx_el]
-                        r2 = xdiff * xdiff + ydiff * ydiff
-                        # Determine the activation level of this axon segment,
-                        # consisting of two things:
-                        # - activation as a function of distance to the
-                        #   stimulating electrode (depends on `rho`):
-                        gauss = c_exp(-r2 / (<float32>2.0 * rho * rho))
-                        # - activation as a function of distance to the cell
-                        #   body (depends on `axlambda`, precalculated during
-                        #   `build` and stored in `axon_segments[idx_ax, 2]`:
-                        sgm_bright = (sgm_bright +
-                                      gauss * axon_segments[idx_ax, 2] * amp)
-                # After summing up the currents from all the electrodes, we
-                # compare the brightness of the segment (`sgm_bright`) to the
-                # previously brightest segment. The brightest segment overall
-                # determines the brightness of the pixel (`px_bright`):
-                if c_abs(sgm_bright) > c_abs(px_bright):
-                    px_bright = sgm_bright
-            if c_abs(px_bright) < thresh_percept:
-                px_bright = <float32>0.0
-            bright[idx_space, idx_time] = px_bright  # Py overhead
+            scratch[tid, n_time + idx_time] = <float32>0.0
+        # `idx_start` and `idx_end` serve as indexes into `axon_segments`.
+        # For example, the axon belonging to the neuron sitting at pixel
+        # `idx_space` has segments
+        # `axon_segments[idx_start[idx_space]:idx_end[idx_space]]`:
+        for idx_ax in range(idx_start[idx_space], idx_end[idx_space]):
+            ax_x = axon_segments[idx_ax, 0]
+            ax_y = axon_segments[idx_ax, 1]
+            # A segment with no location cannot be activated. That is a
+            # property of the segment, so it is checked once here rather than
+            # once per electrode:
+            if c_isnan(ax_x) or c_isnan(ax_y):
+                continue
+            # Activation as a function of distance to the cell body (depends
+            # on `axlambda`, precalculated during `build`):
+            sens = axon_segments[idx_ax, 2]
+            # Activation of this segment over time, by adding up the
+            # contribution of each electrode:
+            for idx_time in range(n_time):
+                scratch[tid, idx_time] = <float32>0.0
+            for idx_el in range(n_el):
+                # An electrode that is zero for the whole stimulus
+                # contributes nothing at any time point:
+                if active[idx_el] == 0:
+                    continue
+                # Calculate the distance between this axon segment and the
+                # center of the stimulating electrode:
+                xdiff = ax_x - xel[idx_el]
+                ydiff = ax_y - yel[idx_el]
+                r2 = xdiff * xdiff + ydiff * ydiff
+                # Too far away for the Gaussian below to resolve:
+                if r2 > cutoff_r2:
+                    continue
+                # Activation as a function of distance to the stimulating
+                # electrode (depends on `rho`). Neither this nor `sens`
+                # depends on time, which is why time is the innermost loop:
+                gauss = sens * c_exp(-r2 / (<float32>2.0 * rho * rho))
+                for idx_time in range(n_time):
+                    scratch[tid, idx_time] = (scratch[tid, idx_time] +
+                                              gauss * stim[idx_el, idx_time])
+            # After summing up the currents from all the electrodes, we
+            # compare the brightness of the segment to the previously
+            # brightest segment. The brightest segment overall determines the
+            # brightness of the pixel:
+            for idx_time in range(n_time):
+                sgm = scratch[tid, idx_time]
+                if c_abs(sgm) > c_abs(scratch[tid, n_time + idx_time]):
+                    scratch[tid, n_time + idx_time] = sgm
+        for idx_time in range(n_time):
+            sgm = scratch[tid, n_time + idx_time]
+            if c_abs(sgm) < thresh_percept:
+                bright[idx_space, idx_time] = <float32>0.0
+            else:
+                bright[idx_space, idx_time] = sgm
     return np.asarray(bright)  # Py overhead

--- a/pulse2percept/models/_granley2021.pyx
+++ b/pulse2percept/models/_granley2021.pyx
@@ -1,5 +1,5 @@
-from libc.math cimport(powf as c_pow, expf as c_exp, fabs as c_abs,
-                       isnan as c_isnan)
+from libc.math cimport(powf as c_pow, expf as c_exp, logf as c_log,
+                       fabs as c_abs, isnan as c_isnan)
 from cython.parallel import prange
 from cython import cdivision  # for modulo operator
 import numpy as np
@@ -27,10 +27,26 @@ cpdef fast_biphasic_axon_map(const float32[::1] amp_el,
                              const uint32[::1] idx_end,
                              float32 rho,
                              float32 thresh_percept,
+                             float32 cutoff_r2,
                              uint32 n_threads):
     """Fast spatial response of the biphasic axon map model
-    Predicts representative percept using entire time interval, 
+    Predicts representative percept using entire time interval,
     and returns this percept repeated at each time point
+
+    The activation of a segment by an electrode is
+    ``exp(-r^2 / (2 rho^2 F_size)) * sensitivity ** (1 / F_streak)``. Both
+    factors are exponentials, so they are evaluated as a single ``exp`` of the
+    summed exponents: the power becomes ``exp(log(sensitivity) / F_streak)``,
+    and ``log(sensitivity)`` depends only on the segment, so it is taken once
+    per segment instead of once per segment and electrode. That trades a
+    ``powf`` per pair -- the most expensive call in the loop -- for one
+    ``logf`` per segment.
+
+    ``F_streak`` is strictly positive: the default streak model clamps it to
+    ``min_lambda ** 2 / axlambda ** 2``, and ``_predict_spatial`` rejects a
+    custom model that returns anything else. Sensitivities are likewise
+    positive, so the logarithm is always defined.
+
     Parameters
     ----------
     amp_el : 1D float array 
@@ -56,6 +72,11 @@ cpdef fast_biphasic_axon_map(const float32[::1] amp_el,
         axon contribution (stored/passed in ``axon``).
     thresh_percept : float32
         Spatial responses smaller than ``thresh_percept`` will be set to zero
+    cutoff_r2 : float32
+        Squared distance (microns^2) at which an electrode of unscaled size
+        stops contributing; scaled per electrode by its ``F_size``. Pass
+        ``inf`` to sum over every electrode. See ``min_current_spread`` on the
+        model for how this is derived.
     n_threads: uint32
         Number of CPU threads to use during parallelization using OpenMP.
 
@@ -64,21 +85,38 @@ cpdef fast_biphasic_axon_map(const float32[::1] amp_el,
     Array with shape (n_points) representing the brightest frame of the percept
     """
     cdef:
-        index_t idx_el, idx_time, idx_space, idx_ax, idx_bright
-        index_t n_el, n_time, n_space, n_ax, n_bright
+        index_t idx_el, idx_space, idx_ax
+        index_t n_el, n_space
         float32[::1] bright
-        float32 px_bright, xdiff, ydiff, r2, amp, gauss_el, gauss_soma
-        float32 sgm_bright, bright_effect, size_effect, streak_effect
+        float32[::1] neg_inv_2rho2, inv_streak, cutoff_el
+        cnp.uint8_t[::1] active
+        float32 px_bright, xdiff, ydiff, r2, ax_x, ax_y, log_sens
+        float32 sgm_bright
 
     n_el = xel.shape[0]
     n_space = len(idx_start)
-    n_bright = n_space
+    if n_threads < 1:  # `num_threads(0)` is not conforming OpenMP
+        n_threads = 1
 
     # An array containing n_space entries
     bright = np.zeros((n_space), dtype=np.float32)  # Py overhead
 
-    # Parallel loop over all pixels to be rendered:
-    for idx_space in prange(n_space, schedule='static', nogil=True, num_threads=n_threads):
+    # Everything that depends only on the electrode is worked out once here,
+    # rather than once for every (segment, electrode) pair:
+    size_np = np.asarray(size_model_el, dtype=np.float32)
+    neg_inv_2rho2 = (-1.0 / (2.0 * rho * rho * size_np)).astype(np.float32)
+    inv_streak = (1.0 / np.asarray(streak_model_el,
+                                   dtype=np.float32)).astype(np.float32)
+    cutoff_el = (cutoff_r2 * size_np).astype(np.float32)
+    active = (np.abs(np.asarray(amp_el, dtype=np.float32)) >
+              0).astype(np.uint8)
+
+    # Parallel loop over all pixels to be rendered. `guided` rather than
+    # `static`: axons differ several-fold in how many segments they have, and
+    # with the cutoff above, how many electrodes reach a given segment varies
+    # too, so equal-sized chunks are not equal-sized work.
+    for idx_space in prange(n_space, schedule='guided', nogil=True,
+                            num_threads=n_threads):
         # Find the brightness value of each pixel (`px_bright`) by finding
         # the strongest activated axon segment:
         px_bright = 0.0
@@ -88,37 +126,39 @@ cpdef fast_biphasic_axon_map(const float32[::1] amp_el,
         # `idx_space` has segments
         # `axon_segments[idx_start[idx_space]:idx_end[idx_space]]`:
         for idx_ax in range(idx_start[idx_space], idx_end[idx_space]):
+            ax_x = axon_segments[idx_ax, 0]
+            ax_y = axon_segments[idx_ax, 1]
+            # A segment with no location cannot be activated. That is a
+            # property of the segment, so it is checked once here rather than
+            # once per electrode:
+            if c_isnan(ax_x) or c_isnan(ax_y):
+                continue
+            # Sensitivity as a function of distance to the cell soma,
+            # precalculated during `build` and stored in
+            # `axon_segments[idx_ax, 2]`. The streak model rescales it by a
+            # per-electrode exponent below; taking the logarithm here turns
+            # that power into a multiply inside the electrode loop:
+            log_sens = c_log(axon_segments[idx_ax, 2])
             # Calculate the activation of each axon segment by adding up
             # the contribution of each electrode:
             sgm_bright = 0.0
             for idx_el in range(n_el):
-                amp = amp_el[idx_el]
-                bright_effect = bright_model_el[idx_el]
-                size_effect = size_model_el[idx_el]
-                streak_effect = streak_model_el[idx_el]
-                if c_abs(amp) > 0:
-                    if (c_isnan(axon_segments[idx_ax, 0]) or
-                            c_isnan(axon_segments[idx_ax, 1])):
-                        continue
-                    # Calculate the distance between this axon segment and
-                    # the center of the stimulating electrode:
-                    xdiff = axon_segments[idx_ax, 0] - xel[idx_el]
-                    ydiff = axon_segments[idx_ax, 1] - yel[idx_el]
-                    r2 = xdiff * xdiff + ydiff * ydiff
-                    # Determine the activation level of this axon segment,
-                    # consisting of two things:
-                    # - activation as a function of distance to the
-                    #   stimulating electrode (depends on `rho`):
-                    gauss_el = c_exp(-r2 / (2.0 * rho * rho * size_effect))
-                    # - activation as a function of distance to the cell
-                    #   soma (depends on `axlambda`, precalculated during
-                    #   `build` and stored in `axon_segments[idx_ax, 2]`
-                    #   precalculated value does not include streak model
-                    #   effect, which must be added now
-                    gauss_soma = c_pow(
-                        axon_segments[idx_ax, 2], 1 / streak_effect)
-                    sgm_bright = (sgm_bright +
-                                  bright_effect * gauss_el * gauss_soma)
+                if active[idx_el] == 0:
+                    continue
+                # Calculate the distance between this axon segment and
+                # the center of the stimulating electrode:
+                xdiff = ax_x - xel[idx_el]
+                ydiff = ax_y - yel[idx_el]
+                r2 = xdiff * xdiff + ydiff * ydiff
+                # Too far away for the exponential below to resolve:
+                if r2 > cutoff_el[idx_el]:
+                    continue
+                # Distance to the electrode and distance to the soma both
+                # enter as exponentials, so they are summed in the exponent
+                # and raised once:
+                sgm_bright = (sgm_bright + bright_model_el[idx_el] *
+                              c_exp(r2 * neg_inv_2rho2[idx_el] +
+                                    log_sens * inv_streak[idx_el]))
             # After summing up the currents from all the electrodes, we
             # compare the brightness of the segment (`sgm_bright`) to the
             # previously brightest segment. The brightest segment overall

--- a/pulse2percept/models/_horsager2009.pyx
+++ b/pulse2percept/models/_horsager2009.pyx
@@ -59,7 +59,7 @@ cpdef temporal_fast(const float32[:, ::1] stim,
     """
     cdef:
         float32 ca, r1, r2, r3_a, r3, r4a, r4b, r4c
-        float32 t_sim, amp
+        float32 t_sim, amp, zero_pow
         float32[:, ::1] percept
         index_t idx_space, idx_sim, idx_stim, idx_frame
         index_t n_space, n_stim, n_percept, n_sim
@@ -74,6 +74,13 @@ cpdef temporal_fast(const float32[:, ::1] stim,
     n_space = stim.shape[0]
 
     percept = np.zeros((n_space, n_percept), dtype=np.float32)  # Py overhead
+    # What the power nonlinearity returns once the half-wave rectifier below
+    # has zeroed its argument. That is the overwhelming majority of steps --
+    # more than 99% for a typical pulse train -- and the answer does not
+    # depend on the step or the location, so it is worked out once here.
+    # Note this is not simply zero: `pow(0, beta)` is 1 at `beta == 0` and
+    # infinite for negative `beta`, and both are reproduced by reusing it.
+    zero_pow = c_pow(<float32>0.0, beta)
 
     for idx_space in prange(n_space, schedule='static', nogil=True, num_threads=n_threads):
         # Because the stationary nonlinearity depends on `max_R3`, which is the
@@ -110,8 +117,14 @@ cpdef temporal_fast(const float32[:, ::1] stim,
             r2 = r2 + dt * (ca - r2) / tau2
             # Half-rectification and power nonlinearity:
             # r3 = c_pow(c_fmax(r1 - eps * r2, 0), beta) # SLOW
+            # `powf` is the most expensive call in this loop, and the
+            # rectifier below zeroes its argument on almost every step. Where
+            # it does, the answer is the `zero_pow` computed before the loop:
             r3_a = r1 - eps * r2
-            r3 = c_pow((r3_a if r3_a > 0.0 else 0.0), beta)
+            if r3_a > 0.0:
+                r3 = c_pow(r3_a, beta)
+            else:
+                r3 = zero_pow
             # Slow response (3-stage leaky integrator):
             r4a = r4a + dt * (r3 - r4a) / tau3
             r4b = r4b + dt * (r4a - r4b) / tau3

--- a/pulse2percept/models/_temporal.pyx
+++ b/pulse2percept/models/_temporal.pyx
@@ -1,6 +1,7 @@
 from libc.math cimport(pow as c_pow, exp as c_exp, fabs as c_abs,
                        sqrt as c_sqrt)
 from cython.parallel import prange
+from cython.parallel cimport threadid
 from cython import cdivision  # modulo, division by zero
 import numpy as np
 cimport numpy as cnp
@@ -10,6 +11,12 @@ ctypedef cnp.float32_t float32
 ctypedef cnp.int32_t int32
 ctypedef cnp.uint32_t uint32
 ctypedef Py_ssize_t index_t
+
+# How many spatial locations one thread integrates at a time. The running
+# brightness for a block this size stays in L1 next to the stimulus row it is
+# read against, and the block is wide enough to fill the vector registers the
+# inner loop compiles down to.
+cdef index_t BLOCK = 64
 
 
 @cdivision(True)
@@ -21,6 +28,17 @@ cpdef fading_fast(const float32[:, ::1] stim,
                   float32 thresh_percept,
                   uint32 n_threads):
     """Cython implementation of the generic fading model
+
+    The leaky integrator has to be stepped in order, so the loop over time is
+    serial -- but each spatial location integrates independently of every
+    other. Time is therefore the *outer* loop and space the inner one, which
+    leaves the inner loop free of any carried dependency and lets it
+    vectorize. Threads take a block of locations each and run the whole time
+    loop over it, so the parallel region is still entered only once.
+
+    The arithmetic per step is unchanged, and each location still sees its
+    steps in the same order, so the result is bit-for-bit what the
+    space-outer version produced.
 
     Parameters
     ----------
@@ -48,18 +66,36 @@ cpdef fading_fast(const float32[:, ::1] stim,
     cdef:
         float32 t_sim, amp, bright
         float32[:, ::1] percept
-        index_t idx_space, idx_sim, idx_stim, idx_frame
-        index_t n_space, n_stim, n_percept, n_sim
+        float32[:, ::1] stim_t
+        float32[:, ::1] scratch
+        index_t idx_space, idx_sim, idx_stim, idx_frame, idx_block
+        index_t n_space, n_stim, n_percept, n_sim, n_blocks, lo, hi, tid
 
     n_percept = len(idx_t_percept)  # Py overhead
     n_stim = len(t_stim)  # Py overhead
     n_sim = idx_t_percept[n_percept - 1] + 1  # no negative indices
     n_space = stim.shape[0]
+    if n_threads < 1:  # `num_threads(0)` is not conforming OpenMP
+        n_threads = 1
 
     percept = np.zeros((n_space, n_percept), dtype=np.float32)  # Py overhead
+    # One simulation step reads the same stimulus frame for every location, so
+    # transpose once and that read becomes a contiguous run:
+    stim_t = np.ascontiguousarray(np.asarray(stim).T)  # Py overhead
+    n_blocks = (n_space + BLOCK - 1) // BLOCK
+    # Running brightness, one row per thread. Rows are BLOCK floats apart, so
+    # no two threads share a cache line.
+    scratch = np.empty((n_threads, BLOCK), dtype=np.float32)  # Py overhead
 
-    for idx_space in prange(n_space, schedule='static', nogil=True, num_threads=n_threads):
-        bright = 0.0
+    for idx_block in prange(n_blocks, schedule='static', nogil=True,
+                            num_threads=n_threads):
+        tid = threadid()
+        lo = idx_block * BLOCK
+        hi = lo + BLOCK
+        if hi > n_space:
+            hi = n_space
+        for idx_space in range(hi - lo):
+            scratch[tid, idx_space] = <float32>0.0
         idx_stim = 0
         idx_frame = 0
         for idx_sim in range(n_sim):
@@ -68,23 +104,30 @@ cpdef fading_fast(const float32[:, ::1] stim,
             # the right frame. Each frame is associated with a time, `t_stim`.
             # We use that frame until `t_sim` advances past it. In other words,
             # we use the `idx_stim`-th frame for all times
-            # t_stim[idx_stim] <= t_sim < t_stim[idx_stim + 1]:
+            # t_stim[idx_stim] <= t_sim < t_stim[idx_stim + 1]. Which frame
+            # that is does not depend on the location, so it is settled here
+            # rather than inside the loop below:
             if idx_stim + 1 < n_stim:
                 if t_sim >= t_stim[idx_stim + 1]:
                     idx_stim = idx_stim + 1
-            amp = stim[idx_space, idx_stim]
-            # Invert stimulus polarity and apply leaky integrator:
-            bright = bright + dt * (-amp - bright) / tau
-            # Brightness is bounded in [0, \inf[
-            if bright < 0.0:
-                bright = 0.0
+            for idx_space in range(hi - lo):
+                amp = stim_t[idx_stim, lo + idx_space]
+                bright = scratch[tid, idx_space]
+                # Invert stimulus polarity and apply leaky integrator:
+                bright = bright + dt * (-amp - bright) / tau
+                # Brightness is bounded in [0, \inf[
+                if bright < 0.0:
+                    bright = 0.0
+                scratch[tid, idx_space] = bright
             if idx_sim == idx_t_percept[idx_frame]:
                 # `idx_t_percept` stores the time points at which we need to
                 # output a percept. We compare `idx_sim` to `idx_t_percept`
                 # rather than `t_sim` to `t_percept` because there is no good
                 # (fast) way to compare two floating point numbers:
-                if c_abs(bright) >= thresh_percept:
-                    percept[idx_space, idx_frame] = bright
+                for idx_space in range(hi - lo):
+                    bright = scratch[tid, idx_space]
+                    if c_abs(bright) >= thresh_percept:
+                        percept[lo + idx_space, idx_frame] = bright
                 idx_frame = idx_frame + 1
 
     return np.asarray(percept)  # Py overhead

--- a/pulse2percept/models/base.py
+++ b/pulse2percept/models/base.py
@@ -237,6 +237,11 @@ class SpatialModel(BaseModel, metaclass=ABCMeta):
             'grid_type': 'rectangular',
             # Below threshold, percept has brightness zero:
             'thresh_percept': 0,
+            # An electrode whose Gaussian current spread at a point has fallen
+            # below this is skipped for that point. The default is small
+            # enough that dropping the term cannot change a float32 result;
+            # see `_cutoff_r2`. Set to 0 to sum over every electrode.
+            'min_current_spread': 1e-8,
             # Visual field map (retinotopy) to be used:
             'vfmap': Curcio1990Map(),
             # Number of gray levels to use in the percept:
@@ -256,6 +261,40 @@ class SpatialModel(BaseModel, metaclass=ABCMeta):
             'n_jobs': None,
         }
         return params
+
+    def _cutoff_r2(self, rho):
+        """Squared distance at which an electrode stops contributing
+
+        Models with a Gaussian current spread ``exp(-r^2 / (2 rho^2))`` spend
+        most of their time on (point, electrode) pairs whose Gaussian has
+        already underflowed the result. This converts ``min_current_spread``
+        into the squared distance at which that happens, for the spatial
+        kernels to compare against.
+
+        The default ``min_current_spread`` of 1e-8 corresponds to a radius of
+        about 6.1 ``rho``. Since the summed brightness is a float32, whose
+        relative resolution is ~1e-7, a term that small cannot change the
+        result -- so the default is an optimization, not an approximation.
+        Raise it to trade accuracy for speed, or set it to 0 to sum over
+        every electrode no matter how distant.
+
+        Parameters
+        ----------
+        rho : float
+            The model's current-spread decay constant (microns).
+
+        Returns
+        -------
+        cutoff_r2 : np.float32
+            Squared distance (microns^2), or ``inf`` if no cutoff applies.
+        """
+        min_spread = self.min_current_spread
+        if min_spread is None or min_spread <= 0:
+            return np.float32(np.inf)
+        if min_spread >= 1:
+            raise ValueError(f"min_current_spread must be smaller than 1 (or "
+                             f"0 to disable the cutoff), not {min_spread}.")
+        return np.float32(-2.0 * rho ** 2 * np.log(min_spread))
 
     def build(self, **build_params):
         """Build the model

--- a/pulse2percept/models/beyeler2019.py
+++ b/pulse2percept/models/beyeler2019.py
@@ -39,6 +39,12 @@ class ScoreboardSpatial(SpatialModel):
     ----------
     rho : double, optional
         Exponential decay constant describing phosphene size (microns).
+    min_current_spread : float, optional
+        An electrode is skipped at grid points where its Gaussian current
+        spread has decayed below this fraction of its peak. The default
+        (1e-8, about 6.1 ``rho`` away) is small enough that the skipped term
+        could not have changed the float32 result, so it buys speed rather
+        than costing accuracy. Set to 0 to sum over every electrode.
     xrange : (x_min, x_max), optional
         A tuple indicating the range of x values to simulate (in degrees of
         visual angle). In a right eye, negative x values correspond to the
@@ -104,6 +110,7 @@ class ScoreboardSpatial(SpatialModel):
                                self.grid.ret.y.ravel(),
                                self.rho,
                                self.thresh_percept,
+                               self._cutoff_r2(self.rho),
                                0, 0, # don't set current boundaries
                                self.n_threads)
 
@@ -124,6 +131,12 @@ class ScoreboardModel(Model):
     ----------
     rho : double, optional
         Exponential decay constant describing phosphene size (microns).
+    min_current_spread : float, optional
+        An electrode is skipped at grid points where its Gaussian current
+        spread has decayed below this fraction of its peak. The default
+        (1e-8, about 6.1 ``rho`` away) is small enough that the skipped term
+        could not have changed the float32 result, so it buys speed rather
+        than costing accuracy. Set to 0 to sum over every electrode.
     xrange : (x_min, x_max), optional
         A tuple indicating the range of x values to simulate (in degrees of
         visual angle). In a right eye, negative x values correspond to the
@@ -191,6 +204,12 @@ class AxonMapSpatial(SpatialModel):
         Exponential decay constant along the axon(microns).
     rho : double, optional
         Exponential decay constant away from the axon(microns).
+    min_current_spread : float, optional
+        An electrode is skipped at axon segments where its Gaussian current
+        spread has decayed below this fraction of its peak. The default
+        (1e-8, about 6.1 ``rho`` away) is small enough that the skipped term
+        could not have changed the float32 result, so it buys speed rather
+        than costing accuracy. Set to 0 to sum over every electrode.
     eye : {'RE', LE'}, optional
         Eye for which to generate the axon map.
     xrange : (x_min, x_max), optional
@@ -754,6 +773,7 @@ class AxonMapSpatial(SpatialModel):
                              self.axon_idx_end.astype(np.uint32),
                              self.rho,
                              self.thresh_percept,
+                             self._cutoff_r2(self.rho),
                              self.n_threads)
 
     def plot(self, use_dva=False, style='hull', annotate=True, autoscale=True,
@@ -890,6 +910,12 @@ class AxonMapModel(Model):
         Exponential decay constant along the axon(microns).
     rho : double, optional
         Exponential decay constant away from the axon(microns).
+    min_current_spread : float, optional
+        An electrode is skipped at axon segments where its Gaussian current
+        spread has decayed below this fraction of its peak. The default
+        (1e-8, about 6.1 ``rho`` away) is small enough that the skipped term
+        could not have changed the float32 result, so it buys speed rather
+        than costing accuracy. Set to 0 to sum over every electrode.
     eye : {'RE', LE'}, optional
         Eye for which to generate the axon map.
     xrange : (x_min, x_max), optional

--- a/pulse2percept/models/beyeler2019.py
+++ b/pulse2percept/models/beyeler2019.py
@@ -22,6 +22,62 @@ from ._beyeler2019 import (fast_scoreboard, fast_axon_map, fast_jansonius,
 import warnings
 
 
+#: Layout of the payload in ``axon_pickle``. Bump this whenever the tuple
+#: written by ``AxonMapSpatial._build`` changes shape or meaning, so that a
+#: cache left over from an older version is regrown instead of misread.
+_AXON_CACHE_VERSION = 2
+
+
+def _is_axon_cache(payload):
+    """Whether an ``axon_pickle`` payload is one this version can read"""
+    return (isinstance(payload, tuple) and len(payload) == 4 and
+            payload[0] == _AXON_CACHE_VERSION)
+
+
+def _flatten_bundles(bundles):
+    """Concatenate a list of bundles, collapsing repeated references
+
+    ``find_closest_axon`` returns one entry per grid point, but those entries
+    are references into a much smaller set of distinct bundles -- a few
+    hundred for several thousand grid points -- and pickling preserves that
+    sharing. Collapsing them keeps the flattened array, and the arc lengths
+    :py:meth:`AxonMapSpatial._calc_axon_sensitivity_flat` accumulates over
+    it, proportional to the number of *distinct* bundles rather than to the
+    number of grid points.
+
+    Bundles that are equal but are separate objects are treated as distinct.
+    That costs a little speed and changes nothing about the result.
+
+    Parameters
+    ----------
+    bundles : list of Nx2 arrays
+        One bundle per point on the grid.
+
+    Returns
+    -------
+    flat : (M, 2) array
+        The distinct bundles, concatenated, in their original dtype.
+    boff : (n_distinct + 1,) array
+        Offsets of each distinct bundle into ``flat``.
+    bundle_id : (len(bundles),) array
+        Which distinct bundle each entry of ``bundles`` refers to.
+    """
+    seen = {}
+    distinct = []
+    bundle_id = np.empty(len(bundles), dtype=np.intp)
+    for pos, bundle in enumerate(bundles):
+        idx = seen.get(id(bundle))
+        if idx is None:
+            idx = seen[id(bundle)] = len(distinct)
+            distinct.append(bundle)
+        bundle_id[pos] = idx
+    lens = np.array([len(bundle) for bundle in distinct], dtype=np.intp)
+    if np.any(lens == 0):
+        raise ValueError("Every bundle must have at least one segment.")
+    flat = np.ascontiguousarray(np.concatenate(distinct))
+    return flat, np.concatenate(([0], np.cumsum(lens))), bundle_id
+
+
 class ScoreboardSpatial(SpatialModel):
     """Scoreboard model of [Beyeler2019]_ (spatial module only)
 
@@ -461,7 +517,7 @@ class AxonMapSpatial(SpatialModel):
         return bundles
 
     def find_closest_axon(self, bundles, xret=None, yret=None,
-                          return_index=False):
+                          return_index=False, return_segment=False):
         """Finds the closest axon segment for a point on the retina
 
         This function will search a number of nerve fiber bundles (``bundles``)
@@ -472,7 +528,7 @@ class AxonMapSpatial(SpatialModel):
         ----------
         bundles : list of Nx2 arrays
             A list of bundles, where every bundle is an Nx2 array consisting of
-            the x,y coordinates of each axon segment (retinal coords, microns). 
+            the x,y coordinates of each axon segment (retinal coords, microns).
             Note that each bundle will most likely have a different N
         xret, yret : scalar or list of scalars
             The x,y location on the retina (in microns, where the fovea is the
@@ -480,6 +536,11 @@ class AxonMapSpatial(SpatialModel):
         return_index : bool, optional
             If True, the function will also return the index into ``bundles``
             that represents the closest axon
+        return_segment : bool, optional
+            If True, the function will also return the row index, within the
+            closest bundle, of the segment nearest the point. The search
+            already determines this, so asking for it here saves
+            :py:meth:`calc_axon_sensitivity` from working it out again.
 
         Returns
         -------
@@ -490,6 +551,9 @@ class AxonMapSpatial(SpatialModel):
         idx_axon : scalar or list of scalars, optional
             If ``return_index`` is True, also returns the index in ``bundles``
             of the closest axon (or list of closest axons).
+        idx_segment : scalar or list of scalars, optional
+            If ``return_segment`` is True, also returns the row index of the
+            closest segment within that axon.
 
         """
         if len(bundles) <= 0:
@@ -500,26 +564,33 @@ class AxonMapSpatial(SpatialModel):
             yret = self.grid.ret.y
         xret = np.asarray(xret, dtype=np.float32)
         yret = np.asarray(yret, dtype=np.float32)
-        # For every axon segment, store the corresponding axon ID:
-        axon_idx = [[idx] * len(ax) for idx, ax in enumerate(bundles)]
-        axon_idx = [item for sublist in axon_idx for item in sublist]
-        axon_idx = np.array(axon_idx, dtype=np.uint32)
-        # Build a long list of all axon segments - their corresponding axon IDs
-        # is given by `axon_idx` above:
+        # Offsets of each bundle into the concatenation of all of them, which
+        # is what the tree is built over. `searchsorted` on these turns a
+        # segment's index in that flat array back into the bundle it came
+        # from, so there is no need to materialize a bundle ID per segment:
+        boff = np.concatenate(([0], np.cumsum([len(ax) for ax in bundles])))
         flat_bundles = np.concatenate(bundles)
         kdtree = cKDTree(flat_bundles, leafsize=60)
         # Create query list of xy pairs
         query = np.stack((xret.ravel(), yret.ravel()), axis=1)
         # Find index of closest segment
-        _, closest_seg = kdtree.query(query)
+        _, closest_seg = kdtree.query(query, workers=-1)
 
         # Look up the axon ID for every axon segment:
-        closest_idx = axon_idx[closest_seg]
+        closest_idx = (np.searchsorted(boff, closest_seg, side='right') -
+                       1).astype(np.uint32)
+        # ...and where within that bundle the closest segment sits:
+        idx_segment = closest_seg - boff[closest_idx]
         if len(closest_idx) == 1:
             closest_idx = closest_idx[0]
+            idx_segment = idx_segment[0]
             closest_axon = bundles[closest_idx]
         else:
             closest_axon = [bundles[n] for n in closest_idx]
+        if return_index and return_segment:
+            return closest_axon, closest_idx, idx_segment
+        if return_segment:
+            return closest_axon, idx_segment
         if return_index:
             return closest_axon, closest_idx
         return closest_axon
@@ -576,31 +647,115 @@ class AxonMapSpatial(SpatialModel):
             falls below ``min_ax_sensitivity`` are trimmed.
 
         """
+        contrib, starts = self._calc_axon_sensitivity_flat(*_flatten_bundles(
+            bundles))
+        return [contrib[lo:hi] for lo, hi in zip(starts[:-1], starts[1:])]
+
+    def _calc_axon_sensitivity_flat(self, flat, boff, bundle_id, seg=None):
+        """Vectorized core of :py:meth:`calc_axon_sensitivity`
+
+        Computes every axon at once rather than one grid point at a time. Two
+        facts make that possible. An axon is a *contiguous* run of its
+        bundle's segments, running back from the one nearest the soma: the
+        distance walked from the soma only grows as you move away from it, so
+        the segments that survive the ``min_ax_sensitivity`` trim are a
+        prefix of that walk. And the arc length along a bundle is a property
+        of the bundle, not of the grid point, so it can be accumulated once
+        per bundle and reused by every grid point that picked it.
+
+        Parameters
+        ----------
+        flat : (M, 2) array
+            All distinct bundles, concatenated.
+        boff : (n_bundles + 1,) array
+            Offsets of each distinct bundle into ``flat``.
+        bundle_id : (n_points,) array
+            Index of the bundle belonging to each point on ``self.grid``.
+        seg : (n_points,) array, optional
+            Index into ``flat`` of the segment nearest each grid point. The
+            nearest-neighbor search in :py:meth:`find_closest_axon` already
+            knows this, so ``_build`` passes it through rather than pay for
+            the search below a second time. Derived here when not given,
+            which is the case for the public entry point.
+
+        Returns
+        -------
+        contrib : (N, 3) array
+            Every axon's segments, concatenated: x, y, sensitivity.
+        starts : (n_points + 1,) array
+            Offsets of each axon into ``contrib``.
+        """
+        lam = self.axlambda
         xyret = np.column_stack((self.grid.ret.x.ravel(),
                                  self.grid.ret.y.ravel()))
-        # Only include axon segments that are < `max_d2` from the soma. These
-        # axon segments will have `sensitivity` > `self.min_ax_sensitivity`:
-        max_d2 = -2.0 * self.axlambda ** 2 * np.log(self.min_ax_sensitivity)
-        axon_contrib = []
-        for xy, bundle in zip(xyret, bundles):
-            idx = np.argmin((bundle[:, 0] - xy[0]) ** 2 +
-                            (bundle[:, 1] - xy[1]) ** 2)
-            # Cut off the part of the fiber that goes beyond the soma:
-            axon = np.flipud(bundle[0: idx + 1, :])
-            # Add the exact location of the soma:
-            axon = np.concatenate((xy.reshape((1, -1)), axon), axis=0)
-            # For every axon segment, calculate distance from soma by
-            # summing up the individual distances between neighboring axon
-            # segments (by "walking along the axon"):
-            d2 = np.cumsum(np.sqrt(np.diff(axon[:, 0], axis=0) ** 2 +
-                                   np.diff(axon[:, 1], axis=0) ** 2)) ** 2
-            idx_d2 = d2 < max_d2
-            sensitivity = np.exp(-d2[idx_d2] / (2.0 * self.axlambda ** 2))
-            idx_d2 = np.concatenate(([False], idx_d2))
-            contrib = np.column_stack((axon[idx_d2, :], sensitivity))
-            axon_contrib.append(contrib)
+        blens = np.diff(boff)
+        # Bundles arrive as float32. Accumulating arc length over hundreds of
+        # segments in float32 loses more than the coordinates are worth, so
+        # the geometry below runs in float64 and only the result is handed
+        # back at the caller's precision:
+        out_dtype = np.promote_types(flat.dtype, np.float32)
+        flat = flat.astype(np.float64, copy=False)
+        xyret = xyret.astype(np.float64, copy=False)
 
-        return axon_contrib
+        # Arc length from the start of a bundle to each of its segments. Laid
+        # out like `flat`, and reset to zero wherever a new bundle begins:
+        step = np.hypot(*(flat[1:] - flat[:-1]).T)
+        step[boff[1:-1] - 1] = 0.0  # never walk across a seam between bundles
+        arc = np.empty(len(flat))
+        arc[0] = 0.0
+        np.cumsum(step, out=arc[1:])
+        arc -= np.repeat(arc[boff[:-1]], blens)
+
+        base = boff[bundle_id]
+        if seg is None:
+            # Distance from every grid point to every segment of *its*
+            # bundle, as one flat array of (point, segment) pairs:
+            lens = blens[bundle_id]
+            pair_off = np.concatenate(([0], np.cumsum(lens)))
+            within = np.arange(pair_off[-1]) - np.repeat(pair_off[:-1], lens)
+            pairs = np.repeat(base, lens) + within
+            d2 = ((flat[pairs, 0] - np.repeat(xyret[:, 0], lens)) ** 2 +
+                  (flat[pairs, 1] - np.repeat(xyret[:, 1], lens)) ** 2)
+            # The segment closest to the soma, resolving ties towards the
+            # lower index the way ``np.argmin`` does:
+            closest = np.repeat(np.minimum.reduceat(d2, pair_off[:-1]), lens)
+            cand = np.where(d2 <= closest, within, np.iinfo(np.intp).max)
+            seg = base + np.minimum.reduceat(cand, pair_off[:-1])
+        else:
+            seg = np.asarray(seg, dtype=np.intp)
+
+        # Walking out from the soma, segment `k` of the bundle sits at
+        # `d0 + (arc[seg] - arc[k])`. Only include segments closer than
+        # `max_d2`; those are the ones whose sensitivity stays above
+        # `min_ax_sensitivity`:
+        d0 = np.hypot(flat[seg, 0] - xyret[:, 0], flat[seg, 1] - xyret[:, 1])
+        max_d2 = -2.0 * lam ** 2 * np.log(self.min_ax_sensitivity)
+        if max_d2 <= 0:
+            # Not even the soma itself clears the bar, so every axon is empty:
+            n_keep = np.zeros(len(bundle_id), dtype=np.intp)
+        else:
+            # That distance falls as `k` rises, so the segments to keep are a
+            # contiguous run ending at `seg`, and its lower end is one
+            # searchsorted away. `arc` only increases *within* a bundle, so
+            # offset each bundle past the last to make the array monotone
+            # overall and the whole lookup a single vectorized call:
+            span = arc[boff[1:] - 1].max() + 1.0
+            offset = bundle_id * span
+            lo = np.searchsorted(arc + np.repeat(np.arange(len(blens)) * span,
+                                                 blens),
+                                 arc[seg] + d0 - np.sqrt(max_d2) + offset,
+                                 side='right')
+            n_keep = np.maximum(seg - np.maximum(lo, base) + 1, 0)
+
+        starts = np.concatenate(([0], np.cumsum(n_keep)))
+        # Segments run *back* from the one nearest the soma:
+        gather = (np.repeat(seg, n_keep) -
+                  (np.arange(starts[-1]) - np.repeat(starts[:-1], n_keep)))
+        dist = np.repeat(d0 + arc[seg], n_keep) - arc[gather]
+        contrib = np.empty((starts[-1], 3), dtype=out_dtype)
+        contrib[:, :2] = flat[gather]
+        contrib[:, 2] = np.exp(-dist ** 2 / (2.0 * lam ** 2))
+        return contrib, starts
 
     def calc_bundle_tangent(self, xc, yc):
         """Calculates orientation of fiber bundle tangent at (xc, yc)
@@ -717,35 +872,52 @@ class AxonMapSpatial(SpatialModel):
         self._correct_loc_od()
         # Check whether pickle file needs to be rebuilt:
         need_axons = False
+        cached = None
         if self.ignore_pickle:
             need_axons = True
         else:
             # Check if math for Jansonius model has been done before:
             if os.path.isfile(self.axon_pickle):
-                params, axons = pickle.load(open(self.axon_pickle, 'rb'))
+                params, cached = pickle.load(open(self.axon_pickle, 'rb'))
                 for key, value in params.items():
                     if (not hasattr(self, key) or
                             not np.allclose(getattr(self, key), value)):
                         need_axons = True
                         break
+                # A cache written by an older version stores something else
+                # here. Rather than try to read it, grow the bundles again and
+                # overwrite it; the file is derived data, so the only cost is
+                # one slow build:
+                if not _is_axon_cache(cached):
+                    need_axons = True
             else:
                 need_axons = True
         # Build the Jansonius model: Grow a number of axon bundles in all dirs:
         if need_axons:
             bundles = self.grow_axon_bundles()
-            axons = self.find_closest_axon(bundles)
-            if type(axons) != list:
-                axons = [axons]
-        # Calculate axon contributions. Axon contribution is a list of
-        # (differently shaped) NumPy arrays, and a list cannot be accessed in
-        # parallel without the gil. Instead we need to concatenate it into a
-        # really long Nx3 array, and pass the start and end indices of each
-        # slice:
-        axon_contrib = self.calc_axon_sensitivity(axons)
-        self.axon_contrib = np.concatenate(axon_contrib).astype(np.float32)
-        len_axons = [a.shape[0] for a in axon_contrib]
-        self.axon_idx_end = np.cumsum(len_axons)
-        self.axon_idx_start = self.axon_idx_end - np.array(len_axons)
+            _, bundle_id, idx_segment = self.find_closest_axon(
+                bundles, return_index=True, return_segment=True)
+            bundle_id = np.atleast_1d(bundle_id).astype(np.intp)
+            idx_segment = np.atleast_1d(idx_segment).astype(np.intp)
+            # Grid points cluster onto a fraction of the bundles that were
+            # grown. Dropping the rest keeps the cache small and the arc
+            # lengths below proportional to what is actually used:
+            used, bundle_id = np.unique(bundle_id, return_inverse=True)
+            bundles = [bundles[idx] for idx in used]
+            bundle_id = np.ravel(bundle_id).astype(np.intp)
+        else:
+            _, bundles, bundle_id, idx_segment = cached
+        # Calculate axon contributions. A list of (differently shaped) NumPy
+        # arrays cannot be accessed in parallel without the gil, so the axons
+        # come back already concatenated into a really long Nx3 array, along
+        # with the start and end indices of each slice:
+        flat, boff, _ = _flatten_bundles(bundles)
+        axon_contrib, starts = self._calc_axon_sensitivity_flat(
+            flat, boff, bundle_id, seg=boff[bundle_id] + idx_segment)
+        self.axon_contrib = np.ascontiguousarray(axon_contrib,
+                                                 dtype=np.float32)
+        self.axon_idx_start = starts[:-1]
+        self.axon_idx_end = starts[1:]
         if need_axons:
             # Pickle axons along with all important parameters:
             params = {'loc_od': self.loc_od,
@@ -753,7 +925,9 @@ class AxonMapSpatial(SpatialModel):
                       'xrange': self.xrange, 'yrange': self.yrange,
                       'xystep': self.xystep, 'n_ax_segments': self.n_ax_segments,
                       'ax_segments_range': self.ax_segments_range}
-            pickle.dump((params, axons), open(self.axon_pickle, 'wb'))
+            pickle.dump((params, (_AXON_CACHE_VERSION, bundles, bundle_id,
+                                  idx_segment)),
+                        open(self.axon_pickle, 'wb'))
 
     def _predict_spatial(self, earray, stim):
         """Predicts the brightness at specific times ``t``"""

--- a/pulse2percept/models/cortex/base.py
+++ b/pulse2percept/models/cortex/base.py
@@ -26,6 +26,12 @@ class CortexSpatial(SpatialModel):
         Default: ['v1']. 
     rho : double, optional
         Exponential decay constant describing current spread size (microns).
+    min_current_spread : float, optional
+        An electrode is skipped at grid points where its Gaussian current
+        spread has decayed below this fraction of its peak. The default
+        (1e-8, about 6.1 ``rho`` away) is small enough that the skipped term
+        could not have changed the float32 result, so it buys speed rather
+        than costing accuracy. Set to 0 to sum over every electrode.
     xrange : (x_min, x_max), optional
         A tuple indicating the range of x values to simulate (in degrees of
         visual angle). In a right eye, negative x values correspond to the
@@ -197,6 +203,12 @@ class ScoreboardSpatial(CortexSpatial):
     ----------
     rho : double, optional
         Exponential decay constant describing phosphene size (microns).
+    min_current_spread : float, optional
+        An electrode is skipped at grid points where its Gaussian current
+        spread has decayed below this fraction of its peak. The default
+        (1e-8, about 6.1 ``rho`` away) is small enough that the skipped term
+        could not have changed the float32 result, so it buys speed rather
+        than costing accuracy. Set to 0 to sum over every electrode.
     regions : list of str, optional
         The regions to simulate. Options are 'v1', 'v2', or 'v3'. Default:
         ['v1']
@@ -270,14 +282,15 @@ class ScoreboardSpatial(CortexSpatial):
         if self.vfmap.split_map:
             separate = 1
             boundary = self.vfmap.left_offset/2
+        cutoff_r2 = self._cutoff_r2(self.rho)
         if self.vfmap.ndim == 3:
             return np.sum([
                 fast_scoreboard_3d(stim.data, x_el, y_el, z_el,
-                                self.grid[region].x.ravel(), 
+                                self.grid[region].x.ravel(),
                                 self.grid[region].y.ravel(),
                                 self.grid[region].z.ravel(),
-                                self.rho, self.thresh_percept, 
-                                separate, boundary, 
+                                self.rho, self.thresh_percept, cutoff_r2,
+                                separate, boundary,
                                 self.n_threads)
                 for region in self.regions ],
             axis = 0)
@@ -285,8 +298,8 @@ class ScoreboardSpatial(CortexSpatial):
             return np.sum([
                 fast_scoreboard(stim.data, x_el, y_el,
                                 self.grid[region].x.ravel(), self.grid[region].y.ravel(),
-                                self.rho, self.thresh_percept, 
-                                separate, boundary, 
+                                self.rho, self.thresh_percept, cutoff_r2,
+                                separate, boundary,
                                 self.n_threads)
                 for region in self.regions ],
             axis = 0)
@@ -312,6 +325,12 @@ class ScoreboardModel(Model):
     ----------
     rho : double, optional
         Exponential decay constant describing phosphene size (microns).
+    min_current_spread : float, optional
+        An electrode is skipped at grid points where its Gaussian current
+        spread has decayed below this fraction of its peak. The default
+        (1e-8, about 6.1 ``rho`` away) is small enough that the skipped term
+        could not have changed the float32 result, so it buys speed rather
+        than costing accuracy. Set to 0 to sum over every electrode.
     regions : list of str, optional
         The regions to simulate. Options are 'v1', 'v2', or 'v3'. Default:
         ['v1']

--- a/pulse2percept/models/granley2021.py
+++ b/pulse2percept/models/granley2021.py
@@ -242,6 +242,13 @@ class BiphasicAxonMapSpatial(AxonMapSpatial):
             Exponential decay constant along the axon(microns).
         rho: double, optional
             Exponential decay constant away from the axon(microns).
+        min_current_spread: float, optional
+            An electrode is skipped at axon segments where its current spread
+            has decayed below this fraction of its peak. The decay is scaled
+            per electrode by that electrode's ``F_size``. The default (1e-8)
+            is small enough that the skipped term could not have changed the
+            float32 result, so it buys speed rather than costing accuracy.
+            Set to 0 to sum over every electrode.
         eye: {'RE', LE'}, optional
             Eye for which to generate the axon map.
         xrange : (x_min, x_max), optional
@@ -440,6 +447,19 @@ class BiphasicAxonMapSpatial(AxonMapSpatial):
         streak_effects = np.array(self.streak_model(elec_params[:, 0], elec_params[:, 1], elec_params[:, 2]),
                                   dtype=np.float32).reshape((-1))
         amps = np.array(elec_params[:, 1], dtype=np.float32).reshape((-1))
+        # The kernel rescales each segment's sensitivity by
+        # ``1 / F_streak`` and each phosphene's size by ``F_size``, both in an
+        # exponent, so neither may be zero or negative. The default models
+        # cannot produce that -- ``DefaultStreakModel`` clamps to
+        # ``min_lambda ** 2 / axlambda ** 2`` -- but a custom one could, and
+        # it would otherwise surface as a silent NaN in the percept:
+        for name, effects in (('size_model', size_effects),
+                              ('streak_model', streak_effects)):
+            if np.any(effects <= 0):
+                raise ValueError(f"{type(self).__name__}.{name} returned a "
+                                 f"non-positive scaling factor "
+                                 f"({effects.min()}). Scaling factors must be "
+                                 f"greater than zero.")
         return fast_biphasic_axon_map(
             amps,
             bright_effects,
@@ -450,6 +470,7 @@ class BiphasicAxonMapSpatial(AxonMapSpatial):
             self.axon_idx_start.astype(np.uint32),
             self.axon_idx_end.astype(np.uint32),
             self.rho, self.thresh_percept,
+            self._cutoff_r2(self.rho),
             self.n_threads)
 
     def predict_percept(self, implant, t_percept=None):
@@ -579,6 +600,13 @@ class BiphasicAxonMapModel(Model):
             Exponential decay constant along the axon(microns).
         rho: double, optional
             Exponential decay constant away from the axon(microns).
+        min_current_spread: float, optional
+            An electrode is skipped at axon segments where its current spread
+            has decayed below this fraction of its peak. The decay is scaled
+            per electrode by that electrode's ``F_size``. The default (1e-8)
+            is small enough that the skipped term could not have changed the
+            float32 result, so it buys speed rather than costing accuracy.
+            Set to 0 to sum over every electrode.
         eye: {'RE', LE'}, optional
             Eye for which to generate the axon map.
         xrange : (x_min, x_max), optional

--- a/pulse2percept/models/tests/test_beyeler2019.py
+++ b/pulse2percept/models/tests/test_beyeler2019.py
@@ -468,15 +468,24 @@ def test_AxonMapModel_calc_axon_sensitivity():
     axons = model.spatial.find_closest_axon(bundles)
     axon_contrib = model.spatial.calc_axon_sensitivity(axons)
 
-    # Check lambda math:
+    # Check lambda math. `calc_axon_sensitivity` walks the axon in float64
+    # and rounds once at the end, so the reference has to be built the same
+    # way: `model_ax` is float32, and accumulating the arc length at that
+    # precision costs about as much accuracy as the whole comparison has to
+    # spare. Building it here in float32 left roughly a 1.2x margin against
+    # the tolerance, which held on some platforms and not on others.
+    max_d2 = -2.0 * model.axlambda ** 2 * np.log(model.min_ax_sensitivity)
     for model_ax, xy in zip(axon_contrib, xyret):
-        axon = np.insert(model_ax, 0, list(xy) + [0], axis=0)
+        axon = np.insert(model_ax, 0, list(xy) + [0],
+                         axis=0).astype(np.float64)
         d2 = np.cumsum(np.sqrt(np.diff(axon[:, 0], axis=0) ** 2 +
                                np.diff(axon[:, 1], axis=0) ** 2))**2
-        max_d2 = -2.0 * model.axlambda ** 2 * np.log(model.min_ax_sensitivity)
         idx_d2 = d2 < max_d2
         sensitivity = np.exp(-d2[idx_d2] / (2.0 * model.spatial.axlambda ** 2))
-        npt.assert_almost_equal(sensitivity, model_ax[:, 2])
+        # A relative bound, unlike `assert_almost_equal`'s absolute one: the
+        # sensitivities span [min_ax_sensitivity, 1], and float32 resolves
+        # them to ~1.2e-7 relative wherever they sit in that range.
+        npt.assert_allclose(model_ax[:, 2], sensitivity, rtol=1e-6)
 
 
 @ pytest.mark.parametrize('pad', (True, False))

--- a/pulse2percept/models/tests/test_beyeler2019.py
+++ b/pulse2percept/models/tests/test_beyeler2019.py
@@ -3,6 +3,8 @@ import numpy as np
 import pytest
 import numpy.testing as npt
 import copy
+import os
+import pickle
 import warnings
 
 from matplotlib.axes import Subplot
@@ -14,6 +16,7 @@ from pulse2percept.percepts import Percept
 from pulse2percept.stimuli import Stimulus
 from pulse2percept.models import (AxonMapSpatial, AxonMapModel,
                                   ScoreboardSpatial, ScoreboardModel)
+from pulse2percept.models.beyeler2019 import _AXON_CACHE_VERSION
 from pulse2percept.topography import Watson2014Map, Watson2014DisplaceMap
 from pulse2percept.utils.testing import assert_warns_msg
 
@@ -666,3 +669,76 @@ def test_predict_percept_thread_count_invariant(ModelClass):
         parallel = ModelClass(
             n_threads=n_threads, **kwargs).build().predict_percept(implant)
         npt.assert_array_equal(parallel.data, serial)
+
+
+def test_AxonMapModel_find_closest_axon_return_segment():
+    """``return_segment`` reports where in the axon the closest point is."""
+    model = AxonMapModel(xystep=2, n_axons=20, xrange=(-12, 12),
+                         yrange=(-12, 12), axons_range=(-45, 45))
+    model.build()
+    spatial = model.spatial
+    bundles = spatial.grow_axon_bundles()
+    xyret = np.column_stack((spatial.grid.ret.x.ravel(),
+                             spatial.grid.ret.y.ravel()))
+
+    axons, idx_seg = spatial.find_closest_axon(bundles, return_segment=True)
+    npt.assert_equal(len(idx_seg), len(xyret))
+    # The reported segment is the one `argmin` would have picked:
+    for axon, seg, xy in zip(axons, idx_seg, xyret):
+        expected = np.argmin((axon[:, 0] - xy[0]) ** 2 +
+                             (axon[:, 1] - xy[1]) ** 2)
+        npt.assert_equal(seg, expected)
+
+    # Both flags together, in the documented order:
+    axons2, idx_ax, idx_seg2 = spatial.find_closest_axon(
+        bundles, return_index=True, return_segment=True)
+    npt.assert_array_equal(idx_seg2, idx_seg)
+    for axon, idx in zip(axons2, idx_ax):
+        npt.assert_array_equal(axon, bundles[idx])
+
+    # A single query point still returns scalars, not arrays:
+    single, idx_ax1, idx_seg1 = spatial.find_closest_axon(
+        bundles, xret=xyret[0, 0], yret=xyret[0, 1], return_index=True,
+        return_segment=True)
+    npt.assert_equal(np.ndim(idx_ax1), 0)
+    npt.assert_equal(np.ndim(idx_seg1), 0)
+    npt.assert_array_equal(single, bundles[idx_ax1])
+
+
+def test_AxonMapModel_calc_axon_sensitivity_empty_bundle():
+    """A bundle with no segments is rejected rather than silently skipped."""
+    model = AxonMapModel(xystep=4, n_axons=5, xrange=(-8, 8), yrange=(-8, 8))
+    model.build()
+    n_points = model.spatial.grid.ret.x.size
+    bundles = [np.zeros((0, 2), dtype=np.float32)] * n_points
+    with pytest.raises(ValueError):
+        model.spatial.calc_axon_sensitivity(bundles)
+
+
+def test_AxonMapModel_build_cache_roundtrip(tmp_path):
+    """A warm build off the cache reproduces the cold build exactly."""
+    pickle_file = str(tmp_path / 'axons.pickle')
+
+    def build(ignore_pickle):
+        return AxonMapModel(xystep=1, xrange=(-8, 8), yrange=(-8, 8),
+                            n_axons=200, axon_pickle=pickle_file,
+                            ignore_pickle=ignore_pickle).build().spatial
+
+    cold = build(True)
+    npt.assert_equal(os.path.isfile(pickle_file), True)
+    warm = build(False)
+    npt.assert_array_equal(warm.axon_contrib, cold.axon_contrib)
+    npt.assert_array_equal(warm.axon_idx_start, cold.axon_idx_start)
+    npt.assert_array_equal(warm.axon_idx_end, cold.axon_idx_end)
+
+    # A cache written by an older version is regrown, not misread:
+    with open(pickle_file, 'rb') as f:
+        params, _ = pickle.load(f)
+    with open(pickle_file, 'wb') as f:
+        pickle.dump((params, [np.zeros((3, 2), dtype=np.float32)]), f)
+    stale = build(False)
+    npt.assert_array_equal(stale.axon_contrib, cold.axon_contrib)
+    # ...and the file is left in the current format:
+    with open(pickle_file, 'rb') as f:
+        _, payload = pickle.load(f)
+    npt.assert_equal(payload[0], _AXON_CACHE_VERSION)

--- a/pulse2percept/models/tests/test_beyeler2019.py
+++ b/pulse2percept/models/tests/test_beyeler2019.py
@@ -11,6 +11,7 @@ import matplotlib.pyplot as plt
 
 from pulse2percept.implants import ArgusI, ArgusII
 from pulse2percept.percepts import Percept
+from pulse2percept.stimuli import Stimulus
 from pulse2percept.models import (AxonMapSpatial, AxonMapModel,
                                   ScoreboardSpatial, ScoreboardModel)
 from pulse2percept.topography import Watson2014Map, Watson2014DisplaceMap
@@ -574,3 +575,94 @@ def test_AxonMapModel_predict_percept():
     msg = ("Nonzero electrode-retina distances do not have any effect on the "
            "model output.")
     assert_warns_msg(UserWarning, model.predict_percept, msg, implant)
+
+
+@pytest.mark.parametrize('ModelClass', (ScoreboardModel, AxonMapModel))
+def test_min_current_spread(ModelClass):
+    """The default current-spread cutoff must not change the percept.
+
+    ``min_current_spread`` drops an electrode's contribution once its
+    Gaussian has decayed past the given fraction of its peak. At the default
+    of 1e-8 the dropped term is below what a float32 sum can resolve, so it
+    is meant to buy speed at no cost to the result.
+    """
+    stim = np.zeros(60)
+    stim[[10, 33, 47]] = [1.0, -0.5, 0.75]
+    implant = ArgusII(stim=stim)
+    kwargs = {'xystep': 0.75, 'xrange': (-12, 12), 'yrange': (-8, 8),
+              'rho': 200}
+
+    exact = ModelClass(min_current_spread=0,
+                       **kwargs).build().predict_percept(implant).data
+    default = ModelClass(**kwargs).build().predict_percept(implant).data
+    npt.assert_allclose(default, exact, rtol=1e-5,
+                        atol=1e-6 * np.abs(exact).max())
+
+    # A coarse cutoff *does* change the result, which is how we know the
+    # parameter reaches the kernel at all:
+    coarse = ModelClass(min_current_spread=0.5,
+                        **kwargs).build().predict_percept(implant).data
+    assert np.abs(coarse - exact).max() > 1e-3
+
+    # A cutoff of 1 or more would drop every electrode:
+    model = ModelClass(min_current_spread=1, **kwargs).build()
+    with pytest.raises(ValueError):
+        model.predict_percept(implant)
+
+
+@pytest.mark.parametrize('ModelClass', (ScoreboardModel, AxonMapModel))
+def test_predict_percept_frames_are_independent(ModelClass):
+    """Each frame of a multi-frame stimulus is predicted on its own.
+
+    The spatial kernels evaluate the electrode-to-point Gaussian once and
+    reuse it across every time point, so this guards against one frame
+    leaking into another.
+    """
+    rng = np.random.default_rng(42)
+    data = rng.normal(size=(60, 4)).astype(np.float32)
+    model = ModelClass(xystep=1, xrange=(-10, 10), yrange=(-8, 8),
+                       rho=200).build()
+
+    joint = model.predict_percept(
+        ArgusII(stim=Stimulus(data, time=[0, 1, 2, 3]))).data
+    npt.assert_equal(joint.shape[-1], 4)
+    for i in range(data.shape[1]):
+        frame = model.predict_percept(
+            ArgusII(stim=Stimulus(data[:, i:i + 1]))).data
+        npt.assert_allclose(joint[..., i], frame[..., 0], rtol=1e-5,
+                            atol=1e-6 * np.abs(frame).max())
+
+
+@pytest.mark.parametrize('ModelClass', (ScoreboardModel, AxonMapModel))
+def test_predict_percept_all_zero_stim(ModelClass):
+    """An all-zero stimulus produces an all-zero percept.
+
+    The kernels skip electrodes that are zero for the whole stimulus, so the
+    case where *every* electrode is skipped is worth pinning down.
+    """
+    model = ModelClass(xystep=1, xrange=(-10, 10), yrange=(-8, 8)).build()
+    percept = model.predict_percept(ArgusII(stim=np.zeros(60)))
+    npt.assert_equal(np.all(percept.data == 0), True)
+
+
+@pytest.mark.parametrize('ModelClass', (ScoreboardModel, AxonMapModel))
+def test_predict_percept_thread_count_invariant(ModelClass):
+    """The percept must not depend on how many threads computed it.
+
+    ``fast_axon_map`` hands each thread its own row of a scratch buffer, so
+    this covers both the indexing of that buffer and the case where the
+    stimulus has a single frame (the padding that keeps two threads off the
+    same cache line).
+    """
+    stim = np.zeros(60)
+    stim[[5, 22, 51]] = [1.0, 0.6, -0.3]
+    implant = ArgusII(stim=stim)
+    kwargs = {'xystep': 1, 'xrange': (-10, 10), 'yrange': (-8, 8),
+              'rho': 200}
+
+    serial = ModelClass(n_threads=1,
+                        **kwargs).build().predict_percept(implant).data
+    for n_threads in (2, 3, 8):
+        parallel = ModelClass(
+            n_threads=n_threads, **kwargs).build().predict_percept(implant)
+        npt.assert_array_equal(parallel.data, serial)

--- a/pulse2percept/models/tests/test_granley2021.py
+++ b/pulse2percept/models/tests/test_granley2021.py
@@ -377,3 +377,86 @@ def test_find_threshold_not_supported(model_cls):
     npt.assert_equal('metadata' in str(excinfo.value), True)
     # predict_percept is unaffected:
     npt.assert_equal(model.predict_percept(implant) is not None, True)
+
+
+def test_BiphasicAxonMapModel_min_current_spread():
+    """The current-spread cutoff must reach this model's kernel too.
+
+    ``min_current_spread`` lives on ``SpatialModel``, so
+    ``BiphasicAxonMapSpatial`` inherits it; this pins that the biphasic
+    kernel actually honours it rather than accepting it and ignoring it.
+    """
+    stim = {e: BiphasicPulseTrain(20, 30, 0.45) for e in ('A2', 'C5', 'F8')}
+    implant = ArgusII(stim=stim)
+    kwargs = {'xrange': (-8, 8), 'yrange': (-8, 8), 'xystep': 0.5,
+              'rho': 200, 'verbose': False}
+
+    exact = BiphasicAxonMapModel(
+        min_current_spread=0, **kwargs).build().predict_percept(implant).data
+    default = BiphasicAxonMapModel(
+        **kwargs).build().predict_percept(implant).data
+    # The default cutoff is below what a float32 sum can resolve:
+    npt.assert_allclose(default, exact, rtol=1e-5,
+                        atol=1e-6 * np.abs(exact).max())
+
+    # A coarse cutoff does change the result, which is how we know it is
+    # wired through rather than silently dropped:
+    coarse = BiphasicAxonMapModel(
+        min_current_spread=0.5, **kwargs).build().predict_percept(implant).data
+    assert np.abs(coarse - exact).max() > 1e-3
+
+
+@pytest.mark.parametrize('attr', ('size_model', 'streak_model'))
+def test_BiphasicAxonMapModel_rejects_nonpositive_effects(attr):
+    """A scaling factor of zero would surface as NaN, so it is rejected.
+
+    Both factors enter the kernel through an exponent, so neither may be
+    zero or negative. The default models cannot produce that, but a custom
+    one could.
+    """
+    model = BiphasicAxonMapModel(xrange=(-4, 4), yrange=(-4, 4), xystep=1,
+                                 verbose=False).build()
+    setattr(model.spatial, attr, lambda freq, amp, pdur: np.zeros_like(amp))
+    implant = ArgusII(stim={'A2': BiphasicPulseTrain(20, 30, 0.45)})
+    with pytest.raises(ValueError, match=attr):
+        model.predict_percept(implant)
+
+    # A positive factor is accepted:
+    setattr(model.spatial, attr, lambda freq, amp, pdur: np.ones_like(amp))
+    npt.assert_equal(model.predict_percept(implant) is not None, True)
+
+
+def test_BiphasicAxonMapModel_reduces_to_AxonMapModel():
+    """With every effect factor at 1, this model *is* the axon map model.
+
+    The biphasic kernel computes
+    ``F_bright * exp(-r^2 / (2 rho^2 F_size)) * sens ** (1 / F_streak)``
+    as a single exponential of summed exponents. Setting all three factors to
+    1 collapses that to ``exp(-r^2 / (2 rho^2)) * sens``, which is exactly
+    what ``AxonMapModel`` computes for a unit-amplitude stimulus -- an
+    independently written kernel, so this pins the fused arithmetic against
+    something that does not share its code.
+    """
+    from pulse2percept.models import AxonMapModel
+
+    kwargs = {'xrange': (-8, 8), 'yrange': (-8, 8), 'xystep': 0.5,
+              'rho': 200, 'axlambda': 800, 'verbose': False}
+    electrodes = ('A2', 'C5', 'F8')
+
+    biphasic = BiphasicAxonMapModel(**kwargs)
+    for attr in ('bright_model', 'size_model', 'streak_model'):
+        setattr(biphasic.spatial, attr,
+                lambda freq, amp, pdur: np.ones_like(np.asarray(amp,
+                                                                dtype=float)))
+    biphasic.build()
+    got = biphasic.predict_percept(ArgusII(
+        stim={e: BiphasicPulseTrain(20, 30, 0.45) for e in electrodes})).data
+
+    plain = AxonMapModel(**kwargs).build()
+    stim = np.zeros(60)
+    names = list(ArgusII().electrode_names)
+    for e in electrodes:
+        stim[names.index(e)] = 1.0
+    want = plain.predict_percept(ArgusII(stim=stim)).data
+
+    npt.assert_allclose(got, want, rtol=1e-5, atol=1e-6 * np.abs(want).max())

--- a/pulse2percept/models/tests/test_horsager2009.py
+++ b/pulse2percept/models/tests/test_horsager2009.py
@@ -5,7 +5,8 @@ import numpy.testing as npt
 import pytest
 
 from pulse2percept.implants import ProsthesisSystem, PointSource
-from pulse2percept.stimuli import BiphasicPulse, BiphasicPulseTrain
+from pulse2percept.stimuli import (BiphasicPulse, BiphasicPulseTrain,
+                                   Stimulus)
 from pulse2percept.percepts import Percept
 from pulse2percept.models import Horsager2009Model, Horsager2009Temporal
 from pulse2percept.utils import FreezeError
@@ -118,3 +119,80 @@ def test_deepcopy_Horsager2009Model():
     # Assert changing the original doesn't affect the copied
     original.verbose = False
     npt.assert_equal(original != copied, True)
+
+def _horsager_reference(data, t_stim, t_percept, dt, tau1, tau2, tau3, eps,
+                        beta, thresh_percept):
+    """The cascade, written out one location and one step at a time."""
+    f = np.float32
+    dt, tau1, tau2, tau3 = f(dt), f(tau1), f(tau2), f(tau3)
+    beta, thresh = f(beta), f(thresh_percept)
+    eps = f(f(eps) / f(1000.0))
+    idx_p = np.uint32(np.round(np.asarray(t_percept) / dt))
+    out = np.zeros((data.shape[0], len(idx_p)), dtype=np.float32)
+    # A negative `beta` makes the nonlinearity infinite wherever the rectifier
+    # zeroed its input, and the cascade below then subtracts inf from inf. The
+    # kernel produces the same NaN, which is what this reference is for:
+    with np.errstate(invalid='ignore', divide='ignore'):
+        for s in range(data.shape[0]):
+            ca = r1 = r2 = r4a = r4b = r4c = f(0.0)
+            idx_stim, frame = 0, 0
+            for i in range(int(idx_p[-1]) + 1):
+                if (idx_stim + 1 < len(t_stim) and
+                        f(i) * dt >= t_stim[idx_stim + 1]):
+                    idx_stim += 1
+                amp = data[s, idx_stim]
+                r1 = f(r1 + dt * (-amp - r1) / tau1)
+                ca = f(ca + dt * (amp if amp > 0 else f(0.0)))
+                r2 = f(r2 + dt * (ca - r2) / tau2)
+                # `pow(0, beta)` is 1 at beta == 0 and inf below it, not 0:
+                r3 = f(np.float_power(f(max(r1 - eps * r2, f(0.0))), beta))
+                r4a = f(r4a + dt * (r3 - r4a) / tau3)
+                r4b = f(r4b + dt * (r4a - r4b) / tau3)
+                r4c = f(r4c + dt * (r4b - r4c) / tau3)
+                if i == idx_p[frame]:
+                    out[s, frame] = r4c if abs(r4c) >= thresh else f(0.0)
+                    frame += 1
+    return out
+
+
+@pytest.mark.parametrize('beta', (3.43, 1.0, 0.0, -0.5))
+def test_Horsager2009Temporal_power_nonlinearity(beta):
+    """The power nonlinearity must hold up for any exponent.
+
+    The kernel skips ``powf`` wherever the half-wave rectifier in front of it
+    has already zeroed the argument, which it does on the overwhelming
+    majority of steps. What it substitutes has to be ``pow(0, beta)``, which
+    is 1 at ``beta == 0`` and infinite for negative ``beta`` -- not zero.
+    """
+    rng = np.random.default_rng(0)
+    data = ((rng.random((3, 6)) - 0.5) * 100).astype(np.float32)
+    t_stim = (np.arange(6) * 4.0).astype(np.float32)
+    t_percept = np.arange(0, 20, 2.0)
+    model = Horsager2009Temporal(dt=0.01, beta=beta).build()
+    got = model.predict_percept(Stimulus(data, time=t_stim),
+                                t_percept=t_percept).data.reshape(3, -1)
+    want = _horsager_reference(data, t_stim, t_percept, model.dt, model.tau1,
+                               model.tau2, model.tau3, model.eps, beta,
+                               model.thresh_percept)
+    npt.assert_allclose(got, want, rtol=1e-5, equal_nan=True)
+
+
+def test_Horsager2009Temporal_beta_zero_is_not_zero():
+    """At beta == 0 the nonlinearity returns 1 even where its input is zero.
+
+    ``x ** 0`` is 1 for every ``x``, including the zero the half-wave
+    rectifier produces, so the cascade charges towards 1 no matter how small
+    the stimulus. A shortcut that assumed ``pow(0, beta) == 0`` would silence
+    the model here; this pins that it does not. The stimulus is tiny but
+    nonzero, because an all-zero one is dropped before the kernel sees it.
+    """
+    stim = Stimulus(np.full((1, 2), 1e-6, dtype=np.float32),
+                    time=np.array([0.0, 400.0]))
+    percept = Horsager2009Temporal(dt=0.01, beta=0.0).build().predict_percept(
+        stim, t_percept=[0, 100, 200, 400])
+    # Driven by r3 == 1 throughout, the three-stage integrator climbs towards
+    # 1 rather than tracking the (negligible) stimulus:
+    npt.assert_array_less(0.5, percept.data[0, 0, -1])
+    npt.assert_array_less(percept.data[0, 0, -1], 1.0)
+    # ...and it is monotonically charging, not decaying:
+    npt.assert_array_less(percept.data[0, 0, :-1], percept.data[0, 0, 1:])

--- a/pulse2percept/models/tests/test_temporal.py
+++ b/pulse2percept/models/tests/test_temporal.py
@@ -79,3 +79,72 @@ def test_deepcopy_FadingTemporal():
     # Assert "destroying" the original doesn't affect the copied
     original = None
     npt.assert_equal(copied is not None, True)
+
+def test_FadingTemporal_matches_reference_integrator():
+    """Pin the leaky integrator against a plain Python reference.
+
+    ``fading_fast`` runs time in the outer loop and space in the inner one so
+    that the inner loop vectorizes. This walks a couple of locations the
+    obvious way -- one at a time, stepping forward -- and checks the kernel
+    agrees exactly.
+    """
+    model = FadingTemporal(dt=0.01, tau=50, thresh_percept=0).build()
+    n_space, n_stim = 3, 5
+    rng = np.random.default_rng(0)
+    data = (rng.random((n_space, n_stim)) - 0.5).astype(np.float32)
+    t_stim = np.arange(n_stim, dtype=np.float32) * 2.0
+    stim = Stimulus(data, time=t_stim)
+    t_percept = np.array([0.0, 2.0, 4.0, 8.0])
+    got = model.predict_percept(stim, t_percept=t_percept).data.reshape(
+        n_space, -1)
+
+    dt, tau = np.float32(model.dt), np.float32(model.tau)
+    idx_p = np.uint32(np.round(t_percept / model.dt))
+    for s in range(n_space):
+        bright = np.float32(0.0)
+        idx_stim, frame = 0, 0
+        for i in range(int(idx_p[-1]) + 1):
+            if idx_stim + 1 < n_stim and np.float32(i) * dt >= t_stim[idx_stim + 1]:
+                idx_stim += 1
+            amp = data[s, idx_stim]
+            bright = np.float32(bright + dt * (-amp - bright) / tau)
+            if bright < 0:
+                bright = np.float32(0.0)
+            if i == idx_p[frame]:
+                npt.assert_array_equal(got[s, frame], bright)
+                frame += 1
+
+
+@pytest.mark.parametrize('n_space', (1, 63, 64, 65, 130))
+def test_FadingTemporal_block_boundaries(n_space):
+    """Locations are integrated in fixed-size blocks; the last one is partial.
+
+    Sizes either side of the block width catch an off-by-one in how the tail
+    of the last block is handled.
+    """
+    model = FadingTemporal(dt=0.05, tau=30).build()
+    rng = np.random.default_rng(n_space)
+    data = (rng.random((n_space, 4)) - 0.7).astype(np.float32)
+    stim = Stimulus(data, time=np.arange(4, dtype=float) * 5)
+    percept = model.predict_percept(stim, t_percept=[0, 5, 10, 15])
+    npt.assert_equal(percept.data.shape, (n_space, 1, 4))
+    # Every location must be integrated, not just the ones in whole blocks:
+    single = np.stack([
+        model.predict_percept(Stimulus(data[i:i + 1], time=stim.time),
+                              t_percept=[0, 5, 10, 15]).data.ravel()
+        for i in range(n_space)])
+    npt.assert_array_equal(percept.data.reshape(n_space, -1), single)
+
+
+def test_FadingTemporal_thread_count_invariant():
+    """Threads take a block of locations each; the result must not depend on
+    how many of them there are."""
+    rng = np.random.default_rng(7)
+    data = (rng.random((200, 6)) - 0.6).astype(np.float32)
+    stim = Stimulus(data, time=np.arange(6, dtype=float) * 3)
+    serial = FadingTemporal(dt=0.05, tau=40, n_threads=1).build(
+        ).predict_percept(stim, t_percept=[0, 5, 10, 15]).data
+    for n_threads in (2, 3, 8):
+        parallel = FadingTemporal(dt=0.05, tau=40, n_threads=n_threads).build(
+            ).predict_percept(stim, t_percept=[0, 5, 10, 15]).data
+        npt.assert_array_equal(parallel, serial)

--- a/pulse2percept/stimuli/base.py
+++ b/pulse2percept/stimuli/base.py
@@ -1156,6 +1156,20 @@ class Stimulus(PrettyPrint):
     @_stim.setter
     def _stim(self, stim):
         self._check_stim(stim)
+        # Every Cython kernel in the library takes the data as
+        # ``float32[:, ::1]``, so the container has to hold it C-contiguous.
+        # Not everything that builds a stimulus produces that: selecting
+        # columns, as ``compress`` does, hands back an F-ordered array for a
+        # multi-electrode stimulus. Left alone it would surface much later, as
+        # a "ndarray is not C-contiguous" from whichever kernel happened to
+        # receive it -- including ``fast_compress_space`` on a second
+        # ``compress``. Fixing it here rather than at each call site keeps the
+        # invariant in one place.
+        data = np.ascontiguousarray(stim['data'])
+        if data is not stim['data']:
+            # `copy` hands out objects that share this dict, so replace it
+            # rather than writing through:
+            stim = {**stim, 'data': data}
         # All checks passed, store the data:
         self.__stim = stim
 

--- a/pulse2percept/stimuli/base.py
+++ b/pulse2percept/stimuli/base.py
@@ -516,13 +516,21 @@ class Stimulus(PrettyPrint):
                     self.metadata = source.metadata
 
         if _electrodes is None:
-            # The source did not name its electrodes, so number them 0..N-1.
-            # Those are unique by construction:
-            _electrodes = np.arange(_data.shape[0])
+            # The source did not name its electrodes, so they are 0..N-1 --
+            # unique by construction. Only build that array if something will
+            # read it: user-supplied `electrodes` replaces it immediately
+            # below, and the sole other reader is the metadata rename further
+            # down, which needs per-electrode metadata to do anything at all.
+            # An image or video stimulus has neither, so skipping this keeps a
+            # million-element arange off the path that builds one.
             _auto_electrodes = True
+            if electrodes is None or self.metadata.get('electrodes'):
+                _electrodes = np.arange(_data.shape[0])
 
         # User can overwrite the names of the electrodes:
         if electrodes is not None:
+            # May still be None, when the block above declined to build it.
+            # The rename below already guards against that.
             _renamed_from = _electrodes
             if isinstance(electrodes, ElectrodeNames):
                 # Names generated from a grid pattern. Flattening one is a

--- a/pulse2percept/stimuli/images.py
+++ b/pulse2percept/stimuli/images.py
@@ -6,7 +6,6 @@ from os.path import dirname, join
 import numpy as np
 import warnings
 from math import isclose
-from copy import deepcopy
 import matplotlib.pyplot as plt
 
 from skimage import img_as_float32, img_as_ubyte
@@ -169,8 +168,10 @@ class ImageStimulus(Stimulus):
             in the range [0, 1].
 
         """
-        img = deepcopy(self.data.reshape(self.img_shape))
+        img = self.data.reshape(self.img_shape)
         if len(self.img_shape) > 2:
+            # Leave any alpha channel alone:
+            img = img.copy()
             img[..., :3] = 1.0 - img[..., :3]
         else:
             img = 1.0 - img
@@ -206,8 +207,12 @@ class ImageStimulus(Stimulus):
         """
         img = self.data.reshape(self.img_shape)
         if img.ndim == 3 and img.shape[2] == 4:
-            # Blend the background with black:
-            img = rgba2rgb(img, background=(0, 0, 0))
+            # Blend the background with black. Doing it in one pass rather
+            # than through ``rgba2rgb`` avoids materializing the intermediate
+            # three-channel image, which for a full-resolution photograph is
+            # the bulk of the work. The arithmetic is the same, so the result
+            # is identical:
+            img = np.clip(img[..., :3] * img[..., 3:4], 0.0, 1.0)
         if img.ndim == 3:
             img = rgb2gray(img)
         return ImageStimulus(img, electrodes=electrodes,

--- a/pulse2percept/stimuli/tests/test_base.py
+++ b/pulse2percept/stimuli/tests/test_base.py
@@ -907,3 +907,29 @@ def test_Stimulus_rename_electrodes_metadata():
                      ['P1', 'P2'])
     npt.assert_equal(Stimulus(plain, electrodes=['P1', 'P2'])
                      .metadata['electrodes'], {})
+
+
+def test_Stimulus_data_is_contiguous():
+    """The data container must stay C-contiguous.
+
+    Every Cython kernel in the library declares its stimulus argument as
+    ``float32[:, ::1]``. Selecting columns, as ``compress`` does, hands back
+    an F-ordered array for a multi-electrode stimulus, which used to surface
+    much later as a "ndarray is not C-contiguous" from whichever kernel
+    received it.
+    """
+    rng = np.random.default_rng(0)
+    data = (rng.random((3, 5)) - 0.5).astype(np.float32)
+    stim = Stimulus(data, time=np.arange(5, dtype=float) * 2)
+    npt.assert_equal(stim.data.flags['C_CONTIGUOUS'], True)
+
+    stim.compress()
+    npt.assert_equal(stim.data.flags['C_CONTIGUOUS'], True)
+    # ...so compressing an already-compressed stimulus works:
+    stim.compress()
+    npt.assert_equal(stim.data.flags['C_CONTIGUOUS'], True)
+
+    # An F-ordered source is accepted and stored C-contiguous:
+    stim = Stimulus(np.asfortranarray(data), time=np.arange(5, dtype=float))
+    npt.assert_equal(stim.data.flags['C_CONTIGUOUS'], True)
+    npt.assert_almost_equal(stim.data, data)

--- a/pulse2percept/stimuli/tests/test_images.py
+++ b/pulse2percept/stimuli/tests/test_images.py
@@ -413,3 +413,47 @@ def test_LogoUCSB():
     npt.assert_equal(logo.time, None)
     npt.assert_almost_equal(logo.data.min(), 0)
     npt.assert_almost_equal(logo.data.max(), 1)
+
+
+def test_ImageStimulus_rgb2gray_matches_skimage():
+    """The fused RGBA blend must agree with skimage's two-step conversion.
+
+    ``rgb2gray`` blends the alpha channel against black itself rather than
+    calling ``rgba2rgb``, to avoid building a full-resolution intermediate.
+    This pins the arithmetic to what skimage would have produced.
+    """
+    from skimage.color import rgba2rgb, rgb2gray as sk_rgb2gray
+
+    rng = np.random.default_rng(0)
+    rgba = rng.random((37, 53, 4)).astype(np.float32)
+    got = ImageStimulus(rgba).rgb2gray().data
+    want = sk_rgb2gray(rgba2rgb(rgba, background=(0, 0, 0)))
+    npt.assert_array_equal(got.ravel(), want.ravel().astype(got.dtype))
+
+    # Three channels take the other branch and must be untouched by the above:
+    rgb = rng.random((37, 53, 3)).astype(np.float32)
+    npt.assert_array_equal(ImageStimulus(rgb).rgb2gray().data.ravel(),
+                           sk_rgb2gray(rgb).ravel())
+
+    # A fully transparent image blends to black; a fully opaque one is
+    # unaffected by the alpha channel:
+    opaque = np.concatenate((rgb, np.ones((37, 53, 1), dtype=np.float32)),
+                            axis=-1)
+    npt.assert_allclose(ImageStimulus(opaque).rgb2gray().data,
+                        ImageStimulus(rgb).rgb2gray().data, rtol=1e-6)
+    clear = np.concatenate((rgb, np.zeros((37, 53, 1), dtype=np.float32)),
+                           axis=-1)
+    npt.assert_equal(np.all(ImageStimulus(clear).rgb2gray().data == 0), True)
+
+
+def test_ImageStimulus_invert_preserves_alpha():
+    """Inverting must leave the alpha channel alone and not touch the source"""
+    rng = np.random.default_rng(1)
+    rgba = rng.random((11, 13, 4)).astype(np.float32)
+    stim = ImageStimulus(rgba)
+    before = stim.data.copy()
+    inverted = stim.invert().data.reshape(11, 13, 4)
+    npt.assert_allclose(inverted[..., :3], 1.0 - rgba[..., :3], rtol=1e-6)
+    npt.assert_array_equal(inverted[..., 3], rgba[..., 3])
+    # The original is untouched:
+    npt.assert_array_equal(stim.data, before)

--- a/pulse2percept/stimuli/tests/test_videos.py
+++ b/pulse2percept/stimuli/tests/test_videos.py
@@ -391,3 +391,19 @@ def test_GirlPool():
     npt.assert_equal(video.vid_shape, (32, 32, 3, 91))
     npt.assert_almost_equal(video.data.min(), 0.0001, decimal=2)
     npt.assert_almost_equal(video.data.max(), 0.9988, decimal=2)
+
+
+def test_VideoStimulus_data_is_contiguous(tmp_path):
+    """Video data must reach the Stimulus constructor C-contiguous.
+
+    Frames are decoded frame-first and then transposed so that time is the
+    last axis. Taking that transpose lazily leaves the array non-contiguous
+    all the way through the conversion to float, and the constructor then has
+    to copy it at four times the size.
+    """
+    fname = str(tmp_path / 'test.mp4')
+    ndarray = np.random.rand(12, 32, 48)
+    mimwrite(fname, (255 * ndarray).astype(np.uint8), fps=5)
+    for kwargs in ({}, {'as_gray': True}, {'resize': (16, 24)}):
+        stim = VideoStimulus(fname, **kwargs)
+        npt.assert_equal(stim.data.flags['C_CONTIGUOUS'], True)

--- a/pulse2percept/stimuli/videos.py
+++ b/pulse2percept/stimuli/videos.py
@@ -96,11 +96,15 @@ class VideoStimulus(Stimulus):
             # Filename provided, read the video:
             reader = video_reader(source, format=format)
             vid = np.array([frame for frame in reader])
-            # Move frame index to the last dimension:
+            # Move frame index to the last dimension. Take the copy here,
+            # while the frames are still 8-bit: a transposed view stays
+            # non-contiguous through the conversion to float below, and the
+            # Stimulus constructor would then have to make the same copy at
+            # four times the size.
             if vid.ndim == 4:
-                vid = vid.transpose((1, 2, 3, 0))
+                vid = np.ascontiguousarray(vid.transpose((1, 2, 3, 0)))
             elif vid.ndim == 3:
-                vid = vid.transpose((1, 2, 0))
+                vid = np.ascontiguousarray(vid.transpose((1, 2, 0)))
             # Combine video metadata with user-specified metadata:
             meta = reader.get_meta_data()
             if meta is not None:


### PR DESCRIPTION
A typical use case for p2p is:

    AxonMapModel(yrange=(-8, 8), xrange=(-12, 12)).build().predict_percept(
        ArgusII(stim=BostonTrain().rgb2gray()))

But almost none of its 87 s are the phosphene model's actual arithmetic. The one-liner now runs in ~0.33 s.

- [x] Added `min_current_spread`, a user-tunable cutoff past which an electrode is skipped
- [x] Replaced `c_pow(x, 2)`, which was compiling to real `powf()` calls and made the scoreboard kernel slower than plain NumPy
- [x] Applied the same `c_pow` fix to the Granley model
- [x] Replaces the per-frame Gaussian falloff loop, which depends only on the electrode and the point, not time
- [x] Vectorized the axon loop in build: axon cache now stores bundles plus indices. It carries a version tag so anything older is regrown instead of misred
- [x] Use one interpolator for the whole video instead of every frame
- [x] Transpose video frames while still 8-bit
- [x] Refactored time/space nested loops of `Model(spatial=…, temporal=FadingTemporal)`