### PR TITLE
[FIX] Raster ordering, pulse scheduling, and temporal-model bugs

### DIFF
--- a/doc/users/release_notes.rst
+++ b/doc/users/release_notes.rst
@@ -30,6 +30,10 @@ API changes:
   :math:`\max(-A, 0)` rather than :math:`-A`: anodic current no longer reduces
   brightness, it is ignored. A stimulus that is purely cathodic is unaffected.
 
+* :py:class:`~pulse2percept.models.FadingTemporal` requires ``tau >= dt``. The
+  integrator steps explicitly, so a shorter time constant overshoots its drive
+  by ``dt / tau`` and oscillates instead of decaying.
+
 * Temporal models gained a ``reduce`` parameter. When ``predict_percept`` picks
   the output times itself (``t_percept=None``), ``reduce='peak'`` makes each
   point report the highest brightness reached over the interval leading up to

--- a/doc/users/release_notes.rst
+++ b/doc/users/release_notes.rst
@@ -15,15 +15,18 @@ Highlights:
    multiplexing. Pulse timing is independent of the video frame rate: a frame
    says when the modulation parameters change, and no longer restarts the pulse
    train. What limits the delivered rate is the hardware you describe -- a
-   ``clock`` or a raster cycle can only round a pulse period *up*, never down,
-   so an electrode is never driven faster, and so never given more charge, than
-   was asked for.
+   ``clock``, or a raster with electrodes on differing rates, can only round a
+   pulse period *up*, never down, so an electrode is never driven faster, and so
+   never given more charge, than was asked for.
 
 *  New :py:class:`~pulse2percept.implants.Raster` classes describe how
    stimulators multiplex electrodes that cannot be driven simultaneously. Each
-   raster group gets a slot in a repeating cycle and pulse periods are whole
-   multiples of that cycle, so two groups provably never pulse at the same
-   instant and the instantaneous current limit holds by construction.
+   group starts its pulse a fixed ``group_dur`` behind the one before it, so two
+   groups provably never pulse at the same instant and the instantaneous current
+   limit holds by construction. Electrodes on *differing* rates drift apart, so
+   there their periods are pinned to whole sweeps to keep the guarantee;
+   electrodes sharing one rate cannot drift and keep their period exactly, which
+   is why rastering costs no frequency under amplitude modulation.
 
 *  :py:class:`~pulse2percept.models.FadingTemporal` now half-wave rectifies its
    drive, so it can see a charge-balanced pulse. Previously the anodic phase of

--- a/doc/users/release_notes.rst
+++ b/doc/users/release_notes.rst
@@ -73,8 +73,9 @@ API changes:
   time axis non-monotonic.
 
 * Zero-amplitude electrodes no longer build (and then discard) a full pulse
-  train, and no longer trip the raster's fit check on a stimulus that delivers
-  no current at all.
+  train, so a dark frame costs no pulses and no time points. Whether a raster
+  *fits* remains a property of the device rather than of the content, so an
+  unworkable raster is still reported for a stimulus that happens to be dark.
 
 * Encoders always sample an image or video at the implant's electrode
   locations when an ``implant`` is given. Sampling used to be skipped whenever

--- a/doc/users/release_notes.rst
+++ b/doc/users/release_notes.rst
@@ -12,10 +12,19 @@ Highlights:
 *  New :py:class:`~pulse2percept.stimuli.Encoder` classes translate images and
    videos into electrical stimulation. Amplitude and frequency modulation are
    supported, including stimulator timing, input resolution, and electrode
-   multiplexing.
+   multiplexing. Pulse timing is independent of the video frame rate: a frame
+   says when the modulation parameters change, and the requested ``freq`` is
+   the rate actually delivered.
 
 *  New :py:class:`~pulse2percept.implants.Raster` classes describe how
-   stimulators multiplex electrodes that cannot be driven simultaneously.
+   stimulators multiplex electrodes that cannot be driven simultaneously. Each
+   raster group gets a slot in a repeating cycle and pulse periods are whole
+   multiples of that cycle, so two groups provably never pulse at the same
+   instant and the instantaneous current limit holds by construction.
+
+*  A percept is now reported on the frame clock of the video it came from --
+   one percept frame per video frame -- rather than at a hardcoded 20 ms or at
+   every point of the pulse train.
 
 * :py:meth:`~pulse2percept.percepts.Percept.play` and
   :py:meth:`~pulse2percept.stimuli.VideoStimulus.play` are roughly 100x faster
@@ -48,6 +57,41 @@ API changes:
   users should remain on v0.9.1.
 
 ## Bug fixes
+
+* Encoders no longer restart the pulse train at every video frame, which
+  silently changed the pulse rate whenever a frame was not a whole number of
+  pulse periods long (at 29.97 fps, ``freq=50`` delivered 59.94 pulses/s).
+
+* :py:class:`~pulse2percept.implants.Raster` now genuinely multiplexes. It used
+  to stagger only the *first* pulse of each frame, after which every group
+  pulsed at the same times and the instantaneous current limit the raster
+  exists to respect was exceeded.
+
+* Encoders no longer assume a custom ``pulse`` starts at time zero. A pulse
+  whose time axis was shifted was measured by its duration but rendered at its
+  offset, which could push it past the end of its frame and leave the assembled
+  time axis non-monotonic.
+
+* Zero-amplitude electrodes no longer build (and then discard) a full pulse
+  train, and no longer trip the raster's fit check on a stimulus that delivers
+  no current at all.
+
+* Encoders always sample an image or video at the implant's electrode
+  locations when an ``implant`` is given. Sampling used to be skipped whenever
+  the source happened to have as many rows as the implant has electrodes, so a
+  10x6 image -- or any RGB image with a third as many pixels -- was encoded
+  as-is, unconverted to grayscale, but still labeled with electrode names.
+
+* :py:class:`~pulse2percept.stimuli.Encoder` and
+  :py:class:`~pulse2percept.implants.Raster` parameters now reject NaN,
+  infinity, and fractional counts (``n_levels``, group indices) instead of
+  silently truncating them, and
+  :py:class:`~pulse2percept.implants.CustomRaster` rejects an electrode listed
+  in two groups.
+
+* :py:func:`~pulse2percept.utils.frame_interval` no longer reports an evenly
+  spaced time axis as non-homogeneous when the frame interval happens to land
+  on a multiple of half of ``tol`` (33.365 ms at the default tolerance).
 
 * :py:class:`~pulse2percept.stimuli.PulseTrain` no longer ends on partial,
   unbalanced pulses when its frequency does not divide ``stim_dur``.

--- a/doc/users/release_notes.rst
+++ b/doc/users/release_notes.rst
@@ -94,6 +94,24 @@ API changes:
 
 ## Bug fixes
 
+* Temporal models no longer read a stimulus frame that is already in the past.
+  :py:class:`~pulse2percept.models.FadingTemporal`,
+  :py:class:`~pulse2percept.models.Nanduri2012Temporal` and
+  :py:class:`~pulse2percept.models.Horsager2009Temporal` advanced at most one
+  frame per simulation step, but a pulse puts its edges on the ``DT`` = 1e-3 ms
+  grid while ``dt`` defaults to 5e-3 ms, so an edge and the sample after it
+  routinely share a step. The integrator then lagged by a frame, which
+  stretched every pulse phase by about one step and could drive brightness from
+  a pulse that had already ended.
+
+  Reported brightness shifts by a fraction of a percent for phases long
+  relative to ``dt``, and by more for short ones: a 0.075 ms phase against the
+  default ``dt`` was being stretched by 7%. The pinned values in the
+  [Horsager2009]_ and [Nanduri2012]_ tests moved accordingly. The equal-
+  brightness conditions of [Horsager2009]_ Figs. 3 and 4 now agree with each
+  other to within about 3% rather than exactly; the exact agreement had been
+  resting on this bug, and refining ``dt`` does not restore it.
+
 * :py:class:`~pulse2percept.stimuli.PulseTrain` no longer ends on partial,
   unbalanced pulses when its frequency does not divide ``stim_dur``.
 

--- a/doc/users/release_notes.rst
+++ b/doc/users/release_notes.rst
@@ -22,6 +22,12 @@ Highlights:
    multiples of that cycle, so two groups provably never pulse at the same
    instant and the instantaneous current limit holds by construction.
 
+*  Timing constraints only ever go one way: ``clock`` and the raster cycle may
+   *lower* the rate an electrode ends up on, and never raise it. Rounding a
+   period down would deliver more charge than was asked for, so a time base
+   that cannot represent a rate exactly gives back the nearest slower one --
+   with ``clock=1``, a requested 300 Hz is delivered as 250 Hz.
+
 *  A percept is now reported on the frame clock of the video it came from --
    one percept frame per video frame -- rather than at a hardcoded 20 ms or at
    every point of the pulse train.

--- a/doc/users/release_notes.rst
+++ b/doc/users/release_notes.rst
@@ -12,27 +12,11 @@ Highlights:
 *  New :py:class:`~pulse2percept.stimuli.Encoder` classes translate images and
    videos into electrical stimulation. Amplitude and frequency modulation are
    supported, including stimulator timing, input resolution, and electrode
-   multiplexing. Pulse timing is independent of the video frame rate: a frame
-   says when the modulation parameters change, and no longer restarts the pulse
-   train. What limits the delivered rate is the hardware you describe -- a
-   ``clock``, or a raster with electrodes on differing rates, can only round a
-   pulse period *up*, never down, so an electrode is never driven faster, and so
-   never given more charge, than was asked for.
+   multiplexing.
 
 *  New :py:class:`~pulse2percept.implants.Raster` classes describe how
    stimulators multiplex electrodes that cannot be driven simultaneously. Each
-   group starts its pulse a fixed ``group_dur`` behind the one before it, so two
-   groups provably never pulse at the same instant and the instantaneous current
-   limit holds by construction. Electrodes on *differing* rates drift apart, so
-   there their periods are pinned to whole sweeps to keep the guarantee;
-   electrodes sharing one rate cannot drift and keep their period exactly, which
-   is why rastering costs no frequency under amplitude modulation.
-
-*  :py:class:`~pulse2percept.models.FadingTemporal` now half-wave rectifies its
-   drive, so it can see a charge-balanced pulse. Previously the anodic phase of
-   a biphasic pulse undid exactly what the cathodic phase had done, and a pulse
-   train produced sub-millisecond transients around zero rather than a percept
-   that persisted between pulses.
+   group starts its pulse a fixed ``group_dur`` behind the one before it.
 
 * :py:meth:`~pulse2percept.percepts.Percept.play` and
   :py:meth:`~pulse2percept.stimuli.VideoStimulus.play` are roughly 100x faster
@@ -45,13 +29,6 @@ API changes:
 * :py:class:`~pulse2percept.models.FadingTemporal` is now driven by
   :math:`\max(-A, 0)` rather than :math:`-A`: anodic current no longer reduces
   brightness, it is ignored. A stimulus that is purely cathodic is unaffected.
-  A charge-balanced pulse still delivers zero net charge, as it must -- what
-  changed is that the model's *drive* is no longer charge-balanced along with
-  it, so such a pulse now produces a response instead of integrating to
-  nothing. At 20 Hz and ``tau=100``, brightness between pulses used to fall to
-  0.6% of the peak it had just reached (99% ripple) and now holds at 61%.
-  Raising ``tau`` used to make the percept dimmer rather than steadier, because
-  the peak scales as :math:`1/\tau` while the floor between pulses does not.
 
 * Temporal models gained a ``reduce`` parameter. When ``predict_percept`` picks
   the output times itself (``t_percept=None``), ``reduce='peak'`` makes each
@@ -59,29 +36,12 @@ API changes:
   it rather than the brightness at the instant it ends. Naming ``t_percept``
   still asks for those instants.
 
-  :py:class:`~pulse2percept.models.FadingTemporal` defaults to ``'peak'`` and
-  tracks it across every ``dt`` step inside its integrator, which is exact at
-  any output rate. The published models keep reporting the closing instant
-  unless asked otherwise; requesting ``'peak'`` from one of those samples each
-  interval eight times and keeps the largest, which is an approximation.
-
-  Electrical stimulation is pulsatile, so an instant sampled from a percept is
-  usually an instant between pulses, and which pulses a frame catches drifts
-  when the frame rate and the pulse rate are incommensurate. Under a raster
-  that showed up as groups appearing in the wrong order or not at all: driving
-  Argus II with ``SequentialRaster(6)`` at 20 Hz against a 29.97 fps video,
-  25 of 94 percept frames came out entirely dark and two of the six rows never
-  appeared at all.
-
 * :py:meth:`~pulse2percept.stimuli.ImageStimulus.encode` and
   :py:meth:`~pulse2percept.stimuli.VideoStimulus.encode` now use
   :py:class:`~pulse2percept.stimuli.AmplitudeEncoder`. Most importantly, gray
   levels map to ``amp_range`` absolutely rather than being stretched to fill
   it, and each frame now produces a pulse train rather than a single pulse.
   Pass ``stretch=True`` for the old gray-level mapping.
-
-* Encoders can operate directly at implant resolution and account for electrode
-  multiplexing through the implant's raster.
 
 * :py:class:`~pulse2percept.implants.ProsthesisSystem` now exposes ``raster``
   and ``max_current``.
@@ -96,24 +56,6 @@ API changes:
   users should remain on v0.9.1.
 
 ## Bug fixes
-
-* Temporal models no longer read a stimulus frame that is already in the past.
-  :py:class:`~pulse2percept.models.FadingTemporal`,
-  :py:class:`~pulse2percept.models.Nanduri2012Temporal` and
-  :py:class:`~pulse2percept.models.Horsager2009Temporal` advanced at most one
-  frame per simulation step, but a pulse puts its edges on the ``DT`` = 1e-3 ms
-  grid while ``dt`` defaults to 5e-3 ms, so an edge and the sample after it
-  routinely share a step. The integrator then lagged by a frame, which
-  stretched every pulse phase by about one step and could drive brightness from
-  a pulse that had already ended.
-
-  Reported brightness shifts by a fraction of a percent for phases long
-  relative to ``dt``, and by more for short ones: a 0.075 ms phase against the
-  default ``dt`` was being stretched by 7%. The pinned values in the
-  [Horsager2009]_ and [Nanduri2012]_ tests moved accordingly. The equal-
-  brightness conditions of [Horsager2009]_ Figs. 3 and 4 now agree with each
-  other to within about 3% rather than exactly; the exact agreement had been
-  resting on this bug, and refining ``dt`` does not restore it.
 
 * :py:class:`~pulse2percept.stimuli.PulseTrain` no longer ends on partial,
   unbalanced pulses when its frequency does not divide ``stim_dur``.
@@ -130,9 +72,6 @@ API changes:
   maps are hashable again, and maps of different classes no longer compare
   equal.
 
-* Temporal models now warn when stimulus polarity produces an all-zero percept
-  instead of silently returning a blank result.
-
 * :py:meth:`~pulse2percept.stimuli.ImageStimulus.encode` and
   :py:meth:`~pulse2percept.stimuli.VideoStimulus.encode` no longer modify their
   inputs in place.
@@ -141,9 +80,6 @@ API changes:
   :py:meth:`~pulse2percept.stimuli.VideoStimulus.play`, and
   :py:meth:`~pulse2percept.percepts.Percept.save` now handle single-frame
   inputs correctly and give a useful error for nonuniform time axes.
-
-* :py:meth:`~pulse2percept.stimuli.VideoStimulus.encode` now correctly infers
-  frame duration from the time axis when frame-rate metadata is absent.
 
 * :py:attr:`~pulse2percept.stimuli.VideoStimulus.vid_shape` now reports the
   number of frames the stimulus actually has, rather than the number the source

--- a/doc/users/release_notes.rst
+++ b/doc/users/release_notes.rst
@@ -13,8 +13,11 @@ Highlights:
    videos into electrical stimulation. Amplitude and frequency modulation are
    supported, including stimulator timing, input resolution, and electrode
    multiplexing. Pulse timing is independent of the video frame rate: a frame
-   says when the modulation parameters change, and the requested ``freq`` is
-   the rate actually delivered.
+   says when the modulation parameters change, and no longer restarts the pulse
+   train. What limits the delivered rate is the hardware you describe -- a
+   ``clock`` or a raster cycle can only round a pulse period *up*, never down,
+   so an electrode is never driven faster, and so never given more charge, than
+   was asked for.
 
 *  New :py:class:`~pulse2percept.implants.Raster` classes describe how
    stimulators multiplex electrodes that cannot be driven simultaneously. Each
@@ -38,18 +41,26 @@ API changes:
 
 * :py:class:`~pulse2percept.models.FadingTemporal` is now driven by
   :math:`\max(-A, 0)` rather than :math:`-A`: anodic current no longer reduces
-  brightness, it is ignored. A stimulus that is purely cathodic is unaffected;
-  a charge-balanced one now delivers net charge instead of integrating to
+  brightness, it is ignored. A stimulus that is purely cathodic is unaffected.
+  A charge-balanced pulse still delivers zero net charge, as it must -- what
+  changed is that the model's *drive* is no longer charge-balanced along with
+  it, so such a pulse now produces a response instead of integrating to
   nothing. At 20 Hz and ``tau=100``, brightness between pulses used to fall to
   0.6% of the peak it had just reached (99% ripple) and now holds at 61%.
   Raising ``tau`` used to make the percept dimmer rather than steadier, because
   the peak scales as :math:`1/\tau` while the floor between pulses does not.
 
-* Temporal models gained a ``reduce`` parameter. When
-  ``predict_percept`` picks the output times itself (``t_percept=None``), each
-  point now reports the peak brightness reached over the interval leading up to
+* Temporal models gained a ``reduce`` parameter. When ``predict_percept`` picks
+  the output times itself (``t_percept=None``), ``reduce='peak'`` makes each
+  point report the highest brightness reached over the interval leading up to
   it rather than the brightness at the instant it ends. Naming ``t_percept``
-  still asks for those instants. Pass ``reduce='last'`` for the old reporting.
+  still asks for those instants.
+
+  :py:class:`~pulse2percept.models.FadingTemporal` defaults to ``'peak'`` and
+  tracks it across every ``dt`` step inside its integrator, which is exact at
+  any output rate. The published models keep reporting the closing instant
+  unless asked otherwise; requesting ``'peak'`` from one of those samples each
+  interval eight times and keeps the largest, which is an approximation.
 
   Electrical stimulation is pulsatile, so an instant sampled from a percept is
   usually an instant between pulses, and which pulses a frame catches drifts
@@ -57,8 +68,7 @@ API changes:
   that showed up as groups appearing in the wrong order or not at all: driving
   Argus II with ``SequentialRaster(6)`` at 20 Hz against a 29.97 fps video,
   25 of 94 percept frames came out entirely dark and two of the six rows never
-  appeared at all. :py:class:`~pulse2percept.models.FadingTemporal` tracks the
-  peak inside its integrator, so it is exact at any output rate.
+  appeared at all.
 
 * :py:meth:`~pulse2percept.stimuli.ImageStimulus.encode` and
   :py:meth:`~pulse2percept.stimuli.VideoStimulus.encode` now use

--- a/doc/users/release_notes.rst
+++ b/doc/users/release_notes.rst
@@ -22,6 +22,12 @@ Highlights:
    multiples of that cycle, so two groups provably never pulse at the same
    instant and the instantaneous current limit holds by construction.
 
+*  :py:class:`~pulse2percept.models.FadingTemporal` now half-wave rectifies its
+   drive, so it can see a charge-balanced pulse. Previously the anodic phase of
+   a biphasic pulse undid exactly what the cathodic phase had done, and a pulse
+   train produced sub-millisecond transients around zero rather than a percept
+   that persisted between pulses.
+
 * :py:meth:`~pulse2percept.percepts.Percept.play` and
   :py:meth:`~pulse2percept.stimuli.VideoStimulus.play` are roughly 100x faster
   and produce much smaller notebooks and documentation pages.
@@ -29,6 +35,30 @@ Highlights:
 * Python 3.14 is now supported. Python 3.11 and NumPy 2 are now required.
 
 API changes:
+
+* :py:class:`~pulse2percept.models.FadingTemporal` is now driven by
+  :math:`\max(-A, 0)` rather than :math:`-A`: anodic current no longer reduces
+  brightness, it is ignored. A stimulus that is purely cathodic is unaffected;
+  a charge-balanced one now delivers net charge instead of integrating to
+  nothing. At 20 Hz and ``tau=100``, brightness between pulses used to fall to
+  0.6% of the peak it had just reached (99% ripple) and now holds at 61%.
+  Raising ``tau`` used to make the percept dimmer rather than steadier, because
+  the peak scales as :math:`1/\tau` while the floor between pulses does not.
+
+* Temporal models gained a ``reduce`` parameter. When
+  ``predict_percept`` picks the output times itself (``t_percept=None``), each
+  point now reports the peak brightness reached over the interval leading up to
+  it rather than the brightness at the instant it ends. Naming ``t_percept``
+  still asks for those instants. Pass ``reduce='last'`` for the old reporting.
+
+  Electrical stimulation is pulsatile, so an instant sampled from a percept is
+  usually an instant between pulses, and which pulses a frame catches drifts
+  when the frame rate and the pulse rate are incommensurate. Under a raster
+  that showed up as groups appearing in the wrong order or not at all: driving
+  Argus II with ``SequentialRaster(6)`` at 20 Hz against a 29.97 fps video,
+  25 of 94 percept frames came out entirely dark and two of the six rows never
+  appeared at all. :py:class:`~pulse2percept.models.FadingTemporal` tracks the
+  peak inside its integrator, so it is exact at any output rate.
 
 * :py:meth:`~pulse2percept.stimuli.ImageStimulus.encode` and
   :py:meth:`~pulse2percept.stimuli.VideoStimulus.encode` now use

--- a/doc/users/release_notes.rst
+++ b/doc/users/release_notes.rst
@@ -22,16 +22,6 @@ Highlights:
    multiples of that cycle, so two groups provably never pulse at the same
    instant and the instantaneous current limit holds by construction.
 
-*  Timing constraints only ever go one way: ``clock`` and the raster cycle may
-   *lower* the rate an electrode ends up on, and never raise it. Rounding a
-   period down would deliver more charge than was asked for, so a time base
-   that cannot represent a rate exactly gives back the nearest slower one --
-   with ``clock=1``, a requested 300 Hz is delivered as 250 Hz.
-
-*  A percept is now reported on the frame clock of the video it came from --
-   one percept frame per video frame -- rather than at a hardcoded 20 ms or at
-   every point of the pulse train.
-
 * :py:meth:`~pulse2percept.percepts.Percept.play` and
   :py:meth:`~pulse2percept.stimuli.VideoStimulus.play` are roughly 100x faster
   and produce much smaller notebooks and documentation pages.
@@ -64,42 +54,6 @@ API changes:
 
 ## Bug fixes
 
-* Encoders no longer restart the pulse train at every video frame, which
-  silently changed the pulse rate whenever a frame was not a whole number of
-  pulse periods long (at 29.97 fps, ``freq=50`` delivered 59.94 pulses/s).
-
-* :py:class:`~pulse2percept.implants.Raster` now genuinely multiplexes. It used
-  to stagger only the *first* pulse of each frame, after which every group
-  pulsed at the same times and the instantaneous current limit the raster
-  exists to respect was exceeded.
-
-* Encoders no longer assume a custom ``pulse`` starts at time zero. A pulse
-  whose time axis was shifted was measured by its duration but rendered at its
-  offset, which could push it past the end of its frame and leave the assembled
-  time axis non-monotonic.
-
-* Zero-amplitude electrodes no longer build (and then discard) a full pulse
-  train, so a dark frame costs no pulses and no time points. Whether a raster
-  *fits* remains a property of the device rather than of the content, so an
-  unworkable raster is still reported for a stimulus that happens to be dark.
-
-* Encoders always sample an image or video at the implant's electrode
-  locations when an ``implant`` is given. Sampling used to be skipped whenever
-  the source happened to have as many rows as the implant has electrodes, so a
-  10x6 image -- or any RGB image with a third as many pixels -- was encoded
-  as-is, unconverted to grayscale, but still labeled with electrode names.
-
-* :py:class:`~pulse2percept.stimuli.Encoder` and
-  :py:class:`~pulse2percept.implants.Raster` parameters now reject NaN,
-  infinity, and fractional counts (``n_levels``, group indices) instead of
-  silently truncating them, and
-  :py:class:`~pulse2percept.implants.CustomRaster` rejects an electrode listed
-  in two groups.
-
-* :py:func:`~pulse2percept.utils.frame_interval` no longer reports an evenly
-  spaced time axis as non-homogeneous when the frame interval happens to land
-  on a multiple of half of ``tol`` (33.365 ms at the default tolerance).
-
 * :py:class:`~pulse2percept.stimuli.PulseTrain` no longer ends on partial,
   unbalanced pulses when its frequency does not divide ``stim_dur``.
 
@@ -117,9 +71,6 @@ API changes:
 
 * Temporal models now warn when stimulus polarity produces an all-zero percept
   instead of silently returning a blank result.
-
-* Time-axis validation warnings now report only the offending points instead
-  of printing the entire time axis.
 
 * :py:meth:`~pulse2percept.stimuli.ImageStimulus.encode` and
   :py:meth:`~pulse2percept.stimuli.VideoStimulus.encode` no longer modify their

--- a/examples/stimuli/plot_image_stim.py
+++ b/examples/stimuli/plot_image_stim.py
@@ -276,7 +276,10 @@ implant.stim = logo_dilate.trim().resize(implant.shape).encode()
 # A real stimulator usually cannot drive every electrode at once, because the
 # current it can source at any instant is limited. Give the implant a
 # :py:class:`~pulse2percept.implants.Raster` and the electrodes take turns
-# instead, a group at a time, all of them within one frame period:
+# instead, a group at a time, all of them within one pulse period. Every group
+# still pulses at the full requested rate; the raster only decides *when*
+# within each period each one fires, so no two groups are ever active at the
+# same instant:
 #
 # .. code-block:: python
 #

--- a/pulse2percept/implants/rasters.py
+++ b/pulse2percept/implants/rasters.py
@@ -36,6 +36,8 @@ class Raster(PrettyPrint, metaclass=ABCMeta):
 
     1.  A pulse has to be short enough to finish inside its own slot.
     2.  An electrode's pulse period has to be a whole number of raster cycles.
+        It is rounded *up* onto that grid, so multiplexing never drives an
+        electrode faster -- and so never delivers more charge -- than asked.
 
     Together they guarantee that no two groups are ever active at the same
     instant, whatever the modulation, so the stimulator sources at most one
@@ -66,6 +68,9 @@ class Raster(PrettyPrint, metaclass=ABCMeta):
         resolution under frequency modulation: a shorter slot means a shorter
         cycle, and pulse periods are quantized onto that cycle. It cannot be
         shorter than a single pulse.
+
+        An encoder with a ``clock`` rounds the slot onto it and rebuilds the
+        cycle from the result, so every group keeps a turn of the same length.
 
     """
     __slots__ = ('group_dur',)

--- a/pulse2percept/implants/rasters.py
+++ b/pulse2percept/implants/rasters.py
@@ -31,24 +31,33 @@ class Raster(PrettyPrint, metaclass=ABCMeta):
     Taking turns is described by a repeating **raster cycle** of duration
     ``n_groups * group_dur``. Group *g* owns the slot that starts ``g *
     group_dur`` into every cycle and lasts ``group_dur``, and it may only pulse
-    inside that slot. Two things follow, and an encoder enforces both (see
+    inside that slot. What an encoder has to guarantee is that no two groups
+    are ever active at the same instant, so that the stimulator sources at most
+    one group's worth of current at a time. Two things buy that (see
     :py:class:`~pulse2percept.stimuli.Encoder`):
 
     1.  A pulse has to be short enough to finish inside its own slot.
-    2.  An electrode's pulse period has to be a whole number of raster cycles.
-        It is rounded *up* onto that grid, so multiplexing never drives an
-        electrode faster -- and so never delivers more charge -- than asked.
+    2.  Electrodes on *different* pulse periods would otherwise drift relative
+        to one another until two slots coincided, so their periods are pinned
+        to whole numbers of raster cycles. Pinning rounds the period *up*, so
+        multiplexing never drives an electrode faster -- and so never delivers
+        more charge -- than asked.
 
-    Together they guarantee that no two groups are ever active at the same
-    instant, whatever the modulation, so the stimulator sources at most one
-    group's worth of current at a time.
+        Electrodes that all share one period cannot drift in the first place:
+        their slots stay a fixed distance apart forever. Nothing is quantized
+        in that case and the requested rate is delivered exactly, even when the
+        period is not a whole number of cycles. This is the usual case under
+        amplitude modulation.
 
     The raster cycle belongs to the *stimulation* schedule, not to the video:
-    it is tied to the pulse period, not to the frame rate. Under amplitude
-    modulation every electrode shares one period, so the cycle is exactly that
-    period and each group pulses once per cycle. Under frequency modulation the
-    cycle is set by the fastest electrode, and slower ones pulse every *m*-th
-    cycle.
+    it is tied to the pulse period, not to the frame rate. With no explicit
+    ``group_dur`` the groups divide the shortest pulse period between them, so
+    under amplitude modulation the cycle is exactly that period and each group
+    pulses once per cycle. An explicit ``group_dur`` instead builds the cycle
+    from the slot, which is generally shorter than the period -- six groups of
+    1 ms make a 6 ms cycle whatever rate the electrodes run at. Under frequency
+    modulation the cycle is set by the fastest electrode, and slower ones pulse
+    every *m*-th cycle.
 
     Subclasses only implement ``groups``.
 

--- a/pulse2percept/implants/rasters.py
+++ b/pulse2percept/implants/rasters.py
@@ -7,18 +7,46 @@ import numpy as np
 from ..utils import PrettyPrint
 
 
+def _finite(name, value):
+    """Reject NaN and infinity, which slip through every ``<`` comparison"""
+    if not np.all(np.isfinite(np.asarray(value, dtype=np.float64))):
+        raise ValueError(f"'{name}' must be finite, not {value}.")
+
+
+def _whole(name, value):
+    """Reject a non-integer count or index, which would silently truncate"""
+    _finite(name, value)
+    if int(value) != value:
+        raise ValueError(f"'{name}' must be a whole number, not {value}.")
+    return int(value)
+
+
 class Raster(PrettyPrint, metaclass=ABCMeta):
     """Abstract base class for all raster patterns
 
     A stimulator usually cannot drive every electrode at once, because the
     total current it can source at any instant is limited. Electrodes are
-    therefore split into *raster groups* that take turns: group 0 fires, then
-    group 1 some milliseconds later, and so on, with the whole sequence
-    completing within one frame.
+    therefore split into *raster groups* that take turns.
 
-    An encoder asks a raster how long each electrode has to wait after the
-    start of a frame before it may pulse; see
-    :py:class:`~pulse2percept.stimuli.Encoder`.
+    Taking turns is described by a repeating **raster cycle** of duration
+    ``n_groups * group_dur``. Group *g* owns the slot that starts ``g *
+    group_dur`` into every cycle and lasts ``group_dur``, and it may only pulse
+    inside that slot. Two things follow, and an encoder enforces both (see
+    :py:class:`~pulse2percept.stimuli.Encoder`):
+
+    1.  A pulse has to be short enough to finish inside its own slot.
+    2.  An electrode's pulse period has to be a whole number of raster cycles.
+
+    Together they guarantee that no two groups are ever active at the same
+    instant, whatever the modulation, so the stimulator sources at most one
+    group's worth of current at a time.
+
+    The raster cycle belongs to the *stimulation* schedule, not to the video:
+    it is tied to the pulse period, not to the frame rate. Under amplitude
+    modulation every electrode shares one period, so the cycle is exactly that
+    period and each group pulses once per cycle. Under frequency modulation the
+    cycle is set by the fastest electrode, and slower ones pulse every *m*-th
+    cycle.
 
     Subclasses only implement ``groups``.
 
@@ -27,26 +55,26 @@ class Raster(PrettyPrint, metaclass=ABCMeta):
     Parameters
     ----------
     group_dur : float, optional
-        Time (ms) between one group firing and the next. If None, the groups
-        are spread evenly over the frame, so that the sequence takes exactly
-        one frame period to complete.
+        Duration (ms) of a single group's slot, and hence the spacing between
+        one group's turn and the next. If None, the groups are spread evenly
+        over the raster cycle, so that the sequence takes exactly one pulse
+        period to complete -- which is what an encoder wants whenever every
+        electrode pulses at the same rate.
 
-        .. note::
-
-           Staggering the *onsets* of two groups only keeps them off the same
-           time point if the first group is finished before the second starts.
-           That holds whenever a group pulses at most once per frame, which is
-           what amplitude modulation does. Under frequency modulation an
-           electrode may pulse many times per frame, and pulses from different
-           groups can then land on top of each other. Set ``max_current`` on
-           the implant to find out when they do.
+        Setting it explicitly makes the cycle ``n_groups * group_dur``
+        regardless of the pulse period, which is how you buy back frequency
+        resolution under frequency modulation: a shorter slot means a shorter
+        cycle, and pulse periods are quantized onto that cycle. It cannot be
+        shorter than a single pulse.
 
     """
     __slots__ = ('group_dur',)
 
     def __init__(self, group_dur=None):
-        if group_dur is not None and group_dur <= 0:
-            raise ValueError("'group_dur' must be positive.")
+        if group_dur is not None:
+            _finite('group_dur', group_dur)
+            if group_dur <= 0:
+                raise ValueError("'group_dur' must be positive.")
         self.group_dur = group_dur
 
     def _pprint_params(self):
@@ -76,35 +104,58 @@ class Raster(PrettyPrint, metaclass=ABCMeta):
         """
         raise NotImplementedError
 
-    def delays(self, electrodes, frame_dur):
-        """How long each electrode waits before pulsing
+    def slot_dur(self, cycle):
+        """Duration (ms) of one group's slot within a raster cycle
+
+        Parameters
+        ----------
+        cycle : float
+            Duration (ms) of one raster cycle, within which every group gets
+            exactly one turn.
+
+        Returns
+        -------
+        slot_dur : float
+            ``group_dur`` if one was given, else the cycle split evenly between
+            the groups.
+
+        """
+        if self.group_dur is not None:
+            return float(self.group_dur)
+        return float(cycle) / self.n_groups
+
+    def offsets(self, electrodes, cycle):
+        """How far into a raster cycle each electrode's slot begins
 
         Parameters
         ----------
         electrodes : array_like
             Electrode names, in the order they appear in the stimulus.
-        frame_dur : float
-            Duration (ms) of a single frame. The whole raster sequence has to
-            complete within it.
+        cycle : float
+            Duration (ms) of one raster cycle. The whole sequence of groups has
+            to fit into it.
 
         Returns
         -------
-        delay : (n_electrodes,) float array
-            Time (ms) between the start of a frame and this electrode's first
-            pulse.
+        offset : (n_electrodes,) float array
+            Time (ms) between the start of a raster cycle and the start of this
+            electrode's slot.
 
         """
         group = np.asarray(self.groups(electrodes), dtype=np.int64)
         if group.min(initial=0) < 0 or group.max(initial=0) >= self.n_groups:
             raise ValueError(f"'groups' must be in 0..{self.n_groups - 1}.")
-        dur = (frame_dur / self.n_groups if self.group_dur is None
-               else self.group_dur)
-        if self.n_groups * dur > frame_dur:
+        dur = self.slot_dur(cycle)
+        # A tick of slack: the cycle is generally not a round number of ms
+        # (a 300 Hz period is 3.333... ms), so an exact `>` would reject the
+        # even split this class computes itself:
+        if self.n_groups * dur > cycle * (1 + 1e-9):
             raise ValueError(f"A raster of {self.n_groups} groups "
                              f"{dur:.3f} ms apart takes "
                              f"{self.n_groups * dur:.3f} ms, which does not "
-                             f"fit into a frame (dur={frame_dur:.3f} ms). "
-                             f"Shorten 'group_dur' or lower the frame rate.")
+                             f"fit into a raster cycle of {cycle:.3f} ms. "
+                             f"Shorten 'group_dur', use fewer groups, or lower "
+                             f"the pulse frequency.")
         return group * dur
 
 
@@ -143,6 +194,7 @@ class SequentialRaster(Raster):
 
     def __init__(self, n_groups, interleave=False, group_dur=None):
         super().__init__(group_dur=group_dur)
+        _finite('n_groups', n_groups)
         if int(n_groups) != n_groups or n_groups < 1:
             raise ValueError(f"'n_groups' must be a positive integer, not "
                              f"{n_groups}.")
@@ -179,16 +231,23 @@ class CustomRaster(Raster):
     groups : list of lists, or dict
         Either a list whose i-th element holds the names of the electrodes in
         group i, or a dict mapping each electrode name onto its group index.
-        Every electrode in the stimulus must be accounted for.
+        Every electrode in the stimulus must be accounted for, and no electrode
+        may appear in two groups.
     group_dur : float, optional
         See :py:class:`~pulse2percept.implants.Raster`.
 
     Examples
     --------
-    Fire the four corners of Argus II before everything else:
+    Fire the four corners of Argus II before everything else. Every other
+    electrode has to be given a group too, or the current limit that the raster
+    exists to respect could be violated without anyone noticing:
 
-    >>> from pulse2percept.implants import CustomRaster
-    >>> raster = CustomRaster([['A1', 'A10', 'F1', 'F10'], ['B5', 'C5']])
+    >>> from pulse2percept.implants import ArgusII, CustomRaster
+    >>> corners = ['A1', 'A10', 'F1', 'F10']
+    >>> rest = [e for e in ArgusII().electrode_names if e not in corners]
+    >>> raster = CustomRaster([corners, rest])
+    >>> raster.n_groups
+    2
 
     """
     __slots__ = ('_group_of', '_n_groups')
