### PR TITLE
[FIX] VideoStimulus compression, alpha level, and JPG/PNG default

### DIFF
--- a/doc/users/release_notes.rst
+++ b/doc/users/release_notes.rst
@@ -38,8 +38,11 @@ API changes:
 * :py:class:`~pulse2percept.implants.ProsthesisSystem` now exposes ``raster``
   and ``max_current``.
 
-* ``play`` gained a ``fmt`` argument. JPEG is now the default for substantially
-  smaller output; use ``fmt='png'`` for pixel-exact frames.
+* ``play`` gained a ``fmt`` argument.
+  :py:meth:`~pulse2percept.stimuli.VideoStimulus.play` defaults to JPEG, which
+  is substantially smaller and faster to build for color video;
+  :py:meth:`~pulse2percept.percepts.Percept.play` defaults to PNG, which is
+  pixel-exact and nearly as compact for scalar data. Pass ``fmt`` to override.
 
 * Minimum dependency versions were raised for NumPy 2 compatibility. NumPy 1.x
   users should remain on v0.9.1.
@@ -78,6 +81,22 @@ API changes:
 
 * :py:meth:`~pulse2percept.stimuli.VideoStimulus.encode` now correctly infers
   frame duration from the time axis when frame-rate metadata is absent.
+
+* :py:attr:`~pulse2percept.stimuli.VideoStimulus.vid_shape` now reports the
+  number of frames the stimulus actually has, rather than the number the source
+  video had before ``compress=True`` dropped the redundant time points. This
+  fixes :py:meth:`~pulse2percept.stimuli.VideoStimulus.play` and every other
+  operation that reshapes ``data`` back into frames. Playing a video that was
+  compressed in *space* raises an explanatory error instead of a reshape error.
+
+* A four-channel :py:class:`~pulse2percept.stimuli.VideoStimulus` is played
+  back as RGBA, as documented: the alpha channel is preserved for ``fmt='png'``
+  and composited onto the axes background for ``fmt='jpg'``, which cannot carry
+  it. Previously the four channels were reinterpreted as RGB, which sheared the
+  color channels across every row.
+
+* The per-frame title in the HTML player no longer piles up on itself or on a
+  title that was already on the axes.
 
 v0.9.1 (2026-08-06)
 -------------------

