### PR TITLE
[ENH] [API] [FIX] Add (Amplitude|Frequency)Encoder, SequentialRaster

### DIFF
--- a/doc/users/release_notes.rst
+++ b/doc/users/release_notes.rst
@@ -33,6 +33,21 @@ Highlights:
    whose period did not divide the frame duration ended with a truncated pulse,
    which injects net charge; a 30 Hz train on a 29.97 fps video did this on
    every frame
+*  New :py:class:`~pulse2percept.implants.Raster` classes describe how a
+   stimulator takes turns between electrodes it cannot drive at the same time.
+   :py:class:`~pulse2percept.implants.SequentialRaster` splits electrodes into
+   groups by position -- on the 6x10
+   :py:class:`~pulse2percept.implants.ArgusII` grid, ``SequentialRaster(6)`` is
+   a line raster -- and :py:class:`~pulse2percept.implants.CustomRaster`
+   assigns them by name. An encoder staggers each group's pulses accordingly,
+   taking the raster from its own ``raster`` argument or from the implant's
+*  :py:class:`~pulse2percept.implants.ProsthesisSystem` gained a ``raster``
+   attribute and a ``max_current`` one, the total current the stimulator can
+   source at any instant. When ``max_current`` is set, assigning a stimulus
+   that exceeds it raises, the way ``safe_mode`` does for charge balance.
+   Encoding ``BostonTrain`` for Argus II at 0-50 uA draws 1310 uA at once
+   without a raster and 298 uA with a six-group line raster, at the cost of a
+   time axis roughly ``n_groups`` times longer
 *  Python 3.14 support; the minimum supported Python is now 3.11
 *  NumPy 2 is now required (``numpy>=2,<3``). If you are pinned to NumPy 
    1.x, stay on v0.9.1 -- ``pip`` will select it for you

--- a/doc/users/release_notes.rst
+++ b/doc/users/release_notes.rst
@@ -89,6 +89,46 @@ Highlights:
    traceback. Both are handled by the new
    :py:func:`~pulse2percept.utils.frame_interval`
 
+Bug fixes:
+
+*  ``Stimulus.time`` is now stored as float64 rather than float32 (the data
+   container stays float32). float32 reaches a resolution of ``DT`` = 1e-3 ms
+   at t = 8.4 s, past which the DT-wide edges of a pulse collapse: a 30 s pulse
+   train lost 952 of its edges outright, and the pulses of a 3 s one were
+   already 2% too narrow. A time axis costs one entry per column where the data
+   costs one per electrode per column, so widening it is nearly free
+*  :py:class:`~pulse2percept.stimuli.PulseTrain` no longer ends on a pulse it
+   cannot finish. It used to round the pulse count *up* and trim to
+   ``stim_dur``, so a train whose frequency did not divide the duration ended
+   mid-phase and was not charge-balanced -- a 30 Hz train in a 33.37 ms window
+   delivered one and a fraction of a second pulse, with a net current of
+   -1.64 uA*ms. The count is now rounded down to whole pulses, and a frequency
+   too slow for the window still yields one pulse rather than none
+*  As a consequence of the two fixes above,
+   :py:attr:`~pulse2percept.stimuli.Stimulus.is_charge_balanced` now reports
+   ``True`` for pulse trains that are in fact balanced. It previously returned
+   ``False`` for any train of more than about five pulses, and hence rejected
+   perfectly good stimuli under ``safe_mode``
+*  :py:class:`~pulse2percept.implants.EnsembleImplant` merged the time axes of
+   its implants with an exact ``np.unique``, so two implants pulsing at the
+   same instant contributed two time points a fraction of a time step apart.
+   It now uses the same tolerance as the
+   :py:class:`~pulse2percept.stimuli.Stimulus` constructor
+*  A temporal model that produces an all-zero percept because the stimulus has
+   the wrong polarity now says so. Brightness is driven by cathodic current in
+   :py:class:`~pulse2percept.models.FadingTemporal` and
+   :py:class:`~pulse2percept.models.Horsager2009Temporal` but by anodic current
+   in :py:class:`~pulse2percept.models.Nanduri2012Temporal`, so assigning a
+   grayscale image or video straight to ``implant.stim`` -- whose gray levels
+   are all nonnegative -- silently returned a blank percept
+*  The "time points must be strictly monotonically increasing" warning now
+   names the offending points instead of printing the entire time axis, which
+   for a long stimulus ran to megabytes of output
+*  :py:meth:`~pulse2percept.stimuli.ImageStimulus.encode` no longer normalizes
+   the pulse it was passed in place, and
+   :py:meth:`~pulse2percept.stimuli.VideoStimulus.encode` no longer shifts its
+   time axis in place
+
 API changes:
 
 *  :py:meth:`~pulse2percept.stimuli.ImageStimulus.encode` and

--- a/doc/users/release_notes.rst
+++ b/doc/users/release_notes.rst
@@ -14,11 +14,25 @@ Highlights:
    would actually deliver: every frame becomes a train of biphasic pulses that
    lasts one frame period.
    :py:class:`~pulse2percept.stimuli.AmplitudeEncoder` maps the gray level of a
-   pixel onto the amplitude of its pulses at a fixed frequency. Passing it an
-   ``implant`` samples the source at the electrode locations *before* building
-   the pulse trains, rather than after: encoding the 94-frame ``BostonTrain``
-   for Argus II now allocates 0.2 MB and takes 50 ms, where encoding it at
-   pixel resolution allocated 308 MB and took 720 ms
+   pixel onto the amplitude of its pulses at a fixed frequency;
+   :py:class:`~pulse2percept.stimuli.FrequencyEncoder` maps it onto how often
+   they come, at a fixed amplitude. Passing either an ``implant`` samples the
+   source at the electrode locations *before* building the pulse trains, rather
+   than after: encoding the 94-frame ``BostonTrain`` for Argus II now allocates
+   0.2 MB and takes 50 ms, where encoding it at pixel resolution allocated
+   308 MB and took 720 ms
+*  Encoders model two properties of real stimulators that also decide how
+   expensive the resulting stimulus is to simulate: ``clock``, the period of
+   the device's time base, onto which pulse periods are rounded; and
+   ``n_levels``, the resolution of its input stage. They matter most for
+   frequency modulation, where electrodes pulsing at different rates otherwise
+   need a time point wherever any of them has a pulse edge -- ``BostonTrain``
+   at frequencies in (0, 300] Hz needs 121,494 time points unquantized, but
+   18,056 on a 1 ms clock
+*  A frame now delivers only pulses it can finish. Previously a pulse train
+   whose period did not divide the frame duration ended with a truncated pulse,
+   which injects net charge; a 30 Hz train on a 29.97 fps video did this on
+   every frame
 *  Python 3.14 support; the minimum supported Python is now 3.11
 *  NumPy 2 is now required (``numpy>=2,<3``). If you are pinned to NumPy 
    1.x, stay on v0.9.1 -- ``pip`` will select it for you

--- a/doc/users/release_notes.rst
+++ b/doc/users/release_notes.rst
@@ -9,6 +9,16 @@ v0.9.2 (unreleased)
 
 Highlights:
 
+*  New :py:class:`~pulse2percept.stimuli.Encoder` classes, which translate the
+   gray levels of an image or a video into the electrical stimulus an implant
+   would actually deliver: every frame becomes a train of biphasic pulses that
+   lasts one frame period.
+   :py:class:`~pulse2percept.stimuli.AmplitudeEncoder` maps the gray level of a
+   pixel onto the amplitude of its pulses at a fixed frequency. Passing it an
+   ``implant`` samples the source at the electrode locations *before* building
+   the pulse trains, rather than after: encoding the 94-frame ``BostonTrain``
+   for Argus II now allocates 0.2 MB and takes 50 ms, where encoding it at
+   pixel resolution allocated 308 MB and took 720 ms
 *  Python 3.14 support; the minimum supported Python is now 3.11
 *  NumPy 2 is now required (``numpy>=2,<3``). If you are pinned to NumPy 
    1.x, stay on v0.9.1 -- ``pip`` will select it for you
@@ -49,6 +59,31 @@ Highlights:
    now raises ``NotImplementedError`` with an explanation instead of a bare
    traceback. Both are handled by the new
    :py:func:`~pulse2percept.utils.frame_interval`
+
+API changes:
+
+*  :py:meth:`~pulse2percept.stimuli.ImageStimulus.encode` and
+   :py:meth:`~pulse2percept.stimuli.VideoStimulus.encode` are now shorthands
+   for :py:class:`~pulse2percept.stimuli.AmplitudeEncoder`, and their behavior
+   changed in four ways:
+
+   -  Gray levels map onto ``amp_range`` **absolutely**: a gray level of 0.5
+      always encodes to the middle of the range. Previously they were stretched
+      to fill it, which made the encoding depend on the content of the source
+      and silently encoded a uniform image as zero amplitude everywhere. Pass
+      ``stretch=True`` for the old behavior.
+   -  Each frame now receives a pulse *train* (new ``freq`` argument,
+      defaulting to 20 Hz) rather than a single pulse.
+   -  The ``pulse`` argument now takes a single pulse to repeat, whose
+      amplitude is normalized away, and is no longer modified in place.
+   -  The new ``implant`` argument encodes at electrode rather than pixel
+      resolution, and is strongly recommended for videos.
+
+*  :py:meth:`~pulse2percept.stimuli.VideoStimulus.encode` used to infer a frame
+   duration of ``1000 / dt`` ms from a video whose metadata carried no frame
+   rate, where ``dt`` is the spacing of its time axis in ms. It now uses ``dt``
+   itself, so such a video no longer comes back a factor of ``1000 / dt**2``
+   too long.
 
 v0.9.1 (2026-08-06)
 -------------------

--- a/examples/stimuli/plot_image_stim.py
+++ b/examples/stimuli/plot_image_stim.py
@@ -261,6 +261,18 @@ implant.stim = logo_dilate.trim().resize(implant.shape).encode()
 #     encoder = p2p.stimuli.AmplitudeEncoder(implant, amp_range=(0, 50))
 #     implant.stim = encoder.encode(p2p.stimuli.BostonTrain())
 #
+# The other way to encode a gray level is as a pulse *rate* at fixed amplitude,
+# which is what :py:class:`~pulse2percept.stimuli.FrequencyEncoder` does. It is
+# considerably more expensive to simulate, because electrodes pulsing at
+# different rates no longer pulse at the same times; ``clock`` (the period of
+# the stimulator's time base) is the lever that keeps that under control:
+#
+# .. code-block:: python
+#
+#     encoder = p2p.stimuli.FrequencyEncoder(implant, freq_range=(0, 300),
+#                                            amp=50, clock=1)
+#     implant.stim = encoder.encode(p2p.stimuli.BostonTrain())
+#
 # Using the image as input to a spatiotemporal model
 # ---------------------------------------------------
 #

--- a/examples/stimuli/plot_image_stim.py
+++ b/examples/stimuli/plot_image_stim.py
@@ -273,6 +273,17 @@ implant.stim = logo_dilate.trim().resize(implant.shape).encode()
 #                                            amp=50, clock=1)
 #     implant.stim = encoder.encode(p2p.stimuli.BostonTrain())
 #
+# A real stimulator usually cannot drive every electrode at once, because the
+# current it can source at any instant is limited. Give the implant a
+# :py:class:`~pulse2percept.implants.Raster` and the electrodes take turns
+# instead, a group at a time, all of them within one frame period:
+#
+# .. code-block:: python
+#
+#     implant.max_current = 1000  # uA, summed over electrodes
+#     implant.raster = p2p.implants.SequentialRaster(6)  # one row at a time
+#     implant.stim = p2p.stimuli.AmplitudeEncoder(implant).encode(video)
+#
 # Using the image as input to a spatiotemporal model
 # ---------------------------------------------------
 #

--- a/examples/stimuli/plot_image_stim.py
+++ b/examples/stimuli/plot_image_stim.py
@@ -233,21 +233,33 @@ percept_dilate.plot(ax=ax2)
 # stimuli with a time component).
 #
 # By default, the ``encode`` method will interpret the gray level of a pixel as
-# the current amplitude of a :py:class:`~pulse2percept.stimuli.BiphasicPulse`
-# with 0.46ms phase duration (500ms total stimulus duration). Gray levels in
-# the range [0, 1] will be mapped onto currents in the range [0, 50] uA:
+# the current amplitude of a 20 Hz train of
+# :py:class:`~pulse2percept.stimuli.BiphasicPulse` (0.46 ms phase duration),
+# lasting 500 ms overall. Gray levels in the range [0, 1] are mapped onto
+# currents in the range [0, 50] uA:
 
 implant.stim = logo_dilate.trim().resize(implant.shape).encode()
 
 ##############################################################################
 # We can customize the range of amplitudes to be used by passing a keyword
-# argument; e.g. ``amp_range=(0, 20)`` to use currents in [0, 20] uA.
+# argument; e.g. ``amp_range=(0, 20)`` to use currents in [0, 20] uA, and the
+# pulse rate with ``freq=50``.
 #
-# We can also specify our own pulse / pulse train to be used. First, we need to
-# create the pulse we want to use (use amplitude 1 uA). Then, we need to pass
-# it as an additional keyword argument; e.g.,
-# ``pulse=BiphasicPulseTrain(10, 1, 0.2, stim_dur=200)`` to use a 10Hz
-# biphasic pulse train (0.2ms phase duration, overall duration 200 ms).
+# We can also specify our own pulse shape to be repeated, by passing a keyword
+# argument such as ``pulse=BiphasicPulse(1, 0.2)``. Its amplitude is normalized
+# away, since that is what the encoding sets; only its shape is used.
+#
+# ``encode`` is a shorthand for
+# :py:class:`~pulse2percept.stimuli.AmplitudeEncoder`, which offers the full
+# set of options. In particular, passing it an ``implant`` samples the image at
+# the electrode locations *before* building the pulse trains, which for a video
+# is the difference between a stimulus of a few hundred kilobytes and one of a
+# few hundred megabytes:
+#
+# .. code-block:: python
+#
+#     encoder = p2p.stimuli.AmplitudeEncoder(implant, amp_range=(0, 50))
+#     implant.stim = encoder.encode(p2p.stimuli.BostonTrain())
 #
 # Using the image as input to a spatiotemporal model
 # ---------------------------------------------------

--- a/pulse2percept/implants/__init__.py
+++ b/pulse2percept/implants/__init__.py
@@ -12,6 +12,7 @@ Different prosthetic implants, such as Argus II, Alpha-IMS, BVT-24, PRIMA, Corti
     base
     electrodes
     electrode_arrays
+    rasters
     argus
     alpha
     bvt
@@ -27,6 +28,7 @@ from .base import ProsthesisSystem, RectangleImplant
 from .electrodes import (Electrode, PointSource, DiskElectrode,
                          SquareElectrode, HexElectrode)
 from .electrode_arrays import ElectrodeArray, ElectrodeGrid
+from .rasters import Raster, SequentialRaster, CustomRaster
 from .argus import ArgusI, ArgusII
 from .alpha import AlphaIMS, AlphaAMS
 from .bvt import BVT24, BVT44
