### PR TITLE
[FIX] Fix Neuropythy shape/NaN, division by zero, units

### DIFF
--- a/doc/users/release_notes.rst
+++ b/doc/users/release_notes.rst
@@ -112,6 +112,16 @@ Bug fixes:
   maps are hashable again, and maps of different classes no longer compare
   equal.
 
+* :py:meth:`~pulse2percept.topography.NeuropythyMap.cortex_to_dva` (and the
+  ``v1_to_dva``, ``v2_to_dva``, ``v3_to_dva`` methods that call it) now returns
+  coordinates with the same shape as its input. Previously NaN inputs were
+  dropped rather than mapped to NaN outputs, which silently shifted every point
+  after them into the wrong slot, and multidimensional inputs came back
+  flattened. Cortical points that land exactly on a mesh vertex now map to that
+  vertex instead of dividing by zero and returning NaN. The docstrings said the
+  cortical coordinates were in mm; they are in um, as the code always
+  assumed.
+
 v0.9.1 (2026-08-06)
 -------------------
 

--- a/pulse2percept/topography/neuropythy.py
+++ b/pulse2percept/topography/neuropythy.py
@@ -308,34 +308,52 @@ class NeuropythyMap(CorticalMap):
         Parameters
         ----------
         xc, yc, zc : float or array_like
-            The x, y, and z-coordinate(s) of the cortex point(s) to look up (in mm).
-        
+            The x, y, and z-coordinate(s) of the cortex point(s) to look up (in um).
+
         Returns
         -------
         x, y : array_like
             The x and y-coordinate(s) of the visual field point(s) (in dva).