--- a/pulse2percept/percepts/base.py
+++ b/pulse2percept/percepts/base.py
@@ -248,7 +248,7 @@ class Percept(Data):
         return ax
 
     def play(self, fps=None, repeat=True, annotate_time=True, ax=None,
-             colorbar=True, fmt='jpg'):
+             colorbar=True, fmt='png'):
         """Animate the percept as HTML with JavaScript
 
         The percept will be played in an interactive player in IPython or
@@ -269,10 +269,13 @@ class Percept(Data):
             A Matplotlib axes object. If None, will create a new Axes object
         colorbar : {True, False}
             Whether to show the colorbar
-        fmt : {'jpg', 'png'}, optional
-            The image format used to embed the frames. 'jpg' keeps notebooks
-            and doc pages an order of magnitude smaller; use 'png' if you need
-            the frames to be pixel-exact.
+        fmt : {'png', 'jpg'}, optional
+            The image format used to embed the frames. A percept is scalar, so
+            'png' ships it as a palettized image of one byte per pixel, which
+            is already compact; 'jpg' roughly halves that again, but a
+            phosphene is exactly the kind of high-contrast blob against black
+            that JPEG rings around. Prefer 'jpg' only if size matters more than
+            pixel-exact frames.
 
             .. versionadded:: 0.10.0
 

--- a/pulse2percept/percepts/tests/test_base.py
+++ b/pulse2percept/percepts/tests/test_base.py
@@ -180,10 +180,12 @@ def test_Percept_play_single_frame():
 
 def test_Percept_play_fmt():
     percept = Percept(np.random.rand(8, 8, 4))
+    # A percept is scalar, so the lossless default already costs only one byte
+    # per pixel -- and JPEG rings around high-contrast phosphenes:
     npt.assert_equal('data:image/jpeg;base64,' in percept.play().to_jshtml(),
-                     True)
+                     False)
     npt.assert_equal('data:image/jpeg;base64,' in
-                     percept.play(fmt='png').to_jshtml(), False)
+                     percept.play(fmt='jpg').to_jshtml(), True)
     with pytest.raises(ValueError):
         percept.play(fmt='gif')
 

--- a/pulse2percept/stimuli/tests/test_videos.py
+++ b/pulse2percept/stimuli/tests/test_videos.py
@@ -366,6 +366,42 @@ def test_VideoStimulus_play(n_frames):
     npt.assert_equal('p2p-anim' in rgb.play().to_jshtml(), True)
 
 
+def test_VideoStimulus_play_compressed():
+    """Compression changes the number of frames, and 'vid_shape' must follow
+
+    A video whose pixels are all nonzero survives spatial compression intact,
+    but runs of identical frames are still dropped from the time axis. The
+    player is handed a dense (Y, X, T) array, so a stale frame count in
+    'vid_shape' makes that reshape fail.
+    """
+    frame = np.random.rand(4, 5) * 0.5 + 0.5
+    other = np.random.rand(4, 5) * 0.5 + 0.5
+    ndarray = np.stack([frame] * 4 + [other] * 4, axis=-1)
+    video = VideoStimulus(ndarray, time=np.arange(8), compress=True)
+    # Four of the eight time points are redundant and have been dropped:
+    npt.assert_equal(video.data.shape[-1], 4)
+    npt.assert_equal(video.vid_shape, (4, 5, 4))
+    # The compressed time axis is no longer homogeneous, hence the explicit fps:
+    html = video.play(fps=10).to_jshtml()
+    npt.assert_equal('"n": 4' in html, True)
+    npt.assert_equal(f't = {video.time[-1]:.2f} ms' in html, True)
+    # An all-zero pixel is dropped instead, and no shape can describe what is
+    # left, so playback fails with an explanation rather than a reshape error:
+    sparse = np.zeros((4, 5, 6))
+    sparse[1, 1, :] = np.linspace(0, 1, 6)
+    with pytest.raises(ValueError):
+        VideoStimulus(sparse, time=np.arange(6), compress=True).play()
+
+
+def test_VideoStimulus_play_rgba():
+    # A four-channel video is RGBA (see the class docstring), not RGB:
+    ndarray = np.random.rand(4, 5, 4, 3)
+    video = VideoStimulus(ndarray, time=np.arange(3))
+    npt.assert_equal(video.vid_shape, (4, 5, 4, 3))
+    for fmt in ('png', 'jpg'):
+        npt.assert_equal('p2p-anim' in video.play(fmt=fmt).to_jshtml(), True)
+
+
 def test_VideoStimulus_play_fmt():
     video = VideoStimulus(np.random.rand(8, 8, 4))
     npt.assert_equal('data:image/jpeg;base64,' in video.play().to_jshtml(),

--- a/pulse2percept/stimuli/tests/test_videos.py
+++ b/pulse2percept/stimuli/tests/test_videos.py
@@ -377,14 +377,20 @@ def test_VideoStimulus_play_compressed():
     frame = np.random.rand(4, 5) * 0.5 + 0.5
     other = np.random.rand(4, 5) * 0.5 + 0.5
     ndarray = np.stack([frame] * 4 + [other] * 4, axis=-1)
-    video = VideoStimulus(ndarray, time=np.arange(8), compress=True)
-    # Four of the eight time points are redundant and have been dropped:
-    npt.assert_equal(video.data.shape[-1], 4)
-    npt.assert_equal(video.vid_shape, (4, 5, 4))
-    # The compressed time axis is no longer homogeneous, hence the explicit fps:
-    html = video.play(fps=10).to_jshtml()
-    npt.assert_equal('"n": 4' in html, True)
-    npt.assert_equal(f't = {video.time[-1]:.2f} ms' in html, True)
+    # Compressing at construction time and compressing afterwards must leave
+    # the stimulus in the same state:
+    eager = VideoStimulus(ndarray, time=np.arange(8), compress=True)
+    lazy = VideoStimulus(ndarray, time=np.arange(8))
+    npt.assert_equal(lazy.vid_shape, (4, 5, 8))
+    lazy.compress()
+    for video in (eager, lazy):
+        # Four of the eight time points are redundant and have been dropped:
+        npt.assert_equal(video.data.shape[-1], 4)
+        npt.assert_equal(video.vid_shape, (4, 5, 4))
+        # The compressed time axis is no longer homogeneous, hence the fps:
+        html = video.play(fps=10).to_jshtml()
+        npt.assert_equal('"n": 4' in html, True)
+        npt.assert_equal(f't = {video.time[-1]:.2f} ms' in html, True)
     # An all-zero pixel is dropped instead, and no shape can describe what is
     # left, so playback fails with an explanation rather than a reshape error:
     sparse = np.zeros((4, 5, 6))

--- a/pulse2percept/stimuli/videos.py
+++ b/pulse2percept/stimuli/videos.py
@@ -154,8 +154,32 @@ class VideoStimulus(Stimulus):
                                             time=time, electrodes=electrodes,
                                             metadata=metadata,
                                             compress=compress)
+        if compress:
+            # Compression drops the time points at which the video does not
+            # change, so the frame count above is no longer the frame count of
+            # the stimulus. ``vid_shape`` has to describe ``self.data``, which
+            # is what every ``data.reshape(vid_shape)`` in this module relies
+            # on. (Compression can also drop all-zero pixels, in which case no
+            # shape describes the data any more; see ``_frames``.)
+            self.vid_shape = (*self.vid_shape[:-1], self.data.shape[-1])
         self.metadata = metadata
         self.rewind()
+
+    def _frames(self):
+        """The stimulus as a dense <rows x columns [x channels] x frames> array
+
+        Raises a ``ValueError`` if the video has been compressed in space,
+        which removes all-zero pixels and therefore leaves nothing that can be
+        reshaped back into a frame.
+        """
+        n_px = int(np.prod(self.vid_shape[:-1]))
+        if self.data.shape[0] != n_px:
+            raise ValueError(
+                f"This video was compressed in space: {self.data.shape[0]} of "
+                f"its {n_px} pixels are left, so its frames cannot be "
+                f"reconstructed. Pass 'compress=False' to keep the video "
+                f"dense.")
+        return self.data.reshape(self.vid_shape)
 
     def _pprint_params(self):
         params = super()._pprint_params()
@@ -660,6 +684,9 @@ class VideoStimulus(Stimulus):
 
         if self.time is None:
             raise ValueError("Cannot animate a percept with time=None.")
+        # Raises if the video was compressed in space, in which case there is
+        # no dense frame left to display:
+        frames = self._frames()
 
         # There are several options to animate a percept in Jupyter/IPython
         # (see https://stackoverflow.com/a/46878531). Displaying the animation
@@ -683,8 +710,7 @@ class VideoStimulus(Stimulus):
         return HTMLAnimation(fig, update, data_gen, repeat=repeat,
                              interval=frame_interval(self.time, fps=fps),
                              save_count=len(self.time), image=mat,
-                             labels=labels, fmt=fmt,
-                             frame_data=self.data.reshape(self.vid_shape))
+                             labels=labels, fmt=fmt, frame_data=frames)
 
 
 class BostonTrain(VideoStimulus):

--- a/pulse2percept/stimuli/videos.py
+++ b/pulse2percept/stimuli/videos.py
@@ -154,16 +154,28 @@ class VideoStimulus(Stimulus):
                                             time=time, electrodes=electrodes,
                                             metadata=metadata,
                                             compress=compress)
-        if compress:
-            # Compression drops the time points at which the video does not
-            # change, so the frame count above is no longer the frame count of
-            # the stimulus. ``vid_shape`` has to describe ``self.data``, which
-            # is what every ``data.reshape(vid_shape)`` in this module relies
-            # on. (Compression can also drop all-zero pixels, in which case no
-            # shape describes the data any more; see ``_frames``.)
-            self.vid_shape = (*self.vid_shape[:-1], self.data.shape[-1])
         self.metadata = metadata
         self.rewind()
+
+    def compress(self):
+        """Compress the source data
+
+        Also brings ``vid_shape`` back in line with the compressed data:
+        compression drops the time points at which the video does not change,
+        so the frame count of the source is no longer the frame count of the
+        stimulus. Every ``data.reshape(vid_shape)`` in this module relies on
+        that invariant. (Compression can also drop all-zero pixels, in which
+        case no shape describes the data any more; see ``_frames``.)
+
+        Returns
+        -------
+        compressed : :py:class:`~pulse2percept.stimuli.VideoStimulus`
+        """
+        super().compress()
+        # ``Stimulus.__init__`` calls this method for ``compress=True``, which
+        # is why ``vid_shape`` is set before the constructor runs: one
+        # implementation then covers both that and an explicit ``compress()``.
+        self.vid_shape = (*self.vid_shape[:-1], self.data.shape[-1])
 
     def _frames(self):
         """The stimulus as a dense <rows x columns [x channels] x frames> array