@@ -43,6 +45,7 @@ __all__ = [
     'BVT24',
     'BVT44',
     'cortex',
+    'CustomRaster',
     'DiskElectrode',
     'Electrode',
     'ElectrodeArray',
@@ -56,7 +59,9 @@ __all__ = [
     'PRIMA55',
     'PRIMA40',
     'ProsthesisSystem',
+    'Raster',
     'RectangleImplant',
+    'SequentialRaster',
     'SquareElectrode',
     'IMIE'
 ]

--- a/pulse2percept/implants/base.py
+++ b/pulse2percept/implants/base.py
@@ -7,6 +7,7 @@ from scipy.interpolate import RegularGridInterpolator
 
 from .electrodes import Electrode, DiskElectrode
 from .electrode_arrays import ElectrodeArray, ElectrodeGrid
+from .rasters import Raster
 from ..stimuli import Stimulus, ImageStimulus, VideoStimulus
 from ..utils import PrettyPrint
 
@@ -38,6 +39,17 @@ class ProsthesisSystem(PrettyPrint):
         function (callable).
     safe_mode : bool, optional
         If safe mode is enabled, only charge-balanced stimuli are allowed.
+    raster : :py:class:`~pulse2percept.implants.Raster`, optional
+        How the stimulator takes turns between electrodes that it cannot drive
+        at the same time. If None, every electrode may fire at once.
+
+        .. versionadded:: 0.9.2
+    max_current : float, optional
+        The total current (uA) the stimulator can source at any one instant,
+        summed over all electrodes. If given, assigning a stimulus that exceeds
+        it raises. If None, no such check is performed.
+
+        .. versionadded:: 0.9.2
 
     Examples
     --------
@@ -55,25 +67,62 @@ class ProsthesisSystem(PrettyPrint):
 
     """
     # Frozen class: User cannot add more class attributes
-    __slots__ = ('_earray', '_stim', '_eye', 'safe_mode', 'preprocess')
+    __slots__ = ('_earray', '_stim', '_eye', 'safe_mode', 'preprocess',
+                 '_raster', '_max_current')
 
     def __init__(self, earray, stim=None, eye='RE', preprocess=False,
-                 safe_mode=False):
+                 safe_mode=False, raster=None, max_current=None):
         self.earray = earray
         self.eye = eye
         self.safe_mode = safe_mode
         self.preprocess = preprocess
+        self.raster = raster
+        self.max_current = max_current
         self.stim = stim
 
     def _pprint_params(self):
         """Return dict of class attributes to pretty-print"""
         params = {
-            'earray': self.earray, 'stim': self.stim, 'safe_mode': self.safe_mode, 
+            'earray': self.earray, 'stim': self.stim, 'safe_mode': self.safe_mode,
             'preprocess': self.preprocess
         }
         if hasattr(self, "eye"):
             params['eye'] = self.eye
+        if self.raster is not None:
+            params['raster'] = self.raster
+        if self.max_current is not None:
+            params['max_current'] = self.max_current
         return params
+
+    @property
+    def raster(self):
+        """Raster pattern
+
+        Most implants do not set this in their constructor, so the slot backing
+        it may never have been written to; an unset raster means all electrodes
+        may fire at once.
+        """
+        return getattr(self, '_raster', None)
+
+    @raster.setter
+    def raster(self, raster):
+        """Raster setter (called upon ``self.raster = raster``)"""
+        if raster is not None and not isinstance(raster, Raster):
+            raise TypeError(f"'raster' must be a Raster object, not "
+                            f"{type(raster)}.")
+        self._raster = raster
+
+    @property
+    def max_current(self):
+        """Total instantaneous current (uA) the stimulator can source"""
+        return getattr(self, '_max_current', None)
+
+    @max_current.setter
+    def max_current(self, max_current):
+        """Current limit setter (called upon ``self.max_current = ...``)"""
+        if max_current is not None and max_current <= 0:
+            raise ValueError("'max_current' must be positive.")
+        self._max_current = max_current
 
     @staticmethod
     def _require_charge_balanced(stim):
@@ -81,13 +130,31 @@ class ProsthesisSystem(PrettyPrint):
         if stim.is_charge_balanced is False:
             raise ValueError("Safety check: Stimulus must be charge-balanced.")
 
+    def _require_within_current_limit(self, stim):
+        # What the stimulator has to source at an instant is the sum over every
+        # electrode active at that instant, whatever the sign of each:
+        if stim.data.size == 0:
+            return
+        total = np.abs(stim.data).sum(axis=0)
+        peak = total.max()
+        if peak > self.max_current:
+            worst = int(np.argmax(total))
+            n_active = int(np.count_nonzero(stim.data[:, worst]))
+            raise ValueError(
+                f"Safety check: stimulus draws {peak:.1f} uA at once "
+                f"({n_active} electrodes active), which exceeds "
+                f"max_current={self.max_current:.1f} uA. Give the implant a "
+                f"'raster' so that fewer electrodes fire at the same time, or "
+                f"lower the amplitude.")
+
     def check_stim(self, stim):
         """Quality-check the stimulus
 
         This method is executed every time a new value is assigned to ``stim``.
 
         If ``safe_mode`` is set to True, this function will only allow stimuli
-        that are charge-balanced.
+        that are charge-balanced. If ``max_current`` is set, it will only allow
+        stimuli whose total instantaneous current stays within it.
 
         The user can define their own checks in implants that inherit from
         :py:class:`~pulse2percept.implants.ProsthesisSystem`.
@@ -101,6 +168,8 @@ class ProsthesisSystem(PrettyPrint):
         """
         if self.safe_mode:
             self._require_charge_balanced(stim)
+        if self.max_current is not None:
+            self._require_within_current_limit(stim)
 
     def preprocess_stim(self, stim):
         """Preprocess the stimulus

--- a/pulse2percept/implants/ensemble.py
+++ b/pulse2percept/implants/ensemble.py
@@ -3,6 +3,7 @@ import numpy as np
 from .base import ProsthesisSystem
 from .electrodes import Electrode
 from .electrode_arrays import ElectrodeArray
+from ..stimuli.base import unique_time_points
 
 class EnsembleImplant(ProsthesisSystem):
     
@@ -200,8 +201,12 @@ class EnsembleImplant(ProsthesisSystem):
             valid_times = [t for t in times if t is not None]
             
             if valid_times:
-                # Get the union of all time points
-                new_times = np.unique(np.concatenate(valid_times))
+                # Get the union of all time points. Two implants that pulse at
+                # the same instant get there by accumulating their own way, so
+                # an exact `np.unique` would keep both copies and leave the
+                # merged axis with points closer together than DT:
+                t_sorted, starts_group, _ = unique_time_points(valid_times)
+                new_times = t_sorted[starts_group]
             else:
                 new_times = None  # No time-dependent stimulation
             

--- a/pulse2percept/implants/rasters.py
+++ b/pulse2percept/implants/rasters.py
@@ -1,0 +1,233 @@
+""":py:class:`~pulse2percept.implants.Raster`,
+   :py:class:`~pulse2percept.implants.SequentialRaster`,
+   :py:class:`~pulse2percept.implants.CustomRaster`"""
+from abc import ABCMeta, abstractmethod
+import numpy as np
+
+from ..utils import PrettyPrint
+
+
+class Raster(PrettyPrint, metaclass=ABCMeta):
+    """Abstract base class for all raster patterns
+
+    A stimulator usually cannot drive every electrode at once, because the
+    total current it can source at any instant is limited. Electrodes are
+    therefore split into *raster groups* that take turns: group 0 fires, then
+    group 1 some milliseconds later, and so on, with the whole sequence
+    completing within one frame.
+
+    An encoder asks a raster how long each electrode has to wait after the
+    start of a frame before it may pulse; see
+    :py:class:`~pulse2percept.stimuli.Encoder`.
+
+    Subclasses only implement ``groups``.
+
+    .. versionadded:: 0.9.2
+
+    Parameters
+    ----------
+    group_dur : float, optional
+        Time (ms) between one group firing and the next. If None, the groups
+        are spread evenly over the frame, so that the sequence takes exactly
+        one frame period to complete.
+
+        .. note::
+
+           Staggering the *onsets* of two groups only keeps them off the same
+           time point if the first group is finished before the second starts.
+           That holds whenever a group pulses at most once per frame, which is
+           what amplitude modulation does. Under frequency modulation an
+           electrode may pulse many times per frame, and pulses from different
+           groups can then land on top of each other. Set ``max_current`` on
+           the implant to find out when they do.
+
+    """
+    __slots__ = ('group_dur',)
+
+    def __init__(self, group_dur=None):
+        if group_dur is not None and group_dur <= 0:
+            raise ValueError("'group_dur' must be positive.")
+        self.group_dur = group_dur
+
+    def _pprint_params(self):
+        """Return a dict of class arguments to pretty-print"""
+        return {'group_dur': self.group_dur, 'n_groups': self.n_groups}
+
+    @property
+    @abstractmethod
+    def n_groups(self):
+        """Number of raster groups"""
+        raise NotImplementedError
+
+    @abstractmethod
+    def groups(self, electrodes):
+        """Assign each electrode to a raster group
+
+        Parameters
+        ----------
+        electrodes : array_like
+            Electrode names, in the order they appear in the stimulus.
+
+        Returns
+        -------
+        group : (n_electrodes,) int array
+            The group each electrode belongs to, in ``0..n_groups-1``.
+
+        """
+        raise NotImplementedError
+
+    def delays(self, electrodes, frame_dur):
+        """How long each electrode waits before pulsing
+
+        Parameters
+        ----------
+        electrodes : array_like
+            Electrode names, in the order they appear in the stimulus.
+        frame_dur : float
+            Duration (ms) of a single frame. The whole raster sequence has to
+            complete within it.
+
+        Returns
+        -------
+        delay : (n_electrodes,) float array
+            Time (ms) between the start of a frame and this electrode's first
+            pulse.
+
+        """
+        group = np.asarray(self.groups(electrodes), dtype=np.int64)
+        if group.min(initial=0) < 0 or group.max(initial=0) >= self.n_groups:
+            raise ValueError(f"'groups' must be in 0..{self.n_groups - 1}.")
+        dur = (frame_dur / self.n_groups if self.group_dur is None
+               else self.group_dur)
+        if self.n_groups * dur > frame_dur:
+            raise ValueError(f"A raster of {self.n_groups} groups "
+                             f"{dur:.3f} ms apart takes "
+                             f"{self.n_groups * dur:.3f} ms, which does not "
+                             f"fit into a frame (dur={frame_dur:.3f} ms). "
+                             f"Shorten 'group_dur' or lower the frame rate.")
+        return group * dur
+
+
+class SequentialRaster(Raster):
+    """Split electrodes into groups that fire one after another
+
+    Electrodes are assigned to groups by their position in the stimulus, which
+    for an :py:class:`~pulse2percept.implants.ElectrodeGrid` runs row by row.
+    So on a 6x10 array such as :py:class:`~pulse2percept.implants.ArgusII`,
+    ``SequentialRaster(6)`` puts each row in its own group -- a line raster.
+
+    .. versionadded:: 0.9.2
+
+    Parameters
+    ----------
+    n_groups : int
+        Number of groups to split the electrodes into.
+    interleave : bool, optional
+        If False (the default), each group is a contiguous block of
+        electrodes. If True, groups are interleaved, so that consecutive
+        electrodes end up in different groups. Interleaving spreads each
+        group's current further across the array.
+    group_dur : float, optional
+        See :py:class:`~pulse2percept.implants.Raster`.
+
+    Examples
+    --------
+    A line raster for Argus II, one row of ten electrodes at a time:
+
+    >>> from pulse2percept.implants import ArgusII, SequentialRaster
+    >>> implant = ArgusII()
+    >>> implant.raster = SequentialRaster(6)
+
+    """
+    __slots__ = ('_n_groups', 'interleave')
+
+    def __init__(self, n_groups, interleave=False, group_dur=None):
+        super().__init__(group_dur=group_dur)
+        if int(n_groups) != n_groups or n_groups < 1:
+            raise ValueError(f"'n_groups' must be a positive integer, not "
+                             f"{n_groups}.")
+        self._n_groups = int(n_groups)
+        self.interleave = interleave
+
+    def _pprint_params(self):
+        """Return a dict of class arguments to pretty-print"""
+        params = super()._pprint_params()
+        params.update({'interleave': self.interleave})
+        return params
+
+    @property
+    def n_groups(self):
+        """Number of raster groups"""
+        return self._n_groups
+
+    def groups(self, electrodes):
+        """Assign each electrode to a raster group"""
+        idx = np.arange(len(electrodes))
+        if self.interleave:
+            return idx % self._n_groups
+        # Contiguous blocks, as evenly sized as the electrode count allows:
+        return idx * self._n_groups // max(1, len(electrodes))
+
+
+class CustomRaster(Raster):
+    """Assign electrodes to raster groups by name
+
+    .. versionadded:: 0.9.2
+
+    Parameters
+    ----------
+    groups : list of lists, or dict
+        Either a list whose i-th element holds the names of the electrodes in
+        group i, or a dict mapping each electrode name onto its group index.
+        Every electrode in the stimulus must be accounted for.
+    group_dur : float, optional
+        See :py:class:`~pulse2percept.implants.Raster`.
+
+    Examples
+    --------
+    Fire the four corners of Argus II before everything else:
+
+    >>> from pulse2percept.implants import CustomRaster
+    >>> raster = CustomRaster([['A1', 'A10', 'F1', 'F10'], ['B5', 'C5']])
+
+    """
+    __slots__ = ('_group_of', '_n_groups')
+
+    def __init__(self, groups, group_dur=None):
+        super().__init__(group_dur=group_dur)
+        if isinstance(groups, dict):
+            group_of = {str(k): int(v) for k, v in groups.items()}
+        else:
+            group_of = {}
+            for idx, names in enumerate(groups):
+                if isinstance(names, str):
+                    raise TypeError(f"Group {idx} must be a list of electrode "
+                                    f"names, not the string '{names}'.")
+                for name in names:
+                    group_of[str(name)] = idx
+        if not group_of:
+            raise ValueError("'groups' cannot be empty.")
+        self._group_of = group_of
+        self._n_groups = max(group_of.values()) + 1
+
+    def _pprint_params(self):
+        """Return a dict of class arguments to pretty-print"""
+        params = super()._pprint_params()
+        params.update({'n_electrodes': len(self._group_of)})
+        return params
+
+    @property
+    def n_groups(self):
+        """Number of raster groups"""
+        return self._n_groups
+
+    def groups(self, electrodes):
+        """Assign each electrode to a raster group"""
+        try:
+            return np.array([self._group_of[str(e)] for e in electrodes])
+        except KeyError:
+            missing = sorted({str(e) for e in electrodes} -
+                             set(self._group_of))
+            raise ValueError(f"No raster group given for electrode(s) "
+                             f"{missing[:10]}. Every electrode in the "
+                             f"stimulus must be assigned to a group.")

--- a/pulse2percept/implants/tests/test_ensemble.py
+++ b/pulse2percept/implants/tests/test_ensemble.py
@@ -6,6 +6,7 @@ from pulse2percept.implants.cortex import Cortivis, Orion
 from pulse2percept.topography import Polimeni2006Map
 from pulse2percept.models.cortex.base import ScoreboardModel
 from pulse2percept.stimuli import BiphasicPulseTrain
+from pulse2percept.utils.constants import DT
 
 def test_EnsembleImplant():
     # Invalid instantiations:
@@ -140,6 +141,11 @@ def test_merge_stimuli():
     implant2.stim = {e : BiphasicPulseTrain(20, 2, .85) for e in implant2.electrode_names}
     implant = EnsembleImplant([implant1, implant2])
     npt.assert_equal(implant.stim.data.shape, (120, 471))
+    # Two implants that pulse at the same instant get there by accumulating
+    # their own way, so merging their time axes needs a tolerance. An exact
+    # union would keep both copies and leave the merged axis with pairs of
+    # points closer together than a time step:
+    npt.assert_equal(np.all(np.diff(implant.stim.time) > 0.95 * DT), True)
     # make sure that implant.metadata['electrodes'] is also merged
     npt.assert_equal(list(implant.stim.metadata['electrodes'].keys()), implant.electrode_names)
     npt.assert_equal(implant.stim.metadata['electrodes']['0-96'], implant1.stim.metadata['electrodes']['96'])

--- a/pulse2percept/implants/tests/test_rasters.py
+++ b/pulse2percept/implants/tests/test_rasters.py
@@ -1,0 +1,114 @@
+import numpy as np
+import numpy.testing as npt
+import pytest
+
+from pulse2percept.implants import (ArgusII, CustomRaster, ProsthesisSystem,
+                                    Raster, SequentialRaster)
+
+
+def test_Raster_is_abstract():
+    with pytest.raises(TypeError):
+        Raster()
+
+
+def test_SequentialRaster():
+    with pytest.raises(ValueError):
+        SequentialRaster(0)
+    with pytest.raises(ValueError):
+        SequentialRaster(2.5)
+    with pytest.raises(ValueError):
+        SequentialRaster(2, group_dur=-1)
+
+    names = ArgusII().electrode_names
+    # On a 6x10 grid, whose electrodes run row by row, six contiguous groups
+    # are the six rows -- a line raster:
+    raster = SequentialRaster(6)
+    npt.assert_equal(raster.n_groups, 6)
+    groups = raster.groups(names)
+    npt.assert_equal(groups, np.repeat(np.arange(6), 10))
+    npt.assert_equal([names[i] for i in np.flatnonzero(groups == 0)][:3],
+                     ['A1', 'A2', 'A3'])
+    # Interleaving puts consecutive electrodes in different groups:
+    inter = SequentialRaster(6, interleave=True).groups(names)
+    npt.assert_equal(inter, np.tile(np.arange(6), 10))
+    # Either way, every group is the same size:
+    npt.assert_equal(np.bincount(groups), np.full(6, 10))
+    npt.assert_equal(np.bincount(inter), np.full(6, 10))
+    npt.assert_equal('n_groups' in str(raster), True)
+
+
+def test_Raster_delays():
+    names = ArgusII().electrode_names
+    # By default the groups are spread evenly over the frame, so the sequence
+    # takes exactly one frame period to get through:
+    delays = SequentialRaster(6).delays(names, 30.0)
+    npt.assert_equal(np.unique(delays), np.arange(6) * 5.0)
+    npt.assert_almost_equal(delays.max() + 5.0, 30.0)
+    # An explicit spacing is used instead, as long as it still fits:
+    delays = SequentialRaster(6, group_dur=2).delays(names, 30.0)
+    npt.assert_equal(np.unique(delays), np.arange(6) * 2.0)
+    with pytest.raises(ValueError):
+        SequentialRaster(6, group_dur=10).delays(names, 30.0)
+    # A raster of one group is no raster at all:
+    npt.assert_equal(SequentialRaster(1).delays(names, 30.0), 0)
+
+
+def test_CustomRaster():
+    with pytest.raises(ValueError):
+        CustomRaster([])
+    with pytest.raises(TypeError):
+        # A bare string is a common slip, and would otherwise be read as a
+        # group of single-character electrode names:
+        CustomRaster(['A1', 'A2'])
+
+    raster = CustomRaster([['A1', 'A2'], ['A3']])
+    npt.assert_equal(raster.n_groups, 2)
+    npt.assert_equal(raster.groups(['A1', 'A3', 'A2']), [0, 1, 0])
+    npt.assert_equal(raster.delays(['A1', 'A3'], 10.0), [0, 5])
+    # A dict says the same thing:
+    same = CustomRaster({'A1': 0, 'A2': 0, 'A3': 1})
+    npt.assert_equal(same.groups(['A1', 'A3', 'A2']), [0, 1, 0])
+    # Every electrode in the stimulus has to be accounted for, or the current
+    # limit the raster exists to respect would be violated silently:
+    with pytest.raises(ValueError):
+        raster.groups(['A1', 'B7'])
+
+
+def test_ProsthesisSystem_raster():
+    implant = ArgusII()
+    # Implants that do not set a raster in their constructor still report one:
+    npt.assert_equal(implant.raster, None)
+    npt.assert_equal(ProsthesisSystem(implant.earray).raster, None)
+    implant.raster = SequentialRaster(6)
+    npt.assert_equal(implant.raster.n_groups, 6)
+    npt.assert_equal('raster' in str(implant), True)
+    with pytest.raises(TypeError):
+        implant.raster = 'line'
+    # It can be set through the constructor too:
+    npt.assert_equal(
+        ProsthesisSystem(implant.earray,
+                         raster=SequentialRaster(3)).raster.n_groups, 3)
+
+
+def test_ProsthesisSystem_max_current():
+    implant = ArgusII()
+    npt.assert_equal(implant.max_current, None)
+    with pytest.raises(ValueError):
+        implant.max_current = 0
+    # 60 electrodes at 20 uA each is 1200 uA at once:
+    implant.max_current = 1500
+    implant.stim = np.full(60, 20)
+    npt.assert_equal(implant.stim.shape, (60, 1))
+    implant.max_current = 1000
+    with pytest.raises(ValueError):
+        implant.stim = np.full(60, 20)
+    # The sign does not matter: what the stimulator sources is the sum of the
+    # magnitudes:
+    with pytest.raises(ValueError):
+        implant.stim = np.full(60, -20)
+    # A single electrode is well within the limit:
+    implant.stim = {'A1': 900}
+    npt.assert_almost_equal(implant.stim.data.max(), 900)
+    # An empty stimulus has nothing to check:
+    implant.stim = None
+    npt.assert_equal(implant.stim, None)

--- a/pulse2percept/models/base.py
+++ b/pulse2percept/models/base.py
@@ -4,6 +4,7 @@
    :py:class:`~pulse2percept.models.SpatialModel`,
    :py:class:`~pulse2percept.models.TemporalModel`"""
 import sys
+import warnings
 from abc import ABCMeta, abstractmethod
 from copy import deepcopy, copy
 import numpy as np
@@ -583,6 +584,15 @@ class TemporalModel(BaseModel, metaclass=ABCMeta):
     #: ``n_jobs`` is an alias for ``n_threads``; see ``_n_jobs_alias``.
     n_jobs = _n_jobs_alias()
 
+    #: Sign of the stimulus current that drives brightness in this model: -1 if
+    #: cathodic (negative) current does, +1 if anodic (positive) current does.
+    #: The two conventions are both in use -- ``FadingTemporal`` and
+    #: ``Horsager2009Temporal`` are cathodic-driven, ``Nanduri2012Temporal`` is
+    #: anodic-driven -- and a stimulus of the wrong polarity produces a blank
+    #: percept rather than an error. This is what lets ``predict_percept`` say
+    #: so; nothing else reads it.
+    _drive_sign = -1
+
     def get_default_params(self):
         """Return a dictionary of default values for all model parameters"""
         params = {
@@ -698,9 +708,34 @@ class TemporalModel(BaseModel, metaclass=ABCMeta):
         else:
             # Calculate the Stimulus at requested time points:
             resp = self._predict_temporal(_stim, t_percept)
+            self._warn_if_blank(_stim, resp)
         return Percept(resp.reshape(_space + [t_percept.size]),
                        space=None, time=t_percept,
                        metadata={'stim': stim})
+
+    def _warn_if_blank(self, stim, resp):
+        """Point out a percept that came out blank for a polarity reason
+
+        A stimulus of the wrong sign is not an error -- the model integrates it
+        and rectifies the result away -- so it otherwise looks exactly like a
+        stimulus that was simply too weak to see. Assigning a grayscale image
+        or video straight to ``implant.stim`` lands here, because gray levels
+        are nonnegative and most temporal models are driven by cathodic
+        current.
+        """
+        if np.any(resp) or not np.any(stim.data):
+            return
+        # Only if *nothing* in the stimulus has the sign the model responds to:
+        if np.any(np.sign(stim.data) == self._drive_sign):
+            return
+        polarity = 'cathodic (negative)' if self._drive_sign < 0 else \
+            'anodic (positive)'
+        warnings.warn(
+            f"{type(self).__name__} produced an all-zero percept: brightness "
+            f"in this model is driven by {polarity} current, and the stimulus "
+            f"has none. Encoding an image or a video with "
+            f"pulse2percept.stimuli.AmplitudeEncoder gives it the right "
+            f"polarity; otherwise negate it.")
 
     def find_threshold(self, stim, bright_th, amp_range=(0, 999), amp_tol=1,
                        bright_tol=0.1, max_iter=100, t_percept=None):

--- a/pulse2percept/models/nanduri2012.py
+++ b/pulse2percept/models/nanduri2012.py
@@ -141,6 +141,10 @@ class Nanduri2012Temporal(TemporalModel):
 
     """
 
+    # Unlike the other temporal models, this one is driven by anodic current;
+    # see ``TemporalModel._drive_sign``:
+    _drive_sign = 1
+
     def get_default_params(self):
         base_params = super(Nanduri2012Temporal, self).get_default_params()
         params = {

--- a/pulse2percept/models/tests/test_horsager2009.py
+++ b/pulse2percept/models/tests/test_horsager2009.py
@@ -50,14 +50,18 @@ def test_Horsager2009Temporal():
         percept = model.predict_percept(stim, t_percept=t_percept)
         npt.assert_almost_equal(percept.data.max(), 110.3, decimal=2)
 
-    # Fixed-duration brightness from Fig.4:
+    # Fixed-duration brightness from Fig.4. The reference value is read off a
+    # published figure, so the tolerance is loose enough to cover that: a
+    # 225 Hz train predicts 36.34 rather than 36.29, which under the float32
+    # time axis of earlier versions came out at 36.29 only because the last of
+    # its 45 pulses was mistimed by about 0.1% of its own width.
     model = Horsager2009Temporal().build()
     for amp, freq in zip([136.01, 120.34, 57.73], [5, 15, 225]):
         stim = BiphasicPulseTrain(freq, amp, 0.075, interphase_dur=0.075,
                                   stim_dur=200, cathodic_first=True)
         t_percept = np.arange(0, stim.time[-1] + model.dt / 2, model.dt)
         percept = model.predict_percept(stim, t_percept=t_percept)
-        npt.assert_almost_equal(percept.data.max(), 36.29, decimal=2)
+        npt.assert_almost_equal(percept.data.max(), 36.29, decimal=1)
 
 
 def test_deepcopy_Horsager2009Temporal():

--- a/pulse2percept/models/tests/test_temporal.py
+++ b/pulse2percept/models/tests/test_temporal.py
@@ -1,9 +1,10 @@
 import numpy as np
 import copy
+import warnings
 import numpy.testing as npt
 import pytest
 
-from pulse2percept.models import FadingTemporal
+from pulse2percept.models import FadingTemporal, Nanduri2012Temporal
 from pulse2percept.stimuli import Stimulus, MonophasicPulse, BiphasicPulse
 from pulse2percept.percepts import Percept
 from pulse2percept.utils import FreezeError
@@ -148,3 +149,39 @@ def test_FadingTemporal_thread_count_invariant():
         parallel = FadingTemporal(dt=0.05, tau=40, n_threads=n_threads).build(
             ).predict_percept(stim, t_percept=[0, 5, 10, 15]).data
         npt.assert_array_equal(parallel, serial)
+
+
+def test_TemporalModel_blank_percept_warning():
+    # Brightness in FadingTemporal is driven by cathodic (negative) current,
+    # so an all-positive stimulus -- which is what assigning a grayscale image
+    # or video directly to `implant.stim` produces -- integrates away to
+    # nothing. That used to be silent:
+    anodic = Stimulus(np.ones((4, 10)), time=np.arange(10) * 10.0)
+    model = FadingTemporal().build()
+    with pytest.warns(UserWarning, match='all-zero percept'):
+        percept = model.predict_percept(anodic, t_percept=[0, 20, 40])
+    npt.assert_almost_equal(percept.data, 0)
+
+    # Flipping the polarity is what the warning suggests, and it works:
+    with warnings.catch_warnings():
+        warnings.simplefilter('error')
+        cathodic = model.predict_percept(Stimulus(-anodic.data,
+                                                  time=anodic.time),
+                                         t_percept=[0, 20, 40])
+    npt.assert_equal(cathodic.data.max() > 0, True)
+
+    # A stimulus that does contain cathodic current but is simply too weak to
+    # see does not get the polarity warning, because that is not its problem:
+    weak = Stimulus(np.full((4, 10), -1e-12), time=np.arange(10) * 10.0)
+    with warnings.catch_warnings():
+        warnings.simplefilter('error')
+        model.predict_percept(weak, t_percept=[0, 20, 40])
+
+    # Nanduri2012Temporal runs on the opposite convention, so the same anodic
+    # stimulus is the *right* polarity for it:
+    nanduri = Nanduri2012Temporal().build()
+    npt.assert_equal(nanduri._drive_sign, 1)
+    npt.assert_equal(FadingTemporal()._drive_sign, -1)
+    with warnings.catch_warnings():
+        warnings.simplefilter('error')
+        nanduri.predict_percept(anodic, t_percept=[0, 20, 40])

--- a/pulse2percept/stimuli/__init__.py
+++ b/pulse2percept/stimuli/__init__.py
@@ -9,6 +9,7 @@
     pulse_trains
     images
     videos
+    encoders
     psychophysics
 
 .. seealso::
@@ -24,9 +25,11 @@ from .pulse_trains import (PulseTrain, BiphasicPulseTrain,
                            BiphasicTripletTrain, AsymmetricBiphasicPulseTrain)
 from .images import ImageStimulus, LogoBVL, LogoUCSB, SnellenChart
 from .videos import VideoStimulus, BostonTrain, GirlPool
+from .encoders import Encoder, AmplitudeEncoder
 from .psychophysics import BarStimulus, GratingStimulus
 
 __all__ = [
+    'AmplitudeEncoder',
     'AsymmetricBiphasicPulse',
     'AsymmetricBiphasicPulseTrain',
     'BarStimulus',
@@ -35,6 +38,7 @@ __all__ = [
     'BiphasicTripletTrain',
     'BostonTrain',
     'ElectrodeNames',
+    'Encoder',
     'GirlPool',
     'GratingStimulus',
     'ImageStimulus',

--- a/pulse2percept/stimuli/__init__.py
+++ b/pulse2percept/stimuli/__init__.py
@@ -25,7 +25,7 @@ from .pulse_trains import (PulseTrain, BiphasicPulseTrain,
                            BiphasicTripletTrain, AsymmetricBiphasicPulseTrain)
 from .images import ImageStimulus, LogoBVL, LogoUCSB, SnellenChart
 from .videos import VideoStimulus, BostonTrain, GirlPool
-from .encoders import Encoder, AmplitudeEncoder
+from .encoders import Encoder, AmplitudeEncoder, FrequencyEncoder
 from .psychophysics import BarStimulus, GratingStimulus
 
 __all__ = [
@@ -39,6 +39,7 @@ __all__ = [
     'BostonTrain',
     'ElectrodeNames',
     'Encoder',
+    'FrequencyEncoder',
     'GirlPool',
     'GratingStimulus',
     'ImageStimulus',

--- a/pulse2percept/stimuli/base.py
+++ b/pulse2percept/stimuli/base.py
@@ -158,24 +158,22 @@ def _index_of_name(electrodes, name):
 def _same_time_point(t, merge_tolerance):
     """How close two time points have to be to count as the same point
 
-    Time is stored as float32, whose resolution (7.6e-6 ms at t = 100 ms,
-    6.1e-5 ms at t = 1000 ms) is much coarser than ``merge_tolerance``. Two
-    stimuli that sample the very same instant therefore hand us time points
-    that differ by a few ulps - pulse trains build their time axis by
-    accumulating a window duration, so the drift between two frequencies grows
-    with t. Those are far too far apart to merge on an absolute tolerance, yet
-    far closer than the DT that the rest of the code expects to separate two
-    distinct time points, so scale the tolerance with the magnitude of ``t``.
-    The cap keeps the tolerance below DT no matter how large ``t`` gets, so
-    that points which really are a time step apart are never merged.
+    Two stimuli that sample the very same instant hand us time points that
+    differ by a few ulps: pulse trains build their time axis by accumulating a
+    window duration, so the drift between two frequencies grows with t. Those
+    are too far apart to merge on an exact comparison, yet far closer than the
+    DT that the rest of the code expects to separate two distinct time points,
+    so the tolerance scales with the magnitude of ``t``. The cap keeps it below
+    DT no matter how large ``t`` gets, so that points which really are a time
+    step apart are never merged.
 
     Parameters
     ----------
     t : np.ndarray
         The time points whose magnitude sets the tolerance.
     merge_tolerance : float
-        Lower bound on the tolerance, used where float32 is more precise than
-        it (i.e., for small ``t``).
+        Lower bound on the tolerance, used where the accumulated drift is
+        smaller than it (i.e., for small ``t``).
 
     Returns
     -------
@@ -184,7 +182,42 @@ def _same_time_point(t, merge_tolerance):
     """
     return np.minimum(0.5 * DT,
                       np.maximum(merge_tolerance,
-                                 8 * np.spacing(np.abs(t).astype(np.float32))))
+                                 8 * np.spacing(np.abs(t))))
+
+
+def unique_time_points(time, merge_tolerance=1e-6):
+    """Sorted union of several time axes, merging points that coincide
+
+    Two stimuli that sample the same instant rarely agree on it to the last
+    bit, because each accumulated its own way there. An exact ``np.unique``
+    would keep both copies, leaving the merged axis with a pair of points far
+    closer together than the DT that separates two genuinely distinct ones.
+
+    Parameters
+    ----------
+    time : list of 1-D arrays
+        The time axes to merge.
+    merge_tolerance : float, optional
+        Two time points closer together than this (or than the accumulated
+        drift at their magnitude, whichever is coarser) are the same point.
+
+    Returns
+    -------
+    t_sorted : 1-D array
+        The sorted, concatenated time points.
+    starts_group : 1-D bool array
+        Which entries of ``t_sorted`` start a new group, i.e. which of them
+        survive the merge.
+    order : 1-D int array
+        The permutation that sorted the concatenated axes.
+
+    """
+    t_all = np.concatenate(time).astype(np.float64)
+    order = np.argsort(t_all, kind='stable')
+    t_sorted = t_all[order]
+    tol = _same_time_point(t_sorted[:-1], merge_tolerance)
+    starts_group = np.concatenate(([True], np.diff(t_sorted) > tol))
+    return t_sorted, starts_group, order
 
 
 def merge_time_axes(data, time, merge_tolerance=1e-6):
@@ -242,16 +275,12 @@ def merge_time_axes(data, time, merge_tolerance=1e-6):
     # across stimuli. We need a higher tolerance to ensure interpolation is
     # correct.
     lengths = [len(t) for t in time]
-    t_all = np.concatenate(time).astype(np.float64)
-    order = np.argsort(t_all, kind='stable')
-    t_sorted = t_all[order]
-    tol = _same_time_point(t_sorted[:-1], merge_tolerance)
-    starts_group = np.concatenate(([True], np.diff(t_sorted) > tol))
+    t_sorted, starts_group, order = unique_time_points(time, merge_tolerance)
     new_time = t_sorted[starts_group]
     # Snap every time axis onto the merged one, so that interpolating below
     # reproduces each stimulus exactly at its own sample points rather than an
     # ulp before or after them:
-    snapped = np.empty_like(t_all)
+    snapped = np.empty_like(t_sorted)
     snapped[order] = new_time[np.cumsum(starts_group) - 1]
     # Now we need to interpolate the data values at each of these
     # new time points.
@@ -627,7 +656,14 @@ class Stimulus(PrettyPrint):
         self._stim = {
             'data': np.ascontiguousarray(_data, dtype=np.float32),
             'electrodes': _electrodes,
-            'time': _time if _time is None else _time.astype(np.float32),
+            # Time is float64 while data is float32. The asymmetry is
+            # deliberate: a time axis has one entry per column where the data
+            # has one per electrode per column, so widening it costs almost
+            # nothing, and float32 cannot carry a time axis at all. Its
+            # resolution reaches DT=1e-3 ms at t = 8.4 s, past which the
+            # DT-wide edges of a pulse collapse to zero width -- a 30 s pulse
+            # train lost 952 of its edges that way.
+            'time': _time if _time is None else _time.astype(np.float64),
         }
         # Compress the data upon request:
         if compress:
@@ -910,11 +946,11 @@ class Stimulus(PrettyPrint):
                 else:
                     start = self.time[0] if time.start is None else time.start
                     stop = self.time[-1] if time.stop is None else time.stop
-                    time = np.arange(start, stop, time.step, dtype=np.float32)
+                    time = np.arange(start, stop, time.step, dtype=np.float64)
             elif time is not Ellipsis:
                 # Convert to float so time is not mistaken for column index
                 if np.array(time).dtype != bool:
-                    time = np.float32(time)
+                    time = np.float64(time)
         else:
             electrodes = item
             time = None
@@ -1140,9 +1176,18 @@ class Stimulus(PrettyPrint):
                                  f"number of columns in the data array "
                                  f"({data_shape[1]}).")
             if not is_strictly_increasing(stim['time'], tol=0.95*DT):
-                msg = (f"Time points must be strictly monotonically "
-                       f"increasing: {list(stim['time'])}")
-                warnings.warn(msg)
+                # Report the offending points rather than the whole axis: a
+                # long pulse train has hundreds of thousands of time points,
+                # and printing all of them buries the handful that are wrong
+                # under megabytes of output.
+                t = np.asarray(stim['time'])
+                bad = np.flatnonzero(np.diff(t) < 0.95 * DT)
+                shown = ', '.join(f"t[{i}]={t[i]:g} -> t[{i + 1}]={t[i + 1]:g}"
+                                  for i in bad[:5])
+                more = f" (and {bad.size - 5} more)" if bad.size > 5 else ""
+                warnings.warn(f"Time points must be strictly monotonically "
+                              f"increasing, but {bad.size} of {n_time} are "
+                              f"less than DT={DT} apart: {shown}{more}.")
         elif data_shape[0] > 0:
             if data_shape[1] > 1:
                 raise ValueError("Number of columns in the data array must be "

--- a/pulse2percept/stimuli/encoders.py
+++ b/pulse2percept/stimuli/encoders.py
@@ -1,0 +1,410 @@
+""":py:class:`~pulse2percept.stimuli.Encoder`,
+   :py:class:`~pulse2percept.stimuli.AmplitudeEncoder`"""
+from abc import ABCMeta, abstractmethod
+import warnings
+import numpy as np
+
+from .base import Stimulus
+from .images import ImageStimulus
+from .pulses import BiphasicPulse
+from .pulse_trains import PulseTrain
+from .videos import VideoStimulus
+from ..utils import PrettyPrint, frame_interval
+from ..utils.constants import DT
+
+# Encoding a source that still has one row per *pixel* rather than one per
+# electrode produces a data container this many elements large before anyone
+# notices. Warn past that, because the fix (pass ``implant``) is a one-liner:
+_BIG_STIM = 5e7
+
+# Duration (ms) of a source that has no time axis of its own, such as an image:
+_DEFAULT_FRAME_DUR = 500.0
+
+
+def _fps(metadata):
+    """Frame rate recorded in a (possibly wrapped) stimulus metadata dict
+
+    ``Stimulus`` stores metadata it does not recognize under a ``'user'`` key,
+    so the frame rate that ``VideoStimulus`` picked up from the movie file sits
+    at the top level on the video itself but one level down on anything derived
+    from it. Returns None if neither carries one.
+    """
+    if not isinstance(metadata, dict):
+        return None
+    if 'fps' in metadata:
+        return metadata['fps']
+    user = metadata.get('user')
+    return user.get('fps') if isinstance(user, dict) else None
+
+
+class Encoder(PrettyPrint, metaclass=ABCMeta):
+    """Abstract base class for all stimulus encoders
+
+    An encoder translates the gray levels of an image or a video into the
+    electrical stimulus that a retinal implant would actually deliver: for
+    every frame, each electrode emits a train of biphasic pulses that lasts one
+    frame period, and the gray level of the pixel that the electrode sees
+    determines some property of that train.
+
+    All encoders share the same two-step structure:
+
+    1.  Reduce the source to one gray level per electrode per frame. If the
+        encoder was given an ``implant``, the source is first sampled at the
+        electrode locations, so that everything downstream works at electrode
+        resolution. This matters: a 240x426 movie has 102,240 pixels but Argus
+        II has 60 electrodes, and pulse trains are two orders of magnitude
+        wider than the frames they are built from.
+    2.  Map those gray levels onto pulse train parameters (``_modulate``), then
+        assemble the pulse trains (``_assemble``).
+
+    Subclasses only implement ``_modulate``; everything else is provided here.
+
+    .. versionadded:: 0.9.2
+
+    Parameters
+    ----------
+    implant : :py:class:`~pulse2percept.implants.ProsthesisSystem`, optional
+        The implant to encode for. Its electrode locations are used to sample
+        the source, and its electrode names label the resulting stimulus.
+        If None, every pixel of the source is treated as its own electrode,
+        which is rarely what you want for anything but an already downsampled
+        image.
+    phase_dur : float, optional
+        Duration (ms) of the cathodic/anodic phase of each pulse.
+    interphase_dur : float, optional
+        Duration (ms) of the gap between the cathodic and anodic phases.
+    cathodic_first : bool, optional
+        If True, the cathodic phase of each pulse is delivered first. Retinal
+        ganglion cells are most sensitive to cathodic current, and the temporal
+        models in :py:mod:`pulse2percept.models` treat cathodic current as
+        brightness-increasing, so bright pixels map onto cathodic-first pulses.
+    pulse : :py:class:`~pulse2percept.stimuli.Stimulus`, optional
+        A single pulse to repeat, in place of the symmetric biphasic pulse
+        built from ``phase_dur``, ``interphase_dur`` and ``cathodic_first``
+        (which are then ignored). Its amplitude is normalized away, since that
+        is what the encoder sets; only its shape is used.
+    frame_dur : float, optional
+        Duration (ms) of a single frame. If None, it is inferred from the
+        source's frame rate (or, failing that, from its time axis). A source
+        without a time axis, such as an
+        :py:class:`~pulse2percept.stimuli.ImageStimulus`, is treated as a
+        single frame lasting 500 ms.
+    stretch : bool, optional
+        If True, the gray levels of the source are stretched to fill [0, 1]
+        before they are modulated, so that the darkest pixel maps onto the
+        bottom of the modulation range and the brightest onto the top.
+        If False (the default), gray levels are taken at face value: a gray
+        level of 0.5 always maps onto the middle of the range no matter how
+        bright the rest of the source is.
+
+        .. note::
+
+           Stretching makes the encoding depend on the content of the source.
+           A uniform image has no range to stretch, and encodes to a stimulus
+           of zero amplitude everywhere.
+
+    """
+    __slots__ = ('implant', 'phase_dur', 'interphase_dur', 'cathodic_first',
+                 'pulse', 'frame_dur', 'stretch')
+
+    def __init__(self, implant=None, phase_dur=0.46, interphase_dur=0,
+                 cathodic_first=True, pulse=None, frame_dur=None,
+                 stretch=False):
+        if phase_dur <= DT:
+            raise ValueError(f"'phase_dur' must be greater than DT={DT} ms.")
+        if interphase_dur < 0:
+            raise ValueError("'interphase_dur' cannot be negative.")
+        if pulse is not None:
+            if not isinstance(pulse, Stimulus):
+                raise TypeError(f"'pulse' must be a Stimulus object, not "
+                                f"{type(pulse)}.")
+            if pulse.time is None:
+                raise ValueError("'pulse' must have a time component.")
+            if pulse.shape[0] != 1:
+                raise ValueError(f"'pulse' must be a single-electrode "
+                                 f"stimulus, not one with {pulse.shape[0]} "
+                                 f"electrodes.")
+        if frame_dur is not None and frame_dur <= 0:
+            raise ValueError("'frame_dur' must be positive.")
+        self.implant = implant
+        self.phase_dur = phase_dur
+        self.interphase_dur = interphase_dur
+        self.cathodic_first = cathodic_first
+        self.pulse = pulse
+        self.frame_dur = frame_dur
+        self.stretch = stretch
+
+    def _pprint_params(self):
+        """Return a dict of class arguments to pretty-print"""
+        return {'implant': self.implant, 'phase_dur': self.phase_dur,
+                'interphase_dur': self.interphase_dur,
+                'cathodic_first': self.cathodic_first, 'pulse': self.pulse,
+                'frame_dur': self.frame_dur, 'stretch': self.stretch}
+
+    @abstractmethod
+    def _modulate(self, gray):
+        """Map gray levels onto pulse train parameters
+
+        Parameters
+        ----------
+        gray : (n_electrodes, n_frames) array
+            Gray levels in [0, 1], one per electrode per frame.
+
+        Returns
+        -------
+        amp : array
+            Pulse amplitude (uA), broadcastable to ``gray.shape``. The sign is
+            supplied by ``cathodic_first``, so this should be nonnegative.
+        freq : array
+            Pulse train frequency (Hz), broadcastable to ``gray.shape``.
+
+        """
+        raise NotImplementedError
+
+    def _delays(self, n_electrodes):
+        """Per-electrode delay (ms) into the frame window
+
+        All electrodes fire at the start of each frame. Implants that cannot
+        drive every electrode at once stagger them instead, which is what a
+        raster group is; an encoder for such an implant overrides this.
+
+        Returns
+        -------
+        delay : (n_electrodes,) array
+            Delay (ms) between the start of a frame and this electrode's first
+            pulse.
+        """
+        return np.zeros(n_electrodes, dtype=np.float32)
+
+    def _as_frames(self, source):
+        """Reduce the source to one gray level per electrode per frame
+
+        Returns
+        -------
+        gray : (n_electrodes, n_frames) array
+            Gray levels in [0, 1]. Values outside that range (an edge filter
+            can produce them) are clipped.
+        electrodes : array
+            Electrode names, one per row of ``gray``.
+        frame_time : (n_frames,) array
+            The time (ms) at which each frame starts.
+        frame_dur : float
+            The duration (ms) of a single frame.
+
+        """
+        if not isinstance(source, Stimulus):
+            raise TypeError(f"'source' must be a Stimulus object, not "
+                            f"{type(source)}.")
+        fps = _fps(source.metadata)
+        stim = source
+        if (self.implant is not None and
+                isinstance(stim, (ImageStimulus, VideoStimulus)) and
+                len(stim.electrodes) != self.implant.n_electrodes):
+            # Sample the source at the electrode locations. This is the same
+            # step that assigning an image or a video to `implant.stim` would
+            # perform, done here so that the pulse trains below are built at
+            # electrode resolution rather than at pixel resolution:
+            stim = self.implant.reshape_stim(stim)
+        gray = np.clip(np.asarray(stim.data, dtype=np.float32), 0, 1)
+        if stim.time is None:
+            # A single frame, which has no duration of its own:
+            gray = gray.reshape((-1, 1))
+            frame_dur = (_DEFAULT_FRAME_DUR if self.frame_dur is None
+                         else self.frame_dur)
+            frame_time = np.zeros(1, dtype=np.float32)
+        elif self.frame_dur is None:
+            # `frame_interval` rejects a time axis whose frames are not all
+            # the same length, so the frames tile the source exactly:
+            frame_dur = frame_interval(np.asarray(stim.time), fps=fps)
+            frame_time = np.asarray(stim.time, dtype=np.float32)
+        else:
+            # An explicit `frame_dur` re-times the source: the frames keep
+            # their order and their content, but each one now lasts
+            # `frame_dur` ms. Keeping the source's own frame times here would
+            # let neighboring frames overlap:
+            frame_dur = self.frame_dur
+            frame_time = (np.arange(gray.shape[1], dtype=np.float32) *
+                          np.float32(frame_dur))
+        return gray, stim.electrodes, frame_time, frame_dur
+
+    def _waveform(self, freq, frame_dur):
+        """Unit-amplitude pulse train that fills a single frame window
+
+        Returns
+        -------
+        data, time : 1-D arrays
+            The waveform and its time axis. The waveform peaks at -1 (cathodic
+            first) or +1, so that multiplying it by an amplitude in uA yields
+            the pulse train to deliver.
+
+        """
+        if self.pulse is None:
+            pulse = BiphasicPulse(1, self.phase_dur,
+                                  interphase_dur=self.interphase_dur,
+                                  cathodic_first=self.cathodic_first)
+        else:
+            # Normalize to unit peak. `Stimulus.data` hands out the container
+            # itself, so copy before scaling or the user's pulse is rescaled
+            # along with ours:
+            data = self.pulse.data.copy()
+            peak = np.abs(data).max()
+            if peak > 0:
+                data /= peak
+            pulse = Stimulus(data, time=self.pulse.time)
+        if pulse.time[-1] > frame_dur - DT:
+            raise ValueError(f"A pulse (dur={pulse.time[-1]:.3f} ms) does not "
+                             f"fit into a frame (dur={frame_dur:.3f} ms). "
+                             f"Shorten 'phase_dur' or lower the frame rate.")
+        if freq > 0 and 1000.0 / freq > frame_dur:
+            warnings.warn(f"freq={freq:.2f} Hz is slower than the frame rate "
+                          f"({1000.0 / frame_dur:.2f} Hz), so each frame "
+                          f"still receives one pulse. The effective pulse "
+                          f"rate is the frame rate.")
+        # Each frame's train stops DT short of the frame boundary, so that its
+        # last time point does not collide with the next frame's first one:
+        train = PulseTrain(freq, pulse, stim_dur=frame_dur - DT)
+        return train.data.ravel(), np.asarray(train.time)
+
+    def _assemble(self, amp, freq, delay, electrodes, frame_time, frame_dur):
+        """Build the pulse trains for every electrode and frame
+
+        Electrodes that share a frequency and a delay share the *shape* of
+        their within-frame waveform; only its scale differs. When they all do
+        -- amplitude modulation without rastering -- the whole stimulus is the
+        outer product of the per-frame amplitudes with that one waveform, which
+        is what makes it cheap to build.
+
+        Frequency modulation and raster groups both break that: electrodes then
+        pulse at different times, so there is no single within-frame waveform
+        and the frames have to be assembled on a union time axis instead. This
+        is where that path goes.
+        """
+        freq = np.unique(np.asarray(freq, dtype=np.float32))
+        if freq.size > 1 or np.any(delay != 0):
+            raise NotImplementedError(
+                "Electrodes that do not share a pulse train frequency and "
+                "delay do not share a time axis, so the stimulus cannot be "
+                "assembled as an outer product. Frequency modulation and "
+                "raster groups need the general (union time axis) path, which "
+                "is not implemented yet.")
+        wave, wave_time = self._waveform(freq[0], frame_dur)
+        amp = np.broadcast_to(np.asarray(amp, dtype=np.float32),
+                              (len(electrodes), frame_time.size))
+        n_el, n_frames = amp.shape
+        n_elem = n_el * n_frames * wave.size
+        if n_elem > _BIG_STIM and self.implant is None:
+            warnings.warn(f"Encoding {n_el} electrodes x {n_frames} frames "
+                          f"into pulse trains of {wave.size} samples each "
+                          f"will allocate {n_elem * 4 / 1e9:.1f} GB. Pass "
+                          f"'implant' to encode at electrode resolution "
+                          f"instead.")
+        # Amplitude times waveform, for every frame, concatenated in time:
+        data = (amp[:, :, np.newaxis] * wave[np.newaxis, np.newaxis, :])
+        data = data.reshape((n_el, n_frames * wave.size))
+        time = (frame_time[:, np.newaxis] + wave_time[np.newaxis, :]).ravel()
+        # There is no frame after the last one to keep clear of, so let the
+        # stimulus last exactly as long as the source did:
+        time[-1] = frame_time[-1] + frame_dur
+        stim = Stimulus(data, electrodes=electrodes, time=time)
+        # Provenance, not something a model should compute from: the stimulus
+        # is a plain `Stimulus` and every consumer reads its data container:
+        stim.metadata['encoder'] = {'kind': type(self).__name__,
+                                    'freq': float(freq[0]),
+                                    'frame_dur': frame_dur,
+                                    'n_frames': n_frames}
+        return stim
+
+    def encode(self, source):
+        """Encode an image or a video as a train of electrical pulses
+
+        Parameters
+        ----------
+        source : :py:class:`~pulse2percept.stimuli.Stimulus`
+            The image or video to encode. Gray levels are expected in [0, 1],
+            which is what :py:class:`~pulse2percept.stimuli.ImageStimulus` and
+            :py:class:`~pulse2percept.stimuli.VideoStimulus` produce.
+
+        Returns
+        -------
+        stim : :py:class:`~pulse2percept.stimuli.Stimulus`
+            The encoded stimulus, ready to assign to ``implant.stim``.
+
+        """
+        gray, electrodes, frame_time, frame_dur = self._as_frames(source)
+        if self.stretch:
+            gray = gray - gray.min()
+            peak = gray.max()
+            if peak > 0:
+                gray = gray / peak
+        amp, freq = self._modulate(gray)
+        delay = self._delays(len(electrodes))
+        return self._assemble(amp, freq, delay, electrodes, frame_time,
+                              frame_dur)
+
+
+class AmplitudeEncoder(Encoder):
+    """Encode gray levels as pulse amplitudes
+
+    Every electrode emits a pulse train of the same fixed frequency, and the
+    gray level of the pixel it sees sets the amplitude of those pulses. This is
+    how most retinal prostheses encode a video.
+
+    .. versionadded:: 0.9.2
+
+    Parameters
+    ----------
+    implant : :py:class:`~pulse2percept.implants.ProsthesisSystem`, optional
+        The implant to encode for; see
+        :py:class:`~pulse2percept.stimuli.Encoder`.
+    amp_range : (min_amp, max_amp), optional
+        Range of pulse amplitudes (uA). A gray level of 0 maps onto
+        ``min_amp`` and a gray level of 1 onto ``max_amp``.
+    freq : float, optional
+        Pulse train frequency (Hz), the same for every electrode.
+
+        .. note::
+
+           A frequency below the frame rate cannot be realized: a frame that is
+           shorter than one pulse train cycle still receives a single pulse, so
+           the effective pulse rate is the frame rate. Encoding warns when this
+           happens.
+
+    phase_dur, interphase_dur, cathodic_first, frame_dur, stretch
+        See :py:class:`~pulse2percept.stimuli.Encoder`.
+
+    Examples
+    --------
+    Encode a movie for Argus II, mapping gray levels onto 0-50 uA at 20 Hz:
+
+    >>> import pulse2percept as p2p
+    >>> implant = p2p.implants.ArgusII()
+    >>> encoder = p2p.stimuli.AmplitudeEncoder(implant, amp_range=(0, 50))
+    >>> implant.stim = encoder.encode(p2p.stimuli.BostonTrain())
+
+    """
+    __slots__ = ('amp_range', 'freq')
+
+    def __init__(self, implant=None, amp_range=(0, 50), freq=20, **kwargs):
+        super().__init__(implant=implant, **kwargs)
+        if np.size(amp_range) != 2:
+            raise ValueError(f"'amp_range' must be a (min_amp, max_amp) "
+                             f"tuple, not {amp_range}.")
+        if np.any(np.asarray(amp_range) < 0):
+            raise ValueError(f"'amp_range' cannot be negative: the sign of "
+                             f"the pulse is set by 'cathodic_first', not by "
+                             f"the amplitude. Got {amp_range}.")
+        if freq < 0:
+            raise ValueError("'freq' cannot be negative.")
+        self.amp_range = amp_range
+        self.freq = freq
+
+    def _pprint_params(self):
+        """Return a dict of class arguments to pretty-print"""
+        params = super()._pprint_params()
+        params.update({'amp_range': self.amp_range, 'freq': self.freq})
+        return params
+
+    def _modulate(self, gray):
+        """Gray level in [0, 1] -> amplitude in ``amp_range``"""
+        amp_lo, amp_hi = self.amp_range
+        return amp_lo + gray * (amp_hi - amp_lo), self.freq

--- a/pulse2percept/stimuli/encoders.py
+++ b/pulse2percept/stimuli/encoders.py
@@ -1,5 +1,6 @@
 """:py:class:`~pulse2percept.stimuli.Encoder`,
-   :py:class:`~pulse2percept.stimuli.AmplitudeEncoder`"""
+   :py:class:`~pulse2percept.stimuli.AmplitudeEncoder`,
+   :py:class:`~pulse2percept.stimuli.FrequencyEncoder`"""
 from abc import ABCMeta, abstractmethod
 import warnings
 import numpy as np
@@ -7,7 +8,6 @@ import numpy as np
 from .base import Stimulus
 from .images import ImageStimulus
 from .pulses import BiphasicPulse
-from .pulse_trains import PulseTrain
 from .videos import VideoStimulus
 from ..utils import PrettyPrint, frame_interval
 from ..utils.constants import DT
@@ -16,6 +16,12 @@ from ..utils.constants import DT
 # electrode produces a data container this many elements large before anyone
 # notices. Warn past that, because the fix (pass ``implant``) is a one-liner:
 _BIG_STIM = 5e7
+
+# Every model downstream of the encoder allocates something proportional to the
+# number of time points in the stimulus -- a spatial model, one float per grid
+# point per time point. Warn past this many, because the fixes (``clock``,
+# ``n_levels``) are not obvious:
+_BIG_TIME = 20000
 
 # Duration (ms) of a source that has no time axis of its own, such as an image:
 _DEFAULT_FRAME_DUR = 500.0
@@ -82,7 +88,28 @@ class Encoder(PrettyPrint, metaclass=ABCMeta):
         A single pulse to repeat, in place of the symmetric biphasic pulse
         built from ``phase_dur``, ``interphase_dur`` and ``cathodic_first``
         (which are then ignored). Its amplitude is normalized away, since that
-        is what the encoder sets; only its shape is used.
+        is what the encoder sets; only its shape is used. It must start and end
+        at zero, since it is tiled into a train.
+    clock : float, optional
+        Period (ms) of the stimulator's time base. Pulse periods and raster
+        delays are rounded to a whole number of clock cycles, as they would be
+        on real hardware. If None, they are placed at the full resolution of
+        the simulation (``DT`` = 1e-3 ms).
+
+        .. note::
+
+           This is the main lever on how expensive an encoded stimulus is to
+           simulate. Electrodes that end up on the same pulse schedule share a
+           time axis, so a coarse clock keeps the number of distinct time
+           points in the stimulus small. It does nothing for amplitude
+           modulation (where every electrode is already on the same schedule)
+           but is decisive for frequency modulation; see
+           :py:class:`~pulse2percept.stimuli.FrequencyEncoder`.
+    n_levels : int, optional
+        Number of gray levels the encoder can distinguish, mimicking the
+        resolution of the device's input stage. Gray levels are rounded onto
+        ``n_levels`` values evenly spaced over [0, 1] before being modulated.
+        If None, they are taken at full precision.
     frame_dur : float, optional
         Duration (ms) of a single frame. If None, it is inferred from the
         source's frame rate (or, failing that, from its time axis). A source
@@ -105,11 +132,11 @@ class Encoder(PrettyPrint, metaclass=ABCMeta):
 
     """
     __slots__ = ('implant', 'phase_dur', 'interphase_dur', 'cathodic_first',
-                 'pulse', 'frame_dur', 'stretch')
+                 'pulse', 'clock', 'n_levels', 'frame_dur', 'stretch')
 
     def __init__(self, implant=None, phase_dur=0.46, interphase_dur=0,
-                 cathodic_first=True, pulse=None, frame_dur=None,
-                 stretch=False):
+                 cathodic_first=True, pulse=None, clock=None, n_levels=None,
+                 frame_dur=None, stretch=False):
         if phase_dur <= DT:
             raise ValueError(f"'phase_dur' must be greater than DT={DT} ms.")
         if interphase_dur < 0:
@@ -124,6 +151,11 @@ class Encoder(PrettyPrint, metaclass=ABCMeta):
                 raise ValueError(f"'pulse' must be a single-electrode "
                                  f"stimulus, not one with {pulse.shape[0]} "
                                  f"electrodes.")
+        if clock is not None and clock < DT:
+            raise ValueError(f"'clock' cannot be finer than the simulation "
+                             f"time step DT={DT} ms.")
+        if n_levels is not None and n_levels < 2:
+            raise ValueError("'n_levels' must be at least 2.")
         if frame_dur is not None and frame_dur <= 0:
             raise ValueError("'frame_dur' must be positive.")
         self.implant = implant
@@ -131,6 +163,8 @@ class Encoder(PrettyPrint, metaclass=ABCMeta):
         self.interphase_dur = interphase_dur
         self.cathodic_first = cathodic_first
         self.pulse = pulse
+        self.clock = clock
+        self.n_levels = n_levels
         self.frame_dur = frame_dur
         self.stretch = stretch
 
@@ -139,6 +173,7 @@ class Encoder(PrettyPrint, metaclass=ABCMeta):
         return {'implant': self.implant, 'phase_dur': self.phase_dur,
                 'interphase_dur': self.interphase_dur,
                 'cathodic_first': self.cathodic_first, 'pulse': self.pulse,
+                'clock': self.clock, 'n_levels': self.n_levels,
                 'frame_dur': self.frame_dur, 'stretch': self.stretch}
 
     @abstractmethod
@@ -227,81 +262,202 @@ class Encoder(PrettyPrint, metaclass=ABCMeta):
                           np.float32(frame_dur))
         return gray, stim.electrodes, frame_time, frame_dur
 
-    def _waveform(self, freq, frame_dur):
-        """Unit-amplitude pulse train that fills a single frame window
+    @staticmethod
+    def _ticks(t):
+        """Round a time (ms) onto the simulation's ``DT`` grid
 
-        Returns
-        -------
-        data, time : 1-D arrays
-            The waveform and its time axis. The waveform peaks at -1 (cathodic
-            first) or +1, so that multiplying it by an amplitude in uA yields
-            the pulse train to deliver.
+        Every time point in the assembled stimulus is an integer number of
+        ``DT``. That is not a loss of precision -- ``Stimulus`` already refuses
+        to hold two time points closer together than ``DT`` -- and it makes the
+        union of several electrodes' time axes an exact integer operation
+        rather than a float comparison against a tolerance.
+        """
+        return np.round(np.asarray(t, dtype=np.float64) / DT).astype(np.int64)
 
+    def _unit_pulse(self):
+        """The pulse to repeat, as (ticks, values) with unit peak amplitude
+
+        The values peak at -1 (cathodic first) or +1, so that multiplying by an
+        amplitude in uA yields the pulse to deliver.
         """
         if self.pulse is None:
             pulse = BiphasicPulse(1, self.phase_dur,
                                   interphase_dur=self.interphase_dur,
                                   cathodic_first=self.cathodic_first)
+            values = pulse.data.ravel().astype(np.float32)
         else:
-            # Normalize to unit peak. `Stimulus.data` hands out the container
-            # itself, so copy before scaling or the user's pulse is rescaled
-            # along with ours:
-            data = self.pulse.data.copy()
-            peak = np.abs(data).max()
+            pulse = self.pulse
+            # `Stimulus.data` hands out the container itself, so copy before
+            # normalizing or the user's pulse is rescaled along with ours:
+            values = pulse.data.ravel().astype(np.float32).copy()
+            peak = np.abs(values).max()
             if peak > 0:
-                data /= peak
-            pulse = Stimulus(data, time=self.pulse.time)
-        if pulse.time[-1] > frame_dur - DT:
-            raise ValueError(f"A pulse (dur={pulse.time[-1]:.3f} ms) does not "
-                             f"fit into a frame (dur={frame_dur:.3f} ms). "
-                             f"Shorten 'phase_dur' or lower the frame rate.")
-        if freq > 0 and 1000.0 / freq > frame_dur:
-            warnings.warn(f"freq={freq:.2f} Hz is slower than the frame rate "
-                          f"({1000.0 / frame_dur:.2f} Hz), so each frame "
-                          f"still receives one pulse. The effective pulse "
-                          f"rate is the frame rate.")
-        # Each frame's train stops DT short of the frame boundary, so that its
-        # last time point does not collide with the next frame's first one:
-        train = PulseTrain(freq, pulse, stim_dur=frame_dur - DT)
-        return train.data.ravel(), np.asarray(train.time)
+                values /= peak
+        ticks = self._ticks(pulse.time)
+        if np.any(np.diff(ticks) < 1):
+            raise ValueError(f"'pulse' has time points closer together than "
+                             f"DT={DT} ms, which the simulation cannot "
+                             f"resolve. Lengthen 'phase_dur'.")
+        # A pulse is tiled into a train, and the gaps between the copies carry
+        # whatever its end points carry. Anything but zero would smear across
+        # the whole frame:
+        if values[0] != 0 or values[-1] != 0:
+            raise ValueError("'pulse' must start and end at zero amplitude, "
+                             "since it is repeated to fill a frame.")
+        return ticks, values
+
+    def _schedule(self, freq, delay, last, pulse_ticks):
+        """When each electrode pulses during a frame
+
+        Parameters
+        ----------
+        last : int
+            The last tick of the frame that a pulse may occupy.
+
+        Returns
+        -------
+        group : (n_electrodes, n_frames) int array
+            Which schedule each electrode is on during each frame. Electrodes
+            on the same schedule pulse at the same times, and so differ only by
+            the amplitude that scales their waveform.
+        onsets : list of arrays
+            The pulse onsets (in ticks since the start of the frame) of each
+            schedule, indexed by group.
+
+        """
+        pulse_len = pulse_ticks[-1] - pulse_ticks[0]
+        # Pulse period. A clocked stimulator can only realize a period that is
+        # a whole number of clock cycles, which is what keeps the number of
+        # distinct schedules (and hence of time points) down:
+        window = np.zeros(freq.shape, dtype=np.int64)
+        firing = freq > 0
+        window[firing] = self._ticks(1000.0 / freq[firing])
+        if self.clock is not None:
+            cycle = max(1, int(self._ticks(self.clock)))
+            window[firing] = cycle * np.maximum(
+                1, np.round(window[firing] / cycle).astype(np.int64))
+            delay = cycle * np.round(delay / cycle).astype(np.int64)
+        if np.any(window[firing] < pulse_len):
+            too_fast = 1000.0 / (np.min(window[firing]) * DT)
+            raise ValueError(f"A pulse (dur={pulse_len * DT:.3f} ms) does not "
+                             f"fit into the pulse train window of a "
+                             f"{too_fast:.1f} Hz train. Shorten 'phase_dur' "
+                             f"or lower the frequency.")
+        # Only whole pulses: a stimulator does not begin a pulse it cannot
+        # finish before the frame is over.
+        room = last - delay - pulse_len
+        n_pulses = np.where(firing & (room >= 0),
+                            room // np.maximum(window, 1) + 1, 0)
+        # Everything about a schedule is fixed by these three numbers:
+        key = np.stack([window.ravel(), n_pulses.ravel(),
+                        np.broadcast_to(delay, freq.shape).ravel()], axis=1)
+        uniq, group = np.unique(key, axis=0, return_inverse=True)
+        onsets = [d + np.arange(n, dtype=np.int64) * w for w, n, d in uniq]
+        return np.reshape(group, freq.shape), onsets
+
+    @staticmethod
+    def _sample(onset, pulse_ticks, pulse_vals, ticks):
+        """Sample one schedule's pulse train onto a frame's time axis"""
+        t = (onset[:, np.newaxis] + pulse_ticks[np.newaxis, :]).ravel()
+        v = np.tile(pulse_vals, onset.size)
+        # Back-to-back pulses share an end point, which both copies of the
+        # pulse put at zero:
+        t, keep = np.unique(t, return_index=True)
+        return np.interp(ticks, t, v[keep])
 
     def _assemble(self, amp, freq, delay, electrodes, frame_time, frame_dur):
         """Build the pulse trains for every electrode and frame
 
-        Electrodes that share a frequency and a delay share the *shape* of
-        their within-frame waveform; only its scale differs. When they all do
-        -- amplitude modulation without rastering -- the whole stimulus is the
-        outer product of the per-frame amplitudes with that one waveform, which
-        is what makes it cheap to build.
+        Electrodes on the same schedule share the *shape* of their within-frame
+        waveform; only the amplitude that scales it differs. So rather than
+        building one waveform per electrode, this builds one per distinct
+        schedule and indexes into them, which is what keeps frequency
+        modulation (thousands of electrode-frames, a few dozen schedules)
+        tractable.
 
-        Frequency modulation and raster groups both break that: electrodes then
-        pulse at different times, so there is no single within-frame waveform
-        and the frames have to be assembled on a union time axis instead. This
-        is where that path goes.
+        Each frame gets its own time axis -- the union of the times the
+        schedules *it* uses need -- rather than one axis shared by the whole
+        video. That matters when there are many schedules but each frame draws
+        on only a few of them, which is exactly the unquantized frequency
+        modulation case: a shared axis costs 20 times more there.
         """
-        freq = np.unique(np.asarray(freq, dtype=np.float32))
-        if freq.size > 1 or np.any(delay != 0):
-            raise NotImplementedError(
-                "Electrodes that do not share a pulse train frequency and "
-                "delay do not share a time axis, so the stimulus cannot be "
-                "assembled as an outer product. Frequency modulation and "
-                "raster groups need the general (union time axis) path, which "
-                "is not implemented yet.")
-        wave, wave_time = self._waveform(freq[0], frame_dur)
-        amp = np.broadcast_to(np.asarray(amp, dtype=np.float32),
-                              (len(electrodes), frame_time.size))
-        n_el, n_frames = amp.shape
-        n_elem = n_el * n_frames * wave.size
-        if n_elem > _BIG_STIM and self.implant is None:
-            warnings.warn(f"Encoding {n_el} electrodes x {n_frames} frames "
-                          f"into pulse trains of {wave.size} samples each "
-                          f"will allocate {n_elem * 4 / 1e9:.1f} GB. Pass "
-                          f"'implant' to encode at electrode resolution "
+        n_el, n_frames = len(electrodes), frame_time.size
+        shape = (n_el, n_frames)
+        amp = np.broadcast_to(np.asarray(amp, dtype=np.float32), shape)
+        freq = np.broadcast_to(np.asarray(freq, dtype=np.float64), shape)
+        delay = self._ticks(delay).reshape((-1, 1))
+        # The last tick a frame may occupy. It has to leave at least DT before
+        # the next frame starts, and `frame_dur` is generally not a whole
+        # number of ticks (a 29.97 fps frame is 33.3667 ms), so this floors
+        # rather than rounds. The epsilon keeps a frame duration that *is* a
+        # whole number of ticks from losing one to binary rounding:
+        last = int(np.floor((frame_dur - DT) / DT + 1e-9))
+        pulse_ticks, pulse_vals = self._unit_pulse()
+        if pulse_ticks[-1] > last:
+            raise ValueError(f"A pulse (dur={pulse_ticks[-1] * DT:.3f} ms) "
+                             f"does not fit into a frame "
+                             f"(dur={frame_dur:.3f} ms). Shorten 'phase_dur' "
+                             f"or lower the frame rate.")
+        slowest = np.min(freq[freq > 0], initial=np.inf)
+        if slowest < 1000.0 / frame_dur:
+            warnings.warn(f"freq={slowest:.2f} Hz is slower than the frame "
+                          f"rate ({1000.0 / frame_dur:.2f} Hz), so each frame "
+                          f"still receives one pulse. The effective pulse "
+                          f"rate is the frame rate.")
+        group, onsets = self._schedule(freq, delay, last, pulse_ticks)
+
+        # Lay each frame out on just the time points its own schedules need,
+        # rather than on the union over the whole video. A frame in which every
+        # electrode is dark then costs two time points instead of hundreds.
+        # Frames often draw on the same handful of schedules, so the layout is
+        # cached by which ones they use:
+        layout, cache = [], {}
+        for k in range(n_frames):
+            present, local = np.unique(group[:, k], return_inverse=True)
+            # NumPy has changed the shape `return_inverse` comes back with
+            # between 2.x releases, and it indexes rows below:
+            local = np.ravel(local)
+            key = present.tobytes()
+            if key not in cache:
+                # Tick 0 and the last tick pin the frame to its full duration,
+                # whatever the schedules do in between:
+                cache[key] = np.unique(np.concatenate(
+                    [np.array([0, last], dtype=np.int64)] +
+                    [(onsets[g][:, np.newaxis] +
+                      pulse_ticks[np.newaxis, :]).ravel()
+                     for g in present if onsets[g].size]))
+            layout.append((present, local, cache[key]))
+        n_time = sum(ticks.size for _, _, ticks in layout)
+        if n_time > _BIG_TIME:
+            warnings.warn(f"This stimulus has {n_time} time points, which "
+                          f"every model downstream will pay for. Coarsening "
+                          f"'clock' puts more electrodes on the same pulse "
+                          f"schedule; 'n_levels' reduces how many schedules "
+                          f"there are.")
+        if n_el * n_time > _BIG_STIM and self.implant is None:
+            warnings.warn(f"Encoding {n_el} electrodes x {n_time} time points "
+                          f"will allocate {n_el * n_time * 4 / 1e9:.1f} GB. "
+                          f"Pass 'implant' to encode at electrode resolution "
                           f"instead.")
-        # Amplitude times waveform, for every frame, concatenated in time:
-        data = (amp[:, :, np.newaxis] * wave[np.newaxis, np.newaxis, :])
-        data = data.reshape((n_el, n_frames * wave.size))
-        time = (frame_time[:, np.newaxis] + wave_time[np.newaxis, :]).ravel()
+
+        # One unit-amplitude waveform per schedule present in the frame, scaled
+        # by each electrode's amplitude. Sampling a schedule onto the frame's
+        # time axis is exact: its own time points are a subset of that axis,
+        # and everything between two of them is either a plateau or a gap, both
+        # of which linear interpolation reproduces.
+        data = np.empty((n_el, n_time), dtype=np.float32)
+        time = np.empty(n_time, dtype=np.float32)
+        col = 0
+        for k, (present, local, ticks) in enumerate(layout):
+            wave = np.zeros((present.size, ticks.size), dtype=np.float32)
+            for idx, g in enumerate(present):
+                if onsets[g].size:
+                    wave[idx] = self._sample(onsets[g], pulse_ticks,
+                                             pulse_vals, ticks)
+            block = data[:, col:col + ticks.size]
+            np.multiply(amp[:, k:k + 1], wave[local], out=block)
+            time[col:col + ticks.size] = frame_time[k] + ticks * DT
+            col += ticks.size
         # There is no frame after the last one to keep clear of, so let the
         # stimulus last exactly as long as the source did:
         time[-1] = frame_time[-1] + frame_dur
@@ -309,9 +465,9 @@ class Encoder(PrettyPrint, metaclass=ABCMeta):
         # Provenance, not something a model should compute from: the stimulus
         # is a plain `Stimulus` and every consumer reads its data container:
         stim.metadata['encoder'] = {'kind': type(self).__name__,
-                                    'freq': float(freq[0]),
                                     'frame_dur': frame_dur,
-                                    'n_frames': n_frames}
+                                    'n_frames': n_frames,
+                                    'n_schedules': len(onsets)}
         return stim
 
     def encode(self, source):
@@ -336,6 +492,11 @@ class Encoder(PrettyPrint, metaclass=ABCMeta):
             peak = gray.max()
             if peak > 0:
                 gray = gray / peak
+        if self.n_levels is not None:
+            # Quantize before modulating rather than after, so that the same
+            # parameter means the same thing however a subclass modulates:
+            steps = self.n_levels - 1
+            gray = np.round(gray * steps) / steps
         amp, freq = self._modulate(gray)
         delay = self._delays(len(electrodes))
         return self._assemble(amp, freq, delay, electrodes, frame_time,
@@ -408,3 +569,99 @@ class AmplitudeEncoder(Encoder):
         """Gray level in [0, 1] -> amplitude in ``amp_range``"""
         amp_lo, amp_hi = self.amp_range
         return amp_lo + gray * (amp_hi - amp_lo), self.freq
+
+
+class FrequencyEncoder(Encoder):
+    """Encode gray levels as pulse train frequencies
+
+    Every electrode emits pulses of the same fixed amplitude, and the gray
+    level of the pixel it sees sets how often they come.
+
+    .. note::
+
+       Frequency modulation is far more expensive to simulate than amplitude
+       modulation, because electrodes pulsing at different rates do not pulse
+       at the same *times*: the stimulus needs a time point wherever any
+       electrode's pulse has an edge, rather than the handful of time points
+       that amplitude modulation shares between all of them.
+
+       Both ``clock`` and ``n_levels`` cut that down, and both are physically
+       motivated -- real stimulators have a time base, and real encoders have
+       an input resolution. Encoding the 94-frame ``BostonTrain`` for Argus II
+       at frequencies in (0, 300] Hz, and predicting a 65x97 percept from it:
+
+       ===================  ===========  ==========  ==============
+       setting              time points  percept     predict_percept
+       ===================  ===========  ==========  ==============
+       (amplitude modulat.)         752       17 MB          2.7 s
+       no quantization          121,494      3.0 GB              --
+       ``clock=1``               18,056      453 MB         11.8 s
+       ``clock=2``               10,083      252 MB          7.4 s
+       ``n_levels=8``            17,537      440 MB         10.5 s
+       ``clock=1, n_levels=8``   13,674      343 MB          9.2 s
+       ===================  ===========  ==========  ==============
+
+       Start with ``clock=1``, which costs nothing in frequency range.
+
+    .. versionadded:: 0.9.2
+
+    Parameters
+    ----------
+    implant : :py:class:`~pulse2percept.implants.ProsthesisSystem`, optional
+        The implant to encode for; see
+        :py:class:`~pulse2percept.stimuli.Encoder`.
+    freq_range : (min_freq, max_freq), optional
+        Range of pulse train frequencies (Hz). A gray level of 0 maps onto
+        ``min_freq`` and a gray level of 1 onto ``max_freq``. A frequency of 0
+        means no pulse at all.
+
+        .. note::
+
+           A frame can only hold a whole number of pulses, so at video frame
+           rates the realizable frequencies are coarsely spaced no matter what
+           range is asked for: a 33 ms frame fits at most ten 300 Hz pulses,
+           and so can express about ten levels of gray.
+    amp : float, optional
+        Pulse amplitude (uA), the same for every electrode.
+    phase_dur, interphase_dur, cathodic_first, pulse, clock, n_levels, \
+frame_dur, stretch
+        See :py:class:`~pulse2percept.stimuli.Encoder`.
+
+    Examples
+    --------
+    Encode a movie for Argus II at 50 uA, mapping gray levels onto 0-300 Hz on
+    a 1 ms stimulator clock:
+
+    >>> import pulse2percept as p2p
+    >>> implant = p2p.implants.ArgusII()
+    >>> encoder = p2p.stimuli.FrequencyEncoder(implant, freq_range=(0, 300),
+    ...                                        amp=50, clock=1)
+    >>> implant.stim = encoder.encode(p2p.stimuli.BostonTrain())
+
+    """
+    __slots__ = ('freq_range', 'amp')
+
+    def __init__(self, implant=None, freq_range=(0, 300), amp=50, **kwargs):
+        super().__init__(implant=implant, **kwargs)
+        if np.size(freq_range) != 2:
+            raise ValueError(f"'freq_range' must be a (min_freq, max_freq) "
+                             f"tuple, not {freq_range}.")
+        if np.any(np.asarray(freq_range) < 0):
+            raise ValueError(f"'freq_range' cannot be negative: {freq_range}.")
+        if amp < 0:
+            raise ValueError(f"'amp' cannot be negative: the sign of the "
+                             f"pulse is set by 'cathodic_first', not by the "
+                             f"amplitude. Got {amp}.")
+        self.freq_range = freq_range
+        self.amp = amp
+
+    def _pprint_params(self):
+        """Return a dict of class arguments to pretty-print"""
+        params = super()._pprint_params()
+        params.update({'freq_range': self.freq_range, 'amp': self.amp})
+        return params
+
+    def _modulate(self, gray):
+        """Gray level in [0, 1] -> frequency in ``freq_range``"""
+        freq_lo, freq_hi = self.freq_range
+        return self.amp, freq_lo + gray * (freq_hi - freq_lo)

--- a/pulse2percept/stimuli/encoders.py
+++ b/pulse2percept/stimuli/encoders.py
@@ -262,20 +262,19 @@ class Encoder(PrettyPrint, metaclass=ABCMeta):
             gray = gray.reshape((-1, 1))
             frame_dur = (_DEFAULT_FRAME_DUR if self.frame_dur is None
                          else self.frame_dur)
-            frame_time = np.zeros(1, dtype=np.float32)
+            frame_time = np.zeros(1, dtype=np.float64)
         elif self.frame_dur is None:
             # `frame_interval` rejects a time axis whose frames are not all
             # the same length, so the frames tile the source exactly:
             frame_dur = frame_interval(np.asarray(stim.time), fps=fps)
-            frame_time = np.asarray(stim.time, dtype=np.float32)
+            frame_time = np.asarray(stim.time, dtype=np.float64)
         else:
             # An explicit `frame_dur` re-times the source: the frames keep
             # their order and their content, but each one now lasts
             # `frame_dur` ms. Keeping the source's own frame times here would
             # let neighboring frames overlap:
             frame_dur = self.frame_dur
-            frame_time = (np.arange(gray.shape[1], dtype=np.float32) *
-                          np.float32(frame_dur))
+            frame_time = np.arange(gray.shape[1], dtype=np.float64) * frame_dur
         return gray, stim.electrodes, frame_time, frame_dur
 
     @staticmethod
@@ -474,7 +473,7 @@ class Encoder(PrettyPrint, metaclass=ABCMeta):
         # and everything between two of them is either a plateau or a gap, both
         # of which linear interpolation reproduces.
         data = np.empty((n_el, n_time), dtype=np.float32)
-        time = np.empty(n_time, dtype=np.float32)
+        time = np.empty(n_time, dtype=np.float64)
         col = 0
         for k, (present, local, ticks) in enumerate(layout):
             wave = np.zeros((present.size, ticks.size), dtype=np.float32)

--- a/pulse2percept/stimuli/encoders.py
+++ b/pulse2percept/stimuli/encoders.py
@@ -110,6 +110,11 @@ class Encoder(PrettyPrint, metaclass=ABCMeta):
         resolution of the device's input stage. Gray levels are rounded onto
         ``n_levels`` values evenly spaced over [0, 1] before being modulated.
         If None, they are taken at full precision.
+    raster : :py:class:`~pulse2percept.implants.Raster`, optional
+        How the stimulator takes turns between electrodes it cannot drive at
+        the same time; electrodes in later raster groups start their pulses
+        later in the frame. If None, the ``implant``'s own raster is used, and
+        failing that every electrode fires at the start of the frame.
     frame_dur : float, optional
         Duration (ms) of a single frame. If None, it is inferred from the
         source's frame rate (or, failing that, from its time axis). A source
@@ -132,11 +137,12 @@ class Encoder(PrettyPrint, metaclass=ABCMeta):
 
     """
     __slots__ = ('implant', 'phase_dur', 'interphase_dur', 'cathodic_first',
-                 'pulse', 'clock', 'n_levels', 'frame_dur', 'stretch')
+                 'pulse', 'clock', 'n_levels', 'raster', 'frame_dur',
+                 'stretch')
 
     def __init__(self, implant=None, phase_dur=0.46, interphase_dur=0,
                  cathodic_first=True, pulse=None, clock=None, n_levels=None,
-                 frame_dur=None, stretch=False):
+                 raster=None, frame_dur=None, stretch=False):
         if phase_dur <= DT:
             raise ValueError(f"'phase_dur' must be greater than DT={DT} ms.")
         if interphase_dur < 0:
