### PR TITLE
[MNT] Rename xystep to step

### DIFF
--- a/.github/scripts/check_install.py
+++ b/.github/scripts/check_install.py
@@ -167,7 +167,7 @@ def check_model_builds() -> list[str]:
         from pulse2percept.implants import ArgusII
         from pulse2percept.models import ScoreboardModel
 
-        model = ScoreboardModel(xrange=(-4, 4), yrange=(-4, 4), xystep=1).build()
+        model = ScoreboardModel(xrange=(-4, 4), yrange=(-4, 4), step=1).build()
         implant = ArgusII()
         implant.stim = {e: 1 for e in ("A1", "F10")}
         percept = model.predict_percept(implant)

--- a/benchmarks/scenarios.py
+++ b/benchmarks/scenarios.py
@@ -15,7 +15,7 @@ first two correspond to these one-liners::
             p2p.implants.ArgusII(stim=p2p.stimuli.LogoBVL())))
 
     p2p.models.ScoreboardModel(yrange=(-4, 4), xrange=(-4, 4), rho=50,
-                               xystep=0.1).build().predict_percept(as_current(
+                               step=0.1).build().predict_percept(as_current(
         p2p.implants.PRIMA(stim=p2p.stimuli.LogoBVL().invert())))
 
 The :func:`as_current` wrapper is a benchmark-only detail; see its docstring
@@ -164,7 +164,7 @@ SCENARIOS = [
         implant=lambda stim: as_current(p2p.implants.PRIMA(stim=stim)),
         model=lambda **kwargs: p2p.models.ScoreboardModel(xrange=(-4, 4),
                                                           yrange=(-4, 4),
-                                                          rho=50, xystep=0.1,
+                                                          rho=50, step=0.1,
                                                           **kwargs),
     ),
     # Granley 2021. Its stimulus is a pulse train rather than an image because
@@ -187,7 +187,7 @@ SCENARIOS = [
         stimulus=lambda: array_ptrain(p2p.implants.ArgusII),
         implant=lambda stim: p2p.implants.ArgusII(stim=stim),
         model=lambda **kwargs: p2p.models.Nanduri2012Model(
-            xrange=(-4, 4), yrange=(-4, 4), xystep=0.5, **kwargs),
+            xrange=(-4, 4), yrange=(-4, 4), step=0.5, **kwargs),
     ),
     # Horsager 2009: a temporal-only model, so predict_percept returns one
     # trace per electrode with no spatial grid at all. The only scenario that
@@ -217,7 +217,7 @@ SCENARIOS = [
         implant=lambda stim: p2p.implants.ArgusII(stim=stim),
         model=lambda **kwargs: p2p.models.Model(
             spatial=p2p.models.ScoreboardSpatial(xrange=(-4, 4),
-                                                 yrange=(-4, 4), xystep=0.5),
+                                                 yrange=(-4, 4), step=0.5),
             temporal=p2p.models.FadingTemporal(), **kwargs),
     ),
     # A 94-frame video: the spatial model runs once per frame, so a single

--- a/doc/topics/cortical.rst
+++ b/doc/topics/cortical.rst
@@ -206,8 +206,8 @@ a Neuralink implant with multiple threads using the NeuropythyMap as follows:
     from pulse2percept.topography import NeuropythyMap
     from pulse2percept.models.cortex import ScoreboardModel
     map = NeuropythyMap('fsaverage', regions=['v1'])
-    model = ScoreboardModel(vfmap=map, xrange=(-4, 0), yrange=(-4, 4), xystep=.25).build()
-    neuralink = Neuralink.from_neuropythy(map, xrange=model.xrange, yrange=model.yrange, xystep=1, rand_insertion_angle=0)
+    model = ScoreboardModel(vfmap=map, xrange=(-4, 0), yrange=(-4, 4), step=.25).build()
+    neuralink = Neuralink.from_neuropythy(map, xrange=model.xrange, yrange=model.yrange, step=1, rand_insertion_angle=0)
     fig = plt.figure(figsize=(10, 5))
     ax1 = fig.add_subplot(121, projection='3d')
     neuralink.plot3D(ax=ax1)

--- a/doc/users/release_notes.rst
+++ b/doc/users/release_notes.rst
@@ -35,18 +35,13 @@ Highlights:
 
 API changes:
 
-* The ``axlambda`` parameter of the axon map models was renamed to ``lam``,
-  which sits better next to ``rho``. The old name still works everywhere the
-  new one does, but raises a ``DeprecationWarning`` and will be removed in
-  v0.11.0.
-
 * :py:class:`~pulse2percept.models.FadingTemporal` is now driven by
   :math:`\max(-A, 0)` rather than :math:`-A`: anodic current no longer reduces
   brightness, it is ignored. A stimulus that is purely cathodic is unaffected.
 
-* :py:class:`~pulse2percept.models.FadingTemporal` requires ``tau >= dt``. The
-  integrator steps explicitly, so a shorter time constant overshoots its drive
-  by ``dt / tau`` and oscillates instead of decaying.
+* Model parameter ``xystep`` was renamed to ``step``, and ``axlambda`` was
+  renamed to ``lam``. The old names still work everywhere the new one do,
+  but raise a ``DeprecationWarning`` and will be removed in v0.11.0.
 
 * Temporal models gained a ``reduce`` parameter. When ``predict_percept`` picks
   the output times itself (``t_percept=None``), ``reduce='peak'`` makes each
@@ -101,7 +96,7 @@ API changes:
   does not apply to it.
 
 * :py:meth:`~pulse2percept.implants.EnsembleImplant.from_coords` requires
-  ``xrange``, ``yrange`` and ``xystep`` together when ``locs`` is not given.
+  ``xrange``, ``yrange`` and ``step`` together when ``locs`` is not given.
   They previously defaulted to a visual-field range, which placed implants at
   coordinates that were never meant to be microns.
 

--- a/doc/users/release_notes.rst
+++ b/doc/users/release_notes.rst
@@ -38,10 +38,12 @@ API changes:
 * :py:class:`~pulse2percept.models.FadingTemporal` is now driven by
   :math:`\max(-A, 0)` rather than :math:`-A`: anodic current no longer reduces
   brightness, it is ignored. A stimulus that is purely cathodic is unaffected.
+  In addition, ``FadingTemporal`` now enforces ``tau >= dt``.
 
-* Model parameter ``xystep`` was renamed to ``step``, and ``axlambda`` was
-  renamed to ``lam``. The old names still work everywhere the new one do,
-  but raise a ``DeprecationWarning`` and will be removed in v0.11.0.
+* The grid-spacing parameter ``xystep`` was renamed to ``step`` across spatial
+  models and implant-grid factory methods. The old name remains supported with 
+  a ``DeprecationWarning`` and will be removed in v0.11.0. The axon-map
+  parameter ``axlambda`` was similarly renamed to ``lam``.
 
 * Temporal models gained a ``reduce`` parameter. When ``predict_percept`` picks
   the output times itself (``t_percept=None``), ``reduce='peak'`` makes each

--- a/examples/implants/plot_implants_cortical.py
+++ b/examples/implants/plot_implants_cortical.py
@@ -82,10 +82,10 @@ plt.show()
 #
 #     nmap = p2p.topography.NeuropythyMap(subject='fsaverage', regions=['v1'])
 #     model = p2p.models.cortex.ScoreboardModel(
-#         rho=500, xrange=(-6, 0), yrange=(-5, 5), xystep=.25, vfmap=nmap
+#         rho=500, xrange=(-6, 0), yrange=(-5, 5), step=.25, vfmap=nmap
 #     ).build()
 #     nlink = Neuralink.from_neuropythy(
-#         nmap, xrange=model.xrange, yrange=model.yrange, xystep=2, rand_insertion_angle=0
+#         nmap, xrange=model.xrange, yrange=model.yrange, step=2, rand_insertion_angle=0
 #     )
 #     print(len(nlink.implants), " total threads")
 #     fig = plt.figure(figsize=(10, 4))

--- a/examples/models/plot_beyeler2019_axonmap.py
+++ b/examples/models/plot_beyeler2019_axonmap.py
@@ -63,7 +63,7 @@ print(model)
 #   specified as a range of x and y coordinates (in degrees of visual angle,
 #   or dva). For example, we are currently sampling x values between -20 dva
 #   and +20dva, and y values between -15 dva and +15 dva.
-# * ``xystep``: The resolution (in dva) at which to sample the visual field.
+# * ``step``: The resolution (in dva) at which to sample the visual field.
 #   For example, we are currently sampling at 0.25 dva in both x and y
 #   direction.
 # * ``loc_od_x``, ``loc_od_y``: the location of the center of the optic disc

--- a/examples/models/plot_beyeler2019_scoreboard.py
+++ b/examples/models/plot_beyeler2019_scoreboard.py
@@ -40,9 +40,10 @@ The first step is to instantiate the
 constructor method.
 
 The model simulates a patch of the visual field specified by ``xrange`` and
-``yrange`` (in degrees of visual angle), sampled at a step size of ``xystep``.
-The grid that is created from these parameters is equivalent to calling NumPy's
-``linspace(xrange[0], xrange[1], num=xystep)``.
+``yrange`` (in degrees of visual angle), sampled at a step size of ``step``.
+``step`` is the spacing between neighboring grid points, so the x axis of the
+grid is NumPy's ``linspace(*xrange, num=round(np.ptp(xrange) / step) + 1)``.
+Pass a tuple ``(x_step, y_step)`` to sample the two axes differently.
 
 By default, this patch is quite large, spanning 30deg x 30deg.
 Because PRIMA is rather small, we want to reduce the window size to 6deg x 6deg
@@ -52,7 +53,7 @@ and sample it at 0.05deg resolution:
 # sphinx_gallery_thumbnail_number = 2
 
 from pulse2percept.models import ScoreboardModel
-model = ScoreboardModel(xrange=(-3, 3), yrange=(-3, 3), xystep=0.05)
+model = ScoreboardModel(xrange=(-3, 3), yrange=(-3, 3), step=0.05)
 
 ##############################################################################
 # Parameters you don't specify will take on default values. You can inspect
@@ -67,7 +68,7 @@ print(model)
 #   specified as a range of x and y coordinates (in degrees of visual angle,
 #   or dva). For example, we are currently sampling x values between -20 dva
 #   and +20dva, and y values between -15 dva and +15 dva.
-# * ``xystep``: The resolution (in dva) at which to sample the visual field.
+# * ``step``: The resolution (in dva) at which to sample the visual field.
 #   For example, we are currently sampling at 0.25 dva in both x and y
 #   direction.
 # * ``thresh_percept``: You can also define a brightness threshold, below which
@@ -118,7 +119,7 @@ implant.plot()
 ##############################################################################
 # The gray window indicates the extent of the grid that was created during
 # ``model.build()`` using the values specified by ``xrange``, ``yrange``, and
-# ``xystep``. As we can see, the window well-covers the implant that we want
+# ``step``. As we can see, the window well-covers the implant that we want
 # to simulate.
 #
 # The easiest way to assign a stimulus to the implant is to pass a NumPy array

--- a/examples/models/plot_beyeler2019_scoreboard.py
+++ b/examples/models/plot_beyeler2019_scoreboard.py
@@ -41,8 +41,11 @@ constructor method.
 
 The model simulates a patch of the visual field specified by ``xrange`` and
 ``yrange`` (in degrees of visual angle), sampled at a step size of ``step``.
-``step`` is the spacing between neighboring grid points, so the x axis of the
-grid is NumPy's ``linspace(*xrange, num=round(np.ptp(xrange) / step) + 1)``.
+``step`` is a *target* spacing: both end points of the range are always
+included, so the x axis of the grid is NumPy's
+``linspace(*xrange, num=round(np.ptp(xrange) / step) + 1)``. When the range is
+not a whole multiple of ``step``, the actual spacing differs slightly --
+``xrange=(0, 1)`` with ``step=0.3`` gives four points spaced 0.333 apart.
 Pass a tuple ``(x_step, y_step)`` to sample the two axes differently.
 
 By default, this patch is quite large, spanning 30deg x 30deg.

--- a/examples/models/plot_dynaphos.py
+++ b/examples/models/plot_dynaphos.py
@@ -45,7 +45,7 @@ print(model)
 #   specified as a range of x and y coordinates (in degrees of visual angle,
 #   or dva). For example, we are currently sampling x values between -20 dva
 #   and +20dva, and y values between -15 dva and +15 dva.
-# * ``xystep``: The resolution (in dva) at which to sample the visual field.
+# * ``step``: The resolution (in dva) at which to sample the visual field.
 #   For example, we are currently sampling at 0.25 dva in both x and y
 #   direction.
 # * ``dt``: The time-step of the model in ms. This determines the frame-rate of the
@@ -71,7 +71,7 @@ print(model)
 # To change parameter values, either pass them directly to the constructor
 # above or set them by hand, like this:
 
-model.xystep = 0.05
+model.step = 0.05
 
 ##############################################################################
 # Then build the model. This is a necessary step before you can actually use
@@ -88,7 +88,7 @@ model.build()
 #     having to rebuild (which takes time).
 #
 #     However, if you change important model parameters outside the constructor
-#     (e.g., by directly setting ``model.xystep = 0.25``), you will have to
+#     (e.g., by directly setting ``model.step = 0.25``), you will have to
 #     call ``model.build()`` again for your changes to take effect.
 #
 # Assigning a stimulus

--- a/examples/models/plot_nanduri2012.py
+++ b/examples/models/plot_nanduri2012.py
@@ -220,7 +220,7 @@ fig.tight_layout()
 # specified in degrees of visual angle (dva). They are sampled at ``xydva``
 # dva:
 
-model = Nanduri2012Model(xystep=0.5, xrange=(-4, 4), yrange=(-4, 4))
+model = Nanduri2012Model(step=0.5, xrange=(-4, 4), yrange=(-4, 4))
 model.build()
 
 ###############################################################################

--- a/examples/models/plot_neuropythy.py
+++ b/examples/models/plot_neuropythy.py
@@ -87,7 +87,7 @@ Lets use all three regions and plot the result (note it can get a little messy):
 .. code-block:: python
 
     nmap = p2p.topography.NeuropythyMap(subject='fsaverage', regions=['v1', 'v2', 'v3'])
-    model = p2p.models.cortex.ScoreboardModel(xrange=(-20, 20), yrange=(-20, 20), xystep=0.5,
+    model = p2p.models.cortex.ScoreboardModel(xrange=(-20, 20), yrange=(-20, 20), step=0.5,
                                               vfmap=nmap, regions=['v1', 'v2', 'v3'])
     fig = plt.figure(figsize=(10, 4))
     ax1 = fig.add_subplot(121, projection='3d')
@@ -119,9 +119,9 @@ Lets place a Neuralink implant across the right hemisphere of the cortex:
 .. code-block:: python
 
     nmap = p2p.topography.NeuropythyMap(subject='fsaverage', regions=['v1'])
-    model = p2p.models.cortex.ScoreboardModel(vfmap=nmap, xrange=(-4, 0), yrange=(-4, 4), xystep=.25).build()
+    model = p2p.models.cortex.ScoreboardModel(vfmap=nmap, xrange=(-4, 0), yrange=(-4, 4), step=.25).build()
     nlink = p2p.implants.cortex.Neuralink.from_neuropythy(
-        nmap, xrange=model.xrange, yrange=model.yrange, xystep=1, rand_insertion_angle=0
+        nmap, xrange=model.xrange, yrange=model.yrange, step=1, rand_insertion_angle=0
     )
     print(len(nlink.implants), " total threads")
 
@@ -140,9 +140,9 @@ electrode on each thread, using the scoreboard model:
 
     nmap = p2p.topography.NeuropythyMap(subject='fsaverage', regions=['v1'], jitter_boundary=True)
     model = p2p.models.cortex.ScoreboardModel(rho=800, xrange=(-15, 15), yrange=(-15, 15),
-                                              xystep=.25, vfmap=nmap).build()
+                                              step=.25, vfmap=nmap).build()
     nlink = p2p.implants.cortex.Neuralink.from_neuropythy(
-        nmap, xrange=model.xrange, yrange=model.yrange, xystep=3, rand_insertion_angle=0
+        nmap, xrange=model.xrange, yrange=model.yrange, step=3, rand_insertion_angle=0
     )
     nlink.stim = {e: 1 for e in [i for i in nlink.electrode_names if i[-1] == '1']}
     percept = model.predict_percept(nlink)

--- a/examples/models/plot_thompson2003.py
+++ b/examples/models/plot_thompson2003.py
@@ -19,7 +19,7 @@ The model can be loaded as follows (using 10% dropout rate):
 import matplotlib.pyplot as plt
 import numpy as np
 import pulse2percept as p2p
-model = p2p.models.Thompson2003Model(xystep=0.2, dropout=0.1)
+model = p2p.models.Thompson2003Model(step=0.2, dropout=0.1)
 model.build()
 
 ###############################################################################

--- a/examples/stimuli/plot_image_stim.py
+++ b/examples/stimuli/plot_image_stim.py
@@ -172,7 +172,7 @@ logo_dilate.save('dilated_logo.png')
 # choose an implant:
 
 # Simulate only what we need (14x14 deg sampled at 0.1 deg):
-model = p2p.models.ScoreboardModel(xrange=(-7, 7), yrange=(-7, 7), xystep=0.1)
+model = p2p.models.ScoreboardModel(xrange=(-7, 7), yrange=(-7, 7), step=0.1)
 model.build()
 
 from pulse2percept.implants import AlphaAMS
