### PR TITLE
[ENH] Checkerboard raster pattern

### DIFF
--- a/doc/users/references.rst
+++ b/doc/users/references.rst
@@ -76,6 +76,12 @@ Studies referenced throughout the Documentation:
                    variability in the human retina. *Vision Research* 49(17),
                    2157-63, doi:`10.1016/j.visres.2009.04.029
                    <https://doi.org/10.1016/j.visres.2009.04.029>`_.
+.. [Kasowski2025] JM Kasowski, A Varshney, R Sadeghi, M Beyeler (2025).
+                  Simulated prosthetic vision confirms checkerboard as an 
+                  effective raster pattern for epiretinal implants.
+                  *Journal of Neural Engineering* 22 046017,
+                  doi:`10.1088/1741-2552/adecc4
+                  <https://doi.org/10.1088/1741-2552/adecc4>`_.
 .. [Layton2014] LN Ayton, PJ Blamey, RH Guymer, CD Luu, DAX Nayagam,
                 NC Sinclair, MN Shivdasani, J Yeoh, MF McCombe, RJ Briggs,
                 NL Opie, J Villalobos, PN Dimitrov, M Varsamidis, MA Petoe,

--- a/doc/users/release_notes.rst
+++ b/doc/users/release_notes.rst
@@ -17,6 +17,8 @@ Highlights:
 *  New :py:class:`~pulse2percept.implants.Raster` classes describe how
    stimulators multiplex electrodes that cannot be driven simultaneously. Each
    group starts its pulse a fixed ``group_dur`` behind the one before it.
+   :py:class:`~pulse2percept.implants.CheckerboardRaster` implements the
+   checkerboard pattern of [Kasowski2025]_.
 
 * :py:meth:`~pulse2percept.percepts.Percept.play` and
   :py:meth:`~pulse2percept.stimuli.VideoStimulus.play` are roughly 100x faster

--- a/pulse2percept/implants/__init__.py
+++ b/pulse2percept/implants/__init__.py
@@ -28,7 +28,8 @@ from .base import ProsthesisSystem, RectangleImplant
 from .electrodes import (Electrode, PointSource, DiskElectrode,
                          SquareElectrode, HexElectrode)
 from .electrode_arrays import ElectrodeArray, ElectrodeGrid
-from .rasters import Raster, SequentialRaster, CustomRaster
+from .rasters import (Raster, SequentialRaster, CheckerboardRaster,
+                      CustomRaster)
 from .argus import ArgusI, ArgusII
 from .alpha import AlphaIMS, AlphaAMS
 from .bvt import BVT24, BVT44