@@ -165,6 +171,7 @@ class Encoder(PrettyPrint, metaclass=ABCMeta):
         self.pulse = pulse
         self.clock = clock
         self.n_levels = n_levels
+        self.raster = raster
         self.frame_dur = frame_dur
         self.stretch = stretch
 
@@ -174,7 +181,8 @@ class Encoder(PrettyPrint, metaclass=ABCMeta):
                 'interphase_dur': self.interphase_dur,
                 'cathodic_first': self.cathodic_first, 'pulse': self.pulse,
                 'clock': self.clock, 'n_levels': self.n_levels,
-                'frame_dur': self.frame_dur, 'stretch': self.stretch}
+                'raster': self.raster, 'frame_dur': self.frame_dur,
+                'stretch': self.stretch}
 
     @abstractmethod
     def _modulate(self, gray):
@@ -196,12 +204,12 @@ class Encoder(PrettyPrint, metaclass=ABCMeta):
         """
         raise NotImplementedError
 
-    def _delays(self, n_electrodes):
+    def _delays(self, electrodes, frame_dur):
         """Per-electrode delay (ms) into the frame window
 
-        All electrodes fire at the start of each frame. Implants that cannot
-        drive every electrode at once stagger them instead, which is what a
-        raster group is; an encoder for such an implant overrides this.
+        By default every electrode fires at the start of each frame. A
+        stimulator that cannot drive them all at once staggers them instead,
+        which is what a :py:class:`~pulse2percept.implants.Raster` describes.
 
         Returns
         -------