--- a/pulse2percept/utils/animation.py
+++ b/pulse2percept/utils/animation.py
@@ -24,7 +24,7 @@ from uuid import uuid4
 
 import numpy as np
 from matplotlib.animation import FuncAnimation
-from matplotlib.colors import to_hex
+from matplotlib.colors import to_hex, to_rgba
 from PIL import Image
 
 from .array import unique
@@ -65,6 +65,15 @@ JPEG_MACROBLOCK = 16
 # Frame duration (in ms) to fall back on for single-frame animations, which
 # have no time step of their own:
 SINGLE_FRAME_INTERVAL = 1000.0 / 30
+
+# The title is blank while the animation is built, and an empty ``Text`` has a
+# degenerate bounding box. Its geometry is therefore measured on a probe
+# string, which must carry both an ascender and a descender so that the band
+# the player clears covers a full line of text:
+TITLE_PROBE = 'Ag'
+
+# Pixels of slack added to that band, to catch antialiasing:
+TITLE_MARGIN = 1
 
 
 def frame_interval(time, fps=None, tol=1e-2):
@@ -192,21 +201,25 @@ def _color_lut(cmap):
     return (np.asarray(lut)[:, :3] * 255).astype(np.uint8)
 
 
-def _sprite_sheet(data, norm, cmap, max_shape, fmt):
+def _sprite_sheet(data, norm, cmap, max_shape, fmt, bg_color=(255, 255, 255)):
     """Color-map every frame and pack them all into a single image
 
     Parameters
     ----------
     data : ndarray
-        Either (Y, X, T) scalar data or (Y, X, 3, T) RGB data in [0, 1]
+        Either (Y, X, T) scalar data, (Y, X, 3, T) RGB data, or (Y, X, 4, T)
+        RGBA data in [0, 1]
     norm : matplotlib.colors.Normalize
-        The normalization of the animated image (ignored for RGB data)
+        The normalization of the animated image (ignored for RGB(A) data)
     cmap : matplotlib.colors.Colormap
-        The colormap of the animated image (ignored for RGB data)
+        The colormap of the animated image (ignored for RGB(A) data)
     max_shape : (height, width)
         Frames are downsampled to at most this size
     fmt : {'jpg', 'png'}
         Whether to encode the sheet as (lossy) JPEG or (lossless) PNG
+    bg_color : (r, g, b), optional
+        The 8-bit color that RGBA frames are flattened onto when the sheet
+        cannot carry an alpha channel (i.e., for JPEG)
 
     Returns
     -------
@@ -216,15 +229,25 @@ def _sprite_sheet(data, norm, cmap, max_shape, fmt):
         distance between two frames on the sheet ('sw', 'sh')
     """
     rgb = np.ndim(data) == 4