@@ -196,7 +255,8 @@ class CustomRaster(Raster):
     def __init__(self, groups, group_dur=None):
         super().__init__(group_dur=group_dur)
         if isinstance(groups, dict):
-            group_of = {str(k): int(v) for k, v in groups.items()}
+            group_of = {str(k): _whole(f'group of {k}', v)
+                        for k, v in groups.items()}
         else:
             group_of = {}
             for idx, names in enumerate(groups):
@@ -204,9 +264,20 @@ class CustomRaster(Raster):
                     raise TypeError(f"Group {idx} must be a list of electrode "
                                     f"names, not the string '{names}'.")
                 for name in names:
-                    group_of[str(name)] = idx
+                    name = str(name)
+                    # Silently letting the last group win would break the very
+                    # guarantee a raster exists to make, since the electrode
+                    # would go on firing in the group it was taken out of:
+                    if name in group_of:
+                        raise ValueError(
+                            f"Electrode '{name}' is in group "
+                            f"{group_of[name]} and group {idx}. Every "
+                            f"electrode belongs to exactly one group.")
+                    group_of[name] = idx
         if not group_of:
             raise ValueError("'groups' cannot be empty.")
+        if min(group_of.values()) < 0:
+            raise ValueError("Group indices cannot be negative.")
         self._group_of = group_of
         self._n_groups = max(group_of.values()) + 1
 

--- a/pulse2percept/implants/rasters.py
+++ b/pulse2percept/implants/rasters.py
@@ -28,36 +28,47 @@ class Raster(PrettyPrint, metaclass=ABCMeta):
     total current it can source at any instant is limited. Electrodes are
     therefore split into *raster groups* that take turns.
 
-    Taking turns is described by a repeating **raster cycle** of duration
-    ``n_groups * group_dur``. Group *g* owns the slot that starts ``g *
-    group_dur`` into every cycle and lasts ``group_dur``, and it may only pulse
-    inside that slot. What an encoder has to guarantee is that no two groups
-    are ever active at the same instant, so that the stimulator sources at most
-    one group's worth of current at a time. Two things buy that (see
+    A raster is a **scheduling constraint, not a hardware state machine**. What
+    it has to deliver is one property: no two groups are ever active at the same
+    instant, so that the stimulator sources at most one group's worth of current
+    however the video is modulated. It is not a switch that cyclically enables
+    group 0, then group 1, then group 0 again forever, and a group's pulses do
+    not have to land at the same phase of a repeating cycle.
+
+    Taking turns is described by a **raster sweep**: group *g* starts its pulse
+    ``g * group_dur`` after group 0 does, so a sweep spans ``n_groups *
+    group_dur``. Two things then keep groups apart for good (see
     :py:class:`~pulse2percept.stimuli.Encoder`):
 
-    1.  A pulse has to be short enough to finish inside its own slot.
-    2.  Electrodes on *different* pulse periods would otherwise drift relative
-        to one another until two slots coincided, so their periods are pinned
-        to whole numbers of raster cycles. Pinning rounds the period *up*, so
-        multiplexing never drives an electrode faster -- and so never delivers
-        more charge -- than asked.
+    1.  A pulse has to be short enough to finish before the next group's turn
+        begins.
+    2.  Electrodes on *different* pulse periods drift relative to one another,
+        and would eventually collide however they started out. Their periods are
+        therefore pinned to whole numbers of the sweep, which fixes their
+        relative phase. Pinning rounds the period *up*, so multiplexing never
+        drives an electrode faster -- and so never delivers more charge -- than
+        asked.
 
-        Electrodes that all share one period cannot drift in the first place:
-        their slots stay a fixed distance apart forever. Nothing is quantized
-        in that case and the requested rate is delivered exactly, even when the
-        period is not a whole number of cycles. This is the usual case under
-        amplitude modulation.
+        Electrodes that share one period cannot drift in the first place: their
+        onsets stay ``group_dur`` apart forever, whatever that period is.
+        Nothing is quantized in that case and the requested rate is delivered
+        exactly, even when the period is not a whole number of sweeps. This is
+        the usual case under amplitude modulation, and it is why rastering costs
+        no frequency there.
 
-    The raster cycle belongs to the *stimulation* schedule, not to the video:
-    it is tied to the pulse period, not to the frame rate. With no explicit
+        So with two groups 1.5 ms apart on a common 10 ms period, group 0 pulses
+        at 0, 10, 20, ... and group 1 at 1.5, 11.5, 21.5, ... -- collision-free,
+        but not a repeating 3 ms schedule, and the 10 ms period is left alone.
+
+    The sweep belongs to the *stimulation* schedule, not to the video: it is
+    tied to the pulse period, not to the frame rate. With no explicit
     ``group_dur`` the groups divide the shortest pulse period between them, so
-    under amplitude modulation the cycle is exactly that period and each group
-    pulses once per cycle. An explicit ``group_dur`` instead builds the cycle
-    from the slot, which is generally shorter than the period -- six groups of
-    1 ms make a 6 ms cycle whatever rate the electrodes run at. Under frequency
-    modulation the cycle is set by the fastest electrode, and slower ones pulse
-    every *m*-th cycle.
+    under amplitude modulation the sweep is exactly that period and each group
+    pulses once per sweep. An explicit ``group_dur`` instead builds the sweep
+    from the slot, which is generally much shorter than the period -- six groups
+    of 1 ms sweep in 6 ms whatever rate the electrodes run at. Under frequency
+    modulation the sweep is set by the fastest electrode, and slower ones pulse
+    every *m*-th sweep.
 
     Subclasses only implement ``groups``.
 
@@ -68,18 +79,18 @@ class Raster(PrettyPrint, metaclass=ABCMeta):
     group_dur : float, optional
         Duration (ms) of a single group's slot, and hence the spacing between
         one group's turn and the next. If None, the groups are spread evenly
-        over the raster cycle, so that the sequence takes exactly one pulse
-        period to complete -- which is what an encoder wants whenever every
-        electrode pulses at the same rate.
+        over the pulse period, so that a sweep takes exactly one period to
+        complete -- which is what an encoder wants whenever every electrode
+        pulses at the same rate.
 
-        Setting it explicitly makes the cycle ``n_groups * group_dur``
+        Setting it explicitly makes the sweep ``n_groups * group_dur``
         regardless of the pulse period, which is how you buy back frequency
         resolution under frequency modulation: a shorter slot means a shorter
-        cycle, and pulse periods are quantized onto that cycle. It cannot be
-        shorter than a single pulse.
+        sweep, and the periods that have to be pinned are pinned onto a finer
+        grid. It cannot be shorter than a single pulse.
 
         An encoder with a ``clock`` rounds the slot onto it and rebuilds the
-        cycle from the result, so every group keeps a turn of the same length.
+        sweep from the result, so every group keeps a turn of the same length.
 
     """
     __slots__ = ('group_dur',)
@@ -118,56 +129,55 @@ class Raster(PrettyPrint, metaclass=ABCMeta):
         """
         raise NotImplementedError
 
-    def slot_dur(self, cycle):
-        """Duration (ms) of one group's slot within a raster cycle
+    def slot_dur(self, period):
+        """Duration (ms) of one group's slot
 
         Parameters
         ----------
-        cycle : float
-            Duration (ms) of one raster cycle, within which every group gets
-            exactly one turn.
+        period : float
+            The pulse period (ms) a sweep has to fit into, so that every group
+            gets its turn before the first one comes round again.
 
         Returns
         -------
         slot_dur : float
-            ``group_dur`` if one was given, else the cycle split evenly between
-            the groups.
+            ``group_dur`` if one was given, else the period split evenly
+            between the groups.
 
         """
         if self.group_dur is not None:
             return float(self.group_dur)
-        return float(cycle) / self.n_groups
+        return float(period) / self.n_groups
 
-    def offsets(self, electrodes, cycle):
-        """How far into a raster cycle each electrode's slot begins
+    def offsets(self, electrodes, period):
+        """How far behind group 0 each electrode's slot begins
 
         Parameters
         ----------
         electrodes : array_like
             Electrode names, in the order they appear in the stimulus.
-        cycle : float
-            Duration (ms) of one raster cycle. The whole sequence of groups has
-            to fit into it.
+        period : float
+            The pulse period (ms) a sweep has to fit into.
 
         Returns
         -------
         offset : (n_electrodes,) float array
-            Time (ms) between the start of a raster cycle and the start of this
+            Time (ms) between the start of a sweep and the start of this
             electrode's slot.
 
         """
         group = np.asarray(self.groups(electrodes), dtype=np.int64)
         if group.min(initial=0) < 0 or group.max(initial=0) >= self.n_groups:
             raise ValueError(f"'groups' must be in 0..{self.n_groups - 1}.")
-        dur = self.slot_dur(cycle)
-        # A tick of slack: the cycle is generally not a round number of ms
+        dur = self.slot_dur(period)
+        # A tick of slack: the period is generally not a round number of ms
         # (a 300 Hz period is 3.333... ms), so an exact `>` would reject the
         # even split this class computes itself:
-        if self.n_groups * dur > cycle * (1 + 1e-9):
+        if self.n_groups * dur > period * (1 + 1e-9):
             raise ValueError(f"A raster of {self.n_groups} groups "
-                             f"{dur:.3f} ms apart takes "
+                             f"{dur:.3f} ms apart sweeps in "
                              f"{self.n_groups * dur:.3f} ms, which does not "
-                             f"fit into a raster cycle of {cycle:.3f} ms. "
+                             f"fit into a pulse period of {period:.3f} ms. "
                              f"Shorten 'group_dur', use fewer groups, or lower "
                              f"the pulse frequency.")
         return group * dur

--- a/pulse2percept/implants/rasters.py
+++ b/pulse2percept/implants/rasters.py
@@ -61,14 +61,21 @@ class Raster(PrettyPrint, metaclass=ABCMeta):
         but not a repeating 3 ms schedule, and the 10 ms period is left alone.
 
     The sweep belongs to the *stimulation* schedule, not to the video: it is
-    tied to the pulse period, not to the frame rate. With no explicit
-    ``group_dur`` the groups divide the shortest pulse period between them, so
-    under amplitude modulation the sweep is exactly that period and each group
-    pulses once per sweep. An explicit ``group_dur`` instead builds the sweep
-    from the slot, which is generally much shorter than the period -- six groups
-    of 1 ms sweep in 6 ms whatever rate the electrodes run at. Under frequency
-    modulation the sweep is set by the fastest electrode, and slower ones pulse
-    every *m*-th sweep.
+    tied to the pulse period, not to the frame rate. Two rules settle how long
+    it is and what it costs:
+
+    *  With ``group_dur=None`` the groups divide the *shortest* pulse period
+       between them, so the sweep is exactly that period. Under frequency
+       modulation that means the fastest electrode pulses once per sweep and
+       slower ones every *m*-th sweep.
+    *  With an explicit ``group_dur`` the sweep is ``n_groups * group_dur``
+       whatever rate the electrodes run at -- six groups of 1 ms sweep in 6 ms.
+       It is then generally much shorter than a pulse period, so even the
+       fastest electrode may pulse only every *m*-th sweep.
+
+    Either way, only periods that *differ* from one another are rounded up onto
+    the sweep; a period they all share is delivered exactly, since fixed group
+    offsets cannot drift into one another.
 
     Subclasses only implement ``groups``.
 

--- a/pulse2percept/implants/tests/test_rasters.py
+++ b/pulse2percept/implants/tests/test_rasters.py
@@ -18,6 +18,14 @@ def test_SequentialRaster():
         SequentialRaster(2.5)
     with pytest.raises(ValueError):
         SequentialRaster(2, group_dur=-1)
+    # NaN slips through every `<` comparison, so it has to be rejected on its
+    # own or it turns into a silently empty schedule much later:
+    with pytest.raises(ValueError):
+        SequentialRaster(np.nan)
+    with pytest.raises(ValueError):
+        SequentialRaster(2, group_dur=np.nan)
+    with pytest.raises(ValueError):
+        SequentialRaster(2, group_dur=np.inf)
 
     names = ArgusII().electrode_names
     # On a 6x10 grid, whose electrodes run row by row, six contiguous groups
@@ -37,20 +45,27 @@ def test_SequentialRaster():
     npt.assert_equal('n_groups' in str(raster), True)
 
 
-def test_Raster_delays():
+def test_Raster_offsets():
     names = ArgusII().electrode_names
-    # By default the groups are spread evenly over the frame, so the sequence
-    # takes exactly one frame period to get through:
-    delays = SequentialRaster(6).delays(names, 30.0)
-    npt.assert_equal(np.unique(delays), np.arange(6) * 5.0)
-    npt.assert_almost_equal(delays.max() + 5.0, 30.0)
-    # An explicit spacing is used instead, as long as it still fits:
-    delays = SequentialRaster(6, group_dur=2).delays(names, 30.0)
-    npt.assert_equal(np.unique(delays), np.arange(6) * 2.0)
+    # By default the groups are spread evenly over the raster cycle, so the
+    # sequence takes exactly one cycle to get through:
+    offsets = SequentialRaster(6).offsets(names, 30.0)
+    npt.assert_equal(np.unique(offsets), np.arange(6) * 5.0)
+    npt.assert_almost_equal(offsets.max() + 5.0, 30.0)
+    npt.assert_almost_equal(SequentialRaster(6).slot_dur(30.0), 5.0)
+    # An explicit slot is used instead, as long as the groups still fit:
+    offsets = SequentialRaster(6, group_dur=2).offsets(names, 30.0)
+    npt.assert_equal(np.unique(offsets), np.arange(6) * 2.0)
+    npt.assert_almost_equal(SequentialRaster(6, group_dur=2).slot_dur(30.0), 2)
     with pytest.raises(ValueError):
-        SequentialRaster(6, group_dur=10).delays(names, 30.0)
+        SequentialRaster(6, group_dur=10).offsets(names, 30.0)
     # A raster of one group is no raster at all:
-    npt.assert_equal(SequentialRaster(1).delays(names, 30.0), 0)
+    npt.assert_equal(SequentialRaster(1).offsets(names, 30.0), 0)
+    # The cycle is generally not a round number of ms -- a 300 Hz period is
+    # 3.333... ms -- so an even split of it must not trip the fit check:
+    cycle = 1000.0 / 300
+    offsets = SequentialRaster(3).offsets(names, cycle)
+    npt.assert_almost_equal(np.unique(offsets), np.arange(3) * cycle / 3)
 
 
 def test_CustomRaster():
@@ -64,7 +79,7 @@ def test_CustomRaster():
     raster = CustomRaster([['A1', 'A2'], ['A3']])
     npt.assert_equal(raster.n_groups, 2)
     npt.assert_equal(raster.groups(['A1', 'A3', 'A2']), [0, 1, 0])
-    npt.assert_equal(raster.delays(['A1', 'A3'], 10.0), [0, 5])
+    npt.assert_equal(raster.offsets(['A1', 'A3'], 10.0), [0, 5])
     # A dict says the same thing:
     same = CustomRaster({'A1': 0, 'A2': 0, 'A3': 1})
     npt.assert_equal(same.groups(['A1', 'A3', 'A2']), [0, 1, 0])
@@ -72,6 +87,24 @@ def test_CustomRaster():
     # limit the raster exists to respect would be violated silently:
     with pytest.raises(ValueError):
         raster.groups(['A1', 'B7'])
+    # An electrode in two groups would go on firing in the group it was taken
+    # out of, which is the one thing a raster is there to prevent:
+    with pytest.raises(ValueError):
+        CustomRaster([['A1', 'A2'], ['A2', 'A3']])
+    # A fractional group index would silently truncate onto a real group:
+    with pytest.raises(ValueError):
+        CustomRaster({'A1': 1.9, 'A2': 0})
+    with pytest.raises(ValueError):
+        CustomRaster({'A1': np.nan, 'A2': 0})
+    with pytest.raises(ValueError):
+        CustomRaster({'A1': -1, 'A2': 0})
+    # The docstring example has to cover every electrode of the implant it
+    # names, or `groups` raises for the ones left out:
+    corners = ['A1', 'A10', 'F1', 'F10']
+    names = ArgusII().electrode_names
+    full = CustomRaster([corners, [e for e in names if e not in corners]])
+    npt.assert_equal(full.n_groups, 2)
+    npt.assert_equal(np.bincount(full.groups(names)), [4, 56])
 
 
 def test_ProsthesisSystem_raster():