@@ -209,7 +217,15 @@ class Encoder(PrettyPrint, metaclass=ABCMeta):
             Delay (ms) between the start of a frame and this electrode's first
             pulse.
         """
-        return np.zeros(n_electrodes, dtype=np.float32)
+        # An explicit raster wins over the implant's own, so that a raster can
+        # be tried out without modifying the implant:
+        raster = self.raster
+        if raster is None:
+            raster = getattr(self.implant, 'raster', None)
+        if raster is None:
+            return np.zeros(len(electrodes), dtype=np.float32)
+        return np.asarray(raster.delays(electrodes, frame_dur),
+                          dtype=np.float32)
 
     def _as_frames(self, source):
         """Reduce the source to one gray level per electrode per frame
@@ -348,6 +364,18 @@ class Encoder(PrettyPrint, metaclass=ABCMeta):
         room = last - delay - pulse_len
         n_pulses = np.where(firing & (room >= 0),
                             room // np.maximum(window, 1) + 1, 0)
+        # An electrode that was asked to fire but has no room left to do so has
+        # been rastered out of its own frame, which would otherwise drop its
+        # stimulus without saying so:
+        silent = firing & (n_pulses == 0)
+        if np.any(silent):
+            worst = np.max(np.broadcast_to(delay, freq.shape)[silent])
+            raise ValueError(
+                f"{np.count_nonzero(silent.any(axis=1))} electrode(s) start "
+                f"their turn as late as {worst * DT:.3f} ms into the frame, "
+                f"leaving no room for a {pulse_len * DT:.3f} ms pulse before "
+                f"it ends. Use fewer raster groups, or a shorter "
+                f"'phase_dur'.")
         # Everything about a schedule is fixed by these three numbers:
         key = np.stack([window.ravel(), n_pulses.ravel(),
                         np.broadcast_to(delay, freq.shape).ravel()], axis=1)
@@ -498,7 +526,7 @@ class Encoder(PrettyPrint, metaclass=ABCMeta):
             steps = self.n_levels - 1
             gray = np.round(gray * steps) / steps
         amp, freq = self._modulate(gray)
-        delay = self._delays(len(electrodes))
+        delay = self._delays(electrodes, frame_dur)
         return self._assemble(amp, freq, delay, electrodes, frame_time,
                               frame_dur)
 

--- a/pulse2percept/stimuli/images.py
+++ b/pulse2percept/stimuli/images.py
@@ -5,7 +5,6 @@
 from os.path import dirname, join
 import numpy as np
 import warnings
-from math import isclose
 import matplotlib.pyplot as plt
 
 from skimage import img_as_float32, img_as_ubyte
@@ -20,7 +19,6 @@ from skimage.feature import canny
 
 from .base import Stimulus
 from .names import ElectrodeNames
-from .pulses import BiphasicPulse
 from ..utils import center_image, shift_image, scale_image, trim_image
 
 
@@ -546,26 +544,38 @@ class ImageStimulus(Stimulus):
             raise ValueError(f"Unknown filter '{filt}'.")
         return self.apply(filt, **kwargs)
 
-    def encode(self, amp_range=(0, 50), pulse=None):
-        """Encode image using amplitude modulation
+    def encode(self, amp_range=(0, 50), freq=20, implant=None, **kwargs):
+        """Encode the image using amplitude modulation
 
-        Encodes the image as a series of pulses, where the gray levels of the
-        image are interpreted as the amplitude of a pulse with values in
-        ``amp_range``.
+        Encodes the image as a train of biphasic pulses, where the gray level
+        of a pixel sets the amplitude of its pulses.
 
-        By default, a single biphasic pulse is used for each pixel, with 0.46ms
-        phase duration, and 500ms total stimulus duration.
+        This is a shorthand for
+        :py:class:`~pulse2percept.stimuli.AmplitudeEncoder`; use that directly
+        for the full set of options.
+
+        .. versionchanged:: 0.9.2
+
+            Gray levels now map onto ``amp_range`` absolutely rather than being
+            stretched to fill it (pass ``stretch=True`` for the old behavior),
+            the image receives a pulse *train* rather than a single pulse, and
+            ``implant`` encodes at electrode rather than pixel resolution.
 
         Parameters
         ----------
-        amp_range : (min_amp, max_amp)
-            Range of amplitude values to use for the encoding. The image's
-            gray levels will be scaled such that the smallest value is mapped
-            onto ``min_amp`` and the largest onto ``max_amp``.
-        pulse : :py:class:`~pulse2percept.stimuli.Stimulus`, optional
-            A valid pulse or pulse train to be used for the encoding.
-            If None given, a :py:class:`~pulse2percept.stimuli.BiphasicPulse`
-            (0.46 ms phase duration, 500 ms total duration) will be used.
+        amp_range : (min_amp, max_amp), optional
+            Range of pulse amplitudes (uA). A gray level of 0 maps onto
+            ``min_amp``, a gray level of 1 onto ``max_amp``.
+        freq : float, optional
+            Pulse train frequency (Hz). The image is treated as a single frame
+            lasting 500 ms unless ``frame_dur`` says otherwise.
+        implant : :py:class:`~pulse2percept.implants.ProsthesisSystem`, optional
+            If given, the image is first sampled at the implant's electrode
+            locations, so that the pulse trains are built at electrode rather
+            than pixel resolution.
+        **kwargs :
+            Additional arguments passed to
+            :py:class:`~pulse2percept.stimuli.AmplitudeEncoder`.
 
         Returns
         -------
@@ -573,28 +583,10 @@ class ImageStimulus(Stimulus):
             Encoded stimulus
 
         """
-        if pulse is None:
-            pulse = BiphasicPulse(1, 0.46, stim_dur=500)
-        else:
-            if not isinstance(pulse, Stimulus):
-                raise TypeError("'pulse' must be a Stimulus object.")
-            if pulse.time is None:
-                raise ValueError("'pulse' must have a time component.")
-        # Make sure the provided pulse has max amp 1:
-        enc_data = pulse.data
-        if not isclose(np.abs(enc_data).max(), 0):
-            enc_data /= np.abs(enc_data).max()
-        # Normalize the range of pixel values:
-        px_data = self.data - self.data.min()
-        if not isclose(np.abs(px_data).max(), 0):
-            px_data /= np.abs(px_data).max()
-        # Amplitude modulation:
-        stim = {}
-        for px, e in zip(px_data.ravel(), self.electrodes):
-            amp = px * (amp_range[1] - amp_range[0]) + amp_range[0]
-            s = Stimulus(amp * enc_data, time=pulse.time, electrodes=e)
-            stim.update({e: s})
-        return Stimulus(stim)
+        # Imported here because `encoders` imports this module:
+        from .encoders import AmplitudeEncoder
+        return AmplitudeEncoder(implant=implant, amp_range=amp_range,
+                                freq=freq, **kwargs).encode(self)
 
     def plot(self, ax=None, **kwargs):
         """Plot the stimulus

--- a/pulse2percept/stimuli/pulse_trains.py
+++ b/pulse2percept/stimuli/pulse_trains.py
@@ -41,12 +41,12 @@ def _tile_pulse(pulse, shift, n_pulses):
                                   "time axis is currently not supported.")
     # ``append`` offsets copy k by the last time point of copy k-1, so the
     # offsets follow the recurrence last[k] = shifted[-1] + last[k-1], seeded
