### PR TITLE
[FIX] ImageStimulus: pass on kwarg to skimage, resize img, center based on loc

### DIFF
--- a/doc/users/release_notes.rst
+++ b/doc/users/release_notes.rst
@@ -61,7 +61,7 @@ API changes:
 * Minimum dependency versions were raised for NumPy 2 compatibility. NumPy 1.x
   users should remain on v0.9.1.
 
-## Bug fixes
+Bug fixes:
 
 * :py:class:`~pulse2percept.stimuli.PulseTrain` no longer ends on partial,
   unbalanced pulses when its frequency does not divide ``stim_dur``.
@@ -74,13 +74,11 @@ API changes:
   identical time points using the same tolerance as
   :py:class:`~pulse2percept.stimuli.Stimulus`.
 
-* Visual-field-map equality now handles array-valued attributes correctly,
-  maps are hashable again, and maps of different classes no longer compare
-  equal.
-
-* :py:meth:`~pulse2percept.stimuli.ImageStimulus.encode` and
-  :py:meth:`~pulse2percept.stimuli.VideoStimulus.encode` no longer modify their
-  inputs in place.
+* Various fixes for :py:class:`~pulse2percept.stimuli.ImageStimulus`:
+  keyword arguments are passed on to scikit-image; inputs are no longer
+  modified in place; :py:meth:`~pulse2percept.stimuli.ImageStimulus.center`
+  honors its ``loc`` argument instead of always centering on the middle of
+  the image.
 
 * :py:meth:`~pulse2percept.percepts.Percept.play`,
   :py:meth:`~pulse2percept.stimuli.VideoStimulus.play`, and
@@ -100,8 +98,9 @@ API changes:
   it. Previously the four channels were reinterpreted as RGB, which sheared the
   color channels across every row.
 
-* The per-frame title in the HTML player no longer piles up on itself or on a
-  title that was already on the axes.
+* Visual-field-map equality now handles array-valued attributes correctly,
+  maps are hashable again, and maps of different classes no longer compare
+  equal.
 
 v0.9.1 (2026-08-06)
 -------------------

--- a/pulse2percept/stimuli/images.py
+++ b/pulse2percept/stimuli/images.py
@@ -134,16 +134,47 @@ class ImageStimulus(Stimulus):
         params.update({'img_shape': self.img_shape})
         return params
 
-    def apply(self, func, *args, **kwargs):
+    def _names_for(self, img, electrodes):
+        """Electrode names for an image derived from this one
+
+        A pixel keeps its name across an operation that leaves the pixel grid
+        alone, which is what makes 'A1' refer to the same thing before and
+        after. An operation that resamples the grid (a resize, a rotation that
+        grows the canvas) has no such correspondence to preserve, so the result
+        is named afresh rather than inheriting names that no longer describe
+        it.
+        """
+        if electrodes is not None:
+            return electrodes
+        return self.electrodes if np.shape(img) == self.img_shape else None
+
+    def apply(self, func, *args, electrodes=None, **kwargs):
         """Apply a function to the image
+
+        .. versionchanged:: 0.10.0
+
+            ``func`` may now change the shape of the image, and ``electrodes``
+            can name the result.
 
         Parameters
         ----------
         func : function
             The function to apply to the image. Must accept a 2D or 3D image
-            and return an image with the same dimensions
+            and return a 2D or 3D image. The returned image need not have the
+            same shape as the original; see ``electrodes``.
         * args :
             Additional positional arguments passed to the function
+        electrodes : int, string or list thereof; optional
+            Optionally, you can provide your own electrode names. If none are
+            given, the original names are carried over whenever ``func`` leaves
+            the shape of the image alone, and the result is named after its
+            place in the new image otherwise (e.g. for
+            ``skimage.transform.resize``). See
+            :py:class:`~pulse2percept.stimuli.ElectrodeNames`.
+
+            .. note::
+               The number of electrode names provided must match the number of
+               pixels in the returned image.
         **kwargs :
             Additional keyword arguments passed to the function
 
@@ -153,7 +184,7 @@ class ImageStimulus(Stimulus):
             A copy of the stimulus object with the new image
         """
         img = func(self.data.reshape(self.img_shape), *args, **kwargs)