--- a/pulse2percept/models/_horsager2009.pyx
+++ b/pulse2percept/models/_horsager2009.pyx
@@ -101,10 +101,13 @@ cpdef temporal_fast(const float32[:, ::1] stim,
             # the right frame. Each frame is associated with a time, `t_stim`.
             # We use that frame until `t_sim` advances past it. In other words,
             # we use the `idx_stim`-th frame for all times
-            # t_stim[idx_stim] <= t_sim < t_stim[idx_stim + 1]:
-            if idx_stim + 1 < n_stim:
-                if t_sim >= t_stim[idx_stim + 1]:
-                    idx_stim = idx_stim + 1
+            # t_stim[idx_stim] <= t_sim < t_stim[idx_stim + 1].
+            # `while`, not `if`: more than one stimulus frame can fall inside a
+            # single simulation step -- an encoded pulse puts its edges on the
+            # DT=1e-3 ms grid, finer than `dt` -- and advancing only one of them
+            # per step leaves this reading a frame that is already in the past:
+            while idx_stim + 1 < n_stim and t_sim >= t_stim[idx_stim + 1]:
+                idx_stim = idx_stim + 1
             amp = stim[idx_space, idx_stim]
             # Fast ganglion cell response. Note the negative sign before `amp`,
             # which is required to reproduce e.g. Fig.3 in the paper,

--- a/pulse2percept/models/_nanduri2012.pyx
+++ b/pulse2percept/models/_nanduri2012.pyx
@@ -196,10 +196,13 @@ cpdef temporal_fast(const float32[:, ::1] stim,
             # the right frame. Each frame is associated with a time, `t_stim`.
             # We use that frame until `t_sim` advances past it. In other words,
             # we use the `idx_stim`-th frame for all times
-            # t_stim[idx_stim] <= t_sim < t_stim[idx_stim + 1]:
-            if idx_stim + 1 < n_stim:
-                if t_sim >= t_stim[idx_stim + 1]:
-                    idx_stim = idx_stim + 1
+            # t_stim[idx_stim] <= t_sim < t_stim[idx_stim + 1].
+            # `while`, not `if`: more than one stimulus frame can fall inside a
+            # single simulation step -- an encoded pulse puts its edges on the
+            # DT=1e-3 ms grid, finer than `dt` -- and advancing only one of them
+            # per step leaves this reading a frame that is already in the past:
+            while idx_stim + 1 < n_stim and t_sim >= t_stim[idx_stim + 1]:
+                idx_stim = idx_stim + 1
             amp = stim[idx_space, idx_stim]
             # Fast ganglion cell response:
             r1 = r1 + dt * (amp - r1) / tau1  # += in threads is a reduction
@@ -222,17 +225,13 @@ cpdef temporal_fast(const float32[:, ::1] stim,
         r4a = 0.0
         r4b = 0.0
         r4c = 0.0
-        idx_stim = 0
         idx_frame = 0
         # Scaling factor depends on `max_r3` from Step 1:
         scale = asymptote * c_expit((max_r3 - shift) / slope) / max_r3
-        # We have to restart the loop over all simulation time steps from 0:
+        # We have to restart the loop over all simulation time steps from 0.
+        # This step reads `all_r3`, which Step 1 already stored per simulation
+        # step, so it needs no stimulus frame lookup of its own:
         for idx_sim in range(n_sim):
-            t_sim = idx_sim * dt
-            # Access the right stimulus frame (same as above):
-            if idx_stim + 1 < n_stim:
-                if t_sim >= t_stim[idx_stim + 1]:
-                    idx_stim = idx_stim + 1
             # Slow response (3-stage leaky integrator):
             r4a = r4a + dt * (all_r3[idx_space, idx_sim] * scale - r4a) / tau3
             r4b = r4b + dt * (r4a - r4b) / tau3

--- a/pulse2percept/models/_temporal.pyx
+++ b/pulse2percept/models/_temporal.pyx
@@ -126,10 +126,18 @@ cpdef fading_fast(const float32[:, ::1] stim,
             # we use the `idx_stim`-th frame for all times
             # t_stim[idx_stim] <= t_sim < t_stim[idx_stim + 1]. Which frame
             # that is does not depend on the location, so it is settled here
-            # rather than inside the loop below:
-            if idx_stim + 1 < n_stim:
-                if t_sim >= t_stim[idx_stim + 1]:
-                    idx_stim = idx_stim + 1
+            # rather than inside the loop below.
+            #
+            # `while`, not `if`: more than one stimulus frame can fall inside a
+            # single simulation step, and skipping only one of them leaves the
+            # integrator reading a frame that is already in the past. Encoded
+            # pulses make that the normal case rather than a corner case --
+            # their edges sit on the DT=1e-3 ms grid while `dt` defaults to
+            # 5e-3 ms, so a pulse edge and the sample after it routinely share
+            # a step. Advancing one frame per step would let a blip that has
+            # already ended drive brightness at a later instant:
+            while idx_stim + 1 < n_stim and t_sim >= t_stim[idx_stim + 1]:
+                idx_stim = idx_stim + 1
             for idx_space in range(hi - lo):
                 amp = stim_t[idx_stim, lo + idx_space]
                 bright = scratch[tid, idx_space]

--- a/pulse2percept/models/_temporal.pyx
+++ b/pulse2percept/models/_temporal.pyx
@@ -18,6 +18,10 @@ ctypedef Py_ssize_t index_t
 # inner loop compiles down to.
 cdef index_t BLOCK = 64
 
+# How a percept time point summarizes the interval that led up to it.
+cdef uint32 REDUCE_LAST = 0
+cdef uint32 REDUCE_PEAK = 1
+
 
 @cdivision(True)
 cpdef fading_fast(const float32[:, ::1] stim,
@@ -26,19 +30,16 @@ cpdef fading_fast(const float32[:, ::1] stim,
                   float32 dt,
                   float32 tau,
                   float32 thresh_percept,
-                  uint32 n_threads):
+                  uint32 n_threads,
+                  uint32 reduce=REDUCE_LAST):
     """Cython implementation of the generic fading model
 
     The leaky integrator has to be stepped in order, so the loop over time is
-    serial -- but each spatial location integrates independently of every
+    serial. But, each spatial location integrates independently of every
     other. Time is therefore the *outer* loop and space the inner one, which
     leaves the inner loop free of any carried dependency and lets it
     vectorize. Threads take a block of locations each and run the whole time
     loop over it, so the parallel region is still entered only once.
-
-    The arithmetic per step is unchanged, and each location still sees its
-    steps in the same order, so the result is bit-for-bit what the
-    space-outer version produced.
 
     Parameters
     ----------
@@ -55,7 +56,20 @@ cpdef fading_fast(const float32[:, ::1] stim,
     thresh_percept : float32
         Spatial responses smaller than ``thresh_percept`` will be set to zero
     n_threads: uint32
-        Number of CPU threads to use during parallelization using OpenMP. Defaults to maximum number of cores on user CPU
+        Number of CPU threads to use during parallelization using OpenMP. 
+        Defaults to maximum number of cores on user CPU
+    reduce : uint32
+        How each percept time point summarizes the interval since the previous
+        one: 0 reports the brightness at that instant, 1 reports the peak
+        brightness reached over the interval.
+
+        Electrical stimulation is pulsatile, so brightness rises and falls
+        within one output interval. Reporting the instant the interval happens
+        to end on samples a signal whose energy lives in sub-millisecond
+        transients, and the sampling phase then walks through the pulse cycle:
+        neighbouring frames come out orders of magnitude apart for no reason a
+        viewer would recognize. The peak is tracked across every ``dt`` step,
+        so it costs one compare per step and is exact at any output rate.
 
     Returns
     -------
@@ -64,10 +78,11 @@ cpdef fading_fast(const float32[:, ::1] stim,
 
     """
     cdef:
-        float32 t_sim, amp, bright
+        float32 t_sim, amp, drive, bright, peak
         float32[:, ::1] percept
         float32[:, ::1] stim_t
         float32[:, ::1] scratch
+        float32[:, ::1] running
         index_t idx_space, idx_sim, idx_stim, idx_frame, idx_block
         index_t n_space, n_stim, n_percept, n_sim, n_blocks, lo, hi, tid
 
@@ -86,6 +101,10 @@ cpdef fading_fast(const float32[:, ::1] stim,
     # Running brightness, one row per thread. Rows are BLOCK floats apart, so
     # no two threads share a cache line.
     scratch = np.empty((n_threads, BLOCK), dtype=np.float32)  # Py overhead
+    # Peak brightness since the last percept time point, laid out the same way.
+    # Allocated even when it is not used, so that the loop below can be written
+    # once:
+    running = np.empty((n_threads, BLOCK), dtype=np.float32)  # Py overhead
 
     for idx_block in prange(n_blocks, schedule='static', nogil=True,
                             num_threads=n_threads):
@@ -96,6 +115,7 @@ cpdef fading_fast(const float32[:, ::1] stim,
             hi = n_space
         for idx_space in range(hi - lo):
             scratch[tid, idx_space] = <float32>0.0
+            running[tid, idx_space] = <float32>0.0
         idx_stim = 0
         idx_frame = 0
         for idx_sim in range(n_sim):
@@ -113,21 +133,38 @@ cpdef fading_fast(const float32[:, ::1] stim,
             for idx_space in range(hi - lo):
                 amp = stim_t[idx_stim, lo + idx_space]
                 bright = scratch[tid, idx_space]
-                # Invert stimulus polarity and apply leaky integrator:
-                bright = bright + dt * (-amp - bright) / tau
+                # Half-wave rectify: only cathodic (negative) current drives
+                # brightness. Without this the model cannot see a
+                # charge-balanced pulse at all:
+                drive = -amp
+                if drive < 0.0:
+                    drive = 0.0
+                bright = bright + dt * (drive - bright) / tau
                 # Brightness is bounded in [0, \inf[
                 if bright < 0.0:
                     bright = 0.0
                 scratch[tid, idx_space] = bright
+                # One compare per step, and it keeps the peak exact however
+                # coarse the output rate is:
+                if bright > running[tid, idx_space]:
+                    running[tid, idx_space] = bright
             if idx_sim == idx_t_percept[idx_frame]:
                 # `idx_t_percept` stores the time points at which we need to
                 # output a percept. We compare `idx_sim` to `idx_t_percept`
                 # rather than `t_sim` to `t_percept` because there is no good
                 # (fast) way to compare two floating point numbers:
                 for idx_space in range(hi - lo):
-                    bright = scratch[tid, idx_space]
+                    if reduce == REDUCE_PEAK:
+                        bright = running[tid, idx_space]
+                    else:
+                        bright = scratch[tid, idx_space]
                     if c_abs(bright) >= thresh_percept:
                         percept[lo + idx_space, idx_frame] = bright
+                    # Start the next interval's peak from where this one left
+                    # off, not from zero: brightness is continuous, so the
+                    # value carried across the boundary is a floor on what the
+                    # next interval reaches:
+                    running[tid, idx_space] = scratch[tid, idx_space]
                 idx_frame = idx_frame + 1
 
     return np.asarray(percept)  # Py overhead

--- a/pulse2percept/models/base.py
+++ b/pulse2percept/models/base.py
@@ -48,8 +48,20 @@ def _n_jobs_alias():
                         "names read and write the same value.")
 
 
-def _frame_clock(stim, dt):
-    """The video frame times (ms) an encoded stimulus was built from
+#: How many instants inside each video frame a percept is sampled at before
+#: being reduced to one value for that frame. Electrical stimulation is
+#: pulsatile, so the brightness a frame produces rises and falls within it; a
+#: single instant lands wherever the pulse cycle happens to be and can differ
+#: from its neighbours by two orders of magnitude for no reason a viewer would
+#: recognize. Sampling across the frame and keeping the peak reports what the
+#: frame actually did. Dynamics much faster than ``frame_dur`` divided by this
+#: are still under-reported -- no finite sampling can summarize a transient
+#: shorter than its own step.
+_FRAME_SUBSAMPLES = 8
+
+
+def _frame_clock(stim, dt, n_sub=1):
+    """When to sample a percept for the video an encoded stimulus came from
 
     An encoder separates the clock that decides *when the picture changes* from
     the clock that decides *when the electrodes pulse*, and records the former
@@ -57,14 +69,25 @@ def _frame_clock(stim, dt):
     reporting: one frame in, one frame out. The pulse train's own time points
     are far finer and carry no extra picture.
 
-    Returns the *end* of each frame, so that frame *k* of the percept reflects
-    the stimulation delivered during frame *k* of the video, rounded onto the
-    model's ``dt`` grid (a 29.97 fps frame is 33.3667 ms, which is not a
-    multiple of the default dt=0.005 ms). It is the frame *interval* that is
+    Each frame is sampled ``n_sub`` times, evenly spaced and ending exactly on
+    the frame boundary, so that a caller can reduce the samples belonging to a
+    frame down to the one number that frame is worth. Everything is rounded
+    onto the model's ``dt`` grid (a 29.97 fps frame is 33.3667 ms, which is not
+    a multiple of the default dt=0.005 ms). It is the frame *interval* that is
     rounded rather than each frame time on its own, so that the percept keeps
     an evenly spaced time axis -- ``play`` and ``save`` infer a frame rate from
-    it and refuse a ragged one. Returns None for anything that did not come out
-    of an encoder.
+    it and refuse a ragged one.
+
+    Returns
+    -------
+    t : (n_frames * n_sub,) array
+        Sample times (ms), in order. Every ``n_sub``-th one, starting at index
+        ``n_sub - 1``, is the end of a frame.
+    n_sub : int
+        How many samples each frame actually got, which is fewer than asked for
+        if a frame is not that many ``dt`` long.
+
+    Returns None for anything that did not come out of an encoder.
 
     .. versionadded:: 0.10.0
 
@@ -80,7 +103,7 @@ def _frame_clock(stim, dt):
     if not isinstance(enc, dict) and 'stim' in meta:
         # A `Percept` on its way from the spatial model to the temporal one
         # carries the stimulus it came from, and the frame clock with it:
-        return _frame_clock(meta['stim'], dt)
+        return _frame_clock(meta['stim'], dt, n_sub=n_sub)
     if not isinstance(enc, dict):
         return None
     try:
@@ -95,7 +118,11 @@ def _frame_clock(stim, dt):
     # of `dt` (which `predict_percept` insists on):
     step = max(1, int(round(frame_dur / dt)))
     start = int(round(float(frame_time[0]) / dt))
-    return (start + (np.arange(frame_time.size) + 1) * step) * dt
+    # A frame cannot be sampled more often than it has `dt` steps:
+    n_sub = max(1, min(int(n_sub), step))
+    within = np.round(np.arange(1, n_sub + 1) * step / n_sub).astype(np.int64)
+    base = start + np.arange(frame_time.size, dtype=np.int64) * step
+    return (base[:, np.newaxis] + within[np.newaxis, :]).ravel() * dt, n_sub
 
 
 class NotBuiltError(ValueError, AttributeError):
@@ -720,15 +747,20 @@ class TemporalModel(BaseModel, metaclass=ABCMeta):
             _space = [len(stim.ydva), len(stim.xdva)]
         _time = stim.time
 
+        n_sub = 1
         if t_percept is None:
             # A stimulus that came out of an encoder knows the frame rate of
             # the video behind it, and that is the rate worth reporting at:
-            # one percept frame per video frame. Failing that, output at a
+            # one percept frame per video frame. Each frame is sampled several
+            # times over and reduced below, since a single instant lands
+            # wherever the pulse cycle happens to be. Failing that, output at a
             # 50 Hz frame rate, always starting at zero and including the last
             # time point:
-            t_percept = _frame_clock(stim, self.dt)
-            if t_percept is None:
+            frames = _frame_clock(stim, self.dt, n_sub=_FRAME_SUBSAMPLES)
+            if frames is None:
                 t_percept = np.arange(0, np.maximum(20, _time[-1]) + 1, 20)
+            else:
+                t_percept, n_sub = frames
         # We need to make sure the requested `t_percept` are sorted and
         # multiples of `dt`:
         t_percept = np.sort([t_percept]).flatten()
@@ -745,8 +777,18 @@ class TemporalModel(BaseModel, metaclass=ABCMeta):
             # Calculate the Stimulus at requested time points:
             resp = self._predict_temporal(_stim, t_percept)
             self._warn_if_blank(_stim, resp)
-        return Percept(resp.reshape(_space + [t_percept.size]),
-                       space=None, time=t_percept,
+        resp = resp.reshape(_space + [t_percept.size])
+        if n_sub > 1:
+            # Reduce each frame's samples to the peak brightness it reached.
+            # That is what a frame of the percept means: electrical stimulation
+            # is pulsatile, so reporting the instant a frame happened to end on
+            # says more about where in the pulse cycle that instant fell than
+            # about the frame. Peak, not mean, because what a pulse train
+            # produces is a flash, and averaging it over the gaps that follow
+            # would scale every frame by its duty cycle instead:
+            resp = resp.reshape(_space + [-1, n_sub]).max(axis=-1)
+            t_percept = t_percept[n_sub - 1::n_sub]
+        return Percept(resp, space=None, time=t_percept,
                        metadata={'stim': stim})
 
     def _warn_if_blank(self, stim, resp):

--- a/pulse2percept/models/base.py
+++ b/pulse2percept/models/base.py
@@ -54,9 +54,16 @@ def _n_jobs_alias():
 #: single instant lands wherever the pulse cycle happens to be and can differ
 #: from its neighbours by two orders of magnitude for no reason a viewer would
 #: recognize. Sampling across the frame and keeping the peak reports what the
-#: frame actually did. Dynamics much faster than ``frame_dur`` divided by this
-#: are still under-reported -- no finite sampling can summarize a transient
-#: shorter than its own step.
+#: frame actually did.
+#:
+#: This is the fallback for models whose kernel cannot track the peak itself
+#: (``_reduces_intervals``), and it is only approximate: dynamics much faster
+#: than ``frame_dur`` divided by this are under-reported, because no finite
+#: sampling can summarize a transient shorter than its own step. A 0.92 ms
+#: pulse against a 33.4 ms frame needs 37 samples to be caught reliably; eight
+#: of them catch it about one frame in seven, which is enough for a model whose
+#: output is already smooth on the millisecond scale and not enough for one
+#: whose output is not.
 _FRAME_SUBSAMPLES = 8
 
 
@@ -626,6 +633,36 @@ class TemporalModel(BaseModel, metaclass=ABCMeta):
     *  ``_build`` (optional): a way to add one-time computations to the build
        process
 
+    Parameters
+    ----------
+    dt : float, optional
+        Sampling time step of the simulation (ms)
+    thresh_percept : float, optional
+        Below threshold, the percept has brightness zero.
+    reduce : {'peak', 'last'}, optional
+        How a percept time point summarizes the interval since the previous
+        one, when ``predict_percept`` picks the output times itself (that is,
+        when ``t_percept`` is None). ``'peak'`` reports the highest brightness
+        reached over the interval; ``'last'`` reports the brightness at the
+        instant the interval ended, which is what every version before 0.10.0
+        did.
+
+        Peak is the default because electrical stimulation is pulsatile: the
+        brightness an interval produces rises and falls within it, so the
+        closing instant says more about where in the pulse cycle it fell than
+        about the interval. Peak rather than mean because what a pulse train
+        produces is a flash, and averaging over the gaps that follow would
+        scale every interval by its duty cycle instead.
+
+        Naming ``t_percept`` overrides this: an explicit time point is a
+        request for that instant, and is always answered with the brightness
+        there.
+
+        .. versionadded:: 0.10.0
+    n_threads : int, optional
+        Number of CPU threads to use during parallelization using OpenMP.
+        Defaults to max number of user CPU cores.
+
     .. versionadded:: 0.6
 
     .. note ::
@@ -651,6 +688,14 @@ class TemporalModel(BaseModel, metaclass=ABCMeta):
     #: so; nothing else reads it.
     _drive_sign = -1
 
+    #: Whether ``_predict_temporal`` accepts a ``reduce`` argument and honors it
+    #: itself, tracking the peak across every ``dt`` step of the interval. That
+    #: is exact and costs one compare per step. Models that leave this False
+    #: fall back to sampling each interval ``_FRAME_SUBSAMPLES`` times, which
+    #: costs memory proportional to the sample count and still misses
+    #: transients shorter than the resulting step.
+    _reduces_intervals = False
+
     def get_default_params(self):
         """Return a dictionary of default values for all model parameters"""
         params = {
@@ -658,6 +703,9 @@ class TemporalModel(BaseModel, metaclass=ABCMeta):
             'dt': 0.005,
             # Below threshold, percept has brightness zero:
             'thresh_percept': 0,
+            # How to summarize an output interval when `predict_percept` picks
+            # the output times itself; see `predict_percept`:
+            'reduce': 'peak',
             # True: print status messages, False: silent
             'verbose': True,
             # `n_jobs` is an alias that writes through to `n_threads`, so it
@@ -685,6 +733,14 @@ class TemporalModel(BaseModel, metaclass=ABCMeta):
         percept: np.ndarray
             A 2D NumPy array (space x time) that specifies the percept at each
             spatial location and time step.
+
+        Notes
+        -----
+        A model that can summarize an interval rather than sample an instant
+        takes a third argument, ``reduce`` ('peak' or 'last'), and sets
+        ``_reduces_intervals = True``. ``predict_percept`` only passes the
+        argument to models that advertise it, so an override with the
+        two-argument signature above keeps working.
         """
         raise NotImplementedError
 
@@ -704,8 +760,9 @@ class TemporalModel(BaseModel, metaclass=ABCMeta):
             applied to each spatial location in the stimulus/percept.
         t_percept : float or list of floats, optional
             The time points at which to output a percept (ms).
-            If None, the percept will be output once very 20 ms (50 Hz frame
-            rate).
+            If None, the percept will be output once per frame of the video the
+            stimulus was encoded from, or failing that once every 20 ms (50 Hz
+            frame rate).
 
             .. note ::
 
@@ -722,6 +779,27 @@ class TemporalModel(BaseModel, metaclass=ABCMeta):
         -----
         *  If a list of time points is provided for ``t_percept``, the values
            will automatically be sorted.
+
+        *  Naming ``t_percept`` asks for the brightness *at those instants*.
+           Leaving it None asks the model to pick the output times, and it then
+           reports what each interval between them *did* rather than where it
+           happened to end -- the peak brightness reached over the interval, or
+           the closing value if ``reduce='last'``.
+
+           The distinction matters because electrical stimulation is pulsatile.
+           A 20 Hz train of 0.46 ms biphasic pulses drives brightness in
+           sub-millisecond transients at a 1.8% duty cycle, so an instant
+           sampled from it is almost always an instant between pulses. Worse,
+           the sampling phase walks: against a 29.97 fps video the frame
+           (33.37 ms) and the pulse period (50 ms) are incommensurate, so which
+           electrodes a frame catches drifts from frame to frame. Under a
+           raster, where each group pulses in its own slot, that shows up as
+           groups appearing in the wrong order or not at all.
+
+        .. versionchanged:: 0.10.0
+
+            Output times chosen by the model summarize their interval instead
+            of sampling its final instant. See ``reduce``.
 
         """
         if not self.is_built:
@@ -748,15 +826,24 @@ class TemporalModel(BaseModel, metaclass=ABCMeta):
         _time = stim.time
 
         n_sub = 1
+        reduce = 'last'
         if t_percept is None:
+            # Nobody asked for a particular instant, so the output times are
+            # this model's to choose -- and having chosen them it owes a
+            # summary of each interval rather than a sample of one instant out
+            # of it. `reduce` says which summary; see the docstring.
+            reduce = self.reduce
+            if reduce not in ('peak', 'last'):
+                raise ValueError(f"'reduce' must be 'peak' or 'last', not "
+                                 f"{self.reduce!r}.")
             # A stimulus that came out of an encoder knows the frame rate of
             # the video behind it, and that is the rate worth reporting at:
-            # one percept frame per video frame. Each frame is sampled several
-            # times over and reduced below, since a single instant lands
-            # wherever the pulse cycle happens to be. Failing that, output at a
+            # one percept frame per video frame. Failing that, output at a
             # 50 Hz frame rate, always starting at zero and including the last
             # time point:
-            frames = _frame_clock(stim, self.dt, n_sub=_FRAME_SUBSAMPLES)
+            want = (_FRAME_SUBSAMPLES
+                    if reduce == 'peak' and not self._reduces_intervals else 1)
+            frames = _frame_clock(stim, self.dt, n_sub=want)
             if frames is None:
                 t_percept = np.arange(0, np.maximum(20, _time[-1]) + 1, 20)
             else:
@@ -773,19 +860,22 @@ class TemporalModel(BaseModel, metaclass=ABCMeta):
         if _stim.data.size == 0:
             # Stimulus was compressed to zero:
             resp = np.zeros(_space + [t_percept.size], dtype=np.float32)
+        elif self._reduces_intervals:
+            # This model tracks the peak inside its own integrator, which is
+            # exact however coarse the output rate is:
+            resp = self._predict_temporal(_stim, t_percept, reduce)
+            self._warn_if_blank(_stim, resp)
         else:
             # Calculate the Stimulus at requested time points:
             resp = self._predict_temporal(_stim, t_percept)
             self._warn_if_blank(_stim, resp)
         resp = resp.reshape(_space + [t_percept.size])
         if n_sub > 1:
-            # Reduce each frame's samples to the peak brightness it reached.
-            # That is what a frame of the percept means: electrical stimulation
-            # is pulsatile, so reporting the instant a frame happened to end on
-            # says more about where in the pulse cycle that instant fell than
-            # about the frame. Peak, not mean, because what a pulse train
-            # produces is a flash, and averaging it over the gaps that follow
-            # would scale every frame by its duty cycle instead:
+            # The fallback for a model that cannot reduce its own intervals:
+            # sample each frame `n_sub` times and keep the peak. Peak, not
+            # mean, because what a pulse train produces is a flash, and
+            # averaging it over the gaps that follow would scale every frame by
+            # its duty cycle instead:
             resp = resp.reshape(_space + [-1, n_sub]).max(axis=-1)
             t_percept = t_percept[n_sub - 1::n_sub]
         return Percept(resp, space=None, time=t_percept,

--- a/pulse2percept/models/base.py
+++ b/pulse2percept/models/base.py
@@ -48,6 +48,56 @@ def _n_jobs_alias():
                         "names read and write the same value.")
 
 
+def _frame_clock(stim, dt):
+    """The video frame times (ms) an encoded stimulus was built from
+
+    An encoder separates the clock that decides *when the picture changes* from
+    the clock that decides *when the electrodes pulse*, and records the former
+    in the stimulus' metadata. That is the rate at which a percept is worth
+    reporting: one frame in, one frame out. The pulse train's own time points
+    are far finer and carry no extra picture.
+
+    Returns the *end* of each frame, so that frame *k* of the percept reflects
+    the stimulation delivered during frame *k* of the video, rounded onto the
+    model's ``dt`` grid (a 29.97 fps frame is 33.3667 ms, which is not a
+    multiple of the default dt=0.005 ms). It is the frame *interval* that is
+    rounded rather than each frame time on its own, so that the percept keeps
+    an evenly spaced time axis -- ``play`` and ``save`` infer a frame rate from
+    it and refuse a ragged one. Returns None for anything that did not come out
+    of an encoder.
+
+    .. versionadded:: 0.10.0
+
+    """
+    meta = getattr(stim, 'metadata', None)
+    if not isinstance(meta, dict):
+        return None
+    enc = meta.get('encoder')
+    if not isinstance(enc, dict):
+        # `Stimulus` files metadata it does not recognize under 'user':
+        user = meta.get('user')
+        enc = user.get('encoder') if isinstance(user, dict) else None
+    if not isinstance(enc, dict) and 'stim' in meta:
+        # A `Percept` on its way from the spatial model to the temporal one
+        # carries the stimulus it came from, and the frame clock with it:
+        return _frame_clock(meta['stim'], dt)
+    if not isinstance(enc, dict):
+        return None
+    try:
+        frame_time = np.asarray(enc['frame_time'], dtype=np.float64)
+        frame_dur = float(enc['frame_dur'])
+    except (KeyError, TypeError, ValueError):
+        return None
+    if frame_time.size == 0 or not np.isfinite(frame_dur) or frame_dur <= 0:
+        return None
+    # Count in whole `dt` steps rather than rounding each frame time, so that
+    # the spacing comes out exactly even and every point is exactly a multiple
+    # of `dt` (which `predict_percept` insists on):
+    step = max(1, int(round(frame_dur / dt)))
+    start = int(round(float(frame_time[0]) / dt))
+    return (start + (np.arange(frame_time.size) + 1) * step) * dt
+
+
 class NotBuiltError(ValueError, AttributeError):
     """Exception class used to raise if model is used before building
 
@@ -671,9 +721,14 @@ class TemporalModel(BaseModel, metaclass=ABCMeta):
         _time = stim.time
 
         if t_percept is None:
-            # If no time vector is given, output at 50 Hz frame rate. We always
-            # start at zero and include the last time point:
-            t_percept = np.arange(0, np.maximum(20, _time[-1]) + 1, 20)
+            # A stimulus that came out of an encoder knows the frame rate of
+            # the video behind it, and that is the rate worth reporting at:
+            # one percept frame per video frame. Failing that, output at a
+            # 50 Hz frame rate, always starting at zero and including the last
+            # time point:
+            t_percept = _frame_clock(stim, self.dt)
+            if t_percept is None:
+                t_percept = np.arange(0, np.maximum(20, _time[-1]) + 1, 20)
         # We need to make sure the requested `t_percept` are sorted and
         # multiples of `dt`:
         t_percept = np.sort([t_percept]).flatten()

--- a/pulse2percept/models/base.py
+++ b/pulse2percept/models/base.py
@@ -67,7 +67,56 @@ def _n_jobs_alias():
 _FRAME_SUBSAMPLES = 8
 
 
-def _frame_clock(stim, dt, n_sub=1):
+def _subsample(t_out, dt, n_sub, start=None):
+    """Sample the interval leading up to each output point ``n_sub`` times
+
+    The fallback for a model that cannot summarize an interval inside its own
+    integrator (see ``_FRAME_SUBSAMPLES``): ask it for several instants per
+    interval and keep the largest. Samples are evenly spaced and land exactly
+    on the output point, so the value there is always among them -- the peak of
+    an interval is then never below the instant it ends on, whatever the
+    sampling does.
+
+    Parameters
+    ----------
+    start : float, optional
+        Where the interval summarized by the *first* output point begins (ms).
+        A frame clock puts its output points on frame *ends*, so the first one
+        summarizes an interval reaching back to the start of frame 0. If None,
+        the first output point has no interval and stands for its own instant.
+
+    Returns
+    -------
+    t : array
+        The instants to evaluate at (ms), strictly increasing.
+    idx : array
+        Where each output point's samples begin in ``t``, ready to pass
+        straight to ``np.maximum.reduceat``.
+
+    .. versionadded:: 0.10.0
+
+    """
+    ticks = np.round(np.asarray(t_out, dtype=np.float64) / dt).astype(np.int64)
+    # An interval runs from the previous output point up to and including this
+    # one. Brightness is continuous, so the value carried across the boundary
+    # is a floor on what the next interval reaches:
+    first = ticks[0] if start is None else int(round(float(start) / dt))
+    lo = np.concatenate(([min(first, ticks[0])], ticks[:-1]))
+    parts = []
+    for a, b in zip(lo, ticks):
+        span = int(b - a)
+        if span <= 0:
+            parts.append(np.array([b], dtype=np.int64))
+            continue
+        # An interval cannot be sampled more often than it has `dt` steps:
+        k = min(int(n_sub), span)
+        parts.append(a + np.round(
+            np.arange(1, k + 1) * span / k).astype(np.int64))
+    idx = np.cumsum([0] + [p.size for p in parts[:-1]])
+    return np.concatenate(parts) * dt, idx
+
+
+def _frame_clock(stim, dt):
     """When to sample a percept for the video an encoded stimulus came from
 
     An encoder separates the clock that decides *when the picture changes* from
@@ -76,23 +125,20 @@ def _frame_clock(stim, dt, n_sub=1):
     reporting: one frame in, one frame out. The pulse train's own time points
     are far finer and carry no extra picture.
 
-    Each frame is sampled ``n_sub`` times, evenly spaced and ending exactly on
-    the frame boundary, so that a caller can reduce the samples belonging to a
-    frame down to the one number that frame is worth. Everything is rounded
-    onto the model's ``dt`` grid (a 29.97 fps frame is 33.3667 ms, which is not
-    a multiple of the default dt=0.005 ms). It is the frame *interval* that is
+    A percept point lands on the end of each frame. Everything is rounded onto
+    the model's ``dt`` grid (a 29.97 fps frame is 33.3667 ms, which is not a
+    multiple of the default dt=0.005 ms). It is the frame *interval* that is
     rounded rather than each frame time on its own, so that the percept keeps
     an evenly spaced time axis -- ``play`` and ``save`` infer a frame rate from
     it and refuse a ragged one.
 
     Returns
     -------
-    t : (n_frames * n_sub,) array
-        Sample times (ms), in order. Every ``n_sub``-th one, starting at index
-        ``n_sub - 1``, is the end of a frame.
-    n_sub : int
-        How many samples each frame actually got, which is fewer than asked for
-        if a frame is not that many ``dt`` long.
+    t : (n_frames,) array
+        The time (ms) at which each frame ends.
+    start : float
+        The time (ms) at which the first frame begins, which is where the
+        interval summarized by ``t[0]`` starts.
 
     Returns None for anything that did not come out of an encoder.
 
@@ -110,7 +156,7 @@ def _frame_clock(stim, dt, n_sub=1):
     if not isinstance(enc, dict) and 'stim' in meta:
         # A `Percept` on its way from the spatial model to the temporal one
         # carries the stimulus it came from, and the frame clock with it:
-        return _frame_clock(meta['stim'], dt, n_sub=n_sub)
+        return _frame_clock(meta['stim'], dt)
     if not isinstance(enc, dict):
         return None
     try:
@@ -125,11 +171,8 @@ def _frame_clock(stim, dt, n_sub=1):
     # of `dt` (which `predict_percept` insists on):
     step = max(1, int(round(frame_dur / dt)))
     start = int(round(float(frame_time[0]) / dt))
-    # A frame cannot be sampled more often than it has `dt` steps:
-    n_sub = max(1, min(int(n_sub), step))
-    within = np.round(np.arange(1, n_sub + 1) * step / n_sub).astype(np.int64)
-    base = start + np.arange(frame_time.size, dtype=np.int64) * step
-    return (base[:, np.newaxis] + within[np.newaxis, :]).ravel() * dt, n_sub
+    ends = start + np.arange(1, frame_time.size + 1, dtype=np.int64) * step
+    return ends * dt, start * dt
 
 
 class NotBuiltError(ValueError, AttributeError):
@@ -548,7 +591,8 @@ class SpatialModel(BaseModel, metaclass=ABCMeta):
             scale = amp / implant.stim.data.max()
             _implant.stim = Stimulus(scale * implant.stim.data,
                                      electrodes=implant.stim.electrodes,
-                                     time=implant.stim.time)
+                                     time=implant.stim.time,
+                                     metadata=deepcopy(implant.stim.metadata))
             return fnc_predict(_implant).data.max()
 
         return bisect(bright_th, inner_predict,
@@ -639,20 +683,27 @@ class TemporalModel(BaseModel, metaclass=ABCMeta):
         Sampling time step of the simulation (ms)
     thresh_percept : float, optional
         Below threshold, the percept has brightness zero.
-    reduce : {'peak', 'last'}, optional
+    reduce : {'last', 'peak'}, optional
         How a percept time point summarizes the interval since the previous
         one, when ``predict_percept`` picks the output times itself (that is,
-        when ``t_percept`` is None). ``'peak'`` reports the highest brightness
-        reached over the interval; ``'last'`` reports the brightness at the
+        when ``t_percept`` is None). ``'last'`` reports the brightness at the
         instant the interval ended, which is what every version before 0.10.0
-        did.
+        did and what the published models still default to. ``'peak'`` reports
+        the highest brightness reached over the interval.
 
-        Peak is the default because electrical stimulation is pulsatile: the
-        brightness an interval produces rises and falls within it, so the
+        Peak is worth reaching for because electrical stimulation is pulsatile:
+        the brightness an interval produces rises and falls within it, so the
         closing instant says more about where in the pulse cycle it fell than
         about the interval. Peak rather than mean because what a pulse train
         produces is a flash, and averaging over the gaps that follow would
         scale every interval by its duty cycle instead.
+        :py:class:`~pulse2percept.models.FadingTemporal` defaults to it.
+
+        How exactly it is computed depends on the model. One that sets
+        ``_reduces_intervals`` tracks the peak across every ``dt`` step inside
+        its own integrator, which is exact at any output rate. Any other model
+        is sampled at several instants per interval instead, which cannot catch
+        a transient shorter than the resulting step; see ``_FRAME_SUBSAMPLES``.
 
         Naming ``t_percept`` overrides this: an explicit time point is a
         request for that instant, and is always answered with the brightness
@@ -704,8 +755,11 @@ class TemporalModel(BaseModel, metaclass=ABCMeta):
             # Below threshold, percept has brightness zero:
             'thresh_percept': 0,
             # How to summarize an output interval when `predict_percept` picks
-            # the output times itself; see `predict_percept`:
-            'reduce': 'peak',
+            # the output times itself; see `predict_percept`. The published
+            # models default to 'last', which is what they have always
+            # reported; a model is free to override it, as `FadingTemporal`
+            # does:
+            'reduce': 'last',
             # True: print status messages, False: silent
             'verbose': True,
             # `n_jobs` is an alias that writes through to `n_threads`, so it
@@ -781,10 +835,10 @@ class TemporalModel(BaseModel, metaclass=ABCMeta):
            will automatically be sorted.
 
         *  Naming ``t_percept`` asks for the brightness *at those instants*.
-           Leaving it None asks the model to pick the output times, and it then
-           reports what each interval between them *did* rather than where it
-           happened to end -- the peak brightness reached over the interval, or
-           the closing value if ``reduce='last'``.
+           Leaving it None asks the model to pick the output times, and
+           ``reduce`` then says what each point reports about the interval
+           leading up to it -- the closing instant, or the peak reached over
+           it.
 
            The distinction matters because electrical stimulation is pulsatile.
            A 20 Hz train of 0.46 ms biphasic pulses drives brightness in
@@ -798,8 +852,8 @@ class TemporalModel(BaseModel, metaclass=ABCMeta):
 
         .. versionchanged:: 0.10.0
 
-            Output times chosen by the model summarize their interval instead
-            of sampling its final instant. See ``reduce``.
+            Output times chosen by the model can summarize their interval
+            instead of sampling its final instant. See ``reduce``.
 
         """
         if not self.is_built:
@@ -825,8 +879,7 @@ class TemporalModel(BaseModel, metaclass=ABCMeta):
             _space = [len(stim.ydva), len(stim.xdva)]
         _time = stim.time
 
-        n_sub = 1
-        reduce = 'last'
+        reduce, t_out, sub_idx = 'last', None, None
         if t_percept is None:
             # Nobody asked for a particular instant, so the output times are
             # this model's to choose -- and having chosen them it owes a
@@ -841,13 +894,19 @@ class TemporalModel(BaseModel, metaclass=ABCMeta):
             # one percept frame per video frame. Failing that, output at a
             # 50 Hz frame rate, always starting at zero and including the last
             # time point:
-            want = (_FRAME_SUBSAMPLES
-                    if reduce == 'peak' and not self._reduces_intervals else 1)
-            frames = _frame_clock(stim, self.dt, n_sub=want)
+            frames = _frame_clock(stim, self.dt)
             if frames is None:
-                t_percept = np.arange(0, np.maximum(20, _time[-1]) + 1, 20)
+                t_out, first = np.arange(0, np.maximum(20, _time[-1]) + 1,
+                                         20), None
             else:
-                t_percept, n_sub = frames
+                t_out, first = frames
+            t_percept = t_out
+            if reduce == 'peak' and not self._reduces_intervals:
+                # This model can only be asked for instants, so approximate the
+                # peak by asking for several per interval and keeping the
+                # largest:
+                t_percept, sub_idx = _subsample(t_out, self.dt,
+                                                _FRAME_SUBSAMPLES, first)
         # We need to make sure the requested `t_percept` are sorted and
         # multiples of `dt`:
         t_percept = np.sort([t_percept]).flatten()
@@ -870,14 +929,13 @@ class TemporalModel(BaseModel, metaclass=ABCMeta):
             resp = self._predict_temporal(_stim, t_percept)
             self._warn_if_blank(_stim, resp)
         resp = resp.reshape(_space + [t_percept.size])
-        if n_sub > 1:
-            # The fallback for a model that cannot reduce its own intervals:
-            # sample each frame `n_sub` times and keep the peak. Peak, not
+        if sub_idx is not None:
+            # Collapse each interval's samples down to the largest. Peak, not
             # mean, because what a pulse train produces is a flash, and
-            # averaging it over the gaps that follow would scale every frame by
-            # its duty cycle instead:
-            resp = resp.reshape(_space + [-1, n_sub]).max(axis=-1)
-            t_percept = t_percept[n_sub - 1::n_sub]
+            # averaging it over the gaps that follow would scale every interval
+            # by its duty cycle instead:
+            resp = np.maximum.reduceat(resp, sub_idx, axis=-1)
+            t_percept = t_out
         return Percept(resp, space=None, time=t_percept,
                        metadata={'stim': stim})
 
@@ -944,8 +1002,14 @@ class TemporalModel(BaseModel, metaclass=ABCMeta):
             raise TypeError(f"'stim' must be a Stimulus, not {type(stim)}.")
 
         def inner_predict(amp, fnc_predict, stim, **kwargs):
+            # Carry the metadata across: it is what tells `predict_percept`
+            # which video the stimulus was encoded from, and hence when to
+            # report a percept. Without it every trial of the search would be
+            # evaluated on a different time base than the caller's own
+            # `predict_percept` will use:
             _stim = Stimulus(amp * stim.data / stim.data.max(),
-                             electrodes=stim.electrodes, time=stim.time)
+                             electrodes=stim.electrodes, time=stim.time,
+                             metadata=deepcopy(stim.metadata))
             return fnc_predict(_stim, **kwargs).data.max()
 
         return bisect(bright_th, inner_predict,
@@ -1307,9 +1371,15 @@ class Model(PrettyPrint):
         def inner_predict(amp, fnc_predict, implant, **kwargs):
             _implant = deepcopy(implant)
             scale = amp / implant.stim.data.max()
+            # Carry the metadata across: it is what tells `predict_percept`
+            # which video the stimulus was encoded from, and hence when to
+            # report a percept. Without it every trial of the search would be
+            # evaluated on a different time base than the caller's own
+            # `predict_percept` will use:
             _implant.stim = Stimulus(scale * implant.stim.data,
                                      electrodes=implant.stim.electrodes,
-                                     time=implant.stim.time)
+                                     time=implant.stim.time,
+                                     metadata=deepcopy(implant.stim.metadata))
             return fnc_predict(_implant, **kwargs).data.max()
 
         return bisect(bright_th, inner_predict,

--- a/pulse2percept/models/temporal.py
+++ b/pulse2percept/models/temporal.py
@@ -7,22 +7,32 @@ from ._temporal import fading_fast
 class FadingTemporal(TemporalModel):
     """A generic temporal model for phosphene fading
 
-    Implements phosphene fading using a leaky integrator:
+    Implements phosphene fading using a leaky integrator driven by the
+    cathodic half of the stimulus:
 
     .. math::
 
-        \\frac{dB}{dt} = -\\frac{A+B}{\\tau}
+        \\frac{dB}{dt} = \\frac{\\max(-A, 0) - B}{\\tau}
 
-    where :math:`A` is the stimulus  amplitude, :math:`B` is the perceived
-    brightness, and :math:`\\tau` is the exponential  decay constant (``tau``).
+    where :math:`A` is the stimulus amplitude, :math:`B` is the perceived
+    brightness, and :math:`\\tau` is the exponential decay constant (``tau``).
 
     The model makes the following assumptions:
 
-    *  Cathodic currents (negative amplitudes) will increase perceived
-       brightness
-    *  Anodic currents (positive amplitudes) will decrease brightness
+    *  Cathodic currents (negative amplitudes) increase perceived brightness
+    *  Anodic currents (positive amplitudes) do not, and are ignored
     *  Brightness is bounded in :math:`[\\theta, \\infty]`, where
        :math:`\\theta` (``thresh_percept``) is a nonnegative scalar
+
+    .. versionchanged:: 0.10.0
+
+        The drive is now half-wave rectified, driven by the cathodic phase.
+        A stimulus that is purely cathodic is unaffected.
+
+    .. note::
+
+        This is the simplest sensical temporal model, not a perceptually
+        validated model of phosphene fading.
 
     Parameters
     ----------
@@ -35,12 +45,22 @@ class FadingTemporal(TemporalModel):
         :math:`\\ln(2) \\tau` milliseconds.
     thresh_percept: float, optional
         Below threshold, the percept has brightness zero.
+    reduce : {'peak', 'last'}, optional
+        How a percept time point summarizes the interval since the previous
+        one, when ``predict_percept`` chooses the output times itself; see
+        :py:class:`~pulse2percept.models.TemporalModel`. This model tracks the
+        peak inside the integrator, so it is exact at any output rate.
     n_threads: int, optional
-            Number of CPU threads to use during parallelization using OpenMP. Defaults to max number of user CPU cores.
+            Number of CPU threads to use during parallelization using OpenMP. 
+            Defaults to max number of user CPU cores.
 
     .. versionadded:: 0.7.1
 
     """
+
+    #: The peak is tracked across every `dt` step inside `fading_fast`, so
+    #: `predict_percept` does not have to subsample the interval itself.
+    _reduces_intervals = True
 
     def get_default_params(self):
         base_params = super(FadingTemporal, self).get_default_params()
@@ -59,7 +79,7 @@ class FadingTemporal(TemporalModel):
         if self.tau < 0:
             raise ValueError('"tau" cannot be negative.')
 
-    def _predict_temporal(self, stim, t_percept):
+    def _predict_temporal(self, stim, t_percept, reduce='last'):
         """Predict the temporal response"""
         # Pass the stimulus as a 2D NumPy array to the fast Cython function:
         stim_data = stim.data.reshape((-1, len(stim.time)))
@@ -74,4 +94,5 @@ class FadingTemporal(TemporalModel):
         # Cython returns a 2D (space x time) NumPy array:
         return fading_fast(stim_data.astype(np.float32),
                            stim.time.astype(np.float32),
-                           idx_percept, self.dt, self.tau, self.thresh_percept, self.n_threads)
+                           idx_percept, self.dt, self.tau, self.thresh_percept,
+                           self.n_threads, 1 if reduce == 'peak' else 0)

--- a/pulse2percept/models/temporal.py
+++ b/pulse2percept/models/temporal.py
@@ -44,6 +44,12 @@ class FadingTemporal(TemporalModel):
         Larger values lead to slower decay.
         Brightness should decay to half its peak ("half-life") after
         :math:`\\ln(2) \\tau` milliseconds.
+
+        It cannot be shorter than ``dt``. The integrator steps explicitly, so
+        a time constant of one step already carries brightness all the way to
+        its drive; anything shorter overshoots and oscillates. ``tau`` also
+        sets the *rise*, not just the decay, so raising it does not make a
+        percept persist -- it makes it dimmer, as :math:`1/\\tau`.
     thresh_percept: float, optional
         Below threshold, the percept has brightness zero.
     reduce : {'peak', 'last'}, optional
@@ -85,6 +91,19 @@ class FadingTemporal(TemporalModel):
         # `tau`, so it does not decay infinitely fast, it produces inf/nan.
         if self.tau <= 0:
             raise ValueError(f'"tau" must be positive, not {self.tau}.')
+        # The integrator steps explicitly, so `dt / tau` is the fraction of the
+        # remaining gap it closes per step. Above 1 it overshoots and then
+        # oscillates, and the overshoot is `dt / tau` -- at tau=dt/4 brightness
+        # alternates between four times its drive and zero, which is not a
+        # leaky integrator in any useful sense:
+        if self.tau < self.dt:
+            raise ValueError(
+                f'"tau" must be at least dt={self.dt}, not {self.tau}. A time '
+                f'constant shorter than one simulation step makes the '
+                f'integrator overshoot its drive by dt/tau and oscillate. '
+                f'tau=dt is the fastest meaningful setting: brightness then '
+                f'reaches its drive within one step, which makes the model a '
+                f'half-wave rectifier. Shorten "dt" to go faster than that.')
 
     def _predict_temporal(self, stim, t_percept, reduce='last'):
         """Predict the temporal response"""

--- a/pulse2percept/models/temporal.py
+++ b/pulse2percept/models/temporal.py
@@ -21,8 +21,9 @@ class FadingTemporal(TemporalModel):
 
     *  Cathodic currents (negative amplitudes) increase perceived brightness
     *  Anodic currents (positive amplitudes) do not, and are ignored
-    *  Brightness is bounded in :math:`[\\theta, \\infty]`, where
-       :math:`\\theta` (``thresh_percept``) is a nonnegative scalar
+    *  Brightness is bounded below by zero. What is reported is then
+       thresholded, so an output value is either 0 or at least
+       :math:`\\theta` (``thresh_percept``, a nonnegative scalar)
 
     .. versionchanged:: 0.10.0
 
@@ -67,6 +68,10 @@ class FadingTemporal(TemporalModel):
         params = {
             # Time constant for the exponential decay:
             'tau': 100,
+            # This model is generic rather than a published fit, so it is free
+            # to report the more useful summary by default. The peak is tracked
+            # inside `fading_fast`, so it costs nothing and is exact:
+            'reduce': 'peak',
         }
         # This is subtle: Rather than calling `params.update(base_params)`, we
         # call `base_params.update(params)`. This will overwrite `base_params`

--- a/pulse2percept/models/temporal.py
+++ b/pulse2percept/models/temporal.py
@@ -81,8 +81,10 @@ class FadingTemporal(TemporalModel):
         return base_params
 
     def _build(self):
-        if self.tau < 0:
-            raise ValueError('"tau" cannot be negative.')
+        # Zero is as unusable as a negative value: the integrator divides by
+        # `tau`, so it does not decay infinitely fast, it produces inf/nan.
+        if self.tau <= 0:
+            raise ValueError(f'"tau" must be positive, not {self.tau}.')
 
     def _predict_temporal(self, stim, t_percept, reduce='last'):
         """Predict the temporal response"""

--- a/pulse2percept/models/tests/test_base.py
+++ b/pulse2percept/models/tests/test_base.py
@@ -624,6 +624,38 @@ def test_Model_predict_percept_frame_clock(fps):
                             np.arange(0, 101, 20))
 
 
+def test_Model_predict_percept_frame_peak():
+    # Electrical stimulation is pulsatile, so brightness rises and falls within
+    # a video frame. Reporting the single instant a frame happened to end on
+    # says more about where in the pulse cycle that instant fell than about the
+    # frame: at 20 Hz against a 29.97 fps video the period (50 ms) and the
+    # frame (33.37 ms) are incommensurate, so the sampling phase walks through
+    # the cycle and neighbouring frames came out two orders of magnitude apart.
+    implant = ArgusI()
+    vid = VideoStimulus(np.random.rand(4, 4, 16), metadata={'fps': 29.97})
+    implant.stim = AmplitudeEncoder(implant, amp_range=(0, 50),
+                                    freq=20).encode(vid)
+    model = Model(temporal=FadingTemporal(tau=100)).build()
+    peak = model.predict_percept(implant)
+    # Same frames, but sampled only at the instant each one ends:
+    at_end = model.predict_percept(implant, t_percept=peak.time)
+    npt.assert_equal(peak.data.shape, at_end.data.shape)
+    npt.assert_almost_equal(peak.time, at_end.time)
+
+    # The default reports the peak each frame reached, so it is never below the
+    # value at the instant the frame ended, and for most frames it is above it:
+    npt.assert_array_less(at_end.data - 1e-6, peak.data)
+    npt.assert_equal(np.any(peak.data > 1.5 * at_end.data), True)
+    # ... which is what stops the frame-to-frame swing from being an artifact
+    # of the sampling phase rather than a property of the video:
+    swing = lambda d: d.max() / np.median(d)
+    npt.assert_equal(swing(peak.data.max(axis=(0, 1))) <
+                     swing(at_end.data.max(axis=(0, 1))), True)
+    # A percept is still one frame per video frame, on an evenly spaced axis:
+    npt.assert_equal(peak.data.shape[-1], 16)
+    npt.assert_almost_equal(np.diff(peak.time), np.diff(peak.time)[0])
+
+
 def test_Model_predict_percept_correctly_parallelizes():
     # setup and time spatial model with 1 thread
     one_thread_spatial = Model(spatial=ValidSpatialModel(n_threads=1)).build()

--- a/pulse2percept/models/tests/test_base.py
+++ b/pulse2percept/models/tests/test_base.py
@@ -9,11 +9,12 @@ from matplotlib.axes import Subplot
 import time
 
 from pulse2percept.implants import ArgusI
-from pulse2percept.stimuli import Stimulus
+from pulse2percept.stimuli import AmplitudeEncoder, Stimulus, VideoStimulus
 from pulse2percept.percepts import Percept
-from pulse2percept.models import (BaseModel, Model, NotBuiltError,
+from pulse2percept.models import (BaseModel, FadingTemporal, Model,
+                                  NotBuiltError, ScoreboardSpatial,
                                   SpatialModel, TemporalModel)
-from pulse2percept.utils import FreezeError
+from pulse2percept.utils import FreezeError, frame_interval
 from pulse2percept.topography import Grid2D, Watson2014Map
 
 
@@ -580,6 +581,47 @@ def test_Model_predict_percept():
     with pytest.raises(TypeError):
         # Must pass an implant:
         model.predict_percept(Stimulus(3))
+
+
+@pytest.mark.parametrize('fps', [29.97, 30, 24])
+def test_Model_predict_percept_frame_clock(fps):
+    # A stimulus that came out of an encoder knows the frame rate of the video
+    # behind it, and that is the rate worth reporting a percept at: one percept
+    # frame per video frame. The pulse train's own time points are far finer
+    # and carry no extra picture, and the hardcoded 20 ms default has nothing
+    # to do with the source.
+    implant = ArgusI()
+    vid = VideoStimulus(np.random.rand(4, 4, 6), metadata={'fps': fps})
+    implant.stim = AmplitudeEncoder(implant, amp_range=(0, 50),
+                                    freq=60).encode(vid)
+    model = Model(temporal=ValidTemporalModel()).build()
+    percept = model.predict_percept(implant)
+    npt.assert_equal(percept.data.shape[-1], 6)
+    # Evenly spaced, and on the model's dt grid -- 1000/29.97 ms is neither a
+    # whole number of dt nor, if rounded point by point, evenly spaced:
+    npt.assert_almost_equal(np.diff(percept.time),
+                            np.diff(percept.time)[0])
+    ratio = percept.time / model.temporal.dt
+    npt.assert_allclose(ratio, np.round(ratio), atol=1e-3)
+    # Close enough to the source's own frame rate to animate at it:
+    npt.assert_almost_equal(frame_interval(percept.time), 1000.0 / fps,
+                            decimal=1)
+    # The spatial model hands the temporal one a Percept rather than a
+    # Stimulus, so the frame clock has to survive that hop too. This leg needs
+    # real models: `ValidTemporalModel` returns one row per electrode, not one
+    # per grid point, so it cannot consume a spatial percept.
+    both = Model(spatial=ScoreboardSpatial(xrange=(-2, 2), yrange=(-2, 2),
+                                           xystep=1),
+                 temporal=FadingTemporal()).build()
+    npt.assert_equal(both.predict_percept(implant).data.shape[-1], 6)
+    # An explicit `t_percept` still wins:
+    npt.assert_equal(
+        model.predict_percept(implant, t_percept=[0, 1, 2]).data.shape[-1], 3)
+    # ... and a stimulus that did not come from an encoder keeps the 20 ms
+    # default it always had:
+    implant.stim = Stimulus(np.ones((16, 2)), time=[0, 100])
+    npt.assert_almost_equal(model.predict_percept(implant).time,
+                            np.arange(0, 101, 20))
 
 
 def test_Model_predict_percept_correctly_parallelizes():

--- a/pulse2percept/models/tests/test_base.py
+++ b/pulse2percept/models/tests/test_base.py
@@ -756,6 +756,44 @@ def test_Model_find_threshold():
         model.find_threshold(Stimulus({'A1': 1}), 20)
 
 
+def test_find_threshold_keeps_encoder_metadata():
+    # `find_threshold` rebuilds the stimulus at each trial amplitude. The
+    # encoder records the video's frame clock in the stimulus metadata, and
+    # that is what decides when `predict_percept` reports a percept -- so a
+    # rebuild that drops it silently evaluates every trial on the 50 Hz
+    # fallback instead of the time base the caller's own `predict_percept`
+    # will use.
+    implant = ArgusI()
+    rng = np.random.default_rng(0)
+    vid = VideoStimulus(rng.random((4, 4, 6)), metadata={'fps': 29.97})
+    with warnings.catch_warnings():
+        warnings.simplefilter('ignore')
+        implant.stim = AmplitudeEncoder(implant, amp_range=(0, 50),
+                                        freq=60).encode(vid)
+    n_frames = implant.stim.metadata['encoder']['n_frames']
+
+    seen = []
+    model = FadingTemporal(tau=100).build()
+    unwrapped = FadingTemporal.predict_percept
+
+    def spy(self, stim, t_percept=None):
+        percept = unwrapped(self, stim, t_percept=t_percept)
+        seen.append(percept.time.size)
+        return percept
+
+    FadingTemporal.predict_percept = spy
+    try:
+        model.find_threshold(implant.stim, 0.2, max_iter=5)
+        npt.assert_equal(set(seen), {n_frames})
+        seen.clear()
+        # ... and the same through the combined model:
+        Model(temporal=FadingTemporal(tau=100)).build().find_threshold(
+            implant, 0.2, max_iter=5)
+        npt.assert_equal(set(seen), {n_frames})
+    finally:
+        FadingTemporal.predict_percept = unwrapped
+
+
 def test_Model_deepcopy_memo():
     model = Model(spatial=ValidSpatialModel())
 

--- a/pulse2percept/models/tests/test_base.py
+++ b/pulse2percept/models/tests/test_base.py
@@ -632,7 +632,8 @@ def test_Model_predict_percept_frame_peak():
     # frame (33.37 ms) are incommensurate, so the sampling phase walks through
     # the cycle and neighbouring frames came out two orders of magnitude apart.
     implant = ArgusI()
-    vid = VideoStimulus(np.random.rand(4, 4, 16), metadata={'fps': 29.97})
+    rng = np.random.default_rng(0)
+    vid = VideoStimulus(rng.random((4, 4, 16)), metadata={'fps': 29.97})
     implant.stim = AmplitudeEncoder(implant, amp_range=(0, 50),
                                     freq=20).encode(vid)
     model = Model(temporal=FadingTemporal(tau=100)).build()
@@ -645,7 +646,7 @@ def test_Model_predict_percept_frame_peak():
     # The default reports the peak each frame reached, so it is never below the
     # value at the instant the frame ended, and for most frames it is above it:
     npt.assert_array_less(at_end.data - 1e-6, peak.data)
-    npt.assert_equal(np.any(peak.data > 1.5 * at_end.data), True)
+    npt.assert_array_less(0.5, np.mean(peak.data > at_end.data + 1e-7))
     # ... which is what stops the frame-to-frame swing from being an artifact
     # of the sampling phase rather than a property of the video:
     swing = lambda d: d.max() / np.median(d)
@@ -654,6 +655,11 @@ def test_Model_predict_percept_frame_peak():
     # A percept is still one frame per video frame, on an evenly spaced axis:
     npt.assert_equal(peak.data.shape[-1], 16)
     npt.assert_almost_equal(np.diff(peak.time), np.diff(peak.time)[0])
+
+    # `reduce='last'` asks for the closing instant instead, which is what every
+    # version before 0.10.0 reported:
+    last = Model(temporal=FadingTemporal(tau=100, reduce='last')).build()
+    npt.assert_array_equal(last.predict_percept(implant).data, at_end.data)
 
 
 def test_Model_predict_percept_correctly_parallelizes():

--- a/pulse2percept/models/tests/test_end_to_end.py
+++ b/pulse2percept/models/tests/test_end_to_end.py
@@ -181,12 +181,28 @@ def test_endtoend_frequency_modulation():
     npt.assert_equal(np.all(np.diff(bright) > 0), True)
     # Brightness tracks the pulse *count* rather than the amplitude, which is
     # what distinguishes frequency modulation from amplitude modulation. It
-    # grows a little slower than the count does, because the model fades
-    # between pulses and a slower train spends longer fading:
+    # grows a little slower than the count does, though: each pulse adds less
+    # the brighter the percept already is, so doubling the rate does not double
+    # the brightness. Normalized against the fastest train, that saturation
+    # puts the slower ones slightly *above* the line the counts would draw:
     counts = np.array([onsets(stim, e).size for e in range(4)],
                       dtype=np.float64)
     npt.assert_allclose(bright / bright[-1], counts / counts[-1], rtol=0.15)
-    npt.assert_array_less(bright / bright[-1], counts / counts[-1] + 1e-6)
+    npt.assert_array_less(counts / counts[-1] - 1e-6, bright / bright[-1])
+    # In closed form, since every pulse here is identical and the percept is
+    # the peak the frame reached: the cathodic phase lifts brightness by
+    # `amp (1 - exp(-phase_dur/tau))` toward `amp`, and what is left of that
+    # lift when the next pulse lands is `exp(-period/tau)` of it, so the peaks
+    # are a geometric series that the n-th pulse has summed n terms of. That
+    # only holds because the drive is rectified -- with the anodic phase
+    # pulling brightness back down, no pulse would leave anything to sum:
+    tau, phase_dur, amp = 100.0, 0.46, 50.0
+    period = np.array(period, dtype=np.float64)
+    npt.assert_allclose(
+        bright,
+        amp * (1 - np.exp(-phase_dur / tau)) *
+        (1 - np.exp(-counts * period / tau)) / (1 - np.exp(-period / tau)),
+        rtol=1e-3)
 
 
 @pytest.mark.parametrize('order', [[0, 1, 2, 3], [3, 2, 1, 0], [1, 3, 0, 2]])

--- a/pulse2percept/models/tests/test_end_to_end.py
+++ b/pulse2percept/models/tests/test_end_to_end.py
@@ -189,6 +189,51 @@ def test_endtoend_frequency_modulation():
     npt.assert_array_less(bright / bright[-1], counts / counts[-1] + 1e-6)
 
 
+@pytest.mark.parametrize('order', [[0, 1, 2, 3], [3, 2, 1, 0], [1, 3, 0, 2]])
+def test_endtoend_raster_order(order):
+    # The raster decides *when in the period* each electrode gets its turn, and
+    # nothing else. Reordering the groups should permute the onsets to match
+    # and leave every other thing about the stimulus alone.
+    implant = make_implant()
+    img = ImageStimulus(np.array([[0.25, 0.50], [0.75, 1.00]]))
+    raster = CustomRaster({n: g for n, g in zip(NAMES, order)})
+    stim = AmplitudeEncoder(implant, amp_range=(0, 50), freq=20,
+                            raster=raster, frame_dur=200).encode(img)
+    implant.stim = stim
+
+    # Each electrode starts in the slot its group was given -- 50 ms period
+    # split four ways is 12.5 ms per slot:
+    npt.assert_almost_equal([onsets(stim, e)[0] for e in range(4)],
+                            np.asarray(order) * 12.5, decimal=3)
+    # Everything else is untouched: same amplitudes, same rate, same current
+    # limit, whichever order the groups take their turns in.
+    npt.assert_almost_equal(np.abs(stim.data).max(axis=1),
+                            [12.5, 25.0, 37.5, 50.0], decimal=4)
+    for e in range(4):
+        npt.assert_almost_equal(np.diff(onsets(stim, e)), 50.0, decimal=3)
+    npt.assert_almost_equal(np.abs(stim.data).sum(axis=0).max(), 50.0)
+
+    # And the percept says the same: the electrodes light up one at a time, in
+    # the order the raster puts them in, and each is as bright as its own gray
+    # level regardless of when its turn comes.
+    model = ScoreboardSpatial(xrange=(-4, 4), yrange=(-4, 4), xystep=0.2,
+                              rho=200).build()
+    percept = model.predict_percept(implant)
+    here, _ = at_electrodes(model, implant)
+    env = percept.data.max(axis=-1)
+    bright = np.array([env[here[n]] for n in NAMES])
+    npt.assert_allclose(bright / bright.max(), [0.25, 0.5, 0.75, 1.0],
+                        rtol=1e-3)
+    lit = np.array([[percept.data[here[n]][t] > 1.0 for n in NAMES]
+                    for t in range(percept.data.shape[-1])])
+    npt.assert_equal(lit.sum(axis=1).max(), 1)
+    # Read off the order in which they first light up, and check it is the
+    # order the raster asked for:
+    first = [int(np.argmax(lit[:, i])) for i in range(4)]
+    npt.assert_equal(np.argsort(first).tolist(),
+                     np.argsort(order).tolist())
+
+
 def test_endtoend_raster_is_what_separates_the_groups():
     # The same four electrodes without a raster: every one of them fires at
     # the start of every period, so the stimulator has to source all of it at

--- a/pulse2percept/models/tests/test_end_to_end.py
+++ b/pulse2percept/models/tests/test_end_to_end.py
@@ -196,13 +196,18 @@ def test_endtoend_frequency_modulation():
     # are a geometric series that the n-th pulse has summed n terms of. That
     # only holds because the drive is rectified -- with the anodic phase
     # pulling brightness back down, no pulse would leave anything to sum:
+    # The closed form is continuous-time while the model samples the stimulus
+    # and holds it over each `dt` step, so the phase the integrator actually
+    # sees is a fraction of a step shorter than `phase_dur`. That is worth a few
+    # tenths of a percent here, which is far tighter than the structure being
+    # checked -- brightness as a geometric series in the pulse count:
     tau, phase_dur, amp = 100.0, 0.46, 50.0
     period = np.array(period, dtype=np.float64)
     npt.assert_allclose(
         bright,
         amp * (1 - np.exp(-phase_dur / tau)) *
         (1 - np.exp(-counts * period / tau)) / (1 - np.exp(-period / tau)),
-        rtol=1e-3)
+        rtol=1e-2)
 
 
 @pytest.mark.parametrize('order', [[0, 1, 2, 3], [3, 2, 1, 0], [1, 3, 0, 2]])

--- a/pulse2percept/models/tests/test_end_to_end.py
+++ b/pulse2percept/models/tests/test_end_to_end.py
@@ -20,11 +20,11 @@ import numpy.testing as npt
 import pytest
 from scipy.integrate import trapezoid
 
-from pulse2percept.implants import (CustomRaster, DiskElectrode, ElectrodeArray,
-                                    ProsthesisSystem)
-from pulse2percept.models import FadingTemporal, ScoreboardSpatial
-from pulse2percept.stimuli import (AmplitudeEncoder, FrequencyEncoder,
-                                   ImageStimulus)
+from pulse2percept.implants import (ArgusII, CustomRaster, DiskElectrode,
+                                    ElectrodeArray, ProsthesisSystem)
+from pulse2percept.models import FadingTemporal, Model, ScoreboardSpatial
+from pulse2percept.stimuli import (AmplitudeEncoder, BostonTrain,
+                                   FrequencyEncoder, ImageStimulus)
 from pulse2percept.utils.constants import DT
 
 # Electrode names in the order `ElectrodeArray` keeps them, and their positions
@@ -276,3 +276,48 @@ def test_endtoend_raster_is_what_separates_the_groups():
     implant.stim = AmplitudeEncoder(implant, amp_range=(0, 50), freq=20,
                                     frame_dur=200).encode(img)
     npt.assert_almost_equal(np.abs(implant.stim.data).sum(axis=0).max(), 50.0)
+
+
+def test_endtoend_slow_train_stays_lit_for_the_whole_video():
+    """A pulse rate well below the frame rate must not extinguish the percept.
+
+    This is the case that crossed every layer at once and that none of the
+    per-layer tests caught. ``BostonTrain`` runs at 29.97 fps (33.365 ms per
+    frame) and a 6 Hz train pulses every 166.67 ms, so the pulse cycle and the
+    percept's own frame grid are incommensurate by 4.995 frames. Reporting a
+    frame by sampling instants out of it therefore walks slowly through the
+    pulse cycle, and once the walk carries every sample off the 0.92 ms window
+    where a pulse actually delivers current it never walks back: the percept
+    used to light up for the first 25 frames and then stay black for the
+    remaining 2.3 seconds.
+
+    Both halves of the fix matter here. A rectified drive is what lets
+    brightness persist between pulses at all, and summarizing each frame by the
+    peak it reached is what stops the report from depending on sampling phase.
+    """
+    implant = ArgusII()
+    with pytest.warns(UserWarning, match='deliver no pulse'):
+        # 6 Hz against 29.97 fps: most frames carry no pulse of their own, and
+        # the encoder says so. That is a property of the stimulus, not a reason
+        # for the percept to go dark:
+        implant.stim = AmplitudeEncoder(implant, amp_range=(0, 50),
+                                        freq=6).encode(BostonTrain())
+    # The encoder schedules pulses across the whole video, not just its start:
+    onset = implant.stim.time[np.any(implant.stim.data < 0, axis=0)]
+    npt.assert_almost_equal(onset.max(), 3000.5, decimal=1)
+
+    model = Model(spatial=ScoreboardSpatial(xrange=(-12, 12), yrange=(-8, 8),
+                                            xystep=1),
+                  temporal=FadingTemporal(tau=100)).build()
+    percept = model.predict_percept(implant)
+    # One percept frame per video frame, covering the whole video:
+    npt.assert_equal(percept.data.shape[-1], 94)
+    npt.assert_array_less(3000, percept.time[-1])
+
+    frame = percept.data.reshape(-1, percept.data.shape[-1]).max(axis=0)
+    # Nothing goes dark, least of all the second half of the video:
+    npt.assert_array_less(0.1 * frame.max(), frame[percept.time > 1000])
+    npt.assert_array_less(0.1 * frame.max(), frame.min())
+    # ... and the swing from frame to frame stays modest, rather than the two
+    # orders of magnitude that sampling an instant out of a pulse train gives:
+    npt.assert_array_less(frame.max() / np.median(frame), 4.0)

--- a/pulse2percept/models/tests/test_end_to_end.py
+++ b/pulse2percept/models/tests/test_end_to_end.py
@@ -1,0 +1,212 @@
+"""End-to-end tests you can check by hand
+
+The encoder tests in ``pulse2percept/stimuli/tests`` drive Argus II with
+``BostonTrain``, which exercises the plumbing but tells you nothing you could
+have predicted with a pencil. These tests run the whole pipeline -- image ->
+encoder -> implant -> model -> percept -- on a deliberately tiny setup where
+every number has a closed form:
+
+*  Four electrodes on the corners of a 1200 um square, far enough apart that
+   each one produces its own phosphene.
+*  A 2x2 image, so that ``reshape_stim`` samples exactly one pixel per
+   electrode (it maps the image grid linearly onto the electrode bounding box,
+   and the electrodes sit on its corners).
+*  Gray levels chosen to be distinct and evenly separated.
+*  One electrode per raster group, so the stimulator drives exactly one
+   electrode at a time.
+"""
+import numpy as np
+import numpy.testing as npt
+import pytest
+from scipy.integrate import trapezoid
+
+from pulse2percept.implants import (CustomRaster, DiskElectrode, ElectrodeArray,
+                                    ProsthesisSystem)
+from pulse2percept.models import FadingTemporal, ScoreboardSpatial
+from pulse2percept.stimuli import (AmplitudeEncoder, FrequencyEncoder,
+                                   ImageStimulus)
+from pulse2percept.utils.constants import DT
+
+# Electrode names in the order `ElectrodeArray` keeps them, and their positions
+# (um). The 2x2 image below is sampled at exactly these four points:
+#     A = top-left pixel, B = top-right, C = bottom-left, D = bottom-right
+NAMES = ['A', 'B', 'C', 'D']
+POS = [(-600.0, -600.0), (600.0, -600.0), (-600.0, 600.0), (600.0, 600.0)]
+
+
+def make_implant():
+    """Four well-separated electrodes, one per raster group"""
+    earray = ElectrodeArray({n: DiskElectrode(x, y, 0, 100)
+                             for n, (x, y) in zip(NAMES, POS)})
+    return ProsthesisSystem(earray)
+
+
+def one_per_group():
+    """A raster that drives exactly one electrode at a time"""
+    return CustomRaster({n: i for i, n in enumerate(NAMES)})
+
+
+def onsets(stim, electrode):
+    """The time (ms) at which each of one electrode's pulses begins"""
+    neg = stim.data[electrode] < 0
+    started = neg & ~np.concatenate(([False], neg[:-1]))
+    # A pulse ramps up over DT, so the first sample at full amplitude sits one
+    # tick past the onset:
+    return stim.time[started] - DT
+
+
+def at_electrodes(model, implant):
+    """The grid index nearest each electrode, and one in the middle"""
+    gx = np.asarray(model.grid.ret.x)
+    gy = np.asarray(model.grid.ret.y)
+    here = {}
+    for n in NAMES:
+        e = implant[n]
+        flat = int(np.argmin((gx - e.x) ** 2 + (gy - e.y) ** 2))
+        here[n] = np.unravel_index(flat, gx.shape)
+    middle = np.unravel_index(int(np.argmin(gx ** 2 + gy ** 2)), gx.shape)
+    return here, middle
+
+
+def test_endtoend_amplitude_modulation():
+    # Four gray levels, evenly spaced, one per electrode:
+    implant = make_implant()
+    img = ImageStimulus(np.array([[0.25, 0.50], [0.75, 1.00]]))
+    stim = AmplitudeEncoder(implant, amp_range=(0, 50), freq=20,
+                            raster=one_per_group(),
+                            frame_dur=200).encode(img)
+    implant.stim = stim
+    npt.assert_equal(list(stim.electrodes), NAMES)
+
+    # --- what the encoder produced --------------------------------------
+    # Gray level maps onto amplitude absolutely: 50 uA * gray.
+    npt.assert_almost_equal(np.abs(stim.data).max(axis=1),
+                            [12.5, 25.0, 37.5, 50.0], decimal=4)
+    # Every electrode pulses at the requested 20 Hz -- rastering costs no
+    # frequency, it only decides where in each 50 ms period an electrode goes.
+    # Four groups split that period into four 12.5 ms slots:
+    for e in range(4):
+        npt.assert_almost_equal(onsets(stim, e)[0], e * 12.5, decimal=3)
+        npt.assert_almost_equal(np.diff(onsets(stim, e)), 50.0, decimal=3)
+    npt.assert_almost_equal(stim.metadata['encoder']['cycle'], 50.0)
+    # The point of the raster: the stimulator sources one electrode's worth of
+    # current at a time. All four at once would be 12.5+25+37.5+50 = 125 uA.
+    npt.assert_almost_equal(np.abs(stim.data).sum(axis=0).max(), 50.0)
+    net = trapezoid(stim.data.astype(np.float64),
+                    x=stim.time.astype(np.float64))
+    npt.assert_almost_equal(net, 0, decimal=4)
+
+    # --- what the model made of it --------------------------------------
+    model = ScoreboardSpatial(xrange=(-4, 4), yrange=(-4, 4), xystep=0.2,
+                              rho=200).build()
+    percept = model.predict_percept(implant)
+    here, middle = at_electrodes(model, implant)
+    # Brightest over time, since no two electrodes are ever on together:
+    env = percept.data.max(axis=-1)
+    bright = np.array([env[here[n]] for n in NAMES])
+
+    # Four separate phosphenes, one per electrode, brightness following the
+    # gray level that produced it:
+    npt.assert_equal(np.all(np.diff(bright) > 0), True)
+    npt.assert_allclose(bright / bright[-1], [0.25, 0.5, 0.75, 1.0], rtol=1e-3)
+    # ... and nothing in between them, so they really are separate blobs:
+    npt.assert_equal(env[middle] < 0.01 * bright[0], True)
+    npt.assert_equal(np.unravel_index(int(np.argmax(env)), env.shape),
+                     here['D'])
+
+    # Size is set by `rho`, not by amplitude: a brighter phosphene is brighter,
+    # not bigger, so all four cover the same area relative to their own peak.
+    gx, gy = np.asarray(model.grid.ret.x), np.asarray(model.grid.ret.y)
+    areas = []
+    for n in NAMES:
+        e = implant[n]
+        quadrant = ((np.sign(gx) == np.sign(e.x)) &
+                    (np.sign(gy) == np.sign(e.y)))
+        blob = np.where(quadrant, env, 0.0)
+        areas.append(int((blob >= blob.max() / 2).sum()))
+    npt.assert_equal(areas, [areas[0]] * 4)
+    npt.assert_equal(areas[0] > 4, True)
+
+    # The raster is visible in the percept itself: at any one instant at most
+    # one electrode is lit. The threshold sits well above the 0.006 of
+    # cross-talk an unlit electrode picks up and well below the 12.5 of the
+    # dimmest lit one:
+    lit = np.array([[percept.data[here[n]][t] > 1.0 for n in NAMES]
+                    for t in range(percept.data.shape[-1])])
+    npt.assert_equal(lit.sum(axis=1).max(), 1)
+    # ... and over the whole stimulus each of them gets a turn:
+    npt.assert_equal(lit.any(axis=0), [True] * 4)
+
+
+def test_endtoend_frequency_modulation():
+    # Gray levels chosen so that the requested rates are 50, 66.7, 100 and
+    # 200 Hz -- whole multiples of the 5 ms raster cycle that the fastest
+    # electrode sets, so nothing has to be quantized away:
+    implant = make_implant()
+    img = ImageStimulus(np.array([[0.25, 1 / 3], [0.5, 1.0]]))
+    stim = FrequencyEncoder(implant, freq_range=(0, 200), amp=50,
+                            raster=one_per_group(),
+                            frame_dur=200).encode(img)
+    implant.stim = stim
+
+    # --- what the encoder produced --------------------------------------
+    # One amplitude for everyone; the gray level sets the rate instead:
+    npt.assert_almost_equal(np.abs(stim.data).max(axis=1), 50.0, decimal=4)
+    npt.assert_almost_equal(stim.metadata['encoder']['cycle'], 5.0)
+    # 200 Hz / 4 groups gives each electrode a 1.25 ms slot, and each pulses at
+    # exactly the rate it asked for:
+    period = [20.0, 15.0, 10.0, 5.0]
+    for e in range(4):
+        npt.assert_almost_equal(onsets(stim, e)[0], e * 1.25, decimal=3)
+        npt.assert_almost_equal(np.diff(onsets(stim, e)), period[e],
+                                decimal=3)
+    # Over a 200 ms frame that is floor((200 - pulse) / period) + 1 pulses:
+    npt.assert_equal([onsets(stim, e).size for e in range(4)],
+                     [10, 14, 20, 40])
+    # Still one electrode at a time, even though they are on different rates.
+    # This is what the raster cycle buys: without it the four trains would
+    # drift onto each other and the stimulator would have to source 200 uA:
+    npt.assert_almost_equal(np.abs(stim.data).sum(axis=0).max(), 50.0)
+    net = trapezoid(stim.data.astype(np.float64),
+                    x=stim.time.astype(np.float64))
+    npt.assert_almost_equal(net, 0, decimal=4)
+
+    # --- what the model made of it --------------------------------------
+    # A temporal model integrates the pulses, so more pulses is brighter even
+    # though every pulse carries the same current:
+    percept = FadingTemporal().build().predict_percept(implant.stim)
+    # One percept frame per video frame -- the image is a single 200 ms frame:
+    npt.assert_equal(percept.data.shape, (4, 1, 1))
+    bright = percept.data[:, 0, 0]
+    npt.assert_equal(np.all(np.diff(bright) > 0), True)
+    # Brightness tracks the pulse *count* rather than the amplitude, which is
+    # what distinguishes frequency modulation from amplitude modulation. It
+    # grows a little slower than the count does, because the model fades
+    # between pulses and a slower train spends longer fading:
+    counts = np.array([onsets(stim, e).size for e in range(4)],
+                      dtype=np.float64)
+    npt.assert_allclose(bright / bright[-1], counts / counts[-1], rtol=0.15)
+    npt.assert_array_less(bright / bright[-1], counts / counts[-1] + 1e-6)
+
+
+def test_endtoend_raster_is_what_separates_the_groups():
+    # The same four electrodes without a raster: every one of them fires at
+    # the start of every period, so the stimulator has to source all of it at
+    # once. This is the failure the raster exists to prevent, and it is why
+    # `max_current` rejects the unrastered version of the very same image.
+    img = ImageStimulus(np.array([[0.25, 0.50], [0.75, 1.00]]))
+    implant = make_implant()
+    plain = AmplitudeEncoder(implant, amp_range=(0, 50), freq=20,
+                             frame_dur=200).encode(img)
+    npt.assert_equal(plain.metadata['encoder']['n_schedules'], 1)
+    npt.assert_almost_equal(np.abs(plain.data).sum(axis=0).max(), 125.0)
+
+    implant.max_current = 60
+    with pytest.raises(ValueError, match='raster'):
+        implant.stim = plain
+    # Giving the implant the raster is enough -- the encoder picks it up, and
+    # the same image now fits inside the current limit:
+    implant.raster = one_per_group()
+    implant.stim = AmplitudeEncoder(implant, amp_range=(0, 50), freq=20,
+                                    frame_dur=200).encode(img)
+    npt.assert_almost_equal(np.abs(implant.stim.data).sum(axis=0).max(), 50.0)

--- a/pulse2percept/models/tests/test_horsager2009.py
+++ b/pulse2percept/models/tests/test_horsager2009.py
@@ -41,27 +41,46 @@ def test_Horsager2009Temporal():
         implant.stim = np.ones((1, 100))
         model.predict_percept(implant.stim, t_percept=[0.2, 0.2])
 
-    # Single-pulse brightness from Fig.3:
+    # Single-pulse brightness from Fig.3. These three (amp, phase_dur) pairs sit
+    # on one threshold curve in the paper, so the model should call them equally
+    # bright. It does so only approximately -- they come out within about 3% of
+    # each other at this `dt`, and the shortest pulse is the one that strays.
+    #
+    # They used to agree to five figures, but that was a numerical accident:
+    # until 0.10.0 the kernel advanced only one stimulus frame per simulation
+    # step, and at dt=5e-3 ms a pulse edge and the sample after it share a step.
+    # That stretched every phase by about one step, which is 7% of a 0.075 ms
+    # phase and 0.1% of a 4 ms one -- inflating exactly the short conditions
+    # that fall short here. Refining `dt` does not bring the agreement back; the
+    # three converge to 101.0, 105.6 and 110.1, so the spread is a property of
+    # the model as implemented, not of the time step.
     model = Horsager2009Temporal().build()
+    bright = []
     for amp, pdur in zip([188.077, 89.74, 10.55], [0.075, 0.15, 4.0]):
         stim = BiphasicPulse(amp, pdur, interphase_dur=pdur, stim_dur=200,
                              cathodic_first=True)
         t_percept = np.arange(0, stim.time[-1] + model.dt / 2, model.dt)
         percept = model.predict_percept(stim, t_percept=t_percept)
-        npt.assert_almost_equal(percept.data.max(), 110.3, decimal=2)
+        bright.append(percept.data.max())
+    npt.assert_allclose(bright, np.mean(bright), rtol=0.03)
+    npt.assert_almost_equal(bright, [107.20, 109.31, 110.13], decimal=2)
 
-    # Fixed-duration brightness from Fig.4. The reference value is read off a
-    # published figure, so the tolerance is loose enough to cover that: a
-    # 225 Hz train predicts 36.34 rather than 36.29, which under the float32
-    # time axis of earlier versions came out at 36.29 only because the last of
-    # its 45 pulses was mistimed by about 0.1% of its own width.
+    # Fixed-duration brightness from Fig.4, which again puts these three
+    # conditions at one threshold. As with Fig.3 above, the model reproduces
+    # that to a few percent rather than exactly, and the agreement was closer
+    # before 0.10.0 only because the kernel was stretching every phase by about
+    # one simulation step. These phases are 0.075 ms, so a 5e-3 ms step is 7% of
+    # one, and the correction moves the three by different amounts.
     model = Horsager2009Temporal().build()
+    bright = []
     for amp, freq in zip([136.01, 120.34, 57.73], [5, 15, 225]):
         stim = BiphasicPulseTrain(freq, amp, 0.075, interphase_dur=0.075,
                                   stim_dur=200, cathodic_first=True)
         t_percept = np.arange(0, stim.time[-1] + model.dt / 2, model.dt)
         percept = model.predict_percept(stim, t_percept=t_percept)
-        npt.assert_almost_equal(percept.data.max(), 36.29, decimal=1)
+        bright.append(percept.data.max())
+    npt.assert_allclose(bright, np.mean(bright), rtol=0.03)
+    npt.assert_almost_equal(bright, [35.27, 36.21, 35.49], decimal=2)
 
 
 def test_deepcopy_Horsager2009Temporal():

--- a/pulse2percept/models/tests/test_nanduri2012.py
+++ b/pulse2percept/models/tests/test_nanduri2012.py
@@ -145,7 +145,11 @@ def test_Nanduri2012Temporal(scale_out):
                                           stim_dur=sdur)
         percept = model.predict_percept(implant.stim, t_percept=t_percept)
         bright_amp.append(percept.data.max())
-    bright_amp_ref = np.array([0.0, 0.00890, 0.0657, 0.1500, 0.1691])
+    # These shifted by under 1.5% in 0.10.0, when the kernel stopped advancing
+    # only one stimulus frame per simulation step: a pulse edge and the sample
+    # after it share a step at this `dt`, so the integrator had been reading a
+    # frame that was already in the past.
+    bright_amp_ref = np.array([0.0, 0.00881, 0.06477, 0.14975, 0.16964])
     npt.assert_almost_equal(bright_amp, scale_out * bright_amp_ref, decimal=3)
 
     bright_freq = []
@@ -156,7 +160,7 @@ def test_Nanduri2012Temporal(scale_out):
                                           stim_dur=sdur)
         percept = model.predict_percept(implant.stim, t_percept=t_percept)
         bright_freq.append(percept.data.max())
-    bright_freq_ref = np.array([0.0, 0.0394, 0.0741, 0.1073, 0.1385])
+    bright_freq_ref = np.array([0.0, 0.03892, 0.07297, 0.10686, 0.13841])
     npt.assert_almost_equal(bright_freq, scale_out * bright_freq_ref,
                             decimal=3)
 

--- a/pulse2percept/models/tests/test_temporal.py
+++ b/pulse2percept/models/tests/test_temporal.py
@@ -56,9 +56,11 @@ def test_FadingTemporal():
     percept = model.predict_percept(stim, np.arange(stim.duration))
     npt.assert_almost_equal(percept.data, 0)
 
-    # tau cannot be negative:
-    with pytest.raises(ValueError):
-        FadingTemporal(tau=-1).build()
+    # tau has to be positive. Zero is as unusable as a negative value -- the
+    # integrator divides by it -- and used to build happily and hand back nan:
+    for tau in (-1, 0):
+        with pytest.raises(ValueError):
+            FadingTemporal(tau=tau).build()
 
 
 def test_deepcopy_FadingTemporal():

--- a/pulse2percept/models/tests/test_temporal.py
+++ b/pulse2percept/models/tests/test_temporal.py
@@ -40,11 +40,14 @@ def test_FadingTemporal():
         stim = Stimulus(np.ones((1, 100)))
         model.predict_percept(stim, t_percept=[0.2, 0.2])
 
-    # Simple decay for single cathodic pulse:
+    # Simple decay for single cathodic pulse. The pulse carries current from
+    # t=DT to t=1, so sample-and-hold on the dt=5e-3 ms grid drives the
+    # integrator for 0.995 ms rather than a round 1 ms -- which is why this
+    # sits just under the 1-exp(-1) = 0.632 an ideal rectangle would give:
     model = FadingTemporal(tau=1).build()
     stim = MonophasicPulse(-1, 1, stim_dur=10)
     percept = model.predict_percept(stim, np.arange(stim.duration))
-    npt.assert_almost_equal(percept.data.ravel()[:3], [0, 0.633, 0.232],
+    npt.assert_almost_equal(percept.data.ravel()[:3], [0, 0.628, 0.230],
                             decimal=3)
     npt.assert_almost_equal(percept.data.ravel()[-1], 0, decimal=3)
 
@@ -110,7 +113,11 @@ def test_FadingTemporal_matches_reference_integrator():
         bright = np.float32(0.0)
         idx_stim, frame = 0, 0
         for i in range(int(idx_p[-1]) + 1):
-            if idx_stim + 1 < n_stim and np.float32(i) * dt >= t_stim[idx_stim + 1]:
+            # Advance until caught up, not by one frame per step: several
+            # stimulus frames can fall inside one `dt`. See
+            # `test_FadingTemporal_frames_closer_together_than_dt`.
+            while (idx_stim + 1 < n_stim and
+                   np.float32(i) * dt >= t_stim[idx_stim + 1]):
                 idx_stim += 1
             amp = data[s, idx_stim]
             drive = np.float32(max(-amp, 0.0))
@@ -157,11 +164,11 @@ def test_FadingTemporal_rectifies_the_drive():
     npt.assert_equal(np.all(np.diff([steady(f) for f in rates]) > 0), True)
 
     # Rectification only removes the anodic half, so a stimulus that never goes
-    # anodic is unaffected. These are the values this model has always given:
+    # anodic is unaffected by it:
     model = FadingTemporal(tau=1).build()
     percept = model.predict_percept(MonophasicPulse(-1, 1, stim_dur=10),
                                     np.arange(10))
-    npt.assert_almost_equal(percept.data.ravel()[:3], [0, 0.633, 0.232],
+    npt.assert_almost_equal(percept.data.ravel()[:3], [0, 0.628, 0.230],
                             decimal=3)
 
 
@@ -263,6 +270,51 @@ def test_FadingTemporal_reduce():
 
     with pytest.raises(ValueError):
         FadingTemporal(reduce='mean').build().predict_percept(stim)
+
+
+def test_FadingTemporal_frames_closer_together_than_dt():
+    """Several stimulus frames can fall inside one simulation step.
+
+    Encoded pulses put their edges on the DT=1e-3 ms grid while `dt` defaults
+    to 5e-3 ms, so this is the normal case rather than a corner case. A kernel
+    that advances one stimulus frame per simulation step falls behind and
+    integrates current the stimulus no longer carries.
+    """
+    # A 0.1 ms cathodic blip that begins and ends strictly between two
+    # simulation steps. Sample-and-hold at t=0.5 has to read the frame that is
+    # current *then* -- amplitude 0 -- so the blip is never seen at all:
+    t_stim = np.array([0.0, 0.1, 0.2, 0.3, 10.0], dtype=np.float32)
+    data = np.array([[0.0, -100.0, 0.0, 0.0, 0.0]], dtype=np.float32)
+    dt = 0.5
+    idx = np.arange(0, 21, dtype=np.uint32)
+    got = fading_fast(data, t_stim, idx, dt, 100.0, 0.0, 1, 0).ravel()
+    npt.assert_array_equal(got, np.zeros_like(got))
+
+    # More generally, the frame in force at each step is what `searchsorted`
+    # says it is, however many frames went by since the last one:
+    rng = np.random.default_rng(11)
+    n_stim = 40
+    # Frame times far closer together than `dt`, plus a couple of long gaps:
+    gaps = rng.choice([0.001, 0.002, 0.05, 1.3], size=n_stim - 1)
+    t_stim = np.concatenate(([0.0], np.cumsum(gaps))).astype(np.float32)
+    data = ((rng.random((3, n_stim)) - 0.5) * 60).astype(np.float32)
+    tau = 25.0
+    idx = np.arange(0, int(t_stim[-1] / dt) + 1, dtype=np.uint32)
+    got = fading_fast(data, t_stim, idx, dt, tau, 0.0, 1, 0)
+
+    frame = np.searchsorted(t_stim, (idx * dt).astype(np.float32),
+                            side='right') - 1
+    npt.assert_equal(np.any(np.diff(frame) > 1), True)  # the case under test
+    want = np.zeros_like(got)
+    for s in range(data.shape[0]):
+        bright = np.float32(0.0)
+        for i, f in enumerate(frame):
+            drive = np.float32(max(-data[s, f], 0.0))
+            bright = np.float32(bright + np.float32(dt) *
+                                (drive - bright) / np.float32(tau))
+            bright = max(bright, np.float32(0.0))
+            want[s, i] = bright
+    npt.assert_allclose(got, want, rtol=1e-6, atol=1e-7)
 
 
 def test_TemporalModel_reduce_fallback():

--- a/pulse2percept/models/tests/test_temporal.py
+++ b/pulse2percept/models/tests/test_temporal.py
@@ -5,7 +5,9 @@ import numpy.testing as npt
 import pytest
 
 from pulse2percept.models import FadingTemporal, Nanduri2012Temporal
-from pulse2percept.stimuli import Stimulus, MonophasicPulse, BiphasicPulse
+from pulse2percept.models._temporal import fading_fast
+from pulse2percept.stimuli import (Stimulus, MonophasicPulse, BiphasicPulse,
+                                   BiphasicPulseTrain)
 from pulse2percept.percepts import Percept
 from pulse2percept.utils import FreezeError
 
@@ -87,12 +89,15 @@ def test_FadingTemporal_matches_reference_integrator():
     ``fading_fast`` runs time in the outer loop and space in the inner one so
     that the inner loop vectorizes. This walks a couple of locations the
     obvious way -- one at a time, stepping forward -- and checks the kernel
-    agrees exactly.
+    agrees exactly. The stimulus straddles zero, so it also pins the half-wave
+    rectification: anodic samples must contribute nothing at all rather than
+    driving brightness down.
     """
     model = FadingTemporal(dt=0.01, tau=50, thresh_percept=0).build()
     n_space, n_stim = 3, 5
     rng = np.random.default_rng(0)
     data = (rng.random((n_space, n_stim)) - 0.5).astype(np.float32)
+    npt.assert_equal(np.any(data > 0) and np.any(data < 0), True)
     t_stim = np.arange(n_stim, dtype=np.float32) * 2.0
     stim = Stimulus(data, time=t_stim)
     t_percept = np.array([0.0, 2.0, 4.0, 8.0])
@@ -108,12 +113,55 @@ def test_FadingTemporal_matches_reference_integrator():
             if idx_stim + 1 < n_stim and np.float32(i) * dt >= t_stim[idx_stim + 1]:
                 idx_stim += 1
             amp = data[s, idx_stim]
-            bright = np.float32(bright + dt * (-amp - bright) / tau)
+            drive = np.float32(max(-amp, 0.0))
+            bright = np.float32(bright + dt * (drive - bright) / tau)
             if bright < 0:
                 bright = np.float32(0.0)
             if i == idx_p[frame]:
                 npt.assert_array_equal(got[s, frame], bright)
                 frame += 1
+
+
+def test_FadingTemporal_rectifies_the_drive():
+    """A charge-balanced pulse train has to produce a percept that persists.
+
+    A leaky integrator is linear, so driving it with -A lets the anodic phase
+    of a biphasic pulse undo exactly what the cathodic phase did: brightness
+    spikes for the length of one phase and returns to zero, leaving a 1.8%
+    duty cycle rather than a phosphene. Half-wave rectifying the drive is what
+    makes the pulse deliver net charge.
+    """
+    train = BiphasicPulseTrain(20, -50, 0.46, stim_dur=1000)
+    model = FadingTemporal(tau=100).build()
+    t = np.round(np.arange(0, 1000, 0.05), 5)
+    bright = model.predict_percept(train, t_percept=t).data.ravel()
+    late = bright[t >= 500]
+    # Brightness holds up between pulses instead of collapsing to zero. The
+    # unrectified model came back to within 0.6% of zero after every pulse:
+    npt.assert_array_less(0.5, late.min() / late.max())
+    # ... and it accumulates over the train rather than repeating one transient:
+    # even at its dimmest the steady state is above what one pulse produces:
+    one_pulse = bright[t < 50].max()
+    npt.assert_array_less(one_pulse, late.min())
+    npt.assert_array_less(2 * one_pulse, late.max())
+
+    # A slower train is dimmer, because it spends longer fading between pulses.
+    # This is the whole basis of frequency modulation, and the unrectified
+    # model could not express it:
+    def steady(freq):
+        stim = BiphasicPulseTrain(freq, -50, 0.46, stim_dur=1000)
+        return model.predict_percept(stim, t_percept=t).data.ravel()[-1]
+
+    rates = [10, 20, 50, 100]
+    npt.assert_equal(np.all(np.diff([steady(f) for f in rates]) > 0), True)
+
+    # Rectification only removes the anodic half, so a stimulus that never goes
+    # anodic is unaffected. These are the values this model has always given:
+    model = FadingTemporal(tau=1).build()
+    percept = model.predict_percept(MonophasicPulse(-1, 1, stim_dur=10),
+                                    np.arange(10))
+    npt.assert_almost_equal(percept.data.ravel()[:3], [0, 0.633, 0.232],
+                            decimal=3)
 
 
 @pytest.mark.parametrize('n_space', (1, 63, 64, 65, 130))
@@ -149,6 +197,71 @@ def test_FadingTemporal_thread_count_invariant():
         parallel = FadingTemporal(dt=0.05, tau=40, n_threads=n_threads).build(
             ).predict_percept(stim, t_percept=[0, 5, 10, 15]).data
         npt.assert_array_equal(parallel, serial)
+
+
+def test_FadingTemporal_peak_is_exact():
+    """The in-kernel peak must equal a dense scan of the same interval.
+
+    Sampling an interval a fixed number of times cannot summarize a transient
+    shorter than its own step, which is why the peak is tracked across every
+    `dt` step instead. That makes it exact however coarse the output rate is,
+    and this pins it against brightness computed at every single step.
+    """
+    rng = np.random.default_rng(3)
+    data = (rng.random((5, 12)) - 0.5).astype(np.float32) * 40
+    t_stim = (np.arange(12) * 4.0).astype(np.float32)
+    dt, tau = 0.05, 20.0
+    # Brightness at every single simulation step:
+    n_sim = int(round(44 / dt)) + 1
+    dense = fading_fast(data, t_stim, np.arange(n_sim, dtype=np.uint32), dt,
+                        tau, 0.0, 1, 0)
+    out = np.array([37, 210, 400, 601, 880], dtype=np.uint32)
+    peak = fading_fast(data, t_stim, out, dt, tau, 0.0, 1, 1)
+    last = fading_fast(data, t_stim, out, dt, tau, 0.0, 1, 0)
+    # The interval a percept point summarizes runs from the previous one up to
+    # and including it -- brightness is continuous, so the value carried across
+    # the boundary is a floor on what the next interval reaches:
+    lo = np.r_[0, out[:-1]]
+    brute = np.stack([dense[:, a:b + 1].max(axis=1)
+                      for a, b in zip(lo, out)], axis=1)
+    npt.assert_array_equal(peak, brute)
+    # Reducing to the closing instant is what the model always did:
+    npt.assert_array_equal(last, dense[:, out])
+    npt.assert_equal(np.all(peak >= last), True)
+    npt.assert_equal(np.any(peak > last), True)
+    # Threads take a block of locations each; the peak must not depend on how
+    # many of them there are:
+    for n_threads in (2, 4, 8):
+        npt.assert_array_equal(
+            fading_fast(np.tile(data, (40, 1)), t_stim, out, dt, tau, 0.0,
+                        n_threads, 1),
+            np.tile(peak, (40, 1)))
+
+
+def test_FadingTemporal_reduce():
+    """`reduce` governs the times the model picks, not the ones you name."""
+    stim = BiphasicPulseTrain(20, -50, 0.46, stim_dur=200)
+    peak_model = FadingTemporal(tau=100).build()
+    npt.assert_equal(peak_model.reduce, 'peak')
+    last_model = FadingTemporal(tau=100, reduce='last').build()
+
+    # Naming `t_percept` asks for those instants, whatever `reduce` says:
+    t = [0, 50, 100, 150]
+    npt.assert_array_equal(peak_model.predict_percept(stim, t_percept=t).data,
+                           last_model.predict_percept(stim, t_percept=t).data)
+
+    # Letting the model pick, `reduce='last'` is the old behaviour exactly:
+    got = last_model.predict_percept(stim)
+    npt.assert_array_equal(
+        got.data, last_model.predict_percept(stim, t_percept=got.time).data)
+    # ... and 'peak' is never below it, because the interval contains its end:
+    peaked = peak_model.predict_percept(stim)
+    npt.assert_almost_equal(peaked.time, got.time)
+    npt.assert_equal(np.all(peaked.data >= got.data), True)
+    npt.assert_equal(np.any(peaked.data > got.data), True)
+
+    with pytest.raises(ValueError):
+        FadingTemporal(reduce='mean').build().predict_percept(stim)
 
 
 def test_TemporalModel_blank_percept_warning():

--- a/pulse2percept/models/tests/test_temporal.py
+++ b/pulse2percept/models/tests/test_temporal.py
@@ -56,11 +56,15 @@ def test_FadingTemporal():
     percept = model.predict_percept(stim, np.arange(stim.duration))
     npt.assert_almost_equal(percept.data, 0)
 
-    # tau has to be positive. Zero is as unusable as a negative value -- the
-    # integrator divides by it -- and used to build happily and hand back nan:
-    for tau in (-1, 0):
+    # tau has to be at least one simulation step. Zero and negatives divide the
+    # integrator by zero; anything under `dt` makes it overshoot its drive by
+    # dt/tau and then oscillate, so at tau=dt/2 brightness alternates between
+    # twice the drive and nothing. All of these used to build happily:
+    for tau in (-1, 0, 0.005 / 2, 0.004):
         with pytest.raises(ValueError):
-            FadingTemporal(tau=tau).build()
+            FadingTemporal(tau=tau, dt=0.005).build()
+    # ... and exactly one step is fine, being the rectifier limit:
+    FadingTemporal(tau=0.005, dt=0.005).build()
 
 
 def test_deepcopy_FadingTemporal():

--- a/pulse2percept/models/tests/test_temporal.py
+++ b/pulse2percept/models/tests/test_temporal.py
@@ -128,8 +128,9 @@ def test_FadingTemporal_rectifies_the_drive():
     A leaky integrator is linear, so driving it with -A lets the anodic phase
     of a biphasic pulse undo exactly what the cathodic phase did: brightness
     spikes for the length of one phase and returns to zero, leaving a 1.8%
-    duty cycle rather than a phosphene. Half-wave rectifying the drive is what
-    makes the pulse deliver net charge.
+    duty cycle rather than a phosphene. The pulse still delivers zero net
+    charge either way; rectifying is what stops the model's *drive* from
+    cancelling along with it.
     """
     train = BiphasicPulseTrain(20, -50, 0.46, stim_dur=1000)
     model = FadingTemporal(tau=100).build()
@@ -262,6 +263,47 @@ def test_FadingTemporal_reduce():
 
     with pytest.raises(ValueError):
         FadingTemporal(reduce='mean').build().predict_percept(stim)
+
+
+def test_TemporalModel_reduce_fallback():
+    """`reduce='peak'` has to mean something for a model that cannot reduce.
+
+    `FadingTemporal` tracks the peak inside its own integrator, but the
+    published models cannot, so `predict_percept` samples each interval
+    several times over and keeps the largest. That fallback used to be wired
+    only into the encoder frame clock: for an ordinary stimulus the output
+    grid was built by a different branch, no subsampling happened, and
+    `reduce='peak'` silently meant `'last'`.
+    """
+    # No encoder metadata, so this takes the plain 20 ms output grid:
+    stim = BiphasicPulseTrain(20, 50, 0.46, stim_dur=200)
+    npt.assert_equal(Nanduri2012Temporal()._reduces_intervals, False)
+    peak = Nanduri2012Temporal(reduce='peak').build().predict_percept(stim)
+    last = Nanduri2012Temporal(reduce='last').build().predict_percept(stim)
+    npt.assert_almost_equal(peak.time, np.arange(0, 201, 20))
+    npt.assert_almost_equal(peak.time, last.time)
+    npt.assert_equal(np.any(peak.data != last.data), True)
+    # The samples land on the output point too, so the peak of an interval is
+    # never below the instant it ends on:
+    npt.assert_array_less(last.data - 1e-7, peak.data)
+
+    # Sampling is only an approximation of the peak, but it may not overshoot
+    # the true one, which brightness at every single `dt` step gives:
+    model = Nanduri2012Temporal(reduce='peak').build()
+    dense = model.predict_percept(
+        stim, t_percept=np.round(np.arange(0, 181, model.dt), 5)).data.ravel()
+    idx = np.round(peak.time / model.dt).astype(int)
+    true = np.array([dense[max(0, a):b + 1].max()
+                     for a, b in zip(np.r_[0, idx[:-1]], idx)])
+    npt.assert_array_less(peak.data.ravel() - 1e-7, true)
+    npt.assert_allclose(peak.data.ravel(), true, atol=0.01)
+
+    # A published model keeps reporting what it always did unless asked:
+    npt.assert_equal(Nanduri2012Temporal().reduce, 'last')
+    npt.assert_array_equal(
+        Nanduri2012Temporal().build().predict_percept(stim).data, last.data)
+    # The generic model is the one that opts in:
+    npt.assert_equal(FadingTemporal().reduce, 'peak')
 
 
 def test_TemporalModel_blank_percept_warning():

--- a/pulse2percept/models/tests/test_temporal.py
+++ b/pulse2percept/models/tests/test_temporal.py
@@ -394,3 +394,79 @@ def test_TemporalModel_blank_percept_warning():
     with warnings.catch_warnings():
         warnings.simplefilter('error')
         nanduri.predict_percept(anodic, t_percept=[0, 20, 40])
+
+
+def test_FadingTemporal_tau_limits():
+    """The two limiting cases of the single time constant.
+
+    `tau` sets how fast brightness chases its drive, and it sets the rise and
+    the decay together -- there is only the one constant. So the limits are not
+    the ones intuition suggests:
+
+    *  `tau` at the simulation step is the *no dynamics* limit. One step is
+       then a full time constant, brightness reaches its drive within a single
+       step, and the model degenerates into a plain half-wave rectifier: the
+       percept is the cathodic part of the stimulus and nothing else.
+    *  `tau` to infinity is *not* the same thing. Brightness never fades, but
+       it never charges either, and the percept vanishes as `1/tau`. A model
+       that holds a percept forever would need the decay decoupled from the
+       rise, which this one cannot express.
+    """
+    dt = 0.005
+    # Edges on the `dt` grid, so sample-and-hold is unambiguous:
+    stim = Stimulus(np.array([[0.0, -50.0, 0.0, 30.0, 0.0]]),
+                    time=[0.0, 1.0, 2.0, 3.0, 4.0])
+    t = np.round(np.arange(0, 4, dt), 5)
+    rectified = np.maximum(-np.asarray(stim.data).ravel(), 0)[
+        np.searchsorted(np.asarray(stim.time), t, side='right') - 1]
+
+    got = FadingTemporal(tau=dt, dt=dt).build().predict_percept(
+        stim, t_percept=t).data.ravel()
+    npt.assert_array_equal(got, rectified)
+    # The anodic half is gone rather than inverted, so this really is a
+    # rectifier and not a pass-through:
+    npt.assert_equal(np.any(np.asarray(stim.data) > 0), True)
+    npt.assert_equal(got.max(), 50.0)
+
+    # Slower than that and brightness lags its drive, so the two part company.
+    # Lagging cuts both ways: brightness never catches the drive while it is on,
+    # and it is still on its way down once the drive has gone:
+    lagged = FadingTemporal(tau=10 * dt, dt=dt).build().predict_percept(
+        stim, t_percept=t).data.ravel()
+    npt.assert_array_less(lagged.max(), rectified.max())
+    npt.assert_equal(np.any(lagged[rectified == 0] > 0), True)
+
+    # The other end: the percept dies away as 1/tau, so `tau` cannot be used to
+    # make a percept persist -- it only makes it dimmer.
+    peaks = []
+    for tau in (1e4, 1e5, 1e6):
+        peaks.append(FadingTemporal(tau=tau).build().predict_percept(
+            stim, t_percept=t).data.max())
+    npt.assert_equal(np.all(np.diff(peaks) < 0), True)
+    npt.assert_allclose(np.multiply(peaks, [1e4, 1e5, 1e6]), 50.0 * 1.0,
+                        rtol=0.05)
+
+
+def test_FadingTemporal_reduce_limits():
+    """`reduce` can only matter where brightness rises and falls."""
+    # Constant cathodic current: brightness climbs toward it and never turns
+    # around, so the peak of every interval is the instant it ends on and the
+    # two settings have nothing to disagree about.
+    rising = Stimulus(np.full((4, 2), -20.0), time=[0.0, 500.0])
+    rising.metadata['encoder'] = {'frame_time': np.arange(10) * 50.0,
+                                  'frame_dur': 50.0, 'n_frames': 10}
+    peak = FadingTemporal(tau=100).build().predict_percept(rising)
+    last = FadingTemporal(tau=100, reduce='last').build().predict_percept(
+        rising)
+    npt.assert_array_equal(peak.data, last.data)
+    npt.assert_array_less(-1e-9, np.diff(peak.data, axis=-1))
+
+    # A pulse train is the case they were built to disagree about:
+    train = BiphasicPulseTrain(20, -50, 0.46, stim_dur=500)
+    train.metadata['encoder'] = {'frame_time': np.arange(10) * 50.0,
+                                 'frame_dur': 50.0, 'n_frames': 10}
+    peak = FadingTemporal(tau=100).build().predict_percept(train)
+    last = FadingTemporal(tau=100, reduce='last').build().predict_percept(
+        train)
+    npt.assert_equal(np.any(peak.data != last.data), True)
+    npt.assert_array_less(last.data - 1e-9, peak.data)

--- a/pulse2percept/stimuli/encoders.py
+++ b/pulse2percept/stimuli/encoders.py
@@ -69,10 +69,11 @@ class Encoder(PrettyPrint, metaclass=ABCMeta):
     another:
 
     *  The **frame clock** belongs to the video. It says when the modulation
-       parameters update -- a new frame is a new gray level, and hence a new
-       amplitude or a new frequency. It is also the rate at which a percept is
-       worth reporting, which is why it is recorded in the encoded stimulus'
-       metadata for :py:meth:`~pulse2percept.models.Model.predict_percept` to
+       parameters update; that is, a new frame is a new gray level, and hence
+       a new amplitude or a new frequency. It is also the rate at which a
+       percept is worth reporting, which is why it is recorded in the encoded
+       stimulus' metadata for 
+       :py:meth:`~pulse2percept.models.Model.predict_percept` to
        pick up. It takes no part in the timing of the pulses themselves.
 
     *  The **pulse clock** belongs to ``freq``. It runs continuously for the
@@ -90,15 +91,7 @@ class Encoder(PrettyPrint, metaclass=ABCMeta):
     *  The **raster sweep** belongs to the
        :py:class:`~pulse2percept.implants.Raster`, and says which electrodes
        may pulse when, so that no two raster groups are ever active at the same
-       instant. Electrodes on *different* periods would drift into one
-       another's slots, so their periods are pinned to whole multiples of the
-       sweep; electrodes that share a period cannot drift and keep it exactly.
-
-    .. versionchanged:: 0.10.0
-
-        Pulse timing no longer restarts at every video frame. Before, a frame
-        that was not a whole number of pulse periods long silently changed the
-        pulse rate: at 29.97 fps, ``freq=50`` delivered 59.94 pulses per second.
+       instant.
 
     All encoders share the same two-step structure:
 
@@ -106,8 +99,8 @@ class Encoder(PrettyPrint, metaclass=ABCMeta):
         encoder was given an ``implant``, the source is first sampled at the
         electrode locations, so that everything downstream works at electrode
         resolution.
-    2.  Map those gray levels onto pulse train parameters (``_modulate``), then
-        assemble the pulse trains (``_assemble``).
+    2.  Map those gray levels onto pulse train parameters (``_modulate``),
+        then assemble the pulse trains (``_assemble``).
 
     Subclasses only implement ``_modulate``; everything else is provided here.
 
@@ -118,18 +111,16 @@ class Encoder(PrettyPrint, metaclass=ABCMeta):
     implant : :py:class:`~pulse2percept.implants.ProsthesisSystem`, optional
         The implant to encode for. Its electrode locations are used to sample
         the source, and its electrode names label the resulting stimulus.
-        If None, every pixel of the source is treated as its own electrode,
-        which is rarely what you want for anything but an already downsampled
-        image.
+        If None, every pixel of the source is treated as its own electrode.
     phase_dur : float, optional
         Duration (ms) of the cathodic/anodic phase of each pulse.
     interphase_dur : float, optional
         Duration (ms) of the gap between the cathodic and anodic phases.
     cathodic_first : bool, optional
-        If True, the cathodic phase of each pulse is delivered first. Retinal
-        ganglion cells are most sensitive to cathodic current, and the temporal
-        models in :py:mod:`pulse2percept.models` treat cathodic current as
-        brightness-increasing, so bright pixels map onto cathodic-first pulses.
+        If True, the cathodic phase of each pulse is delivered first. Most
+        temporal models in :py:mod:`pulse2percept.models` treat cathodic 
+        current as brightness-increasing, so bright pixels map onto 
+        cathodic-first pulses.
     pulse : :py:class:`~pulse2percept.stimuli.Stimulus`, optional
         A single pulse to repeat, in place of the symmetric biphasic pulse
         built from ``phase_dur``, ``interphase_dur`` and ``cathodic_first``
@@ -145,28 +136,18 @@ class Encoder(PrettyPrint, metaclass=ABCMeta):
 
         .. important::
 
-           Every timing constraint here -- the clock, and the raster sweep --
-           may *lower* the rate an electrode ends up on, and none of them may
+           Every timing constraint here (the clock, and the raster sweep) may
+           *lower* the rate an electrode ends up on, and none of them may
            raise it. Rounding a period down would deliver more charge than was
            asked for, so a time base that cannot represent a rate exactly gives
            back the nearest slower one it can.
 
-           That makes a coarse clock expensive in frequency, and the more so
-           the faster the train: realizable periods are ``clock``, ``2*clock``,
-           ``3*clock``, ... , so with ``clock=1`` a requested 300 Hz (3.33 ms)
-           is delivered as 250 Hz (4 ms), and with ``clock=3`` as 166.7 Hz.
+           That makes a coarse clock expensive in frequency: realizable periods
+           are ``clock``, ``2*clock``, ``3*clock``, ... , so with ``clock=1`` 
+           a requested 300 Hz (3.33 ms) is delivered as 250 Hz (4 ms), and with
+           ``clock=3`` as 166.7 Hz.
            Choose it against the top of your frequency range rather than in the
            abstract.
-
-        .. important::
-
-           This is the main lever on how expensive an encoded stimulus is to
-           simulate. Electrodes that end up on the same pulse schedule share a
-           time axis, so a coarse clock keeps the number of distinct time
-           points in the stimulus small. It does nothing for amplitude
-           modulation (where every electrode is already on the same schedule)
-           but is decisive for frequency modulation; see
-           :py:class:`~pulse2percept.stimuli.FrequencyEncoder`.
     n_levels : int, optional
         Number of gray levels the encoder can distinguish, mimicking the
         resolution of the device's input stage. Gray levels are rounded onto
@@ -314,9 +295,7 @@ class Encoder(PrettyPrint, metaclass=ABCMeta):
             # perform, done here so that the pulse trains below are built at
             # electrode resolution rather than at pixel resolution. It is also
             # where RGB becomes gray. Row count is not a usable test of whether
-            # a source is already in electrode coordinates -- a 10x6 image and
-            # an RGB 4x5 image both have exactly as many rows as Argus II has
-            # electrodes -- so always reshape:
+            # a source is already in electrode coordinates, so always reshape:
             stim = self.implant.reshape_stim(stim)
         gray = np.clip(np.asarray(stim.data, dtype=np.float32), 0, 1)
         if stim.time is None:
@@ -412,11 +391,7 @@ class Encoder(PrettyPrint, metaclass=ABCMeta):
         period[firing] = 1000.0 / freq[firing] / DT
         # A clocked stimulator can only realize a period that is a whole number
         # of clock cycles, which is what keeps the number of distinct schedules
-        # (and hence of time points) down. Round the period *up*: a timing
-        # constraint may lower the rate an electrode ends up on, never raise it,
-        # since raising it delivers more charge than the caller asked for. A
-        # 3 ms time base genuinely cannot represent 300 Hz without
-        # overstimulating, and says so by giving 166.7 Hz rather than 333 Hz:
+        # (and hence of time points) down. Round the period *up*:
         if self.clock is not None:
             tick = self.clock / DT
             period[firing] = tick * np.maximum(
@@ -430,22 +405,22 @@ class Encoder(PrettyPrint, metaclass=ABCMeta):
         return firing, period
 
     def _raster_grid(self, electrodes, period, firing, pulse_len):
-        """The slot each electrode may pulse in, and the raster cycle
+        """The slot each electrode may pulse in, and the raster sweep
 
-        The cycle a raster has to get through is the shortest pulse period
-        anyone asked for. Under amplitude modulation that is *the* period, so
-        every group gets its turn exactly once per pulse and the requested
-        frequency is delivered exactly. Under frequency modulation it is set by
-        the fastest electrode, and slower ones pulse every m-th cycle.
+        The sweep has to fit inside the shortest pulse period anyone asked for.
+        With no explicit ``group_dur`` it *is* that period, split evenly between
+        the groups; with one, it is ``n_groups * group_dur`` and generally much
+        shorter than the period.
 
         Returns
         -------
         offset : (n_electrodes,) float array
-            How far into a raster cycle (in ticks) each electrode may start a
-            pulse.
+            How far behind group 0 (in ticks) each electrode may start a pulse.
         cycle : float or None
-            The raster cycle in ticks, onto which pulse periods are quantized.
-            None when there is nothing to multiplex.
+            The sweep in ticks. Periods that differ from one another are
+            quantized onto it by ``_assemble``, so that groups cannot drift
+            together; a period they all share is left exactly as asked. None
+            when there is nothing to multiplex.
 
         """
         # An explicit raster wins over the implant's own, so that a raster can
@@ -528,7 +503,7 @@ class Encoder(PrettyPrint, metaclass=ABCMeta):
             The last tick at which a pulse may *begin*.
         grid : float
             The spacing of the onsets this schedule is allowed to use -- the
-            raster cycle, or failing that the stimulator's clock. A schedule
+            raster sweep, or failing that the stimulator's clock. A schedule
             that goes silent has to come back onto it.
 
         Returns
@@ -558,17 +533,11 @@ class Encoder(PrettyPrint, metaclass=ABCMeta):
         # frames, so track the *phase* of the pulse clock rather than jumping
         # straight to the next pulse. Phase advances at 1/period, which changes
         # the instant a frame boundary goes by; a pulse fires whenever it
-        # reaches 1. Jumping a whole period ahead instead would carry the old
-        # frame's rate across the boundary and miss the new one entirely --
-        # a frame asking for 100 Hz would sit silent because the frame before
-        # it asked for 10 Hz and had already booked the next pulse.
+        # reaches 1.
         onset, frame = [], []
         # A full phase to begin with, so that a schedule's first pulse lands at
         # the start of its slot rather than one period into it. Start counting
-        # in the frame that actually contains that slot: a raster group's turn
-        # can fall several frames into the video when stimulation is slow
-        # relative to it, and beginning at frame 0 would integrate the wrong
-        # rates -- and could even walk `t` backwards to an earlier boundary:
+        # in the frame that actually contains that slot:
         phase, t = 1.0, float(start)
         k = int(np.searchsorted(frame_ticks, round(t), side='right')) - 1
         k = min(max(k, 0), n_frames - 1)
@@ -593,13 +562,11 @@ class Encoder(PrettyPrint, metaclass=ABCMeta):
                     break
                 phase, t, k = due, edge, k + 1
                 continue
-            # The pulse comes due inside this frame. Snap it *forward* onto the
-            # grid this schedule is allowed to use -- the raster cycle, or the
-            # stimulator's clock. Forward rather than to the nearest point,
+            # The pulse comes due inside this frame. Snap it forward onto the
+            # grid this schedule is allowed to use (i.e., the raster cycle, or
+            # the stimulator's clock. Forward rather than to the nearest point,
             # because a grid is a timing constraint and no timing constraint may
             # deliver a pulse earlier (and so at a higher rate) than asked for.
-            # Where the period is already a whole number of grid steps, which is
-            # every case except a rate change landing mid-period, this is exact:
             cross = t + (1.0 - phase) / rate
             tick = int(round(start + grid * np.ceil(
                 (cross - start) / grid - 1e-9)))
@@ -608,7 +575,7 @@ class Encoder(PrettyPrint, metaclass=ABCMeta):
                 tick = int(round(prev + grid))
             if tick > last:
                 break
-            # Which frame the pulse lands in is decided by where it *actually*
+            # Which frame the pulse lands in is decided by where it actually
             # goes, not where it came due: snapping can carry it over a boundary
             # into a frame that wants something else entirely.
             j = int(np.searchsorted(frame_ticks, tick, side='right')) - 1
@@ -642,7 +609,7 @@ class Encoder(PrettyPrint, metaclass=ABCMeta):
     def _assemble(self, amp, freq, electrodes, frame_time, frame_dur):
         """Build the pulse trains for every electrode and frame
 
-        Electrodes that pulse at the same *times* share the shape of their
+        Electrodes that pulse at the same times share the shape of their
         waveform; only the amplitude that scales it differs. So rather than
         building one waveform per electrode, this builds one per distinct
         schedule and indexes into them, which is what keeps frequency
@@ -650,10 +617,7 @@ class Encoder(PrettyPrint, metaclass=ABCMeta):
         tractable.
 
         The time axis is global rather than per-frame. Pulses live at absolute
-        times and no two frames' pulses coincide, so this costs no more than
-        laying each frame out separately did -- and it lets a pulse straddle a
-        frame boundary, which is what keeps the pulse clock free of the frame
-        clock.
+        times and no two frames' pulses coincide.
         """
         n_el, n_frames = len(electrodes), frame_time.size
         shape = (n_el, n_frames)
@@ -666,7 +630,7 @@ class Encoder(PrettyPrint, metaclass=ABCMeta):
         frame_ticks = self._ticks(frame_time)
         total = float(frame_time[-1] + frame_dur)
         # The stimulus lasts exactly as long as the source did. Flooring (with
-        # an epsilon so a duration that *is* a whole number of ticks does not
+        # an epsilon so a duration that is a whole number of ticks does not
         # lose one to binary rounding) leaves at least one tick between the
         # last pulse and the end point that pins the duration:
         end = int(np.floor(total / DT + 1e-9))
@@ -677,7 +641,7 @@ class Encoder(PrettyPrint, metaclass=ABCMeta):
                              f"'phase_dur' or lengthen the source.")
         firing, period = self._periods(freq, pulse_len)
         # An electrode delivering no current has nothing to schedule. Its clock
-        # keeps running (`firing`), so it stays in phase with its neighbors,
+        # keeps running ("firing"), so it stays in phase with its neighbors,
         # but it costs no pulses and no time points:
         active = firing & (amp != 0)
         offset, cycle = self._raster_grid(electrodes, period, firing, pulse_len)
@@ -685,7 +649,7 @@ class Encoder(PrettyPrint, metaclass=ABCMeta):
             # Electrodes on different periods drift relative to one another,
             # and two groups would eventually land on the same instant. Pinning
             # every period to a whole number of raster cycles is what stops
-            # that. Round the period *up* rather than to the nearest cycle:
+            # that. Round the period up rather than to the nearest cycle:
             period[firing] = cycle * np.maximum(
                 1.0, np.ceil(period[firing] / cycle - 1e-9))
 
@@ -804,10 +768,13 @@ class AmplitudeEncoder(Encoder):
     gray level of the pixel it sees sets the amplitude of those pulses. This is
     how most retinal prostheses encode a video.
 
-    Because every electrode shares one pulse period, a raster splits that
-    period evenly between its groups: each group pulses exactly once per period
-    in its own slot, ``freq`` is delivered exactly, and no two groups are ever
-    active at the same instant.
+    Because every electrode shares one pulse period, a raster costs no
+    frequency here: the groups hold fixed offsets from one another and so can
+    never drift together, which means nothing has to be quantized and ``freq``
+    is delivered exactly. With no explicit ``group_dur`` the groups also divide
+    that period evenly, one turn each per pulse; an explicit ``group_dur``
+    packs them into a shorter sweep at the start of every period instead.
+    Either way no two groups are ever active at the same instant.
 
     .. versionadded:: 0.10.0
 
@@ -938,14 +905,22 @@ class FrequencyEncoder(Encoder):
            Realizable frequencies are quantized by ``clock``, and, when a
            raster is in play, onto the raster sweep -- which under frequency
            modulation is the usual case, since the electrodes are by
-           construction on differing rates. The fastest electrode pulses once
-           per sweep and slower ones every m-th sweep, so the realizable rates
-           are ``max_freq / m``.
+           construction on differing rates. Every period becomes a whole number
+           of sweeps, so the realizable rates are ``1000 / (m * sweep)`` Hz.
 
-           Quantizing onto the cycle always rounds the *period* up, so an
+           How coarse that grid is depends on how the sweep was set. With
+           ``group_dur=None`` the sweep is the shortest period asked for, so
+           the fastest electrode keeps its rate and pulses once per sweep while
+           slower ones pulse every *m*-th. With an explicit ``group_dur`` the
+           sweep is ``n_groups * group_dur`` and unrelated to any requested
+           rate, so even the fastest electrode is generally rounded: against a
+           six-group 1 ms sweep, a requested 100 Hz (10 ms) is delivered as
+           83.3 Hz (12 ms, two sweeps).
+
+           Quantizing onto the sweep always rounds the *period* up, so an
            electrode is never driven faster than it was asked for: against a
-           10 ms cycle, 67 Hz comes back as 50 Hz rather than 100 Hz. Rounding
-           to the nearest cycle instead would deliver up to twice the charge
+           10 ms sweep, 67 Hz comes back as 50 Hz rather than 100 Hz. Rounding
+           to the nearest sweep instead would deliver up to twice the charge
            the caller asked for. Shorten ``group_dur`` for a finer grid.
     amp : float, optional
         Pulse amplitude (uA), the same for every electrode.

--- a/pulse2percept/stimuli/encoders.py
+++ b/pulse2percept/stimuli/encoders.py
@@ -423,14 +423,26 @@ class Encoder(PrettyPrint, metaclass=ABCMeta):
         # whether a raster is a workable schedule is a property of the device,
         # not of how bright today's video happens to be.
         fastest = float(np.min(period[firing]))
-        offset = np.asarray(raster.offsets(electrodes, fastest * DT),
-                            dtype=np.float64) / DT
-        cycle = (fastest if raster.group_dur is None else
-                 raster.n_groups * raster.group_dur / DT)
+        # `raster.offsets` validates that the groups fit into the cycle; the
+        # slot is what the offsets are actually built from:
+        raster.offsets(electrodes, fastest * DT)
+        group = np.asarray(raster.groups(electrodes), dtype=np.float64)
+        slot = raster.slot_dur(fastest * DT) / DT
+        if self.clock is not None and raster.group_dur is not None:
+            # An explicit slot is the primitive the cycle is made of, so round
+            # *it* onto the clock and rebuild the cycle from the result. The
+            # other way around -- rounding each offset and the total cycle
+            # independently -- leaves groups with turns of different lengths
+            # and a cycle that is no longer `n_groups` of them:
+            slot = max(1.0, round(slot / (self.clock / DT))) * self.clock / DT
+        offset = group * slot
+        # With no explicit slot the groups divide the pulse period, and it is
+        # the period that has to be preserved: keeping the cycle equal to it is
+        # what makes a rastered train run at exactly the requested rate:
+        cycle = fastest if raster.group_dur is None else raster.n_groups * slot
         if self.clock is not None:
             tick = self.clock / DT
             offset = tick * np.round(offset / tick)
-            cycle = tick * max(1.0, round(cycle / tick))
         # Every group's turn has to be long enough to finish a pulse in. The
         # gap to the *next* group's turn is what a collision would show up as,
         # so measure those rather than the nominal slot -- rounding a slot onto
@@ -486,32 +498,69 @@ class Encoder(PrettyPrint, metaclass=ABCMeta):
             np.clip(frame, 0, n_frames - 1, out=frame)
             keep = active[frame]
             return onset[keep], frame[keep]
-        # Frequency modulation: the period changes from frame to frame, and the
-        # next pulse is scheduled from the previous one rather than from the
-        # frame boundary, so that the pulse clock keeps its phase. `t` stays
-        # unrounded for the same reason the period does -- rounding it here
-        # would let the error accumulate from pulse to pulse:
-        onset, frame, t = [], [], float(start)
-        while t <= last:
-            tick = int(round(t))
-            k = int(np.searchsorted(frame_ticks, tick, side='right')) - 1
-            k = min(max(k, 0), n_frames - 1)
-            if active[k]:
-                onset.append(tick)
-                frame.append(k)
-            if period[k] > 0:
-                # The clock runs even where the amplitude is zero, so a dark
-                # frame does not reset the phase of the frames around it:
-                t += float(period[k])
-            elif k + 1 < n_frames:
-                # Nothing to stay in phase with, so pick the schedule back up
-                # at the next frame -- but on this schedule's own grid, or a
-                # silent stretch would knock every pulse after it off the
-                # stimulator's clock and multiply the time points needed:
-                nxt = float(frame_ticks[k + 1])
-                t = start + grid * np.ceil((nxt - start) / grid)
-            else:
+        # Frequency modulation: the rate is piecewise constant over the video's
+        # frames, so track the *phase* of the pulse clock rather than jumping
+        # straight to the next pulse. Phase advances at 1/period, which changes
+        # the instant a frame boundary goes by; a pulse fires whenever it
+        # reaches 1. Jumping a whole period ahead instead would carry the old
+        # frame's rate across the boundary and miss the new one entirely --
+        # a frame asking for 100 Hz would sit silent because the frame before
+        # it asked for 10 Hz and had already booked the next pulse.
+        onset, frame = [], []
+        # A full phase to begin with, so that a schedule's first pulse lands at
+        # the start of its slot rather than one period into it:
+        phase, k, t = 1.0, 0, float(start)
+        prev = -np.inf
+        while k < n_frames and t <= last:
+            # How far this frame reaches, and how much phase it can supply:
+            edge = float(frame_ticks[k + 1]) if k + 1 < n_frames else np.inf
+            rate = 1.0 / period[k] if period[k] > 0 else 0.0
+            if rate == 0.0:
+                # A stopped clock supplies no phase, so nothing can come due
+                # here however long the frame is. Whatever phase had built up
+                # waits for the frame that starts the clock again:
+                if not np.isfinite(edge):
+                    break
+                t, k = edge, k + 1
+                continue
+            due = phase + (edge - t) * rate
+            if due < 1.0:
+                # The frame runs out before the next pulse comes due, so carry
+                # the phase across the boundary and pick the new rate up there:
+                if not np.isfinite(edge):
+                    break
+                phase, t, k = due, edge, k + 1
+                continue
+            # The pulse comes due inside this frame. Work out where from the
+            # phase alone, and settle which frame it belongs to *before*
+            # snapping it onto a grid -- snapping is a hardware detail, and
+            # deciding the frame from a snapped (and possibly nudged) time can
+            # send the schedule back to a boundary it has already left:
+            cross = t + (1.0 - phase) / rate
+            j = int(np.searchsorted(frame_ticks, round(cross),
+                                    side='right')) - 1
+            j = min(max(j, 0), n_frames - 1)
+            if period[j] <= 0:
+                # The pulse came due right as the clock stopped. Hold it rather
+                # than spending it here: a frame at 0 Hz should not swallow a
+                # pulse, and the frame that starts the clock again should come
+                # up at its full rate rather than a period short.
+                phase, t, k = 1.0, cross, j
+                continue
+            # Round onto the grid this schedule is allowed to use -- the raster
+            # cycle, or the stimulator's clock -- and restart the phase from
+            # where the pulse actually landed, so the error cannot accumulate:
+            tick = int(round(start + grid * np.round((cross - start) / grid)))
+            if tick <= prev:
+                # Never let grid rounding stall or reverse the train:
+                tick = int(round(prev + grid))
+            if tick > last:
                 break
+            if active[j]:
+                onset.append(tick)
+                frame.append(j)
+            prev, phase, t = tick, 0.0, float(tick)
+            k = j
         return (np.asarray(onset, dtype=np.int64).reshape(-1),
                 np.asarray(frame, dtype=np.int64).reshape(-1))
 
@@ -569,9 +618,15 @@ class Encoder(PrettyPrint, metaclass=ABCMeta):
         offset, cycle = self._raster_grid(electrodes, period, firing, pulse_len)
         if cycle is not None:
             # A period that is a whole number of raster cycles is what keeps
-            # two groups from ever drifting onto the same instant:
+            # two groups from ever drifting onto the same instant. Round the
+            # period *up* rather than to the nearest cycle: rounding down
+            # delivers more charge than was asked for, and an electrode asking
+            # for 67 Hz against a 10 ms cycle would come back at 100 Hz rather
+            # than 50. The epsilon keeps a period that already is a whole
+            # number of cycles -- every period, under amplitude modulation --
+            # from being pushed up to the next one by binary rounding:
             period[firing] = cycle * np.maximum(
-                1.0, np.round(period[firing] / cycle))
+                1.0, np.ceil(period[firing] / cycle - 1e-9))
 
         # Everything about when an electrode pulses is fixed by its slot and by
         # the period/activity it carries through the frames:
@@ -789,11 +844,11 @@ class FrequencyEncoder(Encoder):
        setting                  time points
        =======================  ===========
        (amplitude modulation)           442
-       no quantization              142,704
-       ``clock=1``                   21,519
-       ``clock=2``                   10,886
-       ``n_levels=8``                88,748
-       ``clock=1, n_levels=8``       20,987
+       no quantization              143,760
+       ``clock=1``                   21,561
+       ``clock=2``                   10,893
+       ``n_levels=8``               129,031
+       ``clock=1, n_levels=8``       21,155
        =======================  ===========
 
        Start with ``clock=1``, which costs nothing in frequency range, and
@@ -830,6 +885,12 @@ class FrequencyEncoder(Encoder):
            across many groups asks for a lot of a stimulator -- six groups of
            0.92 ms pulses need 5.5 ms per cycle, or at most 181 Hz -- and
            encoding raises rather than quietly delivering something else.
+
+           Quantizing onto the cycle always rounds the *period* up, so an
+           electrode is never driven faster than it was asked for: against a
+           10 ms cycle, 67 Hz comes back as 50 Hz rather than 100 Hz. Rounding
+           to the nearest cycle instead would deliver up to twice the charge
+           the caller asked for. Shorten ``group_dur`` for a finer grid.
     amp : float, optional
         Pulse amplitude (uA), the same for every electrode.
     phase_dur, interphase_dur, cathodic_first, pulse, clock, n_levels, \

--- a/pulse2percept/stimuli/encoders.py
+++ b/pulse2percept/stimuli/encoders.py
@@ -129,6 +129,21 @@ class Encoder(PrettyPrint, metaclass=ABCMeta):
 
         .. important::
 
+           Every timing constraint here -- the clock, and the raster cycle --
+           may *lower* the rate an electrode ends up on, and none of them may
+           raise it. Rounding a period down would deliver more charge than was
+           asked for, so a time base that cannot represent a rate exactly gives
+           back the nearest slower one it can.
+
+           That makes a coarse clock expensive in frequency, and the more so
+           the faster the train: realizable periods are ``clock``, ``2*clock``,
+           ``3*clock``, ... , so with ``clock=1`` a requested 300 Hz (3.33 ms)
+           is delivered as 250 Hz (4 ms), and with ``clock=3`` as 166.7 Hz.
+           Choose it against the top of your frequency range rather than in the
+           abstract.
+
+        .. important::
+
            This is the main lever on how expensive an encoded stimulus is to
            simulate. Electrodes that end up on the same pulse schedule share a
            time axis, so a coarse clock keeps the number of distinct time
@@ -379,11 +394,15 @@ class Encoder(PrettyPrint, metaclass=ABCMeta):
         period[firing] = 1000.0 / freq[firing] / DT
         # A clocked stimulator can only realize a period that is a whole number
         # of clock cycles, which is what keeps the number of distinct schedules
-        # (and hence of time points) down:
+        # (and hence of time points) down. Round the period *up*: a timing
+        # constraint may lower the rate an electrode ends up on, never raise it,
+        # since raising it delivers more charge than the caller asked for. A
+        # 3 ms time base genuinely cannot represent 300 Hz without
+        # overstimulating, and says so by giving 166.7 Hz rather than 333 Hz:
         if self.clock is not None:
             tick = self.clock / DT
             period[firing] = tick * np.maximum(
-                1.0, np.round(period[firing] / tick))
+                1.0, np.ceil(period[firing] / tick - 1e-9))
         if np.any(period[firing] < pulse_len):
             too_fast = 1000.0 / (np.min(period[firing]) * DT)
             raise ValueError(f"A pulse (dur={pulse_len * DT:.3f} ms) does not "
@@ -423,10 +442,10 @@ class Encoder(PrettyPrint, metaclass=ABCMeta):
         # whether a raster is a workable schedule is a property of the device,
         # not of how bright today's video happens to be.
         fastest = float(np.min(period[firing]))
-        # `raster.offsets` validates that the groups fit into the cycle; the
-        # slot is what the offsets are actually built from:
-        raster.offsets(electrodes, fastest * DT)
-        group = np.asarray(raster.groups(electrodes), dtype=np.float64)
+        group = np.asarray(raster.groups(electrodes), dtype=np.int64)
+        if (group.min(initial=0) < 0 or
+                group.max(initial=0) >= raster.n_groups):
+            raise ValueError(f"'groups' must be in 0..{raster.n_groups - 1}.")
         slot = raster.slot_dur(fastest * DT) / DT
         if self.clock is not None and raster.group_dur is not None:
             # An explicit slot is the primitive the cycle is made of, so round
@@ -435,11 +454,20 @@ class Encoder(PrettyPrint, metaclass=ABCMeta):
             # independently -- leaves groups with turns of different lengths
             # and a cycle that is no longer `n_groups` of them:
             slot = max(1.0, round(slot / (self.clock / DT))) * self.clock / DT
-        offset = group * slot
         # With no explicit slot the groups divide the pulse period, and it is
         # the period that has to be preserved: keeping the cycle equal to it is
         # what makes a rastered train run at exactly the requested rate:
         cycle = fastest if raster.group_dur is None else raster.n_groups * slot
+        # Check the slot the hardware will actually use, not the one that was
+        # asked for: a 5.1 ms slot on a 1 ms clock is a 5 ms slot, and two of
+        # those do fit into a 10 ms period even though two of 5.1 ms do not.
+        if cycle > fastest * (1 + 1e-9):
+            raise ValueError(
+                f"A raster of {raster.n_groups} groups {slot * DT:.3f} ms "
+                f"apart takes {cycle * DT:.3f} ms to get through, which does "
+                f"not fit into the {fastest * DT:.3f} ms pulse period. Shorten "
+                f"'group_dur', use fewer groups, or lower the frequency.")
+        offset = group.astype(np.float64) * slot
         if self.clock is not None:
             tick = self.clock / DT
             offset = tick * np.round(offset / tick)
@@ -508,8 +536,14 @@ class Encoder(PrettyPrint, metaclass=ABCMeta):
         # it asked for 10 Hz and had already booked the next pulse.
         onset, frame = [], []
         # A full phase to begin with, so that a schedule's first pulse lands at
-        # the start of its slot rather than one period into it:
-        phase, k, t = 1.0, 0, float(start)
+        # the start of its slot rather than one period into it. Start counting
+        # in the frame that actually contains that slot: a raster group's turn
+        # can fall several frames into the video when stimulation is slow
+        # relative to it, and beginning at frame 0 would integrate the wrong
+        # rates -- and could even walk `t` backwards to an earlier boundary:
+        phase, t = 1.0, float(start)
+        k = int(np.searchsorted(frame_ticks, round(t), side='right')) - 1
+        k = min(max(k, 0), n_frames - 1)
         prev = -np.inf
         while k < n_frames and t <= last:
             # How far this frame reaches, and how much phase it can supply:
@@ -531,31 +565,34 @@ class Encoder(PrettyPrint, metaclass=ABCMeta):
                     break
                 phase, t, k = due, edge, k + 1
                 continue
-            # The pulse comes due inside this frame. Work out where from the
-            # phase alone, and settle which frame it belongs to *before*
-            # snapping it onto a grid -- snapping is a hardware detail, and
-            # deciding the frame from a snapped (and possibly nudged) time can
-            # send the schedule back to a boundary it has already left:
+            # The pulse comes due inside this frame. Snap it *forward* onto the
+            # grid this schedule is allowed to use -- the raster cycle, or the
+            # stimulator's clock. Forward rather than to the nearest point,
+            # because a grid is a timing constraint and no timing constraint may
+            # deliver a pulse earlier (and so at a higher rate) than asked for.
+            # Where the period is already a whole number of grid steps, which is
+            # every case except a rate change landing mid-period, this is exact:
             cross = t + (1.0 - phase) / rate
-            j = int(np.searchsorted(frame_ticks, round(cross),
-                                    side='right')) - 1
-            j = min(max(j, 0), n_frames - 1)
-            if period[j] <= 0:
-                # The pulse came due right as the clock stopped. Hold it rather
-                # than spending it here: a frame at 0 Hz should not swallow a
-                # pulse, and the frame that starts the clock again should come
-                # up at its full rate rather than a period short.
-                phase, t, k = 1.0, cross, j
-                continue
-            # Round onto the grid this schedule is allowed to use -- the raster
-            # cycle, or the stimulator's clock -- and restart the phase from
-            # where the pulse actually landed, so the error cannot accumulate:
-            tick = int(round(start + grid * np.round((cross - start) / grid)))
+            tick = int(round(start + grid * np.ceil(
+                (cross - start) / grid - 1e-9)))
             if tick <= prev:
-                # Never let grid rounding stall or reverse the train:
+                # Never let the grid stall or reverse the train:
                 tick = int(round(prev + grid))
             if tick > last:
                 break
+            # Which frame the pulse lands in is decided by where it *actually*
+            # goes, not where it came due: snapping can carry it over a boundary
+            # into a frame that wants something else entirely.
+            j = int(np.searchsorted(frame_ticks, tick, side='right')) - 1
+            j = min(max(j, 0), n_frames - 1)
+            if period[j] <= 0:
+                # The pulse landed in a frame whose clock is stopped. Hold it
+                # rather than spending it there: a frame at 0 Hz should neither
+                # be given a pulse it did not ask for nor swallow one, and the
+                # frame that starts the clock again should come up at its full
+                # rate rather than a period short.
+                phase, t, k = 1.0, float(tick), j
+                continue
             if active[j]:
                 onset.append(tick)
                 frame.append(j)
@@ -844,15 +881,18 @@ class FrequencyEncoder(Encoder):
        setting                  time points
        =======================  ===========
        (amplitude modulation)           442
-       no quantization              143,760
-       ``clock=1``                   21,561
+       no quantization              143,771
+       ``clock=1``                   21,505
        ``clock=2``                   10,893
-       ``n_levels=8``               129,031
-       ``clock=1, n_levels=8``       21,155
+       ``n_levels=8``               127,327
+       ``clock=1, n_levels=8``       20,917
        =======================  ===========
 
-       Start with ``clock=1``, which costs nothing in frequency range, and
-       coarsen it from there.
+       ``clock`` is not free, though: it buys those time points with frequency
+       resolution, and it spends it at the top of the range where the periods
+       are shortest. Against ``freq_range=(0, 300)``, ``clock=1`` delivers the
+       brightest pixels at 250 Hz rather than 300, and ``clock=2`` at 200 Hz.
+       Pick it against the fastest train you actually need.
 
        ``n_levels`` is a much weaker lever here than the numbers above might
        suggest, and only worth reaching for once ``clock`` is set. Because the

--- a/pulse2percept/stimuli/encoders.py
+++ b/pulse2percept/stimuli/encoders.py
@@ -882,7 +882,7 @@ class FrequencyEncoder(Encoder):
     Every electrode emits pulses of the same fixed amplitude, and the gray
     level of the pixel it sees sets how often they come.
 
-    .. note::
+    .. important::
 
        Frequency modulation is far more expensive to simulate than amplitude
        modulation, because electrodes pulsing at different rates do not pulse
@@ -940,10 +940,7 @@ class FrequencyEncoder(Encoder):
            modulation is the usual case, since the electrodes are by
            construction on differing rates. The fastest electrode pulses once
            per sweep and slower ones every m-th sweep, so the realizable rates
-           are ``max_freq / m``. Multiplexing a fast train across many groups
-           asks for a lot of a stimulator -- six groups of 0.92 ms pulses need
-           5.5 ms per sweep, or at most 181 Hz -- and encoding raises rather
-           than quietly delivering something else.
+           are ``max_freq / m``.
 
            Quantizing onto the cycle always rounds the *period* up, so an
            electrode is never driven faster than it was asked for: against a

--- a/pulse2percept/stimuli/encoders.py
+++ b/pulse2percept/stimuli/encoders.py
@@ -76,15 +76,23 @@ class Encoder(PrettyPrint, metaclass=ABCMeta):
        pick up. It takes no part in the timing of the pulses themselves.
 
     *  The **pulse clock** belongs to ``freq``. It runs continuously for the
-       whole stimulus rather than restarting at every frame, so a requested
-       frequency is the frequency actually delivered. A pulse takes the
-       modulation parameters of the frame its *onset* falls into, so it is
-       never cut in half by a frame boundary.
+       whole stimulus rather than restarting at every frame, so the frame rate
+       has no say in the rate delivered. A pulse takes the modulation
+       parameters of the frame its *onset* falls into, so it is never cut in
+       half by a frame boundary.
+
+       The rate can still come out below the one requested, but only where the
+       hardware you described cannot express it: ``clock`` and the raster cycle
+       both round a pulse period *up*. Neither ever rounds down, so an
+       electrode is never driven faster, and so never given more charge, than
+       was asked for.
 
     *  The **raster cycle** belongs to the
        :py:class:`~pulse2percept.implants.Raster`, and says which electrodes
-       may pulse when. Pulse periods are whole multiples of it, so electrodes
-       in different raster groups provably never pulse at the same instant.
+       may pulse when, so that no two raster groups are ever active at the same
+       instant. Electrodes on *different* periods would drift into one
+       another's slots, so their periods are pinned to whole multiples of the
+       cycle; electrodes that share a period cannot drift and keep it exactly.
 
     .. versionchanged:: 0.10.0
 
@@ -811,8 +819,11 @@ class AmplitudeEncoder(Encoder):
         ``min_amp`` and a gray level of 1 onto ``max_amp``.
     freq : float, optional
         Pulse train frequency (Hz), the same for every electrode. The pulse
-        clock runs independently of the video, so this is the rate actually
-        delivered whatever the frame rate is.
+        clock runs independently of the video, so the frame rate has no say in
+        the rate delivered. Because every electrode shares this one period, a
+        raster does not quantize it either: the groups keep a fixed offset from
+        one another and cannot drift together. Only ``clock`` can lower it, by
+        rounding the period up to a whole number of cycles.
 
         .. note::
 

--- a/pulse2percept/stimuli/encoders.py
+++ b/pulse2percept/stimuli/encoders.py
@@ -27,6 +27,12 @@ _BIG_TIME = 20000
 _DEFAULT_FRAME_DUR = 500.0
 
 
+def _finite(name, value):
+    """Reject NaN and infinity, which slip through every ``<`` comparison"""
+    if not np.all(np.isfinite(np.asarray(value, dtype=np.float64))):
+        raise ValueError(f"'{name}' must be finite, not {value}.")
+
+
 def _fps(metadata):
     """Frame rate recorded in a (possibly wrapped) stimulus metadata dict
 
@@ -47,10 +53,36 @@ class Encoder(PrettyPrint, metaclass=ABCMeta):
     """Abstract base class for all stimulus encoders
 
     An encoder translates the gray levels of an image or a video into the
-    electrical stimulus that a retinal implant would actually deliver: for
-    every frame, each electrode emits a train of biphasic pulses that lasts one
-    frame period, and the gray level of the pixel that the electrode sees
-    determines some property of that train.
+    electrical stimulus that a retinal implant would actually deliver: each
+    electrode emits a train of biphasic pulses, and the gray level of the pixel
+    that the electrode sees determines some property of that train.
+
+    Three clocks are involved, and they are deliberately independent of one
+    another:
+
+    *  The **frame clock** belongs to the video. It says when the modulation
+       parameters update -- a new frame is a new gray level, and hence a new
+       amplitude or a new frequency. It is also the rate at which a percept is
+       worth reporting, which is why it is recorded in the encoded stimulus'
+       metadata for :py:meth:`~pulse2percept.models.Model.predict_percept` to
+       pick up. It takes no part in the timing of the pulses themselves.
+
+    *  The **pulse clock** belongs to ``freq``. It runs continuously for the
+       whole stimulus rather than restarting at every frame, so a requested
+       frequency is the frequency actually delivered. A pulse takes the
+       modulation parameters of the frame its *onset* falls into, so it is
+       never cut in half by a frame boundary.
+
+    *  The **raster cycle** belongs to the
+       :py:class:`~pulse2percept.implants.Raster`, and says which electrodes
+       may pulse when. Pulse periods are whole multiples of it, so electrodes
+       in different raster groups provably never pulse at the same instant.
+
+    .. versionchanged:: 0.10.0
+
+        Pulse timing no longer restarts at every video frame. Before, a frame
+        that was not a whole number of pulse periods long silently changed the
+        pulse rate: at 29.97 fps, ``freq=50`` delivered 59.94 pulses per second.
 
     All encoders share the same two-step structure:
 
@@ -85,12 +117,13 @@ class Encoder(PrettyPrint, metaclass=ABCMeta):
     pulse : :py:class:`~pulse2percept.stimuli.Stimulus`, optional
         A single pulse to repeat, in place of the symmetric biphasic pulse
         built from ``phase_dur``, ``interphase_dur`` and ``cathodic_first``
-        (which are then ignored). Its amplitude is normalized away, since that
-        is what the encoder sets; only its shape is used. It must start and end
-        at zero, since it is tiled into a train.
+        (which are then ignored). Only its *shape* is used: its amplitude is
+        normalized away, since that is what the encoder sets, and its time axis
+        is shifted to start at zero. It must start and end at zero amplitude,
+        since it is tiled into a train.
     clock : float, optional
         Period (ms) of the stimulator's time base. Pulse periods and raster
-        delays are rounded to a whole number of clock cycles, as they would be
+        offsets are rounded to a whole number of clock cycles, as they would be
         on real hardware. If None, they are placed at the full resolution of
         the simulation (``DT`` = 1e-3 ms).
 
@@ -110,9 +143,11 @@ class Encoder(PrettyPrint, metaclass=ABCMeta):
         If None, they are taken at full precision.
     raster : :py:class:`~pulse2percept.implants.Raster`, optional
         How the stimulator takes turns between electrodes it cannot drive at
-        the same time; electrodes in later raster groups start their pulses
-        later in the frame. If None, the ``implant``'s own raster is used, and
-        failing that every electrode fires at the start of the frame.
+        the same time. Each raster group gets its own slot within a repeating
+        raster cycle, and pulse periods are quantized onto that cycle, so no
+        two groups are ever active at once. If None, the ``implant``'s own
+        raster is used, and failing that every electrode fires on the same
+        schedule.
     frame_dur : float, optional
         Duration (ms) of a single frame. If None, it is inferred from the
         source's frame rate (or, failing that, from its time axis). A source
@@ -141,8 +176,10 @@ class Encoder(PrettyPrint, metaclass=ABCMeta):
     def __init__(self, implant=None, phase_dur=0.46, interphase_dur=0,
                  cathodic_first=True, pulse=None, clock=None, n_levels=None,
                  raster=None, frame_dur=None, stretch=False):
+        _finite('phase_dur', phase_dur)
         if phase_dur <= DT:
             raise ValueError(f"'phase_dur' must be greater than DT={DT} ms.")
+        _finite('interphase_dur', interphase_dur)
         if interphase_dur < 0:
             raise ValueError("'interphase_dur' cannot be negative.")
         if pulse is not None:
@@ -155,13 +192,25 @@ class Encoder(PrettyPrint, metaclass=ABCMeta):
                 raise ValueError(f"'pulse' must be a single-electrode "
                                  f"stimulus, not one with {pulse.shape[0]} "
                                  f"electrodes.")
-        if clock is not None and clock < DT:
-            raise ValueError(f"'clock' cannot be finer than the simulation "
-                             f"time step DT={DT} ms.")
-        if n_levels is not None and n_levels < 2:
-            raise ValueError("'n_levels' must be at least 2.")
-        if frame_dur is not None and frame_dur <= 0:
-            raise ValueError("'frame_dur' must be positive.")
+        if clock is not None:
+            _finite('clock', clock)
+            if clock < DT:
+                raise ValueError(f"'clock' cannot be finer than the simulation "
+                                 f"time step DT={DT} ms.")
+        if n_levels is not None:
+            _finite('n_levels', n_levels)
+            # A fractional `n_levels` would quietly become a fractional step
+            # size, and the number of levels you got back would not be the
+            # number you asked for:
+            if int(n_levels) != n_levels:
+                raise ValueError(f"'n_levels' must be a whole number, not "
+                                 f"{n_levels}.")
+            if n_levels < 2:
+                raise ValueError("'n_levels' must be at least 2.")
+        if frame_dur is not None:
+            _finite('frame_dur', frame_dur)
+            if frame_dur <= 0:
+                raise ValueError("'frame_dur' must be positive.")
         self.implant = implant
         self.phase_dur = phase_dur
         self.interphase_dur = interphase_dur
@@ -202,29 +251,6 @@ class Encoder(PrettyPrint, metaclass=ABCMeta):
         """
         raise NotImplementedError
 
-    def _delays(self, electrodes, frame_dur):
-        """Per-electrode delay (ms) into the frame window
-
-        By default every electrode fires at the start of each frame. A
-        stimulator that cannot drive them all at once staggers them instead,
-        which is what a :py:class:`~pulse2percept.implants.Raster` describes.
-
-        Returns
-        -------
-        delay : (n_electrodes,) array
-            Delay (ms) between the start of a frame and this electrode's first
-            pulse.
-        """
-        # An explicit raster wins over the implant's own, so that a raster can
-        # be tried out without modifying the implant:
-        raster = self.raster
-        if raster is None:
-            raster = getattr(self.implant, 'raster', None)
-        if raster is None:
-            return np.zeros(len(electrodes), dtype=np.float32)
-        return np.asarray(raster.delays(electrodes, frame_dur),
-                          dtype=np.float32)
-
     def _as_frames(self, source):
         """Reduce the source to one gray level per electrode per frame
 
@@ -244,15 +270,20 @@ class Encoder(PrettyPrint, metaclass=ABCMeta):
         if not isinstance(source, Stimulus):
             raise TypeError(f"'source' must be a Stimulus object, not "
                             f"{type(source)}.")
+        # Read the frame rate off the *source*: sampling at electrode locations
+        # does not necessarily carry it along.
         fps = _fps(source.metadata)
         stim = source
         if (self.implant is not None and
-                isinstance(stim, (ImageStimulus, VideoStimulus)) and
-                len(stim.electrodes) != self.implant.n_electrodes):
+                isinstance(stim, (ImageStimulus, VideoStimulus))):
             # Sample the source at the electrode locations. This is the same
             # step that assigning an image or a video to `implant.stim` would
             # perform, done here so that the pulse trains below are built at
-            # electrode resolution rather than at pixel resolution:
+            # electrode resolution rather than at pixel resolution. It is also
+            # where RGB becomes gray. Row count is not a usable test of whether
+            # a source is already in electrode coordinates -- a 10x6 image and
+            # an RGB 4x5 image both have exactly as many rows as Argus II has
+            # electrodes -- so always reshape:
             stim = self.implant.reshape_stim(stim)
         gray = np.clip(np.asarray(stim.data, dtype=np.float32), 0, 1)
         if stim.time is None:
@@ -291,7 +322,8 @@ class Encoder(PrettyPrint, metaclass=ABCMeta):
         """The pulse to repeat, as (ticks, values) with unit peak amplitude
 
         The values peak at -1 (cathodic first) or +1, so that multiplying by an
-        amplitude in uA yields the pulse to deliver.
+        amplitude in uA yields the pulse to deliver. The ticks start at zero,
+        whatever the supplied pulse's time axis did.
         """
         if self.pulse is None:
             pulse = BiphasicPulse(1, self.phase_dur,
@@ -311,78 +343,181 @@ class Encoder(PrettyPrint, metaclass=ABCMeta):
             raise ValueError(f"'pulse' has time points closer together than "
                              f"DT={DT} ms, which the simulation cannot "
                              f"resolve. Lengthen 'phase_dur'.")
+        # `Stimulus` only requires a time axis to be ordered, not to start at
+        # zero. What is borrowed from the supplied pulse is its shape, so
+        # anchor it at zero rather than rendering every copy of it that far
+        # into the train:
+        ticks = ticks - ticks[0]
         # A pulse is tiled into a train, and the gaps between the copies carry
         # whatever its end points carry. Anything but zero would smear across
-        # the whole frame:
+        # the whole train:
         if values[0] != 0 or values[-1] != 0:
             raise ValueError("'pulse' must start and end at zero amplitude, "
-                             "since it is repeated to fill a frame.")
+                             "since it is repeated to fill a train.")
         return ticks, values
 
-    def _schedule(self, freq, delay, last, pulse_ticks):
-        """When each electrode pulses during a frame
+    def _periods(self, freq, pulse_len):
+        """Pulse period for every electrode and frame
 
-        Parameters
-        ----------
-        last : int
-            The last tick of the frame that a pulse may occupy.
+        The period is carried as a (possibly fractional) number of ticks rather
+        than being rounded onto the ``DT`` grid, and each pulse onset is
+        rounded only when it is placed. Rounding the period instead would let
+        the error accumulate: a 30 Hz period is 33333.33 ticks, and stepping by
+        33333 of them drifts a third of a tick per pulse, which is enough to
+        walk the train off the frame it belongs to over the course of a video.
 
         Returns
         -------
-        group : (n_electrodes, n_frames) int array
-            Which schedule each electrode is on during each frame. Electrodes
-            on the same schedule pulse at the same times, and so differ only by
-            the amplitude that scales their waveform.
-        onsets : list of arrays
-            The pulse onsets (in ticks since the start of the frame) of each
-            schedule, indexed by group.
+        firing : (n_electrodes, n_frames) bool array
+            Whether the pulse clock is running at all.
+        period : (n_electrodes, n_frames) float array
+            The period, in ticks, or 0 where the clock is not running.
 
         """
-        pulse_len = pulse_ticks[-1] - pulse_ticks[0]
-        # Pulse period. A clocked stimulator can only realize a period that is
-        # a whole number of clock cycles, which is what keeps the number of
-        # distinct schedules (and hence of time points) down:
-        window = np.zeros(freq.shape, dtype=np.int64)
         firing = freq > 0
-        window[firing] = self._ticks(1000.0 / freq[firing])
+        period = np.zeros(freq.shape, dtype=np.float64)
+        period[firing] = 1000.0 / freq[firing] / DT
+        # A clocked stimulator can only realize a period that is a whole number
+        # of clock cycles, which is what keeps the number of distinct schedules
+        # (and hence of time points) down:
         if self.clock is not None:
-            cycle = max(1, int(self._ticks(self.clock)))
-            window[firing] = cycle * np.maximum(
-                1, np.round(window[firing] / cycle).astype(np.int64))
-            delay = cycle * np.round(delay / cycle).astype(np.int64)
-        if np.any(window[firing] < pulse_len):
-            too_fast = 1000.0 / (np.min(window[firing]) * DT)
+            tick = self.clock / DT
+            period[firing] = tick * np.maximum(
+                1.0, np.round(period[firing] / tick))
+        if np.any(period[firing] < pulse_len):
+            too_fast = 1000.0 / (np.min(period[firing]) * DT)
             raise ValueError(f"A pulse (dur={pulse_len * DT:.3f} ms) does not "
                              f"fit into the pulse train window of a "
                              f"{too_fast:.1f} Hz train. Shorten 'phase_dur' "
                              f"or lower the frequency.")
-        # Only whole pulses: a stimulator does not begin a pulse it cannot
-        # finish before the frame is over.
-        room = last - delay - pulse_len
-        n_pulses = np.where(firing & (room >= 0),
-                            room // np.maximum(window, 1) + 1, 0)
-        # An electrode that was asked to fire but has no room left to do so has
-        # been rastered out of its own frame, which would otherwise drop its
-        # stimulus without saying so:
-        silent = firing & (n_pulses == 0)
-        if np.any(silent):
-            worst = np.max(np.broadcast_to(delay, freq.shape)[silent])
+        return firing, period
+
+    def _raster_grid(self, electrodes, period, firing, pulse_len):
+        """The slot each electrode may pulse in, and the raster cycle
+
+        The cycle a raster has to get through is the shortest pulse period
+        anyone asked for. Under amplitude modulation that is *the* period, so
+        every group gets its turn exactly once per pulse and the requested
+        frequency is delivered exactly. Under frequency modulation it is set by
+        the fastest electrode, and slower ones pulse every m-th cycle.
+
+        Returns
+        -------
+        offset : (n_electrodes,) float array
+            How far into a raster cycle (in ticks) each electrode may start a
+            pulse.
+        cycle : float or None
+            The raster cycle in ticks, onto which pulse periods are quantized.
+            None when there is nothing to multiplex.
+
+        """
+        # An explicit raster wins over the implant's own, so that a raster can
+        # be tried out without modifying the implant:
+        raster = self.raster
+        if raster is None:
+            raster = getattr(self.implant, 'raster', None)
+        zero = np.zeros(len(electrodes), dtype=np.float64)
+        if raster is None or raster.n_groups < 2 or not np.any(firing):
+            return zero, None
+        # Derived from the requested frequencies, not from the amplitudes:
+        # whether a raster is a workable schedule is a property of the device,
+        # not of how bright today's video happens to be.
+        fastest = float(np.min(period[firing]))
+        offset = np.asarray(raster.offsets(electrodes, fastest * DT),
+                            dtype=np.float64) / DT
+        cycle = (fastest if raster.group_dur is None else
+                 raster.n_groups * raster.group_dur / DT)
+        if self.clock is not None:
+            tick = self.clock / DT
+            offset = tick * np.round(offset / tick)
+            cycle = tick * max(1.0, round(cycle / tick))
+        # Every group's turn has to be long enough to finish a pulse in. The
+        # gap to the *next* group's turn is what a collision would show up as,
+        # so measure those rather than the nominal slot -- rounding a slot onto
+        # the clock grid can shorten one gap while lengthening another, and two
+        # groups snapping onto the same offset shows up here as a gap of zero.
+        # A pulse also has to clear the next group's slot by a whole tick, since
+        # each onset is rounded onto the DT grid when it is placed:
+        edges = np.append(np.unique(np.round(offset)), np.round(cycle))
+        gap = float(np.min(np.diff(edges), initial=cycle))
+        if gap < pulse_len + 1:
             raise ValueError(
-                f"{np.count_nonzero(silent.any(axis=1))} electrode(s) start "
-                f"their turn as late as {worst * DT:.3f} ms into the frame, "
-                f"leaving no room for a {pulse_len * DT:.3f} ms pulse before "
-                f"it ends. Use fewer raster groups, or a shorter "
-                f"'phase_dur'.")
-        # Everything about a schedule is fixed by these three numbers:
-        key = np.stack([window.ravel(), n_pulses.ravel(),
-                        np.broadcast_to(delay, freq.shape).ravel()], axis=1)
-        uniq, group = np.unique(key, axis=0, return_inverse=True)
-        onsets = [d + np.arange(n, dtype=np.int64) * w for w, n, d in uniq]
-        return np.reshape(group, freq.shape), onsets
+                f"A raster group gets a {gap * DT:.3f} ms turn, which has no "
+                f"room for a {pulse_len * DT:.3f} ms pulse. Use fewer groups, "
+                f"shorten 'phase_dur', or lower the pulse frequency (a faster "
+                f"pulse train leaves each group less time).")
+        return offset, cycle
+
+    @staticmethod
+    def _onsets(start, period, active, frame_ticks, last, grid):
+        """When one schedule pulses, and which frame each pulse belongs to
+
+        Parameters
+        ----------
+        start : float
+            The first tick at which this schedule may pulse.
+        last : int
+            The last tick at which a pulse may *begin*.
+        grid : float
+            The spacing of the onsets this schedule is allowed to use -- the
+            raster cycle, or failing that the stimulator's clock. A schedule
+            that goes silent has to come back onto it.
+
+        Returns
+        -------
+        onset : (n_pulses,) int array
+            The tick each pulse begins at.
+        frame : (n_pulses,) int array
+            The frame whose modulation parameters each pulse carries.
+
+        """
+        n_frames = frame_ticks.size
+        empty = np.zeros(0, dtype=np.int64)
+        # Fast path: one period for the whole stimulus, which is what amplitude
+        # modulation always produces. The onsets are then an arithmetic
+        # sequence, and only the frames that deliver nothing drop out of it:
+        step = float(period[0])
+        if step > 0 and np.all(period == step):
+            if start > last:
+                return empty, empty
+            n = int(np.floor((last - start) / step + 1e-9)) + 1
+            onset = np.round(start + np.arange(n) * step).astype(np.int64)
+            frame = np.searchsorted(frame_ticks, onset, side='right') - 1
+            np.clip(frame, 0, n_frames - 1, out=frame)
+            keep = active[frame]
+            return onset[keep], frame[keep]
+        # Frequency modulation: the period changes from frame to frame, and the
+        # next pulse is scheduled from the previous one rather than from the
+        # frame boundary, so that the pulse clock keeps its phase. `t` stays
+        # unrounded for the same reason the period does -- rounding it here
+        # would let the error accumulate from pulse to pulse:
+        onset, frame, t = [], [], float(start)
+        while t <= last:
+            tick = int(round(t))
+            k = int(np.searchsorted(frame_ticks, tick, side='right')) - 1
+            k = min(max(k, 0), n_frames - 1)
+            if active[k]:
+                onset.append(tick)
+                frame.append(k)
+            if period[k] > 0:
+                # The clock runs even where the amplitude is zero, so a dark
+                # frame does not reset the phase of the frames around it:
+                t += float(period[k])
+            elif k + 1 < n_frames:
+                # Nothing to stay in phase with, so pick the schedule back up
+                # at the next frame -- but on this schedule's own grid, or a
+                # silent stretch would knock every pulse after it off the
+                # stimulator's clock and multiply the time points needed:
+                nxt = float(frame_ticks[k + 1])
+                t = start + grid * np.ceil((nxt - start) / grid)
+            else:
+                break
+        return (np.asarray(onset, dtype=np.int64).reshape(-1),
+                np.asarray(frame, dtype=np.int64).reshape(-1))
 
     @staticmethod
     def _sample(onset, pulse_ticks, pulse_vals, ticks):
-        """Sample one schedule's pulse train onto a frame's time axis"""
+        """Sample one schedule's pulse train onto the stimulus' time axis"""
         t = (onset[:, np.newaxis] + pulse_ticks[np.newaxis, :]).ravel()
         v = np.tile(pulse_vals, onset.size)
         # Back-to-back pulses share an end point, which both copies of the
@@ -390,109 +525,139 @@ class Encoder(PrettyPrint, metaclass=ABCMeta):
         t, keep = np.unique(t, return_index=True)
         return np.interp(ticks, t, v[keep])
 
-    def _assemble(self, amp, freq, delay, electrodes, frame_time, frame_dur):
+    def _assemble(self, amp, freq, electrodes, frame_time, frame_dur):
         """Build the pulse trains for every electrode and frame
 
-        Electrodes on the same schedule share the *shape* of their within-frame
+        Electrodes that pulse at the same *times* share the shape of their
         waveform; only the amplitude that scales it differs. So rather than
         building one waveform per electrode, this builds one per distinct
         schedule and indexes into them, which is what keeps frequency
         modulation (thousands of electrode-frames, a few dozen schedules)
         tractable.
 
-        Each frame gets its own time axis -- the union of the times the
-        schedules *it* uses need -- rather than one axis shared by the whole
-        video. That matters when there are many schedules but each frame draws
-        on only a few of them, which is exactly the unquantized frequency
-        modulation case: a shared axis costs 20 times more there.
+        The time axis is global rather than per-frame. Pulses live at absolute
+        times and no two frames' pulses coincide, so this costs no more than
+        laying each frame out separately did -- and it lets a pulse straddle a
+        frame boundary, which is what keeps the pulse clock free of the frame
+        clock.
         """
         n_el, n_frames = len(electrodes), frame_time.size
         shape = (n_el, n_frames)
-        amp = np.broadcast_to(np.asarray(amp, dtype=np.float32), shape)
-        freq = np.broadcast_to(np.asarray(freq, dtype=np.float64), shape)
-        delay = self._ticks(delay).reshape((-1, 1))
-        # The last tick a frame may occupy. It has to leave at least DT before
-        # the next frame starts, and `frame_dur` is generally not a whole
-        # number of ticks (a 29.97 fps frame is 33.3667 ms), so this floors
-        # rather than rounds. The epsilon keeps a frame duration that *is* a
-        # whole number of ticks from losing one to binary rounding:
-        last = int(np.floor((frame_dur - DT) / DT + 1e-9))
+        amp = np.ascontiguousarray(
+            np.broadcast_to(np.asarray(amp, dtype=np.float32), shape))
+        freq = np.ascontiguousarray(
+            np.broadcast_to(np.asarray(freq, dtype=np.float64), shape))
         pulse_ticks, pulse_vals = self._unit_pulse()
-        if pulse_ticks[-1] > last:
-            raise ValueError(f"A pulse (dur={pulse_ticks[-1] * DT:.3f} ms) "
-                             f"does not fit into a frame "
-                             f"(dur={frame_dur:.3f} ms). Shorten 'phase_dur' "
-                             f"or lower the frame rate.")
-        slowest = np.min(freq[freq > 0], initial=np.inf)
-        if slowest < 1000.0 / frame_dur:
-            warnings.warn(f"freq={slowest:.2f} Hz is slower than the frame "
-                          f"rate ({1000.0 / frame_dur:.2f} Hz), so each frame "
-                          f"still receives one pulse. The effective pulse "
-                          f"rate is the frame rate.")
-        group, onsets = self._schedule(freq, delay, last, pulse_ticks)
+        pulse_len = int(pulse_ticks[-1])
+        frame_ticks = self._ticks(frame_time)
+        total = float(frame_time[-1] + frame_dur)
+        # The stimulus lasts exactly as long as the source did. Flooring (with
+        # an epsilon so a duration that *is* a whole number of ticks does not
+        # lose one to binary rounding) leaves at least one tick between the
+        # last pulse and the end point that pins the duration:
+        end = int(np.floor(total / DT + 1e-9))
+        last = end - 1 - pulse_len
+        if last < 0:
+            raise ValueError(f"A pulse (dur={pulse_len * DT:.3f} ms) does not "
+                             f"fit into a stimulus of {total:.3f} ms. Shorten "
+                             f"'phase_dur' or lengthen the source.")
+        firing, period = self._periods(freq, pulse_len)
+        # An electrode delivering no current has nothing to schedule. Its clock
+        # keeps running (`firing`), so it stays in phase with its neighbors,
+        # but it costs no pulses and no time points:
+        active = firing & (amp != 0)
+        offset, cycle = self._raster_grid(electrodes, period, firing, pulse_len)
+        if cycle is not None:
+            # A period that is a whole number of raster cycles is what keeps
+            # two groups from ever drifting onto the same instant:
+            period[firing] = cycle * np.maximum(
+                1.0, np.round(period[firing] / cycle))
 
-        # Lay each frame out on just the time points its own schedules need,
-        # rather than on the union over the whole video. A frame in which every
-        # electrode is dark then costs two time points instead of hundreds.
-        # Frames often draw on the same handful of schedules, so the layout is
-        # cached by which ones they use:
-        layout, cache = [], {}
-        for k in range(n_frames):
-            present, local = np.unique(group[:, k], return_inverse=True)
-            # NumPy has changed the shape `return_inverse` comes back with
-            # between 2.x releases, and it indexes rows below:
-            local = np.ravel(local)
-            key = present.tobytes()
-            if key not in cache:
-                # Tick 0 and the last tick pin the frame to its full duration,
-                # whatever the schedules do in between:
-                cache[key] = np.unique(np.concatenate(
-                    [np.array([0, last], dtype=np.int64)] +
-                    [(onsets[g][:, np.newaxis] +
-                      pulse_ticks[np.newaxis, :]).ravel()
-                     for g in present if onsets[g].size]))
-            layout.append((present, local, cache[key]))
-        n_time = sum(ticks.size for _, _, ticks in layout)
+        # Everything about when an electrode pulses is fixed by its slot and by
+        # the period/activity it carries through the frames:
+        key = np.concatenate([offset[:, np.newaxis], period,
+                              active.astype(np.float64)], axis=1)
+        uniq, sched = np.unique(key, axis=0, return_inverse=True)
+        # NumPy has changed the shape `return_inverse` comes back with between
+        # 2.x releases, and it indexes rows below:
+        sched = np.ravel(sched)
+        origin = float(frame_ticks[0])
+        # The grid a schedule's onsets live on: the raster cycle if there is
+        # one, else the stimulator's clock, else the simulation's own step.
+        grid = (cycle if cycle is not None else
+                (self.clock / DT if self.clock is not None else 1.0))
+        onsets, frames = [], []
+        for row in uniq:
+            onset, frame = self._onsets(
+                origin + row[0], row[1:1 + n_frames],
+                row[1 + n_frames:].astype(bool), frame_ticks, last, grid)
+            onsets.append(onset)
+            frames.append(frame)
+        # A frame whose gray levels never reach an electrode is content thrown
+        # away, which is what asking for a pulse rate below the frame rate
+        # does. It is no longer a limit on the rate itself:
+        hit = np.zeros(n_frames, dtype=bool)
+        for f in frames:
+            hit[f] = True
+        missed = np.count_nonzero(~hit & active.any(axis=0))
+        if missed:
+            warnings.warn(f"{missed} of {n_frames} frames deliver no pulse at "
+                          f"all, because the pulse period is longer than a "
+                          f"frame ({1000.0 / frame_dur:.2f} fps). Their gray "
+                          f"levels are never sampled; raise the frequency to "
+                          f"see them.")
+
+        ticks = np.unique(np.concatenate(
+            [np.array([0, end], dtype=np.int64)] +
+            [(o[:, np.newaxis] + pulse_ticks[np.newaxis, :]).ravel()
+             for o in onsets if o.size]))
+        n_time = ticks.size
         if n_time > _BIG_TIME:
             warnings.warn(f"This stimulus has {n_time} time points, which "
                           f"every model downstream will pay for. Coarsening "
-                          f"'clock' puts more electrodes on the same pulse "
-                          f"schedule; 'n_levels' reduces how many schedules "
-                          f"there are.")
+                          f"'clock' is the lever that helps most, since it "
+                          f"confines every pulse onset to the same grid; a "
+                          f"'raster' does the same. 'n_levels' helps far less "
+                          f"on its own, because two electrodes on the same "
+                          f"gray level still pulse at different times.")
         if n_el * n_time > _BIG_STIM and self.implant is None:
             warnings.warn(f"Encoding {n_el} electrodes x {n_time} time points "
                           f"will allocate {n_el * n_time * 4 / 1e9:.1f} GB. "
                           f"Pass 'implant' to encode at electrode resolution "
                           f"instead.")
 
-        # One unit-amplitude waveform per schedule present in the frame, scaled
-        # by each electrode's amplitude. Sampling a schedule onto the frame's
+        # One unit-amplitude waveform per schedule, scaled by the amplitude of
+        # whichever frame each pulse belongs to. Sampling a schedule onto the
         # time axis is exact: its own time points are a subset of that axis,
         # and everything between two of them is either a plateau or a gap, both
         # of which linear interpolation reproduces.
-        data = np.empty((n_el, n_time), dtype=np.float32)
-        time = np.empty(n_time, dtype=np.float64)
-        col = 0
-        for k, (present, local, ticks) in enumerate(layout):
-            wave = np.zeros((present.size, ticks.size), dtype=np.float32)
-            for idx, g in enumerate(present):
-                if onsets[g].size:
-                    wave[idx] = self._sample(onsets[g], pulse_ticks,
-                                             pulse_vals, ticks)
-            block = data[:, col:col + ticks.size]
-            np.multiply(amp[:, k:k + 1], wave[local], out=block)
-            time[col:col + ticks.size] = frame_time[k] + ticks * DT
-            col += ticks.size
-        # There is no frame after the last one to keep clear of, so let the
-        # stimulus last exactly as long as the source did:
-        time[-1] = frame_time[-1] + frame_dur
+        data = np.zeros((n_el, n_time), dtype=np.float32)
+        for s, (onset, frame) in enumerate(zip(onsets, frames)):
+            rows = np.flatnonzero(sched == s)
+            if rows.size == 0 or onset.size == 0:
+                continue
+            wave = self._sample(onset, pulse_ticks, pulse_vals, ticks)
+            # Which pulse -- and hence which frame's amplitude -- each time
+            # point belongs to. Points before the first pulse and in the gaps
+            # between pulses carry a zero waveform, so what they pick up here
+            # never reaches the output:
+            at = np.searchsorted(onset, ticks, side='right') - 1
+            np.clip(at, 0, onset.size - 1, out=at)
+            data[rows] = amp[rows][:, frame[at]] * wave
+        time = ticks * DT
+        time[-1] = total
         stim = Stimulus(data, electrodes=electrodes, time=time)
         # Provenance, not something a model should compute from: the stimulus
-        # is a plain `Stimulus` and every consumer reads its data container:
+        # is a plain `Stimulus` and every consumer reads its data container.
+        # `frame_time` is what lets a percept be reported on the video's own
+        # clock rather than on the pulse train's:
         stim.metadata['encoder'] = {'kind': type(self).__name__,
                                     'frame_dur': frame_dur,
                                     'n_frames': n_frames,
-                                    'n_schedules': len(onsets)}
+                                    'frame_time': frame_time,
+                                    'cycle': None if cycle is None else
+                                    cycle * DT,
+                                    'n_schedules': len(uniq)}
         return stim
 
     def encode(self, source):
@@ -523,9 +688,7 @@ class Encoder(PrettyPrint, metaclass=ABCMeta):
             steps = self.n_levels - 1
             gray = np.round(gray * steps) / steps
         amp, freq = self._modulate(gray)
-        delay = self._delays(electrodes, frame_dur)
-        return self._assemble(amp, freq, delay, electrodes, frame_time,
-                              frame_dur)
+        return self._assemble(amp, freq, electrodes, frame_time, frame_dur)
 
 
 class AmplitudeEncoder(Encoder):
@@ -534,6 +697,11 @@ class AmplitudeEncoder(Encoder):
     Every electrode emits a pulse train of the same fixed frequency, and the
     gray level of the pixel it sees sets the amplitude of those pulses. This is
     how most retinal prostheses encode a video.
+
+    Because every electrode shares one pulse period, a raster splits that
+    period evenly between its groups: each group pulses exactly once per period
+    in its own slot, ``freq`` is delivered exactly, and no two groups are ever
+    active at the same instant.
 
     .. versionadded:: 0.10.0
 
@@ -546,14 +714,15 @@ class AmplitudeEncoder(Encoder):
         Range of pulse amplitudes (uA). A gray level of 0 maps onto
         ``min_amp`` and a gray level of 1 onto ``max_amp``.
     freq : float, optional
-        Pulse train frequency (Hz), the same for every electrode.
+        Pulse train frequency (Hz), the same for every electrode. The pulse
+        clock runs independently of the video, so this is the rate actually
+        delivered whatever the frame rate is.
 
         .. note::
 
-           A frequency below the frame rate cannot be realized: a frame that is
-           shorter than one pulse train cycle still receives a single pulse, so
-           the effective pulse rate is the frame rate. Encoding warns when this
-           happens.
+           A frequency below the frame rate is realizable, but wasteful: some
+           frames then receive no pulse at all and their gray levels are never
+           delivered. Encoding warns when this happens.
 
     phase_dur, interphase_dur, cathodic_first, frame_dur, stretch
         See :py:class:`~pulse2percept.stimuli.Encoder`.
@@ -575,10 +744,12 @@ class AmplitudeEncoder(Encoder):
         if np.size(amp_range) != 2:
             raise ValueError(f"'amp_range' must be a (min_amp, max_amp) "
                              f"tuple, not {amp_range}.")
+        _finite('amp_range', amp_range)
         if np.any(np.asarray(amp_range) < 0):
             raise ValueError(f"'amp_range' cannot be negative: the sign of "
                              f"the pulse is set by 'cathodic_first', not by "
                              f"the amplitude. Got {amp_range}.")
+        _finite('freq', freq)
         if freq < 0:
             raise ValueError("'freq' cannot be negative.")
         self.amp_range = amp_range
@@ -610,23 +781,33 @@ class FrequencyEncoder(Encoder):
        electrode's pulse has an edge, rather than the handful of time points
        that amplitude modulation shares between all of them.
 
-       Both ``clock`` and ``n_levels`` cut that down, and both are physically
-       motivated -- real stimulators have a time base, and real encoders have
-       an input resolution. Encoding the 94-frame ``BostonTrain`` for Argus II
-       at frequencies in (0, 300] Hz, and predicting a 65x97 percept from it:
+       ``clock`` is the lever that cuts that down, and it is physically
+       motivated: real stimulators have a time base. Encoding the 94-frame
+       ``BostonTrain`` for Argus II at frequencies in (0, 300] Hz:
 
-       ===================  ===========  ==========  ==============
-       setting              time points  percept     predict_percept
-       ===================  ===========  ==========  ==============
-       (amplitude modulat.)         752       17 MB          2.7 s
-       no quantization          121,494      3.0 GB              --
-       ``clock=1``               18,056      453 MB         11.8 s
-       ``clock=2``               10,083      252 MB          7.4 s
-       ``n_levels=8``            17,537      440 MB         10.5 s
-       ``clock=1, n_levels=8``   13,674      343 MB          9.2 s
-       ===================  ===========  ==========  ==============
+       =======================  ===========
+       setting                  time points
+       =======================  ===========
+       (amplitude modulation)           442
+       no quantization              142,704
+       ``clock=1``                   21,519
+       ``clock=2``                   10,886
+       ``n_levels=8``                88,748
+       ``clock=1, n_levels=8``       20,987
+       =======================  ===========
 
-       Start with ``clock=1``, which costs nothing in frequency range.
+       Start with ``clock=1``, which costs nothing in frequency range, and
+       coarsen it from there.
+
+       ``n_levels`` is a much weaker lever here than the numbers above might
+       suggest, and only worth reaching for once ``clock`` is set. Because the
+       pulse clock keeps its phase across frames, two electrodes quantized onto
+       the same gray level still pulse at different *times* unless their whole
+       history matches; quantizing gray levels no longer collapses them onto a
+       shared schedule the way it would if every frame restarted the train.
+
+       A raster cuts the cost too, and for the same reason a clock does: it
+       confines every onset to the raster grid.
 
     .. versionadded:: 0.10.0
 
@@ -642,10 +823,13 @@ class FrequencyEncoder(Encoder):
 
         .. note::
 
-           A frame can only hold a whole number of pulses, so at video frame
-           rates the realizable frequencies are coarsely spaced no matter what
-           range is asked for: a 33 ms frame fits at most ten 300 Hz pulses,
-           and so can express about ten levels of gray.
+           Realizable frequencies are quantized by ``clock``, and, when a
+           raster is in play, onto the raster cycle: the fastest electrode
+           pulses once per cycle and slower ones every m-th cycle, so the
+           realizable rates are ``max_freq / m``. Multiplexing a fast train
+           across many groups asks for a lot of a stimulator -- six groups of
+           0.92 ms pulses need 5.5 ms per cycle, or at most 181 Hz -- and
+           encoding raises rather than quietly delivering something else.
     amp : float, optional
         Pulse amplitude (uA), the same for every electrode.
     phase_dur, interphase_dur, cathodic_first, pulse, clock, n_levels, \
@@ -671,8 +855,10 @@ frame_dur, stretch
         if np.size(freq_range) != 2:
             raise ValueError(f"'freq_range' must be a (min_freq, max_freq) "
                              f"tuple, not {freq_range}.")
+        _finite('freq_range', freq_range)
         if np.any(np.asarray(freq_range) < 0):
             raise ValueError(f"'freq_range' cannot be negative: {freq_range}.")
+        _finite('amp', amp)
         if amp < 0:
             raise ValueError(f"'amp' cannot be negative: the sign of the "
                              f"pulse is set by 'cathodic_first', not by the "

--- a/pulse2percept/stimuli/encoders.py
+++ b/pulse2percept/stimuli/encoders.py
@@ -33,6 +33,14 @@ def _finite(name, value):
         raise ValueError(f"'{name}' must be finite, not {value}.")
 
 
+def _all_equal(a):
+    """Whether every element of ``a`` is the same value
+
+    Empty counts as equal: there is nothing there to differ.
+    """
+    return a.size == 0 or bool(np.all(a == a.flat[0]))
+
+
 def _fps(metadata):
     """Frame rate recorded in a (possibly wrapped) stimulus metadata dict
 
@@ -447,16 +455,28 @@ class Encoder(PrettyPrint, metaclass=ABCMeta):
                 group.max(initial=0) >= raster.n_groups):
             raise ValueError(f"'groups' must be in 0..{raster.n_groups - 1}.")
         slot = raster.slot_dur(fastest * DT) / DT
-        if self.clock is not None and raster.group_dur is not None:
-            # An explicit slot is the primitive the cycle is made of, so round
-            # *it* onto the clock and rebuild the cycle from the result. The
-            # other way around -- rounding each offset and the total cycle
-            # independently -- leaves groups with turns of different lengths
-            # and a cycle that is no longer `n_groups` of them:
-            slot = max(1.0, round(slot / (self.clock / DT))) * self.clock / DT
-        # With no explicit slot the groups divide the pulse period, and it is
-        # the period that has to be preserved: keeping the cycle equal to it is
-        # what makes a rastered train run at exactly the requested rate:
+        if self.clock is not None:
+            tick = self.clock / DT
+            if raster.group_dur is not None:
+                # An explicit slot is the primitive the cycle is made of, so
+                # round *it* onto the clock and rebuild the cycle from the
+                # result:
+                slot = max(1.0, round(slot / tick)) * tick
+            else:
+                # Splitting the cycle evenly generally lands the group
+                # boundaries between clock edges, and a stimulator can only
+                # start a pulse on one. Take the largest whole number of clock
+                # cycles that still fits every group into the period (floor):
+                slot = np.floor(slot / tick + 1e-9) * tick
+                if slot < tick:
+                    raise ValueError(
+                        f"A {fastest * DT:.3f} ms pulse period holds only "
+                        f"{int(fastest / tick)} clock cycle(s) of "
+                        f"clock={self.clock:g} ms, which is not enough to give "
+                        f"each of {raster.n_groups} raster groups its own turn. "
+                        f"Use fewer groups, a finer 'clock', or a lower "
+                        f"frequency.")
+        # With no explicit slot the groups divide the pulse period:
         cycle = fastest if raster.group_dur is None else raster.n_groups * slot
         # Check the slot the hardware will actually use, not the one that was
         # asked for: a 5.1 ms slot on a 1 ms clock is a 5 ms slot, and two of
@@ -468,17 +488,15 @@ class Encoder(PrettyPrint, metaclass=ABCMeta):
                 f"not fit into the {fastest * DT:.3f} ms pulse period. Shorten "
                 f"'group_dur', use fewer groups, or lower the frequency.")
         offset = group.astype(np.float64) * slot
-        if self.clock is not None:
-            tick = self.clock / DT
-            offset = tick * np.round(offset / tick)
-        # Every group's turn has to be long enough to finish a pulse in. The
-        # gap to the *next* group's turn is what a collision would show up as,
-        # so measure those rather than the nominal slot -- rounding a slot onto
-        # the clock grid can shorten one gap while lengthening another, and two
-        # groups snapping onto the same offset shows up here as a gap of zero.
-        # A pulse also has to clear the next group's slot by a whole tick, since
-        # each onset is rounded onto the DT grid when it is placed:
-        edges = np.append(np.unique(np.round(offset)), np.round(cycle))
+        # Every group's turn has to be long enough to finish a pulse in, and
+        # each pulse has to clear the next group's turn by a whole tick:
+        edges = np.unique(np.round(offset))
+        if edges.size < np.unique(group).size:
+            raise ValueError(
+                f"Two raster groups were given the same {slot * DT:.3f} ms "
+                f"turn, so they would pulse together. Use fewer groups, a "
+                f"finer 'clock', or a lower frequency.")
+        edges = np.append(edges, np.round(cycle))
         gap = float(np.min(np.diff(edges), initial=cycle))
         if gap < pulse_len + 1:
             raise ValueError(
@@ -653,15 +671,11 @@ class Encoder(PrettyPrint, metaclass=ABCMeta):
         # but it costs no pulses and no time points:
         active = firing & (amp != 0)
         offset, cycle = self._raster_grid(electrodes, period, firing, pulse_len)
-        if cycle is not None:
-            # A period that is a whole number of raster cycles is what keeps
-            # two groups from ever drifting onto the same instant. Round the
-            # period *up* rather than to the nearest cycle: rounding down
-            # delivers more charge than was asked for, and an electrode asking
-            # for 67 Hz against a 10 ms cycle would come back at 100 Hz rather
-            # than 50. The epsilon keeps a period that already is a whole
-            # number of cycles -- every period, under amplitude modulation --
-            # from being pushed up to the next one by binary rounding:
+        if cycle is not None and not _all_equal(period[firing]):
+            # Electrodes on different periods drift relative to one another,
+            # and two groups would eventually land on the same instant. Pinning
+            # every period to a whole number of raster cycles is what stops
+            # that. Round the period *up* rather than to the nearest cycle:
             period[firing] = cycle * np.maximum(
                 1.0, np.ceil(period[firing] / cycle - 1e-9))
 
@@ -719,30 +733,20 @@ class Encoder(PrettyPrint, metaclass=ABCMeta):
                           f"instead.")
 
         # One unit-amplitude waveform per schedule, scaled by the amplitude of
-        # whichever frame each pulse belongs to. Sampling a schedule onto the
-        # time axis is exact: its own time points are a subset of that axis,
-        # and everything between two of them is either a plateau or a gap, both
-        # of which linear interpolation reproduces.
+        # whichever frame each pulse belongs to:
         data = np.zeros((n_el, n_time), dtype=np.float32)
         for s, (onset, frame) in enumerate(zip(onsets, frames)):
             rows = np.flatnonzero(sched == s)
             if rows.size == 0 or onset.size == 0:
                 continue
             wave = self._sample(onset, pulse_ticks, pulse_vals, ticks)
-            # Which pulse -- and hence which frame's amplitude -- each time
-            # point belongs to. Points before the first pulse and in the gaps
-            # between pulses carry a zero waveform, so what they pick up here
-            # never reaches the output:
+            # Which pulse each time point belongs to:
             at = np.searchsorted(onset, ticks, side='right') - 1
             np.clip(at, 0, onset.size - 1, out=at)
             data[rows] = amp[rows][:, frame[at]] * wave
         time = ticks * DT
         time[-1] = total
         stim = Stimulus(data, electrodes=electrodes, time=time)
-        # Provenance, not something a model should compute from: the stimulus
-        # is a plain `Stimulus` and every consumer reads its data container.
-        # `frame_time` is what lets a percept be reported on the video's own
-        # clock rather than on the pulse train's:
         stim.metadata['encoder'] = {'kind': type(self).__name__,
                                     'frame_dur': frame_dur,
                                     'n_frames': n_frames,

--- a/pulse2percept/stimuli/encoders.py
+++ b/pulse2percept/stimuli/encoders.py
@@ -82,17 +82,17 @@ class Encoder(PrettyPrint, metaclass=ABCMeta):
        half by a frame boundary.
 
        The rate can still come out below the one requested, but only where the
-       hardware you described cannot express it: ``clock`` and the raster cycle
-       both round a pulse period *up*. Neither ever rounds down, so an
-       electrode is never driven faster, and so never given more charge, than
-       was asked for.
+       hardware you described cannot express it: ``clock``, and a raster with
+       electrodes on differing rates, both round a pulse period *up*. Neither
+       ever rounds down, so an electrode is never driven faster, and so never
+       given more charge, than was asked for.
 
-    *  The **raster cycle** belongs to the
+    *  The **raster sweep** belongs to the
        :py:class:`~pulse2percept.implants.Raster`, and says which electrodes
        may pulse when, so that no two raster groups are ever active at the same
        instant. Electrodes on *different* periods would drift into one
        another's slots, so their periods are pinned to whole multiples of the
-       cycle; electrodes that share a period cannot drift and keep it exactly.
+       sweep; electrodes that share a period cannot drift and keep it exactly.
 
     .. versionchanged:: 0.10.0
 
@@ -145,7 +145,7 @@ class Encoder(PrettyPrint, metaclass=ABCMeta):
 
         .. important::
 
-           Every timing constraint here -- the clock, and the raster cycle --
+           Every timing constraint here -- the clock, and the raster sweep --
            may *lower* the rate an electrode ends up on, and none of them may
            raise it. Rounding a period down would deliver more charge than was
            asked for, so a time base that cannot represent a rate exactly gives
@@ -174,11 +174,13 @@ class Encoder(PrettyPrint, metaclass=ABCMeta):
         If None, they are taken at full precision.
     raster : :py:class:`~pulse2percept.implants.Raster`, optional
         How the stimulator takes turns between electrodes it cannot drive at
-        the same time. Each raster group gets its own slot within a repeating
-        raster cycle, and pulse periods are quantized onto that cycle, so no
-        two groups are ever active at once. If None, the ``implant``'s own
-        raster is used, and failing that every electrode fires on the same
-        schedule.
+        the same time. Each group starts its pulse a fixed ``group_dur`` behind
+        the group before it, so no two groups are ever active at once. Where
+        electrodes run at *differing* rates they would drift into one another,
+        so there their periods are pinned to whole sweeps; electrodes sharing
+        one rate cannot drift and keep their period exactly. If None, the
+        ``implant``'s own raster is used, and failing that every electrode
+        fires on the same schedule.
     frame_dur : float, optional
         Duration (ms) of a single frame. If None, it is inferred from the
         source's frame rate (or, failing that, from its time axis). A source
@@ -934,12 +936,14 @@ class FrequencyEncoder(Encoder):
         .. note::
 
            Realizable frequencies are quantized by ``clock``, and, when a
-           raster is in play, onto the raster cycle: the fastest electrode
-           pulses once per cycle and slower ones every m-th cycle, so the
-           realizable rates are ``max_freq / m``. Multiplexing a fast train
-           across many groups asks for a lot of a stimulator -- six groups of
-           0.92 ms pulses need 5.5 ms per cycle, or at most 181 Hz -- and
-           encoding raises rather than quietly delivering something else.
+           raster is in play, onto the raster sweep -- which under frequency
+           modulation is the usual case, since the electrodes are by
+           construction on differing rates. The fastest electrode pulses once
+           per sweep and slower ones every m-th sweep, so the realizable rates
+           are ``max_freq / m``. Multiplexing a fast train across many groups
+           asks for a lot of a stimulator -- six groups of 0.92 ms pulses need
+           5.5 ms per sweep, or at most 181 Hz -- and encoding raises rather
+           than quietly delivering something else.
 
            Quantizing onto the cycle always rounds the *period* up, so an
            electrode is never driven faster than it was asked for: against a

--- a/pulse2percept/stimuli/tests/test_encoders.py
+++ b/pulse2percept/stimuli/tests/test_encoders.py
@@ -5,7 +5,7 @@ import numpy.testing as npt
 import pytest
 from scipy.integrate import trapezoid
 
-from pulse2percept.implants import ArgusII, SequentialRaster
+from pulse2percept.implants import ArgusII, CustomRaster, SequentialRaster
 from pulse2percept.stimuli import (AmplitudeEncoder, BiphasicPulse,
                                    BostonTrain, Encoder, FrequencyEncoder,
                                    ImageStimulus, MonophasicPulse, Stimulus,
@@ -832,3 +832,108 @@ def test_Encoder_metadata():
                               0, 1, 16).reshape((4, 4))))
     npt.assert_equal(fm.metadata['encoder']['kind'], 'FrequencyEncoder')
     npt.assert_equal(fm.metadata['encoder']['n_schedules'], 4)
+
+
+def test_Encoder_degenerate_raster_is_no_raster():
+    """A raster with one group has nothing to multiplex, so it changes nothing.
+
+    This is the limiting case that says a raster only ever *staggers* onsets:
+    with a single group there is nobody to stagger against, and the encoded
+    stimulus has to come out bit-for-bit what it would have been without one.
+    That holds even with an explicit ``group_dur``, which would otherwise set
+    the sweep length.
+    """
+    implant = ArgusII()
+    img = ImageStimulus(np.random.default_rng(0).random((6, 10)))
+    kwargs = dict(amp_range=(0, 50), freq=20, frame_dur=200)
+    plain = AmplitudeEncoder(implant, **kwargs).encode(img)
+    npt.assert_equal(plain.metadata['encoder']['cycle'], None)
+
+    names = list(implant.electrode_names)
+    for raster in (SequentialRaster(1),
+                   SequentialRaster(1, group_dur=3.0),
+                   SequentialRaster(1, interleave=True),
+                   CustomRaster([names]),
+                   CustomRaster({n: 0 for n in names})):
+        npt.assert_equal(raster.n_groups, 1)
+        got = AmplitudeEncoder(implant, raster=raster, **kwargs).encode(img)
+        npt.assert_array_equal(got.data, plain.data)
+        npt.assert_array_equal(got.time, plain.time)
+        npt.assert_equal(got.metadata['encoder']['cycle'], None)
+        # Nothing is staggered, so every electrode still fires together and the
+        # stimulator has to source the whole array at once:
+        npt.assert_almost_equal(np.abs(got.data).sum(axis=0).max(),
+                                np.abs(plain.data).sum(axis=0).max())
+
+
+def test_Encoder_degenerate_ranges():
+    """A modulation range of zero width stops the gray levels mattering."""
+    implant = ArgusII()
+    img = ImageStimulus(np.random.default_rng(1).random((6, 10)))
+    kwargs = dict(frame_dur=200)
+
+    # One amplitude for every gray level is a constant-amplitude train...
+    flat = AmplitudeEncoder(implant, amp_range=(30, 30), freq=20,
+                            **kwargs).encode(img)
+    npt.assert_almost_equal(np.abs(flat.data).max(axis=1), 30.0, decimal=4)
+    # ... and one frequency for every gray level is the very same stimulus,
+    # since frequency modulation at a constant rate *is* amplitude modulation
+    # at a constant amplitude:
+    same = FrequencyEncoder(implant, freq_range=(20, 20), amp=30,
+                            **kwargs).encode(img)
+    npt.assert_array_equal(same.data, flat.data)
+    npt.assert_array_equal(same.time, flat.time)
+    npt.assert_equal(same.metadata['encoder']['n_schedules'], 1)
+
+    # A black image asks for no current at all, at either end of the range:
+    black = ImageStimulus(np.zeros((6, 10)))
+    for enc in (AmplitudeEncoder(implant, amp_range=(0, 50), **kwargs),
+                FrequencyEncoder(implant, freq_range=(0, 200), amp=50,
+                                 **kwargs)):
+        npt.assert_equal(np.any(enc.encode(black).data), False)
+
+
+def test_Encoder_n_levels_converges():
+    """Quantizing onto enough gray levels is the same as not quantizing."""
+    implant = ArgusII()
+    img = ImageStimulus(np.random.default_rng(2).random((6, 10)))
+    kwargs = dict(amp_range=(0, 50), freq=20, frame_dur=200)
+    ref = AmplitudeEncoder(implant, **kwargs).encode(img)
+    err = [np.abs(AmplitudeEncoder(implant, n_levels=n,
+                                   **kwargs).encode(img).data - ref.data).max()
+           for n in (4, 16, 256, 1 << 16)]
+    # Each step of 4x in the level count is a step of ~4x in accuracy, and the
+    # finest is close enough to be irrelevant next to a 50 uA range:
+    npt.assert_equal(np.all(np.diff(err) < 0), True)
+    npt.assert_array_less(err[-1], 1e-2)
+    # Two levels is the coarsest allowed, and it is a black-or-white encoding:
+    two = AmplitudeEncoder(implant, n_levels=2, **kwargs).encode(img)
+    npt.assert_array_equal(np.unique(np.abs(two.data).max(axis=1)), [0.0, 50.0])
+
+
+def test_Encoder_frame_rate_does_not_move_the_pulses():
+    """The pulse clock is independent of the frame clock.
+
+    Re-timing the same frames only changes how long the stimulus lasts and
+    which gray level each pulse picks up. It must not change *when* the pulses
+    come, which is what a frame-synchronous encoder would get wrong: at 29.97
+    fps a frame is not a whole number of 20 Hz periods, so restarting the train
+    every frame would silently deliver a different rate.
+    """
+    implant = ArgusII()
+    vid = VideoStimulus(np.random.default_rng(3).random((6, 10, 4)),
+                        metadata={'fps': 10})
+    onsets = []
+    for frame_dur in (100.0, 50.0, 25.0):
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore')
+            stim = AmplitudeEncoder(implant, amp_range=(50, 50), freq=20,
+                                    frame_dur=frame_dur).encode(vid)
+        npt.assert_almost_equal(stim.time[-1], 4 * frame_dur)
+        neg = stim.data[0] < 0
+        onsets.append(stim.time[neg & ~np.concatenate(([False], neg[:-1]))])
+    # Every onset the shorter stimulus has, the longer one has at the same time:
+    for short in onsets[1:]:
+        npt.assert_almost_equal(short, onsets[0][:short.size])
+    # ... and the requested 20 Hz is delivered whatever the frame rate:
+    npt.assert_almost_equal(np.diff(onsets[0]), 50.0, decimal=6)

--- a/pulse2percept/stimuli/tests/test_encoders.py
+++ b/pulse2percept/stimuli/tests/test_encoders.py
@@ -591,6 +591,67 @@ def test_FrequencyEncoder_rate_changes_between_frames():
                             [0, 10, 20, 30, 40, 50, 70, 90, 120], decimal=3)
 
 
+def test_Encoder_raster_slots_land_on_the_clock():
+    # A stimulator can only start a pulse on a clock edge, so splitting a
+    # period evenly between the groups has to be resolved onto that grid.
+    # Rounding each group's offset independently could land two of them on the
+    # *same* edge -- six groups sharing a 5 ms period on a 1 ms clock have only
+    # five edges to go round -- and they would then pulse together, which is
+    # the one thing a raster exists to prevent.
+    img = ImageStimulus(np.ones((6, 2)))
+    with pytest.raises(ValueError, match='clock'):
+        AmplitudeEncoder(freq=200, frame_dur=100, clock=1,
+                         raster=SequentialRaster(6)).encode(img)
+    # Given room, every group gets its own whole number of clock cycles, and
+    # the turns come out evenly spaced rather than jittered onto nearby edges:
+    enc = AmplitudeEncoder(freq=20, frame_dur=200, clock=1,
+                           raster=SequentialRaster(6)).encode(img)
+    starts = np.array([pulse_onsets(enc, e)[0] for e in range(0, 12, 2)])
+    npt.assert_almost_equal(starts, np.arange(6) * 8.0, decimal=3)
+    npt.assert_equal(np.unique(starts).size, 6)
+    # The period is untouched: every electrode still runs at the 20 Hz asked
+    # for, and no two groups ever coincide.
+    for e in range(12):
+        npt.assert_almost_equal(np.diff(pulse_onsets(enc, e)), 50, decimal=3)
+    npt.assert_almost_equal(np.abs(enc.data).sum(axis=0).max(), 100)
+
+
+def test_Encoder_raster_short_slot_keeps_the_rate():
+    # A short explicit slot packs the groups into the start of each period.
+    # That must not change the rate: when every electrode is on the same
+    # period -- which is what amplitude modulation always produces -- two
+    # groups a fixed offset apart can never meet, so there is nothing to
+    # quantize away. Pinning the period to the cycle anyway turned a requested
+    # 20 Hz into 18.5 Hz on Argus II with a 1 ms slot.
+    img = ImageStimulus(np.ones((2, 2)))
+    # 10 ms period against a 2 x 1.5 = 3 ms cycle: quantizing would round the
+    # period up to 12 ms (83 Hz):
+    enc = AmplitudeEncoder(freq=100, frame_dur=200,
+                           raster=SequentialRaster(
+                               2, interleave=True,
+                               group_dur=1.5)).encode(img)
+    npt.assert_almost_equal(enc.metadata['encoder']['cycle'], 3)
+    for e, offset in enumerate([0, 1.5, 0, 1.5]):
+        npt.assert_almost_equal(pulse_onsets(enc, e)[0], offset, decimal=3)
+        npt.assert_almost_equal(np.diff(pulse_onsets(enc, e)), 10, decimal=3)
+    # ... and the groups still never pulse at the same instant, which is the
+    # only reason the quantization was there:
+    npt.assert_equal(np.intersect1d(np.round(pulse_onsets(enc, 0), 3),
+                                    np.round(pulse_onsets(enc, 1), 3)).size, 0)
+    npt.assert_almost_equal(np.abs(enc.data).sum(axis=0).max(), 100)
+    # Frequency modulation still has to quantize, because electrodes on
+    # different periods do drift onto each other:
+    fm = FrequencyEncoder(freq_range=(50, 100), amp=10, frame_dur=200,
+                          raster=SequentialRaster(
+                              2, interleave=True,
+                              group_dur=1.5)).encode(
+                                  ImageStimulus(np.array([[1.0, 0.0],
+                                                          [1.0, 0.0]])))
+    for e in range(4):
+        period = np.diff(pulse_onsets(fm, e))
+        npt.assert_allclose(period / 3, np.round(period / 3), atol=1e-3)
+
+
 def test_FrequencyEncoder_rate_changes_with_raster_offset():
     # A raster group's first legal onset can fall several frames into the video
     # when stimulation is slow relative to it, and the phase accumulator has to

--- a/pulse2percept/stimuli/tests/test_encoders.py
+++ b/pulse2percept/stimuli/tests/test_encoders.py
@@ -427,6 +427,21 @@ def test_Encoder_raster():
     npt.assert_almost_equal(pulse_onsets(enc, 1)[0], 5, decimal=3)
     npt.assert_almost_equal(np.diff(pulse_onsets(enc, 1)), 10, decimal=3)
     npt.assert_almost_equal(enc.metadata['encoder']['cycle'], 10)
+    # Whether the groups fit is decided on the slot the hardware will actually
+    # use. Two 5.1 ms slots do not fit into a 10 ms period, but on a 1 ms clock
+    # they are 5 ms slots, and two of those fit exactly:
+    enc = AmplitudeEncoder(freq=100, frame_dur=100, clock=1,
+                           raster=SequentialRaster(
+                               2, interleave=True,
+                               group_dur=5.1)).encode(img)
+    npt.assert_almost_equal(enc.metadata['encoder']['cycle'], 10)
+    npt.assert_almost_equal(pulse_onsets(enc, 1)[0], 5, decimal=3)
+    # Without a clock to round it there is nothing to round, and it is an error:
+    with pytest.raises(ValueError):
+        AmplitudeEncoder(freq=100, frame_dur=100,
+                         raster=SequentialRaster(
+                             2, interleave=True,
+                             group_dur=5.1)).encode(img)
 
 
 def test_Encoder_raster_frequency_modulation():
@@ -574,6 +589,67 @@ def test_FrequencyEncoder_rate_changes_between_frames():
     # 25 Hz frame finishes 20 ms into itself:
     npt.assert_almost_equal(fm_onsets([1.0, 0.5, 0.25])[0],
                             [0, 10, 20, 30, 40, 50, 70, 90, 120], decimal=3)
+
+
+def test_FrequencyEncoder_rate_changes_with_raster_offset():
+    # A raster group's first legal onset can fall several frames into the video
+    # when stimulation is slow relative to it, and the phase accumulator has to
+    # start counting in the frame that *contains* that onset. Starting at frame
+    # 0 integrated the wrong rates and could even walk the schedule backwards
+    # to an earlier frame boundary.
+    # 20 ms frames; the top of the range is 10 Hz, so the raster cycle is
+    # 100 ms and the second of two groups may only pulse at 50, 150, ... ms:
+    vid = VideoStimulus(np.tile(np.array([0, 1, 0, 0, 0, 0], dtype=float),
+                                (1, 2, 1)).reshape(1, 2, 6),
+                        metadata={'fps': 50})
+    with warnings.catch_warnings():
+        warnings.simplefilter('ignore')
+        enc = FrequencyEncoder(freq_range=(0, 10), amp=10,
+                               raster=SequentialRaster(2)).encode(vid)
+    npt.assert_almost_equal(enc.metadata['encoder']['cycle'], 100)
+    # Only the 20-40 ms frame asks for stimulation, and neither group has a
+    # legal slot inside it -- group 0's fall on 0 and 100 ms, group 1's on 50
+    # and 150 ms, all of which land in frames asking for 0 Hz. So nothing is
+    # delivered at all. Both groups used to fire at their own slot anyway, on
+    # the strength of a frame that was nowhere near it:
+    for e in range(2):
+        npt.assert_equal(pulse_onsets(enc, e).size, 0)
+    npt.assert_almost_equal(np.abs(enc.data).max(), 0)
+    # Widen the window so each group does get a legal slot, and both fire --
+    # in their own slots, a cycle apart:
+    vid = VideoStimulus(np.tile(np.array([1, 1, 1, 0, 0, 1, 1, 1, 1, 1],
+                                         dtype=float),
+                                (1, 2, 1)).reshape(1, 2, 10),
+                        metadata={'fps': 50})
+    with warnings.catch_warnings():
+        warnings.simplefilter('ignore')
+        enc = FrequencyEncoder(freq_range=(0, 10), amp=10,
+                               raster=SequentialRaster(2)).encode(vid)
+    npt.assert_almost_equal(pulse_onsets(enc, 0), [0], decimal=3)
+    npt.assert_almost_equal(pulse_onsets(enc, 1), [50], decimal=3)
+    # A pulse is never delivered into a frame that asked for silence:
+    for e in range(2):
+        for t in pulse_onsets(enc, e):
+            npt.assert_equal(vid.data[e, int(t // 20)] > 0, True)
+
+
+def test_Encoder_clock_never_speeds_up():
+    # Same invariant as the raster, for the stimulator's own time base: a
+    # timing constraint may lower the rate an electrode ends up on, never raise
+    # it, since raising it delivers more charge than was asked for. Realizable
+    # periods are whole clock cycles, so a 3.33 ms period on a 1 ms clock
+    # becomes 4 ms (250 Hz), not 3 ms (333 Hz).
+    img = ImageStimulus(np.ones((2, 2)))
+    for clock, freq, want in [(1, 300, 250.0), (2, 300, 250.0),
+                              (3, 300, 1000 / 6), (1, 137, 125.0)]:
+        enc = FrequencyEncoder(freq_range=(freq, freq), amp=10, frame_dur=200,
+                               clock=clock).encode(img)
+        period = np.diff(pulse_onsets(enc))
+        npt.assert_almost_equal(1000.0 / period, want, decimal=3)
+        # Never faster than requested, and on the clock grid:
+        npt.assert_equal(np.all(period >= 1000.0 / freq - 1e-9), True)
+        npt.assert_allclose(period / clock, np.round(period / clock),
+                            atol=1e-6)
 
 
 def test_FrequencyEncoder_raster_never_speeds_up():

--- a/pulse2percept/stimuli/tests/test_encoders.py
+++ b/pulse2percept/stimuli/tests/test_encoders.py
@@ -69,6 +69,22 @@ def test_Encoder_params():
         FrequencyEncoder(freq_range=(-10, 10))
     with pytest.raises(ValueError):
         FrequencyEncoder(amp=-1)
+    # A fractional level count would quietly become a fractional step size, so
+    # the number of levels you got back would not be the number you asked for:
+    with pytest.raises(ValueError):
+        AmplitudeEncoder(n_levels=2.5)
+    # NaN and infinity slip through every `<` comparison, and would otherwise
+    # surface as something inscrutable much further downstream:
+    for kwargs in [{'freq': np.nan}, {'amp_range': (0, np.nan)},
+                   {'phase_dur': np.nan}, {'interphase_dur': np.inf},
+                   {'frame_dur': np.nan}, {'clock': np.nan},
+                   {'n_levels': np.nan}]:
+        with pytest.raises(ValueError):
+            AmplitudeEncoder(**kwargs)
+    with pytest.raises(ValueError):
+        FrequencyEncoder(amp=np.nan)
+    with pytest.raises(ValueError):
+        FrequencyEncoder(freq_range=(0, np.inf))
     # Encoders pretty-print their parameters:
     npt.assert_equal('amp_range' in str(AmplitudeEncoder()), True)
     npt.assert_equal('freq_range' in str(FrequencyEncoder()), True)
@@ -147,10 +163,16 @@ def test_AmplitudeEncoder_freq():
     enc = AmplitudeEncoder(freq=0).encode(img)
     npt.assert_almost_equal(np.abs(enc.data).max(), 0)
     npt.assert_almost_equal(enc.time[-1], 500)
-    # A frequency below the frame rate cannot be realized, because a frame
-    # cannot hold less than one pulse:
-    with pytest.warns(UserWarning, match='slower than the frame rate'):
-        AmplitudeEncoder(freq=10, frame_dur=20).encode(img)
+    # A frequency below the frame rate is realizable -- the pulse clock does
+    # not care what the frame rate is -- but wasteful: whole frames then go by
+    # without delivering anything, and their gray levels never reach the
+    # electrode:
+    vid = VideoStimulus(np.ones((2, 2, 5)), metadata={'fps': 30})
+    with pytest.warns(UserWarning, match='deliver no pulse'):
+        sparse = AmplitudeEncoder(freq=10).encode(vid)
+    # 5 frames of 33.3 ms is 166.7 ms, which holds two 100 ms periods:
+    npt.assert_equal(n_pulses_of(sparse), 2)
+    npt.assert_almost_equal(np.diff(pulse_onsets(sparse)), 100, decimal=3)
     # A pulse that does not fit into a frame is an error, not a warning:
     with pytest.raises(ValueError):
         AmplitudeEncoder(freq=1000, phase_dur=10).encode(img)
@@ -356,8 +378,10 @@ def test_FrequencyEncoder_implant():
     implant.stim = enc
     npt.assert_equal(implant.stim.shape, enc.shape)
     # The clock is what makes this tractable at all: without one, the same
-    # clip needs more than an order of magnitude more time points:
-    npt.assert_equal(enc.shape[1] < 20000, True)
+    # clip needs several times as many time points:
+    unclocked = FrequencyEncoder(implant, freq_range=(0, 300),
+                                 amp=50).encode(BostonTrain())
+    npt.assert_equal(enc.shape[1] < unclocked.shape[1] / 5, True)
 
 
 def test_Encoder_raster():
@@ -365,26 +389,65 @@ def test_Encoder_raster():
     raster = SequentialRaster(2, interleave=True)
     enc = AmplitudeEncoder(freq=100, frame_dur=100,
                            raster=raster).encode(img)
-    # Rastering splits the electrodes across two pulse schedules, offset by
-    # half a frame:
+    # Rastering splits the electrodes across two pulse schedules. The cycle a
+    # raster has to get through is the pulse *period*, not the frame, so the
+    # two groups are offset by half a period:
     npt.assert_equal(enc.metadata['encoder']['n_schedules'], 2)
-    npt.assert_almost_equal(pulse_onsets(enc, 0)[0], 0, decimal=3)
-    npt.assert_almost_equal(pulse_onsets(enc, 1)[0], 50, decimal=3)
-    # The delayed group keeps the same period, and gets as many whole pulses
-    # as still fit in what is left of the frame:
-    npt.assert_almost_equal(np.diff(pulse_onsets(enc, 1)), 10, decimal=3)
+    npt.assert_almost_equal(enc.metadata['encoder']['cycle'], 10)
+    onsets = [pulse_onsets(enc, e) for e in (0, 1)]
+    npt.assert_almost_equal(onsets[0][0], 0, decimal=3)
+    npt.assert_almost_equal(onsets[1][0], 5, decimal=3)
+    # Both groups keep the full requested rate -- rastering costs no
+    # frequency, it only decides *when* within each period an electrode fires:
+    for group in onsets:
+        npt.assert_almost_equal(np.diff(group), 10, decimal=3)
     npt.assert_equal(n_pulses_of(enc, 0), 10)
-    npt.assert_equal(n_pulses_of(enc, 1), 5)
+    npt.assert_equal(n_pulses_of(enc, 1), 10)
+    # The point of all this: the groups never pulse at the same instant, so
+    # the stimulator only ever sources one group's worth of current. Before,
+    # the groups shared every onset from 50 ms on and this was 100:
+    npt.assert_equal(np.intersect1d(np.round(onsets[0], 3),
+                                    np.round(onsets[1], 3)).size, 0)
+    # Two of the four electrodes are in each group, so the stimulator sources
+    # 2 x 50 uA at a time rather than all 4 x 50 uA:
+    npt.assert_almost_equal(np.abs(enc.data).sum(axis=0).max(), 100)
     # Both groups stay charge-balanced:
     net = trapezoid(enc.data.astype(np.float64),
                     x=enc.time.astype(np.float64))
     npt.assert_almost_equal(net, 0, decimal=3)
-    # A clock snaps the delay along with the period:
-    enc = AmplitudeEncoder(freq=100, frame_dur=100, clock=3,
+    # A clock snaps the slot offsets along with the period. A 4.6 ms slot lands
+    # on 5 ms, and the 10 ms period onto the 9 ms cycle the two slots make:
+    enc = AmplitudeEncoder(freq=100, frame_dur=100, clock=1,
                            raster=SequentialRaster(
                                2, interleave=True,
-                               group_dur=5)).encode(img)
-    npt.assert_almost_equal(pulse_onsets(enc, 1)[0], 6, decimal=3)
+                               group_dur=4.6)).encode(img)
+    npt.assert_almost_equal(pulse_onsets(enc, 1)[0], 5, decimal=3)
+    npt.assert_almost_equal(np.diff(pulse_onsets(enc, 1)), 9, decimal=3)
+    npt.assert_almost_equal(enc.metadata['encoder']['cycle'], 9)
+
+
+def test_Encoder_raster_frequency_modulation():
+    # Under frequency modulation electrodes want different periods, so they
+    # can only be kept apart by quantizing every period onto a common raster
+    # cycle. The fastest electrode pulses once per cycle, slower ones every
+    # m-th cycle, and no two groups ever coincide:
+    img = ImageStimulus(np.linspace(0.25, 1, 16).reshape((4, 4)))
+    enc = FrequencyEncoder(freq_range=(0, 120), amp=10, frame_dur=200,
+                           raster=SequentialRaster(4, interleave=True)).encode(img)
+    cycle = enc.metadata['encoder']['cycle']
+    npt.assert_almost_equal(cycle, 1000 / 120)
+    for e in range(16):
+        # Every period is a whole number of raster cycles, which is what keeps
+        # two groups from drifting onto each other:
+        ratio = np.diff(pulse_onsets(enc, e)) / cycle
+        npt.assert_allclose(ratio, np.round(ratio), atol=1e-3)
+    # Which is the whole point: the current limit holds instant by instant:
+    npt.assert_almost_equal(np.abs(enc.data).sum(axis=0).max(), 4 * 10)
+    # Multiplexing a fast train across many groups asks more of a stimulator
+    # than it can give, and that is an error rather than a silent collision:
+    with pytest.raises(ValueError, match='no room'):
+        FrequencyEncoder(freq_range=(0, 300), amp=10, frame_dur=200,
+                         raster=SequentialRaster(6)).encode(img)
 
 
 def test_Encoder_raster_from_implant():
@@ -437,6 +500,110 @@ def test_Encoder_raster_current_limit():
                            raster=SequentialRaster(60)).encode(vid)
     npt.assert_equal(enc.metadata['encoder']['n_schedules'], 60)
     npt.assert_almost_equal(np.abs(enc.data).sum(axis=0).max(), 50)
+
+
+@pytest.mark.parametrize('fps', [29.97, 30, 24, 59.94])
+@pytest.mark.parametrize('freq', [50, 100])
+def test_Encoder_freq_is_actual_freq(fps, freq):
+    # The pulse clock runs independently of the frame clock, so the requested
+    # frequency is the frequency delivered -- whatever the frame rate is, and
+    # whether or not a frame holds a whole number of periods. Before, each
+    # frame restarted the train at its own t=0, and a 29.97 fps video asked for
+    # 50 Hz came back at 59.94 pulses/s.
+    vid = VideoStimulus(np.ones((2, 2, 20)), metadata={'fps': fps})
+    enc = AmplitudeEncoder(freq=freq).encode(vid)
+    onsets = pulse_onsets(enc)
+    npt.assert_almost_equal(np.diff(onsets), 1000.0 / freq, decimal=3)
+    # Pulses stay whole and charge-balanced even where one straddles a frame
+    # boundary, which is what the frame clock used to prevent:
+    net = trapezoid(enc.data.astype(np.float64),
+                    x=enc.time.astype(np.float64))
+    npt.assert_almost_equal(net, 0, decimal=3)
+    npt.assert_equal(np.all(np.diff(enc.time) > 0.95 * DT), True)
+
+
+def test_Encoder_pulse_offset():
+    # `Stimulus` only requires a time axis to be ordered, not to start at zero.
+    # What an encoder borrows from a supplied pulse is its *shape*, so a pulse
+    # whose time axis is shifted has to encode exactly like an unshifted one.
+    # Before, it was measured as 1.01 ms when deciding whether it fit but
+    # rendered 5 ms late, which could push it clean out of its own frame:
+    shape = np.array([[0, -1, -1, 0]], dtype=float)
+    at_zero = Stimulus(shape, time=[0, 0.01, 1, 1.01])
+    shifted = Stimulus(shape, time=[5, 5.01, 6, 6.01])
+    vid = VideoStimulus(np.ones((1, 2, 3)), metadata={'fps': 50})
+    ref = AmplitudeEncoder(pulse=at_zero, freq=1000 / 6).encode(vid)
+    enc = AmplitudeEncoder(pulse=shifted, freq=1000 / 6).encode(vid)
+    npt.assert_almost_equal(enc.time, ref.time)
+    npt.assert_almost_equal(enc.data, ref.data)
+    # The time axis stays strictly increasing across frames. A late pulse used
+    # to run past the end of its frame and send time backwards at the next one:
+    npt.assert_equal(np.all(np.diff(enc.time) > 0.95 * DT), True)
+    # The caller's pulse is left alone:
+    npt.assert_almost_equal(shifted.time, [5, 5.01, 6, 6.01])
+
+
+def test_Encoder_zero_amp():
+    # An electrode delivering no current has nothing to schedule, so a dark
+    # frame costs no pulses and no time points -- it used to build a full pulse
+    # train and then multiply it by zero:
+    black = ImageStimulus(np.zeros((2, 2)))
+    enc = AmplitudeEncoder(amp_range=(0, 50), freq=100,
+                           frame_dur=100).encode(black)
+    npt.assert_equal(np.all(enc.data == 0), True)
+    npt.assert_equal(enc.shape[1], 2)
+    npt.assert_almost_equal(enc.time[-1], 100)
+    # A dark electrode alongside bright ones costs nothing either, and does not
+    # disturb what the bright ones do:
+    half = ImageStimulus(np.array([[0.0, 1.0], [0.0, 1.0]]))
+    enc = AmplitudeEncoder(amp_range=(0, 50), freq=100,
+                           frame_dur=100).encode(half)
+    npt.assert_equal(np.all(enc.data[[0, 2]] == 0), True)
+    npt.assert_equal(n_pulses_of(enc, 1), 10)
+    # A dark *frame* does not reset the phase of the frames around it: the
+    # pulse clock keeps running even where nothing is delivered. Three 25 ms
+    # frames at 200 Hz, with the middle one black:
+    vid = VideoStimulus(np.array([1.0, 0.0, 1.0]).reshape((1, 1, 3)),
+                        metadata={'fps': 40})
+    enc = AmplitudeEncoder(amp_range=(0, 50), freq=200).encode(vid)
+    onsets = pulse_onsets(enc)
+    # Nothing is delivered during the black frame ...
+    npt.assert_equal(np.any((onsets >= 25) & (onsets < 50)), False)
+    # ... and the train picks back up in phase rather than at the frame edge,
+    # so every onset is still a whole number of 5 ms periods from the first:
+    npt.assert_almost_equal(np.mod(onsets, 5), 0, decimal=3)
+    npt.assert_almost_equal(onsets[[0, -1]], [0, 70], decimal=3)
+    # A raster that a stimulus cannot possibly satisfy is a property of the
+    # device, not of how bright today's video is, so it is reported either way:
+    implant = ArgusII()
+    dark = VideoStimulus(np.zeros((6, 10, 3)), metadata={'fps': 30})
+    with pytest.raises(ValueError, match='no room'):
+        AmplitudeEncoder(implant, freq=30,
+                         raster=SequentialRaster(60)).encode(dark)
+    # ... and a workable one costs a dark video nothing:
+    enc = AmplitudeEncoder(implant, amp_range=(0, 50), freq=30, phase_dur=0.2,
+                           raster=SequentialRaster(60)).encode(dark)
+    npt.assert_equal(np.all(enc.data == 0), True)
+    npt.assert_equal(enc.shape[1], 2)
+
+
+def test_Encoder_implant_reshape():
+    # Passing an implant means "sample the source at the electrode locations".
+    # Row count is not a usable test of whether that already happened: a 10x6
+    # image and an RGB 4x5 image both have exactly as many rows as Argus II has
+    # electrodes, and both used to skip sampling (and, for RGB, `rgb2gray`)
+    # while still being labeled with electrode names.
+    implant = ArgusII()
+    for src in [ImageStimulus(np.random.rand(10, 6)),
+                ImageStimulus(np.random.rand(4, 5, 3)),
+                ImageStimulus(np.random.rand(6, 10)),
+                VideoStimulus(np.random.rand(10, 6, 2))]:
+        npt.assert_equal(src.data.shape[0], implant.n_electrodes)
+        enc = AmplitudeEncoder(implant, amp_range=(0, 50)).encode(src)
+        direct = AmplitudeEncoder(amp_range=(0, 50)).encode(
+            implant.reshape_stim(src))
+        npt.assert_almost_equal(enc.data, direct.data, decimal=4)
+        npt.assert_equal(list(enc.electrodes), list(implant.electrode_names))
 
 
 def test_Encoder_metadata():

--- a/pulse2percept/stimuli/tests/test_encoders.py
+++ b/pulse2percept/stimuli/tests/test_encoders.py
@@ -415,15 +415,18 @@ def test_Encoder_raster():
     net = trapezoid(enc.data.astype(np.float64),
                     x=enc.time.astype(np.float64))
     npt.assert_almost_equal(net, 0, decimal=3)
-    # A clock snaps the slot offsets along with the period. A 4.6 ms slot lands
-    # on 5 ms, and the 10 ms period onto the 9 ms cycle the two slots make:
+    # A clock quantizes the *slot*, and the cycle is rebuilt from it, so the
+    # groups keep equal turns. A 4.6 ms slot lands on 5 ms and two of them make
+    # a 10 ms cycle -- which here still holds the requested 100 Hz exactly.
+    # Rounding each offset and the total cycle independently instead would give
+    # a 9 ms cycle made of a 5 ms and a 4 ms turn, and 111 Hz:
     enc = AmplitudeEncoder(freq=100, frame_dur=100, clock=1,
                            raster=SequentialRaster(
                                2, interleave=True,
                                group_dur=4.6)).encode(img)
     npt.assert_almost_equal(pulse_onsets(enc, 1)[0], 5, decimal=3)
-    npt.assert_almost_equal(np.diff(pulse_onsets(enc, 1)), 9, decimal=3)
-    npt.assert_almost_equal(enc.metadata['encoder']['cycle'], 9)
+    npt.assert_almost_equal(np.diff(pulse_onsets(enc, 1)), 10, decimal=3)
+    npt.assert_almost_equal(enc.metadata['encoder']['cycle'], 10)
 
 
 def test_Encoder_raster_frequency_modulation():
@@ -520,6 +523,79 @@ def test_Encoder_freq_is_actual_freq(fps, freq):
                     x=enc.time.astype(np.float64))
     npt.assert_almost_equal(net, 0, decimal=3)
     npt.assert_equal(np.all(np.diff(enc.time) > 0.95 * DT), True)
+
+
+def fm_onsets(grays, fps=20, **kwargs):
+    """Pulse onsets (ms) of a one-pixel video whose gray level changes"""
+    vid = VideoStimulus(np.asarray(grays, dtype=float).reshape(1, 1, -1),
+                        metadata={'fps': fps})
+    with warnings.catch_warnings():
+        warnings.simplefilter('ignore')
+        enc = FrequencyEncoder(freq_range=(0, 100), amp=10,
+                               **kwargs).encode(vid)
+    return pulse_onsets(enc), enc
+
+
+def test_FrequencyEncoder_rate_changes_between_frames():
+    # The rate is piecewise constant over the video's frames, and the pulse
+    # clock has to pick up a new rate the instant a frame boundary goes by.
+    # Scheduling the next pulse a whole period ahead instead would carry the
+    # old frame's rate straight across the boundary: a frame asking for 100 Hz
+    # sat completely silent because the frame before it asked for 10 Hz and had
+    # already booked the next pulse 100 ms out.
+    # 50 ms frames: 10 Hz, then 100 Hz. Half a cycle is banked by 50 ms, so the
+    # first 100 Hz pulse completes it at 55 ms:
+    onsets, enc = fm_onsets([0.1, 1.0])
+    npt.assert_almost_equal(onsets, [0, 55, 65, 75, 85, 95], decimal=3)
+    # Charge balance is what a pulse cut off by a boundary would break:
+    net = trapezoid(enc.data.astype(np.float64),
+                    x=enc.time.astype(np.float64))
+    npt.assert_almost_equal(net, 0, decimal=3)
+    # The other direction: a fast frame followed by a slow one:
+    npt.assert_almost_equal(fm_onsets([1.0, 0.1])[0],
+                            [0, 10, 20, 30, 40, 50], decimal=3)
+    # Each frame gets the rate it asked for, so the counts follow the video.
+    # Note the 50 -> 100 Hz case: at the boundary the 50 Hz frame has banked
+    # half a period, and the new rate finishes it 5 ms later at 55 ms, not
+    # 20 ms later at 60 ms as the old rate would have:
+    for grays, want in [([1.0, 0.5], [0, 10, 20, 30, 40, 50, 70, 90]),
+                        ([0.5, 1.0], [0, 20, 40, 55, 65, 75, 85, 95])]:
+        npt.assert_almost_equal(fm_onsets(grays)[0], want, decimal=3)
+    # A frame at 0 Hz stops the clock rather than swallowing a pulse, and the
+    # frame that starts it again comes up at its full rate:
+    npt.assert_almost_equal(fm_onsets([1.0, 0.0, 1.0])[0],
+                            [0, 10, 20, 30, 40, 100, 110, 120, 130, 140],
+                            decimal=3)
+    npt.assert_equal(fm_onsets([0.0, 0.0])[0].size, 0)
+    npt.assert_almost_equal(fm_onsets([0.0, 1.0])[0],
+                            [50, 60, 70, 80, 90], decimal=3)
+    # Phase carries through a rate change that lands mid-period: 100, then 50,
+    # then 25 Hz. The 50 Hz frame banks half a period by its end, which the
+    # 25 Hz frame finishes 20 ms into itself:
+    npt.assert_almost_equal(fm_onsets([1.0, 0.5, 0.25])[0],
+                            [0, 10, 20, 30, 40, 50, 70, 90, 120], decimal=3)
+
+
+def test_FrequencyEncoder_raster_never_speeds_up():
+    # Quantizing a period onto the raster cycle rounds it *up*: an electrode
+    # must never come back faster than it was asked for, since that delivers
+    # more charge than the caller requested. Against a 10 ms cycle, 67 Hz
+    # becomes 50 Hz rather than 100 Hz.
+    grays = np.array([1.0, 0.67, 0.4, 0.2])
+    img = ImageStimulus(grays.reshape((2, 2)))
+    enc = FrequencyEncoder(freq_range=(0, 100), amp=10, frame_dur=200,
+                           raster=SequentialRaster(4)).encode(img)
+    cycle = enc.metadata['encoder']['cycle']
+    npt.assert_almost_equal(cycle, 10)
+    for e, gray in enumerate(grays):
+        period = np.diff(pulse_onsets(enc, e))
+        # Whole cycles, and never shorter than the requested period:
+        npt.assert_allclose(period / cycle, np.round(period / cycle),
+                            atol=1e-3)
+        npt.assert_equal(np.all(period >= 1000.0 / (100 * gray) - 1e-3), True)
+    # The fastest electrode still lands exactly on the cycle, so asking for the
+    # top of the range costs nothing:
+    npt.assert_almost_equal(np.diff(pulse_onsets(enc, 0)), 10, decimal=3)
 
 
 def test_Encoder_pulse_offset():

--- a/pulse2percept/utils/animation.py
+++ b/pulse2percept/utils/animation.py
@@ -570,20 +570,11 @@ class HTMLAnimation(FuncAnimation):
         try:
             if self._labels is not None:
                 # The player draws the title itself, on a canvas that sits on
-                # top of the static background. Clearing the canvas cannot undo
-                # anything baked into that background, so a title left on the
-                # axes (by an earlier draw, or by the caller) would show
-                # through every frame. Blank it while the background is
-                # rendered; this is also what lets ``_title_geometry`` measure
-                # the empty line box it needs:
+                # top of the static background:
                 title_artist.set_text('')
             bg, width, height = _background(fig, im)
             # ``get_window_extent`` is only meaningful once the figure has been
-            # drawn, which ``_background`` just did. Round the destination rect
-            # outward rather than rounding its size: rounding the size can
-            # leave a row or column of background exposed along the edge of the
-            # image, whereas overshooting by a fraction of a pixel is
-            # invisible.
+            # drawn, which ``_background`` just did:
             bbox = im.get_window_extent()
             title = None
             if self._labels is not None:

--- a/pulse2percept/utils/animation.py
+++ b/pulse2percept/utils/animation.py
@@ -2,12 +2,6 @@
 
 Fast, dependency-free HTML/JavaScript animations.
 
-Matplotlib's ``FuncAnimation.to_jshtml`` re-renders the *entire* figure (axes,
-ticks, tick labels, colorbar, ...) once per frame and embeds every frame as its
-own base64-encoded PNG. Since only the image data and the title actually change
-from frame to frame, that is a lot of wasted work: the cost per frame is on the
-order of hundreds of milliseconds, and the resulting HTML is tens of megabytes.
-
 :py:class:`HTMLAnimation` renders the static parts of the figure exactly once
 and packs all frames into a single, color-mapped sprite sheet that is blitted
 into a ``<canvas>`` by a small vanilla-JavaScript player. This is typically two
@@ -26,8 +20,6 @@ import numpy as np
 from matplotlib.animation import FuncAnimation
 from matplotlib.colors import to_hex, to_rgba
 from PIL import Image
-
-from .array import unique
 
 __all__ = ['HTMLAnimation', 'frame_interval']
 
@@ -100,16 +92,22 @@ def frame_interval(time, fps=None, tol=1e-2):
     """
     if fps is not None:
         return 1000.0 / fps
-    interval = unique(np.diff(time), tol=tol)
-    if len(interval) > 1:
-        raise NotImplementedError(
-            f"Cannot infer the frame rate from a non-homogeneous time axis "
-            f"(found {len(interval)} different time steps). Pass 'fps' "
-            f"instead.")
-    if len(interval) == 0:
+    interval = np.diff(np.asarray(time, dtype=np.float64))
+    if interval.size == 0:
         # A single frame has no time step, and there is nothing to advance to,
         # so any interval will do:
         return SINGLE_FRAME_INTERVAL
+    # Compare the steps against each other rather than quantizing each one onto
+    # a grid of `tol`: a step that lands exactly on a grid boundary (33.365 ms
+    # against tol=1e-2, which is what a 29.97 fps percept comes out at) rounds
+    # up or down depending on floating-point noise far below `tol`, and an
+    # evenly spaced axis then looks like two different steps.
+    spread = float(interval.max() - interval.min())
+    if spread > tol:
+        raise NotImplementedError(
+            f"Cannot infer the frame rate from a non-homogeneous time axis "
+            f"(time steps range over {spread:g} ms, more than tol={tol:g}). "
+            f"Pass 'fps' instead.")
     return float(interval[0])
 
 


### PR DESCRIPTION
Bug fixes to the encoder/raster scheduler and the temporal models it connects to.

Rastering:

- [x] A frame that was not a whole number of pulse periods long silently changed the rate: at 29.97 fps, `freq=50` delivered 59.94 pulses/s.
- [x] Frequency modulation accumulates phase, so a rate change mid-frame is honored and a fast frame after a slow one is no longer skipped
- [x] A raster group's first pulse initializes in the video frame that actually contains its slot, not frame 0.
- [x] `clock` and raster quantization now only ever *lower* a requested rate, never raise it, so an electrode is never given more charge than was asked for.
- [x] A given `group_dur` is quantized onto `clock` before the feasibility check

Temporal models:

- [x]  `FadingTemporal` now half-wave rectifies its drive (`max(-A, 0)`, was `-A`)
- [x] *Kernels no longer read a stale stimulus frame. For all three temporal models,  the integrator lagged by a frame and could integrate  current that had already ended.
- [x] New `reduce` parameter: When `predict_percept` picks the output times   itself, `reduce='peak'` reports the highest brightness over each interval   instead of the instant it ends on
- [x] `find_threshold` preserves stimulus metadata
- [x]  `FadingTemporal` rejects `tau <= 0` (was `tau < 0`; zero divided by zero).