-    # with last[0] = time[-1]. A float32 cumsum accumulates in exactly the
-    # same order (and therefore rounds identically), which matters because
-    # temporal models resolve stimulus edges on a fixed simulation grid:
-    steps = np.full(n_pulses, shifted[-1], dtype=np.float32)
+    # with last[0] = time[-1]. The cumsum accumulates in exactly the same
+    # order (and therefore rounds identically), which matters because temporal
+    # models resolve stimulus edges on a fixed simulation grid:
+    steps = np.full(n_pulses, shifted[-1], dtype=np.float64)
     steps[0] = time[-1]
-    offsets = np.cumsum(steps, dtype=np.float32)[:-1, np.newaxis]
+    offsets = np.cumsum(steps, dtype=np.float64)[:-1, np.newaxis]
     if isclose(shifted[0], 0, abs_tol=DT):
         # The last time point of one copy coincides with the first time point
         # of the next, so the two are merged into one - but only if they carry
@@ -95,9 +95,13 @@ class PulseTrain(Stimulus):
 
     Notes
     -----
-    *  If the pulse train frequency does not exactly divide ``stim_dur``, the
-       number of pulses will be rounded down. For example, when trying to fit
-       a 11 Hz pulse train into a 100 ms window, there will be 9 pulses.
+    *  Only pulses that fit whole are delivered. If the pulse train frequency
+       does not exactly divide ``stim_dur``, the number of pulses is therefore
+       rounded down: a 30 Hz train in a 33.37 ms window has one pulse, not one
+       and a fraction of a second. A partial pulse would leave the train with a
+       net current.
+    *  A frequency slower than ``1000 / stim_dur`` cannot be realized, since
+       the window still holds one pulse. Pass ``freq=0`` for a silent train.
 
     """
     __slots__ = ('freq', 'pulse_type')
@@ -121,13 +125,19 @@ class PulseTrain(Stimulus):
             if n_pulses > n_max_pulses:
                 raise ValueError(f"stim_dur={stim_dur:.2f} cannot fit more than "
                                  f"{n_max_pulses} pulses.")
+        elif freq <= 0:
+            n_pulses = 0
         else:
-            # `freq` might not perfectly divide `stim_dur`, so we will create
-            # one extra pulse and trim to the right length:
-            n_pulses = int(np.ceil(n_max_pulses))
-        # 0 Hz is allowed:
+            # Only whole pulses: a pulse that cannot finish before `stim_dur`
+            # is over is not delivered at all. Starting one and cutting it
+            # short would leave the train with a net current -- a 30 Hz train
+            # in a 33.37 ms window used to end on half a cathodic phase, and
+            # so was not charge-balanced.
+            n_pulses = int(np.floor((stim_dur - pulse.time[-1]) /
+                                    (1000.0 / freq) + 1e-9)) + 1
+        # 0 Hz is allowed, and so is a pulse too long to fit even once:
         if n_pulses <= 0:
-            time = np.array([0, stim_dur], dtype=np.float32)
+            time = np.array([0, stim_dur], dtype=np.float64)
             data = np.array([[0, 0]], dtype=np.float32)
         else:
             # Window duration is the inverse of pulse train frequency:
@@ -144,6 +154,12 @@ class PulseTrain(Stimulus):
             last_col = [np.interp(stim_dur, time, row) for row in data]
             last_col = np.array(last_col).reshape((-1, 1))
             t_idx = time < stim_dur
+            # The interpolated end point has to stay at least DT away from the
+            # last point it follows, or the time axis is no longer strictly
+            # increasing:
+            kept = np.flatnonzero(t_idx)
+            if kept.size and time[kept[-1]] > stim_dur - DT:
+                t_idx[kept[-1]] = False
             data = np.hstack((data[:, t_idx], last_col))
             time = np.append(time[t_idx], stim_dur)
         elif time[-1] < stim_dur - DT:

--- a/pulse2percept/stimuli/pulses.py
+++ b/pulse2percept/stimuli/pulses.py
@@ -86,7 +86,7 @@ class MonophasicPulse(Stimulus):
             # last time point so that the stimulus is exactly `stim_dur` long:
             time[-1] = stim_dur
         data = np.array(data, dtype=np.float32).reshape((1, -1))
-        time = np.array(time, dtype=np.float32)
+        time = np.array(time, dtype=np.float64)
         super().__init__(data, electrodes=electrode, time=time, compress=False)
         self.cathodic = amp <= 0
 
@@ -190,7 +190,7 @@ class BiphasicPulse(Stimulus):
             # last time point so that the stimulus is exactly `stim_dur` long:
             time[-1] = stim_dur
         data = np.array(data, dtype=np.float32).reshape((1, -1))
-        time = np.array(time, dtype=np.float32)
+        time = np.array(time, dtype=np.float64)
         super().__init__(data, electrodes=electrode, time=time, compress=False)
         self.cathodic_first = cathodic_first
 
@@ -308,7 +308,7 @@ class AsymmetricBiphasicPulse(Stimulus):
             # last time point so that the stimulus is exactly `stim_dur` long:
             time[-1] = stim_dur
         data = np.array(data, dtype=np.float32).reshape((1, -1))
-        time = np.array(time, dtype=np.float32)
+        time = np.array(time, dtype=np.float64)
         super().__init__(data, electrodes=electrode, time=time, compress=False)
         self.cathodic_first = cathodic_first
 

--- a/pulse2percept/stimuli/tests/test_base.py
+++ b/pulse2percept/stimuli/tests/test_base.py
@@ -160,6 +160,33 @@ def test_Stimulus():
     assert_warns_msg(UserWarning, Stimulus, None, [[1, 2, 3]], time=[1, 2, 1.9])
 
 
+def test_Stimulus_time_resolution():
+    # Time is stored as float64 while data stays float32. float32 reaches a
+    # resolution of DT at t = 8.4 s, past which two time points a time step
+    # apart are no longer distinguishable:
+    stim = Stimulus(np.ones((2, 3)), time=[0, DT, 2 * DT])
+    npt.assert_equal(stim.time.dtype, np.float64)
+    npt.assert_equal(stim.data.dtype, np.float32)
+    far = 30000.0
+    stim = Stimulus(np.ones((2, 3)), time=[far, far + DT, far + 2 * DT])
+    npt.assert_almost_equal(np.diff(stim.time), DT)
+    # Slicing the time axis does not round it back down either:
+    npt.assert_almost_equal(stim[0, far + DT], 1)
+
+
+def test_Stimulus_nonmonotonic_warning():
+    # The warning names the offending points rather than dumping the whole
+    # time axis, which for a long stimulus ran to megabytes:
+    time = np.arange(1000, dtype=float)
+    time[500] = time[499]
+    with pytest.warns(UserWarning, match='strictly monotonically') as record:
+        Stimulus(np.ones((2, 1000)), time=time)
+    msg = str(record[0].message)
+    npt.assert_equal(len(msg) < 500, True)
+    npt.assert_equal('t[499]' in msg, True)
+    npt.assert_equal('1 of 1000' in msg, True)
+
+
 def test_Stimulus_compress():
     data = np.zeros((2, 7))
     data[0, 0] = 1

--- a/pulse2percept/stimuli/tests/test_encoders.py
+++ b/pulse2percept/stimuli/tests/test_encoders.py
@@ -5,7 +5,7 @@ import numpy.testing as npt
 import pytest
 from scipy.integrate import trapezoid
 
-from pulse2percept.implants import ArgusII
+from pulse2percept.implants import ArgusII, SequentialRaster
 from pulse2percept.stimuli import (AmplitudeEncoder, BiphasicPulse,
                                    BostonTrain, Encoder, FrequencyEncoder,
                                    ImageStimulus, MonophasicPulse, Stimulus,
@@ -360,36 +360,83 @@ def test_FrequencyEncoder_implant():
     npt.assert_equal(enc.shape[1] < 20000, True)
 
 
-class StaggeredEncoder(AmplitudeEncoder):
-    """Stand-in for a raster-aware encoder, to exercise ``_delays``"""
-
-    def _delays(self, n_electrodes):
-        # Two groups, the second one 5 ms into the frame:
-        return 5.0 * (np.arange(n_electrodes) % 2)
-
-
-def test_Encoder_delays():
+def test_Encoder_raster():
     img = ImageStimulus(np.ones((2, 2)))
-    enc = StaggeredEncoder(freq=100, frame_dur=100).encode(img)
-    # Staggering splits the electrodes across two schedules, which is what a
-    # raster group will do:
+    raster = SequentialRaster(2, interleave=True)
+    enc = AmplitudeEncoder(freq=100, frame_dur=100,
+                           raster=raster).encode(img)
+    # Rastering splits the electrodes across two pulse schedules, offset by
+    # half a frame:
     npt.assert_equal(enc.metadata['encoder']['n_schedules'], 2)
     npt.assert_almost_equal(pulse_onsets(enc, 0)[0], 0, decimal=3)
-    npt.assert_almost_equal(pulse_onsets(enc, 1)[0], 5, decimal=3)
+    npt.assert_almost_equal(pulse_onsets(enc, 1)[0], 50, decimal=3)
     # The delayed group keeps the same period, and gets as many whole pulses
     # as still fit in what is left of the frame:
     npt.assert_almost_equal(np.diff(pulse_onsets(enc, 1)), 10, decimal=3)
     npt.assert_equal(n_pulses_of(enc, 0), 10)
-    npt.assert_equal(n_pulses_of(enc, 1), 10)
-    npt.assert_equal(n_pulses_of(StaggeredEncoder(freq=100, frame_dur=95)
-                                 .encode(img), 1), 9)
+    npt.assert_equal(n_pulses_of(enc, 1), 5)
     # Both groups stay charge-balanced:
     net = trapezoid(enc.data.astype(np.float64),
                     x=enc.time.astype(np.float64))
     npt.assert_almost_equal(net, 0, decimal=3)
     # A clock snaps the delay along with the period:
-    enc = StaggeredEncoder(freq=100, frame_dur=100, clock=3).encode(img)
+    enc = AmplitudeEncoder(freq=100, frame_dur=100, clock=3,
+                           raster=SequentialRaster(
+                               2, interleave=True,
+                               group_dur=5)).encode(img)
     npt.assert_almost_equal(pulse_onsets(enc, 1)[0], 6, decimal=3)
+
+
+def test_Encoder_raster_from_implant():
+    implant = ArgusII()
+    implant.raster = SequentialRaster(6)
+    vid = VideoStimulus(np.ones((6, 10, 2)), metadata={'fps': 30})
+    # The encoder picks up the implant's raster without being told:
+    enc = AmplitudeEncoder(implant, freq=30).encode(vid)
+    npt.assert_equal(enc.metadata['encoder']['n_schedules'], 6)
+    delays = [pulse_onsets(enc, e)[0] for e in (0, 10, 20, 30, 40, 50)]
+    npt.assert_almost_equal(delays, np.arange(6) * 1000 / 30 / 6, decimal=2)
+    # An explicit raster on the encoder wins, so one can be tried out without
+    # modifying the implant:
+    enc = AmplitudeEncoder(implant, freq=30,
+                           raster=SequentialRaster(2)).encode(vid)
+    npt.assert_equal(enc.metadata['encoder']['n_schedules'], 2)
+    # And no raster anywhere means every electrode fires at frame onset:
+    implant.raster = None
+    enc = AmplitudeEncoder(implant, freq=30).encode(vid)
+    npt.assert_equal(enc.metadata['encoder']['n_schedules'], 1)
+
+
+def test_Encoder_raster_current_limit():
+    # 60 electrodes at 50 uA is 3000 uA if they all fire at once, but only
+    # 500 uA if they take turns ten at a time:
+    implant = ArgusII()
+    implant.max_current = 1000
+    vid = VideoStimulus(np.ones((6, 10, 3)), metadata={'fps': 30})
+    with pytest.raises(ValueError, match='raster'):
+        implant.stim = AmplitudeEncoder(implant, amp_range=(50, 50),
+                                        freq=30).encode(vid)
+    implant.raster = SequentialRaster(6)
+    implant.stim = AmplitudeEncoder(implant, amp_range=(50, 50),
+                                    freq=30).encode(vid)
+    npt.assert_almost_equal(np.abs(implant.stim.data).sum(axis=0).max(), 500)
+    # A raster that cannot get through all its groups within a frame is not a
+    # usable schedule:
+    with pytest.raises(ValueError):
+        AmplitudeEncoder(implant, freq=30,
+                         raster=SequentialRaster(6, group_dur=20)).encode(vid)
+    # Neither is one whose groups get a turn too short to pulse in. Sixty
+    # 0.92 ms pulses take 55 ms, which does not fit into a 33 ms frame, so
+    # electrode-at-a-time rastering is impossible here rather than merely
+    # dropping the electrodes that come last:
+    with pytest.raises(ValueError, match='no room'):
+        AmplitudeEncoder(implant, freq=30,
+                         raster=SequentialRaster(60)).encode(vid)
+    # Halving the phase duration makes it fit:
+    enc = AmplitudeEncoder(implant, freq=30, phase_dur=0.2,
+                           raster=SequentialRaster(60)).encode(vid)
+    npt.assert_equal(enc.metadata['encoder']['n_schedules'], 60)
+    npt.assert_almost_equal(np.abs(enc.data).sum(axis=0).max(), 50)
 
 
 def test_Encoder_metadata():

--- a/pulse2percept/stimuli/tests/test_encoders.py
+++ b/pulse2percept/stimuli/tests/test_encoders.py
@@ -1,0 +1,237 @@
+import warnings
+
+import numpy as np
+import numpy.testing as npt
+import pytest
+from scipy.integrate import trapezoid
+
+from pulse2percept.implants import ArgusII
+from pulse2percept.stimuli import (AmplitudeEncoder, BiphasicPulse,
+                                   BostonTrain, Encoder, ImageStimulus,
+                                   MonophasicPulse, Stimulus, VideoStimulus)
+from pulse2percept.stimuli import encoders
+from pulse2percept.utils.constants import DT
+
+
+class FreqEncoder(Encoder):
+    """Stand-in for the frequency encoder, to exercise the base class"""
+
+    def _modulate(self, gray):
+        return 20, 10 + 10 * gray
+
+
+def test_Encoder_is_abstract():
+    with pytest.raises(TypeError):
+        Encoder()
+
+
+def test_Encoder_source():
+    enc = AmplitudeEncoder()
+    with pytest.raises(TypeError):
+        enc.encode(np.random.rand(4, 5))
+    with pytest.raises(TypeError):
+        enc.encode('not-a-stimulus')
+
+
+def test_Encoder_params():
+    with pytest.raises(ValueError):
+        AmplitudeEncoder(phase_dur=DT / 2)
+    with pytest.raises(ValueError):
+        AmplitudeEncoder(interphase_dur=-1)
+    with pytest.raises(ValueError):
+        AmplitudeEncoder(frame_dur=0)
+    with pytest.raises(ValueError):
+        AmplitudeEncoder(amp_range=(0, 10, 20))
+    with pytest.raises(ValueError):
+        AmplitudeEncoder(amp_range=(-10, 10))
+    with pytest.raises(ValueError):
+        AmplitudeEncoder(freq=-1)
+    with pytest.raises(TypeError):
+        AmplitudeEncoder(pulse={'invalid': 1})
+    with pytest.raises(ValueError):
+        # A pulse needs a time component:
+        AmplitudeEncoder(pulse=Stimulus(3))
+    with pytest.raises(ValueError):
+        # ... and must live on a single electrode:
+        AmplitudeEncoder(pulse=ImageStimulus(np.random.rand(2, 2)))
+    # Encoders pretty-print their parameters:
+    npt.assert_equal('amp_range' in str(AmplitudeEncoder()), True)
+
+
+def test_AmplitudeEncoder():
+    # A 6-frame video, 1 ms per frame:
+    stim = VideoStimulus(np.random.rand(4, 5, 6))
+    npt.assert_almost_equal(np.diff(stim.time), 1)
+    enc = AmplitudeEncoder(freq=1000).encode(stim)
+    # One electrode per pixel, and the encoded stimulus lasts as long as the
+    # video did:
+    npt.assert_equal(enc.shape[0], 20)
+    npt.assert_almost_equal(enc.time[0], 0)
+    npt.assert_almost_equal(enc.time[-1], 6, decimal=3)
+    # Time points stay strictly monotonically increasing across frames:
+    npt.assert_equal(np.all(np.diff(enc.time) > 0.95 * DT), True)
+    # Cathodic first: the biggest excursion of each electrode is negative:
+    npt.assert_almost_equal(enc.data.min(axis=1), -50 * stim.data.max(axis=1))
+    npt.assert_almost_equal(enc.data.max(axis=1), 50 * stim.data.max(axis=1))
+    # Anodic first flips that around, but the magnitude is the same:
+    ana = AmplitudeEncoder(freq=1000, cathodic_first=False).encode(stim)
+    npt.assert_almost_equal(np.abs(ana.data), np.abs(enc.data))
+    npt.assert_almost_equal(ana.data[:, 1], -enc.data[:, 1])
+    # Pulses are charge-balanced. Integrated in float64, because a float32
+    # time axis cannot resolve the DT-wide pulse edges well enough for
+    # `is_charge_balanced` to survive more than a handful of pulses -- which
+    # is true of `BiphasicPulseTrain` too, and has nothing to do with encoding:
+    net = trapezoid(enc.data.astype(np.float64),
+                    x=enc.time.astype(np.float64))
+    npt.assert_almost_equal(net, 0, decimal=4)
+
+
+@pytest.mark.parametrize('amp_range', [(0, 50), (2, 43), (10, 10)])
+def test_AmplitudeEncoder_amp_range(amp_range):
+    # Gray levels map onto `amp_range` absolutely: a pixel of a given gray
+    # level always encodes to the same amplitude, no matter what the rest of
+    # the image looks like:
+    lo, hi = amp_range
+    for gray in (0.0, 0.25, 1.0):
+        img = ImageStimulus(np.full((4, 4), gray))
+        enc = AmplitudeEncoder(amp_range=amp_range).encode(img)
+        npt.assert_almost_equal(np.abs(enc.data).max(),
+                                lo + gray * (hi - lo), decimal=4)
+    # Both ends of the range are reached by the extremes of the image:
+    img = ImageStimulus(np.linspace(0, 1, 16).reshape((4, 4)))
+    enc = AmplitudeEncoder(amp_range=amp_range).encode(img)
+    npt.assert_almost_equal(np.abs(enc.data).max(axis=1).min(), lo, decimal=4)
+    npt.assert_almost_equal(np.abs(enc.data).max(axis=1).max(), hi, decimal=4)
+
+
+def test_AmplitudeEncoder_stretch():
+    # A uniform image has an absolute gray level, but no range to stretch:
+    img = ImageStimulus(np.full((4, 4), 0.5))
+    npt.assert_almost_equal(np.abs(img.encode().data).max(), 25)
+    npt.assert_almost_equal(
+        np.abs(AmplitudeEncoder(stretch=True).encode(img).data).max(), 0)
+    # Stretching pins the darkest pixel to the bottom of the range and the
+    # brightest to the top:
+    img = ImageStimulus(np.linspace(0.2, 0.6, 16).reshape((4, 4)))
+    enc = AmplitudeEncoder(amp_range=(0, 50), stretch=True).encode(img)
+    npt.assert_almost_equal(np.abs(enc.data).max(axis=1).min(), 0)
+    npt.assert_almost_equal(np.abs(enc.data).max(axis=1).max(), 50)
+
+
+def test_AmplitudeEncoder_freq():
+    # Twice the frequency, twice the pulses per frame:
+    img = ImageStimulus(np.ones((2, 2)))
+    for freq, n_pulses in [(10, 5), (20, 10), (40, 20)]:
+        enc = AmplitudeEncoder(freq=freq).encode(img)
+        # Count the cathodic phases of the first electrode:
+        cathodic = enc.data[0] <= -49
+        npt.assert_equal(np.count_nonzero(np.diff(cathodic.astype(int)) > 0),
+                         n_pulses)
+    # 0 Hz is silence, but still a stimulus of the right duration:
+    enc = AmplitudeEncoder(freq=0).encode(img)
+    npt.assert_almost_equal(np.abs(enc.data).max(), 0)
+    npt.assert_almost_equal(enc.time[-1], 500)
+    # A frequency below the frame rate cannot be realized, because a frame
+    # cannot hold less than one pulse:
+    with pytest.warns(UserWarning, match='slower than the frame rate'):
+        AmplitudeEncoder(freq=10, frame_dur=20).encode(img)
+    # A pulse that does not fit into a frame is an error, not a warning:
+    with pytest.raises(ValueError):
+        AmplitudeEncoder(freq=1000, phase_dur=10).encode(img)
+    # As is a pulse that does not fit into a pulse train window:
+    with pytest.raises(ValueError):
+        AmplitudeEncoder(freq=2000, phase_dur=0.46).encode(img)
+
+
+def test_AmplitudeEncoder_pulse():
+    img = ImageStimulus(np.ones((2, 2)))
+    # A custom pulse is used in place of the default biphasic one, with its
+    # amplitude normalized away:
+    pulse = MonophasicPulse(-20, 0.5)
+    enc = AmplitudeEncoder(pulse=pulse, freq=100,
+                           amp_range=(0, 30)).encode(img)
+    npt.assert_almost_equal(np.abs(enc.data).max(), 30)
+    # A monophasic pulse is not charge-balanced, and encoding does not make it
+    # so: all 50 pulses push charge the same way. Each carries
+    # amp * (phase_dur - DT), the DT coming off the two edges the pulse ramps
+    # over:
+    net = trapezoid(enc.data.astype(np.float64),
+                    x=enc.time.astype(np.float64))
+    npt.assert_almost_equal(net, -30 * (0.5 - DT) * 50, decimal=2)
+    # The caller's pulse is left alone (both its data and its time axis):
+    pulse = BiphasicPulse(20, 0.2)
+    data, time = pulse.data.copy(), pulse.time.copy()
+    AmplitudeEncoder(pulse=pulse, freq=100).encode(img)
+    npt.assert_almost_equal(pulse.data, data)
+    npt.assert_almost_equal(pulse.time, time)
+
+
+def test_AmplitudeEncoder_image():
+    img = ImageStimulus(np.random.rand(4, 5))
+    # An image has no time axis of its own, so it is a single frame that lasts
+    # 500 ms by default:
+    npt.assert_almost_equal(AmplitudeEncoder().encode(img).time[-1], 500)
+    npt.assert_almost_equal(
+        AmplitudeEncoder(frame_dur=123).encode(img).time[-1], 123)
+    # `frame_dur` also overrides the frame rate of a video:
+    vid = VideoStimulus(np.random.rand(4, 5, 3))
+    npt.assert_almost_equal(
+        AmplitudeEncoder(frame_dur=10).encode(vid).time[-1], 30)
+
+
+def test_AmplitudeEncoder_implant():
+    implant = ArgusII()
+    vid = BostonTrain()
+    enc = AmplitudeEncoder(implant, amp_range=(0, 50)).encode(vid)
+    # The video is sampled at the electrode locations, so the stimulus has one
+    # row per electrode rather than one per pixel:
+    npt.assert_equal(enc.shape[0], implant.n_electrodes)
+    npt.assert_equal(list(enc.electrodes), list(implant.electrode_names))
+    npt.assert_equal(np.abs(enc.data).max() <= 50, True)
+    # ... and it is small enough to be worth doing:
+    npt.assert_equal(enc.data.nbytes < 1e6, True)
+    # It can be assigned to the implant without any further reshaping:
+    implant.stim = enc
+    npt.assert_equal(implant.stim.shape, enc.shape)
+    # Sampling first and encoding second gives the same answer as encoding an
+    # already-downsampled video, which is what makes this a pure optimization
+    # for amplitude modulation:
+    sampled = implant.reshape_stim(vid)
+    direct = AmplitudeEncoder(amp_range=(0, 50)).encode(sampled)
+    npt.assert_almost_equal(enc.data, direct.data, decimal=4)
+    npt.assert_almost_equal(enc.time, direct.time)
+
+
+def test_AmplitudeEncoder_big_stim_warning(monkeypatch):
+    # Encoding at pixel resolution is a memory trap, and the way out is to pass
+    # an implant, so say so. The threshold is lowered here rather than actually
+    # allocating the hundreds of megabytes it takes to cross it:
+    monkeypatch.setattr(encoders, '_BIG_STIM', 100)
+    vid = VideoStimulus(np.random.rand(8, 8, 4))
+    with pytest.warns(UserWarning, match="Pass 'implant'"):
+        AmplitudeEncoder(freq=1000).encode(vid)
+    # Passing an implant is the way out, so it does not warn:
+    with warnings.catch_warnings():
+        warnings.simplefilter('error')
+        AmplitudeEncoder(ArgusII(), freq=1000).encode(vid)
+
+
+def test_Encoder_nonseparable():
+    # Electrodes that do not share a frequency do not share a time axis. That
+    # is the general (union time axis) path, which frequency modulation and
+    # raster groups will need:
+    img = ImageStimulus(np.random.rand(4, 4))
+    with pytest.raises(NotImplementedError):
+        FreqEncoder().encode(img)
+    # A subclass that happens to return one frequency for every electrode does
+    # go through the separable path:
+    enc = FreqEncoder().encode(ImageStimulus(np.zeros((4, 4))))
+    npt.assert_almost_equal(np.abs(enc.data).max(), 20)
+
+
+def test_Encoder_metadata():
+    enc = AmplitudeEncoder(freq=50).encode(ImageStimulus(np.ones((2, 2))))
+    npt.assert_equal(enc.metadata['encoder']['kind'], 'AmplitudeEncoder')
+    npt.assert_almost_equal(enc.metadata['encoder']['freq'], 50)
+    npt.assert_almost_equal(enc.metadata['encoder']['frame_dur'], 500)
+    npt.assert_equal(enc.metadata['encoder']['n_frames'], 1)

--- a/pulse2percept/stimuli/tests/test_encoders.py
+++ b/pulse2percept/stimuli/tests/test_encoders.py
@@ -7,17 +7,22 @@ from scipy.integrate import trapezoid
 
 from pulse2percept.implants import ArgusII
 from pulse2percept.stimuli import (AmplitudeEncoder, BiphasicPulse,
-                                   BostonTrain, Encoder, ImageStimulus,
-                                   MonophasicPulse, Stimulus, VideoStimulus)
+                                   BostonTrain, Encoder, FrequencyEncoder,
+                                   ImageStimulus, MonophasicPulse, Stimulus,
+                                   VideoStimulus)
 from pulse2percept.stimuli import encoders
 from pulse2percept.utils.constants import DT
 
 
-class FreqEncoder(Encoder):
-    """Stand-in for the frequency encoder, to exercise the base class"""
-
-    def _modulate(self, gray):
-        return 20, 10 + 10 * gray
+def n_pulses_of(stim, electrode=0, peak=None):
+    """Count the pulses one electrode of an encoded stimulus delivers"""
+    row = stim.data[electrode]
+    peak = np.abs(row).max() if peak is None else peak
+    if peak == 0:
+        return 0
+    firing = np.abs(row) >= 0.99 * peak
+    # Each pulse has a leading and a trailing phase, both at full amplitude:
+    return np.count_nonzero(np.diff(firing.astype(int)) > 0) // 2
 
 
 def test_Encoder_is_abstract():
@@ -54,8 +59,19 @@ def test_Encoder_params():
     with pytest.raises(ValueError):
         # ... and must live on a single electrode:
         AmplitudeEncoder(pulse=ImageStimulus(np.random.rand(2, 2)))
+    with pytest.raises(ValueError):
+        AmplitudeEncoder(clock=DT / 2)
+    with pytest.raises(ValueError):
+        AmplitudeEncoder(n_levels=1)
+    with pytest.raises(ValueError):
+        FrequencyEncoder(freq_range=(0, 10, 20))
+    with pytest.raises(ValueError):
+        FrequencyEncoder(freq_range=(-10, 10))
+    with pytest.raises(ValueError):
+        FrequencyEncoder(amp=-1)
     # Encoders pretty-print their parameters:
     npt.assert_equal('amp_range' in str(AmplitudeEncoder()), True)
+    npt.assert_equal('freq_range' in str(FrequencyEncoder()), True)
 
 
 def test_AmplitudeEncoder():
@@ -216,22 +232,176 @@ def test_AmplitudeEncoder_big_stim_warning(monkeypatch):
         AmplitudeEncoder(ArgusII(), freq=1000).encode(vid)
 
 
-def test_Encoder_nonseparable():
-    # Electrodes that do not share a frequency do not share a time axis. That
-    # is the general (union time axis) path, which frequency modulation and
-    # raster groups will need:
-    img = ImageStimulus(np.random.rand(4, 4))
-    with pytest.raises(NotImplementedError):
-        FreqEncoder().encode(img)
-    # A subclass that happens to return one frequency for every electrode does
-    # go through the separable path:
-    enc = FreqEncoder().encode(ImageStimulus(np.zeros((4, 4))))
-    npt.assert_almost_equal(np.abs(enc.data).max(), 20)
+def whole_pulses(freq, frame_dur, pulse_dur=0.92):
+    """How many pulses of ``freq`` Hz a frame can start *and finish*"""
+    if freq <= 0:
+        return 0
+    last = np.floor((frame_dur - DT) / DT + 1e-9)
+    room = last - round(pulse_dur / DT)
+    return int(room // round(1000.0 / freq / DT)) + 1 if room >= 0 else 0
+
+
+def pulse_onsets(stim, electrode=0):
+    """The time (ms) at which each of one electrode's pulses begins
+
+    Assumes a cathodic-first pulse, so that each pulse contributes exactly one
+    run of negative samples.
+    """
+    neg = stim.data[electrode] < 0
+    started = neg & ~np.concatenate(([False], neg[:-1]))
+    # The first sample at full amplitude sits one tick past the onset, because
+    # a pulse ramps up over DT:
+    return stim.time[started] - DT
+
+
+def test_FrequencyEncoder():
+    # A gray ramp, so that every electrode ends up on a different frequency:
+    grays = np.linspace(0, 1, 16)
+    img = ImageStimulus(grays.reshape((4, 4)))
+    enc = FrequencyEncoder(freq_range=(0, 100), amp=37,
+                           frame_dur=100).encode(img)
+    # Every electrode pulses at the same amplitude, cathodic first:
+    peaks = np.abs(enc.data).max(axis=1)
+    npt.assert_almost_equal(peaks[1:], 37)
+    npt.assert_almost_equal(enc.data.min(), -37)
+    # A gray level of 0 maps onto 0 Hz, which is silence:
+    npt.assert_almost_equal(peaks[0], 0)
+    # ... and the number of pulses grows with the gray level:
+    counts = [n_pulses_of(enc, e, peak=37) for e in range(16)]
+    npt.assert_equal(counts, [whole_pulses(100 * g, 100) for g in grays])
+    npt.assert_equal(np.all(np.diff(counts) >= 0), True)
+    npt.assert_equal(counts[-1], 10)
+    # Electrodes on different frequencies do not share a time axis, so the
+    # stimulus has many more time points than amplitude modulation would:
+    am = AmplitudeEncoder(freq=100, frame_dur=100).encode(img)
+    npt.assert_equal(enc.shape[1] > 4 * am.shape[1], True)
+    npt.assert_equal(enc.time[-1], am.time[-1])
+    npt.assert_equal(np.all(np.diff(enc.time) > 0.95 * DT), True)
+    # Pulses stay charge-balanced no matter how they are interleaved. The
+    # tolerance is set by how well a float32 time axis resolves the DT-wide
+    # pulse edges, not by the encoding; a single truncated pulse would show up
+    # here as several uA*ms, four orders of magnitude above that floor:
+    net = trapezoid(enc.data.astype(np.float64),
+                    x=enc.time.astype(np.float64))
+    npt.assert_almost_equal(net, 0, decimal=3)
+
+
+def test_FrequencyEncoder_whole_pulses():
+    # A frame delivers only pulses it can finish. At 60 Hz a 33.3 ms frame has
+    # room for exactly two 0.92 ms pulses, not two and a fraction of a third:
+    img = ImageStimulus(np.ones((2, 2)))
+    frame_dur = 1000 / 29.97
+    for freq in (30, 60, 90):
+        enc = FrequencyEncoder(freq_range=(freq, freq),
+                               frame_dur=frame_dur).encode(img)
+        npt.assert_equal(n_pulses_of(enc), whole_pulses(freq, frame_dur))
+        # Charge balance is what a truncated pulse would break:
+        net = trapezoid(enc.data.astype(np.float64),
+                        x=enc.time.astype(np.float64))
+        npt.assert_almost_equal(net, 0, decimal=3)
+    # Amplitude modulation obeys the same rule:
+    am = AmplitudeEncoder(freq=60, frame_dur=frame_dur).encode(img)
+    npt.assert_equal(n_pulses_of(am), whole_pulses(60, frame_dur))
+
+
+def test_Encoder_clock():
+    # A clock rounds the pulse period onto a whole number of cycles, so
+    # frequencies that differ by less than that collapse onto one schedule:
+    img = ImageStimulus(np.linspace(0.5, 1, 16).reshape((4, 4)))
+    fine = FrequencyEncoder(freq_range=(0, 300), frame_dur=100).encode(img)
+    coarse = FrequencyEncoder(freq_range=(0, 300), frame_dur=100,
+                              clock=1).encode(img)
+    npt.assert_equal(fine.metadata['encoder']['n_schedules'], 16)
+    npt.assert_equal(coarse.metadata['encoder']['n_schedules'] < 16, True)
+    # ... which is the whole point: far fewer time points to simulate:
+    npt.assert_equal(coarse.shape[1] < fine.shape[1] / 2, True)
+    # Every pulse still lands on the clock grid, and the fine one does not:
+    onsets = pulse_onsets(coarse)
+    npt.assert_almost_equal(onsets, np.round(onsets), decimal=3)
+    npt.assert_equal(np.allclose(pulse_onsets(fine),
+                                 np.round(pulse_onsets(fine)), atol=1e-3),
+                     False)
+    # A clock that cannot resolve DT is not a clock:
+    with pytest.raises(ValueError):
+        FrequencyEncoder(clock=DT / 10)
+
+
+def test_Encoder_n_levels():
+    # Quantizing the gray levels quantizes whatever they are modulated onto:
+    img = ImageStimulus(np.linspace(0, 1, 64).reshape((8, 8)))
+    am = AmplitudeEncoder(amp_range=(0, 50), n_levels=4).encode(img)
+    npt.assert_almost_equal(np.unique(np.abs(am.data).max(axis=1)),
+                            [0, 50 / 3, 100 / 3, 50], decimal=4)
+    # ... and for frequency modulation that is what keeps the time axis small:
+    fm = FrequencyEncoder(freq_range=(0, 300), frame_dur=100).encode(img)
+    fm4 = FrequencyEncoder(freq_range=(0, 300), frame_dur=100,
+                           n_levels=4).encode(img)
+    npt.assert_equal(fm4.metadata['encoder']['n_schedules'], 4)
+    npt.assert_equal(fm4.shape[1] < fm.shape[1], True)
+
+
+def test_Encoder_big_time_warning(monkeypatch):
+    monkeypatch.setattr(encoders, '_BIG_TIME', 100)
+    img = ImageStimulus(np.linspace(0, 1, 16).reshape((4, 4)))
+    with pytest.warns(UserWarning, match='time points'):
+        FrequencyEncoder(freq_range=(0, 300), frame_dur=100).encode(img)
+
+
+def test_FrequencyEncoder_implant():
+    implant = ArgusII()
+    enc = FrequencyEncoder(implant, freq_range=(0, 300), amp=50,
+                           clock=1).encode(BostonTrain())
+    npt.assert_equal(enc.shape[0], implant.n_electrodes)
+    npt.assert_almost_equal(np.abs(enc.data).max(), 50)
+    implant.stim = enc
+    npt.assert_equal(implant.stim.shape, enc.shape)
+    # The clock is what makes this tractable at all: without one, the same
+    # clip needs more than an order of magnitude more time points:
+    npt.assert_equal(enc.shape[1] < 20000, True)
+
+
+class StaggeredEncoder(AmplitudeEncoder):
+    """Stand-in for a raster-aware encoder, to exercise ``_delays``"""
+
+    def _delays(self, n_electrodes):
+        # Two groups, the second one 5 ms into the frame:
+        return 5.0 * (np.arange(n_electrodes) % 2)
+
+
+def test_Encoder_delays():
+    img = ImageStimulus(np.ones((2, 2)))
+    enc = StaggeredEncoder(freq=100, frame_dur=100).encode(img)
+    # Staggering splits the electrodes across two schedules, which is what a
+    # raster group will do:
+    npt.assert_equal(enc.metadata['encoder']['n_schedules'], 2)
+    npt.assert_almost_equal(pulse_onsets(enc, 0)[0], 0, decimal=3)
+    npt.assert_almost_equal(pulse_onsets(enc, 1)[0], 5, decimal=3)
+    # The delayed group keeps the same period, and gets as many whole pulses
+    # as still fit in what is left of the frame:
+    npt.assert_almost_equal(np.diff(pulse_onsets(enc, 1)), 10, decimal=3)
+    npt.assert_equal(n_pulses_of(enc, 0), 10)
+    npt.assert_equal(n_pulses_of(enc, 1), 10)
+    npt.assert_equal(n_pulses_of(StaggeredEncoder(freq=100, frame_dur=95)
+                                 .encode(img), 1), 9)
+    # Both groups stay charge-balanced:
+    net = trapezoid(enc.data.astype(np.float64),
+                    x=enc.time.astype(np.float64))
+    npt.assert_almost_equal(net, 0, decimal=3)
+    # A clock snaps the delay along with the period:
+    enc = StaggeredEncoder(freq=100, frame_dur=100, clock=3).encode(img)
+    npt.assert_almost_equal(pulse_onsets(enc, 1)[0], 6, decimal=3)
 
 
 def test_Encoder_metadata():
     enc = AmplitudeEncoder(freq=50).encode(ImageStimulus(np.ones((2, 2))))
     npt.assert_equal(enc.metadata['encoder']['kind'], 'AmplitudeEncoder')
-    npt.assert_almost_equal(enc.metadata['encoder']['freq'], 50)
     npt.assert_almost_equal(enc.metadata['encoder']['frame_dur'], 500)
     npt.assert_equal(enc.metadata['encoder']['n_frames'], 1)
+    # Amplitude modulation puts every electrode on one schedule; frequency
+    # modulation is what makes that number grow:
+    npt.assert_equal(enc.metadata['encoder']['n_schedules'], 1)
+    fm = FrequencyEncoder(freq_range=(10, 100), n_levels=4,
+                          clock=1).encode(ImageStimulus(np.linspace(
+                              0, 1, 16).reshape((4, 4))))
+    npt.assert_equal(fm.metadata['encoder']['kind'], 'FrequencyEncoder')
+    npt.assert_equal(fm.metadata['encoder']['n_schedules'], 4)

--- a/pulse2percept/stimuli/tests/test_images.py
+++ b/pulse2percept/stimuli/tests/test_images.py
@@ -5,8 +5,8 @@ import pytest
 
 from skimage.io import imsave
 
-from pulse2percept.stimuli import (ImageStimulus, LogoBVL, LogoUCSB,
-                                   SnellenChart)
+from pulse2percept.stimuli import (AmplitudeEncoder, ImageStimulus, LogoBVL,
+                                   LogoUCSB, SnellenChart)
 
 
 def create_dummy_img(fname, shape, mode, gray=1.0, return_data=False):
@@ -319,20 +319,25 @@ def test_ImageStimulus_filter():
 
 
 def test_ImageStimulus_encode():
-    stim = ImageStimulus(np.random.rand(4, 5))
-
-    # Amplitude encoding in default range:
+    # An image is a single frame lasting 500 ms:
+    stim = ImageStimulus(np.linspace(0, 1, 20).reshape((4, 5)))
     enc = stim.encode()
     npt.assert_almost_equal(enc.time[-1], 500)
-    npt.assert_almost_equal(enc.data.max(axis=1).min(), 0)
-    npt.assert_almost_equal(enc.data.max(axis=1).max(), 50)
+    npt.assert_equal(enc.shape[0], stim.shape[0])
+    # Gray levels map onto the amplitude range absolutely, so the darkest and
+    # brightest pixels of this ramp land on its two ends:
+    npt.assert_almost_equal(np.abs(enc.data).max(axis=1), 50 * stim.data[:, 0],
+                            decimal=4)
 
     # Amplitude encoding in custom range:
     enc = stim.encode(amp_range=(2, 43))
     npt.assert_almost_equal(enc.time[-1], 500)
-    npt.assert_almost_equal(enc.data.max(axis=1).min(), 2)
-    npt.assert_almost_equal(enc.data.max(axis=1).max(), 43)
+    npt.assert_almost_equal(np.abs(enc.data).max(axis=1).min(), 2, decimal=4)
+    npt.assert_almost_equal(np.abs(enc.data).max(axis=1).max(), 43, decimal=4)
 
+    # `encode` is a shorthand for AmplitudeEncoder, and forwards to it:
+    npt.assert_almost_equal(stim.encode().data,
+                            AmplitudeEncoder().encode(stim).data)
     with pytest.raises(TypeError):
         stim.encode(pulse={'invalid': 1})
     with pytest.raises(ValueError):

--- a/pulse2percept/stimuli/tests/test_pulse_trains.py
+++ b/pulse2percept/stimuli/tests/test_pulse_trains.py
@@ -1,3 +1,5 @@
+import warnings
+
 import numpy as np
 import pytest
 import numpy.testing as npt
@@ -44,6 +46,52 @@ def test_PulseTrain():
         # Empty stim:
         pulse = Stimulus([[0, 0, 0]], time=[0, 0.1, 0.2], compress=True)
         PulseTrain(10, pulse)
+
+
+def test_PulseTrain_whole_pulses():
+    # A train delivers only pulses it can finish. Starting one and cutting it
+    # short at `stim_dur` leaves a net current behind:
+    frame_dur = 1000 / 29.97
+    for freq, expected in [(20, 1), (30, 1), (60, 2), (90, 3)]:
+        pt = BiphasicPulseTrain(freq, 50, 0.46, stim_dur=frame_dur)
+        n_pulses = np.count_nonzero(
+            np.diff((pt.data[0] < 0).astype(int)) > 0)
+        npt.assert_equal(n_pulses, expected)
+        npt.assert_equal(pt.is_charge_balanced, True)
+        npt.assert_almost_equal(pt.time[-1], frame_dur)
+    # The window still holds one pulse even when the frequency asks for less
+    # than one, so that a slow train is not silence:
+    npt.assert_equal(np.count_nonzero(np.diff(
+        (BiphasicPulseTrain(1, 50, 0.46, stim_dur=10).data[0] < 0
+         ).astype(int)) > 0), 1)
+    # 0 Hz is silence, though:
+    npt.assert_almost_equal(BiphasicPulseTrain(0, 50, 0.46, stim_dur=10).data,
+                            0)
+
+
+def test_PulseTrain_time_axis():
+    # Whatever the frequency, the time axis stays strictly increasing. This
+    # used to fail for the rare frequency whose train ended just short of
+    # `stim_dur`, leaving the trimmed end point less than DT past its
+    # predecessor:
+    for freq in np.linspace(1, 300, 500):
+        with warnings.catch_warnings():
+            warnings.simplefilter('error')
+            pt = BiphasicPulseTrain(freq, 1, 0.46, stim_dur=1000 / 29.97 - DT)
+        npt.assert_equal(np.all(np.diff(pt.time) > 0.95 * DT), True)
+
+
+def test_PulseTrain_charge_balance_over_time():
+    # Charge balance has to survive a long train. The time axis is float64
+    # precisely because float32 cannot resolve a DT-wide pulse edge past
+    # t = 8.4 s, which used to leave even a symmetric train unbalanced:
+    for n_pulses in (6, 60, 600, 6000):
+        pt = BiphasicPulseTrain(1000, 50, 0.46, n_pulses=n_pulses,
+                                stim_dur=n_pulses)
+        npt.assert_equal(pt.is_charge_balanced, True)
+    # Every pulse edge is still exactly DT wide at the end of a 20 s train:
+    pt = BiphasicPulseTrain(50, 50, 0.46, stim_dur=20000)
+    npt.assert_almost_equal(np.diff(pt.time).min(), DT)
 
 
 @pytest.mark.parametrize('amp', (-3, 4))

--- a/pulse2percept/stimuli/tests/test_videos.py
+++ b/pulse2percept/stimuli/tests/test_videos.py
@@ -1,4 +1,5 @@
-from pulse2percept.stimuli import VideoStimulus, BostonTrain, GirlPool
+from pulse2percept.stimuli import (AmplitudeEncoder, VideoStimulus,
+                                   BostonTrain, GirlPool)
 from skimage.io import imsave
 from matplotlib.animation import FuncAnimation
 import numpy as np
@@ -309,25 +310,27 @@ def test_VideoStimulus_filter(tmp_path):
 
 
 def test_VideoStimulus_encode():
+    # 6 frames, 1 ms apart, so the encoded stimulus lasts 6 ms. Note that the
+    # frame duration is the time between frames; before v0.9.2 it was taken to
+    # be `1000 / that`, which made this stimulus 6000 ms long:
     stim = VideoStimulus(np.random.rand(4, 5, 6))
-
-    # Amplitude encoding in default range:
-    enc = stim.encode()
-    npt.assert_almost_equal(enc.time[-1], 6000)
-    # The positions we check depends on the encoding of the pulse! First element
-    # is always zero, second and third are negative phase, etc.
-    npt.assert_almost_equal(np.abs(enc.data[:, ::8]).min(), 0)
-    npt.assert_almost_equal(enc.data[:, 1::8].min(), -50)
-    npt.assert_almost_equal(enc.data[:, 4::8].max(), 50)
+    enc = stim.encode(freq=1000)
+    npt.assert_almost_equal(enc.time[-1], 6, decimal=3)
+    npt.assert_equal(enc.shape[0], stim.shape[0])
+    # Gray levels map onto the amplitude range absolutely, so the brightest
+    # pixel of the video reaches the top of the range and the rest fall short
+    # of it in proportion to how dark they are:
+    npt.assert_almost_equal(np.abs(enc.data).max(axis=1),
+                            50 * stim.data.max(axis=1), decimal=4)
 
     # Amplitude encoding in custom range:
-    enc = stim.encode(amp_range=(2, 43))
-    npt.assert_almost_equal(enc.time[-1], 6000)
-    npt.assert_almost_equal(np.abs(enc.data[:, ::8]).min(), 0)
-    npt.assert_almost_equal(enc.data[:, 1::8].min(), -43)
-    npt.assert_almost_equal(enc.data[:, 4::8].max(), 43)
-    npt.assert_almost_equal(enc.data[:, 4::8].min(), 2)
+    enc = stim.encode(amp_range=(2, 43), freq=1000)
+    npt.assert_almost_equal(np.abs(enc.data).max(axis=1),
+                            2 + 41 * stim.data.max(axis=1), decimal=4)
 
+    # `encode` is a shorthand for AmplitudeEncoder, and forwards to it:
+    npt.assert_almost_equal(stim.encode(freq=1000).data,
+                            AmplitudeEncoder(freq=1000).encode(stim).data)
     with pytest.raises(TypeError):
         stim.encode(pulse={'invalid': 1})
     with pytest.raises(ValueError):

--- a/pulse2percept/stimuli/videos.py
+++ b/pulse2percept/stimuli/videos.py
@@ -3,7 +3,6 @@
    :py:class:`~pulse2percept.stimuli.GirlPool`"""
 from os.path import dirname, join
 import numpy as np
