### PR TITLE
[FIX] Metadata handling when Stimulus objects are passed around

### DIFF
--- a/doc/users/release_notes.rst
+++ b/doc/users/release_notes.rst
@@ -59,6 +59,14 @@ API changes:
   it, and each frame now produces a pulse train rather than a single pulse.
   Pass ``stretch=True`` for the old gray-level mapping.
 
+* Scaling a :py:class:`~pulse2percept.stimuli.BiphasicPulseTrain` now scales
+  the ``amp`` recorded in its metadata, so ``pt * 2`` predicts the percept of a
+  train built at twice the amplitude rather than the original one. Adding a DC
+  offset (``pt + 5``) drops the pulse parameters instead, since the result is
+  no longer a biphasic pulse train;
+  :py:class:`~pulse2percept.models.BiphasicAxonMapModel` then rejects it
+  (:issue:`435`).
+
 * :py:class:`~pulse2percept.implants.ProsthesisSystem` now exposes ``raster``
   and ``max_current``.
 
@@ -107,6 +115,11 @@ Bug fixes:
   and composited onto the axes background for ``fmt='jpg'``, which cannot carry
   it. Previously the four channels were reinterpreted as RGB, which sheared the
   color channels across every row.
+
+* Stimulus metadata now survives ``predict_percept``. Spatial models are handed
+  a copy of the stimulus with duplicate frames collapsed, and that copy used to
+  be built without any metadata, so models that read pulse parameters from it
+  saw none (:issue:`545`).
 
 * Visual-field-map equality now handles array-valued attributes correctly,
   maps are hashable again, and maps of different classes no longer compare

--- a/doc/users/release_notes.rst
+++ b/doc/users/release_notes.rst
@@ -28,15 +28,10 @@ Highlights:
 
 API changes:
 
-* The ``axlambda`` parameter of the axon map models
-  (:py:class:`~pulse2percept.models.AxonMapModel`,
-  :py:class:`~pulse2percept.models.AxonMapSpatial`,
-  :py:class:`~pulse2percept.models.BiphasicAxonMapModel`,
-  :py:class:`~pulse2percept.models.BiphasicAxonMapSpatial`, and
-  :py:class:`~pulse2percept.models.granley2021.DefaultStreakModel`) was
-  renamed to ``lam``, which sits better next to ``rho``. The old name still
-  works everywhere the new one does, but raises a ``DeprecationWarning`` and
-  will be removed in v0.11.0.
+* The ``axlambda`` parameter of the axon map models was renamed to ``lam``,
+  which sits better next to ``rho``. The old name still works everywhere the
+  new one does, but raises a ``DeprecationWarning`` and will be removed in
+  v0.11.0.
 
 * :py:class:`~pulse2percept.models.FadingTemporal` is now driven by
   :math:`\max(-A, 0)` rather than :math:`-A`: anodic current no longer reduces
@@ -59,13 +54,8 @@ API changes:
   it, and each frame now produces a pulse train rather than a single pulse.
   Pass ``stretch=True`` for the old gray-level mapping.
 
-* Scaling a :py:class:`~pulse2percept.stimuli.BiphasicPulseTrain` now scales
-  the ``amp`` recorded in its metadata, so ``pt * 2`` predicts the percept of a
-  train built at twice the amplitude rather than the original one. Adding a DC
-  offset (``pt + 5``) drops the pulse parameters instead, since the result is
-  no longer a biphasic pulse train;
-  :py:class:`~pulse2percept.models.BiphasicAxonMapModel` then rejects it
-  (:issue:`435`).
+* :py:class:`~pulse2percept.stimuli.BiphasicPulseTrain` now records ``amp`` in
+  its metadata as a magnitude.
 
 * :py:class:`~pulse2percept.implants.ProsthesisSystem` now exposes ``raster``
   and ``max_current``.
@@ -116,10 +106,7 @@ Bug fixes:
   it. Previously the four channels were reinterpreted as RGB, which sheared the
   color channels across every row.
 
-* Stimulus metadata now survives ``predict_percept``. Spatial models are handed
-  a copy of the stimulus with duplicate frames collapsed, and that copy used to
-  be built without any metadata, so models that read pulse parameters from it
-  saw none (:issue:`545`).
+* Stimulus metadata now survives ``predict_percept`` and other transformations.
 
 * Visual-field-map equality now handles array-valued attributes correctly,
   maps are hashable again, and maps of different classes no longer compare

--- a/pulse2percept/models/base.py
+++ b/pulse2percept/models/base.py
@@ -541,8 +541,14 @@ class SpatialModel(BaseModel, metaclass=ABCMeta):
                 uniq_time = stim.time[t_unique]
                 if len(uniq_time) == 1:
                     uniq_time = None
-                stim_unique = Stimulus(stim[:, stim.time[t_unique]], 
-                                       electrodes=stim.electrodes, time=uniq_time)
+                # Carry the metadata across: `_predict_spatial` is where
+                # BiphasicAxonMapSpatial and DynaphosModel look up amplitude,
+                # frequency and phase duration, and they only ever see this
+                # de-duplicated copy:
+                stim_unique = Stimulus(stim[:, stim.time[t_unique]],
+                                       electrodes=stim.electrodes,
+                                       time=uniq_time,
+                                       metadata=stim.metadata)
                 resp_unique = self._predict_spatial(implant.earray, stim_unique)
                 # reconstruct original time points, making sure to preserve C ordering
                 resp = resp_unique[..., inverse].copy(order='C')

--- a/pulse2percept/models/granley2021.py
+++ b/pulse2percept/models/granley2021.py
@@ -583,10 +583,10 @@ class BiphasicAxonMapModel(Model):
 
         This model interacts with `Stimulus` objects by reading the intended
         amplitude, frequency, and pulse duration from their metadata, not
-        from the raw stimulus data. Scaling a
-        :py:class:`~pulse2percept.stimuli.BiphasicPulseTrain` (``pt * 2``)
-        updates that metadata and does change the percept; editing the data
-        array in place does not.
+        from the raw stimulus data. The arithmetic operators keep that
+        metadata in sync, so scaling a pulse train (``pt * 2``) or the
+        stimulus assembled from one (``implant.stim * 2``) does change the
+        percept, while editing the data array in place does not.
 
     Parameters
     ----------

--- a/pulse2percept/models/granley2021.py
+++ b/pulse2percept/models/granley2021.py
@@ -582,9 +582,11 @@ class BiphasicAxonMapModel(Model):
         amplitude in microamps.
 
         This model interacts with `Stimulus` objects by reading the intended
-        amplitude, frequency, and pulse duration from their metadata.
-        Scaling, shifting, or otherwise manipulating the raw stimulus data
-        will not change the predicted percept.
+        amplitude, frequency, and pulse duration from their metadata, not
+        from the raw stimulus data. Scaling a
+        :py:class:`~pulse2percept.stimuli.BiphasicPulseTrain` (``pt * 2``)
+        updates that metadata and does change the percept; editing the data
+        array in place does not.
 
     Parameters
     ----------