@@ -317,7 +317,7 @@ model = p2p.models.Model(spatial=p2p.models.ScoreboardSpatial,
 #    temporal model (names ending in **Temporal**).
 #
 # To make the model focus on the same visual field as above, we set ``xrange``,
-# ``yrange``, and choose a proper ``xystep``.
+# ``yrange``, and choose a proper ``step``.
 #
 # The ``rho`` parameter of the scoreboard model controls how much blur we get
 # in the resulting percept. The value of this parameter should be set
@@ -325,7 +325,7 @@ model = p2p.models.Model(spatial=p2p.models.ScoreboardSpatial,
 # implant user.
 # For the purpose of this tutorial, we will set it to 50um:
 
-model.build(xrange=(-7, 7), yrange=(-7, 7), xystep=0.1, rho=50)
+model.build(xrange=(-7, 7), yrange=(-7, 7), step=0.1, rho=50)
 
 ##############################################################################
 # The predicted percept will now be a movie, where the spatial response (i.e.,

--- a/pulse2percept/implants/cortex/neuralink.py
+++ b/pulse2percept/implants/cortex/neuralink.py
@@ -11,7 +11,7 @@ from ..electrodes import Electrode
 from ..electrode_arrays import ElectrodeArray
 from ..base import ProsthesisSystem
 from ...units import as_value, dva, um
-from ...utils import parse_3d_orient
+from ...utils import parse_3d_orient, rename_parameter
 
 
 class EllipsoidElectrode(Electrode):
@@ -262,15 +262,17 @@ class LinearEdgeThread(NeuralinkThread):
 class Neuralink(EnsembleImplant):
 
     @classmethod
-    def from_neuropythy(cls, vfmap, locs=None, xrange=None, yrange=None, xystep=None, 
+    @rename_parameter('xystep', 'step', deprecated_version='0.10.0',
+                      removed_version='0.11.0')
+    def from_neuropythy(cls, vfmap, locs=None, xrange=None, yrange=None, step=None,
                         rand_insertion_angle=None, region='v1', Thread=LinearEdgeThread):
         """
         Create a Neuralink implant [Musk2019]_ from a neuropythy visual field map.
 
         The implant will be created by creating a NeuralinkThread for each
-        visual field location specified either by locs or by xrange, yrange, 
-        and xystep. Each thread will be inserted perpendicular to the 
-        cortical surface at the corresponding location in cortex, with 
+        visual field location specified either by locs or by xrange, yrange,
+        and step. Each thread will be inserted perpendicular to the
+        cortical surface at the corresponding location in cortex, with
         up to rand_insertion_angle degrees of azimuthal rotation.
 
         Parameters
@@ -279,11 +281,17 @@ class Neuralink(EnsembleImplant):
             Visual field map to create implant from.
         locs : np.ndarray with shape (n, 2), optional
             Array of visual field locations (dva) to create threads at. Not
-            needed if using xrange, yrange, and xystep.
+            needed if using xrange, yrange, and step.
         xrange, yrange: tuple of floats, optional
             Range of x and y coordinates (dva) to create threads at.
-        xystep : float, optional
+        step : float or (x_step, y_step), optional
             Spacing (dva) between threads.
+
+            .. versionchanged:: 0.10.0
+
+                Renamed from ``xystep``, which suggested that one step size
+                applies to both axes. The old name still works as a keyword
+                argument, but is deprecated and will be removed in v0.11.0.
         rand_insertion_angle : float, optional
             If not none, insert threads at a random offset from perpendicular,
             with a maximum azimuthal rotation of rand_insertion_angle degrees.
@@ -319,18 +327,18 @@ class Neuralink(EnsembleImplant):
         locs = as_value(locs, dva, 'locs')
         xrange = as_value(xrange, dva, 'xrange')
         yrange = as_value(yrange, dva, 'yrange')
-        xystep = as_value(xystep, dva, 'xystep')
+        step = as_value(step, dva, 'step')
 
         if locs is None:
             if xrange is None:
                 xrange = (-3, 3)
             if yrange is None:
                 yrange = (-3, 3)
-            if xystep is None:
-                xystep = 1
-            
+            if step is None:
+                step = 1
+
             # make a grid of points
-            grid = Grid2D(xrange, yrange, xystep)
+            grid = Grid2D(xrange, yrange, step)
             xlocs = grid.x.flatten()
             ylocs = grid.y.flatten()
         else:
@@ -379,8 +387,10 @@ class Neuralink(EnsembleImplant):
         return cls(threads)
     
     @classmethod
-    def from_cortical_map(cls, implant_type, vfmap, locs=None, xrange=None, 
-                          yrange=None, xystep=None, region='v1'):
+    @rename_parameter('xystep', 'step', deprecated_version='0.10.0',
+                      removed_version='0.11.0')
+    def from_cortical_map(cls, implant_type, vfmap, locs=None, xrange=None,
+                          yrange=None, step=None, region='v1'):
         """
         Override of parent class from cortical map method.
         Uses from_neuropythy instead of from_cortical_map if the provided
@@ -394,11 +404,17 @@ class Neuralink(EnsembleImplant):
             Cortical map to create implant from.
         locs : np.ndarray with shape (n, 2), optional
             Array of visual field locations to create threads at. Not
-            needed if using xrange, yrange, and xystep.
+            needed if using xrange, yrange, and step.
         xrange, yrange: tuple of floats, optional
             Range of x and y coordinates to create threads at.
-        xystep : float, optional
+        step : float or (x_step, y_step), optional
             Spacing between threads.
+
+            .. versionchanged:: 0.10.0
+
+                Renamed from ``xystep``, which suggested that one step size
+                applies to both axes. The old name still works as a keyword
+                argument, but is deprecated and will be removed in v0.11.0.
         region : str, optional
             Region of cortex to create implant in.
 
@@ -411,10 +427,10 @@ class Neuralink(EnsembleImplant):
             raise TypeError("implant_type must be a subclass of NeuralinkThread")
         from ...topography import NeuropythyMap
         if not isinstance(vfmap, NeuropythyMap):
-            return super().from_cortical_map(implant_type, vfmap, locs=locs, xrange=xrange, 
-                                             yrange=yrange, xystep=xystep, region=region)
-        return cls.from_neuropythy(vfmap, locs=locs, xrange=xrange, yrange=yrange, 
-                                    xystep=xystep, region=region, Thread=implant_type)
+            return super().from_cortical_map(implant_type, vfmap, locs=locs, xrange=xrange,
+                                             yrange=yrange, step=step, region=region)
+        return cls.from_neuropythy(vfmap, locs=locs, xrange=xrange, yrange=yrange,
+                                    step=step, region=region, Thread=implant_type)
 
     
 

--- a/pulse2percept/implants/cortex/tests/test_neuralink.py
+++ b/pulse2percept/implants/cortex/tests/test_neuralink.py
@@ -1,4 +1,5 @@
 from string import ascii_uppercase
+import warnings
 
 import numpy.testing as npt
 from pulse2percept.units import (DimensionMismatchError, Quantity, dva,
@@ -13,6 +14,7 @@ from pulse2percept.implants.cortex import (EllipsoidElectrode, LinearEdgeThread,
                                            NeuralinkThread, Neuralink, Cortivis)
 from pulse2percept.topography import Grid2D, NeuropythyMap, Polimeni2006Map
 from pulse2percept.topography.cortex import CorticalMap
+from pulse2percept.utils.testing import assert_warns_msg
 
 
 class StubNeuropythyMap(NeuropythyMap):
@@ -458,7 +460,7 @@ def test_Neuralink_from_neuropythy_default_grid():
 
 def test_Neuralink_from_neuropythy_grid_args():
     nlink = Neuralink.from_neuropythy(StubNeuropythyMap(), xrange=(-1, 1),
-                                      yrange=(0, 2), xystep=1)
+                                      yrange=(0, 2), step=1)
     grid = Grid2D((-1, 1), (0, 2), 1)
     locs = np.stack([grid.x.flatten(), grid.y.flatten()], axis=1)
     points, _ = stub_map_expected(locs)
@@ -550,7 +552,7 @@ def test_Neuralink_from_cortical_map_non_neuropythy():
     vfmap = Polimeni2006Map()
     nlink = Neuralink.from_cortical_map(LinearEdgeThread, vfmap,
                                         xrange=(-1, 1), yrange=(0, 0),
-                                        xystep=1)
+                                        step=1)
     npt.assert_equal(isinstance(nlink, Neuralink), True)
     xc, yc = vfmap.dva_to_v1(np.array([-1., 0., 1.]), np.array([0., 0., 0.]))
     npt.assert_equal(len(nlink.implants), 3)
@@ -596,3 +598,35 @@ def test_LinearEdgeThread_units():
             LinearEdgeThread(**kwargs)
     with pytest.raises(DimensionMismatchError):
         EllipsoidElectrode(rx=1 * ms)
+
+
+@pytest.mark.parametrize('factory, vfmap', [
+    ('from_neuropythy', None),
+    ('from_cortical_map', Polimeni2006Map()),
+])
+def test_Neuralink_deprecated_xystep(factory, vfmap):
+    # `step` was called `xystep` until 0.10.0. Both `Neuralink` factories
+    # take it as an ordinary signature argument, so the old name is forwarded:
+    if factory == 'from_neuropythy':
+        args = (StubNeuropythyMap(),)
+    else:
+        args = (LinearEdgeThread, vfmap)
+    build = getattr(Neuralink, factory)
+    kwargs = {'xrange': (-1, 1), 'yrange': (0, 0)}
+
+    msg = f"The 'xystep' parameter of Neuralink.{factory} is deprecated"
+    assert_warns_msg(DeprecationWarning, build, msg, *args, xystep=1, **kwargs)
+    with pytest.warns(DeprecationWarning):
+        old = build(*args, xystep=1, **kwargs)
+    new = build(*args, step=1, **kwargs)
+    npt.assert_almost_equal([[t.x, t.y, t.z] for t in old.implants.values()],
+                            [[t.x, t.y, t.z] for t in new.implants.values()])
+
+    # Both names are the same parameter, so supplying both must raise:
+    with pytest.raises(TypeError, match="same parameter"):
+        build(*args, xystep=1, step=1, **kwargs)
+
+    # The new name stays silent:
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", DeprecationWarning)
+        build(*args, step=1, **kwargs)

--- a/pulse2percept/implants/ensemble.py
+++ b/pulse2percept/implants/ensemble.py
@@ -5,6 +5,7 @@ from .electrodes import Electrode
 from .electrode_arrays import ElectrodeArray
 from ..stimuli.base import _describe_unit, unique_time_points
 from ..units import DimensionMismatchError, as_value, dva, um
+from ..utils import rename_parameter
 
 class EnsembleImplant(ProsthesisSystem):
     
@@ -12,29 +13,37 @@ class EnsembleImplant(ProsthesisSystem):
     __slots__ = ('_implants', '_earray', '_stim', 'safe_mode', 'preprocess')
 
     @classmethod
-    def from_cortical_map(cls, implant_type, vfmap, locs=None, xrange=None, yrange=None, xystep=None, 
+    @rename_parameter('xystep', 'step', deprecated_version='0.10.0',
+                      removed_version='0.11.0')
+    def from_cortical_map(cls, implant_type, vfmap, locs=None, xrange=None, yrange=None, step=None,
                         region='v1'):
         """
         Create an ensemble implant from a cortical visual field map.
 
         The implant will be created by creating an implant of type `implant_type`
-        for each visual field location specified either by locs or by xrange, yrange, 
-        and xystep. Each implant will be centered at the given location.
+        for each visual field location specified either by locs or by xrange, yrange,
+        and step. Each implant will be centered at the given location.
 
         Parameters
         ----------
         vfmap : p2p.topography.CorticalMap
             Visual field map to create implant from.
         implant_type : type
-            Type of implant to create for the ensemble. Must subclass 
+            Type of implant to create for the ensemble. Must subclass
             p2p.implants.ProsthesisSystem
         locs : np.ndarray with shape (n, 2), optional
-            Array of visual field locations to create implants at (dva). 
-            Not needed if using xrange, yrange, and xystep.
+            Array of visual field locations to create implants at (dva).
+            Not needed if using xrange, yrange, and step.
         xrange, yrange: tuple of floats, optional
             Range of x and y coordinates (dva) to create implants at.
-        xystep : float, optional
+        step : float or (x_step, y_step), optional
             Spacing (dva) between implant centers.
+
+            .. versionchanged:: 0.10.0
+
+                Renamed from ``xystep``, which suggested that one step size
+                applies to both axes. The old name still works as a keyword
+                argument, but is deprecated and will be removed in v0.11.0.
         region : str, optional
             Region of cortex to create implant in.
 
@@ -62,18 +71,18 @@ class EnsembleImplant(ProsthesisSystem):
         locs = as_value(locs, dva, 'locs')
         xrange = as_value(xrange, dva, 'xrange')
         yrange = as_value(yrange, dva, 'yrange')
-        xystep = as_value(xystep, dva, 'xystep')
+        step = as_value(step, dva, 'step')
 
         if locs is None:
             if xrange is None:
                 xrange = (-3, 3)
             if yrange is None:
                 yrange = (-3, 3)
-            if xystep is None:
-                xystep = 1
-            
+            if step is None:
+                step = 1
+
             # make a grid of points
-            grid = Grid2D(xrange, yrange, xystep)
+            grid = Grid2D(xrange, yrange, step)
             xlocs = grid.x.flatten()
             ylocs = grid.y.flatten()
         else:
@@ -86,7 +95,9 @@ class EnsembleImplant(ProsthesisSystem):
 
 
     @classmethod
-    def from_coords(cls, implant_type, locs=None, xrange=None, yrange=None, xystep=None):
+    @rename_parameter('xystep', 'step', deprecated_version='0.10.0',
+                      removed_version='0.11.0')
+    def from_coords(cls, implant_type, locs=None, xrange=None, yrange=None, step=None):
         """
         Create an ensemble implant using physical (cortical or retinal) coordinates.
 
@@ -96,18 +107,24 @@ class EnsembleImplant(ProsthesisSystem):
             The type of implant to create for the ensemble.
         locs : np.ndarray with shape (n, 2), optional
             Array of physical locations (um) to create implants at. Not
-            needed if using xrange, yrange, and xystep.
+            needed if using xrange, yrange, and step.
         xrange, yrange: tuple of floats, optional
             Range of x and y coordinates (um) to create implants at. Required
-            (together with ``xystep``) if ``locs`` is not given.
-        xystep : float, optional
+            (together with ``step``) if ``locs`` is not given.
+        step : float or (x_step, y_step), optional
             Spacing (um) between implant centers.
+
+            .. versionchanged:: 0.10.0
+
+                Renamed from ``xystep``, which suggested that one step size
+                applies to both axes. The old name still works as a keyword
+                argument, but is deprecated and will be removed in v0.11.0.
 
         Raises
         ------
         ValueError
             If neither ``locs`` nor all three of ``xrange``, ``yrange`` and
-            ``xystep`` are given.
+            ``step`` are given.
 
         Notes
         -----
@@ -132,7 +149,7 @@ class EnsembleImplant(ProsthesisSystem):
         locs = as_value(locs, um, 'locs')
         xrange = as_value(xrange, um, 'xrange')
         yrange = as_value(yrange, um, 'yrange')
-        xystep = as_value(xystep, um, 'xystep')
+        step = as_value(step, um, 'step')
 
         if locs is None:
             # There are two ways to say where the implants go, and no default
@@ -141,18 +158,18 @@ class EnsembleImplant(ProsthesisSystem):
             # uses would put every implant inside a 6 um square here.
             missing = [name for name, value in [('xrange', xrange),
                                                 ('yrange', yrange),
-                                                ('xystep', xystep)]
+                                                ('step', step)]
                        if value is None]
             if missing:
                 raise ValueError(
                     f"Pass either 'locs' or all of 'xrange', 'yrange' and "
-                    f"'xystep' (missing: {', '.join(missing)}). Coordinates "
+                    f"'step' (missing: {', '.join(missing)}). Coordinates "
                     f"are physical, in microns.")
 
             # Laid out directly rather than through a `Grid2D`, which is a
             # grid of *visual field* coordinates and would read these microns
             # as degrees:
-            (xgrid, ygrid), _, _ = _rectangular_mesh(xrange, yrange, xystep)
+            (xgrid, ygrid), _, _ = _rectangular_mesh(xrange, yrange, step)
             xlocs = xgrid.flatten()
             ylocs = ygrid.flatten()
         else:

--- a/pulse2percept/implants/tests/test_base.py
+++ b/pulse2percept/implants/tests/test_base.py
@@ -174,7 +174,7 @@ def test_ProsthesisSystem_reshape_stim(rot, gtype, n_frames):
     data[20:-20, 10:-10] = 1
     sampled = implant.reshape_stim(ImageStimulus(data))
     implant.stim = Stimulus(sampled.data, electrodes=sampled.electrodes)
-    model = ScoreboardModel(xrange=(-1, 1), yrange=(-1, 1), rho=30, xystep=0.02)
+    model = ScoreboardModel(xrange=(-1, 1), yrange=(-1, 1), rho=30, step=0.02)
     model.build()
     percept = label(model.predict_percept(implant).data.squeeze().T > 0.2)
     npt.assert_almost_equal(regionprops(percept)[0].orientation, 0, decimal=1)

--- a/pulse2percept/implants/tests/test_ensemble.py
+++ b/pulse2percept/implants/tests/test_ensemble.py
@@ -1,3 +1,5 @@
+import warnings
+
 import numpy as np
 import numpy.testing as npt
 from pulse2percept.units import DimensionMismatchError, mm, ms, um
@@ -9,6 +11,7 @@ from pulse2percept.topography import Polimeni2006Map
 from pulse2percept.models.cortex.base import ScoreboardModel
 from pulse2percept.stimuli import BiphasicPulseTrain
 from pulse2percept.utils.constants import DT
+from pulse2percept.utils.testing import assert_warns_msg
 
 def test_EnsembleImplant():
     # Invalid instantiations:
@@ -176,18 +179,18 @@ def test_EnsembleImplant_from_coords_units():
     # ... and so may the range form:
     ranged = EnsembleImplant.from_coords(Cortivis,
                                          xrange=(-10 * mm, 10 * mm),
-                                         yrange=(0, 0), xystep=10000 * um)
+                                         yrange=(0, 0), step=10000 * um)
     npt.assert_allclose(
         ranged.earray.coordinates(),
         EnsembleImplant.from_coords(Cortivis, xrange=(-10000, 10000),
                                     yrange=(0, 0),
-                                    xystep=10000).earray.coordinates(),
+                                    step=10000).earray.coordinates(),
         rtol=1e-12)
     with pytest.raises(DimensionMismatchError):
         EnsembleImplant.from_coords(Cortivis, locs=locs * ms)
     with pytest.raises(DimensionMismatchError):
         EnsembleImplant.from_coords(Cortivis, xrange=(0, 1 * ms),
-                                    yrange=(0, 0), xystep=1)
+                                    yrange=(0, 0), step=1)
 
 
 def test_EnsembleImplant_from_coords_needs_a_specification():