-from math import isclose
 import matplotlib.pyplot as plt
 
 from skimage.color import rgb2gray
@@ -16,10 +15,8 @@ from imageio import get_reader as video_reader
 
 from .base import Stimulus
 from .names import ElectrodeNames
-from .pulses import BiphasicPulse
 from ..utils import (center_image, shift_image, scale_image, trim_image,
-                     unique, frame_interval, HTMLAnimation)
-from ..utils.constants import DT
+                     frame_interval, HTMLAnimation)
 
 
 class VideoStimulus(Stimulus):
@@ -540,27 +537,39 @@ class VideoStimulus(Stimulus):
             raise ValueError(f"Unknown filter '{filt}'.")
         return self.apply(filt, **kwargs)
 
-    def encode(self, amp_range=(0, 50), pulse=None):
-        """Encode image using amplitude modulation
+    def encode(self, amp_range=(0, 50), freq=20, implant=None, **kwargs):
+        """Encode the video using amplitude modulation
 
-        Encodes the image as a series of pulses, where the gray levels of the
-        image are interpreted as the amplitude of a pulse with values in
-        ``amp_range``.
+        Encodes every frame of the video as a train of biphasic pulses, where
+        the gray level of a pixel sets the amplitude of its pulses. Each train
+        lasts one frame period.
 