+    rgba = rgb and np.shape(data)[-2] == 4
     n_frames = np.shape(data)[-1]
     if rgb:
-        # (Y, X, 3, T) -> (T, Y, X, 3), clipped the same way Matplotlib clips
+        # (Y, X, C, T) -> (T, Y, X, C), clipped the same way Matplotlib clips
         # out-of-range RGB values:
         scaled = np.clip(np.asarray(data, dtype=np.float32), 0, 1) * 255
         frames = np.ascontiguousarray(
             scaled.transpose((3, 0, 1, 2)).astype(np.uint8))
     else:
         frames = _quantize(data, norm)
+    if rgba and fmt == 'jpg':
+        # JPEG has no alpha channel, so the frames have to be flattened onto
+        # what they are drawn on top of. This is what Matplotlib rasterizes as
+        # well; the PNG path keeps the alpha and lets the canvas composite it:
+        alpha = frames[..., 3:].astype(np.float32) / 255.0
+        flat = frames[..., :3] * alpha + np.asarray(bg_color, dtype=np.float32)\
+            * (1.0 - alpha)
+        frames = np.ascontiguousarray(np.round(flat).astype(np.uint8))
+        rgba = False
     # JPEG has no palette, so scalar data must carry its colors itself. Gray
     # colormaps stay single-channel; anything else is expanded to RGB:
     if fmt == 'jpg' and not rgb:
