### PR TITLE
[FIX] min_current_spread, NaN treatment, find_closest_axon

### DIFF
--- a/pulse2percept/models/_beyeler2019.pyx
+++ b/pulse2percept/models/_beyeler2019.pyx
@@ -419,7 +419,8 @@ cpdef fast_axon_map(const float32[:, ::1] stim,
                 xdiff = ax_x - xel[idx_el]
                 ydiff = ax_y - yel[idx_el]
                 r2 = xdiff * xdiff + ydiff * ydiff
-                # Too far away for the Gaussian below to resolve:
+                # Past the cutoff radius. Note this drops `gauss * stim`, not
+                # just `gauss`:
                 if r2 > cutoff_r2:
                     continue
                 # Activation as a function of distance to the stimulating

--- a/pulse2percept/models/_granley2021.pyx
+++ b/pulse2percept/models/_granley2021.pyx
@@ -39,14 +39,13 @@ cpdef fast_biphasic_axon_map(const float32[::1] amp_el,
     summed exponents: the power becomes ``exp(log(sensitivity) / F_streak)``,
     and ``log(sensitivity)`` depends only on the segment, so it is taken once
     per segment instead of once per segment and electrode. That trades a
-    ``powf`` per pair -- the most expensive call in the loop -- for one
+    ``powf`` per pair (i.e., the most expensive call in the loop) for one
     ``logf`` per segment.
 
-    ``F_streak`` is strictly positive: the default streak model clamps it to
-    ``min_lambda ** 2 / axlambda ** 2``, and ``_predict_spatial`` rejects a
-    custom model that returns anything else. Sensitivities are likewise
-    positive, so the logarithm is always defined.
-
+    ``F_streak`` is finite and strictly positive: the default streak model
+    clamps it to ``min_lambda ** 2 / axlambda ** 2``, and ``_predict_spatial``
+    rejects a custom model that returns anything else.
+    
     Parameters
     ----------
     amp_el : 1D float array 
@@ -150,7 +149,7 @@ cpdef fast_biphasic_axon_map(const float32[::1] amp_el,
                 xdiff = ax_x - xel[idx_el]
                 ydiff = ax_y - yel[idx_el]
                 r2 = xdiff * xdiff + ydiff * ydiff
-                # Too far away for the exponential below to resolve:
+                # `SpatialModel._cutoff_r2`:
                 if r2 > cutoff_el[idx_el]:
                     continue
                 # Distance to the electrode and distance to the soma both

--- a/pulse2percept/models/base.py
+++ b/pulse2percept/models/base.py
@@ -220,9 +220,7 @@ class SpatialModel(BaseModel, metaclass=ABCMeta):
             # Below threshold, percept has brightness zero:
             'thresh_percept': 0,
             # An electrode whose Gaussian current spread at a point has fallen
-            # below this is skipped for that point. The default is small
-            # enough that dropping the term cannot change a float32 result;
-            # see `_cutoff_r2`. Set to 0 to sum over every electrode.
+            # below this is skipped for that point:
             'min_current_spread': 1e-8,
             # Visual field map (retinotopy) to be used:
             'vfmap': Curcio1990Map(),
@@ -250,12 +248,17 @@ class SpatialModel(BaseModel, metaclass=ABCMeta):
         into the squared distance at which that happens, for the spatial
         kernels to compare against.
 
-        The default ``min_current_spread`` of 1e-8 corresponds to a radius of
-        about 6.1 ``rho``. Since the summed brightness is a float32, whose
-        relative resolution is ~1e-7, a term that small cannot change the
-        result -- so the default is an optimization, not an approximation.
-        Raise it to trade accuracy for speed, or set it to 0 to sum over
-        every electrode no matter how distant.
+        .. note::
+
+            The default ``min_current_spread`` of 1e-8 corresponds to a radius
+            of about 6.1 ``rho``. The kernels compare the Gaussian against the
+            cutoff *before* scaling it by the stimulus amplitude and summing
+            over electrodes, so what is dropped at a point is
+            ``sum_i gauss_i * amplitude_i`` over the electrodes outside the
+            cutoff.
+
+            Set it to 0 to sum over every electrode no matter how distant and get
+            the exact result, or raise it to trade more accuracy for speed.
 
         Parameters
         ----------

--- a/pulse2percept/models/beyeler2019.py
+++ b/pulse2percept/models/beyeler2019.py
@@ -97,9 +97,10 @@ class ScoreboardSpatial(SpatialModel):
     min_current_spread : float, optional
         An electrode is skipped at grid points where its Gaussian current
         spread has decayed below this fraction of its peak. The default
-        (1e-8, about 6.1 ``rho`` away) is small enough that the skipped term
-        could not have changed the float32 result, so it buys speed rather
-        than costing accuracy. Set to 0 to sum over every electrode.
+        (1e-8, about 6.1 ``rho`` away) drops the Gaussian *times* the 
+        stimulus amplitude, summed over the skipped electrodes, so the error
+        at a point is bounded by ``min_current_spread`` times the summed 
+        amplitude across electrodes.
     xrange : (x_min, x_max), optional
         A tuple indicating the range of x values to simulate (in degrees of
         visual angle). In a right eye, negative x values correspond to the
@@ -189,9 +190,10 @@ class ScoreboardModel(Model):
     min_current_spread : float, optional
         An electrode is skipped at grid points where its Gaussian current
         spread has decayed below this fraction of its peak. The default
-        (1e-8, about 6.1 ``rho`` away) is small enough that the skipped term
-        could not have changed the float32 result, so it buys speed rather
-        than costing accuracy. Set to 0 to sum over every electrode.
+        (1e-8, about 6.1 ``rho`` away) drops the Gaussian *times* the
+        stimulus amplitude, summed over the skipped electrodes, so the error
+        at a point is bounded by ``min_current_spread`` times the summed
+        amplitude across electrodes.
     xrange : (x_min, x_max), optional
         A tuple indicating the range of x values to simulate (in degrees of
         visual angle). In a right eye, negative x values correspond to the
@@ -262,9 +264,10 @@ class AxonMapSpatial(SpatialModel):
     min_current_spread : float, optional
         An electrode is skipped at axon segments where its Gaussian current
         spread has decayed below this fraction of its peak. The default
-        (1e-8, about 6.1 ``rho`` away) is small enough that the skipped term
-        could not have changed the float32 result, so it buys speed rather
-        than costing accuracy. Set to 0 to sum over every electrode.
+        (1e-8, about 6.1 ``rho`` away) drops the Gaussian *times* the stimulus
+        amplitude, summed over the skipped electrodes, so the error at a point
+        is bounded by ``min_current_spread`` times the summed amplitude across
+        electrodes.
     eye : {'RE', LE'}, optional
         Eye for which to generate the axon map.
     xrange : (x_min, x_max), optional
@@ -566,8 +569,8 @@ class AxonMapSpatial(SpatialModel):
         kdtree = cKDTree(flat_bundles, leafsize=60)
         # Create query list of xy pairs
         query = np.stack((xret.ravel(), yret.ravel()), axis=1)
-        # Find index of closest segment
-        _, closest_seg = kdtree.query(query, workers=-1)
+        # Find index of closest segment with the model's thread budget:
+        _, closest_seg = kdtree.query(query, workers=max(1, self.n_threads))
 
         # Look up the axon ID for every axon segment:
         closest_idx = (np.searchsorted(boff, closest_seg, side='right') -
@@ -1068,9 +1071,10 @@ class AxonMapModel(Model):
     min_current_spread : float, optional
         An electrode is skipped at axon segments where its Gaussian current
         spread has decayed below this fraction of its peak. The default
-        (1e-8, about 6.1 ``rho`` away) is small enough that the skipped term
-        could not have changed the float32 result, so it buys speed rather
-        than costing accuracy. Set to 0 to sum over every electrode.
+        (1e-8, about 6.1 ``rho`` away) drops the Gaussian *times* the
+        stimulus amplitude, summed over the skipped electrodes, so the error
+        at a point is bounded by ``min_current_spread`` times the summed
+        amplitude across electrodes.
     eye : {'RE', LE'}, optional
         Eye for which to generate the axon map.
     xrange : (x_min, x_max), optional

--- a/pulse2percept/models/cortex/base.py
+++ b/pulse2percept/models/cortex/base.py
@@ -29,9 +29,10 @@ class CortexSpatial(SpatialModel):
     min_current_spread : float, optional
         An electrode is skipped at grid points where its Gaussian current
         spread has decayed below this fraction of its peak. The default
-        (1e-8, about 6.1 ``rho`` away) is small enough that the skipped term
-        could not have changed the float32 result, so it buys speed rather
-        than costing accuracy. Set to 0 to sum over every electrode.
+        (1e-8, about 6.1 ``rho`` away) drops the Gaussian *times* the
+        stimulus amplitude, summed over the skipped electrodes, so the error
+        at a point is bounded by ``min_current_spread`` times the summed
+        amplitude across electrodes.
     xrange : (x_min, x_max), optional
         A tuple indicating the range of x values to simulate (in degrees of
         visual angle). In a right eye, negative x values correspond to the
@@ -206,9 +207,10 @@ class ScoreboardSpatial(CortexSpatial):
     min_current_spread : float, optional
         An electrode is skipped at grid points where its Gaussian current
         spread has decayed below this fraction of its peak. The default
-        (1e-8, about 6.1 ``rho`` away) is small enough that the skipped term
-        could not have changed the float32 result, so it buys speed rather
-        than costing accuracy. Set to 0 to sum over every electrode.
+        (1e-8, about 6.1 ``rho`` away) drops the Gaussian *times* the
+        stimulus amplitude, summed over the skipped electrodes, so the
+        error at a point is bounded by ``min_current_spread`` times the
+        summed amplitude across electrodes.
     regions : list of str, optional
         The regions to simulate. Options are 'v1', 'v2', or 'v3'. Default:
         ['v1']
@@ -328,9 +330,10 @@ class ScoreboardModel(Model):
     min_current_spread : float, optional
         An electrode is skipped at grid points where its Gaussian current
         spread has decayed below this fraction of its peak. The default
-        (1e-8, about 6.1 ``rho`` away) is small enough that the skipped term
-        could not have changed the float32 result, so it buys speed rather
-        than costing accuracy. Set to 0 to sum over every electrode.
+        (1e-8, about 6.1 ``rho`` away) drops the Gaussian *times* the
+        stimulus amplitude, summed over the skipped electrodes, so the
+        error at a point is bounded by ``min_current_spread`` times the
+        summed amplitude across electrodes.
     regions : list of str, optional
         The regions to simulate. Options are 'v1', 'v2', or 'v3'. Default:
         ['v1']

--- a/pulse2percept/models/granley2021.py
+++ b/pulse2percept/models/granley2021.py
@@ -226,9 +226,11 @@ class BiphasicAxonMapSpatial(AxonMapSpatial):
             An electrode is skipped at axon segments where its current spread
             has decayed below this fraction of its peak. The decay is scaled
             per electrode by that electrode's ``F_size``. The default (1e-8)
-            is small enough that the skipped term could not have changed the
-            float32 result, so it buys speed rather than costing accuracy.
-            Set to 0 to sum over every electrode.
+            is a deliberate approximation: what gets dropped is the
+            exponential *times* that electrode's ``F_bright``, summed over
+            the skipped electrodes, so the error at a point is bounded by
+            ``min_current_spread`` times the summed ``F_bright`` across
+            electrodes.
         eye: {'RE', LE'}, optional
             Eye for which to generate the axon map.
         xrange : (x_min, x_max), optional
@@ -427,12 +429,19 @@ class BiphasicAxonMapSpatial(AxonMapSpatial):
         streak_effects = np.array(self.streak_model(elec_params[:, 0], elec_params[:, 1], elec_params[:, 2]),
                                   dtype=np.float32).reshape((-1))
         amps = np.array(elec_params[:, 1], dtype=np.float32).reshape((-1))
-        # The kernel rescales each segment's sensitivity by
-        # ``1 / F_streak`` and each phosphene's size by ``F_size``, both in an
-        # exponent, so neither may be zero or negative. The default models
-        # cannot produce that -- ``DefaultStreakModel`` clamps to
-        # ``min_lambda ** 2 / axlambda ** 2`` -- but a custom one could, and
-        # it would otherwise surface as a silent NaN in the percept:
+        # A non-finite factor propagates through the kernel's exponent into
+        # the segment brightness, where abs(nan) > abs(px_bright). So we need
+        # to catch it here:
+        for name, effects in (('bright_model', bright_effects),
+                              ('size_model', size_effects),
+                              ('streak_model', streak_effects)):
+            if not np.all(np.isfinite(effects)):
+                raise ValueError(f"{type(self).__name__}.{name} returned a "
+                                 f"non-finite scaling factor. Scaling factors "
+                                 f"must be finite.")
+        # The kernel rescales each segment's sensitivity by 1 / F_streak and
+        # each phosphene's size by F_size, both in an exponent, so neither of
+        # them may be negative:
         for name, effects in (('size_model', size_effects),
                               ('streak_model', streak_effects)):
             if np.any(effects <= 0):
@@ -584,9 +593,14 @@ class BiphasicAxonMapModel(Model):
             An electrode is skipped at axon segments where its current spread
             has decayed below this fraction of its peak. The decay is scaled
             per electrode by that electrode's ``F_size``. The default (1e-8)
-            is small enough that the skipped term could not have changed the
-            float32 result, so it buys speed rather than costing accuracy.
-            Set to 0 to sum over every electrode.
+            is a deliberate approximation: what gets dropped is the
+            exponential *times* that electrode's ``F_bright``, summed over
+            the skipped electrodes, so the error at a point is bounded by
+            ``min_current_spread`` times the summed ``F_bright`` across
+            electrodes. That is negligible for a typical array, but it grows
+            with both array size and brightness scaling, and it can zero out
+            points that are merely dim. Set to 0 to sum over every electrode
+            and get the exact result.
         eye: {'RE', LE'}, optional
             Eye for which to generate the axon map.
         xrange : (x_min, x_max), optional

--- a/pulse2percept/models/tests/test_beyeler2019.py
+++ b/pulse2percept/models/tests/test_beyeler2019.py
@@ -456,6 +456,36 @@ def test_AxonMapModel_find_closest_axon():
     npt.assert_equal(closest_idx, 0)
 
 
+@pytest.mark.parametrize('n_threads', (1, 3))
+def test_AxonMapModel_find_closest_axon_respects_n_threads(monkeypatch,
+                                                           n_threads):
+    """The KD-tree query stays inside the model's thread budget.
+
+    ``n_threads``/``n_jobs`` is the one knob this package gives for capping
+    CPU use, and the tree query is part of ``build``. Passing ``workers=-1``
+    here would let ``AxonMapModel(n_threads=1).build()`` fan out over every
+    core anyway.
+    """
+    from pulse2percept.models import beyeler2019
+
+    seen = []
+
+    class RecordingKDTree(beyeler2019.cKDTree):
+        def query(self, *args, **kwargs):
+            seen.append(kwargs.get('workers'))
+            return super().query(*args, **kwargs)
+
+    monkeypatch.setattr(beyeler2019, 'cKDTree', RecordingKDTree)
+    model = AxonMapSpatial(n_threads=n_threads)
+    bundles = [np.array([[0.0, 0.0], [1.0, 1.0]], dtype=np.float32),
+               np.array([[10.0, 10.0], [11.0, 11.0]], dtype=np.float32)]
+    closest, idx = model.find_closest_axon(bundles, xret=[0.5, 10.5],
+                                           yret=[0.5, 10.5],
+                                           return_index=True)
+    npt.assert_equal(idx, [0, 1])
+    npt.assert_equal(seen, [n_threads])
+
+
 def test_AxonMapModel_calc_axon_sensitivity():
     model = AxonMapModel(xystep=2, n_axons=10,
                          xrange=(-20, 20), yrange=(-15, 15),
@@ -579,12 +609,13 @@ def test_AxonMapModel_predict_percept():
 
 @pytest.mark.parametrize('ModelClass', (ScoreboardModel, AxonMapModel))
 def test_min_current_spread(ModelClass):
-    """The default current-spread cutoff must not change the percept.
+    """The default current-spread cutoff barely moves a sparse percept.
 
     ``min_current_spread`` drops an electrode's contribution once its
-    Gaussian has decayed past the given fraction of its peak. At the default
-    of 1e-8 the dropped term is below what a float32 sum can resolve, so it
-    is meant to buy speed at no cost to the result.
+    Gaussian has decayed past the given fraction of its peak. This pins the
+    everyday case -- a handful of electrodes at unit amplitude, where the
+    default cutoff is not worth thinking about. See
+    ``test_min_current_spread_error_bound`` for the case where it is.
     """
     stim = np.zeros(60)
     stim[[10, 33, 47]] = [1.0, -0.5, 0.75]
@@ -608,6 +639,41 @@ def test_min_current_spread(ModelClass):
     model = ModelClass(min_current_spread=1, **kwargs).build()
     with pytest.raises(ValueError):
         model.predict_percept(implant)
+
+
+@pytest.mark.parametrize('ModelClass', (ScoreboardModel, AxonMapModel))
+@pytest.mark.parametrize('amp', (1.0, 1000.0))
+def test_min_current_spread_error_bound(ModelClass, amp):
+    """The cutoff is an approximation, and stays inside its documented bound.
+
+    The kernels compare the Gaussian against the cutoff *before* scaling it
+    by the stimulus and summing over electrodes, so the quantity dropped at a
+    point is ``sum_i gauss_i * amp_i``, not ``gauss`` alone. Every electrode
+    of the array is driven here so that all 60 individually sub-cutoff terms
+    accumulate -- the adversarial case for a per-electrode cutoff -- and the
+    amplitude is swept because the bound scales with it.
+    """
+    min_spread = 1e-8
+    stim = np.full(60, amp)
+    implant = ArgusII(stim=stim)
+    kwargs = {'xystep': 0.75, 'xrange': (-14, 14), 'yrange': (-10, 10),
+              'rho': 200}
+
+    exact = ModelClass(min_current_spread=0,
+                       **kwargs).build().predict_percept(implant).data
+    default = ModelClass(min_current_spread=min_spread,
+                         **kwargs).build().predict_percept(implant).data
+    # What the docs promise: `min_current_spread` times the summed amplitude,
+    # plus whatever the float32 accumulation itself costs:
+    dropped = min_spread * np.abs(stim).sum()
+    assert np.abs(default - exact).max() <= dropped + 1e-6 * np.abs(exact).max()
+
+    # It is not, however, a no-op. Points that every electrode is far from
+    # come back as exactly zero rather than merely small -- a relative error
+    # of 100% at those points, however small they are in absolute terms:
+    zeroed = (np.abs(exact) > 0) & (default == 0)
+    assert zeroed.any()
+    assert np.abs(exact[zeroed]).max() <= dropped
 
 
 @pytest.mark.parametrize('ModelClass', (ScoreboardModel, AxonMapModel))

--- a/pulse2percept/models/tests/test_granley2021.py
+++ b/pulse2percept/models/tests/test_granley2021.py
@@ -385,7 +385,9 @@ def test_BiphasicAxonMapModel_min_current_spread():
         min_current_spread=0, **kwargs).build().predict_percept(implant).data
     default = BiphasicAxonMapModel(
         **kwargs).build().predict_percept(implant).data
-    # The default cutoff is below what a float32 sum can resolve:
+    # For three electrodes the default cutoff is not worth thinking about;
+    # see `test_BiphasicAxonMapModel_min_current_spread_error_bound` for the
+    # case where it is:
     npt.assert_allclose(default, exact, rtol=1e-5,
                         atol=1e-6 * np.abs(exact).max())
 
@@ -394,6 +396,36 @@ def test_BiphasicAxonMapModel_min_current_spread():
     coarse = BiphasicAxonMapModel(
         min_current_spread=0.5, **kwargs).build().predict_percept(implant).data
     assert np.abs(coarse - exact).max() > 1e-3
+
+
+@pytest.mark.parametrize('amp', (2.0, 50.0))
+def test_BiphasicAxonMapModel_min_current_spread_error_bound(amp):
+    """The cutoff is an approximation here too, with a bound to match.
+
+    The biphasic kernel tests ``r2`` against the cutoff before scaling the
+    exponential by ``F_bright``, so what it drops at a segment is
+    ``sum_i F_bright_i * exp(...)``. The error is therefore bounded by
+    ``min_current_spread * sum(F_bright)``, which grows with the array size
+    and with however hard the brightness model scales -- not by 1e-8 outright.
+    """
+    min_spread = 1e-8
+    freq, pdur = 20, 0.45
+    implant = ArgusII(stim={e: BiphasicPulseTrain(freq, amp, pdur)
+                            for e in ArgusII().electrode_names})
+    kwargs = {'xrange': (-14, 14), 'yrange': (-10, 10), 'xystep': 0.75,
+              'rho': 200, 'axlambda': 800, 'verbose': False}
+
+    model = BiphasicAxonMapModel(min_current_spread=0, **kwargs).build()
+    exact = model.predict_percept(implant).data
+    default = BiphasicAxonMapModel(
+        min_current_spread=min_spread,
+        **kwargs).build().predict_percept(implant).data
+
+    n_el = len(implant.electrode_names)
+    f_bright = np.asarray(model.spatial.bright_model(
+        np.full(n_el, freq), np.full(n_el, amp), np.full(n_el, pdur)))
+    dropped = min_spread * np.abs(f_bright).sum()
+    assert np.abs(default - exact).max() <= dropped + 1e-6 * np.abs(exact).max()
 
 
 @pytest.mark.parametrize('attr', ('size_model', 'streak_model'))
@@ -414,6 +446,31 @@ def test_BiphasicAxonMapModel_rejects_nonpositive_effects(attr):
     # A positive factor is accepted:
     setattr(model.spatial, attr, lambda freq, amp, pdur: np.ones_like(amp))
     npt.assert_equal(model.predict_percept(implant) is not None, True)
+
+
+@pytest.mark.parametrize('attr', ('bright_model', 'size_model',
+                                  'streak_model'))
+@pytest.mark.parametrize('bad', (np.nan, np.inf, -np.inf))
+def test_BiphasicAxonMapModel_rejects_nonfinite_effects(attr, bad):
+    """A non-finite scaling factor is rejected before it reaches the kernel.
+
+    ``nan <= 0`` is false, so the positivity check above does not catch NaN.
+    Left alone it would flow into the kernel's exponent, and then
+    ``abs(nan) > abs(px_bright)`` is false too -- so the affected segments
+    would drop out of the max and the percept would come back quietly wrong
+    instead of raising. Infinities are no better: they turn the sum into
+    ``inf`` or ``nan`` depending on the signs involved. This covers
+    ``bright_model`` as well, which the positivity check deliberately does
+    not (a zero or negative brightness factor is legitimate).
+    """
+    model = BiphasicAxonMapModel(xrange=(-4, 4), yrange=(-4, 4), xystep=1,
+                                 verbose=False).build()
+    setattr(model.spatial, attr,
+            lambda freq, amp, pdur: np.full_like(np.asarray(amp, dtype=float),
+                                                 bad))
+    implant = ArgusII(stim={'A2': BiphasicPulseTrain(20, 30, 0.45)})
+    with pytest.raises(ValueError, match=attr):
+        model.predict_percept(implant)
 
 
 def test_BiphasicAxonMapModel_reduces_to_AxonMapModel():


### PR DESCRIPTION
This PR fixes 3 things introduced by #808:

- [x] `min_current_spread` is an approximation, but the docs called it exact ("cannot change a float32 result"). This is now clarified throughout
- [x] Granley's new custom-effect validation still lets NaN through, producing exactly the silent failure it is trying to prevent. The error propagated in the Cython code into the exponent/sum. The kernel now checks for `isfinite` first
- [x] `find_closest_axon` used all available threads but should respect the model's `n_threads` param