-        By default, a single biphasic pulse is used for each pixel, with 0.46ms
-        phase duration, and 500ms total stimulus duration.
+        This is a shorthand for
+        :py:class:`~pulse2percept.stimuli.AmplitudeEncoder`; use that directly
+        for the full set of options.
+
+        .. versionchanged:: 0.9.2
+
+            Gray levels now map onto ``amp_range`` absolutely rather than being
+            stretched to fill it (pass ``stretch=True`` for the old behavior),
+            each frame receives a pulse *train* rather than a single pulse, and
+            ``implant`` encodes at electrode rather than pixel resolution.
 
         Parameters
         ----------
-        amp_range : (min_amp, max_amp)
-            Range of amplitude values to use for the encoding. The image's
-            gray levels will be scaled such that the smallest value is mapped
-            onto ``min_amp`` and the largest onto ``max_amp``.
-        pulse : :py:class:`~pulse2percept.stimuli.Stimulus`, optional
-            A valid pulse or pulse train to be used for the encoding.
-            If None given, a :py:class:`~pulse2percept.stimuli.BiphasicPulse`
-            (0.46 ms phase duration, stimulus duration inferred from the movie
-            frame rate) will be used.
+        amp_range : (min_amp, max_amp), optional
+            Range of pulse amplitudes (uA). A gray level of 0 maps onto
+            ``min_amp``, a gray level of 1 onto ``max_amp``.
+        freq : float, optional
+            Pulse train frequency (Hz).
+        implant : :py:class:`~pulse2percept.implants.ProsthesisSystem`, optional
+            If given, the video is first sampled at the implant's electrode
+            locations, so that the pulse trains are built at electrode rather
+            than pixel resolution. Strongly recommended: a video has orders of
+            magnitude more pixels than an implant has electrodes.
+        **kwargs :
+            Additional arguments passed to
+            :py:class:`~pulse2percept.stimuli.AmplitudeEncoder`.
 
         Returns
         -------
