### PR TITLE
[OPT] Speed up temporal models

### DIFF
--- a/pulse2percept/models/_horsager2009.pyx
+++ b/pulse2percept/models/_horsager2009.pyx
@@ -1,4 +1,5 @@
 from pulse2percept.utils._fast_math cimport c_fmax
+from pulse2percept.utils._fpmode cimport c_denormals_off, c_fpmode_restore
 from libc.math cimport powf as c_pow, fabs as c_abs, sqrtf as c_sqrt
 from cython.parallel import prange
 from cython import cdivision  # modulo, division by zero
@@ -60,9 +61,11 @@ cpdef temporal_fast(const float32[:, ::1] stim,
     cdef:
         float32 ca, r1, r2, r3_a, r3, r4a, r4b, r4c
         float32 t_sim, amp, zero_pow
+        float32 dt_tau1, dt_tau2, dt_tau3
         float32[:, ::1] percept
         index_t idx_space, idx_sim, idx_stim, idx_frame
         index_t n_space, n_stim, n_percept, n_sim
+        unsigned long long fpmode
 
     # Note that eps must be divided by 1000, because the original model was fit
     # with a microsecond time step and now we are running milliseconds:
@@ -81,8 +84,25 @@ cpdef temporal_fast(const float32[:, ::1] stim,
     # Note this is not simply zero: `pow(0, beta)` is 1 at `beta == 0` and
     # infinite for negative `beta`, and both are reproduced by reusing it.
     zero_pow = c_pow(<float32>0.0, beta)
+    # Each leaky integrator below steps by `dt * (drive - state) / tau`, and
+    # `dt / tau` is the same number on every step at every location. Written
+    # that way it is still a division per stage per step, because reassociating
+    # it is not a transformation a C compiler may make on its own: the two
+    # forms round differently, and neither `/fp:fast` nor `-ffast-math` is on.
+    # Five divisions, each ~14 cycles of latency, sit right on the dependency
+    # chain the loop cannot start the next step without. Dividing once here
+    # turns all five into multiplies:
+    dt_tau1 = dt / tau1
+    dt_tau2 = dt / tau2
+    dt_tau3 = dt / tau3
 
     for idx_space in prange(n_space, schedule='static', nogil=True, num_threads=n_threads):
+        # Between pulses the integrators below decay down through the subnormal
+        # range, where the arithmetic costs ~100x what it does on normal
+        # floats. Flushing to zero there is what keeps this loop bound by its
+        # own arithmetic rather than by microcode; see `utils/_fpmode.pxd`. The
+        # mode is per-thread, hence set here rather than around the `prange`:
+        fpmode = c_denormals_off()
         # Because the stationary nonlinearity depends on `max_R3`, which is the
         # largest value of R3 over all time points, we have to process the
         # stimulus in two steps.
@@ -113,11 +133,11 @@ cpdef temporal_fast(const float32[:, ::1] stim,
             # which is required to reproduce e.g. Fig.3 in the paper,
             # indicating that the model was trained on what we know call
             # "anodic" current:
-            r1 = r1 + dt * (-amp - r1) / tau1  # += in threads is a reduction
+            r1 = r1 + dt_tau1 * (-amp - r1)  # += in threads is a reduction
             # Charge accumulation:
             # ca = ca + dt * c_fmax(amp, 0) # SLOW
             ca = ca + dt * (amp if amp > 0.0 else 0.0)
-            r2 = r2 + dt * (ca - r2) / tau2
+            r2 = r2 + dt_tau2 * (ca - r2)
             # Half-rectification and power nonlinearity:
             # r3 = c_pow(c_fmax(r1 - eps * r2, 0), beta) # SLOW
             # `powf` is the most expensive call in this loop, and the
@@ -129,9 +149,9 @@ cpdef temporal_fast(const float32[:, ::1] stim,
             else:
                 r3 = zero_pow
             # Slow response (3-stage leaky integrator):
-            r4a = r4a + dt * (r3 - r4a) / tau3
-            r4b = r4b + dt * (r4a - r4b) / tau3
-            r4c = r4c + dt * (r4b - r4c) / tau3
+            r4a = r4a + dt_tau3 * (r3 - r4a)
+            r4b = r4b + dt_tau3 * (r4a - r4b)
+            r4c = r4c + dt_tau3 * (r4b - r4c)
             if idx_sim == idx_t_percept[idx_frame]:
                 # `idx_t_percept` stores the time points at which we need to
                 # output a percept. We compare `idx_sim` to `idx_t_percept`
@@ -140,5 +160,7 @@ cpdef temporal_fast(const float32[:, ::1] stim,
                 if c_abs(r4c) >= thresh_percept:
                     percept[idx_space, idx_frame] = r4c
                 idx_frame = idx_frame + 1
+        # Hand the thread back in the floating-point mode it arrived in:
+        c_fpmode_restore(fpmode)
 
     return np.asarray(percept)  # Py overhead

--- a/pulse2percept/models/_nanduri2012.pyx
+++ b/pulse2percept/models/_nanduri2012.pyx
@@ -1,4 +1,5 @@
 from pulse2percept.utils._fast_math cimport c_fmax, c_expit
+from pulse2percept.utils._fpmode cimport c_denormals_off, c_fpmode_restore
 
 from libc.math cimport(powf as c_pow, fabs as c_abs, sqrtf as c_sqrt,
                        isnan as c_isnan)
@@ -163,10 +164,12 @@ cpdef temporal_fast(const float32[:, ::1] stim,
     cdef:
         float32 ca, r1, r2, r3, max_r3, r4a, r4b, r4c
         float32 t_sim, amp, scale
+        float32 dt_tau1, dt_tau2, dt_tau3
         float32[:, ::1] all_r3
         float32[:, ::1] percept
         index_t idx_space, idx_sim, idx_stim, idx_frame
         index_t n_space, n_stim, n_percept, n_sim
+        unsigned long long fpmode
 
     # Note that eps must be divided by 1000, because the original model was fit
     # with a microsecond time step and now we are running milliseconds:
@@ -179,8 +182,24 @@ cpdef temporal_fast(const float32[:, ::1] stim,
 
     all_r3 = np.empty((n_space, n_sim), dtype=np.float32)  # Py overhead
     percept = np.zeros((n_space, n_percept), dtype=np.float32)  # Py overhead
+    # Each leaky integrator below steps by `dt * (drive - state) / tau`, and
+    # `dt / tau` is the same number on every step at every location. Written
+    # that way it is still a division per stage per step, because reassociating
+    # it is not a transformation a C compiler may make on its own: the two
+    # forms round differently, and neither `/fp:fast` nor `-ffast-math` is on.
+    # Five divisions, each ~14 cycles of latency, sit right on the dependency
+    # chain the loop cannot start the next step without. Dividing once here
+    # turns all five into multiplies:
+    dt_tau1 = dt / tau1
+    dt_tau2 = dt / tau2
+    dt_tau3 = dt / tau3
 
     for idx_space in prange(n_space, schedule='static', nogil=True, num_threads=n_threads):
+        # Between pulses the integrators below decay down through the subnormal
+        # range, where the arithmetic costs ~100x what it does on normal
+        # floats; see `utils/_fpmode.pxd`. The mode is per-thread, hence set
+        # here rather than around the `prange`:
+        fpmode = c_denormals_off()
         # Because the stationary nonlinearity depends on `max_R3`, which is the
         # largest value of R3 over all time points, we have to process the
         # stimulus in two steps.
@@ -205,11 +224,11 @@ cpdef temporal_fast(const float32[:, ::1] stim,
                 idx_stim = idx_stim + 1
             amp = stim[idx_space, idx_stim]
             # Fast ganglion cell response:
-            r1 = r1 + dt * (amp - r1) / tau1  # += in threads is a reduction
+            r1 = r1 + dt_tau1 * (amp - r1)  # += in threads is a reduction
             # Charge accumulation:
             # ca = ca + dt * c_fmax(amp, 0.0) # SLOW
             ca = ca + dt * (amp if amp > 0.0 else 0.0)
-            r2 = r2 + dt * (ca - r2) / tau2
+            r2 = r2 + dt_tau2 * (ca - r2)
             # Half-rectification:
             # r3 = c_fmax(r1 - eps * r2, 0.0) # SLOW
             r3 = r1 - eps * r2
@@ -233,9 +252,9 @@ cpdef temporal_fast(const float32[:, ::1] stim,
         # step, so it needs no stimulus frame lookup of its own:
         for idx_sim in range(n_sim):
             # Slow response (3-stage leaky integrator):
-            r4a = r4a + dt * (all_r3[idx_space, idx_sim] * scale - r4a) / tau3
-            r4b = r4b + dt * (r4a - r4b) / tau3
-            r4c = r4c + dt * (r4b - r4c) / tau3
+            r4a = r4a + dt_tau3 * (all_r3[idx_space, idx_sim] * scale - r4a)
+            r4b = r4b + dt_tau3 * (r4a - r4b)
+            r4c = r4c + dt_tau3 * (r4b - r4c)
             if idx_sim == idx_t_percept[idx_frame]:
                 # `idx_t_percept` stores the time points at which we need to
                 # output a percept. We compare `idx_sim` to `idx_t_percept`
@@ -245,5 +264,7 @@ cpdef temporal_fast(const float32[:, ::1] stim,
                     r4c = 0.0
                 percept[idx_space, idx_frame] = r4c * scale_out
                 idx_frame = idx_frame + 1
+        # Hand the thread back in the floating-point mode it arrived in:
+        c_fpmode_restore(fpmode)
 
     return np.asarray(percept)  # Py overhead

--- a/pulse2percept/models/_temporal.pyx
+++ b/pulse2percept/models/_temporal.pyx
@@ -2,6 +2,7 @@ from libc.math cimport(pow as c_pow, exp as c_exp, fabs as c_abs,
                        sqrt as c_sqrt)
 from cython.parallel import prange
 from cython.parallel cimport threadid
+from pulse2percept.utils._fpmode cimport c_denormals_off, c_fpmode_restore
 from cython import cdivision  # modulo, division by zero
 import numpy as np
 cimport numpy as cnp
@@ -78,13 +79,14 @@ cpdef fading_fast(const float32[:, ::1] stim,
 
     """
     cdef:
-        float32 t_sim, amp, drive, bright, peak
+        float32 t_sim, amp, drive, bright, peak, dt_tau
         float32[:, ::1] percept
         float32[:, ::1] stim_t
         float32[:, ::1] scratch
         float32[:, ::1] running
         index_t idx_space, idx_sim, idx_stim, idx_frame, idx_block
         index_t n_space, n_stim, n_percept, n_sim, n_blocks, lo, hi, tid
+        unsigned long long fpmode
 
     n_percept = len(idx_t_percept)  # Py overhead
     n_stim = len(t_stim)  # Py overhead
@@ -94,6 +96,14 @@ cpdef fading_fast(const float32[:, ::1] stim,
         n_threads = 1
 
     percept = np.zeros((n_space, n_percept), dtype=np.float32)  # Py overhead
+    # The integrator below steps by `dt * (drive - bright) / tau`, and `dt/tau`
+    # is the same number on every step at every location. Written that way it
+    # is still a division per step, because reassociating it is not a
+    # transformation a C compiler may make on its own: the two forms round
+    # differently, and neither `/fp:fast` nor `-ffast-math` is on. Dividing
+    # once here takes ~14 cycles of latency off the dependency chain that the
+    # loop cannot start the next step without:
+    dt_tau = dt / tau
     # One simulation step reads the same stimulus frame for every location, so
     # transpose once and that read becomes a contiguous run:
     stim_t = np.ascontiguousarray(np.asarray(stim).T)  # Py overhead
@@ -108,6 +118,11 @@ cpdef fading_fast(const float32[:, ::1] stim,
 
     for idx_block in prange(n_blocks, schedule='static', nogil=True,
                             num_threads=n_threads):
+        # Brightness decays down through the subnormal range between pulses,
+        # where the arithmetic costs ~100x what it does on normal floats; see
+        # `utils/_fpmode.pxd`. The mode is per-thread, hence set here rather
+        # than around the `prange`:
+        fpmode = c_denormals_off()
         tid = threadid()
         lo = idx_block * BLOCK
         hi = lo + BLOCK
@@ -147,7 +162,7 @@ cpdef fading_fast(const float32[:, ::1] stim,
                 drive = -amp
                 if drive < 0.0:
                     drive = 0.0
-                bright = bright + dt * (drive - bright) / tau
+                bright = bright + dt_tau * (drive - bright)
                 # Brightness is bounded in [0, \inf[
                 if bright < 0.0:
                     bright = 0.0
@@ -174,5 +189,7 @@ cpdef fading_fast(const float32[:, ::1] stim,
                     # next interval reaches:
                     running[tid, idx_space] = scratch[tid, idx_space]
                 idx_frame = idx_frame + 1
+        # Hand the thread back in the floating-point mode it arrived in:
+        c_fpmode_restore(fpmode)
 
     return np.asarray(percept)  # Py overhead

--- a/pulse2percept/models/tests/test_temporal.py
+++ b/pulse2percept/models/tests/test_temporal.py
@@ -114,6 +114,12 @@ def test_FadingTemporal_matches_reference_integrator():
         n_space, -1)
 
     dt, tau = np.float32(model.dt), np.float32(model.tau)
+    # `dt / tau` once, not `dt * x / tau` per step: the kernel divides in
+    # advance and multiplies in the loop, since a division sits on the
+    # dependency chain of every step. The two forms differ in the last ulp, so
+    # a reference that divides per step no longer matches exactly -- and it is
+    # the exactness that makes this test worth having.
+    dt_tau = np.float32(dt / tau)
     idx_p = np.uint32(np.round(t_percept / model.dt))
     for s in range(n_space):
         bright = np.float32(0.0)
@@ -127,7 +133,7 @@ def test_FadingTemporal_matches_reference_integrator():
                 idx_stim += 1
             amp = data[s, idx_stim]
             drive = np.float32(max(-amp, 0.0))
-            bright = np.float32(bright + dt * (drive - bright) / tau)
+            bright = np.float32(bright + dt_tau * (drive - bright))
             if bright < 0:
                 bright = np.float32(0.0)
             if i == idx_p[frame]:

--- a/pulse2percept/models/tests/test_temporal.py
+++ b/pulse2percept/models/tests/test_temporal.py
@@ -98,9 +98,9 @@ def test_FadingTemporal_matches_reference_integrator():
     ``fading_fast`` runs time in the outer loop and space in the inner one so
     that the inner loop vectorizes. This walks a couple of locations the
     obvious way -- one at a time, stepping forward -- and checks the kernel
-    agrees exactly. The stimulus straddles zero, so it also pins the half-wave
-    rectification: anodic samples must contribute nothing at all rather than
-    driving brightness down.
+    agrees to within a few ulps. The stimulus straddles zero, so it also pins
+    the half-wave rectification: anodic samples must contribute nothing at all
+    rather than driving brightness down.
     """
     model = FadingTemporal(dt=0.01, tau=50, thresh_percept=0).build()
     n_space, n_stim = 3, 5
@@ -116,9 +116,7 @@ def test_FadingTemporal_matches_reference_integrator():
     dt, tau = np.float32(model.dt), np.float32(model.tau)
     # `dt / tau` once, not `dt * x / tau` per step: the kernel divides in
     # advance and multiplies in the loop, since a division sits on the
-    # dependency chain of every step. The two forms differ in the last ulp, so
-    # a reference that divides per step no longer matches exactly -- and it is
-    # the exactness that makes this test worth having.
+    # dependency chain of every step.
     dt_tau = np.float32(dt / tau)
     idx_p = np.uint32(np.round(t_percept / model.dt))
     for s in range(n_space):
@@ -137,7 +135,17 @@ def test_FadingTemporal_matches_reference_integrator():
             if bright < 0:
                 bright = np.float32(0.0)
             if i == idx_p[frame]:
-                npt.assert_array_equal(got[s, frame], bright)
+                # Close, not equal. `bright + dt_tau * x` is a multiply feeding
+                # an add, which a C compiler may contract into a single fused
+                # multiply-add -- one rounding instead of two. Clang does so by
+                # default wherever FMA is in the baseline instruction set, so
+                # the kernel takes one legal rounding on Apple Silicon and the
+                # other under MSVC on x86-64, and NumPy here always takes the
+                # unfused one. What this test is for is the recurrence, the
+                # frame advance and the rectification; which of two correctly
+                # rounded results the host CPU produces is not something the
+                # library gets to promise.
+                npt.assert_allclose(got[s, frame], bright, rtol=1e-6)
                 frame += 1
 
 

--- a/pulse2percept/utils/_fpmode.pxd
+++ b/pulse2percept/utils/_fpmode.pxd
@@ -1,0 +1,68 @@
+# Subnormal-flushing control for the temporal models' inner loops.
+#
+# Every temporal model in `pulse2percept.models` is a cascade of leaky
+# integrators stepped at `dt`, and between pulses each one decays exponentially
+# toward zero. A pulse train leaves them decaying for a long time: at the
+# default dt=5e-3 ms, a 6 Hz train puts ~33,000 steps between one pulse and the
+# next, which for a tau of half a millisecond is several hundred time
+# constants. Partway down that decay the state enters the subnormal range
+# (|x| < 1.2e-38 in float32), where x86 hands the operation to microcode and
+# takes roughly two orders of magnitude longer than the same arithmetic on
+# normal floats. It does not stay there long -- a few percent of steps -- but
+# at 100x each that is enough to dominate the run: measured on the Horsager
+# 2009 kernel with an Argus II pulse train, the loop runs ~9x slower than the
+# identical loop on values that never go subnormal.
+#
+# Flushing them to zero costs nothing that matters. These are magnitudes below
+# 1e-38 feeding a percept of order 1e-2, so the alternative to zero is not a
+# more accurate answer, it is the same answer reached slowly.
+#
+# The mode lives in a per-thread control register, so it has to be set inside
+# the parallel region rather than around it, and restored afterwards so that
+# importing this library does not silently change the floating-point behavior
+# of everything else in the process.
+
+cdef extern from *:
+    """
+    #if defined(__x86_64__) || defined(_M_X64) || defined(__i386__) || \
+        defined(_M_IX86)
+      #include <xmmintrin.h>
+      /* MXCSR bit 15 (FTZ) flushes subnormal results to zero; bit 6 (DAZ)
+         treats subnormal operands as zero. Both are present on every x86-64
+         CPU, and on 32-bit x86 back to Prescott. */
+      static CYTHON_INLINE unsigned long long p2p_denormals_off(void) {
+          unsigned int prev = _mm_getcsr();
+          _mm_setcsr(prev | 0x8000u | 0x0040u);
+          return (unsigned long long) prev;
+      }
+      static CYTHON_INLINE void p2p_fpmode_restore(unsigned long long prev) {
+          _mm_setcsr((unsigned int) prev);
+      }
+    #elif defined(__aarch64__) && defined(__GNUC__)
+      /* FPCR bit 24 (FZ) is the AArch64 equivalent. Save and restore the whole
+         register rather than just the bit, so nothing else in it is disturbed. */
+      static CYTHON_INLINE unsigned long long p2p_denormals_off(void) {
+          unsigned long long prev;
+          __asm__ __volatile__("mrs %0, fpcr" : "=r" (prev));
+          __asm__ __volatile__("msr fpcr, %0" : : "r" (prev | (1ULL << 24)));
+          return prev;
+      }
+      static CYTHON_INLINE void p2p_fpmode_restore(unsigned long long prev) {
+          __asm__ __volatile__("msr fpcr, %0" : : "r" (prev));
+      }
+    #else
+      /* Unknown architecture: leave the floating-point mode alone. The models
+         are correct either way; only the speed differs. */
+      static CYTHON_INLINE unsigned long long p2p_denormals_off(void) {
+          return 0ULL;
+      }
+      static CYTHON_INLINE void p2p_fpmode_restore(unsigned long long prev) {
+          (void) prev;
+      }
+    #endif
+    """
+    # Stop subnormal results from being computed as subnormals, returning the
+    # previous mode of the calling thread for `c_fpmode_restore`.
+    unsigned long long c_denormals_off "p2p_denormals_off" () noexcept nogil
+    void c_fpmode_restore "p2p_fpmode_restore" (
+        unsigned long long prev) noexcept nogil


### PR DESCRIPTION
Benchmarking revealed that temporal models spend most of their time multiplying and dividing tiny numbers... For example, with the Horsager model and `dt=5e-3 ms`, a typical 6 Hz train leaves ~33,000 steps of nothingness between two pulses. Doing arithmetic with those tiny numbers ("subnormal range") is expensive.

New `utils/_fpmode.pxd` sets flush-to-zero (x86 MXCSR, AArch64 FPCR, no-op elsewhere). This is done in a per-thread register (parallel region). It has no C++ dependency, so the C-compiled kernels can use it without switching. In addition, there were five expensive divisions that had to be done at each step before advancing. Fixing both in `_horsager2009.pyx`, `_nanduri2012.pyx` and `_temporal.pyx` gives (on my laptop):

| model           | before  | after |
|-----------------|---------|-------|
| Horsager2009    | 122.4 s | 3.6 s |
| Nanduri2012     | 125.9 s | 10.2 s |
| FadingTemporal  | 2.9 s   | 2.6 s |

`FadingTemporal` already vectorizes over space, which is why it had less to gain. Accuracy is practically unaffected.