### PR TITLE
[MNT] Rename axlambda to lam

### DIFF
--- a/doc/users/release_notes.rst
+++ b/doc/users/release_notes.rst
@@ -28,6 +28,16 @@ Highlights:
 
 API changes:
 
+* The ``axlambda`` parameter of the axon map models
+  (:py:class:`~pulse2percept.models.AxonMapModel`,
+  :py:class:`~pulse2percept.models.AxonMapSpatial`,
+  :py:class:`~pulse2percept.models.BiphasicAxonMapModel`,
+  :py:class:`~pulse2percept.models.BiphasicAxonMapSpatial`, and
+  :py:class:`~pulse2percept.models.granley2021.DefaultStreakModel`) was
+  renamed to ``lam``, which sits better next to ``rho``. The old name still
+  works everywhere the new one does, but raises a ``DeprecationWarning`` and
+  will be removed in v0.11.0.
+
 * :py:class:`~pulse2percept.models.FadingTemporal` is now driven by
   :math:`\max(-A, 0)` rather than :math:`-A`: anodic current no longer reduces
   brightness, it is ignored. A stimulus that is purely cathodic is unaffected.

--- a/examples/datasets/plot_data_beyeler2019.py
+++ b/examples/datasets/plot_data_beyeler2019.py
@@ -140,7 +140,7 @@ plot_argus_phosphenes(data, argus, axon_map=model)
 # in [Beyeler2019]_, we can tailor the axon map parameters to Subject 2:
 
 import numpy as np