@@ -202,10 +205,10 @@ def test_EnsembleImplant_from_coords_needs_a_specification():
     # A partial grid is not a grid:
     with pytest.raises(ValueError) as excinfo:
         EnsembleImplant.from_coords(Cortivis, xrange=(-1 * mm, 1 * mm),
-                                    xystep=500 * um)
+                                    step=500 * um)
     npt.assert_equal('yrange' in str(excinfo.value), True)
-    for kwargs in ({'yrange': (0, 0), 'xystep': 1000},
-                   {'xrange': (0, 0), 'xystep': 1000},
+    for kwargs in ({'yrange': (0, 0), 'step': 1000},
+                   {'xrange': (0, 0), 'step': 1000},
                    {'xrange': (0, 0), 'yrange': (0, 0)}):
         with pytest.raises(ValueError):
             EnsembleImplant.from_coords(Cortivis, **kwargs)
@@ -214,10 +217,10 @@ def test_EnsembleImplant_from_coords_needs_a_specification():
 def test_EnsembleImplant_from_cortical_map_units():
     """`from_cortical_map` places implants by visual field location (dva)"""
     bare = EnsembleImplant.from_cortical_map(
-        Cortivis, Polimeni2006Map(), xrange=(-2, 2), yrange=(0, 0), xystep=2)
+        Cortivis, Polimeni2006Map(), xrange=(-2, 2), yrange=(0, 0), step=2)
     unitful = EnsembleImplant.from_cortical_map(
         Cortivis, Polimeni2006Map(), xrange=(-2 * dva, 2 * dva),
-        yrange=(0 * dva, 0 * dva), xystep=2 * dva)
+        yrange=(0 * dva, 0 * dva), step=2 * dva)
     npt.assert_allclose(unitful.earray.coordinates(),
                         bare.earray.coordinates(), rtol=1e-12)
     # Locations, too:
@@ -231,12 +234,12 @@ def test_EnsembleImplant_from_cortical_map_units():
         rtol=1e-12)
     # These are degrees, not microns: the whole point of the map is that the
     # two are not interchangeable.
-    for kwargs in ({'xrange': (-2 * mm, 2 * mm)}, {'xystep': 2 * um},
+    for kwargs in ({'xrange': (-2 * mm, 2 * mm)}, {'step': 2 * um},
                    {'locs': locs * um}):
         with pytest.raises(DimensionMismatchError):
             EnsembleImplant.from_cortical_map(
                 Cortivis, Polimeni2006Map(),
-                **{'xrange': (-2, 2), 'yrange': (0, 0), 'xystep': 2, **kwargs})
+                **{'xrange': (-2, 2), 'yrange': (0, 0), 'step': 2, **kwargs})
 
 
 def test_EnsembleImplant_from_coords_is_physical():
@@ -248,7 +251,7 @@ def test_EnsembleImplant_from_coords_is_physical():
     """
     # A range and the equivalent explicit locations must agree:
     ranged = EnsembleImplant.from_coords(Cortivis, xrange=(-10000, 10000),
-                                         yrange=(0, 0), xystep=10000)
+                                         yrange=(0, 0), step=10000)
     listed = EnsembleImplant.from_coords(
         Cortivis, locs=np.array([[-10000., 0.], [0., 0.], [10000., 0.]]))
     npt.assert_equal(len(ranged.implants), 3)
@@ -259,8 +262,39 @@ def test_EnsembleImplant_from_coords_is_physical():
     npt.assert_allclose(
         EnsembleImplant.from_coords(Cortivis, xrange=(-10 * mm, 10 * mm),
                                     yrange=(0, 0),
-                                    xystep=10000 * um).earray.coordinates(),
+                                    step=10000 * um).earray.coordinates(),
         ranged.earray.coordinates(), rtol=1e-12)
     with pytest.raises(DimensionMismatchError):
         EnsembleImplant.from_coords(Cortivis, xrange=(-2 * dva, 2 * dva),
-                                    yrange=(0, 0), xystep=1)
+                                    yrange=(0, 0), step=1)
+
+
+@pytest.mark.parametrize('factory, kwargs', [
+    ('from_coords', {'xrange': (-10000, 10000), 'yrange': (0, 0)}),
+    ('from_cortical_map', {'xrange': (-2, 2), 'yrange': (0, 0)}),
+])
+def test_EnsembleImplant_deprecated_xystep(factory, kwargs):
+    # `step` was called `xystep` until 0.10.0. Both factories are ordinary
+    # signatures, so the old name is forwarded rather than aliased:
+    args = ((Cortivis,) if factory == 'from_coords'
+            else (Cortivis, Polimeni2006Map()))
+    build = getattr(EnsembleImplant, factory)
+    step = 10000 if factory == 'from_coords' else 2
+
+    msg = f"The 'xystep' parameter of EnsembleImplant.{factory} is deprecated"
+    assert_warns_msg(DeprecationWarning, build, msg, *args,
+                     xystep=step, **kwargs)
+    with pytest.warns(DeprecationWarning):
+        old = build(*args, xystep=step, **kwargs)
+    npt.assert_allclose(old.earray.coordinates(),
+                        build(*args, step=step, **kwargs).earray.coordinates(),
+                        rtol=1e-12)
+
+    # Both names are the same parameter, so supplying both must raise:
+    with pytest.raises(TypeError, match="same parameter"):
+        build(*args, xystep=step, step=step, **kwargs)
+
+    # The new name stays silent:
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", DeprecationWarning)
+        build(*args, step=step, **kwargs)

--- a/pulse2percept/models/base.py
+++ b/pulse2percept/models/base.py
@@ -1348,6 +1348,16 @@ class Model(PrettyPrint):
         return BaseModel.time_unit
 
     def __init__(self, spatial=None, temporal=None, **params):
+        # A sub-model passed as a *class* is constructed from `params` below,
+        # and `set_params` then hands the same dict to the resulting instance.
+        # Both paths rewrite renamed parameters, so an old name reaching this
+        # constructor would otherwise be warned about twice. Settle it once,
+        # up front, and let the two paths downstream see only the new name:
+        for model in (spatial, temporal):
+            if isinstance(model, type):
+                params = rename_deprecated_params(
+                    type(self).__name__, params,
+                    getattr(model, '_renamed_params', {}))
         # Set the spatial model:
         if spatial is not None and not isinstance(spatial, SpatialModel):
             if issubclass(spatial, SpatialModel):

--- a/pulse2percept/models/base.py
+++ b/pulse2percept/models/base.py
@@ -18,7 +18,8 @@ from ..topography import Curcio1990Map, Grid2D
 from ..units import (DimensionMismatchError, Quantity, as_value, dva, ms, um,
                      uA)
 from ..utils import (PrettyPrint, FreezeError, Parametrized, bisect,
-                     warn_deprecated_params, rename_deprecated_params)
+                     deprecated_alias, warn_deprecated_params,
+                     rename_deprecated_params)
 from ..utils.constants import ZORDER
 
 
@@ -471,6 +472,11 @@ class SpatialModel(BaseModel, metaclass=ABCMeta):
     #: ``n_jobs`` is an alias for ``n_threads``; see ``_n_jobs_alias``.
     n_jobs = _n_jobs_alias()
 
+    #: ``step`` used to be called ``xystep``. The old name still reads and
+    #: writes ``step``, with a ``DeprecationWarning``:
+    xystep = deprecated_alias('step', deprecated_version='0.10.0',
+                              removed_version='0.11.0')
+
     def __init__(self, **params):
         super().__init__(**params)
         self.grid = None
@@ -483,7 +489,7 @@ class SpatialModel(BaseModel, metaclass=ABCMeta):
             # size):
             'xrange': (-15, 15),  # dva
             'yrange': (-15, 15),  # dva
-            'xystep': 0.25,  # dva
+            'step': 0.25,  # dva
             'grid_type': 'rectangular',
             # Below threshold, percept has brightness zero:
             'thresh_percept': 0,
@@ -516,7 +522,7 @@ class SpatialModel(BaseModel, metaclass=ABCMeta):
             # coordinates when the grid is built:
             'xrange': dva,
             'yrange': dva,
-            'xystep': dva,
+            'step': dva,
         }
 
     def _cutoff_r2(self, rho):
@@ -584,7 +590,7 @@ class SpatialModel(BaseModel, metaclass=ABCMeta):
         if self.vfmap.ndim not in self.ndim:
             raise ValueError(f"Model expects one of {self.ndim} dimensions, but "
                              f"visual field map has {self.vfmap.ndim} dimensions.")
-        self.grid = Grid2D(self.xrange, self.yrange, step=self.xystep,
+        self.grid = Grid2D(self.xrange, self.yrange, step=self.step,
                            grid_type=self.grid_type)
         self.grid.build(self.vfmap)
         self._build()

--- a/pulse2percept/models/beyeler2019.py
+++ b/pulse2percept/models/beyeler2019.py
@@ -24,9 +24,10 @@ import warnings
 
 
 #: Layout of the payload in ``axon_pickle``. Bump this whenever the tuple
-#: written by ``AxonMapSpatial._build`` changes shape or meaning, so that a
-#: cache left over from an older version is regrown instead of misread.
-_AXON_CACHE_VERSION = 2
+#: written by ``AxonMapSpatial._build``, or the parameter dict alongside it,
+#: changes shape or meaning, so that a cache left over from an older version
+#: is regrown instead of misread.
+_AXON_CACHE_VERSION = 3
 
 
 def _is_axon_cache(payload):
@@ -112,10 +113,17 @@ class ScoreboardSpatial(SpatialModel):
         A tuple indicating the range of y values to simulate (in degrees of
         visual angle). Negative y values correspond to the superior retina,
         and positive y values to the inferior retina.
-    xystep : int, double, tuple, optional
+    step : int, double, tuple, optional
         Step size for the range of (x,y) values to simulate (in degrees of
         visual angle). For example, to create a grid with x values [0, 0.5, 1]
-        use ``xrange=(0, 1)`` and ``xystep=0.5``.
+        use ``xrange=(0, 1)`` and ``step=0.5``. Pass a tuple to give the x
+        and y axes different step sizes.
+
+        .. versionchanged:: 0.10.0
+
+            Renamed from ``xystep``, which suggested that one step size
+            applies to both axes. The old name still works, but is
+            deprecated and will be removed in v0.11.0.
     grid_type : {'rectangular', 'hexagonal'}, optional
         Whether to simulate points on a rectangular or hexagonal grid
     vfmap : :py:class:`~pulse2percept.topography.VisualFieldMap`, optional
@@ -206,10 +214,17 @@ class ScoreboardModel(Model):
         A tuple indicating the range of y values to simulate (in degrees of
         visual angle). Negative y values correspond to the superior retina,
         and positive y values to the inferior retina.
-    xystep : int, double, tuple, optional
+    step : int, double, tuple, optional
         Step size for the range of (x,y) values to simulate (in degrees of
         visual angle). For example, to create a grid with x values [0, 0.5, 1]
-        use ``xrange=(0, 1)`` and ``xystep=0.5``.
+        use ``xrange=(0, 1)`` and ``step=0.5``. Pass a tuple to give the x
+        and y axes different step sizes.
+
+        .. versionchanged:: 0.10.0
+
+            Renamed from ``xystep``, which suggested that one step size
+            applies to both axes. The old name still works, but is
+            deprecated and will be removed in v0.11.0.
     grid_type : {'rectangular', 'hexagonal'}, optional
         Whether to simulate points on a rectangular or hexagonal grid
     vfmap : :py:class:`~pulse2percept.topography.VisualFieldMap`, optional
@@ -288,10 +303,17 @@ class AxonMapSpatial(SpatialModel):
         A tuple indicating the range of y values to simulate (in degrees of
         visual angle). Negative y values correspond to the superior retina,
         and positive y values to the inferior retina.
-    xystep : int or double or tuple, optional
+    step : int or double or tuple, optional
         Step size for the range of (x,y) values to simulate (in degrees of
         visual angle). For example, to create a grid with x values [0, 0.5, 1]
-        use ``xrange=(0, 1)`` and ``xystep=0.5``.
+        use ``xrange=(0, 1)`` and ``step=0.5``. Pass a tuple to give the x
+        and y axes different step sizes.
+
+        .. versionchanged:: 0.10.0
+
+            Renamed from ``xystep``, which suggested that one step size
+            applies to both axes. The old name still works, but is
+            deprecated and will be removed in v0.11.0.
     grid_type : {'rectangular', 'hexagonal'}, optional
         Whether to simulate points on a rectangular or hexagonal grid
     vfmap : :py:class:`~pulse2percept.topography.VisualFieldMap`, optional
@@ -885,17 +907,21 @@ class AxonMapSpatial(SpatialModel):
             # Check if math for Jansonius model has been done before:
             if os.path.isfile(self.axon_pickle):
                 params, cached = pickle.load(open(self.axon_pickle, 'rb'))
-                for key, value in params.items():
-                    if (not hasattr(self, key) or
-                            not np.allclose(getattr(self, key), value)):
-                        need_axons = True
-                        break
                 # A cache written by an older version stores something else
                 # here. Rather than try to read it, grow the bundles again and
                 # overwrite it; the file is derived data, so the only cost is
-                # one slow build:
+                # one slow build. Settle this *before* looking at `params`,
+                # whose keys are versioned too -- an old cache names the grid
+                # step `xystep`, and probing that here would warn the user
+                # about a name they never used:
                 if not _is_axon_cache(cached):
                     need_axons = True
+                else:
+                    for key, value in params.items():
+                        if (not hasattr(self, key) or
+                                not np.allclose(getattr(self, key), value)):
+                            need_axons = True
+                            break
             else:
                 need_axons = True
         # Build the Jansonius model: Grow a number of axon bundles in all dirs:
@@ -929,7 +955,7 @@ class AxonMapSpatial(SpatialModel):
             params = {'loc_od': self.loc_od,
                       'n_axons': self.n_axons, 'axons_range': self.axons_range,
                       'xrange': self.xrange, 'yrange': self.yrange,
-                      'xystep': self.xystep, 'n_ax_segments': self.n_ax_segments,
+                      'step': self.step, 'n_ax_segments': self.n_ax_segments,
                       'ax_segments_range': self.ax_segments_range}
             pickle.dump((params, (_AXON_CACHE_VERSION, bundles, bundle_id,
                                   idx_segment)),
@@ -1113,10 +1139,17 @@ class AxonMapModel(Model):
         A tuple indicating the range of y values to simulate (in degrees of
         visual angle). Negative y values correspond to the superior retina,
         and positive y values to the inferior retina.
-    xystep : int or double or tuple, optional
+    step : int or double or tuple, optional
         Step size for the range of (x,y) values to simulate (in degrees of
         visual angle). For example, to create a grid with x values [0, 0.5, 1]
-        use ``xrange=(0, 1)`` and ``xystep=0.5``.
+        use ``xrange=(0, 1)`` and ``step=0.5``. Pass a tuple to give the x
+        and y axes different step sizes.
+
+        .. versionchanged:: 0.10.0
+
+            Renamed from ``xystep``, which suggested that one step size
+            applies to both axes. The old name still works, but is
+            deprecated and will be removed in v0.11.0.
     grid_type : {'rectangular', 'hexagonal'}, optional
         Whether to simulate points on a rectangular or hexagonal grid
     vfmap : :py:class:`~pulse2percept.topography.VisualFieldMap`, optional

--- a/pulse2percept/models/cortex/base.py
+++ b/pulse2percept/models/cortex/base.py
@@ -43,10 +43,17 @@ class CortexSpatial(SpatialModel):
         A tuple indicating the range of y values to simulate (in degrees of
         visual angle). Negative y values correspond to the superior retina,
         and positive y values to the inferior retina.
-    xystep : int, double, tuple, optional
+    step : int, double, tuple, optional
         Step size for the range of (x,y) values to simulate (in degrees of
         visual angle). For example, to create a grid with x values [0, 0.5, 1]
-        use ``xrange=(0, 1)`` and ``xystep=0.5``.
+        use ``xrange=(0, 1)`` and ``step=0.5``. Pass a tuple to give the x
+        and y axes different step sizes.
+
+        .. versionchanged:: 0.10.0
+
+            Renamed from ``xystep``, which suggested that one step size
+            applies to both axes. The old name still works, but is
+            deprecated and will be removed in v0.11.0.
     grid_type : {'rectangular', 'hexagonal'}, optional
         Whether to simulate points on a rectangular or hexagonal grid
     vfmap : :py:class:`~pulse2percept.topography.VisualFieldMap`, optional
@@ -109,7 +116,7 @@ class CortexSpatial(SpatialModel):
         params = {
                     'xrange' : (-5, 5),
                     'yrange' : (-5, 5),
-                    'xystep' : 0.1,
+                    'step' : 0.1,
                     # Visual field regions to simulate
                     'regions' : ['v1']
                  }
@@ -225,10 +232,17 @@ class ScoreboardSpatial(CortexSpatial):
         A tuple indicating the range of y values to simulate (in degrees of
         visual angle). Negative y values correspond to the superior retina,
         and positive y values to the inferior retina.
-    xystep : int, double, tuple, optional
+    step : int, double, tuple, optional
         Step size for the range of (x,y) values to simulate (in degrees of
         visual angle). For example, to create a grid with x values [0, 0.5, 1]
-        use ``xrange=(0, 1)`` and ``xystep=0.5``.
+        use ``xrange=(0, 1)`` and ``step=0.5``. Pass a tuple to give the x
+        and y axes different step sizes.
+
+        .. versionchanged:: 0.10.0
+
+            Renamed from ``xystep``, which suggested that one step size
+            applies to both axes. The old name still works, but is
+            deprecated and will be removed in v0.11.0.
     grid_type : {'rectangular', 'hexagonal'}, optional
         Whether to simulate points on a rectangular or hexagonal grid
     vfmap : :py:class:`~pulse2percept.topography..VisualFieldMap`, optional
@@ -350,10 +364,17 @@ class ScoreboardModel(Model):
         A tuple indicating the range of y values to simulate (in degrees of
         visual angle). Negative y values correspond to the superior retina,
         and positive y values to the inferior retina.
-    xystep : int, double, tuple, optional
+    step : int, double, tuple, optional
         Step size for the range of (x,y) values to simulate (in degrees of
         visual angle). For example, to create a grid with x values [0, 0.5, 1]
-        use ``xrange=(0, 1)`` and ``xystep=0.5``.
+        use ``xrange=(0, 1)`` and ``step=0.5``. Pass a tuple to give the x
+        and y axes different step sizes.
+
+        .. versionchanged:: 0.10.0
+
+            Renamed from ``xystep``, which suggested that one step size
+            applies to both axes. The old name still works, but is
+            deprecated and will be removed in v0.11.0.
     grid_type : {'rectangular', 'hexagonal'}, optional
         Whether to simulate points on a rectangular or hexagonal grid
     vfmap : :py:class:`~pulse2percept.topography..VisualFieldMap`, optional

--- a/pulse2percept/models/cortex/dynaphos.py
+++ b/pulse2percept/models/cortex/dynaphos.py
@@ -7,7 +7,7 @@ from ..base import BaseModel, NotBuiltError, _require_stim_dimension
 from ...percepts import Percept
 from ...implants import ProsthesisSystem
 from ...units import A, Quantity, as_value, dva, Hz, mm, ms, uA
-from ...utils import cart2pol
+from ...utils import cart2pol, deprecated_alias
 from ...utils.constants import MS_PER_S, UM_PER_MM, ZORDER
 from ...topography import Polimeni2006Map
 
@@ -62,10 +62,17 @@ class DynaphosModel(BaseModel):
     yrange : (y_min, y_max), optional
         A tuple indicating the range of y values to simulate (in degrees of
         visual angle).
-    xystep : int, double, tuple, optional
+    step : int, double, tuple, optional
         Step size for the range of (x,y) values to simulate (in degrees of
         visual angle). For example, to create a grid with x values [0, 0.5, 1]
-        use ``x_range=(0, 1)`` and ``xystep=0.5``.
+        use ``xrange=(0, 1)`` and ``step=0.5``. Pass a tuple to give the x
+        and y axes different step sizes.
+
+        .. versionchanged:: 0.10.0
+
+            Renamed from ``xystep``, which suggested that one step size
+            applies to both axes. The old name still works, but is
+            deprecated and will be removed in v0.11.0.
     grid_type : {'rectangular', 'hexagonal'}, optional
         Whether to simulate points on a rectangular or hexagonal grid.
     vfmap : :py:class:`~pulse2percept.topography.VisualFieldMap`, optional
@@ -90,10 +97,17 @@ class DynaphosModel(BaseModel):
         by directly setting ``model.xrange = (-10, 10)``), you will have to call
         ``model.build()`` again for your changes to take effect.
     """