@@ -263,7 +286,7 @@ def _sprite_sheet(data, norm, cmap, max_shape, fmt):
         Image.fromarray(sheet, mode='RGB' if sheet.ndim == 3 else 'L').save(
             buf, format='jpeg', quality=JPEG_QUALITY)
     elif rgb:
-        Image.fromarray(sheet, mode='RGB').save(
+        Image.fromarray(sheet, mode='RGBA' if rgba else 'RGB').save(
             buf, format='png', compress_level=PNG_COMPRESS_LEVEL)
     else:
         # Ship the colormap as a PNG palette: this keeps the sheet at one byte
@@ -295,30 +318,56 @@ def _background(fig, im):
     return buf.getvalue(), width, height
 
 
+def _bg_color(ax):
+    """The 8-bit color that the animated image sits on top of
+
+    Only matters for RGBA frames on a JPEG sheet, which cannot carry an alpha
+    channel and therefore have to be flattened onto their background.
+    """
+    axes_rgba = np.asarray(to_rgba(ax.get_facecolor()), dtype=np.float32)
+    # A transparent axes patch lets the figure show through:
+    fig_rgb = np.asarray(to_rgba(ax.figure.get_facecolor()),
+                         dtype=np.float32)[:3]
+    alpha = axes_rgba[3]
+    return tuple((axes_rgba[:3] * alpha + fig_rgb * (1 - alpha)) * 255)
+
+
 def _title_geometry(title, width, height, dpi):
     """Locate the title so that the player can redraw it for every frame
 
     Returns a dict of canvas coordinates/styles, or None if the title cannot be
     measured (e.g., because the figure has not been drawn yet).
 
-    The title is empty at this point, so its bounding box has zero width but
-    the full height of a line of text, which is exactly what we need: the band
-    to clear, and the anchor the text is aligned to.
+    The title is blank at this point so that it does not end up in the static
+    background, and an empty ``Text`` has a degenerate bounding box: it sits on
+    the baseline and has no height at all. Both the anchor the text is aligned
+    to and the line box that has to be cleared before every frame are therefore
+    measured on ``TITLE_PROBE`` instead.
     """
+    text = title.get_text()
     try:
+        title.set_text(TITLE_PROBE)
         bbox = title.get_window_extent()
     except (RuntimeError, ValueError, AttributeError):
         return None
+    finally:
+        title.set_text(text)
     align = title.get_horizontalalignment()
+    if align == 'left':
+        x = bbox.x0
+    elif align == 'right':
+        x = bbox.x1
+    else:
+        align, x = 'center', (bbox.x0 + bbox.x1) / 2
     return {
         # Only the title's own line box is cleared, so a suptitle or anything
         # else on the figure stays untouched. The band spans the entire figure
         # because the text grows to both sides of its anchor:
-        'rect': [0, round(height - bbox.y1), width,
-                 max(1, round(bbox.y1 - bbox.y0))],
-        'x': round(bbox.x1 if align == 'right' else bbox.x0),
+        'rect': [0, round(height - bbox.y1 - TITLE_MARGIN), width,
+                 max(1, round(bbox.y1 - bbox.y0 + 2 * TITLE_MARGIN))],
+        'x': round(x),
         'y': round(height - (bbox.y0 + bbox.y1) / 2),
-        'align': align if align in ('left', 'right') else 'center',
+        'align': align,
         'font': (f'{_weight2css(title.get_fontweight())} '
                  f'{title.get_fontsize() * dpi / 72.0:.1f}px '
                  f'"DejaVu Sans", Verdana, sans-serif'),
@@ -388,6 +437,9 @@ _PLAYER = Template("""
     if (!sheet.complete || !sheet.naturalWidth) { return; }
     var col = frame % cfg.ncols, row = (frame - col) / cfg.ncols;
     ctx.imageSmoothingEnabled = cfg.smooth;
+    // Frames with an alpha channel are composited onto the static background,
+    // so the previous frame has to go first or they stack up:
+    ctx.clearRect(cfg.rect[0], cfg.rect[1], cfg.rect[2], cfg.rect[3]);
     ctx.drawImage(sheet, col * cfg.sw, row * cfg.sh, cfg.fw, cfg.fh,
                   cfg.rect[0], cfg.rect[1], cfg.rect[2], cfg.rect[3]);
     if (cfg.title) {
@@ -482,8 +534,8 @@ class HTMLAnimation(FuncAnimation):
         The image artist that is updated by ``func``. Its position, colormap,
         and normalization determine how the frames are drawn
     frame_data : ndarray
-        Either (Y, X, T) scalar data or (Y, X, 3, T) RGB data, matching what
-        ``func`` displays in ``image``
+        Either (Y, X, T) scalar data, (Y, X, 3, T) RGB data, or (Y, X, 4, T)
+        RGBA data, matching what ``func`` displays in ``image``
     labels : list of str or None
         Per-frame titles. If None, the title is left alone
     fmt : {'jpg', 'png'}, optional
@@ -515,22 +567,38 @@ class HTMLAnimation(FuncAnimation):
             # The image is hidden while the background is rendered, so it will
             # never get a chance to autoscale itself:
             im.norm.autoscale_None(np.asarray(self._frame_data))
-        bg, width, height = _background(fig, im)
-        # ``get_window_extent`` is only meaningful once the figure has been
-        # drawn, which ``_background`` just did. Round the destination rect
-        # outward rather than rounding its size: rounding the size can leave a
-        # row or column of background exposed along the edge of the image,
-        # whereas overshooting by a fraction of a pixel is invisible.
-        bbox = im.get_window_extent()
+        title_artist = im.axes.title
+        old_title = title_artist.get_text()
+        try:
+            if self._labels is not None:
+                # The player draws the title itself, on a canvas that sits on
+                # top of the static background. Clearing the canvas cannot undo
+                # anything baked into that background, so a title left on the
+                # axes (by an earlier draw, or by the caller) would show
+                # through every frame. Blank it while the background is
+                # rendered; this is also what lets ``_title_geometry`` measure
+                # the empty line box it needs:
+                title_artist.set_text('')
+            bg, width, height = _background(fig, im)
+            # ``get_window_extent`` is only meaningful once the figure has been
+            # drawn, which ``_background`` just did. Round the destination rect
+            # outward rather than rounding its size: rounding the size can
+            # leave a row or column of background exposed along the edge of the
+            # image, whereas overshooting by a fraction of a pixel is
+            # invisible.
+            bbox = im.get_window_extent()
+            title = None
+            if self._labels is not None:
+                title = _title_geometry(title_artist, width, height, fig.dpi)
+        finally:
+            title_artist.set_text(old_title)
         left, right = int(np.floor(bbox.x0)), int(np.ceil(bbox.x1))
         top, bottom = int(np.floor(height - bbox.y1)), \
             int(np.ceil(height - bbox.y0))
         rect = [left, top, max(1, right - left), max(1, bottom - top)]
         sheet = _sprite_sheet(self._frame_data, im.norm, im.cmap,
-                              (rect[3], rect[2]), self._fmt)
-        title = None
-        if self._labels is not None:
-            title = _title_geometry(im.axes.title, width, height, fig.dpi)
+                              (rect[3], rect[2]), self._fmt,
+                              bg_color=_bg_color(im.axes))
         config = {
             'n': int(np.shape(self._frame_data)[-1]),
             'ncols': sheet['ncols'],

--- a/pulse2percept/utils/tests/test_animation.py
+++ b/pulse2percept/utils/tests/test_animation.py
@@ -206,6 +206,34 @@ def test_HTMLAnimation_rgb(fmt):
                                          expected), 24)
 
 
+@pytest.mark.parametrize('fmt', ('png', 'jpg'))
+def test_HTMLAnimation_rgba(fmt):
+    """Four channels are RGBA, not RGB
+
+    ``Image.fromarray(sheet, mode='RGB')`` on an RGBA array does not drop the
+    alpha channel: PIL reads the 4-bytes-per-pixel buffer 3 bytes at a time, so
+    the channels shear across every row and the sheet turns to garbage.
+    """
+    data = np.zeros((6, 8, 4, 5), dtype=np.float32)
+    data[:, :, 0, :] = 1.0     # pure red ...
+    data[:, :, 3, :] = 0.25    # ... at 25% opacity
+    cfg, _, sheet = parse(make_ani(data, fmt=fmt).to_jshtml())
+    npt.assert_equal((cfg['fh'], cfg['fw']), (6, 8))
+    for i in range(5):
+        tile_i = tile(cfg, sheet, i).astype(float)
+        if fmt == 'png':
+            # PNG carries the alpha channel, and the canvas composites it:
+            npt.assert_equal(sheet.mode, 'RGBA')
+            npt.assert_array_less(
+                np.abs(tile_i - [255, 0, 0, 64]).max(axis=-1), 2)
+        else:
+            # JPEG cannot, so the frames are flattened onto the white axes
+            # background, which is what Matplotlib rasterizes as well:
+            npt.assert_equal(sheet.mode, 'RGB')
+            npt.assert_array_less(
+                np.abs(tile_i - [255, 191, 191]).max(axis=-1), 8)
+
+
 @pytest.mark.parametrize('shape', ((65, 97), (30, 40), (16, 16), (13, 11)))
 def test_HTMLAnimation_no_frame_bleed(shape):
     """JPEG blocks must never straddle two frames of the sprite sheet
@@ -236,6 +264,68 @@ def test_HTMLAnimation_labels():
     cfg, _, _ = parse(make_ani(data).to_jshtml())
     npt.assert_equal(cfg['title'], None)
     npt.assert_equal(cfg['labels'], [])
+
+
+def title_ink(label, dpi=100):
+    """The pixels a Matplotlib-rendered axes title actually covers"""
+    rendered = []
+    for text in (label, ''):
+        fig, ax = plt.subplots(figsize=(8, 5))
+        ax.imshow(np.zeros((4, 4)), cmap='gray')
+        ax.set_title(text)
+        buf = BytesIO()
+        fig.savefig(buf, format='png', dpi=dpi)
+        plt.close(fig)
+        rendered.append(np.asarray(Image.open(buf).convert('L'), dtype=int))
+    rows, cols = np.where(rendered[0] != rendered[1])
+    return rows.min(), rows.max(), cols.min(), cols.max()
+
+
+@pytest.mark.parametrize('label', ('t = 0.00 ms', 't = 123.45 ms', 'gjpqy AWM'))
+def test_HTMLAnimation_title_band_covers_text(label):
+    """The band the player clears must cover a whole line of text
+
+    The player redraws the title on the canvas for every frame, but can only
+    erase what it drew itself. A band that is too short (an empty ``Text`` has
+    a degenerate bounding box, so measuring it directly gives a zero-height
+    band) leaves every title standing, and they pile up into an unreadable
+    smear after a few frames.
+    """
+    cfg, _, _ = parse(make_ani(np.random.rand(4, 4, 3),
+                               labels=[label] * 3).to_jshtml())
+    _, top, _, height = cfg['title']['rect']
+    y0, y1, x0, x1 = title_ink(label)
+    npt.assert_equal(top <= y0 and y1 < top + height, True)
+    # ... and the text must be anchored where Matplotlib would put it:
+    npt.assert_equal(cfg['title']['align'], 'center')
+    npt.assert_array_less(abs((x0 + x1) / 2 - cfg['title']['x']), 2)
+
+
+def test_HTMLAnimation_title_not_in_background():
+    """A title left on the axes must not be baked into the background
+
+    The background is a static ``<img>`` underneath the canvas, so anything
+    rendered into it survives the player's ``clearRect`` and shows through
+    every frame. Two ways to get a title onto the axes before the HTML is
+    built: pass in an axes that already has one, or render the inherited
+    ``FuncAnimation`` first (which leaves the last frame's title behind).
+    """
+    data = np.random.rand(4, 4, 3)
+    labels = ['t = 0.00 ms', 't = 1.00 ms', 't = 2.00 ms']
+    ani = make_ani(data, labels=labels)
+    reference = np.asarray(parse(ani.to_jshtml())[1])
+    for stale in ('t = 999.00 ms', 'A title'):
+        ani = make_ani(data, labels=labels)
+        ani._image.axes.set_title(stale)
+        npt.assert_equal(np.asarray(parse(ani.to_jshtml())[1]), reference)
+        # The caller's title is left the way it was found:
+        npt.assert_equal(ani._image.axes.get_title(), stale)
+    # Without labels the player leaves the title alone, so a title on the axes
+    # belongs in the background:
+    ani = make_ani(data)
+    ani._image.axes.set_title('A title')
+    npt.assert_equal(np.any(np.asarray(parse(ani.to_jshtml())[1]) != reference),
+                     True)
 
 
 def test_HTMLAnimation_playback():


### PR DESCRIPTION
This PR fixes a few issues introduced in #809:

- [x] PNG is the better default for images, JPG for videos
- [x] Titles were drawn over a stale background
- [x] RGBA video was mishandled by the sprite sheet
- [x] A compressed `VideoStimulus` could fail to render