-model = AxonMapModel(rho=315, axlambda=500, loc_od=(16.2, 1.38),
+model = AxonMapModel(rho=315, lam=500, loc_od=(16.2, 1.38),
                      xrange=(-30, 30), yrange=(-22.5, 22.5),
                      thresh_percept=1 / np.sqrt(np.e))
 model.build()

--- a/examples/implants/plot_argus.py
+++ b/examples/implants/plot_argus.py
@@ -58,10 +58,10 @@ fig.tight_layout()
 #
 # To simulate the vision provided by Argus II, we first need to set up a new
 # axon map model. We can specify phosphene size (``rho``) and elongation
-# (``axlambda``) as well as the visual field we would like to simulate (given
+# (``lam``) as well as the visual field we would like to simulate (given
 # in degrees of visual angle):
 
-model = p2p.models.AxonMapModel(rho=400, axlambda=200,
+model = p2p.models.AxonMapModel(rho=400, lam=200,
                                 xrange=(-12, 12), yrange=(-8, 8))
 model.build()
 
@@ -96,9 +96,9 @@ model.predict_percept(implant).play()
 # arc-like.
 #
 # To increase the arc length of individual phosphenes, we can choose a larger
-# ``axlambda`` value:
+# ``lam`` value:
 
-model.axlambda = 600
+model.lam = 600
 model.build()
 model.predict_percept(implant).play()
 
@@ -108,7 +108,7 @@ model.predict_percept(implant).play()
 # very different to them:
 
 model.rho = 100
-model.axlambda = 1000
+model.lam = 1000
 model.build()
 model.predict_percept(implant).play()
 
@@ -127,14 +127,14 @@ p2p.stimuli.GirlPool().play()
 
 implant = p2p.implants.ArgusII(stim=p2p.stimuli.GirlPool())
 model.rho = 400
-model.axlambda = 200
+model.lam = 200
 model.build()
 model.predict_percept(implant).play()
 
 ###############################################################################
 # Here is the same video with longer phosphenes:
 
-model.axlambda = 600
+model.lam = 600
 model.build()
 model.predict_percept(implant).play()
 
@@ -142,7 +142,7 @@ model.predict_percept(implant).play()
 # Here is the same video with thin and long phosphenes:
 
 model.rho = 100
-model.axlambda = 1000
+model.lam = 1000
 model.build()
 model.predict_percept(implant).play()
 

--- a/examples/models/plot_beyeler2019_axonmap.py
+++ b/examples/models/plot_beyeler2019_axonmap.py
@@ -38,7 +38,7 @@ Creating the model
 The first step is to instantiate the
 :py:class:`~pulse2percept.models.AxonMapModel` class by calling its
 constructor method.
-The two most important parameters to set are ``rho`` and ``axlambda`` from
+The two most important parameters to set are ``rho`` and ``lam`` from
 the equation above (here set to 150 micrometers and 500 micrometers,
 respectively):
 
@@ -48,7 +48,7 @@ respectively):
 import numpy as np
 from pulse2percept.implants import ArgusII
 from pulse2percept.models import AxonMapModel
-model = AxonMapModel(rho=150, axlambda=500)
+model = AxonMapModel(rho=150, lam=500)
 
 ##############################################################################
 # Parameters you don't specify will take on default values. You can inspect
@@ -102,7 +102,7 @@ model.build()
 #     having to rebuild (which takes time).
 #
 #     However, if you change important model parameters outside the constructor
-#     (e.g., by directly setting ``model.axlambda = 100``), you will have to
+#     (e.g., by directly setting ``model.lam = 100``), you will have to
 #     call ``model.build()`` again for your changes to take effect.
 #
 # Assigning a stimulus
@@ -193,7 +193,7 @@ ax.set_title('Predicted percept')
 # However, you may have to increase the number of axons and number of segments
 # per axon to get a smooth percept out:
 
-model = AxonMapModel(rho=200, axlambda=10, n_axons=3000, n_ax_segments=3000)
+model = AxonMapModel(rho=200, lam=10, n_axons=3000, n_ax_segments=3000)
 model.build()
 percept = model.predict_percept(implant)
 ax = percept.plot()

--- a/examples/models/plot_granley2021_biphasic.py
+++ b/examples/models/plot_granley2021_biphasic.py
@@ -48,7 +48,7 @@ import numpy as np
 from pulse2percept.implants import ArgusII
 from pulse2percept.models import BiphasicAxonMapModel
 from pulse2percept.stimuli import BiphasicPulseTrain
-model = BiphasicAxonMapModel(rho=200, axlambda=800)
+model = BiphasicAxonMapModel(rho=200, lam=800)
 
 ##############################################################################
 # Parameters you don't specify will take on default values. You can inspect
@@ -57,7 +57,7 @@ model = BiphasicAxonMapModel(rho=200, axlambda=800)
 print(model)
 
 ##############################################################################
-# The most important parameters are ``rho`` and ``axlambda``, which control the 
+# The most important parameters are ``rho`` and ``lam``, which control the 
 # radial and axonal current spread, respectively. The parameters ``a0``-``a9`` are 
 # coefficients for the size, streak, and bright models, which will be discussed
 # later in this example.
@@ -200,7 +200,7 @@ print(model.size_model.a5)
 # scaling can easily be disabled by setting ``a0`` to 0 and ``a1`` to 1. If we increase 
 # pulse duration like we did previously, we will now see that only streak length decreases, 
 # and we no longer have to change amplitude to account for change in threshold
-model = BiphasicAxonMapModel(rho=200, axlambda=800)
+model = BiphasicAxonMapModel(rho=200, lam=800)
 model.a0 = 0
 model.a1 = 1
 model.build()
@@ -229,7 +229,7 @@ plt.show()
 # will probably be enough. However, the effect models are completely modular, and 
 # can be replaced by any python callable with the parameters frequency, amplitude, 
 # and pulse duration. For example, we can easily change the model to no longer scale size
-model = BiphasicAxonMapModel(rho=200, axlambda=800)
+model = BiphasicAxonMapModel(rho=200, lam=800)
 def size_modulation(freq, amp, pdur):
     return 1
 model.size_model = size_modulation

--- a/pulse2percept/models/_beyeler2019.pyx
+++ b/pulse2percept/models/_beyeler2019.pyx
@@ -403,7 +403,7 @@ cpdef fast_axon_map(const float32[:, ::1] stim,
             if c_isnan(ax_x) or c_isnan(ax_y):
                 continue
             # Activation as a function of distance to the cell body (depends
-            # on `axlambda`, precalculated during `build`):
+            # on `lam`, precalculated during `build`):
             sens = axon_segments[idx_ax, 2]
             # Activation of this segment over time, by adding up the
             # contribution of each electrode:

--- a/pulse2percept/models/_granley2021.pyx
+++ b/pulse2percept/models/_granley2021.pyx
@@ -43,7 +43,7 @@ cpdef fast_biphasic_axon_map(const float32[::1] amp_el,
     ``logf`` per segment.
 
     ``F_streak`` is finite and strictly positive: the default streak model
-    clamps it to ``min_lambda ** 2 / axlambda ** 2``, and ``_predict_spatial``
+    clamps it to ``min_lambda ** 2 / lam ** 2``, and ``_predict_spatial``
     rejects a custom model that returns anything else.
     
     Parameters

--- a/pulse2percept/models/base.py
+++ b/pulse2percept/models/base.py
@@ -15,7 +15,7 @@ from ..stimuli import Stimulus
 from ..percepts import Percept
 from ..topography import Curcio1990Map, Grid2D
 from ..utils import (PrettyPrint, FreezeError, Parametrized, bisect,
-                     warn_deprecated_params)
+                     warn_deprecated_params, rename_deprecated_params)
 from ..utils.constants import ZORDER
 
 
@@ -1247,9 +1247,12 @@ class Model(PrettyPrint):
         # here too. Collect both sides first so a parameter deprecated on the
         # spatial *and* temporal model only warns once.
         specs = {}
+        renamed = {}
         for model in (self.spatial, self.temporal):
             specs.update(getattr(model, '_deprecated_params', {}))
+            renamed.update(getattr(model, '_renamed_params', {}))
         warn_deprecated_params(type(self).__name__, params, specs)
+        params = rename_deprecated_params(type(self).__name__, params, renamed)
         for key, val in params.items():
             setattr(self, key, val)
 

--- a/pulse2percept/models/base.py
+++ b/pulse2percept/models/base.py
@@ -236,8 +236,10 @@ class BaseModel(Parametrized, metaclass=ABCMeta):
             Example: ``model.build(param1=val)``
 
         """
-        for key, val in build_params.items():
-            setattr(self, key, val)
+        # Via `set_params`, not a bare `setattr` loop, so that a deprecated or
+        # renamed parameter is handled here exactly as it is in the
+        # constructor:
+        self.set_params(**build_params)
         self._build()
         self.is_built = True
         return self
@@ -426,8 +428,8 @@ class SpatialModel(BaseModel, metaclass=ABCMeta):
             Example: ``model.build(param1=val)``
 
         """
-        for key, val in build_params.items():
-            setattr(self, key, val)
+        # See `BaseModel.build`:
+        self.set_params(**build_params)
         if self.vfmap.ndim not in self.ndim:
             raise ValueError(f"Model expects one of {self.ndim} dimensions, but "
                              f"visual field map has {self.vfmap.ndim} dimensions.")

--- a/pulse2percept/models/beyeler2019.py
+++ b/pulse2percept/models/beyeler2019.py
@@ -9,6 +9,7 @@ from scipy.spatial import cKDTree
 import matplotlib.pyplot as plt
 from matplotlib.patches import Ellipse
 
+from ..utils import deprecated_alias
 from ..utils.constants import ZORDER
 from ..topography import Watson2014Map
 from ..implants import ProsthesisSystem, ElectrodeArray
@@ -257,8 +258,14 @@ class AxonMapSpatial(SpatialModel):
 
     Parameters
     ----------
-    axlambda : double, optional
+    lam : double, optional
         Exponential decay constant along the axon(microns).
+
+        .. versionchanged:: 0.10.0
+
+            Renamed from ``axlambda``, which reads poorly next to ``rho``. The
+            old name still works, but is deprecated and will be removed in
+            v0.11.0.
     rho : double, optional
         Exponential decay constant away from the axon(microns).
     min_current_spread : float, optional
@@ -331,7 +338,7 @@ class AxonMapSpatial(SpatialModel):
 
     .. important ::
         If you change important model parameters outside the constructor (e.g.,
-        by directly setting ``model.axlambda = 100``), you will have to call
+        by directly setting ``model.lam = 100``), you will have to call
         ``model.build()`` again for your changes to take effect.
 
     Notes
@@ -339,6 +346,11 @@ class AxonMapSpatial(SpatialModel):
     *  The axon map is not very accurate when the upper bound of
        `ax_segments_range` is greater than 90 deg.
     """
+
+    #: ``lam`` used to be called ``axlambda``. The old name still reads and
+    #: writes ``lam``, with a ``DeprecationWarning``:
+    axlambda = deprecated_alias('lam', deprecated_version='0.10.0',
+                                removed_version='0.11.0')
 
     def __init__(self, **params):
         super(AxonMapSpatial, self).__init__(**params)
@@ -352,7 +364,7 @@ class AxonMapSpatial(SpatialModel):
             # Left or right eye:
             'eye': 'RE',
             'rho': 200,
-            'axlambda': 500,
+            'lam': 500,
             # Set the (x,y) location of the optic disc:
             'loc_od': (15.5, 1.5),
             'n_axons': 1000,
@@ -596,7 +608,7 @@ class AxonMapSpatial(SpatialModel):
 
         This function combines the x,y coordinates of each bundle segment with
         a sensitivity value that depends on the distance of the segment to the
-        cell body and ``self.axlambda``.
+        cell body and ``self.lam``.
 
         The number of ``bundles`` must equal the number of points on
         `self.grid``. The function will then assume that the i-th bundle passes
@@ -607,8 +619,8 @@ class AxonMapSpatial(SpatialModel):
         with the i-th location of the grid.
 
         After that, each axon segment gets a sensitivity value that depends
-        on the distance of the segment to the soma (with decay rate 
-        ``self.axlambda``). This is typically done during the build process, so
+        on the distance of the segment to the soma (with decay rate
+        ``self.lam``). This is typically done during the build process, so
         that the only work left to do during run time is to multiply the
         sensitivity value with the current applied to each segment.
 
@@ -626,7 +638,7 @@ class AxonMapSpatial(SpatialModel):
             Nx3 array, where the first two columns contain the retinal
             coordinates of each axon segment (microns), and the third column
             contains the sensitivity of the segment to electrical current.
-            The latter depends on ``self.axlambda``. Note that each axon will
+            The latter depends on ``self.lam``. Note that each axon will
             most likely have a different N, since segments whose sensitivity
             falls below ``min_ax_sensitivity`` are trimmed.
 
@@ -669,7 +681,7 @@ class AxonMapSpatial(SpatialModel):
         starts : (n_points + 1,) array
             Offsets of each axon into ``contrib``.
         """
-        lam = self.axlambda
+        lam = self.lam
         xyret = np.column_stack((self.grid.ret.x.ravel(),
                                  self.grid.ret.y.ravel()))
         blens = np.diff(boff)
@@ -849,8 +861,8 @@ class AxonMapSpatial(SpatialModel):
             raise ValueError(err_str)
 
     def _build(self):
-        if self.axlambda < 10:
-            raise ValueError('"axlambda" < 10 is not supported by this model. '
+        if self.lam < 10:
+            raise ValueError('"lam" < 10 is not supported by this model. '
                              'Consider using ScoreboardModel instead.')
         # In a left eye, the OD must have a negative x coordinate:
         self._correct_loc_od()
@@ -1064,8 +1076,14 @@ class AxonMapModel(Model):
 
     Parameters
     ----------
-    axlambda : double, optional
+    lam : double, optional
         Exponential decay constant along the axon(microns).
+
+        .. versionchanged:: 0.10.0
+
+            Renamed from ``axlambda``, which reads poorly next to ``rho``. The
+            old name still works, but is deprecated and will be removed in
+            v0.11.0.
     rho : double, optional
         Exponential decay constant away from the axon(microns).
     min_current_spread : float, optional
@@ -1138,7 +1156,7 @@ class AxonMapModel(Model):
 
     .. important ::
         If you change important model parameters outside the constructor (e.g.,
-        by directly setting ``model.axlambda = 100``), you will have to call
+        by directly setting ``model.lam = 100``), you will have to call
         ``model.build()`` again for your changes to take effect.
 
     Notes

--- a/pulse2percept/models/cortex/dynaphos.py
+++ b/pulse2percept/models/cortex/dynaphos.py
@@ -163,8 +163,8 @@ class DynaphosModel(BaseModel):
         """
         # import at runtime to avoid circular import
         from ...topography import Grid2D
-        for key, val in build_params.items():
-            setattr(self, key, val)
+        # See `BaseModel.build`:
+        self.set_params(**build_params)
         # check that freq/pdur fit
         window_dur = 1000.0 / self.freq
         if self.p_dur*2 > window_dur:

--- a/pulse2percept/models/granley2021.py
+++ b/pulse2percept/models/granley2021.py
@@ -7,7 +7,8 @@ from . import AxonMapSpatial, Model
 from ..implants import ProsthesisSystem, ElectrodeArray
 from ..stimuli import BiphasicPulseTrain, Stimulus
 from ..percepts import Percept
-from ..utils import FreezeError
+from ..utils import FreezeError, rename_parameter
+from ..utils.base import has_own_attr
 from .base import NotBuiltError, BaseModel
 from ._granley2021 import fast_biphasic_axon_map
 
@@ -147,16 +148,23 @@ class DefaultStreakModel(BaseModel):
 
     Parameters:
     ------------
-    axlambda :  float32
-        Axlambda parameter of BiphasicAxonMapModel (axonal decay rate)
+    lam :  float32
+        ``lam`` parameter of BiphasicAxonMapModel (axonal decay rate)
+
+        .. versionchanged:: 0.10.0
+
+            Renamed from ``axlambda``. The old name still works as a keyword
+            argument, but is deprecated and will be removed in v0.11.0.
     a7, a8, a9: float, optional
         Regression coefficients for streak length vs pulse duration (Eq 6)
         F_streak = -a7*pdur^a8 + a9
     """
 
-    def __init__(self, axlambda, **params):
+    @rename_parameter('axlambda', 'lam', deprecated_version='0.10.0',
+                      removed_version='0.11.0')
+    def __init__(self, lam, **params):
         super(DefaultStreakModel, self).__init__(**params)
-        self.axlambda = axlambda
+        self.lam = lam
         self.build()
 
     def get_default_params(self):
@@ -175,7 +183,7 @@ class DefaultStreakModel(BaseModel):
         Outputs value for each electrode that lambda should be scaled by (F_streak)
         Must support batching (freq, amp, pdur may be arrays)
         """
-        min_f_streak = self.min_lambda**2 / self.axlambda ** 2
+        min_f_streak = self.min_lambda**2 / self.lam ** 2
         F_streak = self.a9 - self.a7 * pdur ** self.a8
         return np.maximum(F_streak, min_f_streak)
 
@@ -218,8 +226,14 @@ class BiphasicAxonMapSpatial(AxonMapSpatial):
 
         Options:
         --------
-        axlambda: double, optional
+        lam: double, optional
             Exponential decay constant along the axon(microns).
+
+            .. versionchanged:: 0.10.0
+
+                Renamed from ``axlambda``, which reads poorly next to ``rho``.
+                The old name still works, but is deprecated and will be
+                removed in v0.11.0.
         rho: double, optional
             Exponential decay constant away from the axon(microns).
         min_current_spread: float, optional
@@ -300,11 +314,14 @@ class BiphasicAxonMapSpatial(AxonMapSpatial):
         if self.size_model is None:
             self.size_model = DefaultSizeModel(self.rho)
         if self.streak_model is None:
-            self.streak_model = DefaultStreakModel(self.axlambda)
+            self.streak_model = DefaultStreakModel(self.lam)
         for key, val in params.items():
             if key in ['bright_model', 'size_model', 'streak_model']:
                 continue
-            setattr(self, key, val)
+            # `super().__init__` has already warned about any deprecated name
+            # among these, so set the current one rather than warn twice:
+            spec = self._renamed_params.get(key)
+            setattr(self, spec.new_name if spec else key, val)
 
     def __getattr__(self, attr):
         # Called when normal get attribute fails
@@ -337,14 +354,16 @@ class BiphasicAxonMapSpatial(AxonMapSpatial):
         etc
         """
         found = False
-        # try to set it ourselves, but can't use get_attr
-        try:
-            self.__getattribute__(name)
+        # Try to set it ourselves, but can't use get_attr. Probe the type
+        # rather than read the attribute, so that a `deprecated_alias` does
+        # not warn just for being asked whether it exists:
+        if has_own_attr(self, name):
             # if we get here, we have the attribute, not (neccesarily) an effects model
-            super().__setattr__(name, value)
-            found = True
-        except AttributeError:
-            pass
+            try:
+                super().__setattr__(name, value)
+                found = True
+            except AttributeError:
+                pass
         # Check whether the attribute is a part of any
         # bright/size/streak model
         if name not in ['bright_model', 'size_model', 'streak_model', 'is_built', '_is_built']:
@@ -585,8 +604,14 @@ class BiphasicAxonMapModel(Model):
 
         Options:
         ^^^^^^^^
-        axlambda: double, optional
+        lam: double, optional
             Exponential decay constant along the axon(microns).
+
+            .. versionchanged:: 0.10.0
+
+                Renamed from ``axlambda``, which reads poorly next to ``rho``.
+                The old name still works, but is deprecated and will be
+                removed in v0.11.0.
         rho: double, optional
             Exponential decay constant away from the axon(microns).
         min_current_spread: float, optional

--- a/pulse2percept/models/tests/test_beyeler2019.py
+++ b/pulse2percept/models/tests/test_beyeler2019.py
@@ -373,6 +373,45 @@ def test_AxonMap_deprecated_axlambda(cls):
         npt.assert_equal(model.lam, 500)
 
 
+@pytest.mark.parametrize('cls', [AxonMapSpatial, AxonMapModel])
+def test_AxonMap_axlambda_and_lam_collide(cls):
+    # `axlambda` and `lam` are the same parameter, so supplying both must
+    # raise rather than let the order they were passed in decide the value.
+    # `**kwargs` preserves insertion order, so check both spellings:
+    for params in ({'axlambda': 400, 'lam': 500},
+                   {'lam': 500, 'axlambda': 400}):
+        with pytest.raises(TypeError, match="same parameter"):
+            cls(**params)
+        model = cls(xystep=5)
+        with pytest.raises(TypeError, match="same parameter"):
+            model.build(**params)
+        with pytest.raises(TypeError, match="same parameter"):
+            if cls is AxonMapModel:
+                model.set_params(params)
+            else:
+                model.set_params(**params)
+
+
+@pytest.mark.parametrize('cls', [AxonMapSpatial, AxonMapModel])
+def test_AxonMap_axlambda_warning_blames_caller(cls):
+    # A deprecation warning is only actionable if it points at the line that
+    # used the old name. The alias is reached directly on a spatial model, but
+    # through `Model.__getattr__`/`__setattr__` on a composite one, so the
+    # attribution has to hold for both:
+    model = cls(xystep=5)
+    with pytest.warns(DeprecationWarning) as record:
+        model.axlambda
+    npt.assert_equal(record[0].filename, __file__)
+    with pytest.warns(DeprecationWarning) as record:
+        model.axlambda = 400
+    npt.assert_equal(record[0].filename, __file__)
+    # The constructor reaches it through a chain of `super().__init__` calls
+    # instead, whose depth differs between the two classes:
+    with pytest.warns(DeprecationWarning) as record:
+        cls(axlambda=400)
+    npt.assert_equal(record[0].filename, __file__)
+
+
 # Build the model inside the test, not in the decorator: arguments to
 # `parametrize` are evaluated at import time, so building here would run on
 # every pytest invocation (even `--collect-only`, even when this test is

--- a/pulse2percept/models/tests/test_beyeler2019.py
+++ b/pulse2percept/models/tests/test_beyeler2019.py
@@ -5,6 +5,7 @@ import numpy.testing as npt
 import copy
 import os
 import pickle
+import warnings
 
 from matplotlib.axes import Subplot
 import matplotlib.pyplot as plt
@@ -190,7 +191,7 @@ def test_ScoreboardModel_predict_percept():
 
 
 def test_AxonMapSpatial():
-    # AxonMapSpatial automatically sets `rho`, `axlambda`:
+    # AxonMapSpatial automatically sets `rho`, `lam`:
     model = AxonMapSpatial(xystep=5)
 
     # User can set `rho`:
@@ -220,10 +221,10 @@ def test_AxonMapSpatial():
 
     # Lambda cannot be too small:
     with pytest.raises(ValueError):
-        AxonMapSpatial(axlambda=9).build()
+        AxonMapSpatial(lam=9).build()
 
     # Multiple frames are processed independently:
-    model = AxonMapSpatial(rho=200, axlambda=100, xystep=5,
+    model = AxonMapSpatial(rho=200, lam=100, xystep=5,
                            xrange=(-20, 20), yrange=(-15, 15))
     model.build()
     percept = model.predict_percept(ArgusI(stim={'A1': [1, 0], 'B3': [0, 2]}))
@@ -289,7 +290,7 @@ def test_AxonMapSpatial_plot():
 
 
 def test_AxonMapModel():
-    set_params = {'xystep': 2, 'rho': 432, 'axlambda': 20,
+    set_params = {'xystep': 2, 'rho': 432, 'lam': 20,
                   'n_axons': 9, 'n_ax_segments': 50,
                   'xrange': (-30, 30), 'yrange': (-20, 20),
                   'loc_od': (5, 6)}
@@ -331,7 +332,46 @@ def test_AxonMapModel():
 
     # Lambda cannot be too small:
     with pytest.raises(ValueError):
-        AxonMapModel(axlambda=9).build()
+        AxonMapModel(lam=9).build()
+
+
+@pytest.mark.parametrize('cls', [AxonMapSpatial, AxonMapModel])
+def test_AxonMap_deprecated_axlambda(cls):
+    # `lam` was called `axlambda` until 0.10.0. The old name still works,
+    # everywhere the new one does, but warns:
+    msg = "The 'axlambda' parameter of"
+    assert_warns_msg(DeprecationWarning, cls, msg, axlambda=400)
+    with pytest.warns(DeprecationWarning):
+        model = cls(axlambda=400)
+    npt.assert_equal(model.lam, 400)
+
+    # Setting and getting the attribute:
+    assert_warns_msg(DeprecationWarning, setattr, msg, model, 'axlambda', 500)
+    npt.assert_equal(model.lam, 500)
+    with pytest.warns(DeprecationWarning):
+        npt.assert_equal(model.axlambda, 500)
+
+    # And `set_params` and `build`. `Model.set_params` takes a dict, whereas
+    # `SpatialModel.set_params` takes keyword arguments:
+    if cls is AxonMapModel:
+        set_params = lambda: model.set_params({'axlambda': 600})
+    else:
+        set_params = lambda: model.set_params(axlambda=600)
+    assert_warns_msg(DeprecationWarning, set_params, msg)
+    npt.assert_equal(model.lam, 600)
+    # `build` reads the axon cache, which raises a ResourceWarning of its own,
+    # so this one cannot insist on a single warning:
+    with pytest.warns(DeprecationWarning, match="'axlambda' parameter"):
+        model.build(axlambda=700)
+    npt.assert_equal(model.lam, 700)
+
+    # The new name stays silent:
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", DeprecationWarning)
+        model = cls(lam=400)
+        model.lam = 500
+        npt.assert_equal(model.lam, 500)
+
 
 # Build the model inside the test, not in the decorator: arguments to
 # `parametrize` are evaluated at import time, so building here would run on
@@ -503,14 +543,14 @@ def test_AxonMapModel_calc_axon_sensitivity():
     # precision costs about as much accuracy as the whole comparison has to
     # spare. Building it here in float32 left roughly a 1.2x margin against
     # the tolerance, which held on some platforms and not on others.
-    max_d2 = -2.0 * model.axlambda ** 2 * np.log(model.min_ax_sensitivity)
+    max_d2 = -2.0 * model.lam ** 2 * np.log(model.min_ax_sensitivity)
     for model_ax, xy in zip(axon_contrib, xyret):
         axon = np.insert(model_ax, 0, list(xy) + [0],
                          axis=0).astype(np.float64)
         d2 = np.cumsum(np.sqrt(np.diff(axon[:, 0], axis=0) ** 2 +
                                np.diff(axon[:, 1], axis=0) ** 2))**2
         idx_d2 = d2 < max_d2
-        sensitivity = np.exp(-d2[idx_d2] / (2.0 * model.spatial.axlambda ** 2))
+        sensitivity = np.exp(-d2[idx_d2] / (2.0 * model.spatial.lam ** 2))
         # A relative bound, unlike `assert_almost_equal`'s absolute one: the
         # sensitivities span [min_ax_sensitivity, 1], and float32 resolves
         # them to ~1.2e-7 relative wherever they sit in that range.
@@ -559,7 +599,7 @@ def test_AxonMapModel_calc_bundle_tangent_fast():
 
 
 def test_AxonMapModel_predict_percept():
-    model = AxonMapModel(xystep=0.55, axlambda=100, rho=100,
+    model = AxonMapModel(xystep=0.55, lam=100, rho=100,
                          thresh_percept=0,
                          xrange=(-20, 20), yrange=(-15, 15),
                          n_axons=500)
@@ -583,7 +623,7 @@ def test_AxonMapModel_predict_percept():
     npt.assert_almost_equal(np.sum(percept.data[39:, :, 0]), 0)
 
     # Full Argus II with small lambda: 60 bright spots
-    model = AxonMapModel(xystep=1, rho=100, axlambda=40,
+    model = AxonMapModel(xystep=1, rho=100, lam=40,
                          xrange=(-20, 20), yrange=(-15, 15), n_axons=500)
     model.build()
     percept = model.predict_percept(ArgusII(stim=np.ones(60)))
@@ -593,7 +633,7 @@ def test_AxonMapModel_predict_percept():
     npt.assert_equal(np.sum(percept.data > 0.275), 56)
 
     # Model gives same outcome as Spatial:
-    spatial = AxonMapSpatial(xystep=1, rho=100, axlambda=40,
+    spatial = AxonMapSpatial(xystep=1, rho=100, lam=40,
                              xrange=(-20, 20), yrange=(-15, 15), n_axons=500)
     spatial.build()
     spatial_percept = spatial.predict_percept(ArgusII(stim=np.ones(60)))

--- a/pulse2percept/models/tests/test_granley2021.py
+++ b/pulse2percept/models/tests/test_granley2021.py
@@ -355,19 +355,32 @@ def test_biphasicAxonMapModel():
 @pytest.mark.parametrize('cls', [BiphasicAxonMapSpatial, BiphasicAxonMapModel])
 def test_biphasicAxonMap_deprecated_axlambda(cls):
     # `lam` was called `axlambda` until 0.10.0. The old name still works, and
-    # still reaches the streak model, but warns:
-    msg = "The 'axlambda' parameter of"
+    # still reaches the streak model, but warns. These classes inherit the
+    # alias from `AxonMapSpatial`, so pin the class the message names: it has
+    # to be the one the user is holding, not the one it was declared on.
+    msg = f"The 'axlambda' parameter of {cls.__name__} is deprecated"
     assert_warns_msg(DeprecationWarning, cls, msg, axlambda=400)
     with pytest.warns(DeprecationWarning):
         model = cls(axlambda=400)
     npt.assert_equal(model.lam, 400)
     npt.assert_equal(model.streak_model.lam, 400)
 
-    assert_warns_msg(DeprecationWarning, setattr, msg, model, 'axlambda', 500)
+    # Reached through the descriptor rather than the constructor, the alias
+    # only ever sees the spatial model, even on the composite:
+    spatial_msg = ("The 'axlambda' parameter of BiphasicAxonMapSpatial is "
+                   "deprecated")
+    assert_warns_msg(DeprecationWarning, setattr, spatial_msg, model,
+                     'axlambda', 500)
     npt.assert_equal(model.lam, 500)
     npt.assert_equal(model.streak_model.lam, 500)
-    with pytest.warns(DeprecationWarning):
+    with pytest.warns(DeprecationWarning, match="BiphasicAxonMapSpatial"):
         npt.assert_equal(model.axlambda, 500)
+
+    # Supplying both names is an error, whichever order they come in:
+    for params in ({'axlambda': 400, 'lam': 500},
+                   {'lam': 500, 'axlambda': 400}):
+        with pytest.raises(TypeError, match="same parameter"):
+            cls(**params)
 
     # The new name stays silent:
     with warnings.catch_warnings():

--- a/pulse2percept/models/tests/test_granley2021.py
+++ b/pulse2percept/models/tests/test_granley2021.py
@@ -1,4 +1,5 @@
 import copy
+import warnings
 
 import numpy as np
 import pytest
@@ -12,6 +13,7 @@ from pulse2percept.models import BiphasicAxonMapModel, BiphasicAxonMapSpatial, \
 from pulse2percept.models.granley2021 import DefaultBrightModel, \
     DefaultSizeModel, DefaultStreakModel
 from pulse2percept.utils.base import FreezeError
+from pulse2percept.utils.testing import assert_warns_msg
 
 # Building an axon map writes a cache to a relative path; keep it in a
 # temporary directory instead of wherever pytest was started from:
@@ -63,7 +65,7 @@ def test_deepcopy_DefaultStreakModel():
 
 
 def test_eq_DefaultStreakModel():
-    model = DefaultStreakModel(axlambda=200)
+    model = DefaultStreakModel(lam=200)
 
     # Assert not equal for differing classes
     npt.assert_equal(model == DefaultSizeModel, False)
@@ -80,7 +82,7 @@ def test_eq_DefaultStreakModel():
     npt.assert_equal(model == copied, True)
 
     # Assert different models do not equal each other
-    differing_model = DefaultStreakModel(axlambda=300)
+    differing_model = DefaultStreakModel(lam=300)
     npt.assert_equal(model != differing_model, True)
 
 
@@ -133,7 +135,7 @@ def test_deepcopy_BiphasicAxonMapModel():
     npt.assert_equal(original.__dict__, copied.__dict__)
 
     # Assert changing copied doesn't change original
-    copied.spatial.axlambda = 200
+    copied.spatial.lam = 200
     npt.assert_equal(original.spatial != copied.spatial, True)
 
 def test_effects_models():
@@ -177,7 +179,7 @@ def test_effects_models_removed_engine(cls, arg):
 def test_biphasicAxonMapSpatial():
     # Lambda cannot be too small:
     with pytest.raises(ValueError):
-        BiphasicAxonMapSpatial(axlambda=9).build()
+        BiphasicAxonMapSpatial(lam=9).build()
 
     model = BiphasicAxonMapModel(xystep=2).build()
     # Only accepts biphasic pulse trains with no delay dur
@@ -234,7 +236,7 @@ def test_biphasicAxonMapSpatial():
     npt.assert_equal(np.any(percept.data[:, :, 1:]), False)
 
     # Test that default models give expected values
-    model = BiphasicAxonMapSpatial(rho=400, axlambda=600,
+    model = BiphasicAxonMapSpatial(rho=400, lam=600,
                                    xystep=1, xrange=(-20, 20), yrange=(-15, 15))
     model.build()
     implant = ArgusII()
@@ -248,7 +250,7 @@ def test_biphasicAxonMapSpatial():
 
 
 def test_biphasicAxonMapModel():
-    set_params = {'xystep': 2, 'rho': 432, 'axlambda': 20,
+    set_params = {'xystep': 2, 'rho': 432, 'lam': 20,
                   'n_axons': 9, 'n_ax_segments': 50,
                   'xrange': (-30, 30), 'yrange': (-20, 20),
                   'loc_od': (5, 6)}
@@ -270,11 +272,11 @@ def test_biphasicAxonMapModel():
     # If the spatial model and an effects model have a parameter with the
     # Same name, both need to be changed
     model.rho = 350
-    model.axlambda = 450
+    model.lam = 450
     npt.assert_equal(model.spatial.size_model.rho, 350)
-    npt.assert_equal(model.spatial.streak_model.axlambda, 450)
+    npt.assert_equal(model.spatial.streak_model.lam, 450)
     npt.assert_equal(model.rho, 350)
-    npt.assert_equal(model.axlambda, 450)
+    npt.assert_equal(model.lam, 450)
 
     # Effect model parameters can be passed even in constructor
     model = BiphasicAxonMapModel(a0=5, rho=432)
@@ -347,7 +349,49 @@ def test_biphasicAxonMapModel():
 
     # Lambda cannot be too small:
     with pytest.raises(ValueError):
-        BiphasicAxonMapModel(axlambda=9).build()
+        BiphasicAxonMapModel(lam=9).build()
+
+
+@pytest.mark.parametrize('cls', [BiphasicAxonMapSpatial, BiphasicAxonMapModel])
+def test_biphasicAxonMap_deprecated_axlambda(cls):
+    # `lam` was called `axlambda` until 0.10.0. The old name still works, and
+    # still reaches the streak model, but warns:
+    msg = "The 'axlambda' parameter of"
+    assert_warns_msg(DeprecationWarning, cls, msg, axlambda=400)
+    with pytest.warns(DeprecationWarning):
+        model = cls(axlambda=400)
+    npt.assert_equal(model.lam, 400)
+    npt.assert_equal(model.streak_model.lam, 400)
+
+    assert_warns_msg(DeprecationWarning, setattr, msg, model, 'axlambda', 500)
+    npt.assert_equal(model.lam, 500)
+    npt.assert_equal(model.streak_model.lam, 500)
+    with pytest.warns(DeprecationWarning):
+        npt.assert_equal(model.axlambda, 500)
+
+    # The new name stays silent:
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", DeprecationWarning)
+        model = cls(lam=400)
+        model.lam = 500
+        npt.assert_equal(model.lam, 500)
+        npt.assert_equal(model.streak_model.lam, 500)
+
+
+def test_DefaultStreakModel_deprecated_axlambda():
+    # The streak model takes `lam` in its signature, so the old name is only
+    # forwarded as a keyword argument:
+    assert_warns_msg(DeprecationWarning, DefaultStreakModel,
+                     "The 'axlambda' parameter of DefaultStreakModel is "
+                     "deprecated since version 0.10.0, and will be removed in "
+                     "version 0.11.0. Use 'lam' instead.", axlambda=200)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        npt.assert_equal(DefaultStreakModel(axlambda=200).lam, 200)
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", DeprecationWarning)
+        npt.assert_equal(DefaultStreakModel(lam=200).lam, 200)
+        npt.assert_equal(DefaultStreakModel(200).lam, 200)
 
 
 @pytest.mark.parametrize('model_cls', [BiphasicAxonMapModel,
@@ -413,7 +457,7 @@ def test_BiphasicAxonMapModel_min_current_spread_error_bound(amp):
     implant = ArgusII(stim={e: BiphasicPulseTrain(freq, amp, pdur)
                             for e in ArgusII().electrode_names})
     kwargs = {'xrange': (-14, 14), 'yrange': (-10, 10), 'xystep': 0.75,
-              'rho': 200, 'axlambda': 800, 'verbose': False}
+              'rho': 200, 'lam': 800, 'verbose': False}
 
     model = BiphasicAxonMapModel(min_current_spread=0, **kwargs).build()
     exact = model.predict_percept(implant).data
@@ -487,7 +531,7 @@ def test_BiphasicAxonMapModel_reduces_to_AxonMapModel():
     from pulse2percept.models import AxonMapModel
 
     kwargs = {'xrange': (-8, 8), 'yrange': (-8, 8), 'xystep': 0.5,
-              'rho': 200, 'axlambda': 800, 'verbose': False}
+              'rho': 200, 'lam': 800, 'verbose': False}
     electrodes = ('A2', 'C5', 'F8')
 
     biphasic = BiphasicAxonMapModel(**kwargs)

--- a/pulse2percept/utils/__init__.py
+++ b/pulse2percept/utils/__init__.py
@@ -25,8 +25,9 @@ from .images import center_image, scale_image, shift_image, trim_image
 from .convolution import center_vector, conv
 from .optimize import bisect
 from .stats import r2_score, circ_r2_score
-from .deprecation import (deprecated, deprecate_parameter,
-                          warn_deprecated_params)
+from .deprecation import (deprecated, deprecate_parameter, deprecated_alias,
+                          rename_parameter, warn_deprecated_params,
+                          rename_deprecated_params)
 from .three_dim import parse_3d_orient
 
 __all__ = [
@@ -42,6 +43,7 @@ __all__ = [
     'delta_angle',
     'deprecate_parameter',
     'deprecated',
+    'deprecated_alias',
     'frame_interval',
     'FreezeError',
     'Frozen',
@@ -54,6 +56,8 @@ __all__ = [
     'PrettyPrint',
     'r2_score',
     'radial_mask',
+    'rename_deprecated_params',
+    'rename_parameter',
     'sample',
     'scale_image',
     'shift_image',

--- a/pulse2percept/utils/base.py
+++ b/pulse2percept/utils/base.py
@@ -16,7 +16,7 @@ from collections import OrderedDict as ODict
 from functools import wraps
 from string import ascii_uppercase
 
-from .deprecation import warn_deprecated_params
+from .deprecation import warn_deprecated_params, rename_deprecated_params
 
 
 class PrettyPrint(object, metaclass=abc.ABCMeta):
@@ -116,6 +116,24 @@ class FreezeError(AttributeError):
     """
 
 
+def has_own_attr(obj, name):
+    """Whether ``obj`` has an attribute ``name``, without running its getter
+
+    ``hasattr`` *invokes* a property or other descriptor just to answer the
+    question, which for a :py:class:`~pulse2percept.utils.deprecated_alias`
+    means a spurious deprecation warning every time an attribute is merely
+    probed. Looking the name up on the type instead settles the same question
+    without ever reading the instance's value.
+
+    Note that this does not consult ``__getattr__``, so it answers "does the
+    object own this attribute", not the broader "can this attribute be read".
+
+    .. versionadded:: 0.10.0
+
+    """
+    return name in getattr(obj, '__dict__', {}) or hasattr(type(obj), name)
+
+
 def freeze_class(set):
     """Freezes a class
     Raise an error when trying to set an undeclared name, or when calling from
@@ -124,7 +142,10 @@ def freeze_class(set):
     """
 
     def set_attr(self, name, value):
-        if hasattr(self, name):
+        # The cheap check comes first so that assigning to an attribute never
+        # *reads* it (see ``has_own_attr``); `hasattr` then covers the names
+        # that only a ``__getattr__`` knows about:
+        if has_own_attr(self, name) or hasattr(self, name):
             # If attribute already exists, simply set it
             set(self, name, value)
             return
@@ -175,6 +196,12 @@ class Parametrized(Frozen, PrettyPrint, metaclass=abc.ABCMeta):
     # override this (see ``SpatialModel``).
     _deprecated_params = {}
 
+    # Parameters that were renamed, and are still accepted under their old
+    # name. Maps the old name to the ``deprecated_alias`` that forwards it; an
+    # alias registers itself here when it is assigned in a subclass's body
+    # (see ``AxonMapSpatial``).
+    _renamed_params = {}
+
     def __init__(self, **params):
         """Parametrized constructor
 
@@ -191,6 +218,8 @@ class Parametrized(Frozen, PrettyPrint, metaclass=abc.ABCMeta):
         # applying a default must stay silent.
         warn_deprecated_params(type(self).__name__, params,
                                self._deprecated_params)
+        params = rename_deprecated_params(type(self).__name__, params,
+                                          self._renamed_params)
         # Then overwrite any arguments also given in `params`:
         for key, val in params.items():
             if key in defaults:
@@ -209,6 +238,8 @@ class Parametrized(Frozen, PrettyPrint, metaclass=abc.ABCMeta):
         """Set the parameters of this object"""
         warn_deprecated_params(type(self).__name__, params,
                                self._deprecated_params)
+        params = rename_deprecated_params(type(self).__name__, params,
+                                          self._renamed_params)
         for key, value in params.items():
             setattr(self, key, value)
 

--- a/pulse2percept/utils/deprecation.py
+++ b/pulse2percept/utils/deprecation.py
@@ -42,8 +42,8 @@ def _is_internal_module(name):
     test suite is blamed on the test rather than on the machinery underneath
     it -- which is what lets the tests check where a warning points.
     """
-    return ((name == 'pulse2percept' or name.startswith('pulse2percept.'))
-            and '.tests.' not in name)
+    return ((name == 'pulse2percept' or name.startswith('pulse2percept.')) and
+            '.tests.' not in name)
 
 
 def _warn_external(message, category=DeprecationWarning):

--- a/pulse2percept/utils/deprecation.py
+++ b/pulse2percept/utils/deprecation.py
@@ -35,6 +35,50 @@ def _callable_name(func):
     return obj_name
 
 
+def _is_internal_module(name):
+    """Whether a module name belongs to pulse2percept itself
+
+    Test modules are deliberately excluded, so that a warning raised from the
+    test suite is blamed on the test rather than on the machinery underneath
+    it -- which is what lets the tests check where a warning points.
+    """
+    return ((name == 'pulse2percept' or name.startswith('pulse2percept.'))
+            and '.tests.' not in name)
+
+
+def _warn_external(message, category=DeprecationWarning):
+    """Warn, blaming the innermost frame outside pulse2percept
+
+    A deprecation warning is only actionable if it points at the line that
+    used the deprecated name, and no fixed ``stacklevel`` can do that here:
+    the same alias is reached directly (``spatial.lam``), through a composite
+    model's ``__getattr__`` or ``__setattr__``, and through a chain of
+    ``super().__init__`` calls whose depth differs per subclass. So walk out
+    of the package instead, and blame the first frame that is not ours.
+
+    .. seealso::
+
+        Modeled on matplotlib's ``matplotlib._api.warn_external``.
+
+    Parameters
+    ----------
+    message : str
+        The warning message.
+    category : warning class, optional
+        The class of warning to raise.
+
+    """
+    frame = sys._getframe()
+    stacklevel = 1
+    # Stop at the outermost frame even if it is ours, rather than walking off
+    # the top of the stack, which `warnings.warn` would blame on `sys`:
+    while (frame.f_back is not None and
+           _is_internal_module(frame.f_globals.get('__name__', ''))):
+        frame = frame.f_back
+        stacklevel += 1
+    warnings.warn(message, category=category, stacklevel=stacklevel)
+
+
 class deprecated:
     """Decorator to mark deprecated functions and classes with a warning.
 
@@ -394,24 +438,21 @@ class deprecated_alias:
         self.new_name = new_name
         self.deprecated_version = deprecated_version
         self.removed_version = removed_version
-        # Both filled in by ``__set_name__`` when the class body is executed:
+        # Filled in by ``__set_name__`` when the class body is executed:
         self.old_name = None
-        self.owner_name = None
 
     def __set_name__(self, owner, name):
         self.old_name = name
-        self.owner_name = owner.__name__
         # Register on `owner` itself rather than mutate the dict it inherited,
         # which every other class in the hierarchy is looking at too:
         owner._renamed_params = {**getattr(owner, '_renamed_params', {}),
                                  name: self}
 
-    def _get_message(self, obj_name=None):
+    def _get_message(self, obj_name):
         """Builds the message string"""
         clause = _version_clause(self.deprecated_version, self.removed_version)
-        return (f"The '{self.old_name}' parameter of "
-                f"{obj_name or self.owner_name} is deprecated{clause}. "
-                f"Use '{self.new_name}' instead.")
+        return (f"The '{self.old_name}' parameter of {obj_name} is deprecated"
+                f"{clause}. Use '{self.new_name}' instead.")
 
     def __get__(self, obj, objtype=None):
         if obj is None:
@@ -419,14 +460,14 @@ class deprecated_alias:
             # the attribute machinery asks whether the name exists at all.
             # Nothing is being read, so nothing is deprecated yet:
             return self
-        # stacklevel=2 blames the line that touched the attribute:
-        warnings.warn(self._get_message(), category=DeprecationWarning,
-                      stacklevel=2)
+        # Name the class the attribute was reached through, not the one the
+        # alias was declared on: a subclass inherits the alias, and it is the
+        # subclass the user is holding.
+        _warn_external(self._get_message(type(obj).__name__))
         return getattr(obj, self.new_name)
 
     def __set__(self, obj, value):
-        warnings.warn(self._get_message(), category=DeprecationWarning,
-                      stacklevel=2)
+        _warn_external(self._get_message(type(obj).__name__))
         setattr(obj, self.new_name, value)
 
 
@@ -464,7 +505,7 @@ def warn_deprecated_params(obj_name, supplied, specs, stacklevel=3):
                           category=DeprecationWarning, stacklevel=stacklevel)
 
 
-def rename_deprecated_params(obj_name, params, specs, stacklevel=3):
+def rename_deprecated_params(obj_name, params, specs):
     """Rewrite renamed *model* parameters that were supplied by their old name
 
     The counterpart of :py:func:`~pulse2percept.utils.warn_deprecated_params`
@@ -489,10 +530,6 @@ def rename_deprecated_params(obj_name, params, specs, stacklevel=3):
     specs : dict
         Maps a renamed parameter's old name to the
         :py:class:`~pulse2percept.utils.deprecated_alias` describing it.
-    stacklevel : int, optional
-        Passed to ``warnings.warn``. Exact attribution is not possible through
-        a chain of ``super().__init__`` calls of varying depth, so the message
-        names the parameter and the model rather than relying on it.
 
     Returns
     -------
@@ -500,15 +537,29 @@ def rename_deprecated_params(obj_name, params, specs, stacklevel=3):
         ``params`` with every renamed key replaced by its new name. The
         original dict is returned untouched if none of the keys were renamed.
 
+    Raises
+    ------
+    TypeError
+        If both names of the same parameter were supplied. Which one won
+        would otherwise come down to the order they were passed in.
+
     """
     if not any(name in specs for name in params):
         return params
+    # Check every collision up front, so that an invalid call raises rather
+    # than warning about a value it is about to reject. Iterating `specs`
+    # rather than `params` keeps the error deterministic when more than one
+    # parameter was renamed:
+    for old_name, spec in specs.items():
+        if old_name in params and spec.new_name in params:
+            raise TypeError(f"{obj_name} got both '{old_name}' and "
+                            f"'{spec.new_name}', which are the same "
+                            f"parameter. Pass only '{spec.new_name}'.")
     renamed = {}
     for name, val in params.items():
         spec = specs.get(name)
         if spec is not None:
-            warnings.warn(spec._get_message(obj_name),
-                          category=DeprecationWarning, stacklevel=stacklevel)
+            _warn_external(spec._get_message(obj_name))
             name = spec.new_name
         renamed[name] = val
     return renamed

--- a/pulse2percept/utils/deprecation.py
+++ b/pulse2percept/utils/deprecation.py
@@ -1,5 +1,7 @@
 """:py:class:`~pulse2percept.utils.deprecated`,
    :py:class:`~pulse2percept.utils.deprecate_parameter`,
+   :py:class:`~pulse2percept.utils.deprecated_alias`,
+   :py:class:`~pulse2percept.utils.rename_parameter`,
    :py:class:`~pulse2percept.utils.is_deprecated`"""
 
 import sys
@@ -21,6 +23,16 @@ def _version_clause(deprecated_version=None, removed_version=None):
     if removed_version is not None:
         rmv_msg = f", and will be removed in version {removed_version}"
     return dep_msg + rmv_msg
+
+
+def _callable_name(func):
+    """Names a callable the way a user would refer to it"""
+    obj_name = getattr(func, '__qualname__', None) or func.__name__
+    # A decorated constructor is really about the class, so report
+    # `MyClass`, not `MyClass.__init__`:
+    if obj_name.endswith('.__init__'):
+        obj_name = obj_name[:-len('.__init__')]
+    return obj_name
 
 
 class deprecated:
@@ -149,7 +161,9 @@ class deprecate_parameter:
 
     Use this when a parameter is going away but the callable itself stays. To
     deprecate an entire function, class, or property, use
-    :py:class:`~pulse2percept.utils.deprecated` instead.
+    :py:class:`~pulse2percept.utils.deprecated` instead. To keep a parameter
+    that is merely being *renamed* working under its old name, use
+    :py:class:`~pulse2percept.utils.rename_parameter` instead.
 
     .. versionadded:: 0.9.1
 
@@ -208,12 +222,7 @@ class deprecate_parameter:
 
     def _get_obj_name(self, func):
         """Names the decorated callable the way a user would refer to it"""
-        obj_name = getattr(func, '__qualname__', None) or func.__name__
-        # A decorated constructor is really about the class, so report
-        # `MyClass`, not `MyClass.__init__`:
-        if obj_name.endswith('.__init__'):
-            obj_name = obj_name[:-len('.__init__')]
-        return obj_name
+        return _callable_name(func)
 
     def __call__(self, func):
         signature = inspect.signature(func)
@@ -239,6 +248,186 @@ class deprecate_parameter:
             return func(*args, **kwargs)
 
         return wrapped
+
+
+class rename_parameter:
+    """Decorator to rename a single function or method parameter
+
+    Calls that use the old name keep working: the value is forwarded to the
+    new parameter, so the callable behaves exactly as it did before, but a
+    ``DeprecationWarning`` is raised. Use this when a parameter is only being
+    renamed; when its value is no longer read at all, use
+    :py:class:`~pulse2percept.utils.deprecate_parameter` instead.
+
+    Only *keyword* use of the old name is forwarded, which is the only way it
+    can be recognized: a positional argument is bound by position and never
+    mentions either name.
+
+    .. versionadded:: 0.10.0
+
+    .. note::
+
+        Models take their parameters as ``**params``, validated against
+        ``get_default_params`` rather than declared in a signature, so this
+        decorator cannot see them. Rename those with a
+        :py:class:`~pulse2percept.utils.deprecated_alias` instead.
+
+    Parameters
+    ----------
+    old_name : str
+        The name being retired. Must *not* appear in the signature of the
+        decorated callable, otherwise a ``ValueError`` is raised at decoration
+        time (which catches the rename never having been made).
+    new_name : str
+        The name that replaces it. Must appear in the signature, otherwise a
+        ``ValueError`` is raised at decoration time.
+    deprecated_version : float or str
+        The package version in which the old name was first marked as
+        deprecated.
+    removed_version : float or str
+        The package version in which the old name will stop working.
+
+    Examples
+    --------
+    >>> from pulse2percept.utils import rename_parameter
+    >>> @rename_parameter('axlambda', 'lam', deprecated_version='0.10.0',
+    ...                   removed_version='0.11.0')
+    ... def decay(lam=1):
+    ...     return lam
+    >>> decay(lam=3)  # no warning
+    3
+
+    """
+
+    def __init__(self, old_name, new_name, deprecated_version=None,
+                 removed_version=None):
+        self.old_name = old_name
+        self.new_name = new_name
+        self.deprecated_version = deprecated_version
+        self.removed_version = removed_version
+
+    def _get_message(self, obj_name):
+        """Builds the message string"""
+        clause = _version_clause(self.deprecated_version, self.removed_version)
+        return (f"The '{self.old_name}' parameter of {obj_name} is deprecated"
+                f"{clause}. Use '{self.new_name}' instead.")
+
+    def __call__(self, func):
+        signature = inspect.signature(func)
+        obj_name = _callable_name(func)
+        if self.new_name not in signature.parameters:
+            raise ValueError(f"'{self.new_name}' is not a parameter of "
+                             f"{obj_name}. Its signature is {signature}.")
+        if self.old_name in signature.parameters:
+            raise ValueError(f"'{self.old_name}' is still a parameter of "
+                             f"{obj_name}. Rename it to '{self.new_name}' "
+                             f"first.")
+
+        @functools.wraps(func)
+        def wrapped(*args, **kwargs):
+            if self.old_name in kwargs:
+                if self.new_name in kwargs:
+                    raise TypeError(f"{obj_name} got both '{self.old_name}' "
+                                    f"and '{self.new_name}', which are the "
+                                    f"same parameter. Pass only "
+                                    f"'{self.new_name}'.")
+                # Build the message here rather than capturing it in the
+                # closure: `is_deprecated` looks for the word "deprecated" in
+                # closure cells, and the callable itself is *not* deprecated.
+                warnings.warn(self._get_message(obj_name),
+                              category=DeprecationWarning, stacklevel=2)
+                kwargs[self.new_name] = kwargs.pop(self.old_name)
+            return func(*args, **kwargs)
+
+        return wrapped
+
+
+class deprecated_alias:
+    """Class attribute that keeps a renamed parameter usable under its old name
+
+    Assign one in the class body, under the *old* name, to a
+    :py:class:`~pulse2percept.utils.Parametrized` subclass whose parameters
+    live in ``get_default_params`` rather than in a signature:
+
+    .. code-block:: python
+
+        class MyModel(BaseModel):
+
+            axlambda = deprecated_alias('lam', deprecated_version='0.10.0')
+
+            def get_default_params(self):
+                return {'lam': 500}
+
+    Reading or writing ``model.axlambda`` then reads or writes ``model.lam``
+    and raises a ``DeprecationWarning``. The alias also registers itself in
+    the owner's ``_renamed_params``, which is what lets the constructor,
+    ``set_params`` and ``build`` keep accepting the old name as a keyword
+    argument (see
+    :py:func:`~pulse2percept.utils.rename_deprecated_params`).
+
+    To rename a parameter that *is* declared in a signature, use
+    :py:class:`~pulse2percept.utils.rename_parameter` instead.
+
+    .. versionadded:: 0.10.0
+
+    .. note::
+
+        Document the rename by adding a ``.. versionchanged::`` directive to
+        the *new* parameter's entry in the docstring's ``Parameters`` section.
+        The old name has no entry of its own, since nothing should be written
+        against it any more.
+
+    Parameters
+    ----------
+    new_name : str
+        Name of the parameter that replaces the alias.
+    deprecated_version : float or str
+        The package version in which the old name was first marked as
+        deprecated.
+    removed_version : float or str
+        The package version in which the old name will stop working.
+
+    """
+
+    def __init__(self, new_name, deprecated_version=None,
+                 removed_version=None):
+        self.new_name = new_name
+        self.deprecated_version = deprecated_version
+        self.removed_version = removed_version
+        # Both filled in by ``__set_name__`` when the class body is executed:
+        self.old_name = None
+        self.owner_name = None
+
+    def __set_name__(self, owner, name):
+        self.old_name = name
+        self.owner_name = owner.__name__
+        # Register on `owner` itself rather than mutate the dict it inherited,
+        # which every other class in the hierarchy is looking at too:
+        owner._renamed_params = {**getattr(owner, '_renamed_params', {}),
+                                 name: self}
+
+    def _get_message(self, obj_name=None):
+        """Builds the message string"""
+        clause = _version_clause(self.deprecated_version, self.removed_version)
+        return (f"The '{self.old_name}' parameter of "
+                f"{obj_name or self.owner_name} is deprecated{clause}. "
+                f"Use '{self.new_name}' instead.")
+
+    def __get__(self, obj, objtype=None):
+        if obj is None:
+            # Looked up on the class rather than on an instance, which is how
+            # the attribute machinery asks whether the name exists at all.
+            # Nothing is being read, so nothing is deprecated yet:
+            return self
+        # stacklevel=2 blames the line that touched the attribute:
+        warnings.warn(self._get_message(), category=DeprecationWarning,
+                      stacklevel=2)
+        return getattr(obj, self.new_name)
+
+    def __set__(self, obj, value):
+        warnings.warn(self._get_message(), category=DeprecationWarning,
+                      stacklevel=2)
+        setattr(obj, self.new_name, value)
 
 
 def warn_deprecated_params(obj_name, supplied, specs, stacklevel=3):
@@ -273,6 +462,56 @@ def warn_deprecated_params(obj_name, supplied, specs, stacklevel=3):
         if spec is not None:
             warnings.warn(spec._get_message(obj_name),
                           category=DeprecationWarning, stacklevel=stacklevel)
+
+
+def rename_deprecated_params(obj_name, params, specs, stacklevel=3):
+    """Rewrite renamed *model* parameters that were supplied by their old name
+
+    The counterpart of :py:func:`~pulse2percept.utils.warn_deprecated_params`
+    for parameters that were renamed rather than retired: the value is kept,
+    but moves to the new name, and the warning names the replacement.
+
+    Handing the caller a rewritten dict, rather than letting the assignment
+    fall through to the
+    :py:class:`~pulse2percept.utils.deprecated_alias` descriptor, keeps the
+    warning to one per parameter and lets it name the model the user actually
+    called.
+
+    .. versionadded:: 0.10.0
+
+    Parameters
+    ----------
+    obj_name : str
+        Name of the model, as it should appear in the warning.
+    params : dict
+        Parameters the caller supplied. Names that were not renamed are left
+        alone, so it is fine to pass all of them.
+    specs : dict
+        Maps a renamed parameter's old name to the
+        :py:class:`~pulse2percept.utils.deprecated_alias` describing it.
+    stacklevel : int, optional
+        Passed to ``warnings.warn``. Exact attribution is not possible through
+        a chain of ``super().__init__`` calls of varying depth, so the message
+        names the parameter and the model rather than relying on it.
+
+    Returns
+    -------
+    params : dict
+        ``params`` with every renamed key replaced by its new name. The
+        original dict is returned untouched if none of the keys were renamed.
+
+    """
+    if not any(name in specs for name in params):
+        return params
+    renamed = {}
+    for name, val in params.items():
+        spec = specs.get(name)
+        if spec is not None:
+            warnings.warn(spec._get_message(obj_name),
+                          category=DeprecationWarning, stacklevel=stacklevel)
+            name = spec.new_name
+        renamed[name] = val
+    return renamed
 
 
 def is_deprecated(func):

--- a/pulse2percept/utils/deprecation.py
+++ b/pulse2percept/utils/deprecation.py
@@ -51,10 +51,10 @@ def _warn_external(message, category=DeprecationWarning):
 
     A deprecation warning is only actionable if it points at the line that
     used the deprecated name, and no fixed ``stacklevel`` can do that here:
-    the same alias is reached directly (``spatial.lam``), through a composite
-    model's ``__getattr__`` or ``__setattr__``, and through a chain of
-    ``super().__init__`` calls whose depth differs per subclass. So walk out
-    of the package instead, and blame the first frame that is not ours.
+    the same alias is reached directly (``spatial.axlambda``), through a
+    composite model's ``__getattr__`` or ``__setattr__``, and through a chain
+    of ``super().__init__`` calls whose depth differs per subclass. So walk
+    out of the package instead, and blame the first frame that is not ours.
 
     .. seealso::
 

--- a/pulse2percept/utils/tests/test_deprecation.py
+++ b/pulse2percept/utils/tests/test_deprecation.py
@@ -2,6 +2,9 @@ import warnings
 import numpy.testing as npt
 import pytest
 from pulse2percept.utils.deprecation import (deprecated, deprecate_parameter,
+                                             deprecated_alias,
+                                             rename_parameter,
+                                             rename_deprecated_params,
                                              is_deprecated)
 from pulse2percept.utils.testing import assert_warns_msg
 
@@ -163,3 +166,136 @@ def test_deprecate_parameter_unknown_param():
     # decorator's signature binding:
     with pytest.raises(TypeError):
         mock_func_old_param()
+
+
+@rename_parameter('old', 'new', deprecated_version=0.1, removed_version=0.2)
+def mock_func_renamed_param(a, new=3):
+    return a + new
+
+
+class MockClassRenamedParam:
+
+    @rename_parameter('old', 'new', deprecated_version=0.1,
+                      removed_version=0.2)
+    def __init__(self, new):
+        self.new = new
+
+
+def test_rename_parameter():
+    # The old name warns, and names the replacement:
+    assert_warns_msg(DeprecationWarning, mock_func_renamed_param,
+                     "The 'old' parameter of mock_func_renamed_param is "
+                     "deprecated since version 0.1, and will be removed in "
+                     "version 0.2. Use 'new' instead.", 1, old=10)
+    # But unlike a deprecated parameter, its value is *kept*:
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        npt.assert_equal(mock_func_renamed_param(1, old=10), 11)
+    # The new name behaves identically, and does not warn:
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", DeprecationWarning)
+        npt.assert_equal(mock_func_renamed_param(1, new=10), 11)
+        npt.assert_equal(mock_func_renamed_param(1), 4)
+    # Docstring and name survive the wrapping, and the callable itself is not
+    # deprecated:
+    npt.assert_equal(mock_func_renamed_param.__name__,
+                     'mock_func_renamed_param')
+    npt.assert_equal(is_deprecated(mock_func_renamed_param), False)
+
+
+def test_rename_parameter_method():
+    # On a constructor, the warning names the class, not `__init__`:
+    assert_warns_msg(DeprecationWarning, MockClassRenamedParam,
+                     "parameter of MockClassRenamedParam is deprecated",
+                     old=10)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        npt.assert_equal(MockClassRenamedParam(old=10).new, 10)
+
+
+def test_rename_parameter_both_names():
+    # The two names are the same parameter, so passing both is an error
+    # rather than a silent choice between them:
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        with pytest.raises(TypeError):
+            mock_func_renamed_param(1, old=10, new=20)
+
+
+def test_rename_parameter_unknown_param():
+    # The new name has to exist...
+    with pytest.raises(ValueError):
+        @rename_parameter('old', 'nonexistent')
+        def func(a, b=2):
+            return a
+
+    # ...and the old one must be gone from the signature, which catches the
+    # rename never having been made:
+    with pytest.raises(ValueError):
+        @rename_parameter('b', 'a')
+        def func(a, b=2):
+            return a
+
+
+class MockClassAlias:
+
+    old = deprecated_alias('new', deprecated_version=0.1, removed_version=0.2)
+
+    def __init__(self):
+        self.new = 42
+
+
+def test_deprecated_alias():
+    obj = MockClassAlias()
+    # Reading through the alias warns, but returns the current value:
+    assert_warns_msg(DeprecationWarning, lambda: obj.old,
+                     "The 'old' parameter of MockClassAlias is deprecated "
+                     "since version 0.1, and will be removed in version 0.2. "
+                     "Use 'new' instead.")
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        npt.assert_equal(obj.old, 42)
+        # Writing through it warns too, and writes the new name:
+        obj.old = 7
+    npt.assert_equal(obj.new, 7)
+    assert_warns_msg(DeprecationWarning,
+                     lambda: setattr(obj, 'old', 9), "Use 'new' instead")
+    npt.assert_equal(obj.new, 9)
+    # The new name stays silent:
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", DeprecationWarning)
+        obj.new = 3
+        npt.assert_equal(obj.new, 3)
+
+
+def test_deprecated_alias_on_class():
+    # Looked up on the class, the alias returns itself rather than warning:
+    # that is how the attribute machinery asks whether a name exists at all.
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", DeprecationWarning)
+        npt.assert_equal(isinstance(MockClassAlias.old, deprecated_alias),
+                         True)
+        npt.assert_equal(hasattr(MockClassAlias, 'old'), True)
+    # And it registered itself, so that `**params` constructors can find it:
+    npt.assert_equal(MockClassAlias._renamed_params['old'].new_name, 'new')
+
+
+def test_rename_deprecated_params():
+    specs = MockClassAlias._renamed_params
+    # A renamed name is warned about, under the name the caller used, and
+    # rewritten:
+    assert_warns_msg(DeprecationWarning, rename_deprecated_params,
+                     "The 'old' parameter of MyModel is deprecated",
+                     'MyModel', {'old': 1}, specs)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        npt.assert_equal(rename_deprecated_params('MyModel', {'old': 1},
+                                                  specs), {'new': 1})
+    # Everything else is passed straight through, untouched and unwarned:
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", DeprecationWarning)
+        params = {'other': 1}
+        npt.assert_equal(rename_deprecated_params('MyModel', params, specs) is
+                         params, True)
+        npt.assert_equal(rename_deprecated_params('MyModel', params, {}) is
+                         params, True)

--- a/pulse2percept/utils/tests/test_deprecation.py
+++ b/pulse2percept/utils/tests/test_deprecation.py
@@ -268,6 +268,32 @@ def test_deprecated_alias():
         npt.assert_equal(obj.new, 3)
 
 
+class MockSubclassAlias(MockClassAlias):
+    pass
+
+
+def test_deprecated_alias_names_runtime_class():
+    # A subclass inherits the alias, but the warning has to name the class the
+    # user is actually holding, not the one the alias was declared on:
+    assert_warns_msg(DeprecationWarning, lambda: MockSubclassAlias().old,
+                     "The 'old' parameter of MockSubclassAlias is deprecated")
+    assert_warns_msg(DeprecationWarning,
+                     lambda: setattr(MockSubclassAlias(), 'old', 1),
+                     "The 'old' parameter of MockSubclassAlias is deprecated")
+
+
+def test_deprecated_alias_blames_caller():
+    # A deprecation warning is only actionable if it points at the line that
+    # used the old name, so check where it lands and not just what it says:
+    obj = MockClassAlias()
+    with pytest.warns(DeprecationWarning) as record:
+        obj.old
+    npt.assert_equal(record[0].filename, __file__)
+    with pytest.warns(DeprecationWarning) as record:
+        obj.old = 1
+    npt.assert_equal(record[0].filename, __file__)
+
+
 def test_deprecated_alias_on_class():
     # Looked up on the class, the alias returns itself rather than warning:
     # that is how the attribute machinery asks whether a name exists at all.
@@ -299,3 +325,19 @@ def test_rename_deprecated_params():
                          params, True)
         npt.assert_equal(rename_deprecated_params('MyModel', params, {}) is
                          params, True)
+
+
+def test_rename_deprecated_params_both_names():
+    specs = MockClassAlias._renamed_params
+    # The two names are the same parameter, so supplying both must raise
+    # rather than let the order they were passed in decide which one wins.
+    # `**kwargs` preserves insertion order, so check it really is symmetric:
+    for params in ({'old': 1, 'new': 2}, {'new': 2, 'old': 1}):
+        with pytest.raises(TypeError, match="same parameter"):
+            rename_deprecated_params('MyModel', params, specs)
+    # And it raises *instead of* warning, not after it, exactly as the
+    # signature-level `rename_parameter` does:
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", DeprecationWarning)
+        with pytest.raises(TypeError):
+            rename_deprecated_params('MyModel', {'old': 1, 'new': 2}, specs)


### PR DESCRIPTION
Long overdue: `axlambda` was a poor choice next to `rho`. `lam` makes much more sense. Both still work, but `axlambda` is deprecated and will be removed in v0.11.

To make this work, `rename_deprecated_params` was added in `utils`.