@@ -708,9 +710,9 @@ class BiphasicAxonMapModel(Model):
             NOT as raw amplitude in microamps.
 
             The model interacts with `Stimulus` objects by reading the
-            intended amplitude, frequency, and pulse duration from their 
-            metadata. Manipulating the raw stimulus data will not change
-            the predicted percept.
+            intended amplitude, frequency, and pulse duration from their
+            metadata, not from the raw stimulus data. Editing the data
+            array in place will not change the predicted percept.
 
         Parameters
         ----------

--- a/pulse2percept/models/tests/test_base.py
+++ b/pulse2percept/models/tests/test_base.py
@@ -9,7 +9,8 @@ from matplotlib.axes import Subplot
 import time
 
 from pulse2percept.implants import ArgusI
-from pulse2percept.stimuli import AmplitudeEncoder, Stimulus, VideoStimulus
+from pulse2percept.stimuli import (AmplitudeEncoder, BiphasicPulseTrain,
+                                   Stimulus, VideoStimulus)
 from pulse2percept.percepts import Percept
 from pulse2percept.models import (BaseModel, FadingTemporal, Model,
                                   NotBuiltError, ScoreboardSpatial,
@@ -170,6 +171,34 @@ def test_SpatialModel_predict_percept_deduplicates_frames():
     npt.assert_almost_equal(percept.time, [0, 1, 2, 3])
     for idx, amp in enumerate([2, 5, 2, 5]):
         npt.assert_almost_equal(percept.data[..., idx], amp)
+
+
+def test_SpatialModel_predict_percept_keeps_metadata():
+    # `_predict_spatial` only ever sees the de-duplicated copy of the stimulus,
+    # and that copy is where BiphasicAxonMapSpatial and DynaphosModel look up
+    # amplitude, frequency and phase duration. The per-electrode metadata has
+    # to survive the trip:
+    seen_metadata = []
+
+    class RecordingSpatialModel(ValidSpatialModel):
+
+        def _predict_spatial(self, earray, stim):
+            seen_metadata.append(stim.metadata)
+            return np.zeros((self.grid.x.size, stim.data.shape[1]),
+                            dtype=np.float32)
+
+    model = RecordingSpatialModel(xystep=2).build()
+    implant = ArgusI(stim={'A1': BiphasicPulseTrain(20, 10, 0.45,
+                                                    stim_dur=20)})
+    model.predict_percept(implant)
+    npt.assert_equal(len(seen_metadata), 1)
+    npt.assert_equal(list(seen_metadata[0]['electrodes'].keys()), ['A1'])
+    npt.assert_equal(seen_metadata[0]['electrodes']['A1']['metadata']['amp'],
+                     10)
+    # ...also when the caller asks for time points of their own:
+    seen_metadata.clear()
+    model.predict_percept(implant, t_percept=[0, 5, 10])
+    npt.assert_equal(list(seen_metadata[0]['electrodes'].keys()), ['A1'])
 
 
 @pytest.mark.parametrize('param, value', [('engine', 'serial'),

--- a/pulse2percept/models/tests/test_granley2021.py
+++ b/pulse2percept/models/tests/test_granley2021.py
@@ -428,16 +428,26 @@ def test_find_threshold_not_supported(model_cls):
 
 @pytest.mark.parametrize('model_cls', [BiphasicAxonMapModel,
                                        BiphasicAxonMapSpatial])
-def test_scaled_pulse_train_changes_percept(model_cls):
+# Scaling the train itself, and scaling the stimulus the implant made of it -
+# the second is what a user reaches for, and it goes through the per-electrode
+# metadata rather than the train's own:
+@pytest.mark.parametrize('compose', [False, True])
+def test_scaled_pulse_train_changes_percept(model_cls, compose):
     # This model reads amplitude off the stimulus metadata, so a scaled pulse
     # train used to deliver twice the current and predict the very same
     # percept. Scaling now updates the metadata, and has to give what building
     # the train at that amplitude in the first place gives:
     model = model_cls(xrange=(-12, 12), yrange=(-8, 8), xystep=1,
                       n_ax_segments=30).build()
-    pt = BiphasicPulseTrain(20, 1, 0.45, stim_dur=100)
-    single = model.predict_percept(ArgusII(stim={'C5': pt})).data
-    doubled = model.predict_percept(ArgusII(stim={'C5': pt * 2})).data
+    implant = ArgusII(stim={'C5': BiphasicPulseTrain(20, 1, 0.45,
+                                                     stim_dur=100)})
+    single = model.predict_percept(implant).data
+    if compose:
+        implant.stim = implant.stim * 2
+    else:
+        implant.stim = {'C5': BiphasicPulseTrain(20, 1, 0.45,
+                                                 stim_dur=100) * 2}
+    doubled = model.predict_percept(implant).data
     direct = model.predict_percept(ArgusII(
         stim={'C5': BiphasicPulseTrain(20, 2, 0.45, stim_dur=100)})).data
     npt.assert_equal(np.any(single), True)
@@ -447,15 +457,34 @@ def test_scaled_pulse_train_changes_percept(model_cls):
 
 @pytest.mark.parametrize('model_cls', [BiphasicAxonMapModel,
                                        BiphasicAxonMapSpatial])
-def test_offset_pulse_train_rejected(model_cls):
-    # A DC offset makes it something other than a biphasic pulse train, and
-    # the model must say so rather than predict from pulse parameters that no
-    # longer describe the stimulus:
+@pytest.mark.parametrize('modify', [lambda s: s + 5, lambda s: s * np.inf,
+                                    lambda s: s.append(s >> 1)])
+def test_modified_pulse_train_rejected(model_cls, modify):
+    # A DC offset, a non-finite factor and an appended second train all leave
+    # something other than a biphasic pulse train. The model must say so rather
+    # than predict from pulse parameters that no longer describe the stimulus:
     model = model_cls(xrange=(-3, 3), yrange=(-2, 2), xystep=1,
                       n_ax_segments=30).build()
-    pt = BiphasicPulseTrain(20, 1, 0.45, stim_dur=100)
+    implant = ArgusII(stim={'C5': BiphasicPulseTrain(20, 1, 0.45,
+                                                     stim_dur=100)})
+    with np.errstate(divide='ignore', invalid='ignore'):
+        implant.stim = modify(implant.stim)
     with pytest.raises(TypeError):
-        model.predict_percept(ArgusII(stim={'C5': pt + 5}))
+        model.predict_percept(implant)
+
+
+def test_pulse_train_amp_sign_does_not_change_percept():
+    # `BiphasicPulse` takes the magnitude of `amp`, so these two trains have
+    # the very same waveform. The model reads `amp` back from the metadata and
+    # is a function of it rather than of its magnitude, so the metadata has to
+    # store the magnitude - otherwise identical stimuli predict differently:
+    model = BiphasicAxonMapModel(xrange=(-12, 12), yrange=(-8, 8), xystep=1,
+                                 n_ax_segments=30).build()
+    pos = ArgusII(stim={'C5': BiphasicPulseTrain(20, 1, 0.45, stim_dur=100)})
+    neg = ArgusII(stim={'C5': BiphasicPulseTrain(20, -1, 0.45, stim_dur=100)})
+    npt.assert_almost_equal(pos.stim.data, neg.stim.data)
+    npt.assert_array_almost_equal(model.predict_percept(pos).data,
+                                  model.predict_percept(neg).data)
 
 
 def test_BiphasicAxonMapModel_min_current_spread():

--- a/pulse2percept/models/tests/test_granley2021.py
+++ b/pulse2percept/models/tests/test_granley2021.py
@@ -426,6 +426,38 @@ def test_find_threshold_not_supported(model_cls):
     npt.assert_equal(model.predict_percept(implant) is not None, True)
 
 
+@pytest.mark.parametrize('model_cls', [BiphasicAxonMapModel,
+                                       BiphasicAxonMapSpatial])
+def test_scaled_pulse_train_changes_percept(model_cls):
+    # This model reads amplitude off the stimulus metadata, so a scaled pulse
+    # train used to deliver twice the current and predict the very same
+    # percept. Scaling now updates the metadata, and has to give what building
+    # the train at that amplitude in the first place gives:
+    model = model_cls(xrange=(-12, 12), yrange=(-8, 8), xystep=1,
+                      n_ax_segments=30).build()
+    pt = BiphasicPulseTrain(20, 1, 0.45, stim_dur=100)
+    single = model.predict_percept(ArgusII(stim={'C5': pt})).data
+    doubled = model.predict_percept(ArgusII(stim={'C5': pt * 2})).data
+    direct = model.predict_percept(ArgusII(
+        stim={'C5': BiphasicPulseTrain(20, 2, 0.45, stim_dur=100)})).data
+    npt.assert_equal(np.any(single), True)
+    npt.assert_array_almost_equal(doubled, direct)
+    npt.assert_equal(np.allclose(doubled, single), False)
+
+
+@pytest.mark.parametrize('model_cls', [BiphasicAxonMapModel,
+                                       BiphasicAxonMapSpatial])
+def test_offset_pulse_train_rejected(model_cls):
+    # A DC offset makes it something other than a biphasic pulse train, and
+    # the model must say so rather than predict from pulse parameters that no
+    # longer describe the stimulus:
+    model = model_cls(xrange=(-3, 3), yrange=(-2, 2), xystep=1,
+                      n_ax_segments=30).build()
+    pt = BiphasicPulseTrain(20, 1, 0.45, stim_dur=100)
+    with pytest.raises(TypeError):
+        model.predict_percept(ArgusII(stim={'C5': pt + 5}))
+
+
 def test_BiphasicAxonMapModel_min_current_spread():
     """The current-spread cutoff must reach this model's kernel too.
 

--- a/pulse2percept/stimuli/base.py
+++ b/pulse2percept/stimuli/base.py
@@ -294,6 +294,44 @@ def merge_time_axes(data, time, merge_tolerance=1e-6):
     return new_data, [new_time]
 
 
+def _scale_factor(a, op, b, field):
+    """The factor by which an arithmetic operator scales the stimulus data
+
+    Returns 1 for an operator that leaves every amplitude where it is (a shift
+    in time, or adding zero), the factor for one that scales them all by the
+    same number, and None for one that does neither: a DC offset moves the
+    waveform rather than resizing it, and no factor describes that.
+
+    Stimulus types that record the parameters of their waveform in their
+    metadata read this to keep those parameters in sync with the data. See
+    :py:meth:`~pulse2percept.stimuli.Stimulus._rescale_metadata`.
+    """
+    if field == 'time':
+        # Shifting in time moves the whole stimulus, but every amplitude in it
+        # stays what it was:
+        return 1.0
+    # `_apply_operator` has established that exactly one of the operands is a
+    # scalar; the other one is the data:
+    scalar = b if np.ndim(a) else a
+    if op is ops.mul:
+        # Multiplication is commutative, so the operand order is moot:
+        factor = scalar
+    elif op is ops.truediv:
+        # `Stimulus` has no `__rtruediv__`, so this is always data/scalar.
+        # Dividing the data by zero fills it with inf rather than raising, so
+        # the factor must not raise either -- it comes out non-finite below:
+        with np.errstate(divide='ignore', invalid='ignore'):
+            factor = np.divide(1.0, scalar)
+    elif scalar == 0:
+        # `stim + 0` and `stim - 0` change nothing; `0 - stim` flips the sign:
+        factor = -1.0 if np.ndim(b) else 1.0
+    else:
+        return None
+    # `stim * np.inf`, `stim * np.nan` and `stim / 0` leave a waveform of
+    # infinities and NaNs, which is not a scaled version of anything:
+    return factor if np.isfinite(factor) else None
+
+
 class Stimulus(PrettyPrint):
     """Stimulus
 
@@ -686,6 +724,67 @@ class Stimulus(PrettyPrint):
         stim.metadata = deepcopy(self.metadata)
         return stim
 
+    @classmethod
+    def _rescale_params(cls, metadata, factor):
+        """Rewrite waveform parameters for a waveform scaled by ``factor``
+
+        Some stimulus types describe their waveform with parameters that a
+        model reads back instead of measuring the data itself: a
+        :py:class:`~pulse2percept.stimuli.BiphasicPulseTrain` records
+        amplitude, frequency and phase duration, and
+        :py:class:`~pulse2percept.models.BiphasicAxonMapModel` predicts from
+        those rather than from ``data``. Such a type overrides this method, so
+        that an operation on the data carries its parameters along.
+
+        Returns the metadata a stimulus of this class would carry after its
+        data was multiplied by ``factor``, or -- for ``factor=None`` -- after
+        an operation that leaves it no longer describable by those parameters
+        at all. A plain ``Stimulus`` has no such parameters, so there is
+        nothing to keep in sync.
+
+        Parameters
+        ----------
+        metadata : dict
+            The metadata of a stimulus of this class. Never modified in place.
+        factor : float or None
+            The factor the data was scaled by, or None if the operation was
+            not a scaling (see ``_scale_factor``).
+
+        Returns
+        -------
+        metadata : dict
+        """
+        return metadata
+
+    def _rescale_metadata(self, factor):
+        """Keep the metadata in sync with data that was scaled by ``factor``
+
+        Called on the *copy* returned by ``append`` and by the arithmetic
+        operators, once its data container has been replaced. That copy owns
+        its metadata outright (``_shallow_copy`` deep-copies it), so this is
+        free to rewrite it in place.
+
+        A stimulus assembled from a collection carries the metadata of each
+        source under ``metadata['electrodes']``, filed by electrode name and
+        tagged with the class it came from. Dispatch to that class, which is
+        the one that knows what its own parameters mean -- otherwise
+        ``implant.stim * 2`` would scale the data and go on advertising the
+        amplitude the pulse trains were built with.
+        """
+        if factor == 1:
+            # Nothing about the waveform changed
+            return
+        elec_meta = self.metadata.get('electrodes')
+        if not elec_meta:
+            return
+        for entry in elec_meta.values():
+            if not isinstance(entry, dict):
+                continue
+            src, meta = entry.get('type'), entry.get('metadata')
+            if isinstance(meta, dict) and isinstance(src, type) and \
+                    issubclass(src, Stimulus):
+                entry['metadata'] = src._rescale_params(meta, factor)
+
     def compress(self):
         """Compress the source data
 
@@ -764,6 +863,11 @@ class Stimulus(PrettyPrint):
         stim._stim = {'data': data,
                       'electrodes': self.electrodes,
                       'time': time}
+        # Concatenating two waveforms in time is not a rescaling of either, so
+        # any parameters describing the first one no longer describe the
+        # result -- a pulse train appended to another is not one pulse train
+        # at one amplitude and frequency, whatever its type still says:
+        stim._rescale_metadata(None)
         return stim
 
     def remove(self, electrodes):
@@ -1110,6 +1214,10 @@ class Stimulus(PrettyPrint):
         stim._stim = {'data': op(a, b) if field == 'data' else stim.data.copy(),
                       'electrodes': stim.electrodes.copy(),
                       'time': time}
+        # Parameters that describe the waveform (a pulse train's amplitude,
+        # say) have to follow the data, or a model reading them back predicts
+        # from a stimulus that is no longer the one it was handed:
+        stim._rescale_metadata(_scale_factor(a, op, b, field))
         return stim
 
     def __add__(self, scalar):

--- a/pulse2percept/stimuli/pulse_trains.py
+++ b/pulse2percept/stimuli/pulse_trains.py
@@ -2,7 +2,6 @@
    :py:class:`~pulse2percept.stimuli.BiphasicPulseTrain`, 
    :py:class:`~pulse2percept.stimuli.AsymmetricBiphasicPulseTrain`"""
 import numpy as np
-import operator as ops
 from math import isclose
 
 # DT: Sampling time step (ms); defines the duration of the signal edge
@@ -245,64 +244,55 @@ class BiphasicPulseTrain(Stimulus):
         self.freq = freq
         self.cathodic_first = cathodic_first
 
-        # Store metadata for BiphasicAxonMapModel
+        # Store metadata for BiphasicAxonMapModel. `amp` is stored as a
+        # magnitude, because that is all of it that reaches the data:
+        # `BiphasicPulse` takes `np.abs(amp)` and reads the polarity off
+        # `cathodic_first`. Storing the sign the caller happened to type would
+        # have two identical waveforms predict two different percepts, since
+        # the models are functions of `amp` and not of `abs(amp)`.
         self.metadata = {'freq': freq,
-                         'amp': amp,
+                         'amp': abs(amp),
                          'phase_dur': phase_dur,
                          'delay_dur': delay_dur,
                          'user': metadata}
 
-    def _apply_operator(self, a, op, b, field='data'):
-        """Keep the pulse parameters in sync with the operators
+    @classmethod
+    def _rescale_params(cls, metadata, factor):
+        """Keep the pulse parameters in sync with the data
 
-        Models like
         :py:class:`~pulse2percept.models.BiphasicAxonMapModel` and
         :py:class:`~pulse2percept.models.cortex.DynaphosModel` read amplitude,
         frequency and phase duration off the metadata rather than off the data.
-        An operator that rewrites the data but leaves the metadata behind makes
-        the two disagree: ``pt * 2`` delivers twice the current, and the model
-        would go on predicting the very same percept.
+        An operation that rewrites the data but leaves the metadata behind
+        makes the two disagree: ``pt * 2`` delivers twice the current, and the
+        model would go on predicting the very same percept.
 
         Scaling is the one operation that leaves a biphasic pulse train a
-        biphasic pulse train, so it updates ``amp``. Shifting in time moves the
-        whole train, but every pulse in it keeps its amplitude, frequency and
-        duration. Anything else adds a DC offset, which is neither biphasic nor
-        charge-balanced: the pulse parameters are dropped, so that a model
-        asking for them rejects the stimulus rather than predicting from
-        numbers that no longer describe it.
+        biphasic pulse train, so it scales ``amp`` (a negative factor only
+        swaps the two phases, which does not change the magnitude). Anything
+        else -- a DC offset, an appended second train, a non-finite factor --
+        leaves something that is no longer one biphasic pulse train at one
+        amplitude and frequency, so the pulse parameters are dropped: a model
+        asking for them then rejects the stimulus rather than predicting from
+        numbers that no longer describe it. What the user put in ``metadata``
+        is theirs, and survives either way.
         """
-        stim = super()._apply_operator(a, op, b, field=field)
-        if field == 'time' or 'amp' not in stim.metadata:
-            # A shift in time, or a train whose parameters an earlier operator
-            # has already dropped:
-            return stim
-        # `super()` has established that exactly one of the operands is a
-        # scalar; the other one is `self.data`:
-        scalar = b if np.ndim(a) else a
-        if op is ops.mul:
-            # Multiplication is commutative, so the operand order is moot:
-            factor = scalar
-        elif op is ops.truediv:
-            # `Stimulus` has no `__rtruediv__`, so this is always data/scalar.
-            # Dividing the data by zero fills it with inf rather than raising,
-            # so the amplitude has to follow suit:
-            with np.errstate(divide='ignore', invalid='ignore'):
-                factor = np.divide(1.0, scalar)
-        elif scalar == 0:
-            # `pt + 0` and `pt - 0` change nothing, `0 - pt` flips the polarity:
-            factor = -1 if np.ndim(b) else 1
-        else:
-            factor = None
+        if 'amp' not in metadata:
+            # Parameters an earlier operation has already dropped
+            return metadata
         if factor is None:
-            stim.metadata = {'user': stim.metadata.get('user')}
-            return stim
-        # The sign of `amp` carries no information (`BiphasicPulse` takes its
-        # magnitude and reads the polarity off `cathodic_first`), so a negative
-        # factor flips the flag instead of the amplitude:
-        stim.metadata['amp'] = stim.metadata['amp'] * abs(factor)
-        if factor < 0:
-            stim.cathodic_first = not stim.cathodic_first
-        return stim
+            return {'user': metadata.get('user')}
+        return dict(metadata, amp=abs(metadata['amp'] * factor))
+
+    def _rescale_metadata(self, factor):
+        """Keep this train's own parameters, and its polarity, in sync"""
+        if factor == 1:
+            return
+        self.metadata = self._rescale_params(self.metadata, factor)
+        if factor is not None and factor < 0:
+            # The two phases swapped places. `BiphasicPulse` reads the polarity
+            # off this flag, so that is where the sign belongs:
+            self.cathodic_first = not self.cathodic_first
 
     def _pprint_params(self):
         """Return a dict of class arguments to pretty-print"""

--- a/pulse2percept/stimuli/pulse_trains.py
+++ b/pulse2percept/stimuli/pulse_trains.py
@@ -2,6 +2,7 @@
    :py:class:`~pulse2percept.stimuli.BiphasicPulseTrain`, 
    :py:class:`~pulse2percept.stimuli.AsymmetricBiphasicPulseTrain`"""
 import numpy as np
+import operator as ops
 from math import isclose
 
 # DT: Sampling time step (ms); defines the duration of the signal edge
@@ -250,6 +251,58 @@ class BiphasicPulseTrain(Stimulus):
                          'phase_dur': phase_dur,
                          'delay_dur': delay_dur,
                          'user': metadata}
+
+    def _apply_operator(self, a, op, b, field='data'):
+        """Keep the pulse parameters in sync with the operators
+
+        Models like
+        :py:class:`~pulse2percept.models.BiphasicAxonMapModel` and
+        :py:class:`~pulse2percept.models.cortex.DynaphosModel` read amplitude,
+        frequency and phase duration off the metadata rather than off the data.
+        An operator that rewrites the data but leaves the metadata behind makes
+        the two disagree: ``pt * 2`` delivers twice the current, and the model
+        would go on predicting the very same percept.
+
+        Scaling is the one operation that leaves a biphasic pulse train a
+        biphasic pulse train, so it updates ``amp``. Shifting in time moves the
+        whole train, but every pulse in it keeps its amplitude, frequency and
+        duration. Anything else adds a DC offset, which is neither biphasic nor
+        charge-balanced: the pulse parameters are dropped, so that a model
+        asking for them rejects the stimulus rather than predicting from
+        numbers that no longer describe it.
+        """
+        stim = super()._apply_operator(a, op, b, field=field)
+        if field == 'time' or 'amp' not in stim.metadata:
+            # A shift in time, or a train whose parameters an earlier operator
+            # has already dropped:
+            return stim
+        # `super()` has established that exactly one of the operands is a
+        # scalar; the other one is `self.data`:
+        scalar = b if np.ndim(a) else a
+        if op is ops.mul:
+            # Multiplication is commutative, so the operand order is moot:
+            factor = scalar
+        elif op is ops.truediv:
+            # `Stimulus` has no `__rtruediv__`, so this is always data/scalar.
+            # Dividing the data by zero fills it with inf rather than raising,
+            # so the amplitude has to follow suit:
+            with np.errstate(divide='ignore', invalid='ignore'):
+                factor = np.divide(1.0, scalar)
+        elif scalar == 0:
+            # `pt + 0` and `pt - 0` change nothing, `0 - pt` flips the polarity:
+            factor = -1 if np.ndim(b) else 1
+        else:
+            factor = None
+        if factor is None:
+            stim.metadata = {'user': stim.metadata.get('user')}
+            return stim
+        # The sign of `amp` carries no information (`BiphasicPulse` takes its
+        # magnitude and reads the polarity off `cathodic_first`), so a negative
+        # factor flips the flag instead of the amplitude:
+        stim.metadata['amp'] = stim.metadata['amp'] * abs(factor)
+        if factor < 0:
+            stim.cathodic_first = not stim.cathodic_first
+        return stim
 
     def _pprint_params(self):
         """Return a dict of class arguments to pretty-print"""

--- a/pulse2percept/stimuli/tests/test_base.py
+++ b/pulse2percept/stimuli/tests/test_base.py
@@ -738,16 +738,20 @@ def test_Stimulus_shallow_copy():
     # mutable with the original, even though the data container is no longer
     # deep-copied first.
     stim = BiphasicPulseTrain(20, 20, 0.45, stim_dur=100)
-    for derive in (lambda s: s * 2, lambda s: s + 1, lambda s: -s,
-                   lambda s: s >> 1.0, lambda s: s.append(s >> 1.0)):
+    # Negating the train flips its polarity, which `BiphasicPulseTrain` records
+    # on `cathodic_first`; every other derivation leaves the flag alone:
+    for derive, flips in ((lambda s: s * 2, False), (lambda s: s + 1, False),
+                          (lambda s: -s, True), (lambda s: s >> 1.0, False),
+                          (lambda s: s.append(s >> 1.0), False)):
         copied = derive(stim)
         # Same class and extra attributes:
         npt.assert_equal(type(copied), type(stim))
         npt.assert_equal(copied.freq, stim.freq)
-        npt.assert_equal(copied.cathodic_first, stim.cathodic_first)
+        npt.assert_equal(copied.cathodic_first, stim.cathodic_first != flips)
         npt.assert_equal(copied.is_compressed, stim.is_compressed)
-        # Metadata is equal but independent:
-        npt.assert_equal(copied.metadata, stim.metadata)
+        # Metadata is independent. Its contents need not be identical: the
+        # operators keep the pulse parameters in sync with the data (see
+        # test_pulse_trains.py):
         npt.assert_equal(copied.metadata is stim.metadata, False)
         copied.metadata['user'] = 'changed'
         npt.assert_equal(stim.metadata['user'], None)

--- a/pulse2percept/stimuli/tests/test_base.py
+++ b/pulse2percept/stimuli/tests/test_base.py
@@ -749,8 +749,9 @@ def test_Stimulus_shallow_copy():
         npt.assert_equal(copied.freq, stim.freq)
         npt.assert_equal(copied.cathodic_first, stim.cathodic_first != flips)
         npt.assert_equal(copied.is_compressed, stim.is_compressed)
-        # Metadata is independent. Its contents need not be identical: the
-        # operators keep the pulse parameters in sync with the data (see
+        # Metadata is independent. Its contents need not be identical: both
+        # `append` and the operators keep the pulse parameters in sync with the
+        # data, dropping them where they no longer describe it (see
         # test_pulse_trains.py):
         npt.assert_equal(copied.metadata is stim.metadata, False)
         copied.metadata['user'] = 'changed'

--- a/pulse2percept/stimuli/tests/test_pulse_trains.py
+++ b/pulse2percept/stimuli/tests/test_pulse_trains.py
@@ -380,7 +380,13 @@ def test_BiphasicPulseTrain_metadata_shift():
 
 @pytest.mark.parametrize('modify, expected', [
     (lambda s: s * 2, 20), (lambda s: 2 * s, 20), (lambda s: s / 2, 5),
-    (lambda s: -s, 10), (lambda s: s >> 5, 10), (lambda s: s + 0, 10)])
+    (lambda s: -s, 10), (lambda s: s >> 5, 10), (lambda s: s + 0, 10),
+    # A negative factor that also resizes: the composed path dispatches to
+    # `_rescale_params`, not to the pulse train's own `_rescale_metadata`, so
+    # there is no `cathodic_first` to carry the sign and `amp` has to come
+    # back as a magnitude. The direct-BPT polarity tests all use factor -1,
+    # where the magnitude cannot tell the two apart:
+    (lambda s: s * -2, 20), (lambda s: -2 * s, 20), (lambda s: s / -0.5, 20)])
 def test_Stimulus_rescales_electrode_metadata(modify, expected):
     # A pulse train handed to an implant becomes one row of a plain Stimulus,
     # and its parameters move to `metadata['electrodes']` - which is where
@@ -400,6 +406,11 @@ def test_Stimulus_rescales_electrode_metadata(modify, expected):
     npt.assert_equal(modified.metadata['electrodes']['A1']['type'],
                      BiphasicPulseTrain)
     npt.assert_equal(stim.metadata['electrodes']['A1']['metadata']['amp'], 10)
+    # Scaling leaves the entry describable, so only `amp` moves - the entry is
+    # rescaled, not invalidated:
+    for key, value in (('freq', 20), ('phase_dur', 0.45), ('delay_dur', 0)):
+        npt.assert_equal(
+            modified.metadata['electrodes']['A1']['metadata'][key], value)
 
 
 @pytest.mark.parametrize('modify', [lambda s: s + 5, lambda s: 5 - s,
@@ -415,6 +426,95 @@ def test_Stimulus_invalidates_electrode_metadata(modify):
     npt.assert_equal(
         'amp' in modified.metadata['electrodes']['A1']['metadata'], False)
     npt.assert_equal(stim.metadata['electrodes']['A1']['metadata']['amp'], 10)
+
+
+def test_Stimulus_rescale_metadata_leaves_the_source_alone():
+    # A composed stimulus files the very dict its source carries, not a copy
+    # of it, so `composed.metadata[...]['metadata'] is pt.metadata`. Rescaling
+    # the composition must still not reach back into the pulse train the
+    # caller is holding. What keeps it out is the deep copy `_shallow_copy`
+    # takes before `_rescale_metadata` rewrites anything; drop that and an
+    # operator corrupts an object it was never handed:
+    pt = BiphasicPulseTrain(20, 10, 0.45, stim_dur=100)
+    composed = Stimulus({'A1': pt})
+    scaled = composed * 2
+    npt.assert_almost_equal(
+        scaled.metadata['electrodes']['A1']['metadata']['amp'], 20)
+    # Neither the composition nor the train it was built from moved:
+    npt.assert_equal(
+        composed.metadata['electrodes']['A1']['metadata']['amp'], 10)
+    npt.assert_equal(pt.metadata['amp'], 10)
+    # Invalidation is the other way to rewrite the entry, and it must not
+    # reach back either:
+    dropped = composed + 5
+    npt.assert_equal(
+        'amp' in dropped.metadata['electrodes']['A1']['metadata'], False)
+    npt.assert_equal(pt.metadata['amp'], 10)
+    npt.assert_equal(
+        composed.metadata['electrodes']['A1']['metadata']['amp'], 10)
+
+
+@pytest.mark.parametrize('factor', [2, -2, None])
+def test_BiphasicPulseTrain_metadata_rescale_params_does_not_mutate(factor):
+    # `_rescale_params` is documented to return the rewritten metadata and
+    # never to modify the dict it was given. Today every caller hands it a
+    # dict that `_shallow_copy` already deep-copied, so breaking this would
+    # not corrupt anything - which is exactly why it needs its own test. A
+    # subclass author writing the next `_rescale_params` reads the contract,
+    # not the call sites:
+    meta = {'freq': 20, 'amp': 10, 'phase_dur': 0.45, 'delay_dur': 0,
+            'user': None}
+    before = dict(meta)
+    BiphasicPulseTrain._rescale_params(meta, factor)
+    npt.assert_equal(meta, before)
+
+
+def test_Stimulus_rescale_metadata_mixed_sources():
+    # An implant's stimulus need not be all pulse trains. Each electrode's
+    # parameters go to the class that recorded them, so a train is
+    # transformed and an ordinary stimulus - which describes no waveform
+    # parameters at all - comes through exactly as it was:
+    plain = {'electrodes': {}, 'user': {'note': 'mine'}}
+    stim = Stimulus({'A1': BiphasicPulseTrain(20, 10, 0.45, stim_dur=100),
+                     'B2': Stimulus([[1, 2, 3]], time=[0, 1, 2],
+                                    metadata={'note': 'mine'})})
+    npt.assert_equal(stim.metadata['electrodes']['A1']['type'],
+                     BiphasicPulseTrain)
+    npt.assert_equal(stim.metadata['electrodes']['B2']['type'], Stimulus)
+    npt.assert_equal(stim.metadata['electrodes']['B2']['metadata'], plain)
+
+    # Scaling transforms the train's parameters and leaves the plain entry:
+    scaled = (stim * 3).metadata['electrodes']
+    npt.assert_almost_equal(scaled['A1']['metadata']['amp'], 30)
+    npt.assert_equal(scaled['B2']['metadata'], plain)
+
+    # ...and so does an operation that invalidates instead of rescaling:
+    offset = (stim + 5).metadata['electrodes']
+    npt.assert_equal('amp' in offset['A1']['metadata'], False)
+    npt.assert_equal(offset['B2']['metadata'], plain)
+
+
+@pytest.mark.parametrize('entry', [
+    # A type that is not a class, and so has no hook to call:
+    {'metadata': {'amp': 3}, 'type': 'BiphasicPulseTrain'},
+    # A class that is not a Stimulus, whose `_rescale_params` means something
+    # else entirely (or does not exist):
+    {'metadata': {'amp': 3}, 'type': dict},
+    {'metadata': {'amp': 3}},                            # no type recorded
+    {'metadata': 'not-a-dict', 'type': BiphasicPulseTrain},
+    {'type': BiphasicPulseTrain},                        # no metadata recorded
+    'not-an-entry-at-all'])
+def test_Stimulus_rescale_metadata_tolerates_odd_entries(entry):
+    # p2p writes these entries itself, so none of this arises in practice.
+    # But `_rescale_metadata` walks whatever is in the dict and calls a hook
+    # off the type it finds recorded there, so an entry it cannot recognize
+    # has to come through unchanged rather than be assumed to implement the
+    # hook - a user who has hand-edited `metadata` gets their entry back, not
+    # an AttributeError from inside an arithmetic operator:
+    stim = Stimulus({'A1': BiphasicPulseTrain(20, 10, 0.45, stim_dur=100)})
+    stim.metadata['electrodes']['A1'] = entry
+    for modified in (stim * 2, stim * -2, stim + 5, stim.append(stim >> 1)):
+        npt.assert_equal(modified.metadata['electrodes']['A1'], entry)
 
 
 def test_Stimulus_rescale_metadata_leaves_plain_metadata_alone():

--- a/pulse2percept/stimuli/tests/test_pulse_trains.py
+++ b/pulse2percept/stimuli/tests/test_pulse_trains.py
@@ -287,6 +287,73 @@ def test_metadata():
                      ['C3']['metadata']['user'], 'userdataC3')
 
 
+@pytest.mark.parametrize('scale', [2, 0.5, 1, 0])
+def test_BiphasicPulseTrain_metadata_scaling(scale):
+    # BiphasicAxonMapModel reads amp/freq/phase_dur off the metadata rather
+    # than off the data, so scaling the data has to scale `amp` with it.
+    # Otherwise `pt * 2` delivers twice the current and predicts the very same
+    # percept:
+    pt = BiphasicPulseTrain(20, 10, 0.45, stim_dur=100)
+    scaled = pt * scale
+    npt.assert_almost_equal(scaled.metadata['amp'], 10 * scale)
+    npt.assert_almost_equal(scaled.data, scale * pt.data)
+    # Same data and same metadata as the pulse train built that way directly:
+    direct = BiphasicPulseTrain(20, 10 * scale, 0.45, stim_dur=100)
+    npt.assert_almost_equal(scaled.data, direct.data)
+    npt.assert_equal(scaled.metadata, direct.metadata)
+    # Every route to a scaled train agrees, and none of them touches the
+    # original:
+    npt.assert_almost_equal((scale * pt).metadata['amp'], 10 * scale)
+    if scale != 0:
+        npt.assert_almost_equal((pt / (1 / scale)).metadata['amp'], 10 * scale)
+    npt.assert_equal(pt.metadata['amp'], 10)
+    # The other pulse parameters are untouched:
+    for key in ('freq', 'phase_dur', 'delay_dur', 'user'):
+        npt.assert_equal(scaled.metadata[key], pt.metadata[key])
+
+
+def test_BiphasicPulseTrain_metadata_polarity():
+    # `BiphasicPulse` takes the magnitude of `amp` and reads the polarity off
+    # `cathodic_first`, so a negative factor belongs on the flag:
+    pt = BiphasicPulseTrain(20, 10, 0.45, stim_dur=100)
+    for flipped in (-pt, pt * -1, 0 - pt):
+        npt.assert_almost_equal(flipped.data, -pt.data)
+        npt.assert_equal(flipped.metadata['amp'], 10)
+        npt.assert_equal(flipped.cathodic_first, not pt.cathodic_first)
+    # And flipping twice comes back to where it started:
+    npt.assert_equal((-(-pt)).cathodic_first, pt.cathodic_first)
+    # The sign the user passed in is carried along, not overwritten:
+    npt.assert_equal((BiphasicPulseTrain(20, -10, 0.45,
+                                         stim_dur=100) * 2).metadata['amp'],
+                     -20)
+
+
+@pytest.mark.parametrize('modify', [lambda pt: pt + 5, lambda pt: pt - 5,
+                                    lambda pt: 5 - pt, lambda pt: 5 + pt,
+                                    lambda pt: (pt + 5) * 2])
+def test_BiphasicPulseTrain_metadata_invalidated(modify):
+    # A DC offset is neither biphasic nor charge-balanced. Keeping the pulse
+    # parameters would have BiphasicAxonMapModel predict from numbers that no
+    # longer describe the stimulus, so they are dropped instead - the model
+    # rejects a stimulus whose parameters it cannot find:
+    pt = BiphasicPulseTrain(20, 10, 0.45, stim_dur=100, metadata='userdata')
+    modified = modify(pt)
+    for key in ('amp', 'freq', 'phase_dur', 'delay_dur'):
+        npt.assert_equal(key in modified.metadata, False)
+    # The user's own metadata is theirs, and survives:
+    npt.assert_equal(modified.metadata['user'], 'userdata')
+    npt.assert_equal(pt.metadata['amp'], 10)
+
+
+def test_BiphasicPulseTrain_metadata_shift():
+    # A shift moves the whole train, but every pulse in it keeps its
+    # amplitude, frequency and duration:
+    pt = BiphasicPulseTrain(20, 10, 0.45, stim_dur=100)
+    for shifted in (pt >> 5, pt << 5, pt + 0, pt - 0):
+        npt.assert_equal(shifted.metadata, pt.metadata)
+    npt.assert_almost_equal((pt >> 5).time, pt.time + 5)
+
+
 @pytest.mark.parametrize('freq, phase_dur, interphase_dur',
                          [(20, 0.45, 0), (100, 0.45, 0.2), (13, 0.1, 0),
                           (225, 0.075, 0.075), (2000, 0.1, 0)])

--- a/pulse2percept/stimuli/tests/test_pulse_trains.py
+++ b/pulse2percept/stimuli/tests/test_pulse_trains.py
@@ -312,32 +312,55 @@ def test_BiphasicPulseTrain_metadata_scaling(scale):
         npt.assert_equal(scaled.metadata[key], pt.metadata[key])
 
 
-def test_BiphasicPulseTrain_metadata_polarity():
+def test_BiphasicPulseTrain_metadata_amp_is_a_magnitude():
     # `BiphasicPulse` takes the magnitude of `amp` and reads the polarity off
-    # `cathodic_first`, so a negative factor belongs on the flag:
+    # `cathodic_first`, so the sign of `amp` never reaches the data. The
+    # metadata has to record it the same way: the models are functions of
+    # `amp`, not of `abs(amp)`, so a stored sign would have two identical
+    # waveforms predict two different percepts.
+    pos = BiphasicPulseTrain(20, 10, 0.45, stim_dur=100)
+    neg = BiphasicPulseTrain(20, -10, 0.45, stim_dur=100)
+    npt.assert_almost_equal(pos.data, neg.data)
+    npt.assert_equal(pos.metadata, neg.metadata)
+    npt.assert_equal(pos.metadata['amp'], 10)
+    # ...and it stays a magnitude under scaling:
+    npt.assert_equal((neg * 2).metadata['amp'], 20)
+
+
+def test_BiphasicPulseTrain_metadata_polarity():
+    # A negative factor swaps the two phases, which is what `cathodic_first`
+    # records; the amplitude keeps its magnitude:
     pt = BiphasicPulseTrain(20, 10, 0.45, stim_dur=100)
-    for flipped in (-pt, pt * -1, 0 - pt):
+    for flipped in (-pt, pt * -1, 0 - pt, pt / -1):
         npt.assert_almost_equal(flipped.data, -pt.data)
         npt.assert_equal(flipped.metadata['amp'], 10)
         npt.assert_equal(flipped.cathodic_first, not pt.cathodic_first)
-    # And flipping twice comes back to where it started:
+    # Flipping twice comes back to where it started:
     npt.assert_equal((-(-pt)).cathodic_first, pt.cathodic_first)
-    # The sign the user passed in is carried along, not overwritten:
-    npt.assert_equal((BiphasicPulseTrain(20, -10, 0.45,
-                                         stim_dur=100) * 2).metadata['amp'],
-                     -20)
+    # A flipped train is the train that was built the other way round:
+    direct = BiphasicPulseTrain(20, 10, 0.45, stim_dur=100,
+                                cathodic_first=False)
+    npt.assert_almost_equal((-pt).data, direct.data)
+    npt.assert_equal((-pt).metadata, direct.metadata)
 
 
 @pytest.mark.parametrize('modify', [lambda pt: pt + 5, lambda pt: pt - 5,
                                     lambda pt: 5 - pt, lambda pt: 5 + pt,
-                                    lambda pt: (pt + 5) * 2])
+                                    lambda pt: (pt + 5) * 2,
+                                    lambda pt: pt * np.inf,
+                                    lambda pt: pt * np.nan,
+                                    lambda pt: pt / 0,
+                                    lambda pt: pt.append(pt >> 1)])
 def test_BiphasicPulseTrain_metadata_invalidated(modify):
-    # A DC offset is neither biphasic nor charge-balanced. Keeping the pulse
-    # parameters would have BiphasicAxonMapModel predict from numbers that no
-    # longer describe the stimulus, so they are dropped instead - the model
-    # rejects a stimulus whose parameters it cannot find:
+    # A DC offset is neither biphasic nor charge-balanced; a non-finite factor
+    # leaves a waveform of infinities; an appended second train is no longer
+    # one train at one amplitude and frequency. Keeping the pulse parameters
+    # would have BiphasicAxonMapModel predict from numbers that no longer
+    # describe the stimulus, so they are dropped instead - the model rejects a
+    # stimulus whose parameters it cannot find:
     pt = BiphasicPulseTrain(20, 10, 0.45, stim_dur=100, metadata='userdata')
-    modified = modify(pt)
+    with np.errstate(divide='ignore', invalid='ignore'):
+        modified = modify(pt)
     for key in ('amp', 'freq', 'phase_dur', 'delay_dur'):
         npt.assert_equal(key in modified.metadata, False)
     # The user's own metadata is theirs, and survives:
@@ -351,7 +374,59 @@ def test_BiphasicPulseTrain_metadata_shift():
     pt = BiphasicPulseTrain(20, 10, 0.45, stim_dur=100)
     for shifted in (pt >> 5, pt << 5, pt + 0, pt - 0):
         npt.assert_equal(shifted.metadata, pt.metadata)
+        npt.assert_equal(shifted.cathodic_first, pt.cathodic_first)
     npt.assert_almost_equal((pt >> 5).time, pt.time + 5)
+
+
+@pytest.mark.parametrize('modify, expected', [
+    (lambda s: s * 2, 20), (lambda s: 2 * s, 20), (lambda s: s / 2, 5),
+    (lambda s: -s, 10), (lambda s: s >> 5, 10), (lambda s: s + 0, 10)])
+def test_Stimulus_rescales_electrode_metadata(modify, expected):
+    # A pulse train handed to an implant becomes one row of a plain Stimulus,
+    # and its parameters move to `metadata['electrodes']` - which is where
+    # BiphasicAxonMapModel reads them from. Scaling the composed stimulus has
+    # to reach them there too, or `implant.stim * 2` delivers twice the current
+    # and predicts the very same percept:
+    stim = Stimulus({'A1': BiphasicPulseTrain(20, 10, 0.45, stim_dur=100),
+                     'B2': BiphasicPulseTrain(20, 4, 0.45, stim_dur=100)})
+    modified = modify(stim)
+    npt.assert_almost_equal(
+        modified.metadata['electrodes']['A1']['metadata']['amp'], expected)
+    # Every electrode is scaled, not just the first:
+    npt.assert_almost_equal(
+        modified.metadata['electrodes']['B2']['metadata']['amp'],
+        expected * 0.4)
+    # The source class is still recorded, and the original is untouched:
+    npt.assert_equal(modified.metadata['electrodes']['A1']['type'],
+                     BiphasicPulseTrain)
+    npt.assert_equal(stim.metadata['electrodes']['A1']['metadata']['amp'], 10)
+
+
+@pytest.mark.parametrize('modify', [lambda s: s + 5, lambda s: 5 - s,
+                                    lambda s: s * np.inf,
+                                    lambda s: s.append(s >> 1)])
+def test_Stimulus_invalidates_electrode_metadata(modify):
+    # ...and an operation that leaves the electrodes carrying something other
+    # than a biphasic pulse train has to drop their parameters, exactly as it
+    # would on the pulse train itself:
+    stim = Stimulus({'A1': BiphasicPulseTrain(20, 10, 0.45, stim_dur=100)})
+    with np.errstate(divide='ignore', invalid='ignore'):
+        modified = modify(stim)
+    npt.assert_equal(
+        'amp' in modified.metadata['electrodes']['A1']['metadata'], False)
+    npt.assert_equal(stim.metadata['electrodes']['A1']['metadata']['amp'], 10)
+
+
+def test_Stimulus_rescale_metadata_leaves_plain_metadata_alone():
+    # A stimulus that describes no pulse parameters has nothing to keep in
+    # sync, and its metadata must survive the operators untouched:
+    stim = Stimulus(np.ones((2, 3)), metadata={'note': 'mine'})
+    for modified in (stim * 2, stim + 5, -stim, stim >> 1):
+        npt.assert_equal(modified.metadata['user'], {'note': 'mine'})
+    # Same for a source type that records no parameters of its own:
+    pulse = Stimulus({'A1': BiphasicPulse(10, 0.45)})
+    npt.assert_equal((pulse * 2).metadata['electrodes']['A1']['type'],
+                     BiphasicPulse)
 
 
 @pytest.mark.parametrize('freq, phase_dur, interphase_dur',


### PR DESCRIPTION
Closes #435. Closes #545.

- [x] `SpatialModel.predict_percept` silently dropped metadata by rebuilding the stim with `Stimulus(...)` (without `metadata=`).
- [x] Running `pt * 2` (as one would for e.g. a `BiphasicAxonMapModel`) doubles the data but leaves `amp: 10` in place. Some time in the future, we might want to rethink `Stimulus` and make it "metadata first", with waveforms constructed lazily - but now is not the time for that.