+            Both have the same shape as the input. Points that cannot be
+            mapped are NaN: either because the input was NaN, or because no
+            mesh vertex lies within ``cort_nn_thresh`` of them.
         """
         xc = np.array(xc, dtype='float32')
         yc = np.array(yc, dtype='float32')
         zc = np.array(zc, dtype='float32')
         if np.shape(xc) != np.shape(yc) or np.shape(xc) != np.shape(zc):
             raise ValueError("x, y, and z must have the same shape")
+        # The output has the shape of the input, and stays NaN wherever the
+        # point cannot be mapped:
+        out = np.full((*np.shape(xc), 2), np.nan)
         id_nan = np.isnan(xc) | np.isnan(yc) | np.isnan(zc)
-        query = np.stack([np.ravel(xc[~id_nan]), np.ravel(yc[~id_nan]), np.ravel(zc[~id_nan])], axis=-1) / 1000 # convert to mm
+        # Boolean indexing flattens, so the query is always (npoints, 3):
+        query = np.stack([xc[~id_nan], yc[~id_nan], zc[~id_nan]], axis=-1) / 1000 # convert to mm
         if np.size(query) == 0:
-            return np.ones((*np.shape(xc), 2)) * np.nan
+            return out[..., 0], out[..., 1]
         dist, idx = self.cortex_tree.query(query, k=5)#, distance_upper_bound=self.cort_nn_thresh / 1000)
-        idx_nan = np.all(dist > self.cort_nn_thresh / 1000, axis=-1)
-        dist[dist > self.cort_nn_thresh / 1000] = 999999999 # make high so it doesn't contribute to geometric mean
-        neighbors = np.array([[self.region_meshes[self.addr_idxs['region'][i]][self.addr_idxs['hemi'][i]].coordinates[:, self.addr_idxs['addr'][i]] 
-                               for i in nb_pts] 
+        too_far = dist > self.cort_nn_thresh / 1000
+        neighbors = np.array([[self.region_meshes[self.addr_idxs['region'][i]][self.addr_idxs['hemi'][i]].coordinates[:, self.addr_idxs['addr'][i]]
+                               for i in nb_pts]
                               for nb_pts in idx])
-        # use geometric mean based on distance
-        pts = np.sum(neighbors * 1/dist[..., None], axis=1) / np.sum(1/dist, axis=1)[:, None]
-        pts[idx_nan] = [np.nan, np.nan]
-        out = np.ones((*np.shape(xc), 2)) * np.nan
+        # Weight each neighbor by 1/distance, ignoring the ones that are too
+        # far away:
+        weights = np.zeros_like(dist)
+        np.divide(1, dist, out=weights, where=~too_far & (dist > 0))
+        # A query point that landed exactly on a mesh vertex is at zero
+        # distance, which would divide by zero. Give those vertices all of the
+        # weight instead, so the point maps to the vertex itself:
+        exact = dist == 0
+        id_exact = np.any(exact, axis=-1)
+        weights[id_exact] = exact[id_exact]
+        # Points with no neighbor within cort_nn_thresh have no weight at all
+        # to average over, and stay NaN:
+        id_ok = ~np.all(too_far, axis=-1)
+        pts = np.full((len(query), 2), np.nan)
+        pts[id_ok] = (np.sum(neighbors[id_ok] * weights[id_ok, :, None], axis=1) /
+                      np.sum(weights[id_ok], axis=1)[:, None])
         out[~id_nan] = pts
-        return pts[:, 0], pts[:, 1]
+        return out[..., 0], out[..., 1]
     
 
     def v1_to_dva(self, xv1, yv1, zv1):
@@ -348,7 +366,7 @@ class NeuropythyMap(CorticalMap):
         Parameters
         ----------
         xv1, yv1, zv1 : float or array_like
-            The x, y, and z-coordinate(s) of the v1 point(s) to look up (in mm).
+            The x, y, and z-coordinate(s) of the v1 point(s) to look up (in um).
 
         Returns
         -------
@@ -367,7 +385,7 @@ class NeuropythyMap(CorticalMap):
         Parameters
         ----------
         xv2, yv2, zv2 : float or array_like
-            The x, y, and z-coordinate(s) of the v2 point(s) to look up (in mm).
+            The x, y, and z-coordinate(s) of the v2 point(s) to look up (in um).
 
         Returns
         -------
@@ -386,7 +404,7 @@ class NeuropythyMap(CorticalMap):
         Parameters
         ----------
         xv3, yv3, zv3 : float or array_like
-            The x, y, and z-coordinate(s) of the v3 point(s) to look up (in mm).
+            The x, y, and z-coordinate(s) of the v3 point(s) to look up (in um).
 
         Returns
         -------

--- a/pulse2percept/topography/tests/test_neuropythy.py
+++ b/pulse2percept/topography/tests/test_neuropythy.py
@@ -1,11 +1,13 @@
 import numpy as np
 import numpy.testing as npt
 import pytest
+from scipy.spatial import cKDTree
+from types import SimpleNamespace
 from pulse2percept.models.cortex import ScoreboardModel
 from pulse2percept.models import ScoreboardModel as BeyelerScoreboard
 from pulse2percept.implants.cortex import Neuralink
 from pulse2percept.implants import EnsembleImplant
-from pulse2percept.topography import NeuropythyMap
+from pulse2percept.topography import CorticalMap, NeuropythyMap
 import time
 import os
 
@@ -60,6 +62,93 @@ def test_load_fsaverage_or_skip_swallows_any_error():
             npt.assert_equal(type(err).__name__ in str(excinfo.value), True)
         finally:
             mod.NeuropythyMap = orig
+
+
+class ToyNeuropythyMap(NeuropythyMap):
+    """A NeuropythyMap whose cortical mesh is a row of ``n`` vertices.
+
+    ``cortex_to_dva`` only reads the k-d tree and the mesh lookup tables, so
+    filling those in with a toy mesh exercises all of its bookkeeping (output
+    shape, NaN handling, exact hits) with hand-checkable numbers and without a
+    subject download. Vertex ``i`` sits at ``(i, 0, 0)`` mm on the cortex and
+    maps to ``(i, -i)`` dva; vertices are 1 mm apart, which is exactly
+    ``cort_nn_thresh``.
+    """
+
+    def __init__(self, n=6):
+        # NeuropythyMap.__init__ needs neuropythy and a subject, so go
+        # straight to the parameter defaults it would have set:
+        CorticalMap.__init__(self)
+        self.cortex_tree = cKDTree(np.stack([np.arange(n, dtype=float),
+                                             np.zeros(n), np.zeros(n)], axis=-1))
+        self.addr_idxs = {'addr': np.arange(n),
+                          'region': np.array(['v1'] * n),
+                          'hemi': np.zeros(n, dtype=int)}
+        mesh = SimpleNamespace(coordinates=np.stack([np.arange(n, dtype=float),
+                                                     -np.arange(n, dtype=float)]))
+        self.region_meshes = {'v1': (mesh, mesh)}
+
+
+def test_cortex_to_dva_shape_and_nans():
+    """Every input point must get its own output slot (Issue #774)."""
+    nmap = ToyNeuropythyMap()
+    # Vertex i is at i mm == i * 1000 um, and maps to (i, -i) dva:
+    xc = np.array([0., 1000., 2000.])
+    xdva, ydva = nmap.cortex_to_dva(xc, np.zeros(3), np.zeros(3))
+    npt.assert_almost_equal(xdva, [0, 1, 2])
+    npt.assert_almost_equal(ydva, [0, -1, -2])
+
+    # A NaN input must not shift the points after it into its slot:
+    xc = np.array([0., np.nan, 2000.])
+    xdva, ydva = nmap.cortex_to_dva(xc, np.zeros(3), np.zeros(3))
+    npt.assert_equal(xdva.shape, (3,))
+    npt.assert_almost_equal(xdva, [0, np.nan, 2])
+    npt.assert_almost_equal(ydva, [0, np.nan, -2])
+    # A NaN in any one of the three coordinates is enough:
+    for coords in ([np.zeros(2), np.array([np.nan, 0.]), np.zeros(2)],
+                   [np.zeros(2), np.zeros(2), np.array([np.nan, 0.])]):
+        xdva, ydva = nmap.cortex_to_dva(*coords)
+        npt.assert_almost_equal(xdva, [np.nan, 0])
+        npt.assert_almost_equal(ydva, [np.nan, 0])
+
+    # The output has the shape of the input, whatever that shape is:
+    for shape in [(), (1,), (4,), (2, 3), (2, 3, 4)]:
+        zeros = np.zeros(shape)
+        xdva, ydva = nmap.cortex_to_dva(zeros, zeros, zeros)
+        npt.assert_equal(xdva.shape, shape)
+        npt.assert_equal(ydva.shape, shape)
+        # ... including when every point is NaN, which must still return two
+        # arrays rather than a single stacked one:
+        nans = np.full(shape, np.nan)
+        xdva, ydva = nmap.cortex_to_dva(nans, nans, nans)
+        npt.assert_equal(xdva.shape, shape)
+        npt.assert_equal(np.all(np.isnan(xdva)), True)
+        npt.assert_equal(np.all(np.isnan(ydva)), True)
+
+    with pytest.raises(ValueError):
+        nmap.cortex_to_dva(np.zeros(3), np.zeros(2), np.zeros(3))
+
+
+def test_cortex_to_dva_exact_vertex():
+    """A point sitting exactly on a mesh vertex must not divide by zero."""
+    nmap = ToyNeuropythyMap()
+    verts = nmap.cortex_tree.data * 1000  # mm -> um
+    with np.errstate(divide='raise', invalid='raise'):
+        xdva, ydva = nmap.cortex_to_dva(verts[:, 0], verts[:, 1], verts[:, 2])
+    # Each vertex maps to its own dva coordinate, not to a blend with its
+    # neighbors and not to NaN:
+    npt.assert_almost_equal(xdva, np.arange(len(verts)))
+    npt.assert_almost_equal(ydva, -np.arange(len(verts)))
+
+    # Halfway between two vertices, both weigh the same:
+    xdva, ydva = nmap.cortex_to_dva(np.array([2500.]), np.zeros(1), np.zeros(1))
+    npt.assert_almost_equal(xdva, [2.5])
+    npt.assert_almost_equal(ydva, [-2.5])
+
+    # Beyond cort_nn_thresh of every vertex, there is nothing to average:
+    xdva, ydva = nmap.cortex_to_dva(np.array([-2000.]), np.zeros(1), np.zeros(1))
+    npt.assert_almost_equal(xdva, [np.nan])
+    npt.assert_almost_equal(ydva, [np.nan])
 
 
 # use pytest.mark.slow because all neuropythy tests
@@ -289,11 +378,13 @@ def test_cortex_to_dva(regions, neuropythy_available):
     npt.assert_equal(list(nmap.region_meshes.keys()), regions)
     
     if 'v1' in regions:
-        # should work with all shapes
-        npt.assert_equal(nmap.v1_to_dva(0, 0, 0)[0], np.array([np.nan]))
-        nmap.v1_to_dva([100, 200, 300], [100, 200, 300], [100, 200, 300])
-        nmap.v1_to_dva(np.eye(3), np.eye(3), np.eye(3))       
-        
+        # should work with all shapes, and keep them
+        npt.assert_equal(np.isnan(nmap.v1_to_dva(0, 0, 0)[0]), True)
+        npt.assert_equal(nmap.v1_to_dva([100, 200, 300], [100, 200, 300],
+                                        [100, 200, 300])[0].shape, (3,))
+        npt.assert_equal(nmap.v1_to_dva(np.eye(3), np.eye(3), np.eye(3))[0].shape,
+                         (3, 3))
+
         x = np.array([-10035.355, -13315.073,  12075.739, 13630.971])
         y = np.array([ -96637.12, -102852.29,   -95358.4,  -101546.41])
         z = np.array([-10769.129, -3861.491, -7168.826, 924.938])
@@ -304,6 +395,27 @@ def test_cortex_to_dva(regions, neuropythy_available):
         npt.assert_equal(y.shape, (4,))
         npt.assert_almost_equal(xdva, np.array([1, 1, -1, -1]), decimal=1)
         npt.assert_almost_equal(ydva, np.array([1, -1,  1, -1]), decimal=1)
+
+        # A NaN point keeps its own slot rather than dropping out and
+        # shifting the points after it up (Issue #774):
+        xnan, ynan, znan = x.copy(), y.copy(), z.copy()
+        xnan[1], ynan[1], znan[1] = np.nan, np.nan, np.nan
+        xdva, ydva = nmap.v1_to_dva(xnan, ynan, znan)
+        npt.assert_equal(xdva.shape, (4,))
+        npt.assert_almost_equal(xdva, np.array([1, np.nan, -1, -1]), decimal=1)
+        npt.assert_almost_equal(ydva, np.array([1, np.nan, 1, -1]), decimal=1)
+        # ... and the same points laid out as a 2D grid come back as one:
+        xdva, ydva = nmap.v1_to_dva(*[np.stack([c, c]) for c in (x, y, z)])
+        npt.assert_equal(xdva.shape, (2, 4))
+        npt.assert_almost_equal(xdva, np.stack([[1, 1, -1, -1]] * 2), decimal=1)
+        npt.assert_almost_equal(ydva, np.stack([[1, -1, 1, -1]] * 2), decimal=1)
+
+        # Points that land exactly on a mesh vertex have zero distance to it,
+        # which used to divide by zero (Issue #774). They map to that vertex:
+        verts = nmap.cortex_tree.data * 1000  # mm -> um
+        xdva, ydva = nmap.v1_to_dva(verts[:, 0], verts[:, 1], verts[:, 2])
+        npt.assert_equal(np.any(np.isnan(xdva)), False)
+        npt.assert_equal(np.any(np.isnan(ydva)), False)
 
         x = np.arange(-10, -1, .1)
         y = np.arange(-10, -1, .1)
@@ -333,9 +445,11 @@ def test_cortex_to_dva(regions, neuropythy_available):
 
 
     if 'v2' in regions:
-        npt.assert_equal(nmap.v2_to_dva(0, 0, 0)[0], np.array([np.nan]))
-        nmap.v2_to_dva([100, 200, 300], [100, 200, 300], [100, 200, 300])
-        nmap.v2_to_dva(np.eye(3), np.eye(3), np.eye(3))     
+        npt.assert_equal(np.isnan(nmap.v2_to_dva(0, 0, 0)[0]), True)
+        npt.assert_equal(nmap.v2_to_dva([100, 200, 300], [100, 200, 300],
+                                        [100, 200, 300])[0].shape, (3,))
+        npt.assert_equal(nmap.v2_to_dva(np.eye(3), np.eye(3), np.eye(3))[0].shape,
+                         (3, 3))
 
 
         x = np.array([-11731.504, -20458.03,  22283.799] )
@@ -356,9 +470,11 @@ def test_cortex_to_dva(regions, neuropythy_available):
 
     
     if 'v3' in regions:
-        npt.assert_equal(nmap.v3_to_dva(0, 0, 0)[0], np.array([np.nan]))
-        nmap.v3_to_dva([100, 200, 300], [100, 200, 300], [100, 200, 300])
-        nmap.v3_to_dva(np.eye(3), np.eye(3), np.eye(3))
+        npt.assert_equal(np.isnan(nmap.v3_to_dva(0, 0, 0)[0]), True)
+        npt.assert_equal(nmap.v3_to_dva([100, 200, 300], [100, 200, 300],
+                                        [100, 200, 300])[0].shape, (3,))
+        npt.assert_equal(nmap.v3_to_dva(np.eye(3), np.eye(3), np.eye(3))[0].shape,
+                         (3, 3))
 
 
         x = np.array([-23812.113, -23514.828,  28547.275])


### PR DESCRIPTION
Closes #774. Supercedes #775.

- [x] Fixed shape/NaN bug in the Neuropythy topography: The function already built a correctly shaped `out` array and filled `out[~id_nan]`, then threw all that away and returned `pts[:, 0], pts[:, 1]` instead. Now it returns `out[..., 0], out[..., 1]`. The all-NaN early return had the same bug in a different shape. So this wasn't only a shape mismatch, but had points shifting into the wrong slots.
- [x] Fixed division-by-zero error. Replaced the `dist[too_far] = 999999999` idea with explicit weights: out-of-range neighbors get weight 0, and a query landing exactly on a mesh vertex gives that vertex all the weight instead of 1/0. Unmappable points are excluded from the division.
- [x] `cortex_to_dva` and the three `vN_to_dva` docstrings now say um, matching the code and `dva_to_cortex`.