@@ -568,50 +577,10 @@ class VideoStimulus(Stimulus):
             Encoded stimulus
 
         """
-        # Set frame rate, either from metadata or inferred from stim.time:
-        try:
-            frame_dur = 1000.0 / self.metadata['fps']
-        except KeyError:
-            t_diff = unique(np.diff(self.time))
-            if len(t_diff) > 1:
-                raise NotImplementedError
-            frame_dur = 1000.0 / t_diff[0]
-        # If no user-defined pulse is given, use a standard one:
-        if pulse is None:
-            pulse = BiphasicPulse(1, 0.46, stim_dur=frame_dur-DT)
-        else:
-            if not isinstance(pulse, Stimulus):
-                raise TypeError('"pulse" must be a Stimulus object.')
-            if pulse.time is None:
-                raise ValueError('"pulse" must have a time component.')
-            if pulse.time[-1] > frame_dur:
-                raise ValueError(f"'pulse.time[-1]={pulse.time[-1]}' exceeds "
-                                 f"frame_dur={frame_dur}.")
-            if isclose(pulse.time[-1], frame_dur):
-                pulse.time[-1] -= DT
-        # Scale the pixel values to the desired amplitude range:
-        vid_data = self.data.copy() - self.data.min()
-        if not isclose(np.abs(vid_data).max(), 0):
-            vid_data /= np.abs(vid_data).max()
-        vid_data = vid_data * (amp_range[1] - amp_range[0]) + amp_range[0]
-        # Normalize pulse data:
-        enc_data = pulse.data.copy()
-        if not isclose(np.abs(enc_data).max(), 0):
-            enc_data /= np.abs(enc_data).max()
-        # Amplitude encoding: Every pixel value serves as an amplitude, so must
-        # be multiplied with the pulse data. This is easily done with an outer
-        # product, then we just need to concatenate all frames in time:
-        vid_data = np.outer(vid_data.ravel(),
-                            enc_data).reshape((self.shape[0], -1))
-        # The time points are given by the pulse data, we just need to shift:
-        vid_time = np.array([pulse.time + s * frame_dur
-                             for s in range(self.shape[1])]).flatten()
-        # Cosmetics: Make sure resulting stimulus has the desired length up to
-        # DT precision:
-        if not isclose(vid_time[-1], self.shape[1] * frame_dur):
-            vid_time[-1] = self.shape[1] * frame_dur
-        return VideoStimulus(vid_data.reshape((*self.vid_shape[:2], -1)),
-                             electrodes=self.electrodes, time=vid_time)
+        # Imported here because `encoders` imports this module:
+        from .encoders import AmplitudeEncoder
+        return AmplitudeEncoder(implant=implant, amp_range=amp_range,
+                                freq=freq, **kwargs).encode(self)
 
     def __iter__(self):
         """Iterate over all frames in self.data"""

--- a/pulse2percept/utils/_fast_array.pyx
+++ b/pulse2percept/utils/_fast_array.pyx
@@ -4,11 +4,17 @@ cimport numpy as cnp
 cnp.import_array()
 
 
-ctypedef cnp.float32_t float32
+ctypedef cnp.float64_t float64
 ctypedef Py_ssize_t index_t
 
-cpdef bint fast_is_strictly_increasing(float32[::1] a, float32[::1] b, float32 tol) noexcept nogil:
-    """Check if b[i] - a[i] is strictly greater than tol for all i"""
+cpdef bint fast_is_strictly_increasing(float64[::1] a, float64[::1] b, float64 tol) noexcept nogil:
+    """Check if b[i] - a[i] is strictly greater than tol for all i
+
+    Takes float64 because it is used on stimulus time axes, which are stored
+    as float64: float32 cannot resolve two time points a DT=1e-3 ms step apart
+    once they are more than 8.4 s in, and would report a perfectly good time
+    axis as non-increasing.
+    """
     cdef index_t i, arr_len = a.shape[0]
 
     for i in range(arr_len):

--- a/pulse2percept/utils/array.py
+++ b/pulse2percept/utils/array.py
@@ -8,9 +8,9 @@ import numpy as np
 
 
 def is_strictly_increasing(arr, tol=1e-6):
-    a = np.ascontiguousarray(arr[:-1], dtype=np.float32)
-    b = np.ascontiguousarray(arr[1:], dtype=np.float32)
-    return fast_is_strictly_increasing(a, b, np.float32(tol))
+    a = np.ascontiguousarray(arr[:-1], dtype=np.float64)
+    b = np.ascontiguousarray(arr[1:], dtype=np.float64)
+    return fast_is_strictly_increasing(a, b, np.float64(tol))
 
 
 def sample(sequence, k=1):


### PR DESCRIPTION
Real implants use amplitude or frequency modulation of a video stim, and address electrodes in raster groups to stay under the instantaneous current limit. Assigning a video to `implant.stim` feeds raw gray levels to the model as if they were currents. The only alternative, `VideoStimulus.encode()`, encoded at pixel rather than electrode resolution (308 MB for a 94-frame clip), contrast-stretched gray levels so that a uniform image encoded to 0, and had no notion of pulse rate or of the current limit that stops a real stimulator from driving every electrode at once.

- [x] `Encoder` base class with `AmplitudeEncoder` (gray level to pulse amplitude) and `FrequencyEncoder` (gray level to pulse rate). Passing an `implant` samples the source at the electrode locations *before* building pulse trains: 308 MB goes down to 0.2 MB, 0.72 s goes down to 0.05 s on `BostonTrain`.
- [x] `clock` and `n_levels` model a stimulator's time base and input resolution. This is important for frequency modulation, where time-shifted pulses don't share time points.
- [x] `Raster`, `SequentialRaster`, `CustomRaster`, plus `ProsthesisSystem.raster` and `max_current`. 
- [x] `ImageStimulus.encode` / `VideoStimulus.encode` map gray levels absolutely (`stretch=True` restores the old behavior), deliver pulse trains rather than single pulses, and no longer infer frame duration as `1000/dt`


Example pipeline: 

```python
implant = p2p.implants.ArgusII()
implant.raster = p2p.implants.SequentialRaster(6)
implant.stim = p2p.stimuli.AmplitudeEncoder(implant, amp_range=(0, 50),
                                            freq=30).encode(video)
```

Along with that, fixing some bugs that surfaced:

- [x] `Stimulus.time` is now float64 (data stays float32). float32 reaches `DT` resolution at t = 8.4 s, so a 30 s pulse train lost 952 pulse edges... and a 3 s one had edges 2% too narrow.
- [x] `PulseTrain` no longer ends on a pulse it cannot finish. Consequently `is_charge_balanced` reports `True` for balanced trains again; it returned `False` for anything over ~5 pulses, so `safe_mode` rejected them.
- [x] `EnsembleImplant` merged time axes with an exact `np.unique`, leaving pairs of points closer together than a time step.
- [x] Temporal models now warn instead of silently returning a blank percept when the stimulus has the wrong polarity (the conventions differ between models: `FadingTemporal` and `Horsager2009Temporal` are cathodic-driven, `Nanduri2012Temporal` is anodic-driven)