-        return ImageStimulus(img, electrodes=self.electrodes,
+        return ImageStimulus(img, electrodes=self._names_for(img, electrodes),
                              metadata=self.metadata)
 
     def invert(self):
@@ -216,8 +247,14 @@ class ImageStimulus(Stimulus):
         return ImageStimulus(img, electrodes=electrodes,
                              metadata=self.metadata)
 
-    def resize(self, shape, electrodes=None):
+    def resize(self, shape, electrodes=None, **kwargs):
         """Resize the image
+
+        .. versionchanged:: 0.10.0
+
+            Keyword arguments are passed on to scikit-image.
+
+        .. _skimage.transform.resize: https://scikit-image.org/docs/stable/api/skimage.transform.html#skimage.transform.resize
 
         Parameters
         ----------
@@ -232,6 +269,10 @@ class ImageStimulus(Stimulus):
             .. note::
                The number of electrode names provided must match the number of
                pixels in the grayscale image.
+        **kwargs :
+            Additional keyword arguments passed to `skimage.transform.resize`_,
+            such as ``order=0`` for nearest-neighbor interpolation (which keeps
+            a binary image binary).
 
         Returns
         -------
@@ -246,7 +287,8 @@ class ImageStimulus(Stimulus):
             height = int(self.img_shape[0] * width / self.img_shape[1])
         if width < 0:
             width = int(self.img_shape[1] * height / self.img_shape[0])
-        img = img_resize(self.data.reshape(self.img_shape), (height, width))
+        img = img_resize(self.data.reshape(self.img_shape), (height, width),
+                         **kwargs)
 
         return ImageStimulus(img, electrodes=electrodes,
                              metadata=self.metadata)
@@ -419,14 +461,33 @@ class ImageStimulus(Stimulus):
         return ImageStimulus(img, electrodes=self.electrodes,
                              metadata=self.metadata)
 
-    def rotate(self, angle, mode='constant'):
+    def rotate(self, angle, mode='constant', electrodes=None, **kwargs):
         """Rotate the image
+
+        .. versionchanged:: 0.10.0
+
+            Keyword arguments are passed on to scikit-image.
+
+        .. _skimage.transform.rotate: https://scikit-image.org/docs/stable/api/skimage.transform.html#skimage.transform.rotate
 
         Parameters
         ----------
         angle : float
             Angle by which to rotate the image (degrees).
             Positive: counter-clockwise, negative: clockwise
+        mode : str, optional
+            How to fill in the corners the rotation leaves empty; see
+            `skimage.transform.rotate`_.
+        electrodes : int, string or list thereof; optional
+            Optionally, you can provide your own electrode names. If none are
+            given, each pixel keeps the name it had before the rotation, unless
+            ``resize=True`` grew the canvas, in which case the enlarged image is
+            named after its own pixel grid. See
+            :py:class:`~pulse2percept.stimuli.ElectrodeNames`.
+        **kwargs :
+            Additional keyword arguments passed to `skimage.transform.rotate`_,
+            such as ``order``, ``cval``, or ``resize=True`` to grow the image so
+            that it contains every rotated pixel.
 
         Returns
         -------
@@ -434,9 +495,12 @@ class ImageStimulus(Stimulus):
             A copy of the stimulus object containing the rotated image
 
         """
+        # Rotating in place is the common case, and keeps the pixel names
+        # meaningful; ``resize=True`` is available through kwargs:
+        kwargs.setdefault('resize', False)
         img = img_rotate(self.data.reshape(self.img_shape), angle, mode=mode,
-                         resize=False)
-        return ImageStimulus(img, electrodes=self.electrodes,
+                         **kwargs)
+        return ImageStimulus(img, electrodes=self._names_for(img, electrodes),
                              metadata=self.metadata)
 
     def shift(self, shift_cols, shift_rows):
@@ -481,7 +545,7 @@ class ImageStimulus(Stimulus):
         """
         # Calculate center of mass:
         img = self.data.reshape(self.img_shape)
-        return ImageStimulus(center_image(img, loc=None),
+        return ImageStimulus(center_image(img, loc=loc),
                              electrodes=self.electrodes,
                              metadata=self.metadata)
 

--- a/pulse2percept/stimuli/tests/test_images.py
+++ b/pulse2percept/stimuli/tests/test_images.py
@@ -3,7 +3,9 @@ import numpy as np
 import numpy.testing as npt
 import pytest
 
+from skimage.color import rgb2gray
 from skimage.io import imsave
+from skimage.transform import resize as img_resize
 
 from pulse2percept.stimuli import (AmplitudeEncoder, ImageStimulus, LogoBVL,
                                    LogoUCSB, SnellenChart)
@@ -93,6 +95,53 @@ def test_ImageStimulus_resize():
     with pytest.raises(ValueError):
         stim.resize((-1, -1))
     os.remove(fname)
+
+
+def test_ImageStimulus_resize_kwargs():
+    """Keyword arguments reach scikit-image (Issue #501)"""
+    # A white square on black. Nearest-neighbor interpolation keeps the image
+    # binary; the default (bilinear, with anti-aliasing on the way down) does
+    # not, which is what makes the two distinguishable:
+    ndarray = np.zeros((8, 8), dtype=np.float32)
+    ndarray[2:6, 2:6] = 1
+    stim = ImageStimulus(ndarray)
+    nearest = stim.resize((4, 4), order=0, anti_aliasing=False)
+    npt.assert_equal(np.isin(nearest.data, [0, 1]).all(), True)
+    npt.assert_equal(np.isin(stim.resize((4, 4)).data, [0, 1]).all(), False)
+    # An unknown keyword argument is scikit-image's to reject, not ours:
+    with pytest.raises(TypeError):
+        stim.resize((4, 4), not_a_skimage_kwarg=0)
+
+
+def test_ImageStimulus_apply():
+    ndarray = np.random.rand(8, 12).astype(np.float32)
+    stim = ImageStimulus(ndarray)
+    # A shape-preserving function keeps every pixel's name:
+    halved = stim.apply(lambda x: 0.5 * x)
+    npt.assert_almost_equal(halved.data, 0.5 * stim.data)
+    npt.assert_equal(halved.img_shape, (8, 12))
+    npt.assert_equal(np.asarray(halved.electrodes),
+                     np.asarray(stim.electrodes))
+    # A function that changes the resolution is allowed, and the result is
+    # named after its own pixel grid (Issue #500):
+    resized = stim.apply(img_resize, (4, 6))
+    npt.assert_equal(resized.img_shape, (4, 6))
+    npt.assert_equal(resized.shape, (24, 1))
+    npt.assert_equal(resized.electrodes[0], 'A1')
+    npt.assert_equal(resized.electrodes[-1], 'D6')
+    # Positional and keyword arguments both make it through:
+    npt.assert_equal(stim.apply(img_resize, (4, 6), order=0).img_shape, (4, 6))
+    npt.assert_equal(stim.apply(img_resize, output_shape=(4, 6)).img_shape,
+                     (4, 6))
+    # Names can be given explicitly, whether or not the shape changed:
+    named = stim.apply(img_resize, (2, 2), electrodes=['a', 'b', 'c', 'd'])
+    npt.assert_equal(list(named.electrodes), ['a', 'b', 'c', 'd'])
+    with pytest.raises(ValueError):
+        stim.apply(img_resize, (2, 2), electrodes=['a', 'b'])
+    # Dropping the color channels changes the pixel count too:
+    rgb = ImageStimulus(np.random.rand(8, 12, 3).astype(np.float32))
+    npt.assert_equal(rgb.apply(rgb2gray).img_shape, (8, 12))
+
 
 def test_ImageStimulus_crop():
     # test img with color channels
@@ -238,6 +287,36 @@ def test_ImageStimulus_rotate():
     os.remove(fname)
 
 
+def test_ImageStimulus_rotate_kwargs():
+    """Keyword arguments reach scikit-image (Issue #501)"""
+    ndarray = np.zeros((5, 5), dtype=np.float32)
+    ndarray[2, :] = 1
+    stim = ImageStimulus(ndarray)
+    # Nearest-neighbor interpolation keeps the bar binary, bilinear does not:
+    npt.assert_equal(np.isin(stim.rotate(45, order=0).data, [0, 1]).all(), True)
+    npt.assert_equal(np.isin(stim.rotate(45, order=1).data, [0, 1]).all(),
+                     False)
+    # 'cval' fills the corners the rotation leaves empty:
+    corners = ([0, 0, 4, 4], [0, 4, 0, 4])
+    npt.assert_almost_equal(
+        stim.rotate(45, order=0, cval=0.3).data.reshape(5, 5)[corners], 0.3)
+    npt.assert_almost_equal(
+        stim.rotate(45, order=0).data.reshape(5, 5)[corners], 0)
+    # 'resize' grows the canvas, so the result is named after its own grid
+    # rather than inheriting 25 names it has no room for:
+    grown = stim.rotate(45, resize=True)
+    npt.assert_equal(grown.img_shape, (7, 7))
+    npt.assert_equal(grown.shape, (49, 1))
+    npt.assert_equal(grown.electrodes[-1], 'G7')
+    # Rotating in place keeps every pixel's name:
+    same = stim.rotate(45)
+    npt.assert_equal(same.img_shape, (5, 5))
+    npt.assert_equal(np.asarray(same.electrodes), np.asarray(stim.electrodes))
+    # Names can be given explicitly:
+    npt.assert_equal(len(stim.rotate(45, electrodes=np.arange(25)).electrodes),
+                     25)
+
+
 def test_ImageStimulus_shift():
     # Create a horizontal bar:
     fname = 'test.png'
@@ -273,6 +352,11 @@ def test_ImageStimulus_center():
     stim = ImageStimulus(fname)
     npt.assert_almost_equal(stim.data, stim.center().data)
     npt.assert_almost_equal(stim.data, stim.shift(0, 2).center().data)
+    # 'loc' places the CoM somewhere other than the image center:
+    top = stim.center(loc=(2, 0))
+    npt.assert_almost_equal(top.data.reshape(shape)[0, :], 1)
+    npt.assert_almost_equal(top.data.reshape(shape)[1:, :], 0)
+    npt.assert_almost_equal(stim.center(loc=(2, 2)).data, stim.data)
     os.remove(fname)
 
 

--- a/pulse2percept/stimuli/tests/test_videos.py
+++ b/pulse2percept/stimuli/tests/test_videos.py
@@ -1,6 +1,8 @@
 from pulse2percept.stimuli import (AmplitudeEncoder, VideoStimulus,
                                    BostonTrain, GirlPool)
+from skimage.color import rgb2gray
 from skimage.io import imsave
+from skimage.transform import resize as vid_resize
 from matplotlib.animation import FuncAnimation
 import numpy as np
 import numpy.testing as npt
@@ -95,6 +97,22 @@ def test_VideoStimulus_resize(tmp_path):
     npt.assert_equal(stim.resize((-1, 24)).vid_shape, (16, 24, 3, 10))
     with pytest.raises(ValueError):
         stim.resize((-1, -1))
+
+
+def test_VideoStimulus_resize_kwargs():
+    """Keyword arguments reach scikit-image (Issue #501)"""
+    # A white square on black. Nearest-neighbor interpolation keeps the video
+    # binary; the default (bilinear, with anti-aliasing on the way down) does
+    # not, which is what makes the two distinguishable:
+    ndarray = np.zeros((8, 8, 3), dtype=np.float32)
+    ndarray[2:6, 2:6] = 1
+    stim = VideoStimulus(ndarray)
+    nearest = stim.resize((4, 4), order=0, anti_aliasing=False)
+    npt.assert_equal(np.isin(nearest.data, [0, 1]).all(), True)
+    npt.assert_equal(np.isin(stim.resize((4, 4)).data, [0, 1]).all(), False)
+    # An unknown keyword argument is scikit-image's to reject, not ours:
+    with pytest.raises(TypeError):
+        stim.resize((4, 4), not_a_skimage_kwarg=0)
 
 
 def test_VideoStimulus_crop(tmp_path):
@@ -222,6 +240,36 @@ def test_VideoStimulus_rotate():
         npt.assert_almost_equal(data[4, 0, i], 0)
 
 
+@pytest.mark.parametrize('shape', [(5, 5, 3), (5, 5, 3, 3)])
+def test_VideoStimulus_rotate_kwargs(shape):
+    """Keyword arguments reach scikit-image (Issue #501)
+
+    A grayscale video is rotated in one pass and a color one frame by frame,
+    so both paths have to forward what they are given.
+    """
+    ndarray = np.zeros(shape, dtype=np.float32)
+    ndarray[2] = 1
+    stim = VideoStimulus(ndarray)
+    # Nearest-neighbor interpolation keeps the bar binary, bilinear does not:
+    npt.assert_equal(np.isin(stim.rotate(45, order=0).data, [0, 1]).all(), True)
+    npt.assert_equal(np.isin(stim.rotate(45, order=1).data, [0, 1]).all(),
+                     False)
+    # 'cval' fills the corners the rotation leaves empty:
+    rot = stim.rotate(45, order=0, cval=0.3)
+    npt.assert_almost_equal(rot.data.reshape(rot.vid_shape)[0, 0], 0.3)
+    # 'resize' grows each frame, so the result is named after its own grid
+    # rather than inheriting names it has no room for:
+    grown = stim.rotate(45, resize=True)
+    npt.assert_equal(grown.vid_shape, (7, 7, *shape[2:]))
+    npt.assert_equal(grown.shape[0], np.prod(grown.vid_shape[:-1]))
+    npt.assert_equal(grown.electrodes[0], 'A1' if len(shape) == 3 else 'A1_R')
+    # Rotating in place keeps every pixel's name, and the time axis is intact:
+    same = stim.rotate(45)
+    npt.assert_equal(same.vid_shape, shape)
+    npt.assert_equal(np.asarray(same.electrodes), np.asarray(stim.electrodes))
+    npt.assert_almost_equal(same.time, stim.time)
+
+
 def test_VideoStimulus_shift():
     # Create a horizontal bar:
     shape = (5, 5, 3)
@@ -347,6 +395,32 @@ def test_VideoStimulus_apply(tmp_path):
 
     applied = stim.apply(lambda x: 0.5 * x)
     npt.assert_almost_equal(applied.data, stim.data * 0.5)
+    # A shape-preserving function keeps every pixel's name:
+    npt.assert_equal(np.asarray(applied.electrodes),
+                     np.asarray(stim.electrodes))
+    npt.assert_equal(applied.vid_shape, stim.vid_shape)
+
+    # A function that changes the resolution is allowed, and the result is
+    # named after its own pixel grid (Issue #500):
+    resized = stim.apply(vid_resize, (16, 24))
+    npt.assert_equal(resized.vid_shape, (16, 24, shape[0]))
+    npt.assert_equal(resized.shape, (16 * 24, shape[0]))
+    npt.assert_equal(resized.electrodes[0], 'A1')
+    npt.assert_equal(resized.electrodes[-1], 'P24')
+    npt.assert_almost_equal(resized.time, stim.time)
+    # Positional and keyword arguments both make it through:
+    npt.assert_equal(stim.apply(vid_resize, (8, 12), order=0).vid_shape,
+                     (8, 12, shape[0]))
+    npt.assert_equal(stim.apply(vid_resize, output_shape=(8, 12)).vid_shape,
+                     (8, 12, shape[0]))
+    # Names can be given explicitly:
+    named = stim.apply(vid_resize, (1, 2), electrodes=['a', 'b'])
+    npt.assert_equal(list(named.electrodes), ['a', 'b'])
+    with pytest.raises(ValueError):
+        stim.apply(vid_resize, (1, 2), electrodes=['a', 'b', 'c'])
+    # Dropping the color channels changes the pixel count too:
+    rgb = VideoStimulus(np.random.rand(6, 8, 3, 4).astype(np.float32))
+    npt.assert_equal(rgb.apply(rgb2gray).vid_shape, (6, 8, 4))
 
 
 @pytest.mark.parametrize('n_frames', (1, 2, 3, 10, 14))

--- a/pulse2percept/stimuli/videos.py
+++ b/pulse2percept/stimuli/videos.py
@@ -198,31 +198,65 @@ class VideoStimulus(Stimulus):
         params.update({'vid_shape': self.vid_shape})
         return params
 
-    def apply(self, func, *args, **kwargs):
+    def _names_for(self, vid, electrodes):
+        """Electrode names for a video derived from this one
+
+        A pixel keeps its name across an operation that leaves the pixel grid
+        alone, which is what makes 'A1' refer to the same thing before and
+        after. An operation that resamples the grid (a resize, a rotation that
+        grows the canvas) has no such correspondence to preserve, so the result
+        is named afresh rather than inheriting names that no longer describe
+        it. Only the frame layout is compared; the number of frames is the time
+        axis, not an electrode count.
+        """
+        if electrodes is not None:
+            return electrodes
+        same = np.shape(vid)[:-1] == self.vid_shape[:-1]
+        return self.electrodes if same else None
+
+    def apply(self, func, *args, electrodes=None, **kwargs):
         """Apply a function to each frame of the video
+
+        .. versionchanged:: 0.10.0
+
+            ``func`` may now change the shape of a frame, and ``electrodes``
+            can name the result.
 
         Parameters
         ----------
         func : function
             The function to apply to each frame in the video. Must accept a 2D
-            or 3D image and return an image with the same dimensions
+            or 3D image and return a 2D or 3D image. The returned frames need
+            not have the same shape as the originals (but must all have the
+            same shape as each other); see ``electrodes``.
         *args :
             Additional positional arguments passed to the function
+        electrodes : int, string or list thereof; optional
+            Optionally, you can provide your own electrode names. If none are
+            given, the original names are carried over whenever ``func`` leaves
+            the shape of a frame alone, and the result is named after its place
+            in the new frame otherwise (e.g. for
+            ``skimage.transform.resize``). See
+            :py:class:`~pulse2percept.stimuli.ElectrodeNames`.
+
+            .. note::
+               The number of electrode names provided must match the number of
+               pixels in a returned frame.
         **kwargs :
             Additional keyword arguments passed to the function
 
         Returns
         -------
-        stim : `ImageStimulus`
-            A copy of the stimulus object with the new image
+        stim : `VideoStimulus`
+            A copy of the stimulus object with the new video
         """
         vid = np.array([func(frame.reshape(self.vid_shape[:-1]), *args,
                              **kwargs)
                         for frame in self])
         # Move first axis (frames) to last:
         vid = np.moveaxis(vid, 0, -1)
-        return VideoStimulus(vid, electrodes=self.electrodes, time=self.time,
-                             metadata=self.metadata)
+        return VideoStimulus(vid, electrodes=self._names_for(vid, electrodes),
+                             time=self.time, metadata=self.metadata)
 
     def invert(self):
         """Invert the gray levels of the video
@@ -266,8 +300,14 @@ class VideoStimulus(Stimulus):
         return VideoStimulus(vid, electrodes=electrodes, time=self.time,
                              metadata=self.metadata)
 
-    def resize(self, shape, electrodes=None):
+    def resize(self, shape, electrodes=None, **kwargs):
         """Resize the video
+
+        .. versionchanged:: 0.10.0
+
+            Keyword arguments are passed on to scikit-image.
+
+        .. _skimage.transform.resize: https://scikit-image.org/docs/stable/api/skimage.transform.html#skimage.transform.resize
 
         Parameters
         ----------
@@ -284,6 +324,10 @@ class VideoStimulus(Stimulus):
             .. note::
                The number of electrode names provided must match the number of
                pixels in the resized video.
+        **kwargs :
+            Additional keyword arguments passed to `skimage.transform.resize`_,
+            such as ``order=0`` for nearest-neighbor interpolation (which keeps
+            a binary video binary).
 
         Returns
         -------
@@ -299,7 +343,7 @@ class VideoStimulus(Stimulus):
         if width < 0:
             width = int(self.vid_shape[1] * height / self.vid_shape[0])
         vid = vid_resize(self.data.reshape(self.vid_shape),
-                         (height, width, *self.vid_shape[2:]))
+                         (height, width, *self.vid_shape[2:]), **kwargs)
         return VideoStimulus(vid, electrodes=electrodes, time=self.time,
                              metadata=self.metadata)
 
@@ -448,14 +492,33 @@ class VideoStimulus(Stimulus):
         return VideoStimulus(vid, electrodes=electrodes, metadata=self.metadata,
                              time=self.time)
 
-    def rotate(self, angle, mode='constant'):
+    def rotate(self, angle, mode='constant', electrodes=None, **kwargs):
         """Rotate each frame of the video
+
+        .. versionchanged:: 0.10.0
+
+            Keyword arguments are passed on to scikit-image.
+
+        .. _skimage.transform.rotate: https://scikit-image.org/docs/stable/api/skimage.transform.html#skimage.transform.rotate
 
         Parameters
         ----------
         angle : float
             Angle by which to rotate each video frame (degrees).
             Positive: counter-clockwise, negative: clockwise
+        mode : str, optional
+            How to fill in the corners the rotation leaves empty; see
+            `skimage.transform.rotate`_.
+        electrodes : int, string or list thereof; optional
+            Optionally, you can provide your own electrode names. If none are
+            given, each pixel keeps the name it had before the rotation, unless
+            ``resize=True`` grew the frame, in which case the enlarged video is
+            named after its own pixel grid. See
+            :py:class:`~pulse2percept.stimuli.ElectrodeNames`.
+        **kwargs :
+            Additional keyword arguments passed to `skimage.transform.rotate`_,
+            such as ``order``, ``cval``, or ``resize=True`` to grow each frame
+            so that it contains every rotated pixel.
 
         Returns
         -------
@@ -463,14 +526,20 @@ class VideoStimulus(Stimulus):
             A copy of the stimulus object containing the rotated video
 
         """
+        # Rotating in place is the common case, and keeps the pixel names
+        # meaningful; ``resize=True`` is available through kwargs:
+        kwargs.setdefault('resize', False)
         data = self.data.reshape(self.vid_shape)
         if len(self.vid_shape) == 3:
-            # Grayscale videos can be fed directly into rotate:
-            data = vid_rotate(data, angle, mode=mode, resize=False)
-            return VideoStimulus(data, electrodes=self.electrodes,
+            # A grayscale video can be fed to `rotate` in one go, with its
+            # frames standing in for the color channels it expects:
+            data = vid_rotate(data, angle, mode=mode, **kwargs)
+            return VideoStimulus(data,
+                                 electrodes=self._names_for(data, electrodes),
                                  metadata=self.metadata, time=self.time)
         # Else need to feed in each frame individually:
-        return self.apply(vid_rotate, angle, mode=mode, resize=False)
+        return self.apply(vid_rotate, angle, mode=mode, electrodes=electrodes,
+                          **kwargs)
 
     def shift(self, shift_cols, shift_rows):
         """Shift the image foreground


### PR DESCRIPTION
Fixes various `ImageStimulus` bugs:

- [x] Its methods should pass kwargs to scikit-image (#501)
- [x] `apply` now takes an `electrodes` kwarg and tolerates functions that change resolution (#500)
- [x] `center` now centers based on `loc`

Closes #500 and #501