+    #: ``step`` used to be called ``xystep``. The old name still reads and
+    #: writes ``step``, with a ``DeprecationWarning``. Declared here rather
+    #: than inherited: this model derives from ``BaseModel``, not
+    #: ``SpatialModel``, and lays out its own grid.
+    xystep = deprecated_alias('step', deprecated_version='0.10.0',
+                              removed_version='0.11.0')
+
     @property
     def regions(self):
         return self._regions
-    
+
     @regions.setter
     def regions(self, regions):
         
@@ -113,7 +127,7 @@ class DynaphosModel(BaseModel):
             params = {
                 'xrange': (-5, 5),  # dva
                 'yrange': (-5, 5),  # dva
-                'xystep': 0.25,  # dva
+                'step': 0.25,  # dva
                 'grid_type': 'rectangular',
                 # Use [Polemeni2006]_ visual field map with parameters specified in the paper
                 'vfmap': Polimeni2006Map(a=0.75,k=17.3,b=120,alpha1=0.95),
@@ -164,7 +178,7 @@ class DynaphosModel(BaseModel):
             **super().get_param_units(),
             'xrange': dva,
             'yrange': dva,
-            'xystep': dva,
+            'step': dva,
             'dt': ms,
             # Decay constants, both converted to seconds where they are used:
             'tau_act': ms,
@@ -209,7 +223,7 @@ class DynaphosModel(BaseModel):
                             f"pulse train window (dur={window_dur:.2f} "
                             f"ms)")
         # Build the spatial grid:
-        self.grid = Grid2D(self.xrange, self.yrange, step=self.xystep,
+        self.grid = Grid2D(self.xrange, self.yrange, step=self.step,
                            grid_type=self.grid_type)
         self.grid.build(self.vfmap)
         self._build()

--- a/pulse2percept/models/cortex/tests/test_base.py
+++ b/pulse2percept/models/cortex/tests/test_base.py
@@ -20,7 +20,7 @@ from pulse2percept.topography import Watson2014Map
 def test_ScoreboardSpatial(ModelClass, jitter_boundary, regions):
     # ScoreboardSpatial automatically sets `regions`
     vfmap = Polimeni2006Map(k=15, a=.5, b=90, jitter_boundary=jitter_boundary, regions=regions)
-    model = ModelClass(xrange=(-3, 3), yrange=(-3, 3), xystep=0.1, vfmap=vfmap).build()
+    model = ModelClass(xrange=(-3, 3), yrange=(-3, 3), step=0.1, vfmap=vfmap).build()
     npt.assert_equal(model.regions, regions)
     npt.assert_equal(model.vfmap.regions, regions)
 
@@ -35,7 +35,7 @@ def test_ScoreboardSpatial(ModelClass, jitter_boundary, regions):
 
     # Converting ret <=> dva
     vfmap = Polimeni2006Map(k=15, a=0.5, b=90, jitter_boundary=jitter_boundary, regions=regions)
-    model = ModelClass(xrange=(-3, 3), yrange=(-3, 3), xystep=1, vfmap=vfmap).build()
+    model = ModelClass(xrange=(-3, 3), yrange=(-3, 3), step=1, vfmap=vfmap).build()
     npt.assert_equal(isinstance(model.vfmap, Polimeni2006Map), True)
     if jitter_boundary:
         npt.assert_equal(np.isnan(model.vfmap.dva_to_v1([0], [0])), False)
@@ -67,7 +67,7 @@ def test_ScoreboardSpatial(ModelClass, jitter_boundary, regions):
     [['v1'], ['v2'], ['v3'], ['v1', 'v2'], ['v2', 'v3'], ['v1', 'v3'], ['v1', 'v2', 'v3']])
 def test_predict_spatial(ModelClass, regions):
     # test that no current can spread between hemispheres
-    model = ModelClass(xrange=(-3, 3), yrange=(-3, 3), xystep=0.5, rho=100000, regions=regions).build()
+    model = ModelClass(xrange=(-3, 3), yrange=(-3, 3), step=0.5, rho=100000, regions=regions).build()
     implant = Orion(x = 15000)
     implant.stim = {e:5 for e in implant.electrode_names}
     percept = model.predict_percept(implant)
@@ -77,7 +77,7 @@ def test_predict_spatial(ModelClass, regions):
 
     # implant only in v1, shouldnt change with v2/v3
     vfmap = Polimeni2006Map(k=15, a=0.5, b=90)
-    model = ModelClass(xrange=(-5, 0), yrange=(-3, 3), xystep=0.1, rho=400, vfmap=vfmap).build()
+    model = ModelClass(xrange=(-5, 0), yrange=(-3, 3), step=0.1, rho=400, vfmap=vfmap).build()
     elecs = [79, 49, 19, 80, 50, 20, 90, 61, 31, 2, 72, 42, 12, 83, 53, 23, 93, 64, 34, 5, 75, 45, 15, 86, 56, 26, 96, 67, 37, 8, 68, 38]
     implant = Cortivis(x=30000, y=0, rot=0, stim={str(i) : [1, 0] for i in elecs})
     percept = model.predict_percept(implant)
@@ -94,7 +94,7 @@ def test_predict_spatial(ModelClass, regions):
     if 'v1' in regions:
         # make sure cortical representation is flipped
         vfmap = Polimeni2006Map(k=15, a=0.5, b=90)
-        model = ModelClass(xrange=(-5, 0), yrange=(-3, 3), xystep=0.1, rho=400, vfmap=vfmap).build()
+        model = ModelClass(xrange=(-5, 0), yrange=(-3, 3), step=0.1, rho=400, vfmap=vfmap).build()
         implant = Orion(x=30000, y=0, rot=0, stim={'40' : 1,  '94' :5})
         percept = model.predict_percept(implant)
         half = model.grid.shape[0] // 2
@@ -105,9 +105,9 @@ def test_predict_spatial(ModelClass, regions):
 @pytest.mark.parametrize('regions', [['v1', 'v2'], ['v1', 'v3'], ['v2', 'v3']])
 def test_predict_spatial_regionsum(ModelClass,regions):
     print(regions)
-    model1 = ModelClass(xrange=(-3, 3), yrange=(-3, 3), xystep=0.1, rho=10000, regions=regions[0]).build()
-    model2 = ModelClass(xrange=(-3, 3), yrange=(-3, 3), xystep=0.1, rho=10000, regions=regions[1]).build()
-    model_both = ModelClass(xrange=(-3, 3), yrange=(-3, 3), xystep=0.1, rho=10000, regions=regions).build()
+    model1 = ModelClass(xrange=(-3, 3), yrange=(-3, 3), step=0.1, rho=10000, regions=regions[0]).build()
+    model2 = ModelClass(xrange=(-3, 3), yrange=(-3, 3), step=0.1, rho=10000, regions=regions[1]).build()
+    model_both = ModelClass(xrange=(-3, 3), yrange=(-3, 3), step=0.1, rho=10000, regions=regions).build()
 
     implant = Orion(x = 10000, y=10000)
     implant.stim = {e : 1 for e in implant.electrode_names}
@@ -125,8 +125,8 @@ def test_eq_beyeler(ModelClass, stimval):
     
 
     vfmap = Watson2014Map()
-    cortex = ModelClass(xrange=(-3, 3), yrange=(-3, 3), xystep=0.1, rho=200 * stimval, regions=['ret'], vfmap=vfmap).build()
-    retina = BeyelerScoreboard(xrange=(-3, 3), yrange=(-3, 3), xystep=0.1, rho=200 * stimval).build()
+    cortex = ModelClass(xrange=(-3, 3), yrange=(-3, 3), step=0.1, rho=200 * stimval, regions=['ret'], vfmap=vfmap).build()
+    retina = BeyelerScoreboard(xrange=(-3, 3), yrange=(-3, 3), step=0.1, rho=200 * stimval).build()
 
     implant = ArgusII()
     implant.stim = {e : 3 for e in implant.electrode_names[::stimval+1]}
@@ -176,7 +176,7 @@ def test_plot(ModelClass):
 def test_poli_nlink():
     # make sure that the polimeni map and neuralink work togther with scoreboard
     # since this is an odd combo of 2d map and 3d implant
-    model = ScoreboardModel(rho=800, xystep=.5).build()
+    model = ScoreboardModel(rho=800, step=.5).build()
     npt.assert_equal(model.grid.v1.z is None, True)
     npt.assert_equal(model.grid.v1.x is None, False)
     implant = LinearEdgeThread(x=20000,)

--- a/pulse2percept/models/cortex/tests/test_dynaphos.py
+++ b/pulse2percept/models/cortex/tests/test_dynaphos.py
@@ -2,6 +2,7 @@ import numpy.testing as npt
 import pytest
 import numpy as np
 import copy
+import warnings
 import matplotlib.pyplot as plt
 
 from pulse2percept.models.cortex import DynaphosModel
@@ -12,9 +13,10 @@ from pulse2percept.percepts import Percept
 from pulse2percept.stimuli import BiphasicPulseTrain
 from pulse2percept.units import (DimensionMismatchError, Quantity, mA,
                                  ms, s, uA, um)
+from pulse2percept.utils.testing import assert_warns_msg
 
 def test_DynaphosModel():
-    model = DynaphosModel(xrange=(-3, 3), yrange=(-3, 3), xystep=0.1).build()
+    model = DynaphosModel(xrange=(-3, 3), yrange=(-3, 3), step=0.1).build()
 
     npt.assert_equal(model.regions, ['v1'])
     npt.assert_equal(model.vfmap.regions, ['v1'])
@@ -39,7 +41,7 @@ def test_DynaphosModel():
 
 def test_predict_spatial():
     # test that no current can spread between hemispheres
-    model = DynaphosModel(xrange=(-3, 3), yrange=(-3, 3), xystep=0.5).build()
+    model = DynaphosModel(xrange=(-3, 3), yrange=(-3, 3), step=0.5).build()
     implant = Orion(x = 15000)
     implant.stim = {e:BiphasicPulseTrain(freq=300,amp=2000,phase_dur=0.17) for e in implant.electrode_names}
     # Check brightest frame of percept
@@ -49,7 +51,7 @@ def test_predict_spatial():
     npt.assert_equal(np.all(percept[:, :half] != 0), True)
 
 def test_temporal_predict():
-    model = DynaphosModel(xystep=0.1).build()
+    model = DynaphosModel(step=0.1).build()
     # User can set params
     model.dt = 40
     npt.assert_equal(model.dt, 40)
@@ -126,7 +128,7 @@ def test_DynaphosModel_units():
     23.900000000000002 after the multiplication, which is why this compares
     with a tolerance rather than for equality.
     """
-    kwargs = dict(xrange=(-3, 3), yrange=(-3, 3), xystep=0.5)
+    kwargs = dict(xrange=(-3, 3), yrange=(-3, 3), step=0.5)
     bare = DynaphosModel(rheobase=23.9, **kwargs).build()
     unitful = DynaphosModel(rheobase=0.0239 * mA, **kwargs).build()
     npt.assert_allclose(unitful.rheobase, 23.9, rtol=1e-12)
@@ -144,7 +146,7 @@ def test_DynaphosModel_units():
 
 def test_DynaphosModel_t_percept_units():
     """This model overrides `predict_percept`, so it normalizes for itself"""
-    model = DynaphosModel(xrange=(-3, 3), yrange=(-3, 3), xystep=1).build()
+    model = DynaphosModel(xrange=(-3, 3), yrange=(-3, 3), step=1).build()
     implant = Cortivis(stim={'11': BiphasicPulseTrain(20, 50, 0.45,
                                                       stim_dur=100)})
     bare = model.predict_percept(implant, t_percept=[0, 20, 40])
@@ -166,7 +168,7 @@ def test_DynaphosModel_default_frame_clock_stops_at_the_stimulus():
     """
     stim = BiphasicPulseTrain(20, 50, 0.1, stim_dur=10)
     implant = Cortivis(stim={'11': stim})
-    kwargs = dict(xrange=(-2, 2), yrange=(-2, 2), xystep=1)
+    kwargs = dict(xrange=(-2, 2), yrange=(-2, 2), step=1)
 
     # Coarser than a millisecond, which is the case the literal was written
     # for, and still the same clock it always produced:
@@ -181,3 +183,37 @@ def test_DynaphosModel_default_frame_clock_stops_at_the_stimulus():
     npt.assert_equal(percept.time[-1] <= implant.stim.time[-1], True)
     # The endpoint is included, not dropped:
     npt.assert_allclose(percept.time[-1], implant.stim.time[-1], rtol=1e-12)
+
+
+def test_DynaphosModel_deprecated_xystep():
+    # `step` was called `xystep` until 0.10.0. Dynaphos derives from
+    # `BaseModel` rather than `SpatialModel` and lays out its own grid, so it
+    # declares the alias itself and has to be checked separately:
+    msg = "The 'xystep' parameter of DynaphosModel is deprecated"
+    assert_warns_msg(DeprecationWarning, DynaphosModel, msg, xystep=1)
+    with pytest.warns(DeprecationWarning):
+        model = DynaphosModel(xrange=(-2, 2), yrange=(-2, 2), xystep=1)
+    npt.assert_almost_equal(model.step, 1)
+
+    assert_warns_msg(DeprecationWarning, setattr, msg, model, 'xystep', 2)
+    npt.assert_almost_equal(model.step, 2)
+    with pytest.warns(DeprecationWarning):
+        npt.assert_almost_equal(model.xystep, 2)
+
+    assert_warns_msg(DeprecationWarning, model.set_params, msg, xystep=1)
+    npt.assert_almost_equal(model.step, 1)
+    assert_warns_msg(DeprecationWarning, model.build, msg, xystep=0.5)
+    npt.assert_almost_equal(model.step, 0.5)
+    npt.assert_almost_equal(np.unique(np.diff(model.grid.x[0, :]))[0], 0.5)
+
+    # Both names are the same parameter, so supplying both must raise:
+    for params in ({'xystep': 1, 'step': 2}, {'step': 2, 'xystep': 1}):
+        with pytest.raises(TypeError, match="same parameter"):
+            DynaphosModel(**params)
+
+    # The new name stays silent:
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", DeprecationWarning)
+        model = DynaphosModel(step=1)
+        model.step = 2
+        npt.assert_almost_equal(model.step, 2)

--- a/pulse2percept/models/granley2021.py
+++ b/pulse2percept/models/granley2021.py
@@ -272,10 +272,17 @@ class BiphasicAxonMapSpatial(AxonMapSpatial):
             A tuple indicating the range of y values to simulate (in degrees of
             visual angle). Negative y values correspond to the superior retina,
             and positive y values to the inferior retina.
-        xystep : int, double, tuple
+        step : int, double, tuple
             Step size for the range of (x,y) values to simulate (in degrees of
             visual angle). For example, to create a grid with x values [0, 0.5, 1]