@@ -44,6 +45,7 @@ __all__ = [
     'ArgusII',
     'BVT24',
     'BVT44',
+    'CheckerboardRaster',
     'cortex',
     'CustomRaster',
     'DiskElectrode',

--- a/pulse2percept/implants/rasters.py
+++ b/pulse2percept/implants/rasters.py
@@ -1,8 +1,11 @@
 """:py:class:`~pulse2percept.implants.Raster`,
    :py:class:`~pulse2percept.implants.SequentialRaster`,
+   :py:class:`~pulse2percept.implants.CheckerboardRaster`,
    :py:class:`~pulse2percept.implants.CustomRaster`"""
 from abc import ABCMeta, abstractmethod
+from itertools import permutations
 import numpy as np
+from scipy.spatial import cKDTree
 
 from ..utils import PrettyPrint
 
@@ -250,6 +253,407 @@ class SequentialRaster(Raster):
             return idx % self._n_groups
         # Contiguous blocks, as evenly sized as the electrode count allows:
         return idx * self._n_groups // max(1, len(electrodes))
+
+
+def _reduce(w1, w2):
+    """Shortest basis of the lattice spanned by ``w1`` and ``w2``
+
+    Lagrange-Gauss reduction: repeatedly subtract the one vector from the other
+    until neither can be shortened. What comes back spans the same lattice, but
+    ``w1`` is now its shortest nonzero vector and ``w2`` the shortest one
+    independent of it -- so every short vector of the lattice is a combination
+    with small coefficients, and the searches below only have to look a few
+    steps in each direction.
+    """
+    w1, w2 = np.asarray(w1, dtype=float), np.asarray(w2, dtype=float)
+    for _ in range(100):
+        if w1 @ w1 > w2 @ w2:
+            w1, w2 = w2, w1
+        mu = np.round((w2 @ w1) / (w1 @ w1))
+        if mu == 0:
+            break
+        w2 = w2 - mu * w1
+    return w1, w2
+
+
+def _combos(w1, w2, reach):
+    """Every combination ``m * w1 + n * w2`` with ``|m|, |n| <= reach``"""
+    steps = np.arange(-reach, reach + 1)
+    m, n = np.meshgrid(steps, steps)
+    return m.ravel()[:, None] * w1 + n.ravel()[:, None] * w2
+
+
+def _spectrum(w1, w2, n_terms=8):
+    """Lengths of the shortest nonzero vectors of the lattice, ascending
+
+    This is what "maximally spaced" is measured by. Two electrodes of the same
+    group are always some lattice vector apart, so the shortest vector is the
+    closest two simultaneously active electrodes ever come, the next one is the
+    second-closest, and so on. Comparing whole spectra rather than just the
+    first entry settles the frequent ties: on a square grid, four groups can be
+    laid out as every other row and column, which puts *four* neighbours at the
+    minimum distance, or in the offset pattern this picks, which puts only two
+    there and the rest further out.
+    """
+    d = np.linalg.norm(_combos(*_reduce(w1, w2), reach=4), axis=1)
+    return np.sort(d[d > 1e-9])[:n_terms]
+
+
+def _min_rep(delta, w1, w2):
+    """Shortest vector that differs from ``delta`` by a lattice vector
+
+    Two groups are the same pattern displaced by ``delta``, but the pattern
+    repeats with the lattice, so the eye is free to match any electrode of the
+    first group with any electrode of the second. What it sees is the shortest
+    of those matches, which is what this returns -- the jump the percept
+    appears to make when one group hands over to the next.
+    """
+    w1, w2 = _reduce(w1, w2)
+    basis = np.column_stack([w1, w2])
+    # Land in the neighborhood of the origin first, so a short search finishes
+    # the job whatever `delta` came in as:
+    delta = delta - basis @ np.round(np.linalg.solve(basis, delta))
+    cand = delta + _combos(w1, w2, reach=2)
+    d = np.linalg.norm(cand, axis=1) / np.linalg.norm(w1)
+    # Ties are common and are genuinely ambiguous percepts; break them the same
+    # way every time so that the schedule is reproducible:
+    return cand[np.lexsort((cand[:, 1], cand[:, 0], np.round(d, 9)))[0]]
+
+
+def _drift(steps, scale):
+    """How far the percept wanders over every run of consecutive jumps
+
+    ``steps`` holds the jump from each group to the next, so a run of them adds
+    up to the displacement the pattern accumulates over that stretch of the
+    sweep. A raster that shifts one electrode over and over is exactly the case
+    where those sums keep growing, which is the apparent motion the pattern is
+    there to avoid; one that doubles back keeps them bounded. The last run is
+    the whole sweep, so drift that survives from one sweep to the next is
+    counted too.
+
+    Returns the worst run and the total over all runs, both in units of the
+    electrode spacing. Smaller is better on both counts.
+    """
+    n = steps.shape[-2]
+    zero = np.zeros(steps.shape[:-2] + (1, 2))
+    walk = np.concatenate([zero, np.cumsum(steps, axis=-2)], axis=-2)
+    start, stop = np.triu_indices(n + 1, k=1)
+    d = np.linalg.norm(walk[..., stop, :] - walk[..., start, :], axis=-1)
+    d = np.round(d / scale, 6)
+    return d.max(axis=-1), d.sum(axis=-1)
+
+
+def _firing_order(jump, scale):
+    """The order to fire the groups in, as a list of group labels
+
+    Any order fires every group exactly once, so they all obey the current
+    limit equally; what differs is what the sequence looks like. This picks the
+    one whose percept wanders least (see :py:func:`_drift`).
+    """
+    n = len(jump)
+    if n < 3:
+        return list(range(n))
+    if n <= 8:
+        # Small enough to settle exactly. The first group is fixed, since
+        # rotating a sweep only moves the origin of time:
+        order = np.array([(0,) + p for p in permutations(range(1, n))])
+        steps = jump[order, np.roll(order, -1, axis=1)]
+        worst, total = _drift(steps, scale)
+        # `lexsort` is stable, so among equally good orders this takes the
+        # first, and `permutations` yields them in a fixed order:
+        return order[np.lexsort((total, worst))[0]].tolist()
+
+    def score(order):
+        steps = jump[order, np.roll(order, -1)]
+        return _drift(steps, scale)
+
+    # Too many orders to enumerate, so take the groups one at a time and then
+    # improve on that by reversing stretches until nothing helps. This lands on
+    # the same answer as the exhaustive search wherever both can be run:
+    order = [0]
+    while len(order) < n:
+        rest = [g for g in range(n) if g not in order]
+        order.append(min(rest, key=lambda g: score(order + [g])))
+    order = np.array(order)
+    for _ in range(100):
+        best, before = score(order), order
+        for i in range(1, n):
+            for j in range(i + 1, n):
+                cand = np.concatenate([order[:i], order[i:j + 1][::-1],
+                                       order[j + 1:]])
+                cand_score = score(cand)
+                if cand_score < best:
+                    order, best = cand, cand_score
+        if np.array_equal(order, before):
+            break
+    return order.tolist()
+
+
+def _lattice(xy):
+    """Integer coordinates of each electrode, and the two steps they count off
+
+    Every regular grid (rectangular or hexagonal, at any rotation) is a
+    lattice: two steps that reach every electrode by whole numbers of each.
+    """
+    n = len(xy)
+    if n < 2:
+        return np.zeros((n, 2), dtype=np.int64), np.eye(2)
+    # The lattice steps are among the shortest gaps between electrodes, and a
+    # handful of nearest neighbors is enough to turn them up:
+    _, idx = cKDTree(xy).query(xy, k=min(n, 9))
+    diff = (xy[idx[:, 1:]] - xy[:, None, :]).reshape(-1, 2)
+    d = np.linalg.norm(diff, axis=1)
+    # Two electrodes in the same spot are no step at all, and would otherwise
+    # be taken for one of zero length:
+    apart = d > 1e-9 * d.max(initial=0.0)
+    if not np.any(apart):
+        raise NotImplementedError(
+            "A checkerboard needs electrodes on a regular grid, and these are "
+            "all in the same place.")
+    diff, d = diff[apart], d[apart]
+    diff = diff[np.argsort(np.round(d / d.max(), 9), kind='stable')]
+    u = diff[0]
+    # The second step has to leave the line the first one traces out:
+    cross = np.abs(u[0] * diff[:, 1] - u[1] * diff[:, 0])
+    off_axis = np.flatnonzero(cross > 1e-6 * (u @ u))
+    if len(off_axis) == 0:
+        # Electrodes on a single line: any second step will do, since nothing
+        # is ever placed along it.
+        v = np.array([-u[1], u[0]])
+    else:
+        v = diff[off_axis[0]]
+    u, v = _reduce(u, v)
+    basis = np.column_stack([u, v])
+    ij = np.linalg.solve(basis, (xy - xy[0]).T).T
+    # Negated so that a NaN, which fails every comparison, raises rather than
+    # slipping through as a grid:
+    if not np.abs(ij - np.rint(ij)).max() <= 1e-6:
+        raise NotImplementedError(
+            "A checkerboard needs electrodes on a regular grid, and these do "
+            "not lie on one. Use a grid implant (an ElectrodeGrid, such as "
+            "ArgusII or PRIMA), or assign the groups by hand with a "
+            "CustomRaster.")
+    return np.rint(ij).astype(np.int64), basis
+
+
+def _sublattices(ij, n_groups, balance):
+    """Every way of splitting the grid into ``n_groups`` even groups
+
+    A group is one coset of a sublattice of index ``n_groups``: take every
+    ``a``-th electrode along the first step and every ``d``-th along the
+    second, with ``a * d = n_groups``, and skew the two against each other by
+    ``k``. That enumeration is exhaustive -- every index-``n_groups``
+    sublattice has exactly one such (Hermite) form -- so the best pattern is
+    the best of these and there is nothing else to look for.
+
+    Yields ``(labels, a, d, k, biggest)`` for the splits that come out even
+    enough, biggest group first, since that is the one the current limit is
+    read off.
+    """
+    even = int(np.ceil(len(ij) / n_groups))
+    for a in range(1, n_groups + 1):
+        if n_groups % a:
+            continue
+        d = n_groups // a
+        for k in range(a):
+            # Which coset an electrode falls in: how far along the second step
+            # it sits, and how far along the first once the skew is undone.
+            q = np.mod(ij[:, 1], d)
+            p = np.mod(ij[:, 0] - k * ((ij[:, 1] - q) // d), a)
+            labels = q * a + p
+            count = np.bincount(labels, minlength=n_groups)
+            # An idle group is a group's worth of current left unused, and an
+            # oversized one is what the limit ends up being set by:
+            if count.min() and count.max() <= even * (1 + balance) + 1e-9:
+                yield labels, a, d, k, int(count.max())
+
+
+def _suggest(ij, n_groups, balance, n_show=4):
+    """The nearest group counts that do fit this grid, for an error message"""
+    reach = range(2, min(len(ij), 2 * n_groups + 8) + 1)
+    fits = [n for n in reach
+            if next(_sublattices(ij, n, balance), None) is not None]
+    near = sorted(sorted(fits, key=lambda n: (abs(n - n_groups), n))[:n_show])
+    return ', '.join(str(n) for n in near) if near else 'no other count'
+
+
+class CheckerboardRaster(Raster):
+    """Split electrodes into groups that are spread as far apart as possible
+
+    Implements a generalized form of the checkerboard raster pattern tested
+    in [Kasowski2025]_, which found that scattering raster groups over the
+    whole array beat horizontal, vertical, and random rasters at letter
+    recognition and motion discrimination, and matched not rastering at all.
+
+    Mathematically speaking, a raster group is a coset of a sublattice of the
+    electrode grid. Within a group, electrodes sit as far from one another as
+    the electrode count allows. Each group is a coarser copy of the grid.
+    Between groups, the order is chosen so the pattern doubles back rather
+    than marching on (to reduce apparent motion). For example: Five groups on
+    a square grid come out one over, two over, one back, two over, so that
+    the percept steps right, down, left, down, and back rather than sliding
+    across the array.
+
+    The grid does not have to be rectangular: hexagonal grids, rotated grids,
+    grids with unequal row and column spacing, and grids with electrodes
+    trimmed off are all handled, since the pattern is derived from where the
+    electrodes actually are. Arrays whose electrodes do not lie on a grid at
+    all raise ``NotImplementedError``.
+
+    .. note::
+
+        Not every ``n_groups`` fits a given grid, and one that does not
+        raises a ``ValueError`` listing counts that do.
+        
+        It is worth checking :py:attr:`min_spacing` on the ones that do fit,
+        because a count can be accepted and still leave neighbors in the same
+        group. The standard example is two groups on a hex grid, which
+        degenerates to a line raster. In other words, implants like PRIMA
+        cannot be two-colored; they want 3, 4, or 7 raster groups instead.
+
+    .. versionadded:: 0.10.0
+
+    Parameters
+    ----------
+    implant : :py:class:`~pulse2percept.implants.ProsthesisSystem`
+        The implant to build the pattern for, or its
+        :py:class:`~pulse2percept.implants.ElectrodeArray`. The electrodes have
+        to lie on a grid, and their names are how the raster recognizes them
+        later, so this has to be the implant the stimulus will be applied to.
+    n_groups : int
+        Number of groups to split the electrodes into.
+    balance : float, optional
+        How much bigger the largest group may be than an even split would make
+        it, as a fraction of it. The largest group is what sets the current the
+        stimulator has to source, so this is the price being paid; what it buys
+        is spacing, because the patterns that spread furthest do not always
+        land evenly on a grid whose edges have been trimmed. Pass 0 to insist
+        on an even split and take whatever spacing comes with it.
+    group_dur : float, optional
+        See :py:class:`~pulse2percept.implants.Raster`.
+
+    Examples
+    --------
+    Five groups of twelve on Argus II, as in Kasowski et al. (2025):
+
+    >>> from pulse2percept.implants import ArgusII, CheckerboardRaster
+    >>> implant = ArgusII()
+    >>> implant.raster = CheckerboardRaster(implant, 5)
+    >>> implant.raster.n_groups
+    5
+
+    No two electrodes of a group are closer than sqrt(5) pitches, where a line
+    raster would have them adjacent:
+
+    >>> round(implant.raster.min_spacing / 575, 3)  # 575 um pitch
+    2.236
+
+    References
+    ----------
+    .. [Kasowski2025] J M Kasowski, A Varshney, R Sadeghi, M Beyeler (2025).
+       Simulated prosthetic vision confirms checkerboard as an effective raster
+       pattern for epiretinal implants. *Journal of Neural Engineering*
+       22:046017.
+
+    """
+    __slots__ = ('_n_groups', '_group_of', '_min_spacing')
+
+    def __init__(self, implant, n_groups, balance=0.05, group_dur=None):
+        super().__init__(group_dur=group_dur)
+        _finite('n_groups', n_groups)
+        if int(n_groups) != n_groups or n_groups < 1:
+            raise ValueError(f"'n_groups' must be a positive integer, not "
+                             f"{n_groups}.")
+        n_groups = int(n_groups)
+        _finite('balance', balance)
+        if balance < 0:
+            raise ValueError(f"'balance' cannot be negative, not {balance}.")
+        # A ProsthesisSystem carries the array; anything else has to be one.
+        # Duck-typed rather than imported, since `base` imports this module:
+        earray = getattr(implant, 'earray', implant)
+        names = getattr(earray, 'electrode_names', None)
+        elecs = getattr(earray, 'electrode_objects', None)
+        if names is None or elecs is None:
+            raise TypeError(f"'implant' must be a ProsthesisSystem or an "
+                            f"ElectrodeArray, not {type(implant)}.")
+        names = list(names)
+        xy = np.array([[e.x, e.y] for e in elecs], dtype=np.float64)
+        if len(xy) < n_groups:
+            raise ValueError(f"{len(xy)} electrode(s) cannot be split into "
+                             f"{n_groups} groups.")
+        ij, basis = _lattice(xy)
+        u, v = basis.T
+        scale = min(np.linalg.norm(u), np.linalg.norm(v))
+
+        # Of the splits that are even enough, keep the one whose groups are
+        # spread furthest apart, and of those the most even:
+        best = None
+        for labels, a, d, k, biggest in _sublattices(ij, n_groups, balance):
+            w1, w2 = a * u, k * u + d * v
+            key = (tuple(np.round(_spectrum(w1, w2) / scale, 6)), -biggest)
+            if best is None or key > best[0]:
+                best = (key, labels, w1, w2)
+        if best is None:
+            raise ValueError(
+                f"No checkerboard of {n_groups} groups fits these "
+                f"{len(xy)} electrodes. A group is every a-th electrode "
+                f"across by every d-th down (a * d = {n_groups}), and on this "
+                f"grid every such pattern leaves one group more than "
+                f"{balance:.0%} bigger than an even split. Try "
+                f"{_suggest(ij, n_groups, balance)} groups instead, or raise "
+                f"'balance' to allow groups of unequal size.")
+        labels, w1, w2 = best[1:]
+        self._min_spacing = float(_spectrum(w1, w2, n_terms=1)[0])
+
+        # Fire them in the order that wanders least. `labels` says which
+        # pattern an electrode belongs to; the group index it gets is when that
+        # pattern takes its turn:
+        first = np.array([np.flatnonzero(labels == g)[0]
+                          for g in range(n_groups)])
+        jump = np.zeros((n_groups, n_groups, 2))
+        for g1 in range(n_groups):
+            for g2 in range(n_groups):
+                if g1 != g2:
+                    jump[g1, g2] = _min_rep(xy[first[g2]] - xy[first[g1]],
+                                            w1, w2)
+        slot = np.empty(n_groups, dtype=np.int64)
+        slot[_firing_order(jump, scale)] = np.arange(n_groups)
+
+        self._n_groups = n_groups
+        self._group_of = {str(name): int(slot[label])
+                          for name, label in zip(names, labels)}
+
+    def _pprint_params(self):
+        """Return a dict of class arguments to pretty-print"""
+        params = super()._pprint_params()
+        params.update({'min_spacing': self.min_spacing})
+        return params
+
+    @property
+    def n_groups(self):
+        """Number of raster groups"""
+        return self._n_groups
+
+    @property
+    def min_spacing(self):
+        """Distance (um) between the closest two electrodes of a group
+
+        How much the checkerboard bought over a line raster, which leaves
+        neighboring electrodes in the same group and so would report the
+        electrode pitch.
+        """
+        return self._min_spacing
+
+    def groups(self, electrodes):
+        """Assign each electrode to a raster group"""
+        try:
+            return np.array([self._group_of[str(e)] for e in electrodes])
+        except KeyError:
+            missing = sorted({str(e) for e in electrodes} -
+                             set(self._group_of))
+            raise ValueError(f"Electrode(s) {missing[:10]} are not on the "
+                             f"grid this raster was built for. Build it from "
+                             f"the implant the stimulus is applied to.")
 
 
 class CustomRaster(Raster):

--- a/pulse2percept/implants/rasters.py
+++ b/pulse2percept/implants/rasters.py
@@ -415,6 +415,10 @@ def _canonical(vectors, scale):
     first would let the same implant come out mirrored on one machine and not
     on another. Instead one of each +/- pair is dropped, and the rest are
     ordered by length and then by direction, which leaves nothing to chance.
+
+    The second step comes back as None when every vector given points the same
+    way, which is for the caller to make sense of: it means the electrodes
+    considered so far are in a line, not that the array is.
     """
     d = np.linalg.norm(vectors, axis=1)
     tol = 1e-9 * scale
@@ -425,17 +429,34 @@ def _canonical(vectors, scale):
         raise NotImplementedError(
             "A checkerboard needs electrodes on a regular grid, and these are "
             "all in the same place.")
+    # Counted in units of the shortest gap, so that the order they come out in
+    # cannot depend on how wide a net was cast to find them:
     vectors = vectors[np.lexsort((-vectors[:, 1], -vectors[:, 0],
-                                  np.round(d / scale, 9)))]
+                                  np.round(d / d.min(), 9)))]
     u = vectors[0]
     # The second step has to leave the line the first one traces out:
     cross = np.abs(u[0] * vectors[:, 1] - u[1] * vectors[:, 0])
     off_axis = np.flatnonzero(cross > 1e-6 * (u @ u))
-    if len(off_axis) == 0:
-        # Electrodes on a single line: any second step will do, since nothing
-        # is ever placed along it.
-        return u, np.array([-u[1], u[0]])
-    return u, vectors[off_axis[0]]
+    return u, (vectors[off_axis[0]] if len(off_axis) else None)
+
+
+def _closest(xy, labels, n_groups):
+    """Distance between the closest two electrodes that ever fire together
+
+    A pattern is judged by the closest pair it actually leaves active at the
+    same time, which is not the shortest step of the lattice it was cut from:
+    the implant is a finite piece of that lattice, and on a small or trimmed
+    one the electrodes that would have been closest need not be there at all.
+    Infinite when no group holds more than one electrode, since then there is
+    no pair to keep apart.
+    """
+    closest = np.inf
+    for g in range(n_groups):
+        pos = xy[labels == g]
+        if len(pos) > 1:
+            closest = min(closest,
+                          float(cKDTree(pos).query(pos, k=2)[0][:, 1].min()))
+    return closest
 
 
 def _combos(w1, w2, reach):
@@ -560,17 +581,30 @@ def _lattice(xy):
     n = len(xy)
     if n < 2:
         return np.zeros((n, 2), dtype=np.int64), np.eye(2)
+    scale = float(np.linalg.norm(xy.max(axis=0) - xy.min(axis=0)))
+    tree = cKDTree(xy)
     # The lattice steps are among the shortest gaps between electrodes, and a
-    # handful of nearest neighbors is enough to turn them up:
-    _, idx = cKDTree(xy).query(xy, k=min(n, 9))
-    diff = (xy[idx[:, 1:]] - xy[:, None, :]).reshape(-1, 2)
-    scale = np.linalg.norm(diff, axis=1).max(initial=0.0)
-    u, v = _canonical(diff, scale)
+    # handful of nearest neighbors usually turns both of them up. Usually, but
+    # not always: rows 1050 um apart with electrodes 100 um along them put
+    # twenty gaps in the near neighborhood of every electrode before the step
+    # to the next row appears. So the net is cast wider until the second step
+    # shows up, and only an array that is a line all the way out has none.
+    k = min(n, 9)
+    while True:
+        _, idx = tree.query(xy, k=k)
+        diff = (xy[idx[:, 1:]] - xy[:, None, :]).reshape(-1, 2)
+        u, v = _canonical(diff, scale)
+        if v is not None or k == n:
+            break
+        k = min(n, 2 * k)
+    if v is None:
+        # Electrodes on a single line: any second step will do, since nothing
+        # is ever placed along it.
+        v = np.array([-u[1], u[0]])
     # The gaps that were seen need not be the shortest two the lattice has, so
     # they are reduced onto those -- and then settled by the rule a second
     # time, since the reduction is free to hand them back either way round:
-    u, v = _canonical(_combos(*_reduce(u, v), reach=2),
-                      np.linalg.norm(u) or scale)
+    u, v = _canonical(_combos(*_reduce(u, v), reach=2), np.linalg.norm(u))
     basis = np.column_stack([u, v])
     ij = np.linalg.solve(basis, (xy - xy[0]).T).T
     # Negated so that a NaN, which fails every comparison, raises rather than
@@ -651,7 +685,12 @@ class CheckerboardRaster(Raster):
     .. note::
 
         Not every ``n_groups`` fits a given grid, and one that does not
-        raises a ``ValueError`` listing counts that do.
+        raises a ``ValueError`` and specifies counts that do.
+
+        Both halves of the pattern are searched for when the raster is built,
+        and the order the groups fire in is settled exactly only up to eight
+        groups; beyond that a heuristic stands in for it, and the search grows
+        with the group count.
         
         It is worth checking :py:attr:`min_spacing` on the ones that do fit,
         because a count can be accepted and still leave neighbors in the same
@@ -675,8 +714,10 @@ class CheckerboardRaster(Raster):
         it, as a fraction of it. The largest group is what sets the current the
         stimulator has to source, so this is the price being paid; what it buys
         is spacing, because the patterns that spread furthest do not always
-        land evenly on a grid whose edges have been trimmed. Pass 0 to insist
-        on an even split and take whatever spacing comes with it.
+        land evenly on a grid whose edges have been trimmed. Pass 0 to add no
+        imbalance beyond the rounding an uneven electrode count forces anyway
+        -- 378 electrodes in 5 groups are 76, 76, 75, 75, 76 at ``balance=0``,
+        never 76 apiece -- and take whatever spacing comes with it.
     group_dur : float, optional
         See :py:class:`~pulse2percept.implants.Raster`.
 
@@ -734,13 +775,21 @@ class CheckerboardRaster(Raster):
         scale = min(np.linalg.norm(u), np.linalg.norm(v))
 
         # Of the splits that are even enough, keep the one whose groups are
-        # spread furthest apart, and of those the most even:
+        # spread furthest apart, and of those the most even. What "furthest
+        # apart" means is the closest pair of electrodes the split actually
+        # leaves firing together: the lattice a split is cut from says how far
+        # apart its sites are, but the implant only holds a finite piece of
+        # that lattice, and on a small or trimmed one the sites that would have
+        # been closest need not be there at all. The lattice spectrum comes in
+        # behind it, to settle ties and keep the pattern regular:
         best = None
         for labels, a, d, k, biggest in _sublattices(ij, n_groups, balance):
             w1, w2 = a * u, k * u + d * v
-            key = (tuple(np.round(_spectrum(w1, w2) / scale, 6)), -biggest)
+            spacing = _closest(xy, labels, n_groups)
+            key = (round(spacing / scale, 6),
+                   tuple(np.round(_spectrum(w1, w2) / scale, 6)), -biggest)
             if best is None or key > best[0]:
-                best = (key, labels, w1, w2)
+                best = (key, labels, w1, w2, spacing)
         if best is None:
             raise ValueError(
                 f"No checkerboard of {n_groups} groups fits these "
@@ -750,8 +799,7 @@ class CheckerboardRaster(Raster):
                 f"{balance:.0%} bigger than an even split. Try "
                 f"{_suggest(ij, n_groups, balance)} groups instead, or raise "
                 f"'balance' to allow groups of unequal size.")
-        labels, w1, w2 = best[1:]
-        self._min_spacing = float(_spectrum(w1, w2, n_terms=1)[0])
+        labels, w1, w2, self._min_spacing = best[1:]
 
         # Fire them in the order that wanders least. `labels` says which
         # pattern an electrode belongs to; the group index it gets is when that
@@ -788,7 +836,10 @@ class CheckerboardRaster(Raster):
 
         How much the checkerboard bought over a line raster, which leaves
         neighboring electrodes in the same group and so would report the
-        electrode pitch.
+        electrode pitch. Measured between electrodes the implant actually has,
+        so a small or trimmed array can come out better spaced than the pattern
+        it was cut from. Infinite when no group holds more than one electrode,
+        since then no two electrodes ever fire together.
         """
         return self._min_spacing
 

--- a/pulse2percept/implants/rasters.py
+++ b/pulse2percept/implants/rasters.py
@@ -4,10 +4,14 @@
    :py:class:`~pulse2percept.implants.CustomRaster`"""
 from abc import ABCMeta, abstractmethod
 from itertools import permutations
+import matplotlib.pyplot as plt
+from matplotlib.collections import PatchCollection
+from matplotlib.patches import Circle
 import numpy as np
 from scipy.spatial import cKDTree
 
 from ..utils import PrettyPrint
+from ..utils.constants import ZORDER
 
 
 def _finite(name, value):
@@ -138,6 +142,126 @@ class Raster(PrettyPrint, metaclass=ABCMeta):
 
         """
         raise NotImplementedError
+
+    def members(self, electrodes, group):
+        """The electrodes that take their turn together in one group
+
+        The inverse of :py:meth:`groups`, which says what group each electrode
+        is in. This says which electrodes are in a group.
+
+        Parameters
+        ----------
+        electrodes : array_like
+            Electrode names, in the order they appear in the stimulus.
+        group : int
+            Which group to look up, in ``0..n_groups-1``. Groups take their
+            turns in index order, so group 0 is the one that goes first.
+
+        Returns
+        -------
+        members : array
+            The entries of ``electrodes`` belonging to ``group``, in the order
+            they were given: names in, names out.
+
+        Examples
+        --------
+        >>> from pulse2percept.implants import ArgusII, SequentialRaster
+        >>> names = ArgusII().electrode_names
+        >>> SequentialRaster(6).members(names, 0)[:4]
+        array(['A1', 'A2', 'A3', 'A4'], dtype='<U3')
+
+        """
+        group = _whole('group', group)
+        if group < 0 or group >= self.n_groups:
+            raise ValueError(f"'group' must be in 0..{self.n_groups - 1}, not "
+                             f"{group}.")
+        return np.asarray(electrodes)[self.groups(electrodes) == group]
+
+    def plot(self, implant, annotate=None, ax=None, cmap='viridis',
+             autoscale=True):
+        """Plot the electrode array, colored by raster group
+
+        What a raster does is spatial, so the quickest way to tell whether it
+        does what was wanted is to look at it. Colors run in the order the
+        groups take their turns, so the picture shows the schedule as well as
+        the pattern: with
+        :py:class:`~pulse2percept.implants.CheckerboardRaster` a group's
+        electrodes should be scattered over the whole array rather than
+        gathered into a line, and neighboring colors should not lie next to
+        one another in a consistent direction.
+
+        Parameters
+        ----------
+        implant : :py:class:`~pulse2percept.implants.ProsthesisSystem`
+            The implant to draw, or its
+            :py:class:`~pulse2percept.implants.ElectrodeArray`. Its electrodes
+            are the ones the raster is asked about, so this has to be an
+            implant the raster covers.
+        annotate : bool, optional
+            Whether to write the group index into each electrode. If None,
+            they are written whenever there are few enough electrodes
+            (at most 120) for the numbers to be readable.
+        ax : matplotlib.axes.Axes, optional
+            Axes to draw on. If None, uses the current axes.
+        cmap : str, optional
+            Matplotlib colormap the group colors are taken from, evenly
+            spaced. A sequential map is the useful default, since the order
+            the colors run in is the order the groups fire in.
+        autoscale : bool, optional
+            Whether to fit the x/y limits to the implant.
+
+        Returns
+        -------
+        ax : matplotlib.axes.Axes
+            The axes drawn on.
+
+        """
+        earray = getattr(implant, 'earray', implant)
+        names = getattr(earray, 'electrode_names', None)
+        elecs = getattr(earray, 'electrode_objects', None)
+        if names is None or elecs is None:
+            raise TypeError(f"'implant' must be a ProsthesisSystem or an "
+                            f"ElectrodeArray, not {type(implant)}.")
+        names, elecs = list(names), list(elecs)
+        group = np.asarray(self.groups(names), dtype=np.int64)
+        if annotate is None:
+            annotate = len(names) <= 120
+        if ax is None:
+            ax = plt.gca()
+        ax.set_aspect('equal')
+        # One color per group, spread over the colormap. A single group would
+        # otherwise sit at the very end of it:
+        spread = (np.linspace(0, 1, self.n_groups) if self.n_groups > 1
+                  else np.array([0.5]))
+        colors = plt.get_cmap(cmap)(spread)
+        xy = np.array([[e.x, e.y] for e in elecs], dtype=np.float64)
+        # Sized by the array rather than by what each electrode reports, since
+        # neither of the two shapes an implant is usually built from would show
+        # its color: a PointSource is a 5 um dot however far apart they are,
+        # and a HexElectrode is drawn nearly transparent. Just short of half
+        # the closest gap, so that neighbors nearly touch and never overlap:
+        gap = cKDTree(xy).query(xy, k=2)[0][:, 1].min() if len(xy) > 1 else 1.0
+        patches = [Circle(pos, radius=0.38 * gap, fc=colors[g],
+                          ec=(0.3, 0.3, 0.3, 1), lw=0.5)
+                   for pos, g in zip(xy, group)]
+        if annotate:
+            for pos, g in zip(xy, group):
+                # A white backing, since a group index has to stay readable
+                # against both ends of the colormap:
+                ax.text(pos[0], pos[1], str(g), ha='center', va='center',
+                        color='black', size='large',
+                        bbox={'boxstyle': 'square,pad=0.1', 'ec': 'none',
+                              'fc': (1, 1, 1, 0.7)},
+                        zorder=ZORDER['annotate'])
+        ax.add_collection(PatchCollection(patches, match_original=True,
+                                          zorder=ZORDER['foreground']))
+        if autoscale:
+            ax.autoscale(True)
+        if ax.get_xlabel() == "":
+            ax.set_xlabel('x (microns)')
+        if ax.get_ylabel() == "":
+            ax.set_ylabel('y (microns)')
+        return ax
 
     def slot_dur(self, period):
         """Duration (ms) of one group's slot
@@ -534,7 +658,7 @@ class CheckerboardRaster(Raster):
 
     Examples
     --------
-    Five groups of twelve on Argus II, as in Kasowski et al. (2025):
+    Five groups of twelve on Argus II, as in [Kasowski2025]_:
 
     >>> from pulse2percept.implants import ArgusII, CheckerboardRaster
     >>> implant = ArgusII()
@@ -548,12 +672,12 @@ class CheckerboardRaster(Raster):
     >>> round(implant.raster.min_spacing / 575, 3)  # 575 um pitch
     2.236
 
-    References
-    ----------
-    .. [Kasowski2025] J M Kasowski, A Varshney, R Sadeghi, M Beyeler (2025).
-       Simulated prosthetic vision confirms checkerboard as an effective raster
-       pattern for epiretinal implants. *Journal of Neural Engineering*
-       22:046017.
+    The pattern is easiest to check by eye
+    (:py:meth:`~pulse2percept.implants.Raster.plot`), and the electrodes that
+    fire together are :py:meth:`~pulse2percept.implants.Raster.members`:
+
+    >>> implant.raster.members(implant.electrode_names, 0)[:4].tolist()
+    ['A1', 'A6', 'B3', 'B8']
 
     """
     __slots__ = ('_n_groups', '_group_of', '_min_spacing')

--- a/pulse2percept/implants/rasters.py
+++ b/pulse2percept/implants/rasters.py
@@ -391,13 +391,51 @@ def _reduce(w1, w2):
     """
     w1, w2 = np.asarray(w1, dtype=float), np.asarray(w2, dtype=float)
     for _ in range(100):
-        if w1 @ w1 > w2 @ w2:
+        # Compared with room to spare, and rounded off a step short of the
+        # halfway mark, because both decisions are otherwise made on the last
+        # bit of a float: on a square grid the two steps are exactly as long as
+        # each other, and on a hexagonal one they lean on each other by exactly
+        # half a step. Which way an exact comparison then falls is a matter of
+        # how the positions were arrived at, and differs between platforms.
+        if w1 @ w1 > w2 @ w2 * (1 + 1e-9):
             w1, w2 = w2, w1
-        mu = np.round((w2 @ w1) / (w1 @ w1))
+        mu = np.round(np.round((w2 @ w1) / (w1 @ w1), 9))
         if mu == 0:
             break
         w2 = w2 - mu * w1
     return w1, w2
+
+
+def _canonical(vectors, scale):
+    """Two lattice steps picked out of ``vectors`` by a rule, not by position
+
+    A grid has four shortest gaps, or six on a hexagonal one, all exactly as
+    long as each other, and every gap turns up with both signs. Which of them
+    is met first is an accident of how they were collected, so taking the
+    first would let the same implant come out mirrored on one machine and not
+    on another. Instead one of each +/- pair is dropped, and the rest are
+    ordered by length and then by direction, which leaves nothing to chance.
+    """
+    d = np.linalg.norm(vectors, axis=1)
+    tol = 1e-9 * scale
+    flat = np.abs(vectors[:, 1]) <= tol
+    keep = (d > tol) & ((vectors[:, 1] > tol) | (flat & (vectors[:, 0] > 0)))
+    vectors, d = vectors[keep], d[keep]
+    if not len(vectors):
+        raise NotImplementedError(
+            "A checkerboard needs electrodes on a regular grid, and these are "
+            "all in the same place.")
+    vectors = vectors[np.lexsort((-vectors[:, 1], -vectors[:, 0],
+                                  np.round(d / scale, 9)))]
+    u = vectors[0]
+    # The second step has to leave the line the first one traces out:
+    cross = np.abs(u[0] * vectors[:, 1] - u[1] * vectors[:, 0])
+    off_axis = np.flatnonzero(cross > 1e-6 * (u @ u))
+    if len(off_axis) == 0:
+        # Electrodes on a single line: any second step will do, since nothing
+        # is ever placed along it.
+        return u, np.array([-u[1], u[0]])
+    return u, vectors[off_axis[0]]
 
 
 def _combos(w1, w2, reach):
@@ -526,27 +564,13 @@ def _lattice(xy):
     # handful of nearest neighbors is enough to turn them up:
     _, idx = cKDTree(xy).query(xy, k=min(n, 9))
     diff = (xy[idx[:, 1:]] - xy[:, None, :]).reshape(-1, 2)
-    d = np.linalg.norm(diff, axis=1)
-    # Two electrodes in the same spot are no step at all, and would otherwise
-    # be taken for one of zero length:
-    apart = d > 1e-9 * d.max(initial=0.0)
-    if not np.any(apart):
-        raise NotImplementedError(
-            "A checkerboard needs electrodes on a regular grid, and these are "
-            "all in the same place.")
-    diff, d = diff[apart], d[apart]
-    diff = diff[np.argsort(np.round(d / d.max(), 9), kind='stable')]
-    u = diff[0]
-    # The second step has to leave the line the first one traces out:
-    cross = np.abs(u[0] * diff[:, 1] - u[1] * diff[:, 0])
-    off_axis = np.flatnonzero(cross > 1e-6 * (u @ u))
-    if len(off_axis) == 0:
-        # Electrodes on a single line: any second step will do, since nothing
-        # is ever placed along it.
-        v = np.array([-u[1], u[0]])
-    else:
-        v = diff[off_axis[0]]
-    u, v = _reduce(u, v)
+    scale = np.linalg.norm(diff, axis=1).max(initial=0.0)
+    u, v = _canonical(diff, scale)
+    # The gaps that were seen need not be the shortest two the lattice has, so
+    # they are reduced onto those -- and then settled by the rule a second
+    # time, since the reduction is free to hand them back either way round:
+    u, v = _canonical(_combos(*_reduce(u, v), reach=2),
+                      np.linalg.norm(u) or scale)
     basis = np.column_stack([u, v])
     ij = np.linalg.solve(basis, (xy - xy[0]).T).T
     # Negated so that a NaN, which fails every comparison, raises rather than

--- a/pulse2percept/implants/tests/test_rasters.py
+++ b/pulse2percept/implants/tests/test_rasters.py
@@ -1,12 +1,15 @@
+from copy import deepcopy
 import matplotlib.pyplot as plt
 import numpy as np
 import numpy.testing as npt
 import pytest
+from scipy.spatial import cKDTree
 
 from pulse2percept.implants import (AlphaIMS, ArgusII, BVT24,
                                     CheckerboardRaster, CustomRaster,
                                     ElectrodeGrid, PRIMA, ProsthesisSystem,
                                     Raster, SequentialRaster)
+from pulse2percept.implants import rasters
 
 
 def test_Raster_is_abstract():
@@ -148,10 +151,22 @@ def test_CheckerboardRaster_grids():
     # Rotating the implant rotates the pattern with it, since the pattern is
     # read off the electrode positions:
     upright = ProsthesisSystem(ElectrodeGrid((10, 10), 400))
-    turned = ProsthesisSystem(ElectrodeGrid((10, 10), 400, rot=37))
-    npt.assert_equal(CheckerboardRaster(turned, 5).groups(
-        turned.electrode_names),
-        CheckerboardRaster(upright, 5).groups(upright.electrode_names))
+    expected = CheckerboardRaster(upright, 5).groups(upright.electrode_names)
+    for angle in [11, 37, 84]:
+        turned = ProsthesisSystem(ElectrodeGrid((10, 10), 400, rot=angle))
+        npt.assert_equal(
+            CheckerboardRaster(turned, 5).groups(turned.electrode_names),
+            expected)
+    # Past a quarter turn the two grid directions trade places, so the pattern
+    # comes out transposed. It is the same pattern in every way that matters --
+    # which is what is checked here -- just not the same labelling:
+    for angle in [117, 300]:
+        turned = ProsthesisSystem(ElectrodeGrid((10, 10), 400, rot=angle))
+        raster = CheckerboardRaster(turned, 5)
+        npt.assert_almost_equal(raster.min_spacing, 400 * np.sqrt(5),
+                                decimal=3)
+        npt.assert_equal(np.bincount(raster.groups(turned.electrode_names)),
+                         np.full(5, 20))
 
     # Grids with electrodes trimmed off still work. PRIMA's 378 electrodes do
     # not divide by four, so the groups come out as even as 378 allows:
@@ -175,6 +190,52 @@ def test_CheckerboardRaster_grids():
     with pytest.raises(ValueError):
         CheckerboardRaster(prima, 20)
     npt.assert_equal(CheckerboardRaster(prima, 20, balance=0.2).n_groups, 20)
+
+
+def test_CheckerboardRaster_is_reproducible(monkeypatch):
+    # The pattern is built from the gaps between electrodes, and a grid has
+    # four gaps of exactly the same length (six on a hex grid), each of which
+    # turns up with both signs. Nothing about the order they are found in may
+    # reach the answer, or the same implant comes out mirrored on someone
+    # else's machine -- which is what used to happen, since neighbors at equal
+    # distance come back from the tree in a platform-dependent order.
+    class Scrambled(cKDTree):
+        seed = 0
+
+        def query(self, x, k):
+            dist, idx = super().query(x, k)
+            rng = np.random.RandomState(Scrambled.seed)
+            for row_d, row_i in zip(dist, idx):
+                tie = np.round(row_d, 6)
+                for t in np.unique(tie):
+                    at = np.flatnonzero(tie == t)
+                    to = rng.permutation(at)
+                    row_d[at], row_i[at] = row_d[to], row_i[to]
+            return dist, idx
+
+    hexgrid = ProsthesisSystem(ElectrodeGrid((10, 10), 400, type='hex'))
+    for implant in [ArgusII(), hexgrid, PRIMA()]:
+        names = implant.electrode_names
+        expected = CheckerboardRaster(implant, 5).groups(names)
+        for seed in range(4):
+            Scrambled.seed = seed
+            monkeypatch.setattr(rasters, 'cKDTree', Scrambled)
+            npt.assert_equal(CheckerboardRaster(implant, 5).groups(names),
+                             expected)
+            monkeypatch.undo()
+
+    # Nor may the last bit of a float, which is all that separates one
+    # platform's trigonometry from another's:
+    implant = ArgusII()
+    names = implant.electrode_names
+    expected = CheckerboardRaster(implant, 5).groups(names)
+    rng = np.random.RandomState(0)
+    for _ in range(4):
+        nudged = ProsthesisSystem(deepcopy(implant.earray))
+        for elec in nudged.earray.electrode_objects:
+            elec.x *= 1 + rng.uniform(-1, 1) * 1e-13
+            elec.y *= 1 + rng.uniform(-1, 1) * 1e-13
+        npt.assert_equal(CheckerboardRaster(nudged, 5).groups(names), expected)
 
 
 def test_CheckerboardRaster_groups():

--- a/pulse2percept/implants/tests/test_rasters.py
+++ b/pulse2percept/implants/tests/test_rasters.py
@@ -76,12 +76,14 @@ def test_Raster_offsets():
 
 def _min_spacing(implant, raster):
     """Closest two electrodes that the raster ever activates together"""
-    names = implant.electrode_names
-    xy = np.array([[e.x, e.y] for e in implant.earray.electrode_objects])
-    groups = raster.groups(names)
+    earray = getattr(implant, 'earray', implant)
+    xy = np.array([[e.x, e.y] for e in earray.electrode_objects])
+    groups = raster.groups(earray.electrode_names)
     closest = np.inf
     for group in np.unique(groups):
         pos = xy[groups == group]
+        if len(pos) < 2:
+            continue
         d = np.linalg.norm(pos[:, None, :] - pos[None, :, :], axis=-1)
         closest = min(closest, d[~np.eye(len(pos), dtype=bool)].min())
     return closest
@@ -181,6 +183,23 @@ def test_CheckerboardRaster_grids():
         CheckerboardRaster(prima, 5, balance=0).min_spacing <=
         CheckerboardRaster(prima, 5, balance=0.5).min_spacing, True)
 
+    # Rows and columns need not be spaced the same. A grid can be stretched
+    # far enough that an electrode's twenty nearest neighbors are all in its
+    # own row, and the step to the next row still has to be found -- looking
+    # only at the near neighborhood used to miss it and reject the grid:
+    for spacing, n in [((100, 1050), 5), ((100, 1050), 4), ((25, 3000), 5)]:
+        stretched = ElectrodeGrid((3, 20), spacing=spacing)
+        raster = CheckerboardRaster(stretched, n)
+        count = np.bincount(raster.groups(stretched.electrode_names))
+        npt.assert_equal(count, np.full(n, 60 // n))
+        npt.assert_almost_equal(_min_spacing(stretched, raster),
+                                raster.min_spacing, decimal=3)
+    # Electrodes really in a line have no second direction to find, and are
+    # still split into groups spread along it:
+    row = ElectrodeGrid((1, 12), 200)
+    npt.assert_equal(np.bincount(CheckerboardRaster(row, 4).groups(
+        row.electrode_names)), np.full(4, 3))
+
     # An implant whose electrodes are not on a grid cannot be checkered:
     with pytest.raises(NotImplementedError):
         CheckerboardRaster(BVT24(), 2)
@@ -190,6 +209,32 @@ def test_CheckerboardRaster_grids():
     with pytest.raises(ValueError):
         CheckerboardRaster(prima, 20)
     npt.assert_equal(CheckerboardRaster(prima, 20, balance=0.2).n_groups, 20)
+
+
+def test_CheckerboardRaster_min_spacing():
+    # `min_spacing` is measured between electrodes the implant actually has,
+    # not between the sites of the endless lattice the pattern was cut from.
+    # The two agree on an array big enough that the closest sites are all
+    # present, and part company on a small one -- where the finite array is
+    # the better spaced of the two, so reporting the lattice would undersell
+    # it and picking a pattern by it would settle for less:
+    for shape, n_groups in [((2, 6), 6), ((2, 3), 4), ((3, 4), 4), ((4, 4), 8),
+                            ((6, 10), 5), ((5, 5), 5)]:
+        grid = ElectrodeGrid(shape, 100)
+        raster = CheckerboardRaster(grid, n_groups)
+        npt.assert_almost_equal(raster.min_spacing, _min_spacing(grid, raster),
+                                decimal=6)
+    # Two rows of six in six groups is a pair per group, and the pairs can be
+    # put a whole diagonal apart -- ranking by the lattice alone settled for
+    # sqrt(5) here, since the lattice cannot tell that the sites in between
+    # are not on the implant:
+    pairs = ElectrodeGrid((2, 6), 100)
+    npt.assert_almost_equal(CheckerboardRaster(pairs, 6).min_spacing,
+                            100 * np.sqrt(10), decimal=6)
+    # A group of one electrode has no pair to keep apart:
+    singles = ElectrodeGrid((2, 2), 100)
+    npt.assert_equal(np.isinf(CheckerboardRaster(singles, 4).min_spacing),
+                     True)
 
 
 def test_CheckerboardRaster_is_reproducible(monkeypatch):

--- a/pulse2percept/implants/tests/test_rasters.py
+++ b/pulse2percept/implants/tests/test_rasters.py
@@ -1,10 +1,12 @@
+import matplotlib.pyplot as plt
 import numpy as np
 import numpy.testing as npt
 import pytest
 
-from pulse2percept.implants import (ArgusII, BVT24, CheckerboardRaster,
-                                    CustomRaster, ElectrodeGrid, PRIMA,
-                                    ProsthesisSystem, Raster, SequentialRaster)
+from pulse2percept.implants import (AlphaIMS, ArgusII, BVT24,
+                                    CheckerboardRaster, CustomRaster,
+                                    ElectrodeGrid, PRIMA, ProsthesisSystem,
+                                    Raster, SequentialRaster)
 
 
 def test_Raster_is_abstract():
@@ -192,6 +194,74 @@ def test_CheckerboardRaster_groups():
                      np.arange(5) * 5.0)
     implant.raster = raster
     npt.assert_equal(implant.raster.n_groups, 5)
+
+
+def test_Raster_members():
+    implant = ArgusII()
+    names = implant.electrode_names
+    # `members` is the inverse of `groups`: the electrodes of one group, in
+    # the order they were passed in:
+    raster = SequentialRaster(6)
+    npt.assert_equal(raster.members(names, 0), names[:10])
+    npt.assert_equal(raster.members(names, 5), names[50:])
+    # Names in, names out -- whatever was passed is what comes back, so a
+    # list of indices gives the indices of the group:
+    npt.assert_equal(SequentialRaster(6).members(range(60), 1),
+                     np.arange(10, 20))
+    # Every electrode is in exactly one group, and no group is lost:
+    for r in [SequentialRaster(4), CheckerboardRaster(implant, 4),
+              CustomRaster([names[:20], names[20:]])]:
+        found = np.concatenate([r.members(names, g)
+                                for g in range(r.n_groups)])
+        npt.assert_equal(sorted(found), sorted(names))
+    # A group that does not exist is a mistake, not an empty answer:
+    with pytest.raises(ValueError):
+        raster.members(names, 6)
+    with pytest.raises(ValueError):
+        raster.members(names, -1)
+    with pytest.raises(ValueError):
+        raster.members(names, 1.5)
+    with pytest.raises(ValueError):
+        raster.members(names, np.nan)
+
+
+def test_Raster_plot():
+    implant = ArgusII()
+    raster = CheckerboardRaster(implant, 5)
+    ax = raster.plot(implant)
+    # One patch per electrode, colored by group, and a group index written
+    # into each of them:
+    npt.assert_equal(len(ax.collections[0].get_paths()), 60)
+    npt.assert_equal(len(ax.texts), 60)
+    npt.assert_equal(sorted(t.get_text() for t in ax.texts),
+                     sorted(str(g) for g in raster.groups(
+                         implant.electrode_names)))
+    # Electrodes of one group share a color, and different groups do not:
+    colors = ax.collections[0].get_facecolor()
+    groups = raster.groups(implant.electrode_names)
+    npt.assert_equal(len(np.unique(colors[groups == 0], axis=0)), 1)
+    npt.assert_equal(len(np.unique(colors, axis=0)), 5)
+    plt.close('all')
+
+    # Annotating 1500 electrodes would be unreadable, so it is left off unless
+    # asked for:
+    npt.assert_equal(len(SequentialRaster(2).plot(AlphaIMS()).texts), 0)
+    plt.close('all')
+    npt.assert_equal(
+        len(SequentialRaster(2).plot(implant, annotate=False).texts), 0)
+    plt.close('all')
+
+    # Any raster can be plotted on any implant it covers, grid or not:
+    for r, imp in [(SequentialRaster(3), BVT24()),
+                   (CheckerboardRaster(PRIMA(), 7), PRIMA()),
+                   (CustomRaster({n: 0 for n in ArgusII().electrode_names}),
+                    ArgusII())]:
+        npt.assert_equal(len(r.plot(imp).collections[0].get_paths()),
+                         imp.n_electrodes)
+        plt.close('all')
+    # The array is what the electrodes are read from, so it has to be one:
+    with pytest.raises(TypeError):
+        raster.plot('ArgusII')
 
 
 def test_CustomRaster():

--- a/pulse2percept/implants/tests/test_rasters.py
+++ b/pulse2percept/implants/tests/test_rasters.py
@@ -2,8 +2,9 @@ import numpy as np
 import numpy.testing as npt
 import pytest
 
-from pulse2percept.implants import (ArgusII, CustomRaster, ProsthesisSystem,
-                                    Raster, SequentialRaster)
+from pulse2percept.implants import (ArgusII, BVT24, CheckerboardRaster,
+                                    CustomRaster, ElectrodeGrid, PRIMA,
+                                    ProsthesisSystem, Raster, SequentialRaster)
 
 
 def test_Raster_is_abstract():
@@ -66,6 +67,131 @@ def test_Raster_offsets():
     cycle = 1000.0 / 300
     offsets = SequentialRaster(3).offsets(names, cycle)
     npt.assert_almost_equal(np.unique(offsets), np.arange(3) * cycle / 3)
+
+
+def _min_spacing(implant, raster):
+    """Closest two electrodes that the raster ever activates together"""
+    names = implant.electrode_names
+    xy = np.array([[e.x, e.y] for e in implant.earray.electrode_objects])
+    groups = raster.groups(names)
+    closest = np.inf
+    for group in np.unique(groups):
+        pos = xy[groups == group]
+        d = np.linalg.norm(pos[:, None, :] - pos[None, :, :], axis=-1)
+        closest = min(closest, d[~np.eye(len(pos), dtype=bool)].min())
+    return closest
+
+
+def test_CheckerboardRaster():
+    with pytest.raises(ValueError):
+        CheckerboardRaster(ArgusII(), 0)
+    with pytest.raises(ValueError):
+        CheckerboardRaster(ArgusII(), 2.5)
+    with pytest.raises(ValueError):
+        CheckerboardRaster(ArgusII(), np.nan)
+    with pytest.raises(ValueError):
+        CheckerboardRaster(ArgusII(), 2, balance=-0.1)
+    with pytest.raises(ValueError):
+        CheckerboardRaster(ArgusII(), 2, group_dur=-1)
+    # More groups than electrodes is not a raster:
+    with pytest.raises(ValueError):
+        CheckerboardRaster(ArgusII(), 61)
+    with pytest.raises(TypeError):
+        CheckerboardRaster('ArgusII', 2)
+
+    implant = ArgusII()
+    names = implant.electrode_names
+    raster = CheckerboardRaster(implant, 5)
+    npt.assert_equal(raster.n_groups, 5)
+    groups = raster.groups(names)
+    # Every electrode is in exactly one group, and the groups are the same
+    # size -- an oversized group is what the current limit gets set by:
+    npt.assert_equal(np.bincount(groups), np.full(5, 12))
+    # Two groups is the checkerboard the pattern is named after: neighbors
+    # always land in different groups, so nothing closer than the diagonal is
+    # ever active at once:
+    two = CheckerboardRaster(implant, 2)
+    npt.assert_almost_equal(two.min_spacing, 575 * np.sqrt(2), decimal=3)
+    # Five groups do better still, at sqrt(5) pitches -- the knight's move
+    # pattern of Kasowski et al. (2025):
+    npt.assert_almost_equal(raster.min_spacing, 575 * np.sqrt(5), decimal=3)
+    # ... and `min_spacing` is what it says it is:
+    for r in [two, raster, CheckerboardRaster(implant, 4)]:
+        npt.assert_almost_equal(_min_spacing(implant, r), r.min_spacing,
+                                decimal=3)
+    # A line raster leaves neighbors in the same group, which is the whole
+    # point of not using one:
+    npt.assert_equal(_min_spacing(implant, SequentialRaster(6)), 575)
+    npt.assert_equal('min_spacing' in str(raster), True)
+
+    # Groups take turns in an order that doubles back instead of marching
+    # across the array. On a 6x10 grid five groups lie one per column, and
+    # firing them in that order would sweep steadily to the right:
+    order = [np.flatnonzero(groups == g)[0] for g in range(5)]
+    npt.assert_equal(order, [0, 1, 3, 2, 4])
+
+
+def test_CheckerboardRaster_grids():
+    # A hex grid is handled the same way, and its 7-group pattern is the one
+    # that puts every group on a hex lattice of its own, sqrt(7) pitches wide:
+    hexgrid = ProsthesisSystem(ElectrodeGrid((14, 14), 200, type='hex'))
+    raster = CheckerboardRaster(hexgrid, 7)
+    npt.assert_almost_equal(raster.min_spacing, 200 * np.sqrt(7), decimal=3)
+    npt.assert_almost_equal(_min_spacing(hexgrid, raster), raster.min_spacing,
+                            decimal=3)
+    # A hex grid cannot be two-colored the way a square one can, so two groups
+    # buy nothing there and the caller has to notice through `min_spacing`:
+    npt.assert_almost_equal(CheckerboardRaster(hexgrid, 2).min_spacing, 200)
+
+    # Rotating the implant rotates the pattern with it, since the pattern is
+    # read off the electrode positions:
+    upright = ProsthesisSystem(ElectrodeGrid((10, 10), 400))
+    turned = ProsthesisSystem(ElectrodeGrid((10, 10), 400, rot=37))
+    npt.assert_equal(CheckerboardRaster(turned, 5).groups(
+        turned.electrode_names),
+        CheckerboardRaster(upright, 5).groups(upright.electrode_names))
+
+    # Grids with electrodes trimmed off still work. PRIMA's 378 electrodes do
+    # not divide by four, so the groups come out as even as 378 allows:
+    prima = PRIMA()
+    raster = CheckerboardRaster(prima, 4)
+    count = np.bincount(raster.groups(prima.electrode_names))
+    npt.assert_equal(count.sum(), 378)
+    npt.assert_equal(count.max() <= np.ceil(378 / 4) * 1.05, True)
+    npt.assert_almost_equal(raster.min_spacing, 200)
+    # Demanding an exactly even split is allowed, and costs spacing:
+    npt.assert_equal(
+        CheckerboardRaster(prima, 5, balance=0).min_spacing <=
+        CheckerboardRaster(prima, 5, balance=0.5).min_spacing, True)
+
+    # An implant whose electrodes are not on a grid cannot be checkered:
+    with pytest.raises(NotImplementedError):
+        CheckerboardRaster(BVT24(), 2)
+    # Neither can a count that leaves no pattern even enough to be worth
+    # having. PRIMA's trimmed edges are what put 20 groups out of reach, and
+    # allowing bigger groups is what buys it back:
+    with pytest.raises(ValueError):
+        CheckerboardRaster(prima, 20)
+    npt.assert_equal(CheckerboardRaster(prima, 20, balance=0.2).n_groups, 20)
+
+
+def test_CheckerboardRaster_groups():
+    implant = ArgusII()
+    raster = CheckerboardRaster(implant, 5)
+    # The raster only knows the electrodes it was built for. Silently dropping
+    # the others would break the current limit it exists to respect:
+    with pytest.raises(ValueError):
+        raster.groups(['A1', 'not-an-electrode'])
+    # A subset of the stimulus is fine, and keeps the assignment it had:
+    subset = ['F10', 'A1', 'C5']
+    npt.assert_equal(raster.groups(subset),
+                     [raster.groups(implant.electrode_names)[i]
+                      for i in [59, 0, 24]])
+    # It plugs into the schedule like any other raster:
+    npt.assert_equal(np.unique(raster.offsets(implant.electrode_names, 25.0)),
+                     np.arange(5) * 5.0)
+    implant.raster = raster
+    npt.assert_equal(implant.raster.n_groups, 5)
 
 
 def test_CustomRaster():


### PR DESCRIPTION
Adds `CheckerboardRaster`, which implements the raster pattern of [Kasowski et al. (2025)](https://doi.org/10.1088/1741-2552/adecc4), which scatters raster groups over the whole array, generalized to all implants with a rect or hex grid.

We needed some math for that: A raster group turns out to be a coset of a sublattice of the electrode grid,
which makes both halves of the pattern a small exhaustive search

- within a group, every sublattice is enumerated in Hermite normal form and ranked by how far apart it keeps simultaneously active electrodes
- between groups, the firing order is chosen so the percept moves back and forth (instead of "marching on") in an effort to avoid or at least reduce apparent motion

Some caveats:

- hex grids can't be two-colored; so implants like PRIMA are better off with 3, 4, or 7 raster groups
- `n_groups` obviously has to fit the grid; we don't need exact divisibility because the `balance` parameter allows for some groups to be slightly larger than others (default is 5%). Pass `balance=0` to add no imbalance beyond the rounding that an uneven electrode count forces anyway

Also adds two methods to the `Raster` base class, so every raster type has them:

- `members(electrodes, group)`: the electrodes that take their turn together, basically the inverse of `groups()`
- `plot(implant)`: draws the array colored by group, with colors running in firing order, so the picture shows the schedule as well as the pattern