-            use ``x_range=(0, 1)`` and ``xystep=0.5``.
+            use ``xrange=(0, 1)`` and ``step=0.5``. Pass a tuple to give the x
+            and y axes different step sizes.
+
+            .. versionchanged:: 0.10.0
+
+                Renamed from ``xystep``, which suggested that one step size
+                applies to both axes. The old name still works, but is
+                deprecated and will be removed in v0.11.0.
         grid_type : {'rectangular', 'hexagonal'}
             Whether to simulate points on a rectangular or hexagonal grid
         vfmap : :py:class:`~pulse2percept.topography.VisualFieldMap`, optional
@@ -665,10 +672,17 @@ class BiphasicAxonMapModel(Model):
             A tuple indicating the range of y values to simulate (in degrees of
             visual angle). Negative y values correspond to the superior retina,
             and positive y values to the inferior retina.
-        xystep : int, double, tuple
+        step : int, double, tuple
             Step size for the range of (x,y) values to simulate (in degrees of
             visual angle). For example, to create a grid with x values [0, 0.5, 1]
-            use ``x_range=(0, 1)`` and ``xystep=0.5``.
+            use ``xrange=(0, 1)`` and ``step=0.5``. Pass a tuple to give the x
+            and y axes different step sizes.
+
+            .. versionchanged:: 0.10.0
+
+                Renamed from ``xystep``, which suggested that one step size
+                applies to both axes. The old name still works, but is
+                deprecated and will be removed in v0.11.0.
         grid_type : {'rectangular', 'hexagonal'}
             Whether to simulate points on a rectangular or hexagonal grid
         vfmap : :py:class:`~pulse2percept.topography.VisualFieldMap`, optional

--- a/pulse2percept/models/tests/test_base.py
+++ b/pulse2percept/models/tests/test_base.py
@@ -12,8 +12,8 @@ from pulse2percept.implants import ArgusI, ArgusII
 from pulse2percept.stimuli import (AmplitudeEncoder, BiphasicPulseTrain,
                                    ImageStimulus, Stimulus, VideoStimulus)
 from pulse2percept.percepts import Percept
-from pulse2percept.models import (BaseModel, FadingTemporal, Model,
-                                  NotBuiltError, ScoreboardSpatial,
+from pulse2percept.models import (AxonMapSpatial, BaseModel, FadingTemporal,
+                                  Model, NotBuiltError, ScoreboardSpatial,
                                   SpatialModel, TemporalModel)
 from pulse2percept.units import (DimensionMismatchError, Quantity,
                                  dimensionless, dva, mA, mm, ms, s, uA, um,
@@ -265,6 +265,39 @@ def test_SpatialModel_deprecated_xystep(composite):
         npt.assert_almost_equal(model.step, 3)
         model.build(step=4)
         npt.assert_almost_equal(model.step, 4)
+
+
+@pytest.mark.parametrize('old, new', [('xystep', 'step'), ('axlambda', 'lam')])
+def test_Model_renamed_param_warns_once_for_a_class(old, new):
+    """A sub-model passed as a class is still only one use of the old name
+
+    `Model` accepts a class where it documents an instance, and then builds it
+    from the same ``params`` dict that `set_params` receives. Both of those
+    rewrite renamed parameters, so the old name reaches the machinery twice
+    even though the caller wrote it once.
+    """
+    for spatial in (AxonMapSpatial, AxonMapSpatial()):
+        with pytest.warns(DeprecationWarning) as record:
+            model = Model(spatial=spatial, **{old: 400})
+        deprecations = [w for w in record
+                        if issubclass(w.category, DeprecationWarning)]
+        npt.assert_equal(len(deprecations), 1)
+        # The message names the model the caller actually constructed, and
+        # points at the line that named the old parameter:
+        npt.assert_equal(f"The '{old}' parameter of Model is deprecated"
+                         in str(deprecations[0].message), True)
+        npt.assert_equal(deprecations[0].filename, __file__)
+        npt.assert_almost_equal(getattr(model, new), 400)
+
+        # Both names are still the same parameter through this path:
+        with pytest.raises(TypeError, match="same parameter"):
+            Model(spatial=spatial, **{old: 400, new: 500})
+
+        # ...and the new name stays silent:
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", DeprecationWarning)
+            npt.assert_almost_equal(
+                getattr(Model(spatial=spatial, **{new: 500}), new), 500)
 
 
 @pytest.mark.parametrize('composite', [False, True])

--- a/pulse2percept/models/tests/test_base.py
+++ b/pulse2percept/models/tests/test_base.py
@@ -19,6 +19,7 @@ from pulse2percept.units import (DimensionMismatchError, Quantity,
                                  dimensionless, dva, mA, mm, ms, s, uA, um,
                                  us)
 from pulse2percept.utils import FreezeError, frame_interval
+from pulse2percept.utils.testing import assert_warns_msg
 from pulse2percept.topography import Grid2D, Watson2014Map
 
 
@@ -84,10 +85,10 @@ def test_SpatialModel():
     npt.assert_equal(isinstance(model.grid.ret.x, np.ndarray), True)
 
     # Can overwrite default values:
-    model = ValidSpatialModel(xystep=1.234)
-    npt.assert_almost_equal(model.xystep, 1.234)
-    model.build(xystep=2.345)
-    npt.assert_almost_equal(model.xystep, 2.345)
+    model = ValidSpatialModel(step=1.234)
+    npt.assert_almost_equal(model.step, 1.234)
+    model.build(step=2.345)
+    npt.assert_almost_equal(model.step, 2.345)
 
     # Cannot add more attributes:
     with pytest.raises(AttributeError):
@@ -136,7 +137,7 @@ def test_SpatialModel_predict_percept_time_order():
             # so the caller can tell which frame ended up where:
             return np.tile(stim.data[0], (self.grid.x.size, 1))
 
-    model = RecordingSpatialModel(xystep=2).build()
+    model = RecordingSpatialModel(step=2).build()
     # Amplitudes chosen so that sorting the frames by value shuffles them with
     # respect to time (sorted: 1, 2, 3 -> frames 1, 2, 0):
     implant = ArgusI(stim={'A1': [3, 1, 2]})
@@ -165,7 +166,7 @@ def test_SpatialModel_predict_percept_deduplicates_frames():
             n_calls.append(stim.data.shape[1])
             return np.tile(stim.data[0], (self.grid.x.size, 1))
 
-    model = CountingSpatialModel(xystep=2).build()
+    model = CountingSpatialModel(step=2).build()
     # Four time points, but only two distinct frames:
     implant = ArgusI(stim={'A1': [2, 5, 2, 5]})
     percept = model.predict_percept(implant)
@@ -190,7 +191,7 @@ def test_SpatialModel_predict_percept_keeps_metadata():
             return np.zeros((self.grid.x.size, stim.data.shape[1]),
                             dtype=np.float32)
 
-    model = RecordingSpatialModel(xystep=2).build()
+    model = RecordingSpatialModel(step=2).build()
     implant = ArgusI(stim={'A1': BiphasicPulseTrain(20, 10, 0.45,
                                                     stim_dur=20)})
     model.predict_percept(implant)
@@ -214,6 +215,115 @@ def test_SpatialModel_removed_params(param, value):
         ValidSpatialModel(**{param: value})
     with pytest.raises(AttributeError):
         ValidSpatialModel().set_params(**{param: value})
+
+
+@pytest.mark.parametrize('composite', [False, True])
+def test_SpatialModel_deprecated_xystep(composite):
+    # `step` was called `xystep` until 0.10.0. The old name still works
+    # everywhere the new one does, but warns:
+    def make(**params):
+        if composite:
+            return Model(spatial=ValidSpatialModel(), **params)
+        return ValidSpatialModel(**params)
+
+    msg = "The 'xystep' parameter of"
+    assert_warns_msg(DeprecationWarning, make, msg, xystep=2)
+    with pytest.warns(DeprecationWarning):
+        model = make(xystep=2)
+    npt.assert_almost_equal(model.step, 2)
+
+    # Setting and getting the attribute:
+    assert_warns_msg(DeprecationWarning, setattr, msg, model, 'xystep', 3)
+    npt.assert_almost_equal(model.step, 3)
+    with pytest.warns(DeprecationWarning):
+        npt.assert_almost_equal(model.xystep, 3)
+
+    # And `set_params` and `build`. `Model.set_params` takes a dict, whereas
+    # `SpatialModel.set_params` takes keyword arguments:
+    if composite:
+        set_params = lambda: model.set_params({'xystep': 4})
+    else:
+        set_params = lambda: model.set_params(xystep=4)
+    assert_warns_msg(DeprecationWarning, set_params, msg)
+    npt.assert_almost_equal(model.step, 4)
+    assert_warns_msg(DeprecationWarning, model.build, msg, xystep=5)
+    npt.assert_almost_equal(model.step, 5)
+    # The grid really was laid out at the value the old name carried:
+    npt.assert_almost_equal(np.unique(np.diff(model.grid.x[0, :]))[0], 5)
+
+    # The old name is still a per-axis step, which is the whole reason it
+    # reads poorly:
+    with pytest.warns(DeprecationWarning):
+        model = make(xystep=(2, 4))
+    npt.assert_almost_equal(model.step, (2, 4))
+
+    # The new name stays silent:
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", DeprecationWarning)
+        model = make(step=2)
+        model.step = 3
+        npt.assert_almost_equal(model.step, 3)
+        model.build(step=4)
+        npt.assert_almost_equal(model.step, 4)
+
+
+@pytest.mark.parametrize('composite', [False, True])
+def test_SpatialModel_xystep_and_step_collide(composite):
+    # `xystep` and `step` are the same parameter, so supplying both must raise
+    # rather than let the order they were passed in decide the value.
+    # `**kwargs` preserves insertion order, so check both spellings:
+    for params in ({'xystep': 2, 'step': 3}, {'step': 3, 'xystep': 2}):
+        with pytest.raises(TypeError, match="same parameter"):
+            if composite:
+                Model(spatial=ValidSpatialModel(), **params)
+            else:
+                ValidSpatialModel(**params)
+        model = (Model(spatial=ValidSpatialModel()) if composite
+                 else ValidSpatialModel())
+        with pytest.raises(TypeError, match="same parameter"):
+            model.build(**params)
+        with pytest.raises(TypeError, match="same parameter"):
+            if composite:
+                model.set_params(params)
+            else:
+                model.set_params(**params)
+
+
+@pytest.mark.parametrize('composite', [False, True])
+def test_SpatialModel_xystep_warning_blames_caller(composite):
+    # A deprecation warning is only actionable if it points at the line that
+    # used the old name. The alias is reached directly on a spatial model, but
+    # through `Model.__getattr__`/`__setattr__` on a composite one:
+    model = (Model(spatial=ValidSpatialModel()) if composite
+             else ValidSpatialModel())
+    with pytest.warns(DeprecationWarning) as record:
+        model.xystep
+    npt.assert_equal(record[0].filename, __file__)
+    with pytest.warns(DeprecationWarning) as record:
+        model.xystep = 2
+    npt.assert_equal(record[0].filename, __file__)
+    # The constructor reaches it through a chain of `super().__init__` calls
+    # instead, whose depth differs between the two classes:
+    with pytest.warns(DeprecationWarning) as record:
+        if composite:
+            Model(spatial=ValidSpatialModel(), xystep=2)
+        else:
+            ValidSpatialModel(xystep=2)
+    npt.assert_equal(record[0].filename, __file__)
+
+
+def test_SpatialModel_xystep_units():
+    # The old name forwards to `step`, so it is normalized the same way:
+    with pytest.warns(DeprecationWarning):
+        model = ValidSpatialModel(xystep=0.5 * dva)
+    npt.assert_almost_equal(model.step, 0.5)
+    npt.assert_equal(isinstance(model.step, Quantity), False)
+    with pytest.warns(DeprecationWarning):
+        model.xystep = 1 * dva
+    npt.assert_almost_equal(model.step, 1)
+    with pytest.raises(DimensionMismatchError):
+        with pytest.warns(DeprecationWarning):
+            ValidSpatialModel(xystep=1 * um)
 
 
 @pytest.mark.parametrize('param, value', [('engine', 'serial'),
@@ -332,20 +442,20 @@ def test_Model_units():
 def test_SpatialModel_units():
     # A range can be given as a quantity wrapping a pair...
     model = ScoreboardSpatial(xrange=(-5, 5) * dva, yrange=(-4, 4) * dva,
-                              xystep=1 * dva)
+                              step=1 * dva)
     npt.assert_almost_equal(model.xrange, [-5, 5])
     npt.assert_almost_equal(model.yrange, [-4, 4])
-    npt.assert_almost_equal(model.xystep, 1)
+    npt.assert_almost_equal(model.step, 1)
     # ... or as a pair of quantities, which keeps the tuple it was given:
     model = ScoreboardSpatial(xrange=(-5 * dva, 5 * dva))
     npt.assert_equal(model.xrange, (-5, 5))
     # Either way it grids identically to the bare-number spelling:
-    bare = ScoreboardSpatial(xrange=(-5, 5), yrange=(-5, 5), xystep=1).build()
+    bare = ScoreboardSpatial(xrange=(-5, 5), yrange=(-5, 5), step=1).build()
     for unitful in (ScoreboardSpatial(xrange=(-5, 5) * dva,
-                                      yrange=(-5, 5) * dva, xystep=1 * dva),
+                                      yrange=(-5, 5) * dva, step=1 * dva),
                     ScoreboardSpatial(xrange=(-5 * dva, 5 * dva),
                                       yrange=(-5 * dva, 5 * dva),
-                                      xystep=1 * dva)):
+                                      step=1 * dva)):
         unitful.build()
         npt.assert_almost_equal(bare.grid.x, unitful.grid.x)
         npt.assert_almost_equal(bare.grid.y, unitful.grid.y)
@@ -526,11 +636,11 @@ def test_Model():
     model = Model(spatial=ValidSpatialModel())
     npt.assert_equal(model.has_space, True)
     npt.assert_equal(model.has_time, False)
-    npt.assert_almost_equal(model.xystep, 0.25)
-    npt.assert_almost_equal(model.spatial.xystep, 0.25)
-    model.xystep = 2
-    npt.assert_almost_equal(model.xystep, 2)
-    npt.assert_almost_equal(model.spatial.xystep, 2)
+    npt.assert_almost_equal(model.step, 0.25)
+    npt.assert_almost_equal(model.spatial.step, 0.25)
+    model.step = 2
+    npt.assert_almost_equal(model.step, 2)
+    npt.assert_almost_equal(model.spatial.step, 2)
     # Cannot add more attributes:
     with pytest.raises(AttributeError):
         model.a
@@ -556,14 +666,14 @@ def test_Model():
     model = Model(spatial=ValidSpatialModel(), temporal=ValidTemporalModel())
     npt.assert_equal(model.has_space, True)
     npt.assert_equal(model.has_time, True)
-    npt.assert_almost_equal(model.xystep, 0.25)
-    npt.assert_almost_equal(model.spatial.xystep, 0.25)
+    npt.assert_almost_equal(model.step, 0.25)
+    npt.assert_almost_equal(model.spatial.step, 0.25)
     npt.assert_almost_equal(model.dt, 5e-3)
     npt.assert_almost_equal(model.temporal.dt, 5e-3)
     # Setting a new spatial parameter:
-    model.xystep = 2
-    npt.assert_almost_equal(model.xystep, 2)
-    npt.assert_almost_equal(model.spatial.xystep, 2)
+    model.step = 2
+    npt.assert_almost_equal(model.step, 2)
+    npt.assert_almost_equal(model.spatial.step, 2)
     # Setting a new temporal parameter:
     model.dt = 1
     npt.assert_almost_equal(model.dt, 1)
@@ -583,9 +693,9 @@ def test_Model():
 def test_Model_set_params():
     # SpatialModel, but no TemporalModel:
     model = Model(spatial=ValidSpatialModel())
-    model.set_params({'xystep': 2.33})
-    npt.assert_almost_equal(model.xystep, 2.33)
-    npt.assert_almost_equal(model.spatial.xystep, 2.33)
+    model.set_params({'step': 2.33})
+    npt.assert_almost_equal(model.step, 2.33)
+    npt.assert_almost_equal(model.spatial.step, 2.33)
 
     # TemporalModel, but no SpatialModel:
     model = Model(temporal=ValidTemporalModel())
@@ -596,10 +706,10 @@ def test_Model_set_params():
     # SpatialModel and TemporalModel:
     model = Model(spatial=ValidSpatialModel(), temporal=ValidTemporalModel())
     # Setting both using the convenience function:
-    model.set_params({'xystep': 5, 'dt': 2.33})
-    npt.assert_almost_equal(model.xystep, 5)
-    npt.assert_almost_equal(model.spatial.xystep, 5)
-    npt.assert_equal(hasattr(model.temporal, 'xystep'), False)
+    model.set_params({'step': 5, 'dt': 2.33})
+    npt.assert_almost_equal(model.step, 5)
+    npt.assert_almost_equal(model.spatial.step, 5)
+    npt.assert_equal(hasattr(model.temporal, 'step'), False)
     npt.assert_almost_equal(model.dt, 2.33)
     npt.assert_almost_equal(model.temporal.dt, 2.33)
     npt.assert_equal(hasattr(model.spatial, 'dt'), False)
@@ -699,7 +809,7 @@ def test_Model_predict_percept_frame_clock(fps):
     # real models: `ValidTemporalModel` returns one row per electrode, not one
     # per grid point, so it cannot consume a spatial percept.
     both = Model(spatial=ScoreboardSpatial(xrange=(-2, 2), yrange=(-2, 2),
-                                           xystep=1),
+                                           step=1),
                  temporal=FadingTemporal()).build()
     npt.assert_equal(both.predict_percept(implant).data.shape[-1], 6)
     # An explicit `t_percept` still wins:
@@ -810,7 +920,7 @@ class ScalingTemporalModel(ValidTemporalModel):
 
 
 def test_SpatialModel_find_threshold():
-    model = ScalingSpatialModel(xystep=5).build()
+    model = ScalingSpatialModel(step=5).build()
     implant = ArgusI(stim={'A1': 1})
 
     # Brightness equals amplitude, so the threshold is the target brightness:
@@ -834,7 +944,7 @@ def test_TemporalModel_find_threshold():
 
 
 def test_Model_find_threshold():
-    model = Model(spatial=ScalingSpatialModel(xystep=5)).build()
+    model = Model(spatial=ScalingSpatialModel(step=5)).build()
     implant = ArgusI(stim={'A1': 1})
 
     npt.assert_almost_equal(model.find_threshold(implant, 20), 20, decimal=0)
@@ -928,7 +1038,7 @@ def test_Model_pprint_params():
     npt.assert_equal('spatial' in params, True)
     npt.assert_equal('temporal' in params, True)
     # Parameters of the sub-models are pulled up:
-    npt.assert_equal('xystep' in params, True)
+    npt.assert_equal('step' in params, True)
     npt.assert_equal('dt' in params, True)
     npt.assert_equal(isinstance(str(both), str), True)
 
@@ -948,24 +1058,24 @@ def test_Model_deepcopy_preserves_submodels_and_params():
     # Model parameters are forwarded to the sub-models, so they live in
     # `spatial`/`temporal` rather than in `Model.__dict__`. Rebuilding the
     # copy from the constructor alone would silently reset them to defaults:
-    model = Model(spatial=ValidSpatialModel(xystep=5, thresh_percept=0.5))
+    model = Model(spatial=ValidSpatialModel(step=5, thresh_percept=0.5))
     copied = copy.deepcopy(model)
-    npt.assert_almost_equal(copied.xystep, 5)
+    npt.assert_almost_equal(copied.step, 5)
     npt.assert_almost_equal(copied.thresh_percept, 0.5)
     npt.assert_equal(copied == model, True)
 
     # The copy is independent of the original:
-    copied.xystep = 3
-    npt.assert_almost_equal(model.xystep, 5)
+    copied.step = 3
+    npt.assert_almost_equal(model.step, 5)
 
     # A built model stays built:
-    built = Model(spatial=ValidSpatialModel(xystep=5)).build()
+    built = Model(spatial=ValidSpatialModel(step=5)).build()
     npt.assert_equal(copy.deepcopy(built).is_built, True)
 
 
 def test_model_unit_contract():
     """Every model states the units its numerical implementation works in"""
-    spatial = ScoreboardSpatial(xrange=(-2, 2), yrange=(-2, 2), xystep=1)
+    spatial = ScoreboardSpatial(xrange=(-2, 2), yrange=(-2, 2), step=1)
     temporal = FadingTemporal()
     for model in (spatial, temporal, Model(spatial=spatial),
                   Model(spatial=spatial, temporal=temporal)):
@@ -987,7 +1097,7 @@ def test_model_electrode_coords_follow_the_stimulus():
     coordinates up by name rather than taking the array as it stands.
     """
     implant = ArgusII()
-    model = ScoreboardSpatial(xrange=(-2, 2), yrange=(-2, 2), xystep=1)
+    model = ScoreboardSpatial(xrange=(-2, 2), yrange=(-2, 2), step=1)
     # A subset, in an order that is not the array's:
     stim = Stimulus({'F10': 1, 'A1': 2, 'C5': 3})
     x, y, z = model._electrode_coords(implant.earray, stim)
@@ -1011,10 +1121,10 @@ def test_model_t_percept_units():
     """`t_percept` is a time, spelled however the caller likes"""
     implant = ArgusII(stim=BiphasicPulseTrain(20, 50, 0.45, stim_dur=100))
     spatial = ScoreboardSpatial(xrange=(-2, 2), yrange=(-2, 2),
-                                xystep=1).build()
+                                step=1).build()
     temporal = FadingTemporal().build()
     composite = Model(spatial=ScoreboardSpatial(xrange=(-2, 2), yrange=(-2, 2),
-                                                xystep=1),
+                                                step=1),
                       temporal=FadingTemporal()).build()
     for model, stim in [(spatial, implant), (temporal, implant.stim),
                         (composite, implant)]:
@@ -1036,9 +1146,9 @@ def test_model_find_threshold_units():
     implant = ArgusII(stim={'A1': BiphasicPulseTrain(20, 20, 0.45,
                                                      stim_dur=100)})
     spatial = ScoreboardSpatial(xrange=(-2, 2), yrange=(-2, 2),
-                                xystep=1).build()
+                                step=1).build()
     composite = Model(spatial=ScoreboardSpatial(xrange=(-2, 2), yrange=(-2, 2),
-                                                xystep=1)).build()
+                                                step=1)).build()
     for model in (spatial, composite):
         bare = model.find_threshold(implant, 0.1, amp_range=(0, 200),
                                     amp_tol=1)
@@ -1072,10 +1182,10 @@ def test_model_requires_a_current_stimulus():
     """
     img = ImageStimulus(np.linspace(0, 1, 16).reshape((4, 4)))
     spatial = ScoreboardSpatial(xrange=(-2, 2), yrange=(-2, 2),
-                                xystep=1).build()
+                                step=1).build()
     temporal = FadingTemporal().build()
     composite = Model(spatial=ScoreboardSpatial(xrange=(-2, 2), yrange=(-2, 2),
-                                                xystep=1),
+                                                step=1),
                       temporal=FadingTemporal()).build()
     # `implant.stim = img` stays legal (see `check_stim`), and it is the model
     # that refuses to read it:
@@ -1149,8 +1259,8 @@ def test_model_units_are_a_numerical_contract():
                     electrodes=['A1'], time=np.arange(10, dtype=float))
     implant = ArgusII(stim=ramp)
     canonical = RecordingSpatial(xrange=(-2, 2), yrange=(-2, 2),
-                                 xystep=1).build()
-    milli = MilliSpatial(xrange=(-2, 2), yrange=(-2, 2), xystep=1).build()
+                                 step=1).build()
+    milli = MilliSpatial(xrange=(-2, 2), yrange=(-2, 2), step=1).build()
     canonical.predict_percept(implant)
     milli.predict_percept(implant)
     a, m = canonical.seen, milli.seen
@@ -1228,7 +1338,7 @@ def test_percept_time_crosses_model_boundary():
     ramp = Stimulus(np.arange(21, dtype=float).reshape((1, -1)),
                     electrodes=['A1'], time=np.arange(21, dtype=float))
     implant = ArgusII(stim=ramp)
-    spatial = SecondSpatial(xrange=(-2, 2), yrange=(-2, 2), xystep=1).build()
+    spatial = SecondSpatial(xrange=(-2, 2), yrange=(-2, 2), step=1).build()
     temporal = MilliTemporal().build()
     npt.assert_equal(spatial.time_unit, s)
     npt.assert_equal(temporal.time_unit, ms)
@@ -1255,7 +1365,7 @@ def test_percept_time_crosses_model_boundary():
 
     # The same crossing through a composite, which is where it really happens:
     model = Model(spatial=SecondSpatial(xrange=(-2, 2), yrange=(-2, 2),
-                                        xystep=1),
+                                        step=1),
                   temporal=MilliTemporal()).build()
     # A composite reports the unit of the stage that reads `t_percept` and
     # writes the percept, which is the temporal model:

--- a/pulse2percept/models/tests/test_beyeler2019.py
+++ b/pulse2percept/models/tests/test_beyeler2019.py
@@ -27,7 +27,7 @@ pytestmark = pytest.mark.usefixtures('axon_cache_in_tmp')
 
 def test_ScoreboardSpatial():
     # ScoreboardSpatial automatically sets `rho`:
-    model = ScoreboardSpatial(xystep=5)
+    model = ScoreboardSpatial(step=5)
 
     # User can set `rho`:
     model.rho = 123
@@ -54,7 +54,7 @@ def test_ScoreboardSpatial():
     npt.assert_almost_equal(percept.data, 0)
 
     # Multiple frames are processed independently:
-    model = ScoreboardSpatial(rho=200, xystep=5,
+    model = ScoreboardSpatial(rho=200, step=5,
                               xrange=(-20, 20), yrange=(-15, 15))
     model.build()
     percept = model.predict_percept(ArgusI(stim={'A1': [1, 0], 'B3': [0, 2]}))
@@ -91,7 +91,7 @@ def test_deepcopy_ScoreboardSpatial():
 
 def test_ScoreboardModel():
     # ScoreboardModel automatically sets `rho`:
-    model = ScoreboardModel(xystep=5)
+    model = ScoreboardModel(step=5)
     npt.assert_equal(model.has_space, True)
     npt.assert_equal(model.has_time, False)
     npt.assert_equal(hasattr(model.spatial, 'rho'), True)
@@ -119,7 +119,7 @@ def test_ScoreboardModel():
     npt.assert_almost_equal(model.predict_percept(implant).data, 0)
 
     # Multiple frames are processed independently:
-    model = ScoreboardModel(rho=200, xystep=5,
+    model = ScoreboardModel(rho=200, step=5,
                             xrange=(-20, 20), yrange=(-15, 15))
     model.build()
     percept = model.predict_percept(ArgusI(stim={'A1': [1, 2]}))
@@ -154,7 +154,7 @@ def test_deepcopy_ScoreboardModel():
 
 
 def test_ScoreboardModel_predict_percept():
-    model = ScoreboardModel(xystep=0.55, rho=100, thresh_percept=0,
+    model = ScoreboardModel(step=0.55, rho=100, thresh_percept=0,
                             xrange=(-20, 20), yrange=(-15, 15))
     model.build()
     # Single-electrode stim:
@@ -170,14 +170,14 @@ def test_ScoreboardModel_predict_percept():
     npt.assert_almost_equal(percept.data[33, 46, 0], np.max(percept.data))
 
     # Full Argus II: 60 bright spots
-    model = ScoreboardModel(xystep=0.55, rho=100)
+    model = ScoreboardModel(step=0.55, rho=100)
     model.build()
     percept = model.predict_percept(ArgusII(stim=np.ones(60)))
     npt.assert_equal(np.sum(np.isclose(percept.data, 0.8, rtol=0.1, atol=0.1)),
                      88)
 
     # Model gives same outcome as Spatial:
-    spatial = ScoreboardSpatial(xystep=1, rho=100)
+    spatial = ScoreboardSpatial(step=1, rho=100)
     spatial.build()
     spatial_percept = model.predict_percept(ArgusII(stim=np.ones(60)))
     npt.assert_almost_equal(percept.data, spatial_percept.data)
@@ -192,7 +192,7 @@ def test_ScoreboardModel_predict_percept():
 
 def test_AxonMapSpatial():
     # AxonMapSpatial automatically sets `rho`, `lam`:
-    model = AxonMapSpatial(xystep=5)
+    model = AxonMapSpatial(step=5)
 
     # User can set `rho`:
     model.rho = 123
@@ -224,7 +224,7 @@ def test_AxonMapSpatial():
         AxonMapSpatial(lam=9).build()
 
     # Multiple frames are processed independently:
-    model = AxonMapSpatial(rho=200, lam=100, xystep=5,
+    model = AxonMapSpatial(rho=200, lam=100, step=5,
                            xrange=(-20, 20), yrange=(-15, 15))
     model.build()
     percept = model.predict_percept(ArgusI(stim={'A1': [1, 0], 'B3': [0, 2]}))
@@ -290,7 +290,7 @@ def test_AxonMapSpatial_plot():
 
 
 def test_AxonMapModel():
-    set_params = {'xystep': 2, 'rho': 432, 'lam': 20,
+    set_params = {'step': 2, 'rho': 432, 'lam': 20,
                   'n_axons': 9, 'n_ax_segments': 50,
                   'xrange': (-30, 30), 'yrange': (-20, 20),
                   'loc_od': (5, 6)}
@@ -328,7 +328,7 @@ def test_AxonMapModel():
     with pytest.raises(ValueError):
         AxonMapModel(eye='invalid').build()
     with pytest.raises(ValueError):
-        AxonMapModel(xystep=5).build(eye='invalid')
+        AxonMapModel(step=5).build(eye='invalid')
 
     # Lambda cannot be too small:
     with pytest.raises(ValueError):
@@ -382,7 +382,7 @@ def test_AxonMap_axlambda_and_lam_collide(cls):
                    {'lam': 500, 'axlambda': 400}):
         with pytest.raises(TypeError, match="same parameter"):
             cls(**params)
-        model = cls(xystep=5)
+        model = cls(step=5)
         with pytest.raises(TypeError, match="same parameter"):
             model.build(**params)
         with pytest.raises(TypeError, match="same parameter"):
@@ -398,7 +398,7 @@ def test_AxonMap_axlambda_warning_blames_caller(cls):
     # used the old name. The alias is reached directly on a spatial model, but
     # through `Model.__getattr__`/`__setattr__` on a composite one, so the
     # attribution has to hold for both:
-    model = cls(xystep=5)
+    model = cls(step=5)
     with pytest.warns(DeprecationWarning) as record:
         model.axlambda
     npt.assert_equal(record[0].filename, __file__)
@@ -447,7 +447,7 @@ def test_deepcopy_AxonMapModel(build):
 def test_AxonMapModel__jansonius2009(eye, loc_od, sign):
     # With `rho` starting at 0, all axons should originate in the optic disc
     # center
-    model = AxonMapModel(loc_od=loc_od, xystep=2,
+    model = AxonMapModel(loc_od=loc_od, step=2,
                          ax_segments_range=(0, 45),
                          n_ax_segments=100)
     for phi0 in [-135.0, 66.0, 128.0]:
@@ -457,7 +457,7 @@ def test_AxonMapModel__jansonius2009(eye, loc_od, sign):
 
     # These axons should all end at the meridian
     for phi0 in [110.0, 135.0, 160.0]:
-        model = AxonMapModel(loc_od=(15, 2), xystep=2,
+        model = AxonMapModel(loc_od=(15, 2), step=2,
                              n_ax_segments=801,
                              ax_segments_range=(0, 45))
         ax_pos = model.spatial._jansonius2009(sign * phi0)
@@ -466,28 +466,28 @@ def test_AxonMapModel__jansonius2009(eye, loc_od, sign):
     # `phi0` must be within [-180, 180]
     for phi0 in [-200.0, 181.0]:
         with pytest.raises(ValueError):
-            failed = AxonMapModel(xystep=2)
+            failed = AxonMapModel(step=2)
             failed.spatial._jansonius2009(phi0)
 
     # `n_rho` must be >= 1
     for n_rho in [-1, 0]:
         with pytest.raises(ValueError):
-            model = AxonMapModel(n_ax_segments=n_rho, xystep=2)
+            model = AxonMapModel(n_ax_segments=n_rho, step=2)
             model.spatial._jansonius2009(0.0)
 
     # `ax_segments_range` must have min <= max
     for lorho in [-200.0, 90.0]:
         with pytest.raises(ValueError):
-            model = AxonMapModel(ax_segments_range=(lorho, 45), xystep=2)
+            model = AxonMapModel(ax_segments_range=(lorho, 45), step=2)
             model.spatial._jansonius2009(0)
     for hirho in [-200.0, 40.0]:
         with pytest.raises(ValueError):
-            model = AxonMapModel(ax_segments_range=(45, hirho), xystep=2)
+            model = AxonMapModel(ax_segments_range=(45, hirho), step=2)
             model.spatial._jansonius2009(0)
 
     # A single axon fiber with `phi0`=0 should return a single pixel location
     # that corresponds to the optic disc
-        model = AxonMapModel(loc_od=loc_od, xystep=2, eye=eye,
+        model = AxonMapModel(loc_od=loc_od, step=2, eye=eye,
                              ax_segments_range=(0, 0),
                              n_ax_segments=1)
         single_fiber = model.spatial._jansonius2009(0)
@@ -497,7 +497,7 @@ def test_AxonMapModel__jansonius2009(eye, loc_od, sign):
 
 def test_AxonMapModel_grow_axon_bundles():
     for n_axons in [1, 2, 3, 5, 10]:
-        model = AxonMapModel(xystep=2, n_axons=n_axons,
+        model = AxonMapModel(step=2, n_axons=n_axons,
                              axons_range=(-20, 20), xrange=(-20, 20),
                              yrange=(-15, 15))
         bundles = model.spatial.grow_axon_bundles()
@@ -505,7 +505,7 @@ def test_AxonMapModel_grow_axon_bundles():
 
 
 def test_AxonMapModel_find_closest_axon():
-    model = AxonMapModel(xystep=1, n_axons=5,
+    model = AxonMapModel(step=1, n_axons=5,
                          xrange=(-20, 20), yrange=(-15, 15),
                          axons_range=(-45, 45))
     model.build()
@@ -566,7 +566,7 @@ def test_AxonMapModel_find_closest_axon_respects_n_threads(monkeypatch,
 
 
 def test_AxonMapModel_calc_axon_sensitivity():
-    model = AxonMapModel(xystep=2, n_axons=10,
+    model = AxonMapModel(step=2, n_axons=10,
                          xrange=(-20, 20), yrange=(-15, 15),
                          axons_range=(-30, 30))
     model.build()
@@ -599,7 +599,7 @@ def test_AxonMapModel_calc_axon_sensitivity():
 def test_AxonMapModel_calc_axon_sensitivity_removed_pad():
     # 'pad' used to pad all axons to the length of the longest one for the
     # (now removed) jax backend. Deprecated in 0.9.1, removed in 0.10.0:
-    model = AxonMapModel(xystep=2, n_axons=10, xrange=(-20, 20),
+    model = AxonMapModel(step=2, n_axons=10, xrange=(-20, 20),
                          yrange=(-15, 15), axons_range=(-30, 30))
     model.build()
     axons = model.spatial.find_closest_axon(model.spatial.grow_axon_bundles())
@@ -608,7 +608,7 @@ def test_AxonMapModel_calc_axon_sensitivity_removed_pad():
 
 
 def test_AxonMapModel_calc_bundle_tangent():
-    model = AxonMapModel(xystep=5, n_axons=500,
+    model = AxonMapModel(step=5, n_axons=500,
                          xrange=(-20, 20), yrange=(-15, 15),
                          n_ax_segments=500, axons_range=(-180, 180),
                          ax_segments_range=(3, 50))
@@ -623,7 +623,7 @@ def test_AxonMapModel_calc_bundle_tangent():
 
 
 def test_AxonMapModel_calc_bundle_tangent_fast():
-    model = AxonMapModel(xystep=5, n_axons=500,
+    model = AxonMapModel(step=5, n_axons=500,
                          xrange=(-20, 20), yrange=(-15, 15),
                          n_ax_segments=500, axons_range=(-180, 180),
                          ax_segments_range=(3, 50))
@@ -638,7 +638,7 @@ def test_AxonMapModel_calc_bundle_tangent_fast():
 
 
 def test_AxonMapModel_predict_percept():
-    model = AxonMapModel(xystep=0.55, lam=100, rho=100,
+    model = AxonMapModel(step=0.55, lam=100, rho=100,
                          thresh_percept=0,
                          xrange=(-20, 20), yrange=(-15, 15),
                          n_axons=500)
@@ -662,7 +662,7 @@ def test_AxonMapModel_predict_percept():
     npt.assert_almost_equal(np.sum(percept.data[39:, :, 0]), 0)
 
     # Full Argus II with small lambda: 60 bright spots
-    model = AxonMapModel(xystep=1, rho=100, lam=40,
+    model = AxonMapModel(step=1, rho=100, lam=40,
                          xrange=(-20, 20), yrange=(-15, 15), n_axons=500)
     model.build()
     percept = model.predict_percept(ArgusII(stim=np.ones(60)))
@@ -672,7 +672,7 @@ def test_AxonMapModel_predict_percept():
     npt.assert_equal(np.sum(percept.data > 0.275), 56)
 
     # Model gives same outcome as Spatial:
-    spatial = AxonMapSpatial(xystep=1, rho=100, lam=40,
+    spatial = AxonMapSpatial(step=1, rho=100, lam=40,
                              xrange=(-20, 20), yrange=(-15, 15), n_axons=500)
     spatial.build()
     spatial_percept = spatial.predict_percept(ArgusII(stim=np.ones(60)))
@@ -699,7 +699,7 @@ def test_min_current_spread(ModelClass):
     stim = np.zeros(60)
     stim[[10, 33, 47]] = [1.0, -0.5, 0.75]
     implant = ArgusII(stim=stim)
-    kwargs = {'xystep': 0.75, 'xrange': (-12, 12), 'yrange': (-8, 8),
+    kwargs = {'step': 0.75, 'xrange': (-12, 12), 'yrange': (-8, 8),
               'rho': 200}
 
     exact = ModelClass(min_current_spread=0,
@@ -735,7 +735,7 @@ def test_min_current_spread_error_bound(ModelClass, amp):
     min_spread = 1e-8
     stim = np.full(60, amp)
     implant = ArgusII(stim=stim)
-    kwargs = {'xystep': 0.75, 'xrange': (-14, 14), 'yrange': (-10, 10),
+    kwargs = {'step': 0.75, 'xrange': (-14, 14), 'yrange': (-10, 10),
               'rho': 200}
 
     exact = ModelClass(min_current_spread=0,
@@ -765,7 +765,7 @@ def test_predict_percept_frames_are_independent(ModelClass):
     """
     rng = np.random.default_rng(42)
     data = rng.normal(size=(60, 4)).astype(np.float32)
-    model = ModelClass(xystep=1, xrange=(-10, 10), yrange=(-8, 8),
+    model = ModelClass(step=1, xrange=(-10, 10), yrange=(-8, 8),
                        rho=200).build()
 
     joint = model.predict_percept(
@@ -785,7 +785,7 @@ def test_predict_percept_all_zero_stim(ModelClass):
     The kernels skip electrodes that are zero for the whole stimulus, so the
     case where *every* electrode is skipped is worth pinning down.
     """
-    model = ModelClass(xystep=1, xrange=(-10, 10), yrange=(-8, 8)).build()
+    model = ModelClass(step=1, xrange=(-10, 10), yrange=(-8, 8)).build()
     percept = model.predict_percept(ArgusII(stim=np.zeros(60)))
     npt.assert_equal(np.all(percept.data == 0), True)
 
@@ -802,7 +802,7 @@ def test_predict_percept_thread_count_invariant(ModelClass):
     stim = np.zeros(60)
     stim[[5, 22, 51]] = [1.0, 0.6, -0.3]
     implant = ArgusII(stim=stim)
-    kwargs = {'xystep': 1, 'xrange': (-10, 10), 'yrange': (-8, 8),
+    kwargs = {'step': 1, 'xrange': (-10, 10), 'yrange': (-8, 8),
               'rho': 200}
 
     serial = ModelClass(n_threads=1,
@@ -815,7 +815,7 @@ def test_predict_percept_thread_count_invariant(ModelClass):
 
 def test_AxonMapModel_find_closest_axon_return_segment():
     """``return_segment`` reports where in the axon the closest point is."""
-    model = AxonMapModel(xystep=2, n_axons=20, xrange=(-12, 12),
+    model = AxonMapModel(step=2, n_axons=20, xrange=(-12, 12),
                          yrange=(-12, 12), axons_range=(-45, 45))
     model.build()
     spatial = model.spatial
@@ -849,7 +849,7 @@ def test_AxonMapModel_find_closest_axon_return_segment():
 
 def test_AxonMapModel_calc_axon_sensitivity_empty_bundle():
     """A bundle with no segments is rejected rather than silently skipped."""
-    model = AxonMapModel(xystep=4, n_axons=5, xrange=(-8, 8), yrange=(-8, 8))
+    model = AxonMapModel(step=4, n_axons=5, xrange=(-8, 8), yrange=(-8, 8))
     model.build()
     n_points = model.spatial.grid.ret.x.size
     bundles = [np.zeros((0, 2), dtype=np.float32)] * n_points
@@ -862,7 +862,7 @@ def test_AxonMapModel_build_cache_roundtrip(tmp_path):
     pickle_file = str(tmp_path / 'axons.pickle')
 
     def build(ignore_pickle):
-        return AxonMapModel(xystep=1, xrange=(-8, 8), yrange=(-8, 8),
+        return AxonMapModel(step=1, xrange=(-8, 8), yrange=(-8, 8),
                             n_axons=200, axon_pickle=pickle_file,
                             ignore_pickle=ignore_pickle).build().spatial
 
@@ -883,4 +883,39 @@ def test_AxonMapModel_build_cache_roundtrip(tmp_path):
     # ...and the file is left in the current format:
     with open(pickle_file, 'rb') as f:
         _, payload = pickle.load(f)
+    npt.assert_equal(payload[0], _AXON_CACHE_VERSION)
+
+
+def test_AxonMapModel_build_rejects_pre_step_cache(tmp_path):
+    """A cache naming the grid step `xystep` is regrown, and stays quiet
+
+    The parameter dict is versioned along with the payload, so a cache written
+    before the rename is discarded outright. Reading it instead would probe
+    `self.xystep` -- a deprecated name the caller never used -- and warn about
+    it on every build, since the stale entry validates and the file is
+    therefore never rewritten.
+    """
+    pickle_file = str(tmp_path / 'axons.pickle')
+
+    def build(ignore_pickle=False):
+        return AxonMapModel(step=1, xrange=(-8, 8), yrange=(-8, 8),
+                            n_axons=200, axon_pickle=pickle_file,
+                            ignore_pickle=ignore_pickle).build().spatial
+
+    cold = build(ignore_pickle=True)
+    with open(pickle_file, 'rb') as f:
+        params, payload = pickle.load(f)
+    # Rewrite it the way v0.9.1 would have:
+    params['xystep'] = params.pop('step')
+    with open(pickle_file, 'wb') as f:
+        pickle.dump((params, (2, *payload[1:])), f)
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", DeprecationWarning)
+        warm = build()
+    npt.assert_array_equal(warm.axon_contrib, cold.axon_contrib)
+    # The stale file was replaced, so the next build is a cache hit:
+    with open(pickle_file, 'rb') as f:
+        params, payload = pickle.load(f)
+    npt.assert_equal('xystep' in params, False)
     npt.assert_equal(payload[0], _AXON_CACHE_VERSION)

--- a/pulse2percept/models/tests/test_end_to_end.py
+++ b/pulse2percept/models/tests/test_end_to_end.py
@@ -97,7 +97,7 @@ def test_endtoend_amplitude_modulation():
     npt.assert_almost_equal(net, 0, decimal=4)
 
     # --- what the model made of it --------------------------------------
-    model = ScoreboardSpatial(xrange=(-4, 4), yrange=(-4, 4), xystep=0.2,
+    model = ScoreboardSpatial(xrange=(-4, 4), yrange=(-4, 4), step=0.2,
                               rho=200).build()
     percept = model.predict_percept(implant)
     here, middle = at_electrodes(model, implant)
@@ -237,7 +237,7 @@ def test_endtoend_raster_order(order):
     # And the percept says the same: the electrodes light up one at a time, in
     # the order the raster puts them in, and each is as bright as its own gray
     # level regardless of when its turn comes.
-    model = ScoreboardSpatial(xrange=(-4, 4), yrange=(-4, 4), xystep=0.2,
+    model = ScoreboardSpatial(xrange=(-4, 4), yrange=(-4, 4), step=0.2,
                               rho=200).build()
     percept = model.predict_percept(implant)
     here, _ = at_electrodes(model, implant)
@@ -307,7 +307,7 @@ def test_endtoend_slow_train_stays_lit_for_the_whole_video():
     npt.assert_almost_equal(onset.max(), 3000.5, decimal=1)
 
     model = Model(spatial=ScoreboardSpatial(xrange=(-12, 12), yrange=(-8, 8),
-                                            xystep=1),
+                                            step=1),
                   temporal=FadingTemporal(tau=100)).build()
     percept = model.predict_percept(implant)
     # One percept frame per video frame, covering the whole video:

--- a/pulse2percept/models/tests/test_granley2021.py
+++ b/pulse2percept/models/tests/test_granley2021.py
@@ -210,7 +210,7 @@ def test_biphasicAxonMapSpatial():
     with pytest.raises(ValueError):
         BiphasicAxonMapSpatial(lam=9).build()
 
-    model = BiphasicAxonMapModel(xystep=2).build()
+    model = BiphasicAxonMapModel(step=2).build()
     # Only accepts biphasic pulse trains with no delay dur
     implant = ArgusI(stim=np.ones(16))
     with pytest.raises(TypeError):
@@ -228,7 +228,7 @@ def test_biphasicAxonMapSpatial():
     npt.assert_equal(percept.time, None)
 
     # Should be equal to axon map model if effects models return 1
-    model = BiphasicAxonMapSpatial(xystep=2)
+    model = BiphasicAxonMapSpatial(step=2)
     def bright_model(freq, amp, pdur): return 1
     def size_model(freq, amp, pdur): return 1
     def streak_model(freq, amp, pdur): return 1
@@ -236,7 +236,7 @@ def test_biphasicAxonMapSpatial():
     model.size_model = size_model
     model.streak_model = streak_model
     model.build()
-    axon_map = AxonMapSpatial(xystep=2).build()
+    axon_map = AxonMapSpatial(step=2).build()
     implant = ArgusII()
     implant.stim = Stimulus({'A5': BiphasicPulseTrain(20, 1, 0.45)})
     percept = model.predict_percept(implant)
@@ -245,13 +245,13 @@ def test_biphasicAxonMapSpatial():
         percept.data[:, :, 0], percept_axon.max(axis='frames'))
 
     # Effect models must be callable
-    model = BiphasicAxonMapSpatial(xystep=2)
+    model = BiphasicAxonMapSpatial(step=2)
     model.bright_model = 1.0
     with pytest.raises(TypeError):
         model.build()
 
     # If t_percept is not specified, there should only be one frame
-    model = BiphasicAxonMapSpatial(xystep=2)
+    model = BiphasicAxonMapSpatial(step=2)
     model.build()
     implant = ArgusII()
     implant.stim = Stimulus({'A5': BiphasicPulseTrain(20, 1, 0.45)})
@@ -266,7 +266,7 @@ def test_biphasicAxonMapSpatial():
 
     # Test that default models give expected values
     model = BiphasicAxonMapSpatial(rho=400, lam=600,
-                                   xystep=1, xrange=(-20, 20), yrange=(-15, 15))
+                                   step=1, xrange=(-20, 20), yrange=(-15, 15))
     model.build()
     implant = ArgusII()
     implant.stim = Stimulus({'A4': BiphasicPulseTrain(20, 1, 1)})
@@ -279,7 +279,7 @@ def test_biphasicAxonMapSpatial():
 
 
 def test_biphasicAxonMapModel():
-    set_params = {'xystep': 2, 'rho': 432, 'lam': 20,
+    set_params = {'step': 2, 'rho': 432, 'lam': 20,
                   'n_axons': 9, 'n_ax_segments': 50,
                   'xrange': (-30, 30), 'yrange': (-20, 20),
                   'loc_od': (5, 6)}
@@ -374,7 +374,7 @@ def test_biphasicAxonMapModel():
     with pytest.raises(ValueError):
         BiphasicAxonMapModel(eye='invalid').build()
     with pytest.raises(ValueError):
-        BiphasicAxonMapModel(xystep=5).build(eye='invalid')
+        BiphasicAxonMapModel(step=5).build(eye='invalid')
 
     # Lambda cannot be too small:
     with pytest.raises(ValueError):
@@ -443,7 +443,7 @@ def test_find_threshold_not_supported(model_cls):
     # the stimulus metadata, so the inherited `find_threshold` - which bisects
     # on a scaled copy of the stimulus data - cannot converge. It has to say
     # so rather than fail somewhere deeper with a confusing message.
-    model = model_cls(xrange=(-3, 3), yrange=(-2, 2), xystep=1,
+    model = model_cls(xrange=(-3, 3), yrange=(-2, 2), step=1,
                       n_ax_segments=30).build()
     implant = ArgusII(stim={'A1': BiphasicPulseTrain(20, 1, 0.45,
                                                      stim_dur=100)})
@@ -466,7 +466,7 @@ def test_scaled_pulse_train_changes_percept(model_cls, compose):
     # train used to deliver twice the current and predict the very same
     # percept. Scaling now updates the metadata, and has to give what building
     # the train at that amplitude in the first place gives:
-    model = model_cls(xrange=(-12, 12), yrange=(-8, 8), xystep=1,
+    model = model_cls(xrange=(-12, 12), yrange=(-8, 8), step=1,
                       n_ax_segments=30).build()
     implant = ArgusII(stim={'C5': BiphasicPulseTrain(20, 1, 0.45,
                                                      stim_dur=100)})
@@ -492,7 +492,7 @@ def test_modified_pulse_train_rejected(model_cls, modify):
     # A DC offset, a non-finite factor and an appended second train all leave
     # something other than a biphasic pulse train. The model must say so rather
     # than predict from pulse parameters that no longer describe the stimulus:
-    model = model_cls(xrange=(-3, 3), yrange=(-2, 2), xystep=1,
+    model = model_cls(xrange=(-3, 3), yrange=(-2, 2), step=1,
                       n_ax_segments=30).build()
     implant = ArgusII(stim={'C5': BiphasicPulseTrain(20, 1, 0.45,
                                                      stim_dur=100)})
@@ -507,7 +507,7 @@ def test_pulse_train_amp_sign_does_not_change_percept():
     # the very same waveform. The model reads `amp` back from the metadata and
     # is a function of it rather than of its magnitude, so the metadata has to
     # store the magnitude - otherwise identical stimuli predict differently:
-    model = BiphasicAxonMapModel(xrange=(-12, 12), yrange=(-8, 8), xystep=1,
+    model = BiphasicAxonMapModel(xrange=(-12, 12), yrange=(-8, 8), step=1,
                                  n_ax_segments=30).build()
     pos = ArgusII(stim={'C5': BiphasicPulseTrain(20, 1, 0.45, stim_dur=100)})
     neg = ArgusII(stim={'C5': BiphasicPulseTrain(20, -1, 0.45, stim_dur=100)})
@@ -525,7 +525,7 @@ def test_BiphasicAxonMapModel_min_current_spread():
     """
     stim = {e: BiphasicPulseTrain(20, 30, 0.45) for e in ('A2', 'C5', 'F8')}
     implant = ArgusII(stim=stim)
-    kwargs = {'xrange': (-8, 8), 'yrange': (-8, 8), 'xystep': 0.5,
+    kwargs = {'xrange': (-8, 8), 'yrange': (-8, 8), 'step': 0.5,
               'rho': 200, 'verbose': False}
 
     exact = BiphasicAxonMapModel(
@@ -559,7 +559,7 @@ def test_BiphasicAxonMapModel_min_current_spread_error_bound(amp):
     freq, pdur = 20, 0.45
     implant = ArgusII(stim={e: BiphasicPulseTrain(freq, amp, pdur)
                             for e in ArgusII().electrode_names})
-    kwargs = {'xrange': (-14, 14), 'yrange': (-10, 10), 'xystep': 0.75,
+    kwargs = {'xrange': (-14, 14), 'yrange': (-10, 10), 'step': 0.75,
               'rho': 200, 'lam': 800, 'verbose': False}
 
     model = BiphasicAxonMapModel(min_current_spread=0, **kwargs).build()
@@ -583,7 +583,7 @@ def test_BiphasicAxonMapModel_rejects_nonpositive_effects(attr):
     zero or negative. The default models cannot produce that, but a custom
     one could.
     """
-    model = BiphasicAxonMapModel(xrange=(-4, 4), yrange=(-4, 4), xystep=1,
+    model = BiphasicAxonMapModel(xrange=(-4, 4), yrange=(-4, 4), step=1,
                                  verbose=False).build()
     setattr(model.spatial, attr, lambda freq, amp, pdur: np.zeros_like(amp))
     implant = ArgusII(stim={'A2': BiphasicPulseTrain(20, 30, 0.45)})
@@ -610,7 +610,7 @@ def test_BiphasicAxonMapModel_rejects_nonfinite_effects(attr, bad):
     ``bright_model`` as well, which the positivity check deliberately does
     not (a zero or negative brightness factor is legitimate).
     """
-    model = BiphasicAxonMapModel(xrange=(-4, 4), yrange=(-4, 4), xystep=1,
+    model = BiphasicAxonMapModel(xrange=(-4, 4), yrange=(-4, 4), step=1,
                                  verbose=False).build()
     setattr(model.spatial, attr,
             lambda freq, amp, pdur: np.full_like(np.asarray(amp, dtype=float),
@@ -633,7 +633,7 @@ def test_BiphasicAxonMapModel_reduces_to_AxonMapModel():
     """
     from pulse2percept.models import AxonMapModel
 
-    kwargs = {'xrange': (-8, 8), 'yrange': (-8, 8), 'xystep': 0.5,
+    kwargs = {'xrange': (-8, 8), 'yrange': (-8, 8), 'step': 0.5,
               'rho': 200, 'lam': 800, 'verbose': False}
     electrodes = ('A2', 'C5', 'F8')
 
@@ -660,8 +660,8 @@ def test_BiphasicAxonMap_t_percept_units():
     """This model overrides `predict_percept`, so it normalizes for itself"""
     implant = ArgusII(stim={'A1': BiphasicPulseTrain(20, 1, 0.45,
                                                      stim_dur=100)})
-    for model in (BiphasicAxonMapSpatial(xystep=2).build(),
-                  BiphasicAxonMapModel(xystep=2).build()):
+    for model in (BiphasicAxonMapSpatial(step=2).build(),
+                  BiphasicAxonMapModel(step=2).build()):
         # A single time point is one time point, not something with a `len`:
         npt.assert_equal(model.predict_percept(implant,
                                                t_percept=20).data.shape[-1], 1)
@@ -683,14 +683,14 @@ def test_BiphasicAxonMap_dimension_before_waveform():
     """
     img = ImageStimulus(np.linspace(0, 1, 16).reshape((4, 4)))
     implant = ArgusII(preprocess=False, stim=img)
-    for model in (BiphasicAxonMapSpatial(xystep=2).build(),
-                  BiphasicAxonMapModel(xystep=2).build()):
+    for model in (BiphasicAxonMapSpatial(step=2).build(),
+                  BiphasicAxonMapModel(step=2).build()):
         with pytest.raises(DimensionMismatchError) as excinfo:
             model.predict_percept(implant)
         npt.assert_equal('AmplitudeEncoder' in str(excinfo.value), True)
     # A current-valued stimulus of the wrong waveform still gets the
     # model-specific message:
     with pytest.raises(TypeError) as excinfo:
-        BiphasicAxonMapSpatial(xystep=2).build().predict_percept(
+        BiphasicAxonMapSpatial(step=2).build().predict_percept(
             ArgusII(stim={'A1': MonophasicPulse(-1, 0.45, stim_dur=100)}))
     npt.assert_equal('BiphasicPulseTrain' in str(excinfo.value), True)

--- a/pulse2percept/models/tests/test_nanduri2012.py
+++ b/pulse2percept/models/tests/test_nanduri2012.py
@@ -14,7 +14,7 @@ from pulse2percept.utils import FreezeError
 
 def test_Nanduri2012Spatial():
     # Nanduri2012Spatial automatically sets `atten_a`:
-    model = Nanduri2012Spatial(xystep=5)
+    model = Nanduri2012Spatial(step=5)
 
     # User can set `atten_a`:
     model.atten_a = 12345
@@ -44,7 +44,7 @@ def test_Nanduri2012Spatial():
         model.predict_percept(implant)
 
     # Multiple frames are processed independently:
-    model = Nanduri2012Spatial(atten_a=14000, xystep=5,
+    model = Nanduri2012Spatial(atten_a=14000, step=5,
                                xrange=(-20, 20), yrange=(-15, 15))
     model.build()
     percept = model.predict_percept(ArgusI(stim={'A1': [1, 2]}))
@@ -180,7 +180,7 @@ def test_deepcopy_Nanduri2012Temporal():
     npt.assert_equal(original != copied, True)
 
 def test_Nanduri2012Model():
-    model = Nanduri2012Model(xystep=5)
+    model = Nanduri2012Model(step=5)
     npt.assert_equal(hasattr(model, 'has_time'), True)
     npt.assert_equal(model.has_time, True)
 
@@ -283,7 +283,7 @@ def test_Nanduri2012Model_predict_percept():
                      (1, 1, 2))
 
     # Brightness vs. size (use values from Nanduri paper):
-    model = Nanduri2012Model(xystep=0.5, xrange=(-4, 4), yrange=(-4, 4))
+    model = Nanduri2012Model(step=0.5, xrange=(-4, 4), yrange=(-4, 4))
     model.build()
     implant = ProsthesisSystem(ElectrodeArray(DiskElectrode(0, 0, 0, 260)))
     amp_th = 30

--- a/pulse2percept/models/tests/test_thompson2003.py
+++ b/pulse2percept/models/tests/test_thompson2003.py
@@ -17,7 +17,7 @@ from pulse2percept.utils.testing import assert_warns_msg
 
 def test_Thompson2003Spatial():
     # Thompson2003Spatial automatically sets `radius`:
-    model = Thompson2003Spatial(xystep=5)
+    model = Thompson2003Spatial(step=5)
     # User can set `radius`:
     model.radius = 123
     npt.assert_equal(model.radius, 123)
@@ -40,7 +40,7 @@ def test_Thompson2003Spatial():
     npt.assert_almost_equal(percept.data, 0)
 
     # Multiple frames are processed independently:
-    model = Thompson2003Spatial(radius=200, xystep=5,
+    model = Thompson2003Spatial(radius=200, step=5,
                                 xrange=(-20, 20), yrange=(-15, 15))
     model.build()
     percept = model.predict_percept(ArgusI(stim={'A1': [1, 0], 'B3': [0, 2]}))
@@ -81,7 +81,7 @@ def test_deepcopy_Thompson2003Spatial():
 
 
 def test_Thompson2003Model():
-    model = Thompson2003Model(xystep=5)
+    model = Thompson2003Model(step=5)
     npt.assert_equal(model.has_space, True)
     npt.assert_equal(model.has_time, False)
     npt.assert_equal(hasattr(model.spatial, 'radius'), True)
@@ -109,7 +109,7 @@ def test_Thompson2003Model():
     npt.assert_almost_equal(model.predict_percept(implant).data, 0)
 
     # Multiple frames are processed independently:
-    model = Thompson2003Model(radius=1000, xystep=5,
+    model = Thompson2003Model(radius=1000, step=5,
                               xrange=(-20, 20), yrange=(-15, 15))
     model.build()
     percept = model.predict_percept(ArgusI(stim={'A1': [1, 2]}))
@@ -122,7 +122,7 @@ def test_Thompson2003Model():
 
 
 def test_Thompson2003Model_predict_percept():
-    model = Thompson2003Model(xystep=0.55, radius=100, thresh_percept=0,
+    model = Thompson2003Model(step=0.55, radius=100, thresh_percept=0,
                               xrange=(-20, 20), yrange=(-15, 15))
     model.build()
     # Single-electrode stim:
@@ -136,14 +136,14 @@ def test_Thompson2003Model_predict_percept():
     npt.assert_almost_equal(percept.data[33, 46, 0], np.max(percept.data))
 
     # Full Argus II: 60 bright spots
-    model = Thompson2003Model(xystep=0.55, radius=100)
+    model = Thompson2003Model(step=0.55, radius=100)
     model.build()
     percept = model.predict_percept(ArgusII(stim=np.ones(60)))
     npt.assert_equal(np.sum(np.isclose(percept.data, 1.0, rtol=0.1, atol=0.1)),
                      84)
 
     # Model gives same outcome as Spatial:
-    spatial = Thompson2003Spatial(xystep=1, radius=100)
+    spatial = Thompson2003Spatial(step=1, radius=100)
     spatial.build()
     spatial_percept = model.predict_percept(ArgusII(stim=np.ones(60)))
     npt.assert_almost_equal(percept.data, spatial_percept.data)

--- a/pulse2percept/models/thompson2003.py
+++ b/pulse2percept/models/thompson2003.py
@@ -46,10 +46,17 @@ class Thompson2003Spatial(SpatialModel):
         A tuple indicating the range of y values to simulate (in degrees of
         visual angle). Negative y values correspond to the superior retina,
         and positive y values to the inferior retina.
-    xystep : int, double, tuple, optional
+    step : int, double, tuple, optional
         Step size for the range of (x,y) values to simulate (in degrees of
         visual angle). For example, to create a grid with x values [0, 0.5, 1]
-        use ``xrange=(0, 1)`` and ``xystep=0.5``.
+        use ``xrange=(0, 1)`` and ``step=0.5``. Pass a tuple to give the x
+        and y axes different step sizes.
+
+        .. versionchanged:: 0.10.0
+
+            Renamed from ``xystep``, which suggested that one step size
+            applies to both axes. The old name still works, but is
+            deprecated and will be removed in v0.11.0.
     grid_type : {'rectangular', 'hexagonal'}, optional
         Whether to simulate points on a rectangular or hexagonal grid
     vfmap : :py:class:`~pulse2percept.topography.VisualFieldMap`, optional
@@ -138,10 +145,17 @@ class Thompson2003Model(Model):
         A tuple indicating the range of y values to simulate (in degrees of
         visual angle). Negative y values correspond to the superior retina,
         and positive y values to the inferior retina.
-    xystep : int, double, tuple, optional
+    step : int, double, tuple, optional
         Step size for the range of (x,y) values to simulate (in degrees of
         visual angle). For example, to create a grid with x values [0, 0.5, 1]
-        use ``xrange=(0, 1)`` and ``xystep=0.5``.
+        use ``xrange=(0, 1)`` and ``step=0.5``. Pass a tuple to give the x
+        and y axes different step sizes.
+
+        .. versionchanged:: 0.10.0
+
+            Renamed from ``xystep``, which suggested that one step size
+            applies to both axes. The old name still works, but is
+            deprecated and will be removed in v0.11.0.
     grid_type : {'rectangular', 'hexagonal'}, optional
         Whether to simulate points on a rectangular or hexagonal grid
     vfmap : :py:class:`~pulse2percept.topography.VisualFieldMap`, optional

--- a/pulse2percept/topography/base.py
+++ b/pulse2percept/topography/base.py
@@ -188,7 +188,7 @@ class Grid2D(PrettyPrint):
        (number of y coordinates) x (number of x coordinates).
     *  If a range is zero, the step size is irrelevant.
     *  ``x_range``, ``y_range`` and ``step`` may be given as plain numbers of
-       degrees or as unitful quantities (e.g. ``xystep=0.5 * dva``), and are
+       degrees or as unitful quantities (e.g. ``step=0.5 * dva``), and are
        stored as plain numbers. See :py:mod:`pulse2percept.units`.
 
     .. versionchanged:: 0.10.0

--- a/pulse2percept/topography/base.py
+++ b/pulse2percept/topography/base.py
@@ -37,9 +37,10 @@ def _rectangular_mesh(x_range, y_range, step):
     x_range, y_range : (min, max)
         The range each axis spans, end points included.
     step : float or (x_step, y_step)
-        Spacing along each axis. A zero-width range gets a single point
-        whatever the step, since ``linspace(0, 0, num=5)`` would otherwise
-        return five copies of it.
+        Target spacing along each axis. Both end points are included, so the
+        spacing actually laid down is the one nearest ``step`` that reaches
+        them. A zero-width range gets a single point whatever the step, since
+        ``linspace(0, 0, num=5)`` would otherwise return five copies of it.
 
     Returns
     -------
@@ -178,6 +179,12 @@ class Grid2D(PrettyPrint):
     step : int, double, tuple
         Step size (dva). If int or double, the same step will apply to both x
         and y ranges. If a tuple, it is interpreted as (x_step, y_step).
+
+        This is a *target* spacing rather than an exact one: both end points
+        of a range are always included, so a range that is not a whole
+        multiple of ``step`` is sampled at the nearest spacing that reaches
+        both. ``Grid2D((0, 1), (0, 0), step=0.3)`` gives four points spaced
+        0.333 apart, not three spaced 0.3 with the last one short.
     grid_type : {'rectangular', 'hexagonal'}
         The grid type
 

--- a/pulse2percept/topography/tests/test_neuropythy.py
+++ b/pulse2percept/topography/tests/test_neuropythy.py
@@ -292,7 +292,7 @@ def test_Neuralink_from_neuropythy(neuropythy_available):
     npt.assert_almost_equal(nlink.implants['B'].direction, orient2, decimal=4)
 
     nmap.jitter_boundary=True
-    nlink = Neuralink.from_neuropythy(nmap, xrange=[-5, 5], yrange=(-3, 3), xystep=1)
+    nlink = Neuralink.from_neuropythy(nmap, xrange=[-5, 5], yrange=(-3, 3), step=1)
     npt.assert_equal(len(nlink.implants), 77)
     # thank god for chatgpt
     npt.assert_equal(list(nlink.implants.keys()), ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J',
@@ -334,7 +334,7 @@ def test_ndim_mixup(neuropythy_available):
 @pytest.mark.slow
 def test_neuropythy_scoreboard(neuropythy_available):
     nmap = NeuropythyMap('fsaverage')
-    model = ScoreboardModel(rho=800, xystep=.25, vfmap=nmap).build()
+    model = ScoreboardModel(rho=800, step=.25, vfmap=nmap).build()
     implant = Neuralink.from_neuropythy(nmap, xrange=(-3, 3), yrange=(-3, 3))
     implant.stim = {e : 1 for e in implant.electrode_names}
     percept = model.predict_percept(implant)
@@ -342,7 +342,7 @@ def test_neuropythy_scoreboard(neuropythy_available):
     npt.assert_almost_equal(np.max(percept.data), 27.3698, decimal=3)
 
     nmap = NeuropythyMap('fsaverage', regions=['v2'])
-    model = ScoreboardModel(rho=800, xystep=.25, vfmap=nmap).build()
+    model = ScoreboardModel(rho=800, step=.25, vfmap=nmap).build()
     implant = Neuralink.from_neuropythy(nmap, xrange=(-3, 3), yrange=(-3, 3), region='v2')
     implant.stim = {e : 1 for e in implant.electrode_names}
     percept = model.predict_percept(implant)
@@ -351,7 +351,7 @@ def test_neuropythy_scoreboard(neuropythy_available):
 
     # mega implant
     nmap = NeuropythyMap('fsaverage', regions=['v1', 'v2', 'v3'])
-    model = ScoreboardModel(rho=800, xystep=.25, vfmap=nmap).build()
+    model = ScoreboardModel(rho=800, step=.25, vfmap=nmap).build()
     i1 = Neuralink.from_neuropythy(nmap, xrange=(-3, 3), yrange=(-3, 3), region='v1')
     i2 = Neuralink.from_neuropythy(nmap, xrange=(-3, 3), yrange=(-3, 3), region='v2')
     i3 = Neuralink.from_neuropythy(nmap, xrange=(-3, 3), yrange=(-3, 3), region='v3')

--- a/pulse2percept/units/tests/test_integration.py
+++ b/pulse2percept/units/tests/test_integration.py
@@ -160,7 +160,7 @@ def test_every_spelling_builds_the_same_object():
     # that the comparisons below have something in them:
     implant = ArgusII(stim={'C5': BiphasicPulseTrain(20, 41.7, 0.45,
                                                      stim_dur=100)})
-    grid = dict(xrange=(-8, 8), yrange=(-8, 8), xystep=2)
+    grid = dict(xrange=(-8, 8), yrange=(-8, 8), step=2)
     _same(lambda r: ScoreboardSpatial(rho=r, **grid).build(), length, lengths,
           lambda m: m.predict_percept(implant).data, 'ScoreboardSpatial.rho')
     _same(lambda lam: AxonMapSpatial(lam=lam, rho=575, n_axons=100,
@@ -173,12 +173,12 @@ def test_every_spelling_builds_the_same_object():
           lambda g: g.x, 'Grid2D.x_range')
     _same(lambda a: ScoreboardSpatial(rho=575, xrange=(-4 * a, 4 * a),
                                       yrange=(-4 * a, 4 * a),
-                                      xystep=a).build(), angle, angles,
+                                      step=a).build(), angle, angles,
           lambda m: m.predict_percept(implant).data,
           'ScoreboardSpatial.xrange')
     _same(lambda a: EnsembleImplant.from_cortical_map(
         Cortivis, Polimeni2006Map(), xrange=(-a, a), yrange=(-a, a),
-        xystep=2 * a), angle, angles,
+        step=2 * a), angle, angles,
         lambda e: np.array([[el.x, el.y]
                             for el in e.earray.electrode_objects]),
         'EnsembleImplant.from_cortical_map')
@@ -191,7 +191,7 @@ def test_every_spelling_builds_the_same_object():
     unitful = Model(spatial=ScoreboardSpatial(rho=0.575 * mm,
                                               xrange=(-8 * dva, 8 * dva),
                                               yrange=(-8 * dva, 8 * dva),
-                                              xystep=2 * dva),
+                                              step=2 * dva),
                     temporal=FadingTemporal(tau=0.02 * s)).build()
     imp_bare = ArgusII(x=575, stim={'C5': BiphasicPulseTrain(
         20, 41.7, 0.45, stim_dur=100)})
@@ -216,7 +216,7 @@ def test_the_whole_rejection_matrix():
     """
     img = ImageStimulus(np.linspace(0, 1, 36).reshape((6, 6)))
     current = Stimulus({'A1': BiphasicPulseTrain(20, 50, 0.45, stim_dur=100)})
-    model = ScoreboardSpatial(xrange=(-2, 2), yrange=(-2, 2), xystep=1).build()
+    model = ScoreboardSpatial(xrange=(-2, 2), yrange=(-2, 2), step=1).build()
 
     # dimensionless -> model: gray levels are not small currents.
     with pytest.raises(DimensionMismatchError):


### PR DESCRIPTION
Rename a model's `xystep` to `step`, bringing it in line with `Grid2D`. Old name still works but throws a deprecated warning and will be removed in 0.11