### PR TITLE
[ENH] [API] Simplify API and improve interplay of encoders, rasters, and units

### DIFF
--- a/.github/scripts/check_install.py
+++ b/.github/scripts/check_install.py
@@ -167,7 +167,12 @@ def check_model_builds() -> list[str]:
         from pulse2percept.implants import ArgusII
         from pulse2percept.models import ScoreboardModel
 
-        model = ScoreboardModel(xrange=(-4, 4), yrange=(-4, 4), step=1).build()
+        # This runs against released versions too, and 0.10.0 renamed the
+        # grid spacing parameter `xystep` -> `step`. Ask the installed model
+        # which spelling it takes rather than assuming the current one.
+        spacing = "step" if hasattr(ScoreboardModel(), "step") else "xystep"
+        model = ScoreboardModel(xrange=(-4, 4), yrange=(-4, 4),
+                                **{spacing: 1}).build()
         implant = ArgusII()
         implant.stim = {e: 1 for e in ("A1", "F10")}
         percept = model.predict_percept(implant)

--- a/benchmarks/README.rst
+++ b/benchmarks/README.rst
@@ -219,11 +219,12 @@ when that work regresses. Use the ``array_ptrain`` helper, as above.
 parameters off each electrode and rejects an image; a temporal model given a
 single-frame stimulus measures nothing temporal.
 
-**An image is not a stimulus.** Gray levels are dimensionless and
-``predict_percept`` refuses them; user code turns an image into current with
-an ``Encoder``. A benchmark that did the same would measure a pulse train per
-electrode rather than the single static frame the image scenarios exist for,
-so they call the ``as_current`` helper instead, which says out loud what the
+**An image is not a stimulus.** Gray levels are dimensionless, and both
+``implant.stim`` and ``predict_percept`` refuse them; user code turns an image
+into current with a ``StimulusEncoder``. A benchmark that did the same would
+measure a pulse train per electrode rather than the single static frame the
+image scenarios exist for, so they call the ``as_current`` helper instead,
+which samples the picture onto the electrodes and says out loud what the
 library used to assume silently. Its docstring has the reasoning.
 
 **Sub-model parameters go on the sub-model instance**, as above. Keywords

--- a/benchmarks/scenarios.py
+++ b/benchmarks/scenarios.py
@@ -11,12 +11,12 @@ The scenarios below are the reference workloads for the library's main purpose
 first two correspond to these one-liners::
 
     p2p.models.AxonMapModel(yrange=(-8, 8), xrange=(-12, 12)).build(
-        ).predict_percept(as_current(
-            p2p.implants.ArgusII(stim=p2p.stimuli.LogoBVL())))
+        ).predict_percept(as_current(p2p.implants.ArgusII(),
+                                     p2p.stimuli.LogoBVL()))
 
     p2p.models.ScoreboardModel(yrange=(-4, 4), xrange=(-4, 4), rho=50,
                                step=0.1).build().predict_percept(as_current(
-        p2p.implants.PRIMA(stim=p2p.stimuli.LogoBVL().invert())))
+        p2p.implants.PRIMA(), p2p.stimuli.LogoBVL().invert()))
 
 The :func:`as_current` wrapper is a benchmark-only detail; see its docstring
 for why these workloads do not go through an encoder the way user code should.
@@ -66,11 +66,12 @@ def array_ptrain(implant_cls):
 GRAY_LEVEL_UA = 1.0
 
 
-def as_current(implant, amp_max=GRAY_LEVEL_UA):
-    """Reinterpret an implant's gray levels as a static current, in microamps.
+def as_current(implant, picture, amp_max=GRAY_LEVEL_UA):
+    """Sample a picture onto an implant, reading its gray levels as microamps.
 
-    An image is dimensionless, and ``predict_percept`` refuses one: gray levels
-    are not small currents. Turning one into current is an encoder's job (see
+    An image is dimensionless, and neither an implant nor ``predict_percept``
+    accepts one: gray levels are not small currents. Turning one into current
+    is an encoder's job (see
     :py:class:`~pulse2percept.stimuli.AmplitudeEncoder`), and that is what a
     user should write.
 
@@ -79,11 +80,11 @@ def as_current(implant, amp_max=GRAY_LEVEL_UA):
     single static frame these scenarios have always measured -- and measuring
     something else is how a performance suite loses its history. So the
     reinterpretation the library used to perform silently is spelled out here
-    instead, on the amplitudes the implant has already resampled onto its
-    electrodes. What the kernels see does not change: the same electrodes, the
-    same number of columns, the same numbers in them.
+    instead, on the amplitudes ``reshape_stim`` has resampled onto the
+    implant's electrodes. What the kernels see does not change: the same
+    electrodes, the same number of columns, the same numbers in them.
     """
-    stim = implant.stim
+    stim = implant.reshape_stim(picture)
     data = stim.data * amp_max
     if stim.time is None:
         # A *flat* sequence means N electrodes stimulated once each with no
@@ -152,7 +153,7 @@ SCENARIOS = [
     Scenario(
         id='argus2_axonmap_logobvl',
         stimulus=lambda: p2p.stimuli.LogoBVL(),
-        implant=lambda stim: as_current(p2p.implants.ArgusII(stim=stim)),
+        implant=lambda stim: as_current(p2p.implants.ArgusII(), stim),
         model=lambda **kwargs: p2p.models.AxonMapModel(xrange=(-12, 12),
                                                        yrange=(-8, 8),
                                                        **kwargs),
@@ -161,7 +162,7 @@ SCENARIOS = [
     Scenario(
         id='prima_scoreboard_logobvl',
         stimulus=lambda: p2p.stimuli.LogoBVL().invert(),
-        implant=lambda stim: as_current(p2p.implants.PRIMA(stim=stim)),
+        implant=lambda stim: as_current(p2p.implants.PRIMA(), stim),
         model=lambda **kwargs: p2p.models.ScoreboardModel(xrange=(-4, 4),
                                                           yrange=(-4, 4),
                                                           rho=50, step=0.1,
@@ -204,7 +205,7 @@ SCENARIOS = [
     Scenario(
         id='argus2_thompson2003_logobvl',
         stimulus=lambda: p2p.stimuli.LogoBVL(),
-        implant=lambda stim: as_current(p2p.implants.ArgusII(stim=stim)),
+        implant=lambda stim: as_current(p2p.implants.ArgusII(), stim),
         model=lambda **kwargs: p2p.models.Thompson2003Model(
             xrange=(-12, 12), yrange=(-8, 8), **kwargs),
     ),
@@ -226,7 +227,7 @@ SCENARIOS = [
     Scenario(
         id='argus2_axonmap_bostontrain',
         stimulus=lambda: p2p.stimuli.BostonTrain().rgb2gray(),
-        implant=lambda stim: as_current(p2p.implants.ArgusII(stim=stim)),
+        implant=lambda stim: as_current(p2p.implants.ArgusII(), stim),
         model=lambda **kwargs: p2p.models.AxonMapModel(xrange=(-12, 12),
                                                        yrange=(-8, 8),
                                                        **kwargs),

--- a/doc/topics/units.rst
+++ b/doc/topics/units.rst
@@ -145,9 +145,9 @@ field you are, and on which retinotopic map you believe in. That is what a
     x_um, y_um = Watson2014Map().dva_to_ret(2 * dva, 3 * dva)
 
 **Gray levels are not small currents.** An image or a video is dimensionless,
-and a model that stimulates tissue will refuse one. An
-:py:class:`~pulse2percept.stimuli.Encoder` is what says how much current a
-gray level stands for:
+and a model that stimulates tissue will refuse one, as will an electrical
+implant. A :py:class:`~pulse2percept.stimuli.StimulusEncoder` is what says how
+much current a gray level stands for:
 
 .. code-block:: python
 
@@ -160,6 +160,43 @@ gray level stands for:
 
     model = ScoreboardModel().build()
     percept = model.predict_percept(ArgusII(stim=stim))
+
+Assigning the image itself raises, rather than reading its gray levels as
+microamps. There is no default answer to *how much* current a gray level
+stands for, and choosing one is what an encoder is for.
+
+Shorthands that are not conversions
+-----------------------------------
+
+A few arguments accept a quantity of a dimension they do not store, because
+there is exactly one thing it can mean there. These are shorthands resolved at
+the boundary, not conversions: what is stored afterwards is the ordinary
+number it always was.
+
+**A retinal extent, for a visual field range.** A spatial model simulates a
+patch of the visual field, sampled uniformly in dva. On a retinal model you
+may name that patch by the piece of retina it lands on, and the model's own
+:py:class:`~pulse2percept.topography.VisualFieldMap` resolves it:
+
+.. doctest::
+
+    >>> from pulse2percept.models import ScoreboardModel
+    >>> from pulse2percept.topography import Curcio1990Map
+    >>> from pulse2percept.units import mm
+    >>> model = ScoreboardModel(xrange=(-2.8 * mm, 2.8 * mm),
+    ...                         vfmap=Curcio1990Map())
+    >>> model.xrange  # 280 um to the degree
+    (-10.0, 10.0)
+
+The range is resolved once, when it is assigned, so a map installed afterwards
+does not reinterpret it. ``step`` has no such spelling: a grid spaced evenly on
+the retina is a different grid, not a different spelling of this one. Neither
+has a cortical model, where a length is not shorthand for anything.
+
+**A frequency, for a frame rate.** ``fps`` counts frames per second, so it
+takes hertz as readily as a bare number: ``percept.play(fps=30)``,
+``percept.play(fps=30 * Hz)`` and ``percept.play(fps=0.03 * kHz)`` are the same
+call, and ``percept.play(fps=30 * ms)`` raises.
 
 Asking what an object's numbers mean
 ------------------------------------

--- a/doc/topics/units.rst
+++ b/doc/topics/units.rst
@@ -145,9 +145,10 @@ field you are, and on which retinotopic map you believe in. That is what a
     x_um, y_um = Watson2014Map().dva_to_ret(2 * dva, 3 * dva)
 
 **Gray levels are not small currents.** An image or a video is dimensionless,
-and a model that stimulates tissue will refuse one, as will an electrical
-implant. A :py:class:`~pulse2percept.stimuli.StimulusEncoder` is what says how
-much current a gray level stands for:
+and a model that stimulates tissue will refuse one. A
+:py:class:`~pulse2percept.stimuli.StimulusEncoder` is what says how much
+current a gray level stands for, and an implant that has one encodes on
+assignment:
 
 .. code-block:: python
 
@@ -156,14 +157,16 @@ much current a gray level stands for:
     from pulse2percept.models import ScoreboardModel
 
     img = ImageStimulus('path-to-image.png')
-    stim = AmplitudeEncoder(ArgusII(), amp_range=(0, 50)).encode(img)
+
+    implant = ArgusII(encoder=AmplitudeEncoder(amp_range=(0, 50)))
+    implant.stim = img            # encoded here, and now measured in uA
 
     model = ScoreboardModel().build()
-    percept = model.predict_percept(ArgusII(stim=stim))
+    percept = model.predict_percept(implant)
 
-Assigning the image itself raises, rather than reading its gray levels as
-microamps. There is no default answer to *how much* current a gray level
-stands for, and choosing one is what an encoder is for.
+Assigning the image to an implant *without* an encoder raises, rather than
+reading its gray levels as microamps. There is no default answer to *how much*
+current a gray level stands for, and choosing one is what an encoder is for.
 
 Shorthands that are not conversions
 -----------------------------------

--- a/doc/topics/units.rst
+++ b/doc/topics/units.rst
@@ -188,10 +188,19 @@ may name that patch by the piece of retina it lands on, and the model's own
     >>> model.xrange  # 280 um to the degree
     (-10.0, 10.0)
 
+Each range is converted along its corresponding retinal meridian: ``xrange``
+through ``ret_to_dva(x, 0)`` and ``yrange`` through ``ret_to_dva(0, y)``. The
+resulting grid is still rectangular and uniformly sampled in dva, exactly as
+if you had typed those degrees yourself. Under a nonlinear map such as
+:py:class:`~pulse2percept.topography.Watson2014Map` it is therefore not the
+image of a retinal rectangle: naming retinal lengths says how far to simulate,
+it does not make the grid uniform in retinal space.
+
+For the same reason ``step`` has no such spelling -- a grid spaced evenly on
+the retina is a different grid, not a different spelling of this one -- and
+neither has a cortical model, where a length is not shorthand for anything.
 The range is resolved once, when it is assigned, so a map installed afterwards
-does not reinterpret it. ``step`` has no such spelling: a grid spaced evenly on
-the retina is a different grid, not a different spelling of this one. Neither
-has a cortical model, where a length is not shorthand for anything.
+does not reinterpret it.
 
 **A frequency, for a frame rate.** ``fps`` counts frames per second, so it
 takes hertz as readily as a bare number: ``percept.play(fps=30)``,

--- a/doc/users/faq.rst
+++ b/doc/users/faq.rst
@@ -37,7 +37,7 @@ A typical workflow looks roughly like this::
 
     image / video
          |
-         |  optional Encoder
+         |  optional StimulusEncoder
          v
       Stimulus
          |
@@ -329,7 +329,7 @@ Most pulse2percept simulations involve four objects, plus an optional encoder:
     The predicted visual percept, represented across visual space and,
     optionally, time.
 
-:py:class:`~pulse2percept.stimuli.Encoder`
+:py:class:`~pulse2percept.stimuli.StimulusEncoder`
     An optional step that converts higher-level input such as an image or video
     into the electrical stimulus delivered by an implant.
 
@@ -353,13 +353,13 @@ from that stimulus.
     percept is its prediction.
 
 
-Do I need an Encoder?
----------------------
+Do I need a StimulusEncoder?
+----------------------------
 
 No.
 
-Use an :py:class:`~pulse2percept.stimuli.Encoder` when you want to translate
-image or video content into electrical stimulation. For example,
+Use a :py:class:`~pulse2percept.stimuli.StimulusEncoder` when you want to
+translate image or video content into electrical stimulation. For example,
 :py:class:`~pulse2percept.stimuli.AmplitudeEncoder` maps image intensity onto
 pulse amplitude, whereas
 :py:class:`~pulse2percept.stimuli.FrequencyEncoder` maps it onto pulse
@@ -483,9 +483,9 @@ stimulation**.
 
 :py:class:`~pulse2percept.stimuli.ImageStimulus` and
 :py:class:`~pulse2percept.stimuli.VideoStimulus` can represent image and video
-content. An :py:class:`~pulse2percept.stimuli.Encoder` can then sample that
-content at the electrode locations and convert the resulting intensities into
-electrical pulse trains.
+content. A :py:class:`~pulse2percept.stimuli.StimulusEncoder` can then sample
+that content at the electrode locations and convert the resulting intensities
+into electrical pulse trains.
 
 For example:
 

--- a/doc/users/faq.rst
+++ b/doc/users/faq.rst
@@ -37,7 +37,7 @@ A typical workflow looks roughly like this::
 
     image / video
          |
-         |  optional StimulusEncoder
+         |  optional StimulusEncoder (usually the implant's own)
          v
       Stimulus
          |
@@ -356,18 +356,25 @@ from that stimulus.
 Do I need a StimulusEncoder?
 ----------------------------
 
-No.
+Only if you are assigning image or video content to an implant that does not
+already have one.
 
-Use a :py:class:`~pulse2percept.stimuli.StimulusEncoder` when you want to
-translate image or video content into electrical stimulation. For example,
+A :py:class:`~pulse2percept.stimuli.StimulusEncoder` translates image or video
+content into electrical stimulation. For example,
 :py:class:`~pulse2percept.stimuli.AmplitudeEncoder` maps image intensity onto
 pulse amplitude, whereas
 :py:class:`~pulse2percept.stimuli.FrequencyEncoder` maps it onto pulse
 frequency.
 
+Devices whose video processing is known carry an encoder of their own, in
+which case ``implant.stim = image`` encodes for you.
+:py:class:`~pulse2percept.implants.ArgusII` is one of them. Assign a different
+encoder to ``implant.encoder`` to say how the encoding should be done, or
+``None`` to switch it off.
+
 If you already know the electrical stimulation you want to simulate, construct
 a :py:class:`~pulse2percept.stimuli.Stimulus` directly or assign stimulation
-to the implant. No encoder is required.
+to the implant. An electrical stimulus never goes through the encoder.
 
 .. important::
 
@@ -492,16 +499,25 @@ For example:
 .. code-block:: python
 
     from pulse2percept.implants import ArgusII
-    from pulse2percept.stimuli import AmplitudeEncoder, BostonTrain
+    from pulse2percept.stimuli import BostonTrain
+
+    implant = ArgusII(stim=BostonTrain())
+
+:py:class:`~pulse2percept.implants.ArgusII` comes with an encoder of its own,
+so the video is encoded on assignment. To say how, give the implant a
+different one:
+
+.. code-block:: python
+
+    from pulse2percept.stimuli import AmplitudeEncoder
     from pulse2percept.units import uA, Hz
 
-    implant = ArgusII()
+    implant = ArgusII(encoder=AmplitudeEncoder(amp_range=(0, 50 * uA),
+                                               freq=20 * Hz))
+    implant.stim = BostonTrain()
 
-    encoder = AmplitudeEncoder(implant, amp_range=(0, 50 * uA), freq=20 * Hz)
-    implant.stim = encoder.encode(BostonTrain())
-
-The resulting ``implant.stim`` is electrical stimulation and can be passed to
-a computational model in the usual way.
+Either way the resulting ``implant.stim`` is electrical stimulation and can be
+passed to a computational model in the usual way.
 
 .. note::
 

--- a/doc/users/release_notes.rst
+++ b/doc/users/release_notes.rst
@@ -100,11 +100,6 @@ API changes:
   video first. Preprocessing still runs before the check, so an implant whose
   ``preprocess`` turns pictures into current is unaffected.
 
-* The abstract encoder base class ``Encoder`` was renamed to
-  :py:class:`~pulse2percept.stimuli.StimulusEncoder`. The old name still
-  resolves, to the same class object, with a ``DeprecationWarning``, and will
-  be removed in v0.11.0.
-
 * ``fps`` arguments (:py:meth:`~pulse2percept.percepts.Percept.play`,
   :py:meth:`~pulse2percept.percepts.Percept.save`,
   :py:meth:`~pulse2percept.stimuli.VideoStimulus.play`,
@@ -113,8 +108,9 @@ API changes:
 
 * ``xrange`` and ``yrange`` on a retinal spatial model accept a physical
   extent (``xrange=(-4 * mm, 4 * mm)``), which the model's ``vfmap`` resolves
-  into the visual field range that piece of retina covers. The range is stored
-  in degrees of visual angle, exactly as before. This is shorthand for a
+  into the visual field range that piece of retina covers, each range along
+  its own retinal meridian. The range is stored in degrees of visual angle and
+  the grid stays uniform in dva, exactly as before. This is shorthand for a
   visual field extent rather than a unit conversion, so it is not offered for
   ``step`` and not offered on cortical models.
 

--- a/doc/users/release_notes.rst
+++ b/doc/users/release_notes.rst
@@ -12,7 +12,12 @@ Highlights:
 *  New :py:class:`~pulse2percept.stimuli.StimulusEncoder` classes translate
    images and videos into electrical stimulation. Amplitude and frequency
    modulation are supported, including stimulator timing, input resolution,
-   and electrode multiplexing.
+   and electrode multiplexing. An implant carries its own encoder, so
+   ``implant.stim = image`` encodes on assignment::
+
+       implant = p2p.implants.ArgusII(stim=p2p.stimuli.BostonTrain())
+       percept = p2p.models.AxonMapModel().build().predict_percept(implant)
+       percept.play()
 
 *  New :py:class:`~pulse2percept.implants.Raster` classes describe how
    stimulators multiplex electrodes that cannot be driven simultaneously. Each
@@ -61,8 +66,15 @@ API changes:
 * :py:class:`~pulse2percept.stimuli.BiphasicPulseTrain` now records ``amp`` in
   its metadata as a magnitude.
 
-* :py:class:`~pulse2percept.implants.ProsthesisSystem` now exposes ``raster``
-  and ``max_current``.
+* :py:class:`~pulse2percept.implants.ProsthesisSystem` now exposes ``encoder``,
+  ``raster`` and ``max_current``. A raster is bound to the implant it is
+  assigned to (:py:meth:`~pulse2percept.implants.Raster.bind`), so
+  ``CheckerboardRaster`` works its pattern out from that implant's electrode
+  geometry and ``implant.raster.plot()`` needs no argument.
+  :py:class:`~pulse2percept.implants.ArgusII` defaults to an
+  :py:class:`~pulse2percept.stimuli.AmplitudeEncoder` at 6 Hz and a
+  :py:class:`~pulse2percept.implants.SequentialRaster` of six groups 2 ms
+  apart; pass ``encoder=None`` or ``raster=None`` to switch either off.
 
 * ``play`` gained a ``fmt`` argument.
   :py:meth:`~pulse2percept.stimuli.VideoStimulus.play` defaults to JPEG, which
@@ -87,18 +99,23 @@ API changes:
   is not the physical quantity the model reads. Assigning an
   :py:class:`~pulse2percept.stimuli.ImageStimulus` or
   :py:class:`~pulse2percept.stimuli.VideoStimulus` straight to ``implant.stim``
-  previously had its gray levels silently treated as microamps. Encode it with
-  :py:class:`~pulse2percept.stimuli.AmplitudeEncoder` or
-  :py:class:`~pulse2percept.stimuli.FrequencyEncoder` first, or give the
-  implant a ``preprocess`` function that does. The same check guards the
-  ``safe_mode`` and ``max_current`` safety checks.
+  previously had its gray levels silently treated as microamps. The same check
+  guards the ``safe_mode`` and ``max_current`` safety checks.
 
 * :py:class:`~pulse2percept.implants.ProsthesisSystem` now declares
-  ``stimulus_unit`` (microamps) and refuses a stimulus of another dimension
-  as it is assigned, rather than letting it through to fail in the model.
-  ``ArgusII(stim=BostonTrain())`` therefore raises immediately; encode the
-  video first. Preprocessing still runs before the check, so an implant whose
-  ``preprocess`` turns pictures into current is unaffected.
+  ``stimulus_unit`` (microamps) and never stores a stimulus of another
+  dimension. A picture assigned to an implant that has an ``encoder`` is
+  encoded on the way in; one assigned to an implant without an encoder raises,
+  rather than letting it through to fail in the model. Preprocessing still runs
+  first, so an implant whose ``preprocess`` turns pictures into current is
+  unaffected, and its output is not encoded a second time.
+
+* A :py:class:`~pulse2percept.stimuli.StimulusEncoder` no longer holds an
+  implant or a raster of its own. The implant is named where the encoding
+  happens -- ``encoder.encode(source, implant=implant)`` -- and the raster
+  comes from that implant, so device scheduling is described in exactly one
+  place. :py:class:`~pulse2percept.implants.CheckerboardRaster` likewise takes
+  ``n_groups`` alone and learns its geometry when it is bound.
 
 * ``fps`` arguments (:py:meth:`~pulse2percept.percepts.Percept.play`,
   :py:meth:`~pulse2percept.percepts.Percept.save`,

--- a/doc/users/release_notes.rst
+++ b/doc/users/release_notes.rst
@@ -20,15 +20,15 @@ Highlights:
        percept.play()
 
 *  Spatial models read modulation frames; temporal models read electrical
-   events. An encoded stimulus has two descriptions of itself -- the pulse
-   train the device delivers (``implant.stim``) and the modulation the encoder
-   asked for (:py:attr:`~pulse2percept.implants.ProsthesisSystem.spatial_stim`,
-   one amplitude per electrode per frame, with no waveform, pulse clock or
-   raster in it). A model with no temporal component reads the latter, since a
-   pulse train is a statement about time that it has no way to express;
-   otherwise an encoded image would come back as a sequence of raster slots.
-   :py:meth:`~pulse2percept.stimuli.StimulusEncoder.encode_spatial` produces it
-   on its own.
+   events. An implant that encodes a picture keeps two descriptions of it: the
+   pulse train the device delivers (``implant.stim``) and the modulation the
+   encoder asked for -- one amplitude per electrode per frame, with no
+   waveform, pulse clock or raster in it. A model with no temporal component
+   reads the latter, since a pulse train is a statement about time that it has
+   no way to express; otherwise an encoded image would come back as a sequence
+   of raster slots rather than as the image. So
+   :py:meth:`~pulse2percept.models.SpatialModel.predict_percept` reports one
+   percept frame per video frame, and one frame for an image.
 
 *  New :py:class:`~pulse2percept.implants.Raster` classes describe how
    stimulators multiplex electrodes that cannot be driven simultaneously. Each

--- a/doc/users/release_notes.rst
+++ b/doc/users/release_notes.rst
@@ -19,6 +19,17 @@ Highlights:
        percept = p2p.models.AxonMapModel().build().predict_percept(implant)
        percept.play()
 
+*  Spatial models read modulation frames; temporal models read electrical
+   events. An encoded stimulus has two descriptions of itself -- the pulse
+   train the device delivers (``implant.stim``) and the modulation the encoder
+   asked for (:py:attr:`~pulse2percept.implants.ProsthesisSystem.spatial_stim`,
+   one amplitude per electrode per frame, with no waveform, pulse clock or
+   raster in it). A model with no temporal component reads the latter, since a
+   pulse train is a statement about time that it has no way to express;
+   otherwise an encoded image would come back as a sequence of raster slots.
+   :py:meth:`~pulse2percept.stimuli.StimulusEncoder.encode_spatial` produces it
+   on its own.
+
 *  New :py:class:`~pulse2percept.implants.Raster` classes describe how
    stimulators multiplex electrodes that cannot be driven simultaneously. Each
    group starts its pulse a fixed ``group_dur`` behind the one before it.

--- a/doc/users/release_notes.rst
+++ b/doc/users/release_notes.rst
@@ -9,10 +9,10 @@ v0.10.0 Encoders (unreleased)
 
 Highlights:
 
-*  New :py:class:`~pulse2percept.stimuli.Encoder` classes translate images and
-   videos into electrical stimulation. Amplitude and frequency modulation are
-   supported, including stimulator timing, input resolution, and electrode
-   multiplexing.
+*  New :py:class:`~pulse2percept.stimuli.StimulusEncoder` classes translate
+   images and videos into electrical stimulation. Amplitude and frequency
+   modulation are supported, including stimulator timing, input resolution,
+   and electrode multiplexing.
 
 *  New :py:class:`~pulse2percept.implants.Raster` classes describe how
    stimulators multiplex electrodes that cannot be driven simultaneously. Each
@@ -92,6 +92,34 @@ API changes:
   :py:class:`~pulse2percept.stimuli.FrequencyEncoder` first, or give the
   implant a ``preprocess`` function that does. The same check guards the
   ``safe_mode`` and ``max_current`` safety checks.
+
+* :py:class:`~pulse2percept.implants.ProsthesisSystem` now declares
+  ``stimulus_unit`` (microamps) and refuses a stimulus of another dimension
+  as it is assigned, rather than letting it through to fail in the model.
+  ``ArgusII(stim=BostonTrain())`` therefore raises immediately; encode the
+  video first. Preprocessing still runs before the check, so an implant whose
+  ``preprocess`` turns pictures into current is unaffected.
+
+* The abstract encoder base class ``Encoder`` was renamed to
+  :py:class:`~pulse2percept.stimuli.StimulusEncoder`. The old name still
+  resolves, to the same class object, with a ``DeprecationWarning``, and will
+  be removed in v0.11.0.
+
+* ``fps`` arguments (:py:meth:`~pulse2percept.percepts.Percept.play`,
+  :py:meth:`~pulse2percept.percepts.Percept.save`,
+  :py:meth:`~pulse2percept.stimuli.VideoStimulus.play`,
+  :py:func:`~pulse2percept.utils.frame_interval`) accept a frequency
+  quantity (``30 * Hz``, ``0.03 * kHz``) as well as a plain number of hertz.
+
+* ``xrange`` and ``yrange`` on a retinal spatial model accept a physical
+  extent (``xrange=(-4 * mm, 4 * mm)``), which the model's ``vfmap`` resolves
+  into the visual field range that piece of retina covers. The range is stored
+  in degrees of visual angle, exactly as before. This is shorthand for a
+  visual field extent rather than a unit conversion, so it is not offered for
+  ``step`` and not offered on cortical models.
+
+* Warnings raised while encoding (missed frames, large time axes, large
+  allocations) now point at the calling line rather than at ``encoders.py``.
 
 * :py:attr:`~pulse2percept.stimuli.Stimulus.is_charge_balanced` returns None
   for a stimulus that is not a current, rather than answering a question that

--- a/examples/implants/plot_argus.py
+++ b/examples/implants/plot_argus.py
@@ -84,11 +84,21 @@ p2p.stimuli.BostonTrain().play()
 # After feeding the resulting stimulus through the axon map model, we get a
 # pretty good idea of what this video would look like to an Argus II patient:
 
-# The video is encoded into current first -- a model reads microamps, not gray
-# levels -- at a pulse rate that keeps up with the frame rate:
+# Argus II knows how it encodes video -- gray level onto pulse amplitude at
+# 6 Hz, six rows of electrodes taking turns -- so assigning the video is all it
+# takes. What ends up in ``implant.stim`` is current, which is what a model
+# reads.
+#
+# The encoder warns that most frames of this 30 fps clip carry no pulse of
+# their own: 6 Hz is the rate the real device runs at, and it is slower than
+# the video. Pass ``encoder=p2p.stimuli.AmplitudeEncoder(freq=30)`` to deliver
+# every frame instead.
+#
+# `AxonMapModel` is a spatial model, so it reports a percept at every time
+# point the pulse trains have unless told otherwise; `t_percept` asks for one
+# frame per video frame instead:
 video = p2p.stimuli.BostonTrain()
-implant = p2p.implants.ArgusII()
-implant.stim = video.encode(implant=implant, freq=30)
+implant = p2p.implants.ArgusII(stim=video)
 model.predict_percept(implant, t_percept=video.time).play()
 
 ###############################################################################
@@ -130,8 +140,7 @@ p2p.stimuli.GirlPool().play()
 # then feed it through the axon map model:
 
 video = p2p.stimuli.GirlPool()
-implant = p2p.implants.ArgusII()
-implant.stim = video.encode(implant=implant, freq=30)
+implant = p2p.implants.ArgusII(stim=video)
 model.rho = 400
 model.lam = 200
 model.build()

--- a/examples/implants/plot_argus.py
+++ b/examples/implants/plot_argus.py
@@ -87,19 +87,15 @@ p2p.stimuli.BostonTrain().play()
 # Argus II knows how it encodes video -- gray level onto pulse amplitude at
 # 6 Hz, six rows of electrodes taking turns -- so assigning the video is all it
 # takes. What ends up in ``implant.stim`` is current, which is what a model
-# reads.
+# reads, and the percept comes back at one frame per video frame.
 #
 # The encoder warns that most frames of this 30 fps clip carry no pulse of
 # their own: 6 Hz is the rate the real device runs at, and it is slower than
 # the video. Pass ``encoder=p2p.stimuli.AmplitudeEncoder(freq=30)`` to deliver
 # every frame instead.
-#
-# `AxonMapModel` is a spatial model, so it reports a percept at every time
-# point the pulse trains have unless told otherwise; `t_percept` asks for one
-# frame per video frame instead:
 video = p2p.stimuli.BostonTrain()
 implant = p2p.implants.ArgusII(stim=video)
-model.predict_percept(implant, t_percept=video.time).play()
+model.predict_percept(implant).play()
 
 ###############################################################################
 # The above simulation is basically equivalent to the scoreboard model, because
@@ -114,7 +110,7 @@ model.predict_percept(implant, t_percept=video.time).play()
 
 model.lam = 600
 model.build()
-model.predict_percept(implant, t_percept=video.time).play()
+model.predict_percept(implant).play()
 
 ###############################################################################
 # On the other hand, some retinal implant recipients (e.g., 51-009) report
@@ -124,7 +120,7 @@ model.predict_percept(implant, t_percept=video.time).play()
 model.rho = 100
 model.lam = 1000
 model.build()
-model.predict_percept(implant, t_percept=video.time).play()
+model.predict_percept(implant).play()
 
 
 ###############################################################################
@@ -144,14 +140,14 @@ implant = p2p.implants.ArgusII(stim=video)
 model.rho = 400
 model.lam = 200
 model.build()
-model.predict_percept(implant, t_percept=video.time).play()
+model.predict_percept(implant).play()
 
 ###############################################################################
 # Here is the same video with longer phosphenes:
 
 model.lam = 600
 model.build()
-model.predict_percept(implant, t_percept=video.time).play()
+model.predict_percept(implant).play()
 
 ###############################################################################
 # Here is the same video with thin and long phosphenes:
@@ -159,7 +155,7 @@ model.predict_percept(implant, t_percept=video.time).play()
 model.rho = 100
 model.lam = 1000
 model.build()
-model.predict_percept(implant, t_percept=video.time).play()
+model.predict_percept(implant).play()
 
 ###############################################################################
 # In reality, the vision provided by Argus II may be even worse for several

--- a/examples/stimuli/plot_image_stim.py
+++ b/examples/stimuli/plot_image_stim.py
@@ -261,15 +261,18 @@ implant.stim = logo_dilate.trim().resize(implant.shape).encode()
 #
 # ``encode`` is a shorthand for
 # :py:class:`~pulse2percept.stimuli.AmplitudeEncoder`, which offers the full
-# set of options. In particular, passing it an ``implant`` samples the image at
-# the electrode locations *before* building the pulse trains, which for a video
-# is the difference between a stimulus of a few hundred kilobytes and one of a
-# few hundred megabytes:
+# set of options. Give one to an implant and the implant encodes whatever
+# picture is assigned to it -- sampling it at the electrode locations *before*
+# building the pulse trains, which for a video is the difference between a
+# stimulus of a few hundred kilobytes and one of a few hundred megabytes:
 #
 # .. code-block:: python
 #
-#     encoder = p2p.stimuli.AmplitudeEncoder(implant, amp_range=(0, 50))
-#     implant.stim = encoder.encode(p2p.stimuli.BostonTrain())
+#     implant.encoder = p2p.stimuli.AmplitudeEncoder(amp_range=(0, 50))
+#     implant.stim = p2p.stimuli.BostonTrain()
+#
+# :py:class:`~pulse2percept.implants.ArgusII` brings one along already, so
+# ``p2p.implants.ArgusII(stim=p2p.stimuli.BostonTrain())`` is the whole setup.
 #
 # The other way to encode a gray level is as a pulse *rate* at fixed amplitude,
 # which is what :py:class:`~pulse2percept.stimuli.FrequencyEncoder` does. It is
@@ -279,9 +282,9 @@ implant.stim = logo_dilate.trim().resize(implant.shape).encode()
 #
 # .. code-block:: python
 #
-#     encoder = p2p.stimuli.FrequencyEncoder(implant, freq_range=(0, 300),
-#                                            amp=50, clock=1)
-#     implant.stim = encoder.encode(p2p.stimuli.BostonTrain())
+#     implant.encoder = p2p.stimuli.FrequencyEncoder(freq_range=(0, 300),
+#                                                    amp=50, clock=1)
+#     implant.stim = p2p.stimuli.BostonTrain()
 #
 # A real stimulator usually cannot drive every electrode at once, because the
 # current it can source at any instant is limited. Give the implant a
@@ -295,7 +298,19 @@ implant.stim = logo_dilate.trim().resize(implant.shape).encode()
 #
 #     implant.max_current = 1000  # uA, summed over electrodes
 #     implant.raster = p2p.implants.SequentialRaster(6)  # one row at a time
-#     implant.stim = p2p.stimuli.AmplitudeEncoder(implant).encode(video)
+#     implant.stim = video
+#
+# The raster belongs to the implant, and is the only place the schedule is
+# described: assigning one binds it to that implant, so
+# :py:class:`~pulse2percept.implants.CheckerboardRaster` can work its pattern
+# out from where the electrodes actually are, and
+# :py:meth:`~pulse2percept.implants.Raster.plot` can draw it without being
+# told what to draw:
+#
+# .. code-block:: python
+#
+#     implant.raster = p2p.implants.CheckerboardRaster(5)
+#     implant.raster.plot()
 #
 # Using the image as input to a spatiotemporal model
 # ---------------------------------------------------

--- a/examples/stimuli/plot_video_stim.py
+++ b/examples/stimuli/plot_video_stim.py
@@ -99,18 +99,18 @@ video.resize((40, 40)).rotate(10).invert().filter('median').play()
 #
 # :py:class:`~pulse2percept.stimuli.VideoStimulus` can be used in
 # combination with any :py:meth:`~pulse2percept.implants.ProsthesisSystem`.
-# To make this work, the stimulus needs to have the same number of pixels as
-# the implant has electrodes.
+# What an implant delivers is current, though, not gray levels, so the video
+# has to be encoded first: sampled at the electrode locations, and turned into
+# a pulse train whose amplitude says how bright each pixel was.
 #
-# In most cases, the implant contains a rectangular grid of electrodes, so
-# we just have to resize the video first so that the number of pixels in each
-# frame of the video matches the number of electrodes in the implant:
+# An implant that knows how its device does this carries a
+# :py:class:`~pulse2percept.stimuli.StimulusEncoder` of its own, and encodes
+# whatever video is assigned to it. Here we replace Argus II's own 6 Hz encoder
+# with a 30 Hz one, so that every frame of this 30 fps video gets a pulse:
 
-implant = p2p.implants.ArgusII()
-# Assign the resized video to the implant, encoded into current: a model reads
-# current, and `encode` is what says how much of it a gray level stands for
-# (here 0-50 uA, as a 30 Hz pulse train that keeps up with the frame rate).
-implant.stim = video.resize(implant.shape).encode(freq=30)
+implant = p2p.implants.ArgusII(
+    encoder=p2p.stimuli.AmplitudeEncoder(amp_range=(0, 50), freq=30))
+implant.stim = video
 
 ##############################################################################
 # Then you can feed the video directly into any of the available models

--- a/examples/stimuli/plot_video_stim.py
+++ b/examples/stimuli/plot_video_stim.py
@@ -119,8 +119,9 @@ implant.stim = video
 
 model = p2p.models.AxonMapModel()
 model.build()
-# One percept frame per video frame:
-percept = model.predict_percept(implant, t_percept=video.time)
+# One percept frame per video frame: a spatial model reads the modulation the
+# encoder asked for, not the pulse train realizing it.
+percept = model.predict_percept(implant)
 percept.play()
 
 ##############################################################################

--- a/pulse2percept/implants/argus.py
+++ b/pulse2percept/implants/argus.py
@@ -6,6 +6,14 @@ from collections import OrderedDict
 from .base import ProsthesisSystem
 from .electrodes import DiskElectrode
 from .electrode_arrays import ElectrodeGrid
+from .rasters import SequentialRaster
+from ..stimuli import AmplitudeEncoder
+from ..units import Hz, ms
+
+# Distinguishes "the caller said nothing", which gets the device's own default,
+# from an explicit None, which switches the feature off. A plain None default
+# could not tell the two apart:
+_DEVICE_DEFAULT = object()
 
 
 class ArgusI(ProsthesisSystem):
@@ -209,6 +217,21 @@ class ArgusII(ProsthesisSystem):
         function (callable).
     safe_mode : bool, optional
         If safe mode is enabled, only charge-balanced stimuli are allowed.
+    encoder : :py:class:`~pulse2percept.stimuli.StimulusEncoder`, optional
+        How the device turns a picture into stimulation. Defaults to a fresh
+        :py:class:`~pulse2percept.stimuli.AmplitudeEncoder` at 6 Hz, which is
+        the rate Argus II runs its video at. Pass ``encoder=None`` to switch
+        automatic encoding off, so that an image or a video assigned to
+        ``stim`` is refused rather than encoded.
+
+        .. versionadded:: 0.10.0
+    raster : :py:class:`~pulse2percept.implants.Raster`, optional
+        How the stimulator takes turns between electrodes. Defaults to a fresh
+        :py:class:`~pulse2percept.implants.SequentialRaster` of six groups
+        2 ms apart, i.e. one row of ten electrodes at a time. Pass
+        ``raster=None`` to drive every electrode at once.
+
+        .. versionadded:: 0.10.0
 
     Examples
     --------
@@ -217,8 +240,9 @@ class ArgusII(ProsthesisSystem):
 
     >>> from pulse2percept.implants import ArgusII
     >>> ArgusII(x=0, y=0, z=100, rot=5)  # doctest: +NORMALIZE_WHITESPACE
-    ArgusII(earray=ElectrodeGrid, eye='RE', preprocess=True,
-            safe_mode=False, shape=(6, 10), stim=None)
+    ArgusII(earray=ElectrodeGrid, encoder=AmplitudeEncoder, eye='RE',
+            preprocess=True, raster=SequentialRaster, safe_mode=False,
+            shape=(6, 10), stim=None)
 
     Get access to electrode 'E7', either by name or by row/column index:
 
@@ -230,12 +254,20 @@ class ArgusII(ProsthesisSystem):
     DiskElectrode(activated=True, name='E7', r=112.5, x=862.5,
                   y=862.5, z=100.0)
 
+    Because the device brings its own encoder, a picture can be assigned
+    straight to ``stim`` and comes back as current:
+
+    >>> from pulse2percept.stimuli import LogoBVL
+    >>> ArgusII(stim=LogoBVL()).stim.unit
+    uA
+
     """
     # Frozen class: User cannot add more class attributes
     __slots__ = ('shape',)
 
     def __init__(self, x=0, y=0, z=0, rot=0, eye='RE', stim=None,
-                 preprocess=True, safe_mode=False):
+                 preprocess=True, safe_mode=False, encoder=_DEVICE_DEFAULT,
+                 raster=_DEVICE_DEFAULT):
         self.safe_mode = safe_mode
         self.preprocess = preprocess
         self.shape = (6, 10)
@@ -245,8 +277,17 @@ class ArgusII(ProsthesisSystem):
         self.earray = ElectrodeGrid(self.shape, spacing, x=x, y=y, z=z, r=r,
                                     rot=rot, names=names, etype=DiskElectrode)
 
+        # Built per instance rather than shared between them: a raster binds to
+        # the implant it schedules, and an encoder is a mutable object the
+        # caller may go on to tweak.
+        self.encoder = (AmplitudeEncoder(freq=6 * Hz)
+                        if encoder is _DEVICE_DEFAULT else encoder)
+        self.raster = (SequentialRaster(6, group_dur=2 * ms)
+                       if raster is _DEVICE_DEFAULT else raster)
+
         # Beware of race condition: Stim must be set last, because it requires
-        # indexing into self.electrodes:
+        # indexing into self.electrodes -- and, for a picture, the encoder and
+        # raster set just above:
         self.stim = stim
 
         # Set left/right eye:

--- a/pulse2percept/implants/base.py
+++ b/pulse2percept/implants/base.py
@@ -31,7 +31,14 @@ class ProsthesisSystem(PrettyPrint):
         The electrode array used to deliver electrical stimuli to the retina.
     stim : :py:class:`~pulse2percept.stimuli.Stimulus` source type
         A valid source type for the :py:class:`~pulse2percept.stimuli.Stimulus`
-        object (e.g., scalar, NumPy array, pulse train).
+        object (e.g., scalar, NumPy array, pulse train). It must be electrical
+        (see
+        :py:attr:`~pulse2percept.implants.ProsthesisSystem.stimulus_unit`);
+        encode an image or a video first.
+
+        .. versionchanged:: 0.10.0
+            A stimulus that is not a current is refused here, instead of at
+            the point where a model tries to read it.
     eye : 'LE' or 'RE'
         A string indicating whether the system is implanted in the left ('LE')
         or right eye ('RE')
@@ -76,6 +83,16 @@ class ProsthesisSystem(PrettyPrint):
     # Frozen class: User cannot add more class attributes
     __slots__ = ('_earray', '_stim', '_eye', 'safe_mode', 'preprocess',
                  '_raster', '_max_current')
+
+    #: The physical quantity this system delivers, mirroring
+    #: :py:attr:`~pulse2percept.models.BaseModel.stimulus_unit`. An electrical
+    #: prosthesis delivers current, so a stimulus that is not a current is not
+    #: a stimulus it can deliver, and is refused when it is assigned rather
+    #: than when a model eventually tries to read it. Only the *dimension* has
+    #: to match: `Stimulus` has already converted an amplitude given as
+    #: ``0.05 * mA`` into 50 uA by the time it gets here. A device that
+    #: delivered something else (light, say) would override this.
+    stimulus_unit = uA
 
     def __init__(self, earray, stim=None, eye='RE', preprocess=False,
                  safe_mode=False, raster=None, max_current=None):
@@ -132,22 +149,46 @@ class ProsthesisSystem(PrettyPrint):
             raise ValueError("'max_current' must be positive.")
         self._max_current = max_current
 
+    def _require_deliverable_stim(self, stim):
+        """Refuse a stimulus this system cannot physically deliver
+
+        The implant's half of the boundary that
+        :py:func:`~pulse2percept.models.base._require_stim_dimension` guards on
+        the model's side. Both are needed: a model must not read gray levels as
+        microamps whatever produced them, and an implant that accepted a
+        picture would only fail once a model got hold of it, several steps
+        away from the assignment that was actually wrong.
+
+        Checked on the *final* stimulus, after ``preprocess`` and after any
+        reshaping onto the electrode grid, so that a preprocessing step that
+        turns an image into current is exactly as valid as encoding it first.
+        """
+        if stim.unit.dimension == self.stimulus_unit.dimension:
+            return
+        raise DimensionMismatchError(
+            f"{type(self).__name__} delivers "
+            f"{_describe_unit(self.stimulus_unit)}, but this stimulus is "
+            f"measured in {_describe_unit(stim.unit)}. Encode image or video "
+            f"input with pulse2percept.stimuli.AmplitudeEncoder or "
+            f"FrequencyEncoder before assigning it to the implant, or give "
+            f"the implant a 'preprocess' function that does.")
+
     @staticmethod
     def _require_current_stim(stim, check):
         """Refuse to run an electrical safety check on something that isn't
 
-        Called by each check rather than by ``check_stim``, because an implant
-        with no current limit and no safe mode is not asking an electrical
-        question at all, and a dimensionless stimulus is free to pass through
-        it on its way to a preprocessing step.
+        Called by each check rather than by ``check_stim``, because a safety
+        check is a claim about electricity and each one has to say so for
+        itself: ``check_stim`` is public, and is called directly by tests and
+        by subclasses on stimuli that never went through the setter.
         """
         if stim.unit.dimension != uA.dimension:
             raise DimensionMismatchError(
                 f"Safety check '{check}' needs an electrical stimulus to "
                 f"check, and this one is measured in "
                 f"{_describe_unit(stim.unit)}. Encode it into current first "
-                f"(see pulse2percept.stimuli.Encoder), or give the implant a "
-                f"'preprocess' function that does.")
+                f"(see pulse2percept.stimuli.StimulusEncoder), or give the "
+                f"implant a 'preprocess' function that does.")
 
     @classmethod
     def _require_charge_balanced(cls, stim):
@@ -189,11 +230,12 @@ class ProsthesisSystem(PrettyPrint):
 
         Both are questions about electricity, and neither can be answered about
         a stimulus that is not a current, so each raises a
-        :py:class:`~pulse2percept.units.DimensionMismatchError` on one. An
-        implant that asks for neither does not run either check, which is why a
-        dimensionless stimulus may still be assigned to one -- ``preprocess``
-        has already had its chance to turn it into current, and if it did not,
-        no safety claim is being made about it either.
+        :py:class:`~pulse2percept.units.DimensionMismatchError` on one. In the
+        ordinary flow this cannot happen: assigning to
+        :py:attr:`~pulse2percept.implants.ProsthesisSystem.stim` has already
+        checked the stimulus against
+        :py:attr:`~pulse2percept.implants.ProsthesisSystem.stimulus_unit`.
+        ``check_stim`` is public, though, and may be handed anything.
 
         The user can define their own checks in implants that inherit from
         :py:class:`~pulse2percept.implants.ProsthesisSystem`.
@@ -369,6 +411,19 @@ class ProsthesisSystem(PrettyPrint):
            Unless when using dictionary notation, the number of stimuli must
            equal the number of electrodes in ``earray``.
 
+        The stimulus must be one the implant can deliver; for an electrical
+        prosthesis that means a current (see
+        :py:attr:`~pulse2percept.implants.ProsthesisSystem.stimulus_unit`).
+        Assigning an image or a video raises a
+        :py:class:`~pulse2percept.units.DimensionMismatchError`, because there
+        is no principled default mapping from a gray level to an amplitude or
+        a frequency: say which you want with an
+        :py:class:`~pulse2percept.stimuli.AmplitudeEncoder` or a
+        :py:class:`~pulse2percept.stimuli.FrequencyEncoder`.
+
+        .. versionchanged:: 0.10.0
+            A non-electrical stimulus is refused on assignment.
+
         Examples
         --------
         Send a biphasic pulse (30uA, 0.45ms phase duration) to an implant made
@@ -419,6 +474,12 @@ class ProsthesisSystem(PrettyPrint):
             # want to try and reshape the stimulus to fit the array:
             if len(stim.electrodes) > self.n_electrodes:
                 stim = self.reshape_stim(stim)
+
+            # Whatever came in is now a Stimulus laid out on this implant's
+            # electrodes. Whether it is a stimulus the implant can *deliver*
+            # is the next question, and it is asked before anything else looks
+            # at the numbers:
+            self._require_deliverable_stim(stim)
 
             # Make sure all electrode names are valid:
             for electrode in stim.electrodes:

--- a/pulse2percept/implants/base.py
+++ b/pulse2percept/implants/base.py
@@ -8,7 +8,7 @@ from scipy.interpolate import RegularGridInterpolator
 from .electrodes import Electrode, DiskElectrode
 from .electrode_arrays import ElectrodeArray, ElectrodeGrid
 from .rasters import Raster
-from ..stimuli import Stimulus, ImageStimulus, VideoStimulus
+from ..stimuli import Stimulus, ImageStimulus, StimulusEncoder, VideoStimulus
 from ..stimuli.base import _describe_unit
 from ..units import DimensionMismatchError, as_value, uA, um
 from ..utils import PrettyPrint
@@ -33,12 +33,13 @@ class ProsthesisSystem(PrettyPrint):
         A valid source type for the :py:class:`~pulse2percept.stimuli.Stimulus`
         object (e.g., scalar, NumPy array, pulse train). It must be electrical
         (see
-        :py:attr:`~pulse2percept.implants.ProsthesisSystem.stimulus_unit`);
-        encode an image or a video first.
+        :py:attr:`~pulse2percept.implants.ProsthesisSystem.stimulus_unit`), or
+        an image or a video that the implant's ``encoder`` turns into one.
 
         .. versionchanged:: 0.10.0
-            A stimulus that is not a current is refused here, instead of at
-            the point where a model tries to read it.
+            A stimulus that is neither a current nor something the implant's
+            ``encoder`` can turn into one is refused here, instead of at the
+            point where a model tries to read it.
     eye : 'LE' or 'RE'
         A string indicating whether the system is implanted in the left ('LE')
         or right eye ('RE')
@@ -50,9 +51,21 @@ class ProsthesisSystem(PrettyPrint):
         If safe mode is enabled, only charge-balanced stimuli are allowed.
         Safety is an electrical property, so this also requires the stimulus
         to be measured in units of current.
+    encoder : :py:class:`~pulse2percept.stimuli.StimulusEncoder`, optional
+        How the device turns a picture into stimulation. If given, assigning an
+        image or a video to
+        :py:attr:`~pulse2percept.implants.ProsthesisSystem.stim` encodes it
+        first, so that ``implant.stim`` always ends up electrical. If None,
+        such a stimulus is refused, since there is no principled default
+        mapping from a gray level to an amplitude or a frequency.
+
+        .. versionadded:: 0.10.0
     raster : :py:class:`~pulse2percept.implants.Raster`, optional
         How the stimulator takes turns between electrodes that it cannot drive
-        at the same time. If None, every electrode may fire at once.
+        at the same time. If None, every electrode may fire at once. Assigning
+        one binds it to this implant (see
+        :py:meth:`~pulse2percept.implants.Raster.bind`), and it is the raster
+        the ``encoder`` schedules against.
 
         .. versionadded:: 0.10.0
     max_current : float, optional
@@ -82,7 +95,7 @@ class ProsthesisSystem(PrettyPrint):
     """
     # Frozen class: User cannot add more class attributes
     __slots__ = ('_earray', '_stim', '_eye', 'safe_mode', 'preprocess',
-                 '_raster', '_max_current')
+                 '_encoder', '_raster', '_max_current')
 
     #: The physical quantity this system delivers, mirroring
     #: :py:attr:`~pulse2percept.models.BaseModel.stimulus_unit`. An electrical
@@ -95,13 +108,17 @@ class ProsthesisSystem(PrettyPrint):
     stimulus_unit = uA
 
     def __init__(self, earray, stim=None, eye='RE', preprocess=False,
-                 safe_mode=False, raster=None, max_current=None):
+                 safe_mode=False, encoder=None, raster=None, max_current=None):
         self.earray = earray
         self.eye = eye
         self.safe_mode = safe_mode
         self.preprocess = preprocess
+        self.encoder = encoder
         self.raster = raster
         self.max_current = max_current
+        # Beware of race condition: the stimulus goes last, because assigning
+        # it may have to encode a picture, which needs the encoder, the raster
+        # and the electrode array to be in place already.
         self.stim = stim
 
     def _pprint_params(self):
@@ -112,11 +129,33 @@ class ProsthesisSystem(PrettyPrint):
         }
         if hasattr(self, "eye"):
             params['eye'] = self.eye
+        if self.encoder is not None:
+            params['encoder'] = self.encoder
         if self.raster is not None:
             params['raster'] = self.raster
         if self.max_current is not None:
             params['max_current'] = self.max_current
         return params
+
+    @property
+    def encoder(self):
+        """Stimulus encoder
+
+        How this device turns a picture into stimulation. Most implants do not
+        set one in their constructor, so the slot backing it may never have
+        been written to; no encoder means an image or a video assigned to
+        :py:attr:`~pulse2percept.implants.ProsthesisSystem.stim` is refused
+        rather than silently given a modulation scheme nobody chose.
+        """
+        return getattr(self, '_encoder', None)
+
+    @encoder.setter
+    def encoder(self, encoder):
+        """Encoder setter (called upon ``self.encoder = encoder``)"""
+        if encoder is not None and not isinstance(encoder, StimulusEncoder):
+            raise TypeError(f"'encoder' must be a StimulusEncoder object, not "
+                            f"{type(encoder)}.")
+        self._encoder = encoder
 
     @property
     def raster(self):
@@ -125,15 +164,26 @@ class ProsthesisSystem(PrettyPrint):
         Most implants do not set this in their constructor, so the slot backing
         it may never have been written to; an unset raster means all electrodes
         may fire at once.
+
+        Assigning a raster binds it to this implant (see
+        :py:meth:`~pulse2percept.implants.Raster.bind`), which is what lets a
+        geometry-dependent pattern such as
+        :py:class:`~pulse2percept.implants.CheckerboardRaster` work itself out
+        and what lets :py:meth:`~pulse2percept.implants.Raster.plot` be called
+        without an argument.
         """
         return getattr(self, '_raster', None)
 
     @raster.setter
     def raster(self, raster):
         """Raster setter (called upon ``self.raster = raster``)"""
-        if raster is not None and not isinstance(raster, Raster):
-            raise TypeError(f"'raster' must be a Raster object, not "
-                            f"{type(raster)}.")
+        if raster is not None:
+            if not isinstance(raster, Raster):
+                raise TypeError(f"'raster' must be a Raster object, not "
+                                f"{type(raster)}.")
+            # Before the slot is written to, so that a raster that cannot be
+            # laid out on this array leaves the implant as it was:
+            raster.bind(self)
         self._raster = raster
 
     @property
@@ -168,10 +218,11 @@ class ProsthesisSystem(PrettyPrint):
         raise DimensionMismatchError(
             f"{type(self).__name__} delivers "
             f"{_describe_unit(self.stimulus_unit)}, but this stimulus is "
-            f"measured in {_describe_unit(stim.unit)}. Encode image or video "
-            f"input with pulse2percept.stimuli.AmplitudeEncoder or "
-            f"FrequencyEncoder before assigning it to the implant, or give "
-            f"the implant a 'preprocess' function that does.")
+            f"measured in {_describe_unit(stim.unit)}. Give the implant an "
+            f"'encoder' (pulse2percept.stimuli.AmplitudeEncoder or "
+            f"FrequencyEncoder) so that image or video input is encoded on "
+            f"assignment, encode it yourself first, or give the implant a "
+            f"'preprocess' function that does.")
 
     @staticmethod
     def _require_current_stim(stim, check):
@@ -411,18 +462,21 @@ class ProsthesisSystem(PrettyPrint):
            Unless when using dictionary notation, the number of stimuli must
            equal the number of electrodes in ``earray``.
 
-        The stimulus must be one the implant can deliver; for an electrical
-        prosthesis that means a current (see
+        What is stored is always something the implant can deliver; for an
+        electrical prosthesis that means a current (see
         :py:attr:`~pulse2percept.implants.ProsthesisSystem.stimulus_unit`).
-        Assigning an image or a video raises a
-        :py:class:`~pulse2percept.units.DimensionMismatchError`, because there
-        is no principled default mapping from a gray level to an amplitude or
-        a frequency: say which you want with an
+        An image or a video is not that, so it is run through the implant's
+        :py:attr:`~pulse2percept.implants.ProsthesisSystem.encoder` on the way
+        in. Without an encoder there is no principled default mapping from a
+        gray level to an amplitude or a frequency, so assigning one raises a
+        :py:class:`~pulse2percept.units.DimensionMismatchError`: say which you
+        want with an
         :py:class:`~pulse2percept.stimuli.AmplitudeEncoder` or a
         :py:class:`~pulse2percept.stimuli.FrequencyEncoder`.
 
         .. versionchanged:: 0.10.0
-            A non-electrical stimulus is refused on assignment.
+            A non-electrical stimulus is encoded on assignment if the implant
+            has an encoder, and refused otherwise.
 
         Examples
         --------
@@ -438,6 +492,13 @@ class ProsthesisSystem(PrettyPrint):
 
         >>> from pulse2percept.implants import ArgusII
         >>> implant = ArgusII(stim={'B7': 13})
+
+        Argus II comes with an encoder, so an image can be assigned directly:
+
+        >>> from pulse2percept.stimuli import LogoBVL
+        >>> implant = ArgusII(stim=LogoBVL())
+        >>> implant.stim.unit
+        uA
 
         """
         return self._stim
@@ -468,6 +529,16 @@ class ProsthesisSystem(PrettyPrint):
             else:
                 # Use electrode names as stimulus coordinates:
                 stim = Stimulus(data, electrodes=self.electrode_names)
+
+            # A picture is not something an implant can deliver, so this is
+            # where it becomes stimulation. Preprocessing goes first and may
+            # have done the job already (a `preprocess` that encodes is exactly
+            # as valid as an `encoder`), in which case there is nothing
+            # dimensionless left to encode:
+            if (self.encoder is not None and
+                    stim.unit.dimension.is_dimensionless and
+                    stim.unit.dimension != self.stimulus_unit.dimension):
+                stim = self.encoder.encode(stim, implant=self)
 
             # If the stim is larger than the number of electrodes, most commonly
             # we're dealing with an image or video stim. In this case, we might

--- a/pulse2percept/implants/base.py
+++ b/pulse2percept/implants/base.py
@@ -94,8 +94,8 @@ class ProsthesisSystem(PrettyPrint):
 
     """
     # Frozen class: User cannot add more class attributes
-    __slots__ = ('_earray', '_stim', '_eye', 'safe_mode', 'preprocess',
-                 '_encoder', '_raster', '_max_current')
+    __slots__ = ('_earray', '_stim', '_spatial_stim', '_eye', 'safe_mode',
+                 'preprocess', '_encoder', '_raster', '_max_current')
 
     #: The physical quantity this system delivers, mirroring
     #: :py:attr:`~pulse2percept.models.BaseModel.stimulus_unit`. An electrical
@@ -426,6 +426,10 @@ class ProsthesisSystem(PrettyPrint):
         self.earray.deactivate(electrodes)
         if self.stim is not None:
             self.stim.remove(electrodes)
+        # An electrode switched off delivers nothing, whichever of the two
+        # representations of the stimulus is being read:
+        if self.spatial_stim is not None:
+            self.spatial_stim.remove(electrodes)
 
     @property
     def earray(self):
@@ -500,12 +504,53 @@ class ProsthesisSystem(PrettyPrint):
         >>> implant.stim.unit
         uA
 
+        See Also
+        --------
+        spatial_stim : the modulation behind an encoded stimulus, without the
+                       pulse train.
+
         """
         return self._stim
+
+    @property
+    def spatial_stim(self):
+        """The modulation behind an encoded stimulus, if there is one
+
+        When a picture is assigned to
+        :py:attr:`~pulse2percept.implants.ProsthesisSystem.stim`, the encoder
+        produces two descriptions of the same thing (see
+        :py:class:`~pulse2percept.stimuli.StimulusEncoder`):
+
+        *  ``stim`` is what the device *delivers* -- biphasic pulses on a pulse
+           clock, with the raster deciding which electrodes may fire when.
+        *  ``spatial_stim`` is what the encoder *asked for* -- one amplitude
+           per electrode per frame of the source, with no waveform, no pulse
+           clock and no raster in it.
+
+        Both are in microamps and both cover the same electrodes. Which one a
+        model reads is decided by whether it has a temporal component: a model
+        that integrates over time needs the pulses, and a model that does not
+        cannot express them, so it reads these modulation frames instead (see
+        :py:meth:`~pulse2percept.models.SpatialModel.predict_percept`).
+
+        None whenever ``stim`` was not produced by this implant's encoder --
+        an electrical stimulus assigned directly is already the only
+        description there is of itself.
+
+        .. versionadded:: 0.10.0
+
+        """
+        return getattr(self, '_spatial_stim', None)
 
     @stim.setter
     def stim(self, data):
         """Stimulus setter (called upon ``self.stim = data``)"""
+        # Whatever is being assigned, the modulation behind the *previous*
+        # stimulus is not a description of it. Cleared here and rebuilt below
+        # only where this implant's own encoder produced it, so that it can
+        # never be left describing the picture before last:
+        self._spatial_stim = None
+        spatial = None
         # if stim is empty or None
         if data is None:
             self._stim = None
@@ -534,11 +579,13 @@ class ProsthesisSystem(PrettyPrint):
             # where it becomes stimulation. Preprocessing goes first and may
             # have done the job already (a `preprocess` that encodes is exactly
             # as valid as an `encoder`), in which case there is nothing
-            # dimensionless left to encode:
+            # dimensionless left to encode. Both halves of the encoding are
+            # kept: what the device delivers, and the modulation it was asked
+            # for (see `spatial_stim`).
             if (self.encoder is not None and
                     stim.unit.dimension.is_dimensionless and
                     stim.unit.dimension != self.stimulus_unit.dimension):
-                stim = self.encoder.encode(stim, implant=self)
+                spatial, stim = self.encoder._encode_both(stim, implant=self)
 
             # If the stim is larger than the number of electrodes, most commonly
             # we're dealing with an image or video stim. In this case, we might
@@ -559,12 +606,17 @@ class ProsthesisSystem(PrettyPrint):
                     raise ValueError(f'Electrode "{electrode}" not found in '
                                      f'implant.')
             # Remove deactivated electrodes from the stimulus:
-            stim.remove([name for (name, e) in self.electrodes.items()
-                         if not e.activated and name in stim.electrodes])
-            # Perform safety checks, etc.:
+            off = [name for (name, e) in self.electrodes.items()
+                   if not e.activated and name in stim.electrodes]
+            stim.remove(off)
+            if spatial is not None:
+                spatial.remove(off)
+            # Perform safety checks, etc. These are all questions about what
+            # gets delivered, so they are asked of the pulse train:
             self.check_stim(stim)
             # Store stimulus:
             self._stim = deepcopy(stim)
+            self._spatial_stim = None if spatial is None else deepcopy(spatial)
 
     @property
     def eye(self):

--- a/pulse2percept/implants/base.py
+++ b/pulse2percept/implants/base.py
@@ -427,9 +427,9 @@ class ProsthesisSystem(PrettyPrint):
         if self.stim is not None:
             self.stim.remove(electrodes)
         # An electrode switched off delivers nothing, whichever of the two
-        # representations of the stimulus is being read:
-        if self.spatial_stim is not None:
-            self.spatial_stim.remove(electrodes)
+        # descriptions of the stimulus is being read:
+        if getattr(self, '_spatial_stim', None) is not None:
+            self._spatial_stim.remove(electrodes)
 
     @property
     def earray(self):
@@ -504,51 +504,21 @@ class ProsthesisSystem(PrettyPrint):
         >>> implant.stim.unit
         uA
 
-        See Also
-        --------
-        spatial_stim : the modulation behind an encoded stimulus, without the
-                       pulse train.
-
         """
         return self._stim
-
-    @property
-    def spatial_stim(self):
-        """The modulation behind an encoded stimulus, if there is one
-
-        When a picture is assigned to
-        :py:attr:`~pulse2percept.implants.ProsthesisSystem.stim`, the encoder
-        produces two descriptions of the same thing (see
-        :py:class:`~pulse2percept.stimuli.StimulusEncoder`):
-
-        *  ``stim`` is what the device *delivers* -- biphasic pulses on a pulse
-           clock, with the raster deciding which electrodes may fire when.
-        *  ``spatial_stim`` is what the encoder *asked for* -- one amplitude
-           per electrode per frame of the source, with no waveform, no pulse
-           clock and no raster in it.
-
-        Both are in microamps and both cover the same electrodes. Which one a
-        model reads is decided by whether it has a temporal component: a model
-        that integrates over time needs the pulses, and a model that does not
-        cannot express them, so it reads these modulation frames instead (see
-        :py:meth:`~pulse2percept.models.SpatialModel.predict_percept`).
-
-        None whenever ``stim`` was not produced by this implant's encoder --
-        an electrical stimulus assigned directly is already the only
-        description there is of itself.
-
-        .. versionadded:: 0.10.0
-
-        """
-        return getattr(self, '_spatial_stim', None)
 
     @stim.setter
     def stim(self, data):
         """Stimulus setter (called upon ``self.stim = data``)"""
-        # Whatever is being assigned, the modulation behind the *previous*
-        # stimulus is not a description of it. Cleared here and rebuilt below
-        # only where this implant's own encoder produced it, so that it can
-        # never be left describing the picture before last:
+        # `_spatial_stim` is the other description of an encoded stimulus: the
+        # modulation the encoder asked for, one amplitude per electrode per
+        # frame of the source, with no waveform, pulse clock or raster in it.
+        # `stim` stays the pulse train the device delivers; this is what a
+        # reader with no clock of its own can make sense of, and it is read by
+        # `pulse2percept.models.SpatialModel.predict_percept`. Cleared on every
+        # path through this setter and rebuilt below only where this implant's
+        # own encoder produced it, so that it can never be left describing the
+        # picture before last:
         self._spatial_stim = None
         spatial = None
         # if stim is empty or None
@@ -581,7 +551,7 @@ class ProsthesisSystem(PrettyPrint):
             # as valid as an `encoder`), in which case there is nothing
             # dimensionless left to encode. Both halves of the encoding are
             # kept: what the device delivers, and the modulation it was asked
-            # for (see `spatial_stim`).
+            # for (see `_spatial_stim` above).
             if (self.encoder is not None and
                     stim.unit.dimension.is_dimensionless and
                     stim.unit.dimension != self.stimulus_unit.dimension):

--- a/pulse2percept/implants/rasters.py
+++ b/pulse2percept/implants/rasters.py
@@ -46,7 +46,7 @@ class Raster(PrettyPrint, metaclass=ABCMeta):
     Taking turns is described by a **raster sweep**: group *g* starts its pulse
     ``g * group_dur`` after group 0 does, so a sweep spans ``n_groups *
     group_dur``. Two things then keep groups apart for good (see
-    :py:class:`~pulse2percept.stimuli.Encoder`):
+    :py:class:`~pulse2percept.stimuli.StimulusEncoder`):
 
     1.  A pulse has to be short enough to finish before the next group's turn
         begins.

--- a/pulse2percept/implants/rasters.py
+++ b/pulse2percept/implants/rasters.py
@@ -29,6 +29,20 @@ def _whole(name, value):
     return int(value)
 
 
+def _electrode_array(implant):
+    """The electrode array of a prosthesis system, or the array itself
+
+    Duck-typed rather than imported, since ``implants.base`` imports this
+    module.
+    """
+    earray = getattr(implant, 'earray', implant)
+    if (getattr(earray, 'electrode_names', None) is None or
+            getattr(earray, 'coordinates', None) is None):
+        raise TypeError(f"'implant' must be a ProsthesisSystem or an "
+                        f"ElectrodeArray, not {type(implant)}.")
+    return earray
+
+
 class Raster(PrettyPrint, metaclass=ABCMeta):
     """Abstract base class for all raster patterns
 
@@ -85,7 +99,20 @@ class Raster(PrettyPrint, metaclass=ABCMeta):
     the sweep; a period they all share is delivered exactly, since fixed group
     offsets cannot drift into one another.
 
-    Subclasses only implement ``groups``.
+    A raster is *bound* to the implant it schedules. Assigning it to
+    :py:attr:`~pulse2percept.implants.ProsthesisSystem.raster` binds it, which
+    is what lets a subclass whose pattern depends on where the electrodes are
+    (:py:class:`~pulse2percept.implants.CheckerboardRaster`) work the geometry
+    out, and what lets :py:meth:`plot` draw the array without being handed it
+    again:
+
+    .. code::
+
+        implant.raster = CheckerboardRaster(5)
+        implant.raster.plot()
+
+    Subclasses only implement ``groups``, and override ``bind`` if their
+    pattern depends on the implant.
 
     .. versionadded:: 0.10.0
 
@@ -113,7 +140,7 @@ class Raster(PrettyPrint, metaclass=ABCMeta):
         :py:mod:`pulse2percept.units`.
 
     """
-    __slots__ = ('group_dur',)
+    __slots__ = ('group_dur', '_implant')
 
     def __init__(self, group_dur=None):
         # A slot is a duration, and it is combined with pulse periods, the
@@ -124,10 +151,64 @@ class Raster(PrettyPrint, metaclass=ABCMeta):
             if group_dur <= 0:
                 raise ValueError("'group_dur' must be positive.")
         self.group_dur = group_dur
+        self._implant = None
 
     def _pprint_params(self):
         """Return a dict of class arguments to pretty-print"""
+        # Deliberately without the implant: a ProsthesisSystem pretty-prints
+        # its raster, so naming it back here would recurse.
         return {'group_dur': self.group_dur, 'n_groups': self.n_groups}
+
+    @property
+    def implant(self):
+        """The implant this raster is bound to, or None
+
+        Set by assigning the raster to
+        :py:attr:`~pulse2percept.implants.ProsthesisSystem.raster` (see
+        :py:meth:`bind`).
+        """
+        return getattr(self, '_implant', None)
+
+    def bind(self, implant):
+        """Bind the raster to an implant
+
+        A raster describes how one particular device takes turns between its
+        electrodes, so it is bound to that device rather than handed to every
+        method that needs it. This is called for you when the raster is
+        assigned to
+        :py:attr:`~pulse2percept.implants.ProsthesisSystem.raster`.
+
+        Binding is also where a pattern that depends on the electrode geometry
+        is worked out, so a subclass that has such a pattern overrides this and
+        recomputes. Rebinding therefore always recomputes: the same raster
+        object assigned to a second implant describes *that* implant.
+
+        Parameters
+        ----------
+        implant : :py:class:`~pulse2percept.implants.ProsthesisSystem`
+            The implant to bind to, or its
+            :py:class:`~pulse2percept.implants.ElectrodeArray`.
+
+        Returns
+        -------
+        self : :py:class:`~pulse2percept.implants.Raster`
+            The raster, so that ``CheckerboardRaster(5).bind(implant)`` reads
+            as one expression.
+
+        """
+        _electrode_array(implant)
+        self._implant = implant
+        return self
+
+    def _bound(self, implant=None):
+        """The implant to answer a question about, bound or given"""
+        implant = self.implant if implant is None else implant
+        if implant is None:
+            raise ValueError(
+                f"This {type(self).__name__} is not bound to an implant. "
+                f"Assign it to 'implant.raster' first, or pass the implant "
+                f"explicitly.")
+        return _electrode_array(implant)
 
     @property
     @abstractmethod
@@ -186,7 +267,7 @@ class Raster(PrettyPrint, metaclass=ABCMeta):
                              f"{group}.")
         return np.asarray(electrodes)[self.groups(electrodes) == group]
 
-    def plot(self, implant, annotate=None, ax=None, cmap='viridis',
+    def plot(self, implant=None, annotate=None, ax=None, cmap='viridis',
              autoscale=True):
         """Plot the electrode array, colored by raster group
 
@@ -201,11 +282,12 @@ class Raster(PrettyPrint, metaclass=ABCMeta):
 
         Parameters
         ----------
-        implant : :py:class:`~pulse2percept.implants.ProsthesisSystem`
+        implant : :py:class:`~pulse2percept.implants.ProsthesisSystem`, optional
             The implant to draw, or its
             :py:class:`~pulse2percept.implants.ElectrodeArray`. Its electrodes
             are the ones the raster is asked about, so this has to be an
-            implant the raster covers.
+            implant the raster covers. If None, the implant the raster is
+            bound to is drawn (see :py:meth:`bind`).
         annotate : bool, optional
             Whether to write the group index into each electrode. If None,
             they are written whenever there are few enough electrodes
@@ -225,13 +307,8 @@ class Raster(PrettyPrint, metaclass=ABCMeta):
             The axes drawn on.
 
         """
-        earray = getattr(implant, 'earray', implant)
-        names = getattr(earray, 'electrode_names', None)
-        coords = getattr(earray, 'coordinates', None)
-        if names is None or coords is None:
-            raise TypeError(f"'implant' must be a ProsthesisSystem or an "
-                            f"ElectrodeArray, not {type(implant)}.")
-        names = list(names)
+        earray = self._bound(implant)
+        names = list(earray.electrode_names)
         group = np.asarray(self.groups(names), dtype=np.int64)
         if annotate is None:
             annotate = len(names) <= 120
@@ -245,7 +322,7 @@ class Raster(PrettyPrint, metaclass=ABCMeta):
         colors = plt.get_cmap(cmap)(spread)
         # Microns, which is what the axis labels below say and what the patch
         # radii are sized in:
-        xy = coords(um)[:, :2]
+        xy = earray.coordinates(um)[:, :2]
         # Sized by the array rather than by what each electrode reports, since
         # neither of the two shapes an implant is usually built from would show
         # its color: a PointSource is a 5 um dot however far apart they are,
@@ -695,16 +772,25 @@ class CheckerboardRaster(Raster):
     electrodes actually are. Arrays whose electrodes do not lie on a grid at
     all raise ``NotImplementedError``.
 
+    The pattern depends on where the electrodes are, so it is worked out when
+    the raster is **bound** to an implant -- which assigning it to
+    :py:attr:`~pulse2percept.implants.ProsthesisSystem.raster` does. Until
+    then the raster knows how many groups it will have but not which electrode
+    goes in which, and :py:meth:`groups`, :py:attr:`min_spacing` and
+    :py:meth:`~pulse2percept.implants.Raster.plot` all raise. Binding it to a
+    second implant recomputes the pattern for that one.
+
     .. note::
 
         Not every ``n_groups`` fits a given grid, and one that does not
-        raises a ``ValueError`` and specifies counts that do.
+        raises a ``ValueError`` (naming counts that do) when the raster is
+        bound.
 
-        Both halves of the pattern are searched for when the raster is built,
-        and the order the groups fire in is settled exactly only up to eight
-        groups; beyond that a heuristic stands in for it, and the search grows
-        with the group count.
-        
+        Both halves of the pattern are searched for at binding time, and the
+        order the groups fire in is settled exactly only up to eight groups;
+        beyond that a heuristic stands in for it, and the search grows with the
+        group count.
+
         It is worth checking :py:attr:`min_spacing` on the ones that do fit,
         because a count can be accepted and still leave neighbors in the same
         group. The standard example is two groups on a hex grid, which
@@ -715,11 +801,6 @@ class CheckerboardRaster(Raster):
 
     Parameters
     ----------
-    implant : :py:class:`~pulse2percept.implants.ProsthesisSystem`
-        The implant to build the pattern for, or its
-        :py:class:`~pulse2percept.implants.ElectrodeArray`. The electrodes have
-        to lie on a grid, and their names are how the raster recognizes them
-        later, so this has to be the implant the stimulus will be applied to.
     n_groups : int
         Number of groups to split the electrodes into.
     balance : float, optional
@@ -740,7 +821,7 @@ class CheckerboardRaster(Raster):
 
     >>> from pulse2percept.implants import ArgusII, CheckerboardRaster
     >>> implant = ArgusII()
-    >>> implant.raster = CheckerboardRaster(implant, 5)
+    >>> implant.raster = CheckerboardRaster(5)
     >>> implant.raster.n_groups
     5
 
@@ -758,29 +839,36 @@ class CheckerboardRaster(Raster):
     ['A1', 'A6', 'B3', 'B8']
 
     """
-    __slots__ = ('_n_groups', '_group_of', '_min_spacing')
+    __slots__ = ('_n_groups', '_balance', '_group_of', '_min_spacing')
 
-    def __init__(self, implant, n_groups, balance=0.05, group_dur=None):
+    def __init__(self, n_groups, balance=0.05, group_dur=None):
         super().__init__(group_dur=group_dur)
         _finite('n_groups', n_groups)
         if int(n_groups) != n_groups or n_groups < 1:
             raise ValueError(f"'n_groups' must be a positive integer, not "
                              f"{n_groups}.")
-        n_groups = int(n_groups)
         _finite('balance', balance)
         if balance < 0:
             raise ValueError(f"'balance' cannot be negative, not {balance}.")
-        # A ProsthesisSystem carries the array; anything else has to be one.
-        # Duck-typed rather than imported, since `base` imports this module:
-        earray = getattr(implant, 'earray', implant)
-        names = getattr(earray, 'electrode_names', None)
-        coords = getattr(earray, 'coordinates', None)
-        if names is None or coords is None:
-            raise TypeError(f"'implant' must be a ProsthesisSystem or an "
-                            f"ElectrodeArray, not {type(implant)}.")
-        names = list(names)
+        self._n_groups = int(n_groups)
+        self._balance = balance
+        # Which electrode goes in which group is a fact about a particular
+        # array, and is worked out in `bind`:
+        self._group_of = None
+        self._min_spacing = None
+
+    def bind(self, implant):
+        """Work the checkerboard out for this implant's electrode grid
+
+        See :py:meth:`~pulse2percept.implants.Raster.bind`. Called for you
+        when the raster is assigned to
+        :py:attr:`~pulse2percept.implants.ProsthesisSystem.raster`.
+        """
+        earray = _electrode_array(implant)
+        names = list(earray.electrode_names)
+        n_groups, balance = self._n_groups, self._balance
         # Microns, which is what `min_spacing` reports the answer in:
-        xy = coords(um)[:, :2]
+        xy = earray.coordinates(um)[:, :2]
         if len(xy) < n_groups:
             raise ValueError(f"{len(xy)} electrode(s) cannot be split into "
                              f"{n_groups} groups.")
@@ -813,7 +901,7 @@ class CheckerboardRaster(Raster):
                 f"{balance:.0%} bigger than an even split. Try "
                 f"{_suggest(ij, n_groups, balance)} groups instead, or raise "
                 f"'balance' to allow groups of unequal size.")
-        labels, w1, w2, self._min_spacing = best[1:]
+        labels, w1, w2, min_spacing = best[1:]
 
         # Fire them in the order that wanders least. `labels` says which
         # pattern an electrode belongs to; the group index it gets is when that
@@ -829,14 +917,19 @@ class CheckerboardRaster(Raster):
         slot = np.empty(n_groups, dtype=np.int64)
         slot[_firing_order(jump, scale)] = np.arange(n_groups)
 
-        self._n_groups = n_groups
+        # Only once the pattern is known, so that a raster that could not be
+        # laid out on this array keeps whatever it was bound to before:
+        super().bind(implant)
+        self._min_spacing = min_spacing
         self._group_of = {str(name): int(slot[label])
                           for name, label in zip(names, labels)}
+        return self
 
     def _pprint_params(self):
         """Return a dict of class arguments to pretty-print"""
         params = super()._pprint_params()
-        params.update({'min_spacing': self.min_spacing})
+        params.update({'balance': self._balance,
+                       'min_spacing': self.min_spacing})
         return params
 
     @property
@@ -853,20 +946,27 @@ class CheckerboardRaster(Raster):
         electrode pitch. Measured between electrodes the implant actually has,
         so a small or trimmed array can come out better spaced than the pattern
         it was cut from. Infinite when no group holds more than one electrode,
-        since then no two electrodes ever fire together.
+        since then no two electrodes ever fire together. None until the raster
+        is bound to an implant, since there is no grid to measure yet.
         """
         return self._min_spacing
 
     def groups(self, electrodes):
         """Assign each electrode to a raster group"""
+        if self._group_of is None:
+            raise ValueError(
+                "This CheckerboardRaster is not bound to an implant, so it "
+                "does not know where the electrodes are. Assign it to "
+                "'implant.raster' first.")
         try:
             return np.array([self._group_of[str(e)] for e in electrodes])
         except KeyError:
             missing = sorted({str(e) for e in electrodes} -
                              set(self._group_of))
             raise ValueError(f"Electrode(s) {missing[:10]} are not on the "
-                             f"grid this raster was built for. Build it from "
-                             f"the implant the stimulus is applied to.")
+                             f"grid this raster was bound to. Assign the "
+                             f"raster to the implant the stimulus is applied "
+                             f"to.")
 
 
 class CustomRaster(Raster):

--- a/pulse2percept/implants/tests/test_argus.py
+++ b/pulse2percept/implants/tests/test_argus.py
@@ -254,9 +254,7 @@ def test_ArgusII_encodes_pictures_on_assignment():
     npt.assert_almost_equal(argus.stim.time[-1], 500)
     npt.assert_almost_equal(np.abs(argus.stim.data).max(), 50, decimal=4)
     # The raster is in there too: six groups, each 2 ms behind the one before:
-    meta = argus.stim.metadata['encoder']
-    npt.assert_equal(meta['kind'], 'AmplitudeEncoder')
-    npt.assert_almost_equal(meta['cycle'], 12)
+    npt.assert_almost_equal(argus.stim.metadata['encoder']['cycle'], 12)
     # ... which is what a raster is for: at no instant is more than one group
     # of electrodes drawing current.
     groups = argus.raster.groups(argus.stim.electrodes)
@@ -269,7 +267,7 @@ def test_ArgusII_encodes_pictures_on_assignment():
         argus = implants.ArgusII(stim=BostonTrain())
     npt.assert_equal(argus.stim.unit, uA)
     meta = argus.stim.metadata['encoder']
-    npt.assert_equal(meta['n_frames'], 94)
+    npt.assert_equal(meta['frame_time'].size, 94)
     npt.assert_almost_equal(meta['frame_dur'], 1000 / 29.97, decimal=3)
 
     # Without an encoder the very same picture is refused, since there is no

--- a/pulse2percept/implants/tests/test_argus.py
+++ b/pulse2percept/implants/tests/test_argus.py
@@ -3,6 +3,10 @@ import pytest
 import numpy.testing as npt
 
 from pulse2percept import implants
+from pulse2percept.implants import SequentialRaster
+from pulse2percept.models import AxonMapModel
+from pulse2percept.stimuli import AmplitudeEncoder, BostonTrain, LogoBVL
+from pulse2percept.units import DimensionMismatchError, uA
 
 
 @pytest.mark.parametrize('ztype', ('float', 'list'))
@@ -186,3 +190,97 @@ def test_ArgusII(ztype, x, y, rot):
     argus = implants.ArgusII(stim=np.ones(60))
     npt.assert_equal(argus.stim.shape, (60, 1))
     npt.assert_almost_equal(argus.stim.data, 1)
+
+
+def test_ArgusII_defaults():
+    """Argus II brings its own encoder and raster, and each instance a fresh one
+    """
+    argus = implants.ArgusII()
+    # 6 Hz amplitude modulation, which is the rate the device runs video at:
+    npt.assert_equal(isinstance(argus.encoder, AmplitudeEncoder), True)
+    npt.assert_almost_equal(argus.encoder.freq, 6)
+    # Six sequential groups (one row of ten electrodes each), 2 ms apart:
+    npt.assert_equal(isinstance(argus.raster, SequentialRaster), True)
+    npt.assert_equal(argus.raster.n_groups, 6)
+    npt.assert_almost_equal(argus.raster.group_dur, 2)
+    npt.assert_equal(argus.raster.groups(argus.electrode_names),
+                     np.repeat(np.arange(6), 10))
+    # The raster is bound to the implant that owns it, so it plots itself:
+    npt.assert_equal(argus.raster.implant is argus, True)
+
+    # Each instance gets its own, so tweaking one implant's does not reach
+    # every other Argus II in the session:
+    other = implants.ArgusII()
+    npt.assert_equal(other.encoder is argus.encoder, False)
+    npt.assert_equal(other.raster is argus.raster, False)
+    other.encoder.freq = 20
+    npt.assert_almost_equal(argus.encoder.freq, 6)
+
+    # An explicit None switches each feature off, and is told apart from the
+    # argument simply not being given:
+    npt.assert_equal(implants.ArgusII(encoder=None).encoder, None)
+    npt.assert_equal(implants.ArgusII(raster=None).raster, None)
+    npt.assert_equal(implants.ArgusII(raster=None).encoder is None, False)
+    # ... and switching the raster off really does stop the multiplexing: every
+    # electrode then fires on the same schedule, at the same instant.
+    unrastered = implants.ArgusII(raster=None, stim=LogoBVL())
+    npt.assert_equal(unrastered.stim.metadata['encoder']['cycle'], None)
+    # There is an instant at which every electrode is at its own peak, so the
+    # stimulator has to source the whole array at once:
+    npt.assert_almost_equal(np.abs(unrastered.stim.data).sum(axis=0).max(),
+                            np.abs(unrastered.stim.data).max(axis=1).sum(),
+                            decimal=3)
+    rastered = implants.ArgusII(stim=LogoBVL())
+    npt.assert_array_less(np.abs(rastered.stim.data).sum(axis=0).max(),
+                          np.abs(unrastered.stim.data).sum(axis=0).max())
+    # ... and either can be replaced outright:
+    custom = implants.ArgusII(encoder=AmplitudeEncoder(freq=20),
+                              raster=SequentialRaster(3))
+    npt.assert_almost_equal(custom.encoder.freq, 20)
+    npt.assert_equal(custom.raster.n_groups, 3)
+    with pytest.raises(TypeError):
+        implants.ArgusII(encoder='amplitude')
+    with pytest.raises(TypeError):
+        implants.ArgusII(raster='line')
+
+
+def test_ArgusII_encodes_pictures_on_assignment():
+    """The device's own defaults are what make `ArgusII(stim=picture)` work"""
+    argus = implants.ArgusII(stim=LogoBVL())
+    npt.assert_equal(argus.stim.unit, uA)
+    npt.assert_equal(argus.stim.shape[0], argus.n_electrodes)
+    npt.assert_equal(list(argus.stim.electrodes), list(argus.electrode_names))
+    # 6 Hz over the 500 ms an image is treated as lasting is three pulses:
+    npt.assert_almost_equal(argus.stim.time[-1], 500)
+    npt.assert_almost_equal(np.abs(argus.stim.data).max(), 50, decimal=4)
+    # The raster is in there too: six groups, each 2 ms behind the one before:
+    meta = argus.stim.metadata['encoder']
+    npt.assert_equal(meta['kind'], 'AmplitudeEncoder')
+    npt.assert_almost_equal(meta['cycle'], 12)
+    # ... which is what a raster is for: at no instant is more than one group
+    # of electrodes drawing current.
+    groups = argus.raster.groups(argus.stim.electrodes)
+    for column in argus.stim.data.T:
+        npt.assert_equal(np.unique(groups[column != 0]).size <= 1, True)
+
+    # A video keeps its own frame clock, which is what a model reports at:
+    with pytest.warns(UserWarning, match='deliver no pulse'):
+        # 6 Hz against 29.97 fps: most frames carry no pulse of their own
+        argus = implants.ArgusII(stim=BostonTrain())
+    npt.assert_equal(argus.stim.unit, uA)
+    meta = argus.stim.metadata['encoder']
+    npt.assert_equal(meta['n_frames'], 94)
+    npt.assert_almost_equal(meta['frame_dur'], 1000 / 29.97, decimal=3)
+
+    # Without an encoder the very same picture is refused, since there is no
+    # default mapping from a gray level onto an amplitude:
+    with pytest.raises(DimensionMismatchError):
+        implants.ArgusII(encoder=None, stim=LogoBVL())
+
+    # And the whole point of it: a picture goes straight into a model, with no
+    # encoding step for the caller to spell out.
+    model = AxonMapModel(xrange=(-4, 4), yrange=(-3, 3), step=1, rho=200,
+                         lam=100).build()
+    percept = model.predict_percept(implants.ArgusII(stim=LogoBVL()))
+    npt.assert_equal(percept.data.shape[:2], model.grid.x.shape)
+    npt.assert_equal(np.any(percept.data > 0), True)

--- a/pulse2percept/implants/tests/test_base.py
+++ b/pulse2percept/implants/tests/test_base.py
@@ -13,7 +13,8 @@ from skimage.measure import label, regionprops
 from pulse2percept.implants import (PointSource, ElectrodeArray, ElectrodeGrid,
                                     ProsthesisSystem, RectangleImplant,
                                     PhotovoltaicPixel)
-from pulse2percept.stimuli import Stimulus, ImageStimulus, VideoStimulus, LogoBVL
+from pulse2percept.stimuli import (Stimulus, ImageStimulus, VideoStimulus,
+                                   BostonTrain, LogoBVL)
 from pulse2percept.stimuli import (AmplitudeEncoder, BiphasicPulse,
                                    MonophasicPulse)
 from pulse2percept.implants import (ArgusII, DiskElectrode)
@@ -154,16 +155,20 @@ def test_ProsthesisSystem_stim():
 @pytest.mark.parametrize('n_frames', (1, 3, 4))
 def test_ProsthesisSystem_reshape_stim(rot, gtype, n_frames):
     implant = ProsthesisSystem(ElectrodeGrid((10, 10), 30, rot=rot, type=gtype))
-    # Smoke test the automatic reshaping:
+    # Smoke test the reshaping. It is called on the way to `implant.stim`, but
+    # a picture is not a stimulus an implant can deliver, so it is exercised
+    # directly here (which is also how an encoder reaches it):
     n_px = 21
-    implant.stim = ImageStimulus(np.ones((n_px, n_px, n_frames)).squeeze())
-    npt.assert_equal(implant.stim.data.shape, (implant.n_electrodes, 1))
-    npt.assert_equal(implant.stim.time, None)
-    implant.stim = VideoStimulus(np.ones((n_px, n_px, 3 * n_frames)),
-                                 time=2 * np.arange(3 * n_frames))
-    npt.assert_equal(implant.stim.data.shape,
+    reshaped = implant.reshape_stim(
+        ImageStimulus(np.ones((n_px, n_px, n_frames)).squeeze()))
+    npt.assert_equal(reshaped.data.shape, (implant.n_electrodes, 1))
+    npt.assert_equal(reshaped.time, None)
+    reshaped = implant.reshape_stim(
+        VideoStimulus(np.ones((n_px, n_px, 3 * n_frames)),
+                      time=2 * np.arange(3 * n_frames)))
+    npt.assert_equal(reshaped.data.shape,
                      (implant.n_electrodes, 3 * n_frames))
-    npt.assert_equal(implant.stim.time, 2 * np.arange(3 * n_frames))
+    npt.assert_equal(reshaped.time, 2 * np.arange(3 * n_frames))
 
     # Verify that a horizontal stimulus will always appear horizontally, even if
     # the device is rotated. What is under test is where `reshape_stim` puts
@@ -181,7 +186,7 @@ def test_ProsthesisSystem_reshape_stim(rot, gtype, n_frames):
 
     # Smoke test a large hex grid (old code results in MemoryError):
     implant = PhotovoltaicArray(r=2, spacing=40, rot=rot)
-    implant.stim = LogoBVL()
+    implant.reshape_stim(LogoBVL())
 
 
 def test_ProsthesisSystem_deactivate():
@@ -285,20 +290,21 @@ def test_ProsthesisSystem_reshape_stim_frames_independent():
     vid = rng.random((24, 31, n_frames)).astype(np.float32)
     implant = ProsthesisSystem(ElectrodeGrid((6, 8), 200))
 
-    implant.stim = VideoStimulus(vid, time=np.arange(n_frames))
-    joint = implant.stim.data
+    joint = implant.reshape_stim(VideoStimulus(vid,
+                                               time=np.arange(n_frames))).data
     npt.assert_equal(joint.shape, (implant.n_electrodes, n_frames))
 
     for f in range(n_frames):
-        implant.stim = ImageStimulus(vid[..., f])
-        npt.assert_allclose(implant.stim.data[:, 0], joint[:, f], rtol=1e-5,
+        single = implant.reshape_stim(ImageStimulus(vid[..., f]))
+        npt.assert_allclose(single.data[:, 0], joint[:, f], rtol=1e-5,
                             atol=1e-7)
 
     # Pixels outside the electrode footprint are filled with zero, not
     # extrapolated, so an all-zero frame stays all zero:
     vid[..., 2] = 0
-    implant.stim = VideoStimulus(vid, time=np.arange(n_frames))
-    npt.assert_equal(np.all(implant.stim.data[:, 2] == 0), True)
+    sampled = implant.reshape_stim(VideoStimulus(vid,
+                                                 time=np.arange(n_frames)))
+    npt.assert_equal(np.all(sampled.data[:, 2] == 0), True)
 
 
 def test_implant_geometry_units():
@@ -404,24 +410,21 @@ def test_ProsthesisSystem_max_current_units():
 
 
 def test_ProsthesisSystem_safety_checks_are_electrical():
-    """Electrical safety may only be asked about an electrical stimulus"""
-    img = ImageStimulus(np.linspace(0, 1, 16).reshape((4, 4)))
-    vid = VideoStimulus(np.ones((6, 10, 3)) * 0.5, time=[0, 20, 40])
+    """Electrical safety may only be asked about an electrical stimulus
 
-    # No electrical policy requested, so no electrical question is asked and a
-    # picture may still be assigned. This is what keeps preprocessing
-    # workflows, which turn images into current, working:
-    implant = ArgusII(preprocess=False, safe_mode=False)
-    implant.stim = img
-    npt.assert_equal(implant.stim.unit, dimensionless)
-    implant.stim = vid
-    npt.assert_equal(implant.stim.unit, dimensionless)
+    In the ordinary flow the setter has already refused anything that is not a
+    current (see ``test_ProsthesisSystem_requires_an_electrical_stimulus``), so
+    these guards are reached by calling ``check_stim`` directly -- which is
+    public, and which a subclass may call on a stimulus of its own making.
+    """
+    img = ImageStimulus(np.linspace(0, 1, 16).reshape((4, 4)))
+    sampled = ArgusII().reshape_stim(img)
 
     # `safe_mode` is a claim about electricity, and cannot be made about a
     # picture -- it must not integrate gray levels and pronounce them safe:
     implant = ArgusII(preprocess=False, safe_mode=True)
     with pytest.raises(DimensionMismatchError) as excinfo:
-        implant.stim = img
+        implant.check_stim(sampled)
     npt.assert_equal("Safety check 'safe_mode'" in str(excinfo.value), True)
     npt.assert_equal('dimensionless' in str(excinfo.value), True)
 
@@ -429,7 +432,7 @@ def test_ProsthesisSystem_safety_checks_are_electrical():
     implant = ArgusII(preprocess=False, safe_mode=False)
     implant.max_current = 100 * uA
     with pytest.raises(DimensionMismatchError) as excinfo:
-        implant.stim = img
+        implant.check_stim(sampled)
     npt.assert_equal("Safety check 'max_current'" in str(excinfo.value), True)
     # Including an empty one: the guard sits before the empty-data fast path,
     # since an empty picture is just as much the wrong kind of thing.
@@ -440,6 +443,49 @@ def test_ProsthesisSystem_safety_checks_are_electrical():
     # An empty *electrical* stimulus is fine, as before:
     implant.check_stim(Stimulus(np.zeros((60, 0)),
                                 electrodes=ArgusII().electrode_names))
+
+
+def test_ProsthesisSystem_requires_an_electrical_stimulus():
+    """An implant delivers current, so a picture is refused on assignment
+
+    Not when a model eventually reads it: the assignment is the line that was
+    wrong, and there is no principled default mapping from a gray level onto an
+    amplitude or a frequency for the implant to apply on the user's behalf.
+    """
+    img = ImageStimulus(np.linspace(0, 1, 16).reshape((4, 4)))
+    npt.assert_equal(ProsthesisSystem.stimulus_unit, uA)
+
+    for source in (img, VideoStimulus(np.ones((6, 10, 3)) * 0.5,
+                                      time=[0, 20, 40]), BostonTrain()):
+        with pytest.raises(DimensionMismatchError) as excinfo:
+            ArgusII(stim=source)
+        npt.assert_equal('AmplitudeEncoder' in str(excinfo.value), True)
+        npt.assert_equal('dimensionless' in str(excinfo.value), True)
+        implant = ArgusII()
+        with pytest.raises(DimensionMismatchError):
+            implant.stim = source
+        # Nothing was stored, so the implant is left as it was:
+        npt.assert_equal(implant.stim, None)
+
+    # Encoded, the very same picture goes through:
+    implant = ArgusII()
+    implant.stim = AmplitudeEncoder(implant, amp_range=(0, 50)).encode(img)
+    npt.assert_equal(implant.stim.unit, uA)
+
+    # ... and so does everything that was electrical all along:
+    for source in ({'A1': 20}, np.ones(60),
+                   {'A1': BiphasicPulse(0.02 * mA, 0.45, stim_dur=50)}):
+        implant = ArgusII(stim=source)
+        npt.assert_equal(implant.stim.unit, uA)
+    for source in (20, BiphasicPulse(20, 0.45, stim_dur=50)):
+        single = ProsthesisSystem(DiskElectrode(0, 0, 0, 100), stim=source)
+        npt.assert_equal(single.stim.unit, uA)
+
+    # A subclass may declare that it delivers something else:
+    class Projector(ArgusII):
+        stimulus_unit = dimensionless
+
+    npt.assert_equal(Projector(stim=img).stim.unit, dimensionless)
 
 
 def test_ProsthesisSystem_preprocess_crosses_the_boundary():

--- a/pulse2percept/implants/tests/test_base.py
+++ b/pulse2percept/implants/tests/test_base.py
@@ -563,18 +563,13 @@ def test_ProsthesisSystem_spatial_stim():
     # `stim` is still the delivered pulse train -- that invariant is what makes
     # the safety checks and the temporal models meaningful:
     npt.assert_equal(implant.stim.time.size > 1, True)
-    npt.assert_equal(implant.stim.metadata['encoder']['modulation'], False)
     # ... and beside it sits what the encoder actually asked each electrode
     # for: one column, no waveform, no raster.
-    npt.assert_equal(implant.spatial_stim.shape, (60, 1))
-    npt.assert_equal(implant.spatial_stim.time, None)
-    npt.assert_equal(implant.spatial_stim.unit, uA)
+    npt.assert_equal(implant._spatial_stim.shape, (60, 1))
+    npt.assert_equal(implant._spatial_stim.time, None)
+    npt.assert_equal(implant._spatial_stim.unit, uA)
     npt.assert_almost_equal(np.abs(implant.stim.data).max(axis=1),
-                            implant.spatial_stim.data.ravel(), decimal=4)
-    # It is read-only: `stim` is the one place a stimulus is assigned, and it
-    # is what decides whether there is any modulation behind it.
-    with pytest.raises(AttributeError):
-        implant.spatial_stim = implant.stim
+                            implant._spatial_stim.data.ravel(), decimal=4)
 
     # A video keeps one column per video frame:
     vid = VideoStimulus(np.random.default_rng(0).random((6, 10, 4)),
@@ -583,26 +578,26 @@ def test_ProsthesisSystem_spatial_stim():
         # 6 Hz against 20 fps; irrelevant here, but it is not the modulation
         # that goes short of frames, only the train delivering it:
         implant.stim = vid
-    npt.assert_equal(implant.spatial_stim.shape, (60, 4))
-    npt.assert_almost_equal(implant.spatial_stim.time, np.arange(4) * 50.0)
+    npt.assert_equal(implant._spatial_stim.shape, (60, 4))
+    npt.assert_almost_equal(implant._spatial_stim.time, np.arange(4) * 50.0)
 
     # Anything that did not come out of this implant's encoder has only the
     # one description of itself, and assigning it clears the stale one:
     for source in ({'A1': 20}, np.ones(60), None,
                    AmplitudeEncoder(amp_range=(0, 50)).encode(img)):
         implant.stim = source
-        npt.assert_equal(implant.spatial_stim, None)
+        npt.assert_equal(implant._spatial_stim, None)
     # ... including an implant that never had an encoder:
-    npt.assert_equal(ArgusII(stim={'A1': 20}).spatial_stim, None)
-    npt.assert_equal(ProsthesisSystem(ArgusII().earray).spatial_stim, None)
+    npt.assert_equal(ArgusII(stim={'A1': 20})._spatial_stim, None)
+    npt.assert_equal(ProsthesisSystem(ArgusII().earray)._spatial_stim, None)
 
     # Switching an electrode off reaches both descriptions, or a model reading
     # one of them would go on stimulating through a dead electrode:
     implant = ArgusII(stim=img)
     implant.deactivate(['A1', 'B2'])
     npt.assert_equal(implant.stim.shape[0], 58)
-    npt.assert_equal(implant.spatial_stim.shape[0], 58)
-    npt.assert_equal('A1' in implant.spatial_stim.electrodes, False)
+    npt.assert_equal(implant._spatial_stim.shape[0], 58)
+    npt.assert_equal('A1' in implant._spatial_stim.electrodes, False)
 
 
 def test_ProsthesisSystem_preprocess_crosses_the_boundary():

--- a/pulse2percept/implants/tests/test_base.py
+++ b/pulse2percept/implants/tests/test_base.py
@@ -16,7 +16,7 @@ from pulse2percept.implants import (PointSource, ElectrodeArray, ElectrodeGrid,
 from pulse2percept.stimuli import (Stimulus, ImageStimulus, VideoStimulus,
                                    BostonTrain, LogoBVL)
 from pulse2percept.stimuli import (AmplitudeEncoder, BiphasicPulse,
-                                   MonophasicPulse)
+                                   FrequencyEncoder, MonophasicPulse)
 from pulse2percept.implants import (ArgusII, DiskElectrode)
 from pulse2percept.models import ScoreboardModel
 
@@ -446,11 +446,12 @@ def test_ProsthesisSystem_safety_checks_are_electrical():
 
 
 def test_ProsthesisSystem_requires_an_electrical_stimulus():
-    """An implant delivers current, so a picture is refused on assignment
+    """An implant delivers current, so a picture it cannot encode is refused
 
     Not when a model eventually reads it: the assignment is the line that was
-    wrong, and there is no principled default mapping from a gray level onto an
-    amplitude or a frequency for the implant to apply on the user's behalf.
+    wrong, and without an encoder there is no principled default mapping from a
+    gray level onto an amplitude or a frequency for the implant to apply on the
+    user's behalf.
     """
     img = ImageStimulus(np.linspace(0, 1, 16).reshape((4, 4)))
     npt.assert_equal(ProsthesisSystem.stimulus_unit, uA)
@@ -458,18 +459,22 @@ def test_ProsthesisSystem_requires_an_electrical_stimulus():
     for source in (img, VideoStimulus(np.ones((6, 10, 3)) * 0.5,
                                       time=[0, 20, 40]), BostonTrain()):
         with pytest.raises(DimensionMismatchError) as excinfo:
-            ArgusII(stim=source)
-        npt.assert_equal('AmplitudeEncoder' in str(excinfo.value), True)
+            ArgusII(encoder=None, stim=source)
+        npt.assert_equal('encoder' in str(excinfo.value), True)
         npt.assert_equal('dimensionless' in str(excinfo.value), True)
-        implant = ArgusII()
+        implant = ArgusII(encoder=None)
         with pytest.raises(DimensionMismatchError):
             implant.stim = source
         # Nothing was stored, so the implant is left as it was:
         npt.assert_equal(implant.stim, None)
+        # A generic system has no encoder either:
+        with pytest.raises(DimensionMismatchError):
+            ProsthesisSystem(ArgusII().earray, stim=source)
 
     # Encoded, the very same picture goes through:
-    implant = ArgusII()
-    implant.stim = AmplitudeEncoder(implant, amp_range=(0, 50)).encode(img)
+    implant = ArgusII(encoder=None)
+    implant.stim = AmplitudeEncoder(amp_range=(0, 50)).encode(img,
+                                                              implant=implant)
     npt.assert_equal(implant.stim.unit, uA)
 
     # ... and so does everything that was electrical all along:
@@ -481,31 +486,102 @@ def test_ProsthesisSystem_requires_an_electrical_stimulus():
         single = ProsthesisSystem(DiskElectrode(0, 0, 0, 100), stim=source)
         npt.assert_equal(single.stim.unit, uA)
 
-    # A subclass may declare that it delivers something else:
+    # A subclass may declare that it delivers something else, in which case a
+    # picture is already what it delivers and the encoder stays out of it:
     class Projector(ArgusII):
         stimulus_unit = dimensionless
 
     npt.assert_equal(Projector(stim=img).stim.unit, dimensionless)
 
 
-def test_ProsthesisSystem_preprocess_crosses_the_boundary():
-    """Preprocessing may turn a picture into current before safety sees it"""
+def test_ProsthesisSystem_encoder():
+    """A picture assigned to an implant with an encoder is encoded on the way in
+    """
     img = ImageStimulus(np.linspace(0, 1, 16).reshape((4, 4)))
-    encoder = AmplitudeEncoder(ArgusII(), amp_range=(0, 20), freq=20)
-    implant = ArgusII(safe_mode=True, preprocess=lambda x: encoder.encode(x))
+    implant = ProsthesisSystem(ArgusII().earray)
+    npt.assert_equal(implant.encoder, None)
+    with pytest.raises(TypeError):
+        implant.encoder = 'amplitude'
+    with pytest.raises(TypeError):
+        ProsthesisSystem(ArgusII().earray, encoder=ArgusII())
+
+    # Giving it one is all it takes:
+    implant.encoder = AmplitudeEncoder(amp_range=(0, 50), freq=20)
+    npt.assert_equal('encoder' in str(implant), True)
+    implant.stim = img
+    npt.assert_equal(implant.stim.unit, uA)
+    npt.assert_equal(implant.stim.shape[0], implant.n_electrodes)
+    npt.assert_almost_equal(np.abs(implant.stim.data).max(), 50)
+    # What it stored is exactly what encoding it by hand gives:
+    by_hand = implant.encoder.encode(img, implant=implant)
+    npt.assert_almost_equal(implant.stim.data, by_hand.data)
+    npt.assert_almost_equal(implant.stim.time, by_hand.time)
+
+    # A custom encoder is honored, and its parameters reach the stimulus:
+    implant.encoder = AmplitudeEncoder(amp_range=(10, 30), freq=50,
+                                       frame_dur=100)
+    implant.stim = img
+    npt.assert_almost_equal(np.abs(implant.stim.data).max(), 30)
+    npt.assert_almost_equal(implant.stim.time[-1], 100)
+    npt.assert_equal(implant.stim.metadata['encoder']['kind'],
+                     'AmplitudeEncoder')
+    implant.encoder = FrequencyEncoder(freq_range=(0, 100), amp=42,
+                                       frame_dur=100)
+    implant.stim = img
+    npt.assert_almost_equal(np.abs(implant.stim.data).max(), 42)
+    npt.assert_equal(implant.stim.metadata['encoder']['kind'],
+                     'FrequencyEncoder')
+
+    # An electrical stimulus bypasses the encoder entirely, whatever is
+    # installed -- there is nothing left to encode:
+    implant.encoder = AmplitudeEncoder(amp_range=(0, 50))
+    for source in ({'A1': 20}, np.ones(60),
+                   BiphasicPulse(20, 0.45, stim_dur=50)):
+        implant.stim = source
+        npt.assert_equal(implant.stim.unit, uA)
+        npt.assert_equal('encoder' in implant.stim.metadata, False)
+
+    # The encoder sees the implant it is installed on, so it samples at that
+    # implant's electrodes and schedules against that implant's raster. An
+    # amplitude range that starts above zero keeps every electrode active, so
+    # the schedules are the raster groups and nothing else:
+    implant.encoder = AmplitudeEncoder(amp_range=(10, 50))
+    implant.raster = implants.SequentialRaster(6)
+    implant.stim = img
+    npt.assert_equal(implant.stim.metadata['encoder']['n_schedules'], 6)
+    delays = [implant.stim.time[np.argmax(implant.stim.data[e] < 0)]
+              for e in (0, 10, 20, 30, 40, 50)]
+    npt.assert_almost_equal(delays, np.arange(6) * 50 / 6, decimal=2)
+
+
+def test_ProsthesisSystem_preprocess_crosses_the_boundary():
+    """Preprocessing may turn a picture into current before the encoder sees it
+    """
+    img = ImageStimulus(np.linspace(0, 1, 16).reshape((4, 4)))
+    encoder = AmplitudeEncoder(amp_range=(0, 20), freq=20)
+    bare = ArgusII(encoder=None, raster=None)
+    implant = ArgusII(safe_mode=True, encoder=None, raster=None,
+                      preprocess=lambda x: encoder.encode(x, implant=bare))
     implant.max_current = 100 * mA
     implant.stim = img
     npt.assert_equal(implant.stim.unit, uA)
     npt.assert_equal(implant.stim.is_charge_balanced, True)
+    # Preprocessing that already crossed the boundary leaves the encoder with
+    # nothing to do, so an installed one does not encode twice:
+    encoded = encoder.encode(img, implant=bare)
+    twice = ArgusII(raster=None,
+                    preprocess=lambda x: encoder.encode(x, implant=bare))
+    twice.stim = img
+    npt.assert_almost_equal(twice.stim.data, encoded.data)
     # The same chain, assigned already-encoded, and this time with a limit
     # tight enough to matter:
     implant = ArgusII(preprocess=False, safe_mode=True)
     implant.max_current = 100 * uA
     with pytest.raises(ValueError) as excinfo:
-        implant.stim = encoder.encode(img)
+        implant.stim = encoded
     npt.assert_equal('exceeds max_current' in str(excinfo.value), True)
     implant.max_current = 2 * mA
-    implant.stim = encoder.encode(img)
+    implant.stim = encoded
     npt.assert_equal(implant.stim.unit, uA)
 
 

--- a/pulse2percept/implants/tests/test_base.py
+++ b/pulse2percept/implants/tests/test_base.py
@@ -554,6 +554,57 @@ def test_ProsthesisSystem_encoder():
     npt.assert_almost_equal(delays, np.arange(6) * 50 / 6, decimal=2)
 
 
+def test_ProsthesisSystem_spatial_stim():
+    """An encoded stimulus keeps the modulation it was asked for, not just the
+    pulse train it was realized as
+    """
+    img = ImageStimulus(np.linspace(0, 1, 16).reshape((4, 4)))
+    implant = ArgusII(stim=img)
+    # `stim` is still the delivered pulse train -- that invariant is what makes
+    # the safety checks and the temporal models meaningful:
+    npt.assert_equal(implant.stim.time.size > 1, True)
+    npt.assert_equal(implant.stim.metadata['encoder']['modulation'], False)
+    # ... and beside it sits what the encoder actually asked each electrode
+    # for: one column, no waveform, no raster.
+    npt.assert_equal(implant.spatial_stim.shape, (60, 1))
+    npt.assert_equal(implant.spatial_stim.time, None)
+    npt.assert_equal(implant.spatial_stim.unit, uA)
+    npt.assert_almost_equal(np.abs(implant.stim.data).max(axis=1),
+                            implant.spatial_stim.data.ravel(), decimal=4)
+    # It is read-only: `stim` is the one place a stimulus is assigned, and it
+    # is what decides whether there is any modulation behind it.
+    with pytest.raises(AttributeError):
+        implant.spatial_stim = implant.stim
+
+    # A video keeps one column per video frame:
+    vid = VideoStimulus(np.random.default_rng(0).random((6, 10, 4)),
+                        metadata={'fps': 20})
+    with pytest.warns(UserWarning, match='deliver no pulse'):
+        # 6 Hz against 20 fps; irrelevant here, but it is not the modulation
+        # that goes short of frames, only the train delivering it:
+        implant.stim = vid
+    npt.assert_equal(implant.spatial_stim.shape, (60, 4))
+    npt.assert_almost_equal(implant.spatial_stim.time, np.arange(4) * 50.0)
+
+    # Anything that did not come out of this implant's encoder has only the
+    # one description of itself, and assigning it clears the stale one:
+    for source in ({'A1': 20}, np.ones(60), None,
+                   AmplitudeEncoder(amp_range=(0, 50)).encode(img)):
+        implant.stim = source
+        npt.assert_equal(implant.spatial_stim, None)
+    # ... including an implant that never had an encoder:
+    npt.assert_equal(ArgusII(stim={'A1': 20}).spatial_stim, None)
+    npt.assert_equal(ProsthesisSystem(ArgusII().earray).spatial_stim, None)
+
+    # Switching an electrode off reaches both descriptions, or a model reading
+    # one of them would go on stimulating through a dead electrode:
+    implant = ArgusII(stim=img)
+    implant.deactivate(['A1', 'B2'])
+    npt.assert_equal(implant.stim.shape[0], 58)
+    npt.assert_equal(implant.spatial_stim.shape[0], 58)
+    npt.assert_equal('A1' in implant.spatial_stim.electrodes, False)
+
+
 def test_ProsthesisSystem_preprocess_crosses_the_boundary():
     """Preprocessing may turn a picture into current before the encoder sees it
     """

--- a/pulse2percept/implants/tests/test_base.py
+++ b/pulse2percept/implants/tests/test_base.py
@@ -523,14 +523,10 @@ def test_ProsthesisSystem_encoder():
     implant.stim = img
     npt.assert_almost_equal(np.abs(implant.stim.data).max(), 30)
     npt.assert_almost_equal(implant.stim.time[-1], 100)
-    npt.assert_equal(implant.stim.metadata['encoder']['kind'],
-                     'AmplitudeEncoder')
     implant.encoder = FrequencyEncoder(freq_range=(0, 100), amp=42,
                                        frame_dur=100)
     implant.stim = img
     npt.assert_almost_equal(np.abs(implant.stim.data).max(), 42)
-    npt.assert_equal(implant.stim.metadata['encoder']['kind'],
-                     'FrequencyEncoder')
 
     # An electrical stimulus bypasses the encoder entirely, whatever is
     # installed -- there is nothing left to encode:
@@ -548,10 +544,10 @@ def test_ProsthesisSystem_encoder():
     implant.encoder = AmplitudeEncoder(amp_range=(10, 50))
     implant.raster = implants.SequentialRaster(6)
     implant.stim = img
-    npt.assert_equal(implant.stim.metadata['encoder']['n_schedules'], 6)
     delays = [implant.stim.time[np.argmax(implant.stim.data[e] < 0)]
               for e in (0, 10, 20, 30, 40, 50)]
     npt.assert_almost_equal(delays, np.arange(6) * 50 / 6, decimal=2)
+    npt.assert_equal(len(np.unique(np.abs(implant.stim.data) > 0, axis=0)), 6)
 
 
 def test_ProsthesisSystem_spatial_stim():

--- a/pulse2percept/implants/tests/test_prima.py
+++ b/pulse2percept/implants/tests/test_prima.py
@@ -235,6 +235,8 @@ def test_PRIMA40(ztype, x, y, rot):
 
 def test_PRIMA40_reshape_stim():
     # Smoke test a high-res hex implant with an ImageStimulus, where the
-    # old approach runs out of memory easily
-    PRIMA40(stim=LogoBVL())
+    # old approach runs out of memory easily. A picture is not a stimulus an
+    # implant can deliver, so the sampling is exercised where an encoder
+    # reaches it:
+    PRIMA40().reshape_stim(LogoBVL())
     

--- a/pulse2percept/implants/tests/test_rasters.py
+++ b/pulse2percept/implants/tests/test_rasters.py
@@ -94,24 +94,24 @@ def _min_spacing(implant, raster):
 
 def test_CheckerboardRaster():
     with pytest.raises(ValueError):
-        CheckerboardRaster(ArgusII(), 0)
+        CheckerboardRaster(0)
     with pytest.raises(ValueError):
-        CheckerboardRaster(ArgusII(), 2.5)
+        CheckerboardRaster(2.5)
     with pytest.raises(ValueError):
-        CheckerboardRaster(ArgusII(), np.nan)
+        CheckerboardRaster(np.nan)
     with pytest.raises(ValueError):
-        CheckerboardRaster(ArgusII(), 2, balance=-0.1)
+        CheckerboardRaster(2, balance=-0.1)
     with pytest.raises(ValueError):
-        CheckerboardRaster(ArgusII(), 2, group_dur=-1)
+        CheckerboardRaster(2, group_dur=-1)
     # More groups than electrodes is not a raster:
     with pytest.raises(ValueError):
-        CheckerboardRaster(ArgusII(), 61)
+        CheckerboardRaster(61).bind(ArgusII())
     with pytest.raises(TypeError):
-        CheckerboardRaster('ArgusII', 2)
+        CheckerboardRaster(2).bind('ArgusII')
 
     implant = ArgusII()
     names = implant.electrode_names
-    raster = CheckerboardRaster(implant, 5)
+    raster = CheckerboardRaster(5).bind(implant)
     npt.assert_equal(raster.n_groups, 5)
     groups = raster.groups(names)
     # Every electrode is in exactly one group, and the groups are the same
@@ -120,13 +120,13 @@ def test_CheckerboardRaster():
     # Two groups is the checkerboard the pattern is named after: neighbors
     # always land in different groups, so nothing closer than the diagonal is
     # ever active at once:
-    two = CheckerboardRaster(implant, 2)
+    two = CheckerboardRaster(2).bind(implant)
     npt.assert_almost_equal(two.min_spacing, 575 * np.sqrt(2), decimal=3)
     # Five groups do better still, at sqrt(5) pitches -- the knight's move
     # pattern of Kasowski et al. (2025):
     npt.assert_almost_equal(raster.min_spacing, 575 * np.sqrt(5), decimal=3)
     # ... and `min_spacing` is what it says it is:
-    for r in [two, raster, CheckerboardRaster(implant, 4)]:
+    for r in [two, raster, CheckerboardRaster(4).bind(implant)]:
         npt.assert_almost_equal(_min_spacing(implant, r), r.min_spacing,
                                 decimal=3)
     # A line raster leaves neighbors in the same group, which is the whole
@@ -145,29 +145,31 @@ def test_CheckerboardRaster_grids():
     # A hex grid is handled the same way, and its 7-group pattern is the one
     # that puts every group on a hex lattice of its own, sqrt(7) pitches wide:
     hexgrid = ProsthesisSystem(ElectrodeGrid((14, 14), 200, type='hex'))
-    raster = CheckerboardRaster(hexgrid, 7)
+    raster = CheckerboardRaster(7).bind(hexgrid)
     npt.assert_almost_equal(raster.min_spacing, 200 * np.sqrt(7), decimal=3)
     npt.assert_almost_equal(_min_spacing(hexgrid, raster), raster.min_spacing,
                             decimal=3)
     # A hex grid cannot be two-colored the way a square one can, so two groups
     # buy nothing there and the caller has to notice through `min_spacing`:
-    npt.assert_almost_equal(CheckerboardRaster(hexgrid, 2).min_spacing, 200)
+    npt.assert_almost_equal(CheckerboardRaster(2).bind(hexgrid).min_spacing,
+                            200)
 
     # Rotating the implant rotates the pattern with it, since the pattern is
     # read off the electrode positions:
     upright = ProsthesisSystem(ElectrodeGrid((10, 10), 400))
-    expected = CheckerboardRaster(upright, 5).groups(upright.electrode_names)
+    expected = CheckerboardRaster(5).bind(upright).groups(
+        upright.electrode_names)
     for angle in [11, 37, 84]:
         turned = ProsthesisSystem(ElectrodeGrid((10, 10), 400, rot=angle))
         npt.assert_equal(
-            CheckerboardRaster(turned, 5).groups(turned.electrode_names),
+            CheckerboardRaster(5).bind(turned).groups(turned.electrode_names),
             expected)
     # Past a quarter turn the two grid directions trade places, so the pattern
     # comes out transposed. It is the same pattern in every way that matters --
     # which is what is checked here -- just not the same labelling:
     for angle in [117, 300]:
         turned = ProsthesisSystem(ElectrodeGrid((10, 10), 400, rot=angle))
-        raster = CheckerboardRaster(turned, 5)
+        raster = CheckerboardRaster(5).bind(turned)
         npt.assert_almost_equal(raster.min_spacing, 400 * np.sqrt(5),
                                 decimal=3)
         npt.assert_equal(np.bincount(raster.groups(turned.electrode_names)),
@@ -176,15 +178,15 @@ def test_CheckerboardRaster_grids():
     # Grids with electrodes trimmed off still work. PRIMA's 378 electrodes do
     # not divide by four, so the groups come out as even as 378 allows:
     prima = PRIMA()
-    raster = CheckerboardRaster(prima, 4)
+    raster = CheckerboardRaster(4).bind(prima)
     count = np.bincount(raster.groups(prima.electrode_names))
     npt.assert_equal(count.sum(), 378)
     npt.assert_equal(count.max() <= np.ceil(378 / 4) * 1.05, True)
     npt.assert_almost_equal(raster.min_spacing, 200)
     # Demanding an exactly even split is allowed, and costs spacing:
     npt.assert_equal(
-        CheckerboardRaster(prima, 5, balance=0).min_spacing <=
-        CheckerboardRaster(prima, 5, balance=0.5).min_spacing, True)
+        CheckerboardRaster(5, balance=0).bind(prima).min_spacing <=
+        CheckerboardRaster(5, balance=0.5).bind(prima).min_spacing, True)
 
     # Rows and columns need not be spaced the same. A grid can be stretched
     # far enough that an electrode's twenty nearest neighbors are all in its
@@ -192,7 +194,7 @@ def test_CheckerboardRaster_grids():
     # only at the near neighborhood used to miss it and reject the grid:
     for spacing, n in [((100, 1050), 5), ((100, 1050), 4), ((25, 3000), 5)]:
         stretched = ElectrodeGrid((3, 20), spacing=spacing)
-        raster = CheckerboardRaster(stretched, n)
+        raster = CheckerboardRaster(n).bind(stretched)
         count = np.bincount(raster.groups(stretched.electrode_names))
         npt.assert_equal(count, np.full(n, 60 // n))
         npt.assert_almost_equal(_min_spacing(stretched, raster),
@@ -200,18 +202,19 @@ def test_CheckerboardRaster_grids():
     # Electrodes really in a line have no second direction to find, and are
     # still split into groups spread along it:
     row = ElectrodeGrid((1, 12), 200)
-    npt.assert_equal(np.bincount(CheckerboardRaster(row, 4).groups(
+    npt.assert_equal(np.bincount(CheckerboardRaster(4).bind(row).groups(
         row.electrode_names)), np.full(4, 3))
 
     # An implant whose electrodes are not on a grid cannot be checkered:
     with pytest.raises(NotImplementedError):
-        CheckerboardRaster(BVT24(), 2)
+        CheckerboardRaster(2).bind(BVT24())
     # Neither can a count that leaves no pattern even enough to be worth
     # having. PRIMA's trimmed edges are what put 20 groups out of reach, and
     # allowing bigger groups is what buys it back:
     with pytest.raises(ValueError):
-        CheckerboardRaster(prima, 20)
-    npt.assert_equal(CheckerboardRaster(prima, 20, balance=0.2).n_groups, 20)
+        CheckerboardRaster(20).bind(prima)
+    npt.assert_equal(CheckerboardRaster(20, balance=0.2).bind(prima).n_groups,
+                     20)
 
 
 def test_CheckerboardRaster_min_spacing():
@@ -224,7 +227,7 @@ def test_CheckerboardRaster_min_spacing():
     for shape, n_groups in [((2, 6), 6), ((2, 3), 4), ((3, 4), 4), ((4, 4), 8),
                             ((6, 10), 5), ((5, 5), 5)]:
         grid = ElectrodeGrid(shape, 100)
-        raster = CheckerboardRaster(grid, n_groups)
+        raster = CheckerboardRaster(n_groups).bind(grid)
         npt.assert_almost_equal(raster.min_spacing, _min_spacing(grid, raster),
                                 decimal=6)
     # Two rows of six in six groups is a pair per group, and the pairs can be
@@ -232,11 +235,11 @@ def test_CheckerboardRaster_min_spacing():
     # sqrt(5) here, since the lattice cannot tell that the sites in between
     # are not on the implant:
     pairs = ElectrodeGrid((2, 6), 100)
-    npt.assert_almost_equal(CheckerboardRaster(pairs, 6).min_spacing,
+    npt.assert_almost_equal(CheckerboardRaster(6).bind(pairs).min_spacing,
                             100 * np.sqrt(10), decimal=6)
     # A group of one electrode has no pair to keep apart:
     singles = ElectrodeGrid((2, 2), 100)
-    npt.assert_equal(np.isinf(CheckerboardRaster(singles, 4).min_spacing),
+    npt.assert_equal(np.isinf(CheckerboardRaster(4).bind(singles).min_spacing),
                      True)
 
 
@@ -264,11 +267,11 @@ def test_CheckerboardRaster_is_reproducible(monkeypatch):
     hexgrid = ProsthesisSystem(ElectrodeGrid((10, 10), 400, type='hex'))
     for implant in [ArgusII(), hexgrid, PRIMA()]:
         names = implant.electrode_names
-        expected = CheckerboardRaster(implant, 5).groups(names)
+        expected = CheckerboardRaster(5).bind(implant).groups(names)
         for seed in range(4):
             Scrambled.seed = seed
             monkeypatch.setattr(rasters, 'cKDTree', Scrambled)
-            npt.assert_equal(CheckerboardRaster(implant, 5).groups(names),
+            npt.assert_equal(CheckerboardRaster(5).bind(implant).groups(names),
                              expected)
             monkeypatch.undo()
 
@@ -276,19 +279,20 @@ def test_CheckerboardRaster_is_reproducible(monkeypatch):
     # platform's trigonometry from another's:
     implant = ArgusII()
     names = implant.electrode_names
-    expected = CheckerboardRaster(implant, 5).groups(names)
+    expected = CheckerboardRaster(5).bind(implant).groups(names)
     rng = np.random.RandomState(0)
     for _ in range(4):
         nudged = ProsthesisSystem(deepcopy(implant.earray))
         for elec in nudged.earray.electrode_objects:
             elec.x *= 1 + rng.uniform(-1, 1) * 1e-13
             elec.y *= 1 + rng.uniform(-1, 1) * 1e-13
-        npt.assert_equal(CheckerboardRaster(nudged, 5).groups(names), expected)
+        npt.assert_equal(CheckerboardRaster(5).bind(nudged).groups(names),
+                         expected)
 
 
 def test_CheckerboardRaster_groups():
     implant = ArgusII()
-    raster = CheckerboardRaster(implant, 5)
+    raster = CheckerboardRaster(5).bind(implant)
     # The raster only knows the electrodes it was built for. Silently dropping
     # the others would break the current limit it exists to respect:
     with pytest.raises(ValueError):
@@ -318,7 +322,7 @@ def test_Raster_members():
     npt.assert_equal(SequentialRaster(6).members(range(60), 1),
                      np.arange(10, 20))
     # Every electrode is in exactly one group, and no group is lost:
-    for r in [SequentialRaster(4), CheckerboardRaster(implant, 4),
+    for r in [SequentialRaster(4), CheckerboardRaster(4).bind(implant),
               CustomRaster([names[:20], names[20:]])]:
         found = np.concatenate([r.members(names, g)
                                 for g in range(r.n_groups)])
@@ -336,7 +340,7 @@ def test_Raster_members():
 
 def test_Raster_plot():
     implant = ArgusII()
-    raster = CheckerboardRaster(implant, 5)
+    raster = CheckerboardRaster(5).bind(implant)
     ax = raster.plot(implant)
     # One patch per electrode, colored by group, and a group index written
     # into each of them:
@@ -362,7 +366,7 @@ def test_Raster_plot():
 
     # Any raster can be plotted on any implant it covers, grid or not:
     for r, imp in [(SequentialRaster(3), BVT24()),
-                   (CheckerboardRaster(PRIMA(), 7), PRIMA()),
+                   (CheckerboardRaster(7).bind(PRIMA()), PRIMA()),
                    (CustomRaster({n: 0 for n in ArgusII().electrode_names}),
                     ArgusII())]:
         npt.assert_equal(len(r.plot(imp).collections[0].get_paths()),
@@ -415,7 +419,6 @@ def test_CustomRaster():
 def test_ProsthesisSystem_raster():
     implant = ArgusII()
     # Implants that do not set a raster in their constructor still report one:
-    npt.assert_equal(implant.raster, None)
     npt.assert_equal(ProsthesisSystem(implant.earray).raster, None)
     implant.raster = SequentialRaster(6)
     npt.assert_equal(implant.raster.n_groups, 6)
@@ -426,6 +429,51 @@ def test_ProsthesisSystem_raster():
     npt.assert_equal(
         ProsthesisSystem(implant.earray,
                          raster=SequentialRaster(3)).raster.n_groups, 3)
+
+
+def test_ProsthesisSystem_raster_binds():
+    # Assigning a raster binds it, which is what lets a geometry-dependent
+    # pattern work itself out and what lets `plot` be called with no argument:
+    implant = ArgusII()
+    raster = CheckerboardRaster(5)
+    # Before binding it knows how many groups it will have and nothing else:
+    npt.assert_equal(raster.n_groups, 5)
+    npt.assert_equal(raster.implant, None)
+    npt.assert_equal(raster.min_spacing, None)
+    with pytest.raises(ValueError):
+        raster.groups(implant.electrode_names)
+    with pytest.raises(ValueError):
+        raster.plot()
+
+    implant.raster = raster
+    npt.assert_equal(raster.implant is implant, True)
+    npt.assert_almost_equal(raster.min_spacing, 575 * np.sqrt(5), decimal=3)
+    groups = raster.groups(implant.electrode_names)
+    npt.assert_equal(np.bincount(groups), np.full(5, 12))
+    # And `plot` no longer needs to be told what to draw:
+    npt.assert_equal(len(raster.plot().collections[0].get_paths()), 60)
+    plt.close('all')
+
+    # Rebinding recomputes: the same object on a different array describes
+    # *that* array, rather than answering about the one it came from:
+    other = ProsthesisSystem(ElectrodeGrid((4, 5), 400))
+    other.raster = raster
+    npt.assert_equal(raster.implant is other, True)
+    npt.assert_almost_equal(raster.min_spacing, 400 * np.sqrt(5), decimal=3)
+    npt.assert_equal(np.bincount(raster.groups(other.electrode_names)),
+                     np.full(5, 4))
+    with pytest.raises(ValueError):
+        # Argus II's electrodes are not on the grid it is now bound to:
+        raster.groups(implant.electrode_names)
+    # A raster that cannot be laid out on an array leaves the implant alone:
+    with pytest.raises(NotImplementedError):
+        BVT24().raster = CheckerboardRaster(2)
+    # The other two bind too, even though there is no geometry to work out:
+    for r in [SequentialRaster(6), CustomRaster([implant.electrode_names])]:
+        implant.raster = r
+        npt.assert_equal(r.implant is implant, True)
+        npt.assert_equal(len(r.plot().collections[0].get_paths()), 60)
+        plt.close('all')
 
 
 def test_ProsthesisSystem_max_current():
@@ -479,33 +527,32 @@ def test_Raster_units():
 def test_Raster_units_end_to_end():
     """A rastered encoding is the same whichever way its timings are spelled"""
     from pulse2percept.stimuli import AmplitudeEncoder, ImageStimulus
-    implant = ArgusII()
     img = ImageStimulus(np.linspace(0, 1, 16).reshape((4, 4)))
-    bare = AmplitudeEncoder(implant, amp_range=(0, 50),
-                            raster=SequentialRaster(6, group_dur=1))
-    unitful = AmplitudeEncoder(implant, amp_range=(0, 0.05 * mA),
-                               raster=SequentialRaster(6,
-                                                       group_dur=1000 * us))
-    npt.assert_array_equal(bare.encode(img).data, unitful.encode(img).data)
-    npt.assert_array_equal(bare.encode(img).time, unitful.encode(img).time)
+    plain = ArgusII(raster=SequentialRaster(6, group_dur=1))
+    unitful_raster = ArgusII(raster=SequentialRaster(6, group_dur=1000 * us))
+    bare = AmplitudeEncoder(amp_range=(0, 50)).encode(img, implant=plain)
+    unitful = AmplitudeEncoder(amp_range=(0, 0.05 * mA)).encode(
+        img, implant=unitful_raster)
+    npt.assert_array_equal(bare.data, unitful.data)
+    npt.assert_array_equal(bare.time, unitful.time)
 
 
 def test_Raster_reads_coordinates_in_microns():
     """Raster geometry goes through the array's coordinate API"""
     implant = ArgusII()
-    raster = CheckerboardRaster(implant, 5)
+    raster = CheckerboardRaster(5).bind(implant)
     # `min_spacing` is documented in microns, which is what `coordinates()`
     # returns, and Argus II has a 575 um pitch:
     npt.assert_allclose(raster.min_spacing, np.sqrt(5) * 575, rtol=1e-12)
     # Moving the implant does not change the pattern or the spacing:
-    moved = CheckerboardRaster(ArgusII(x=15 * mm, y=-0.5 * mm), 5)
+    moved = CheckerboardRaster(5).bind(ArgusII(x=15 * mm, y=-0.5 * mm))
     npt.assert_allclose(moved.min_spacing, raster.min_spacing, rtol=1e-12)
     npt.assert_array_equal(moved.groups(implant.electrode_names),
                            raster.groups(implant.electrode_names))
     # Both entry points accept an implant or its array, and refuse anything
     # that cannot say where its electrodes are:
-    npt.assert_equal(CheckerboardRaster(implant.earray, 5).n_groups, 5)
-    for call in (lambda: CheckerboardRaster('not an implant', 2),
+    npt.assert_equal(CheckerboardRaster(5).bind(implant.earray).n_groups, 5)
+    for call in (lambda: CheckerboardRaster(2).bind('not an implant'),
                  lambda: SequentialRaster(2).plot('not an implant')):
         with pytest.raises(TypeError):
             call()

--- a/pulse2percept/models/base.py
+++ b/pulse2percept/models/base.py
@@ -253,6 +253,77 @@ def _require_stim_dimension(model, stim):
         f"is what says how much current a gray level stands for.")
 
 
+def _spatial_input(implant):
+    """The stimulus a model with no temporal component reads off an implant
+
+    A pulse train is a description of *when* current flows, and a raster is a
+    description of which electrodes are allowed to flow at the same time. Both
+    are facts about time, and a model with no temporal component has no
+    machinery to express either: handed the delivered train, it reports the
+    stimulus one instant at a time, so an encoded image comes out as a
+    sequence of raster slots rather than as the image.
+
+    So where the encoder left the modulation behind the delivered train (see
+    :py:attr:`~pulse2percept.implants.ProsthesisSystem.spatial_stim`), that is
+    what a spatial model reads: one amplitude per electrode per frame of the
+    source, which is exactly as much of the stimulus as such a model can say
+    anything about. Everything else -- a stimulus assigned as current, an
+    implant with no encoder -- has only the one description of itself, and it
+    is used unchanged.
+    """
+    spatial = getattr(implant, 'spatial_stim', None)
+    return implant.stim if spatial is None else spatial
+
+
+def _rescale(stim, scale):
+    """A copy of ``stim`` with every amplitude multiplied by ``scale``
+
+    The metadata is carried across: it is what tells ``predict_percept`` which
+    video the stimulus was encoded from, and hence when to report a percept.
+    Without it every trial of a ``find_threshold`` search would be evaluated
+    on a different time base than the caller's own ``predict_percept`` uses.
+    """
+    return Stimulus(scale * stim.data, electrodes=stim.electrodes,
+                    time=stim.time,
+                    metadata=deepcopy(stim.metadata))._inherit_units(stim)
+
+
+def _rescaled_implant(implant, amp):
+    """A copy of ``implant`` whose stimulus peaks at ``amp``
+
+    What ``find_threshold`` varies from trial to trial. *Both* descriptions of
+    the stimulus are scaled, because which one a model reads depends on
+    whether it has a temporal component (see :py:func:`_spatial_input`), and a
+    search run on one description would not be a search for the threshold of
+    what the caller's own ``predict_percept`` reports.
+    """
+    trial = deepcopy(implant)
+    scale = amp / implant.stim.data.max()
+    trial.stim = _rescale(implant.stim, scale)
+    if implant.spatial_stim is not None:
+        # After the assignment above, which clears it -- an ordinary stimulus
+        # assigned to an implant has no modulation behind it:
+        trial._spatial_stim = _rescale(implant.spatial_stim, scale)
+    return trial
+
+
+def _delivered(implant):
+    """The same implant, made to hand a spatial model the pulse train
+
+    The other side of :py:func:`_spatial_input`. A spatial model that feeds a
+    temporal one is the case where the pulses are exactly what has to get
+    through, since integrating them is what the temporal model is for. A
+    shallow copy is enough to say so: nothing but the stimulus attribute
+    differs, and neither the electrode array nor the stimulus itself is
+    duplicated.
+    """
+    if getattr(implant, 'spatial_stim', None) is None:
+        return implant
+    stand_in = copy(implant)
+    stand_in._spatial_stim = None
+    return stand_in
+
+
 class NotBuiltError(ValueError, AttributeError):
     """Exception class used to raise if model is used before building
 
@@ -782,6 +853,28 @@ class SpatialModel(BaseModel, metaclass=ABCMeta):
             Don't override this method if you are creating your own model.
             Customize ``_predict_spatial`` instead.
 
+        .. note::
+
+            **A spatial model reads modulation frames, not pulses.** Where the
+            implant's stimulus came from an encoder, what is read is
+            :py:attr:`~pulse2percept.implants.ProsthesisSystem.spatial_stim`
+            -- one amplitude per electrode per frame of the source video --
+            rather than the pulse train in
+            :py:attr:`~pulse2percept.implants.ProsthesisSystem.stim`.
+
+            A pulse train says *when* current flows, and a raster says which
+            electrodes are allowed to flow together. Both are facts about
+            time, and a model with no temporal component can express neither:
+            handed the train, it would report the stimulus one instant at a
+            time, so an encoded image would come back as a sequence of raster
+            slots instead of as the image. So an image gives one percept
+            frame, and a video one percept frame per video frame.
+
+            A model that *does* have a temporal component is the opposite
+            case, and :py:class:`~pulse2percept.models.Model` hands its
+            spatial stage the delivered pulse train: integrating those pulses
+            is exactly what the temporal stage is for.
+
         Parameters
         ----------
         implant: :py:class:`~pulse2percept.implants.ProsthesisSystem`
@@ -791,7 +884,8 @@ class SpatialModel(BaseModel, metaclass=ABCMeta):
             The time points at which to output a percept, counted in this
             model's :py:attr:`~pulse2percept.models.BaseModel.time_unit`
             (milliseconds, for every model p2p ships).
-            If None, ``implant.stim.time`` is used.
+            If None, the time points of the stimulus being read are used --
+            the frame times, for an encoded stimulus.
             May be given as a unitful quantity (e.g. ``[0, 20] * ms``); see
             :py:mod:`pulse2percept.units`.
 
@@ -812,13 +906,19 @@ class SpatialModel(BaseModel, metaclass=ABCMeta):
         if implant.stim is None:
             # Nothing to see here:
             return None
-        _require_stim_dimension(self, implant.stim)
-        if implant.stim.time is None and t_percept is not None:
+        source = _spatial_input(implant)
+        _require_stim_dimension(self, source)
+        if source.time is None and t_percept is not None:
+            # A single-frame source (an image) modulates the electrodes to one
+            # steady thing, so there are no times to ask about even though the
+            # pulse train delivering it does have a time axis:
+            what = ("the modulation behind this stimulus"
+                    if source is not implant.stim else "stimulus")
             raise ValueError(f"Cannot calculate spatial response at times "
-                             f"t_percept={t_percept} because stimulus does not "
+                             f"t_percept={t_percept} because {what} does not "
                              f"have a time component.")
         # Make sure we don't change the user's Stimulus object:
-        stim = deepcopy(implant.stim)
+        stim = deepcopy(source)
         # Make sure to operate on the compressed stim:
         if not stim.is_compressed:
             stim.compress()
@@ -932,14 +1032,7 @@ class SpatialModel(BaseModel, metaclass=ABCMeta):
         amp_tol = as_value(amp_tol, self.stimulus_unit, 'amp_tol')
 
         def inner_predict(amp, fnc_predict, implant):
-            _implant = deepcopy(implant)
-            scale = amp / implant.stim.data.max()
-            _implant.stim = Stimulus(
-                scale * implant.stim.data,
-                electrodes=implant.stim.electrodes, time=implant.stim.time,
-                metadata=deepcopy(implant.stim.metadata)
-            )._inherit_units(implant.stim)
-            return fnc_predict(_implant).data.max()
+            return fnc_predict(_rescaled_implant(implant, amp)).data.max()
 
         return bisect(bright_th, inner_predict,
                       args=[self.predict_percept, implant],
@@ -1403,15 +1496,7 @@ class TemporalModel(BaseModel, metaclass=ABCMeta):
         t_percept = as_value(t_percept, self.time_unit, 't_percept')
 
         def inner_predict(amp, fnc_predict, stim, **kwargs):
-            # Carry the metadata across: it is what tells `predict_percept`
-            # which video the stimulus was encoded from, and hence when to
-            # report a percept. Without it every trial of the search would be
-            # evaluated on a different time base than the caller's own
-            # `predict_percept` will use:
-            _stim = Stimulus(
-                amp * stim.data / stim.data.max(), electrodes=stim.electrodes,
-                time=stim.time,
-                metadata=deepcopy(stim.metadata))._inherit_units(stim)
+            _stim = _rescale(stim, amp / stim.data.max())
             return fnc_predict(_stim, **kwargs).data.max()
 
         return bisect(bright_th, inner_predict,
@@ -1790,8 +1875,12 @@ class Model(PrettyPrint):
 
         if self.has_space and self.has_time:
             # Need to calculate the spatial response at all stimulus points
-            # (i.e., whenever the stimulus changes):
-            resp = self.spatial.predict_percept(implant, t_percept=None)
+            # (i.e., whenever the stimulus changes). Of the delivered pulse
+            # train, not of the modulation behind it: the pulses are what the
+            # temporal model integrates, and dropping them here would leave it
+            # nothing to do (see `_delivered`).
+            resp = self.spatial.predict_percept(_delivered(implant),
+                                                t_percept=None)
             if implant.stim.time is not None:
                 # Then pass that to the temporal model, which will output at
                 # all `t_percept` time steps:
@@ -1861,19 +1950,8 @@ class Model(PrettyPrint):
         t_percept = as_value(t_percept, self.time_unit, 't_percept')
 
         def inner_predict(amp, fnc_predict, implant, **kwargs):
-            _implant = deepcopy(implant)
-            scale = amp / implant.stim.data.max()
-            # Carry the metadata across: it is what tells `predict_percept`
-            # which video the stimulus was encoded from, and hence when to
-            # report a percept. Without it every trial of the search would be
-            # evaluated on a different time base than the caller's own
-            # `predict_percept` will use:
-            _implant.stim = Stimulus(
-                scale * implant.stim.data,
-                electrodes=implant.stim.electrodes, time=implant.stim.time,
-                metadata=deepcopy(implant.stim.metadata)
-            )._inherit_units(implant.stim)
-            return fnc_predict(_implant, **kwargs).data.max()
+            return fnc_predict(_rescaled_implant(implant, amp),
+                               **kwargs).data.max()
 
         return bisect(bright_th, inner_predict,
                       args=[self.predict_percept, implant],

--- a/pulse2percept/models/base.py
+++ b/pulse2percept/models/base.py
@@ -263,15 +263,14 @@ def _spatial_input(implant):
     stimulus one instant at a time, so an encoded image comes out as a
     sequence of raster slots rather than as the image.
 
-    So where the encoder left the modulation behind the delivered train (see
-    :py:attr:`~pulse2percept.implants.ProsthesisSystem.spatial_stim`), that is
-    what a spatial model reads: one amplitude per electrode per frame of the
-    source, which is exactly as much of the stimulus as such a model can say
-    anything about. Everything else -- a stimulus assigned as current, an
-    implant with no encoder -- has only the one description of itself, and it
-    is used unchanged.
+    So where the implant's encoder left the modulation behind the delivered
+    train (``_spatial_stim``), that is what a spatial model reads: one
+    amplitude per electrode per frame of the source, which is exactly as much
+    of the stimulus as such a model can say anything about. Everything else --
+    a stimulus assigned as current, an implant with no encoder -- has only the
+    one description of itself, and it is used unchanged.
     """
-    spatial = getattr(implant, 'spatial_stim', None)
+    spatial = getattr(implant, '_spatial_stim', None)
     return implant.stim if spatial is None else spatial
 
 
@@ -299,11 +298,12 @@ def _rescaled_implant(implant, amp):
     """
     trial = deepcopy(implant)
     scale = amp / implant.stim.data.max()
+    modulation = getattr(implant, '_spatial_stim', None)
     trial.stim = _rescale(implant.stim, scale)
-    if implant.spatial_stim is not None:
+    if modulation is not None:
         # After the assignment above, which clears it -- an ordinary stimulus
         # assigned to an implant has no modulation behind it:
-        trial._spatial_stim = _rescale(implant.spatial_stim, scale)
+        trial._spatial_stim = _rescale(modulation, scale)
     return trial
 
 
@@ -317,7 +317,7 @@ def _delivered(implant):
     differs, and neither the electrode array nor the stimulus itself is
     duplicated.
     """
-    if getattr(implant, 'spatial_stim', None) is None:
+    if getattr(implant, '_spatial_stim', None) is None:
         return implant
     stand_in = copy(implant)
     stand_in._spatial_stim = None
@@ -855,12 +855,11 @@ class SpatialModel(BaseModel, metaclass=ABCMeta):
 
         .. note::
 
-            **A spatial model reads modulation frames, not pulses.** Where the
-            implant's stimulus came from an encoder, what is read is
-            :py:attr:`~pulse2percept.implants.ProsthesisSystem.spatial_stim`
-            -- one amplitude per electrode per frame of the source video --
-            rather than the pulse train in
-            :py:attr:`~pulse2percept.implants.ProsthesisSystem.stim`.
+            **This method reads modulation frames, not pulses.** Where
+            ``implant.stim`` was produced by the implant's own
+            :py:class:`~pulse2percept.stimuli.StimulusEncoder`, what is read
+            is one amplitude per electrode per frame of the source video,
+            rather than the pulse train delivering it.
 
             A pulse train says *when* current flows, and a raster says which
             electrodes are allowed to flow together. Both are facts about
@@ -870,10 +869,14 @@ class SpatialModel(BaseModel, metaclass=ABCMeta):
             slots instead of as the image. So an image gives one percept
             frame, and a video one percept frame per video frame.
 
-            A model that *does* have a temporal component is the opposite
-            case, and :py:class:`~pulse2percept.models.Model` hands its
-            spatial stage the delivered pulse train: integrating those pulses
-            is exactly what the temporal stage is for.
+            :py:class:`~pulse2percept.models.Model` hands its spatial stage
+            the delivered pulse train instead whenever it also has a temporal
+            stage, since integrating those pulses is what that stage is for.
+            Models that replace ``predict_percept`` outright rather than
+            customizing ``_predict_spatial`` --
+            :py:class:`~pulse2percept.models.BiphasicAxonMapSpatial` and
+            :py:class:`~pulse2percept.models.cortex.DynaphosModel` -- read
+            ``implant.stim`` directly and are unaffected by any of this.
 
         Parameters
         ----------

--- a/pulse2percept/models/base.py
+++ b/pulse2percept/models/base.py
@@ -509,11 +509,14 @@ class SpatialModel(BaseModel, metaclass=ABCMeta):
           On a retinal model they may also be given as a physical extent
           (e.g. ``xrange=(-4 * mm, 4 * mm)``), which the model's ``vfmap``
           resolves into the visual field range that piece of retina covers.
-          The range is stored in dva either way, so changing ``vfmap``
-          afterwards does not reinterpret it. This is shorthand, not a unit
-          conversion: ``step`` has no such spelling, since a grid spaced
-          evenly on the retina is a different grid from one spaced evenly in
-          the visual field.
+          Each range is converted along its own retinal meridian, and the grid
+          that results is rectangular and uniformly sampled in dva exactly as
+          it always was -- under a nonlinear map it is therefore not the image
+          of a retinal rectangle. The range is stored in dva either way, so
+          changing ``vfmap`` afterwards does not reinterpret it. This is
+          shorthand, not a unit conversion: ``step`` has no such spelling,
+          since a grid spaced evenly on the retina is a different grid from
+          one spaced evenly in the visual field.
 
     .. seealso ::
 
@@ -569,6 +572,14 @@ class SpatialModel(BaseModel, metaclass=ABCMeta):
         what is stored afterwards is an ordinary pair of dva. Changing
         ``vfmap`` later therefore does not reinterpret a range that has already
         been resolved -- the same rule an implant's coordinates follow.
+
+        Each range is converted along its own retinal meridian: ``xrange``
+        through ``ret_to_dva(x, 0)`` and ``yrange`` through
+        ``ret_to_dva(0, y)``. The grid built from the result is rectangular and
+        uniformly sampled in dva, exactly as it is for a range given in degrees,
+        so under a nonlinear map it is not the image of a retinal rectangle.
+        Naming retinal lengths says how far to simulate; it does not change what
+        the grid is uniform in.
 
         This is deliberately not a unit conversion, and
         :py:class:`~pulse2percept.units.Quantity` will not do it: how far a

--- a/pulse2percept/models/base.py
+++ b/pulse2percept/models/base.py
@@ -14,9 +14,9 @@ from ..implants import ProsthesisSystem
 from ..stimuli import Stimulus
 from ..stimuli.base import _describe_unit
 from ..percepts import Percept
-from ..topography import Curcio1990Map, Grid2D
-from ..units import (DimensionMismatchError, Quantity, as_value, dva, ms, um,
-                     uA)
+from ..topography import Curcio1990Map, Grid2D, RetinalMap
+from ..units import (DimensionMismatchError, Quantity, Unit, as_value, dva, ms,
+                     um, uA)
 from ..utils import (PrettyPrint, FreezeError, Parametrized, bisect,
                      deprecated_alias, warn_deprecated_params,
                      rename_deprecated_params)
@@ -171,9 +171,9 @@ def _frame_clock(stim, dt, unit=ms):
     if frame_time.size == 0 or not np.isfinite(frame_dur) or frame_dur <= 0:
         return None
     # An encoder records its frame clock in milliseconds (see
-    # `pulse2percept.stimuli.Encoder`), and what comes back has to be in the
-    # calling model's own time unit, since that is what it compares `dt` and
-    # `t_percept` in. A no-op for every model p2p ships:
+    # `pulse2percept.stimuli.StimulusEncoder`), and what comes back has to be
+    # in the calling model's own time unit, since that is what it compares
+    # `dt` and `t_percept` in. A no-op for every model p2p ships:
     if unit != ms:
         frame_time = Quantity(frame_time, ms).to_value(unit)
         frame_dur = Quantity(frame_dur, ms).to_value(unit)
@@ -184,6 +184,41 @@ def _frame_clock(stim, dt, unit=ms):
     start = int(round(float(frame_time[0]) / dt))
     ends = start + np.arange(1, frame_time.size + 1, dtype=np.int64) * step
     return ends * dt, start * dt
+
+
+def _vfmap_first(params):
+    """Order parameters so that ``vfmap`` is applied before the others
+
+    A retinal extent assigned to ``xrange``/``yrange`` is resolved through the
+    model's visual field map at assignment time (see
+    :py:meth:`SpatialModel._retinal_range_to_dva`), so which map is installed
+    when that happens decides what the range comes out as. Parameters are
+    otherwise applied in the order they were given, and
+
+    .. code-block:: python
+
+        AxonMapModel(xrange=(-2.8 * mm, 2.8 * mm), vfmap=Curcio1990Map())
+
+    has to use the map the caller asked for rather than whichever one was
+    already there. Only ``vfmap`` is moved; everything else keeps its order,
+    so nothing else becomes order-sensitive.
+    """
+    if 'vfmap' not in params:
+        return params
+    return {'vfmap': params['vfmap'],
+            **{key: val for key, val in params.items() if key != 'vfmap'}}
+
+
+def _length_valued(value):
+    """Whether a value, or either half of a pair, is a physical length
+
+    What tells a retinal extent apart from a visual one is the *dimension* of
+    what was passed, not the unit: ``mm``, ``um`` and ``m`` are all the same
+    shorthand, and a bare number is no shorthand at all.
+    """
+    values = value if isinstance(value, (list, tuple)) else [value]
+    return any(isinstance(v, (Quantity, Unit)) and v.dimension == um.dimension
+               for v in values)
 
 
 def _require_stim_dimension(model, stim):
@@ -200,8 +235,8 @@ def _require_stim_dimension(model, stim):
     Gaussian current spread and called the result brightness would be doing
     exactly the silent reinterpretation ``stimulus_unit`` exists to declare
     away. A picture becomes a stimulus by being encoded (see
-    :py:class:`~pulse2percept.stimuli.Encoder`), which is where the gray
-    levels are given a current to stand for.
+    :py:class:`~pulse2percept.stimuli.StimulusEncoder`), which is where the
+    gray levels are given a current to stand for.
 
     A :py:class:`~pulse2percept.percepts.Percept` is not checked: it is
     brightness, the output of a spatial model, and carries no unit.
@@ -463,6 +498,23 @@ class SpatialModel(BaseModel, metaclass=ABCMeta):
         You will not be able to add more parameters outside the constructor;
         e.g., ``model.newparam = 1`` will lead to a ``FreezeError``.
 
+    Notes
+    -----
+    *  ``xrange`` and ``yrange`` say which patch of the **visual field** to
+       simulate, in degrees of visual angle, and may be given as plain numbers
+       or as unitful quantities (e.g. ``xrange=(-12 * dva, 12 * dva)``).
+
+       .. versionchanged:: 0.10.0
+
+          On a retinal model they may also be given as a physical extent
+          (e.g. ``xrange=(-4 * mm, 4 * mm)``), which the model's ``vfmap``
+          resolves into the visual field range that piece of retina covers.
+          The range is stored in dva either way, so changing ``vfmap``
+          afterwards does not reinterpret it. This is shorthand, not a unit
+          conversion: ``step`` has no such spelling, since a grid spaced
+          evenly on the retina is a different grid from one spaced evenly in
+          the visual field.
+
     .. seealso ::
 
         *  `Basic Concepts > Computational Models > Building your own model
@@ -478,8 +530,96 @@ class SpatialModel(BaseModel, metaclass=ABCMeta):
                               removed_version='0.11.0')
 
     def __init__(self, **params):
-        super().__init__(**params)
+        # `vfmap` first: `xrange`/`yrange` may be given as a retinal extent,
+        # which is resolved through the map as it is assigned. See
+        # `_vfmap_first`.
+        super().__init__(**_vfmap_first(params))
         self.grid = None
+
+    def set_params(self, **params):
+        """Set the parameters of this model
+
+        ``vfmap`` is applied before the other parameters, so that a retinal
+        extent given for ``xrange``/``yrange`` in the same call is resolved
+        through the map the caller asked for. See ``_vfmap_first``.
+        """
+        super().set_params(**_vfmap_first(params))
+
+    def _normalize_param_value(self, name, value):
+        """Convert a unitful parameter into the unit it is stored in
+
+        Extends the generic conversion (see
+        :py:meth:`~pulse2percept.utils.Parametrized._normalize_param_value`)
+        with the one parameter whose unit is not the whole story: a *physical*
+        ``xrange``/``yrange`` is shorthand for the visual field range that
+        extent covers, which only the model's visual field map can say.
+        Everything else, ``step`` included, is converted as usual.
+        """
+        if name in ('xrange', 'yrange') and _length_valued(value):
+            return self._retinal_range_to_dva(name, value)
+        return super()._normalize_param_value(name, value)
+
+    def _retinal_range_to_dva(self, name, value):
+        """Resolve a retinal extent into the visual field range it spans
+
+        The model simulates a patch of the *visual field*, sampled uniformly in
+        degrees of visual angle, and that is what ``xrange``/``yrange`` are and
+        stay. Giving them in microns says which patch by naming the piece of
+        retina it lands on; the map turns that into degrees here, once, and
+        what is stored afterwards is an ordinary pair of dva. Changing
+        ``vfmap`` later therefore does not reinterpret a range that has already
+        been resolved -- the same rule an implant's coordinates follow.
+
+        This is deliberately not a unit conversion, and
+        :py:class:`~pulse2percept.units.Quantity` will not do it: how far a
+        degree reaches on tissue is what a visual field map is for. It is also
+        deliberately not offered for ``step``, since a grid spaced evenly on
+        the retina is not the same grid as one spaced evenly in the visual
+        field, and only the latter is what :py:class:`Grid2D` builds.
+
+        Parameters
+        ----------
+        name : {'xrange', 'yrange'}
+            Which of the two ranges is being assigned.
+        value : (min, max)
+            The extent, as a pair of lengths.
+
+        Returns
+        -------
+        (min_dva, max_dva) : tuple of float
+            The same extent in degrees of visual angle, in increasing order.
+
+        """
+        vfmap = getattr(self, 'vfmap', None)
+        if not isinstance(vfmap, RetinalMap):
+            raise DimensionMismatchError(
+                f"'{name}' is a visual field extent, measured in degrees of "
+                f"visual angle. A physical length is shorthand for one only "
+                f"on a retinal map, and this model's vfmap is a "
+                f"{type(vfmap).__name__}. Specify '{name}' in dva instead.")
+        # In the unit the map's tissue side is measured in, which is what its
+        # inverse transform below expects:
+        extent = np.asarray(as_value(value, vfmap.tissue_unit, name),
+                            dtype=np.float64).ravel()
+        if extent.size != 2:
+            raise ValueError(f"'{name}' must be a (min, max) pair, not "
+                             f"{value}.")
+        lo, hi = extent
+        try:
+            if name == 'xrange':
+                lo_dva, _ = vfmap.ret_to_dva(lo, 0)
+                hi_dva, _ = vfmap.ret_to_dva(hi, 0)
+            else:
+                _, lo_dva = vfmap.ret_to_dva(0, lo)
+                _, hi_dva = vfmap.ret_to_dva(0, hi)
+        except NotImplementedError:
+            raise NotImplementedError(
+                f"This visual field map ({type(vfmap).__name__}) cannot infer "
+                f"a visual field range from retinal distance. Specify "
+                f"'{name}' in dva instead.") from None
+        # Sorted, because the retinal y axis points the opposite way from the
+        # visual field's, so the two end points can come back swapped:
+        return tuple(sorted((float(lo_dva), float(hi_dva))))
 
     def get_default_params(self):
         """Return a dictionary of default values for all model parameters"""
@@ -514,7 +654,12 @@ class SpatialModel(BaseModel, metaclass=ABCMeta):
         return params
 
     def get_param_units(self):
-        """Return a dict of the units that parameters are stored in"""
+        """Return a dict of the units that parameters are stored in
+
+        ``xrange`` and ``yrange`` additionally accept a retinal extent, which
+        is not a unit conversion and so does not appear here; see
+        ``_retinal_range_to_dva``.
+        """
         return {
             **super().get_param_units(),
             # The simulated patch of visual field is specified in degrees of
@@ -1557,7 +1702,10 @@ class Model(PrettyPrint):
             renamed.update(getattr(model, '_renamed_params', {}))
         warn_deprecated_params(type(self).__name__, params, specs)
         params = rename_deprecated_params(type(self).__name__, params, renamed)
-        for key, val in params.items():
+        # Each parameter is forwarded to the sub-models one at a time, so the
+        # order they are applied in is decided here rather than by
+        # `SpatialModel.set_params`. See `_vfmap_first`:
+        for key, val in _vfmap_first(params).items():
             setattr(self, key, val)
 
     def build(self, **build_params):

--- a/pulse2percept/models/beyeler2019.py
+++ b/pulse2percept/models/beyeler2019.py
@@ -387,7 +387,7 @@ class AxonMapSpatial(SpatialModel):
         params = {
             # Left or right eye:
             'eye': 'RE',
-            'rho': 200,
+            'rho': 300,
             'lam': 500,
             # Set the (x,y) location of the optic disc:
             'loc_od': (15.5, 1.5),

--- a/pulse2percept/models/cortex/base.py
+++ b/pulse2percept/models/cortex/base.py
@@ -5,7 +5,7 @@
 from ..base import Model, SpatialModel
 from ...topography import Polimeni2006Map
 from .._beyeler2019 import fast_scoreboard, fast_scoreboard_3d
-from ...units import um
+from ...units import DimensionMismatchError, um
 from ...utils.constants import UM_PER_MM, ZORDER
 import numpy as np
 
@@ -109,6 +109,22 @@ class CortexSpatial(SpatialModel):
 
         if not isinstance(self.regions, list):
             self.regions = [self.regions]
+
+    def _retinal_range_to_dva(self, name, value):
+        """A cortical model has no retinal extent for a length to stand for
+
+        :py:class:`~pulse2percept.models.SpatialModel` decides this from the
+        map that is installed at the time of assignment, which here is not yet
+        the cortical one: this constructor puts that in place only *after*
+        ``super().__init__`` has applied the parameters. Refusing here rather
+        than there keeps a length from being read as a retinal extent in the
+        window in between.
+        """
+        raise DimensionMismatchError(
+            f"'{name}' is a visual field extent, measured in degrees of "
+            f"visual angle. A physical length is shorthand for one only on a "
+            f"retinal map, and {type(self).__name__} is cortical. Specify "
+            f"'{name}' in dva instead.")
 
     def get_default_params(self):
         """Returns all settable parameters of the scoreboard model"""

--- a/pulse2percept/models/tests/test_base.py
+++ b/pulse2percept/models/tests/test_base.py
@@ -1659,7 +1659,7 @@ def test_spatial_model_reads_modulation_not_pulses():
     npt.assert_equal(percept.data.shape[-1], 1)
     # ... and every electrode the image lights is lit in it, rather than the
     # one raster group that happened to be firing at the sampled instant:
-    lit = implant.spatial_stim.data.ravel() > 0
+    lit = implant._spatial_stim.data.ravel() > 0
     npt.assert_equal(lit.sum() > 10, True)
     groups = implant.raster.groups(implant.electrode_names)
     # No instant of the delivered train ever holds more than one group, so
@@ -1670,7 +1670,7 @@ def test_spatial_model_reads_modulation_not_pulses():
     # Which is what the percept says too: it is the same picture the
     # modulation asked for, run through the model.
     direct = spatial.predict_percept(
-        ArgusII(encoder=None, stim=implant.spatial_stim))
+        ArgusII(encoder=None, stim=implant._spatial_stim))
     npt.assert_almost_equal(percept.data, direct.data)
 
     # A video reports one percept frame per *video* frame:
@@ -1696,7 +1696,7 @@ def test_spatial_model_reads_modulation_not_pulses():
     both.predict_percept(implant)
     npt.assert_array_less(seen[-1], 0)
     # ... and the implant it was handed is untouched by that:
-    npt.assert_equal(implant.spatial_stim is None, False)
+    npt.assert_equal(implant._spatial_stim is None, False)
     # Spatial-only, the same model class reads the modulation instead:
     seen.clear()
     Recording(xrange=(-12, 12), yrange=(-8, 8),
@@ -1707,7 +1707,7 @@ def test_spatial_model_reads_modulation_not_pulses():
     # modulation behind it, so there is nothing to prefer.
     plain = ArgusII(stim={'A1': BiphasicPulseTrain(20, 50, 0.45,
                                                    stim_dur=100)})
-    npt.assert_equal(plain.spatial_stim, None)
+    npt.assert_equal(plain._spatial_stim, None)
     npt.assert_equal(
         spatial.predict_percept(plain).data.shape[-1],
         plain.stim.time.size)
@@ -1725,7 +1725,7 @@ def test_find_threshold_scales_both_representations():
     # The answer is a threshold of what `predict_percept` reports, which is
     # only true if both descriptions were scaled together:
     scaled = ArgusII(encoder=None, stim=Stimulus(
-        implant.spatial_stim.data * amp_th / implant.stim.data.max(),
-        electrodes=implant.spatial_stim.electrodes))
+        implant._spatial_stim.data * amp_th / implant.stim.data.max(),
+        electrodes=implant._spatial_stim.electrodes))
     npt.assert_allclose(model.predict_percept(scaled).data.max(), 50,
                         rtol=0.05)

--- a/pulse2percept/models/tests/test_base.py
+++ b/pulse2percept/models/tests/test_base.py
@@ -10,7 +10,8 @@ import time
 
 from pulse2percept.implants import ArgusI, ArgusII
 from pulse2percept.stimuli import (AmplitudeEncoder, BiphasicPulseTrain,
-                                   ImageStimulus, Stimulus, VideoStimulus)
+                                   BostonTrain, ImageStimulus, LogoBVL,
+                                   Stimulus, VideoStimulus)
 from pulse2percept.percepts import Percept
 from pulse2percept.models import (AxonMapModel, AxonMapSpatial, BaseModel,
                                   FadingTemporal, Model, NotBuiltError,
@@ -1635,3 +1636,96 @@ def test_TemporalModel_default_frame_rate_is_50Hz():
     brief = Stimulus(-np.ones((1, 3)), electrodes=['A1'], time=[0, 5, 10])
     npt.assert_allclose(SecondTemporal().build().predict_percept(brief).time,
                         [0, 0.02], rtol=1e-9)
+
+
+def test_spatial_model_reads_modulation_not_pulses():
+    """Spatial models see modulation frames; temporal models see pulses.
+
+    A pulse train says *when* current flows and a raster says which electrodes
+    may flow together. Both are facts about time, and a model with no temporal
+    component has no way to express either: handed the delivered train, it
+    reports the stimulus one instant at a time, so an encoded image comes back
+    as a sequence of raster slots rather than as the image. Argus II rasters
+    six groups by default, which is exactly the case that showed it.
+    """
+    logo = LogoBVL()
+    implant = ArgusII(stim=logo)
+    spatial = ScoreboardSpatial(xrange=(-12, 12), yrange=(-8, 8),
+                                step=1).build()
+
+    # One frame in, one frame out -- not one per pulse edge:
+    percept = spatial.predict_percept(implant)
+    npt.assert_equal(implant.stim.time.size > 50, True)
+    npt.assert_equal(percept.data.shape[-1], 1)
+    # ... and every electrode the image lights is lit in it, rather than the
+    # one raster group that happened to be firing at the sampled instant:
+    lit = implant.spatial_stim.data.ravel() > 0
+    npt.assert_equal(lit.sum() > 10, True)
+    groups = implant.raster.groups(implant.electrode_names)
+    # No instant of the delivered train ever holds more than one group, so
+    # anything above one is more than a raster slot's worth of picture:
+    npt.assert_equal(len(np.unique(groups[lit])) > 1, True)
+    for column in implant.stim.data.T:
+        npt.assert_equal(np.unique(groups[column != 0]).size <= 1, True)
+    # Which is what the percept says too: it is the same picture the
+    # modulation asked for, run through the model.
+    direct = spatial.predict_percept(
+        ArgusII(encoder=None, stim=implant.spatial_stim))
+    npt.assert_almost_equal(percept.data, direct.data)
+
+    # A video reports one percept frame per *video* frame:
+    with pytest.warns(UserWarning, match='deliver no pulse'):
+        implant = ArgusII(stim=BostonTrain())
+    npt.assert_equal(spatial.predict_percept(implant).data.shape[-1], 94)
+
+    # A model with a temporal component is the opposite case: the pulses are
+    # what it integrates, so it has to see them, and the spatial stage it is
+    # built on must not quietly swap them out.
+    seen = []
+
+    class Recording(ScoreboardSpatial):
+        def _predict_spatial(self, earray, stim):
+            # A pulse train has cathodic phases in it; modulation amplitudes
+            # are never negative. So the sign says which one arrived:
+            seen.append(float(stim.data.min()))
+            return super()._predict_spatial(earray, stim)
+
+    implant = ArgusII(stim=logo)
+    both = Model(spatial=Recording(xrange=(-12, 12), yrange=(-8, 8), step=1),
+                 temporal=FadingTemporal(tau=100)).build()
+    both.predict_percept(implant)
+    npt.assert_array_less(seen[-1], 0)
+    # ... and the implant it was handed is untouched by that:
+    npt.assert_equal(implant.spatial_stim is None, False)
+    # Spatial-only, the same model class reads the modulation instead:
+    seen.clear()
+    Recording(xrange=(-12, 12), yrange=(-8, 8),
+              step=1).build().predict_percept(implant)
+    npt.assert_array_less(-1e-12, seen[-1])
+
+    # Nothing changes for a stimulus that was assigned as current: there is no
+    # modulation behind it, so there is nothing to prefer.
+    plain = ArgusII(stim={'A1': BiphasicPulseTrain(20, 50, 0.45,
+                                                   stim_dur=100)})
+    npt.assert_equal(plain.spatial_stim, None)
+    npt.assert_equal(
+        spatial.predict_percept(plain).data.shape[-1],
+        plain.stim.time.size)
+
+
+def test_find_threshold_scales_both_representations():
+    # `find_threshold` varies the amplitude between trials. A spatial model
+    # reads the modulation, so a search that scaled only the pulse train would
+    # evaluate every trial on the unscaled picture and never move.
+    implant = ArgusII(stim=LogoBVL())
+    model = ScoreboardModel(xrange=(-12, 12), yrange=(-8, 8), step=1).build()
+    amp_th = model.find_threshold(implant, 50, amp_range=(0, 500),
+                                  amp_tol=0.5)
+    npt.assert_equal(0 < amp_th < 500, True)
+    # The answer is a threshold of what `predict_percept` reports, which is
+    # only true if both descriptions were scaled together:
+    scaled = ArgusII(encoder=None, stim=Stimulus(
+        implant.spatial_stim.data * amp_th / implant.stim.data.max(),
+        electrodes=implant.spatial_stim.electrodes))
+    npt.assert_allclose(model.predict_percept(scaled).data.max(), 50,
+                        rtol=0.05)

--- a/pulse2percept/models/tests/test_base.py
+++ b/pulse2percept/models/tests/test_base.py
@@ -13,14 +13,19 @@ from pulse2percept.stimuli import (AmplitudeEncoder, BiphasicPulseTrain,
                                    ImageStimulus, Stimulus, VideoStimulus)
 from pulse2percept.percepts import Percept
 from pulse2percept.models import (AxonMapSpatial, BaseModel, FadingTemporal,
-                                  Model, NotBuiltError, ScoreboardSpatial,
-                                  SpatialModel, TemporalModel)
+                                  Model, NotBuiltError, ScoreboardModel,
+                                  ScoreboardSpatial, SpatialModel,
+                                  TemporalModel)
+from pulse2percept.models.cortex import (ScoreboardSpatial as
+                                         CortexScoreboardSpatial)
 from pulse2percept.units import (DimensionMismatchError, Quantity,
                                  dimensionless, dva, mA, mm, ms, s, uA, um,
                                  us)
 from pulse2percept.utils import FreezeError, frame_interval
 from pulse2percept.utils.testing import assert_warns_msg
-from pulse2percept.topography import Grid2D, Watson2014Map
+from pulse2percept.topography import (Curcio1990Map, Grid2D,
+                                      Polimeni2006Map, RetinalMap,
+                                      Watson2014Map)
 
 
 class ValidBaseModel(BaseModel):
@@ -492,11 +497,94 @@ def test_SpatialModel_units():
         unitful.build()
         npt.assert_almost_equal(bare.grid.x, unitful.grid.x)
         npt.assert_almost_equal(bare.grid.y, unitful.grid.y)
-    # A range in the wrong dimension is caught elementwise too:
+    # A range in the wrong dimension is caught elementwise too. A *length* is
+    # the one exception, and means something specific; see
+    # `test_SpatialModel_retinal_range`:
     with pytest.raises(DimensionMismatchError):
-        ScoreboardSpatial(xrange=(-5 * um, 5 * um))
+        ScoreboardSpatial(xrange=(-5 * ms, 5 * ms))
     with pytest.raises(DimensionMismatchError):
-        ScoreboardSpatial(xrange=(-5, 5) * um)
+        ScoreboardSpatial(xrange=(-5, 5) * uA)
+    # The grid spacing takes dva and nothing else: a grid spaced evenly on the
+    # retina is a different grid, not a different spelling of this one.
+    with pytest.raises(DimensionMismatchError):
+        ScoreboardSpatial(step=100 * um)
+    with pytest.raises(DimensionMismatchError):
+        ScoreboardSpatial(xystep=100 * um)
+
+
+def test_SpatialModel_retinal_range():
+    """A retinal extent is shorthand for the visual field range it covers"""
+    # Curcio1990Map puts 280 um to the degree, so 2.8 mm is 10 dva:
+    model = ScoreboardSpatial(xrange=(-2.8 * mm, 2.8 * mm),
+                              yrange=(-1.4 * mm, 1.4 * mm),
+                              vfmap=Curcio1990Map(), step=1)
+    npt.assert_allclose(model.xrange, (-10, 10), rtol=1e-12)
+    npt.assert_allclose(model.yrange, (-5, 5), rtol=1e-12)
+    # What is stored is plain dva, not a quantity, and it grids exactly like
+    # the dva spelling does:
+    for value in (model.xrange, model.yrange):
+        npt.assert_equal(isinstance(value, Quantity), False)
+    bare = ScoreboardSpatial(xrange=(-10, 10), yrange=(-5, 5),
+                             vfmap=Curcio1990Map(), step=1).build()
+    npt.assert_almost_equal(bare.grid.x, model.build().grid.x)
+    npt.assert_almost_equal(bare.grid.y, model.grid.y)
+    # Which map is installed decides the answer, so the user's map has to be
+    # applied first however the parameters were ordered:
+    for order in ({'xrange': (-2.8 * mm, 2.8 * mm), 'vfmap': Curcio1990Map()},
+                  {'vfmap': Curcio1990Map(), 'xrange': (-2.8 * mm, 2.8 * mm)}):
+        npt.assert_allclose(ScoreboardSpatial(step=1, **order).xrange,
+                            (-10, 10), rtol=1e-12)
+        npt.assert_allclose(ScoreboardModel(step=1, **order).xrange,
+                            (-10, 10), rtol=1e-12)
+        npt.assert_allclose(
+            ScoreboardSpatial(step=1).build(**order).xrange, (-10, 10),
+            rtol=1e-12)
+        npt.assert_allclose(
+            ScoreboardModel(step=1).build(**order).xrange, (-10, 10),
+            rtol=1e-12)
+    # A quantity wrapping a pair says the same thing:
+    npt.assert_allclose(
+        ScoreboardSpatial(xrange=(-2.8, 2.8) * mm, vfmap=Curcio1990Map(),
+                          step=1).xrange, (-10, 10), rtol=1e-12)
+    # The retinal y axis points the other way, so the pair comes back sorted
+    # rather than reversed:
+    yrange = ScoreboardSpatial(yrange=(1.4 * mm, -1.4 * mm),
+                               vfmap=Curcio1990Map(), step=1).yrange
+    npt.assert_allclose(yrange, (-5, 5), rtol=1e-12)
+    # Resolved once, at assignment: a later map does not reinterpret it.
+    model = ScoreboardSpatial(xrange=(-2.8 * mm, 2.8 * mm),
+                              vfmap=Curcio1990Map(), step=1)
+    model.vfmap = Watson2014Map()
+    npt.assert_allclose(model.xrange, (-10, 10), rtol=1e-12)
+    # Direct assignment is sequential, and uses the map in place at the time:
+    model = ScoreboardSpatial(step=1)
+    model.vfmap = Curcio1990Map()
+    model.xrange = (-2.8 * mm, 2.8 * mm)
+    npt.assert_allclose(model.xrange, (-10, 10), rtol=1e-12)
+    # It must be a pair, whatever the units:
+    with pytest.raises(ValueError):
+        ScoreboardSpatial(xrange=2.8 * mm, vfmap=Curcio1990Map())
+
+
+def test_SpatialModel_retinal_range_needs_a_retinal_map():
+    """Only a retinal map can say what visual field an extent covers"""
+    # A cortical map is not one, whether it was passed explicitly ...
+    with pytest.raises(DimensionMismatchError) as excinfo:
+        ScoreboardSpatial(xrange=(-2 * mm, 2 * mm), vfmap=Polimeni2006Map())
+    npt.assert_equal('in dva instead' in str(excinfo.value), True)
+    # ... or is the model's own default, which a cortical model installs only
+    # after its parameters have been applied:
+    with pytest.raises(DimensionMismatchError):
+        CortexScoreboardSpatial(yrange=(-2 * mm, 2 * mm))
+
+    # A retinal map without an inverse cannot answer either, and says so:
+    class NoInverse(RetinalMap):
+        def dva_to_ret(self, xdva, ydva):
+            return 280.0 * xdva, -280.0 * ydva
+
+    with pytest.raises(NotImplementedError) as excinfo:
+        ScoreboardSpatial(xrange=(-2 * mm, 2 * mm), vfmap=NoInverse())
+    npt.assert_equal('in dva instead' in str(excinfo.value), True)
 
 
 def test_TemporalModel():
@@ -1220,9 +1308,17 @@ def test_model_requires_a_current_stimulus():
     composite = Model(spatial=ScoreboardSpatial(xrange=(-2, 2), yrange=(-2, 2),
                                                 step=1),
                       temporal=FadingTemporal()).build()
-    # `implant.stim = img` stays legal (see `check_stim`), and it is the model
-    # that refuses to read it:
-    implant = ArgusII(preprocess=False, stim=img)
+    # `implant.stim = img` is refused by the implant itself (see
+    # `ProsthesisSystem.stimulus_unit`), so the model-side guard is reached
+    # through an implant that claims to deliver something else. Both are
+    # needed: the implant one catches the assignment that was actually wrong,
+    # and this one is what no model may be talked out of.
+    class Projector(ArgusII):
+        stimulus_unit = dimensionless
+
+    with pytest.raises(DimensionMismatchError):
+        ArgusII(preprocess=False, stim=img)
+    implant = Projector(preprocess=False, stim=img)
     npt.assert_equal(implant.stim.unit, dimensionless)
     for model in (spatial, composite):
         with pytest.raises(DimensionMismatchError) as excinfo:

--- a/pulse2percept/models/tests/test_base.py
+++ b/pulse2percept/models/tests/test_base.py
@@ -943,8 +943,8 @@ def test_Model_predict_percept_frame_clock(fps):
     # to do with the source.
     implant = ArgusI()
     vid = VideoStimulus(np.random.rand(4, 4, 6), metadata={'fps': fps})
-    implant.stim = AmplitudeEncoder(implant, amp_range=(0, 50),
-                                    freq=60).encode(vid)
+    implant.stim = AmplitudeEncoder(amp_range=(0, 50), freq=60).encode(
+        vid, implant=implant)
     model = Model(temporal=ValidTemporalModel()).build()
     percept = model.predict_percept(implant)
     npt.assert_equal(percept.data.shape[-1], 6)
@@ -985,8 +985,8 @@ def test_Model_predict_percept_frame_peak():
     implant = ArgusI()
     rng = np.random.default_rng(0)
     vid = VideoStimulus(rng.random((4, 4, 16)), metadata={'fps': 29.97})
-    implant.stim = AmplitudeEncoder(implant, amp_range=(0, 50),
-                                    freq=20).encode(vid)
+    implant.stim = AmplitudeEncoder(amp_range=(0, 50), freq=20).encode(
+        vid, implant=implant)
     model = Model(temporal=FadingTemporal(tau=100)).build()
     peak = model.predict_percept(implant)
     # Same frames, but sampled only at the instant each one ends:
@@ -1119,8 +1119,8 @@ def test_find_threshold_keeps_encoder_metadata():
     vid = VideoStimulus(rng.random((4, 4, 6)), metadata={'fps': 29.97})
     with warnings.catch_warnings():
         warnings.simplefilter('ignore')
-        implant.stim = AmplitudeEncoder(implant, amp_range=(0, 50),
-                                        freq=60).encode(vid)
+        implant.stim = AmplitudeEncoder(amp_range=(0, 50), freq=60).encode(
+            vid, implant=implant)
     n_frames = implant.stim.metadata['encoder']['n_frames']
 
     seen = []
@@ -1340,16 +1340,16 @@ def test_model_requires_a_current_stimulus():
     composite = Model(spatial=ScoreboardSpatial(xrange=(-2, 2), yrange=(-2, 2),
                                                 step=1),
                       temporal=FadingTemporal()).build()
-    # `implant.stim = img` is refused by the implant itself (see
-    # `ProsthesisSystem.stimulus_unit`), so the model-side guard is reached
-    # through an implant that claims to deliver something else. Both are
-    # needed: the implant one catches the assignment that was actually wrong,
-    # and this one is what no model may be talked out of.
+    # `implant.stim = img` is either encoded by the implant or refused by it
+    # (see `ProsthesisSystem.stimulus_unit`), so the model-side guard is
+    # reached through an implant that claims to deliver something else. Both
+    # are needed: the implant one catches the assignment that was actually
+    # wrong, and this one is what no model may be talked out of.
     class Projector(ArgusII):
         stimulus_unit = dimensionless
 
     with pytest.raises(DimensionMismatchError):
-        ArgusII(preprocess=False, stim=img)
+        ArgusII(preprocess=False, encoder=None, stim=img)
     implant = Projector(preprocess=False, stim=img)
     npt.assert_equal(implant.stim.unit, dimensionless)
     for model in (spatial, composite):
@@ -1361,7 +1361,8 @@ def test_model_requires_a_current_stimulus():
         temporal.predict_percept(implant.stim)
 
     # Encoded, it goes through:
-    encoded = AmplitudeEncoder(ArgusII(), amp_range=(0, 50)).encode(img)
+    encoded = AmplitudeEncoder(amp_range=(0, 50)).encode(
+        img, implant=ArgusII(raster=None))
     npt.assert_equal(encoded.unit, uA)
     for model in (spatial, composite):
         npt.assert_equal(model.predict_percept(ArgusII(stim=encoded)) is None,
@@ -1459,9 +1460,14 @@ def test_model_units_are_a_numerical_contract():
         [0.0, 0.005], rtol=1e-12)
 
     # The dimension guard reads the declared unit: mA and uA are the same
-    # dimension, so an ordinary stimulus is fine and a picture is not.
+    # dimension, so an ordinary stimulus is fine and a picture is not. An
+    # implant with an encoder never carries one, so this needs an implant that
+    # claims to deliver gray levels:
+    class Projector(ArgusII):
+        stimulus_unit = dimensionless
+
     with pytest.raises(DimensionMismatchError):
-        milli.predict_percept(ArgusII(preprocess=False, stim=ImageStimulus(
+        milli.predict_percept(Projector(preprocess=False, stim=ImageStimulus(
             np.linspace(0, 1, 16).reshape((4, 4)))))
 
 

--- a/pulse2percept/models/tests/test_base.py
+++ b/pulse2percept/models/tests/test_base.py
@@ -12,10 +12,10 @@ from pulse2percept.implants import ArgusI, ArgusII
 from pulse2percept.stimuli import (AmplitudeEncoder, BiphasicPulseTrain,
                                    ImageStimulus, Stimulus, VideoStimulus)
 from pulse2percept.percepts import Percept
-from pulse2percept.models import (AxonMapSpatial, BaseModel, FadingTemporal,
-                                  Model, NotBuiltError, ScoreboardModel,
-                                  ScoreboardSpatial, SpatialModel,
-                                  TemporalModel)
+from pulse2percept.models import (AxonMapModel, AxonMapSpatial, BaseModel,
+                                  FadingTemporal, Model, NotBuiltError,
+                                  ScoreboardModel, ScoreboardSpatial,
+                                  SpatialModel, TemporalModel)
 from pulse2percept.models.cortex import (ScoreboardSpatial as
                                          CortexScoreboardSpatial)
 from pulse2percept.units import (DimensionMismatchError, Quantity,
@@ -564,6 +564,38 @@ def test_SpatialModel_retinal_range():
     # It must be a pair, whatever the units:
     with pytest.raises(ValueError):
         ScoreboardSpatial(xrange=2.8 * mm, vfmap=Curcio1990Map())
+
+
+def test_SpatialModel_retinal_range_nonlinear_map():
+    """The motivating case: an axon map model sized in millimeters
+
+    Every other test here uses ``Curcio1990Map``, where the transform is a
+    single factor and so cannot tell a real conversion apart from a lucky one.
+    ``AxonMapModel`` defaults to ``Watson2014Map``, whose inverse is a quartic
+    polynomial in the eccentricity, so this pins the answer to the map rather
+    than to a scale factor. No ``build``: growing axon bundles is expensive
+    and has nothing to do with what the range came out as.
+    """
+    model = AxonMapModel(xrange=(-4 * mm, 4 * mm), yrange=(-2 * mm, 2 * mm))
+    npt.assert_equal(isinstance(model.vfmap, Watson2014Map), True)
+    # Each range is resolved along its own meridian, which is what makes the
+    # two answers independent of one another:
+    watson = Watson2014Map()
+    npt.assert_allclose(model.xrange,
+                        (watson.ret_to_dva(-4000, 0)[0],
+                         watson.ret_to_dva(4000, 0)[0]), rtol=1e-12)
+    # The retinal y axis points the other way, so the pair comes back sorted
+    # rather than in the order the eccentricities were given:
+    npt.assert_allclose(model.yrange,
+                        sorted((watson.ret_to_dva(0, -2000)[1],
+                                watson.ret_to_dva(0, 2000)[1])), rtol=1e-12)
+    # And the map really is consulted: a linear 280 um/dva reading would put
+    # the edge of the x range half a degree away from where Watson does.
+    npt.assert_equal(abs(model.xrange[1] - 4000 / 280.0) > 0.4, True)
+    # The spatial model alone answers identically, and is what the composite
+    # forwarded to:
+    npt.assert_allclose(AxonMapSpatial(xrange=(-4 * mm, 4 * mm)).xrange,
+                        model.xrange, rtol=1e-12)
 
 
 def test_SpatialModel_retinal_range_needs_a_retinal_map():

--- a/pulse2percept/models/tests/test_base.py
+++ b/pulse2percept/models/tests/test_base.py
@@ -1122,7 +1122,7 @@ def test_find_threshold_keeps_encoder_metadata():
         warnings.simplefilter('ignore')
         implant.stim = AmplitudeEncoder(amp_range=(0, 50), freq=60).encode(
             vid, implant=implant)
-    n_frames = implant.stim.metadata['encoder']['n_frames']
+    n_frames = implant.stim.metadata['encoder']['frame_time'].size
 
     seen = []
     model = FadingTemporal(tau=100).build()

--- a/pulse2percept/models/tests/test_end_to_end.py
+++ b/pulse2percept/models/tests/test_end_to_end.py
@@ -262,7 +262,9 @@ def test_endtoend_raster_is_what_separates_the_groups():
     implant = make_implant()
     plain = AmplitudeEncoder(amp_range=(0, 50), freq=20,
                              frame_dur=200).encode(img, implant=implant)
-    npt.assert_equal(plain.metadata['encoder']['n_schedules'], 1)
+    # Every electrode fires at the same times, so the stimulator has to
+    # source all of them at once:
+    npt.assert_equal(len(np.unique(np.abs(plain.data) > 0, axis=0)), 1)
     npt.assert_almost_equal(np.abs(plain.data).sum(axis=0).max(), 125.0)
 
     implant.max_current = 60

--- a/pulse2percept/models/tests/test_end_to_end.py
+++ b/pulse2percept/models/tests/test_end_to_end.py
@@ -34,11 +34,11 @@ NAMES = ['A', 'B', 'C', 'D']
 POS = [(-600.0, -600.0), (600.0, -600.0), (-600.0, 600.0), (600.0, 600.0)]
 
 
-def make_implant():
+def make_implant(raster=None):
     """Four well-separated electrodes, one per raster group"""
     earray = ElectrodeArray({n: DiskElectrode(x, y, 0, 100)
                              for n, (x, y) in zip(NAMES, POS)})
-    return ProsthesisSystem(earray)
+    return ProsthesisSystem(earray, raster=raster)
 
 
 def one_per_group():
@@ -70,11 +70,10 @@ def at_electrodes(model, implant):
 
 def test_endtoend_amplitude_modulation():
     # Four gray levels, evenly spaced, one per electrode:
-    implant = make_implant()
+    implant = make_implant(one_per_group())
     img = ImageStimulus(np.array([[0.25, 0.50], [0.75, 1.00]]))
-    stim = AmplitudeEncoder(implant, amp_range=(0, 50), freq=20,
-                            raster=one_per_group(),
-                            frame_dur=200).encode(img)
+    stim = AmplitudeEncoder(amp_range=(0, 50), freq=20,
+                            frame_dur=200).encode(img, implant=implant)
     implant.stim = stim
     npt.assert_equal(list(stim.electrodes), NAMES)
 
@@ -142,11 +141,10 @@ def test_endtoend_frequency_modulation():
     # Gray levels chosen so that the requested rates are 50, 66.7, 100 and
     # 200 Hz -- whole multiples of the 5 ms raster cycle that the fastest
     # electrode sets, so nothing has to be quantized away:
-    implant = make_implant()
+    implant = make_implant(one_per_group())
     img = ImageStimulus(np.array([[0.25, 1 / 3], [0.5, 1.0]]))
-    stim = FrequencyEncoder(implant, freq_range=(0, 200), amp=50,
-                            raster=one_per_group(),
-                            frame_dur=200).encode(img)
+    stim = FrequencyEncoder(freq_range=(0, 200), amp=50,
+                            frame_dur=200).encode(img, implant=implant)
     implant.stim = stim
 
     # --- what the encoder produced --------------------------------------
@@ -215,11 +213,11 @@ def test_endtoend_raster_order(order):
     # The raster decides *when in the period* each electrode gets its turn, and
     # nothing else. Reordering the groups should permute the onsets to match
     # and leave every other thing about the stimulus alone.
-    implant = make_implant()
     img = ImageStimulus(np.array([[0.25, 0.50], [0.75, 1.00]]))
-    raster = CustomRaster({n: g for n, g in zip(NAMES, order)})
-    stim = AmplitudeEncoder(implant, amp_range=(0, 50), freq=20,
-                            raster=raster, frame_dur=200).encode(img)
+    implant = make_implant(CustomRaster({n: g
+                                         for n, g in zip(NAMES, order)}))
+    stim = AmplitudeEncoder(amp_range=(0, 50), freq=20,
+                            frame_dur=200).encode(img, implant=implant)
     implant.stim = stim
 
     # Each electrode starts in the slot its group was given -- 50 ms period
@@ -262,8 +260,8 @@ def test_endtoend_raster_is_what_separates_the_groups():
     # `max_current` rejects the unrastered version of the very same image.
     img = ImageStimulus(np.array([[0.25, 0.50], [0.75, 1.00]]))
     implant = make_implant()
-    plain = AmplitudeEncoder(implant, amp_range=(0, 50), freq=20,
-                             frame_dur=200).encode(img)
+    plain = AmplitudeEncoder(amp_range=(0, 50), freq=20,
+                             frame_dur=200).encode(img, implant=implant)
     npt.assert_equal(plain.metadata['encoder']['n_schedules'], 1)
     npt.assert_almost_equal(np.abs(plain.data).sum(axis=0).max(), 125.0)
 
@@ -273,8 +271,9 @@ def test_endtoend_raster_is_what_separates_the_groups():
     # Giving the implant the raster is enough -- the encoder picks it up, and
     # the same image now fits inside the current limit:
     implant.raster = one_per_group()
-    implant.stim = AmplitudeEncoder(implant, amp_range=(0, 50), freq=20,
-                                    frame_dur=200).encode(img)
+    implant.stim = AmplitudeEncoder(amp_range=(0, 50), freq=20,
+                                    frame_dur=200).encode(img,
+                                                          implant=implant)
     npt.assert_almost_equal(np.abs(implant.stim.data).sum(axis=0).max(), 50.0)
 
 
@@ -295,16 +294,19 @@ def test_endtoend_slow_train_stays_lit_for_the_whole_video():
     brightness persist between pulses at all, and summarizing each frame by the
     peak it reached is what stops the report from depending on sampling phase.
     """
-    implant = ArgusII()
+    # Argus II's own defaults: an amplitude encoder at 6 Hz, and a six-group
+    # raster. So the whole setup is `ArgusII(stim=BostonTrain())`.
     with pytest.warns(UserWarning, match='deliver no pulse'):
         # 6 Hz against 29.97 fps: most frames carry no pulse of their own, and
         # the encoder says so. That is a property of the stimulus, not a reason
         # for the percept to go dark:
-        implant.stim = AmplitudeEncoder(implant, amp_range=(0, 50),
-                                        freq=6).encode(BostonTrain())
-    # The encoder schedules pulses across the whole video, not just its start:
+        implant = ArgusII(stim=BostonTrain())
+    # The encoder schedules pulses across the whole video, not just its start.
+    # The last of the six raster groups takes its turn 5 x 2 = 10 ms behind the
+    # first, which is what puts the final pulse past the 3000.5 ms that an
+    # unrastered Argus II would end on:
     onset = implant.stim.time[np.any(implant.stim.data < 0, axis=0)]
-    npt.assert_almost_equal(onset.max(), 3000.5, decimal=1)
+    npt.assert_almost_equal(onset.max(), 3010.5, decimal=1)
 
     model = Model(spatial=ScoreboardSpatial(xrange=(-12, 12), yrange=(-8, 8),
                                             step=1),

--- a/pulse2percept/models/tests/test_granley2021.py
+++ b/pulse2percept/models/tests/test_granley2021.py
@@ -13,8 +13,8 @@ from pulse2percept.models import BiphasicAxonMapModel, BiphasicAxonMapSpatial, \
     AxonMapSpatial
 from pulse2percept.models.granley2021 import DefaultBrightModel, \
     DefaultSizeModel, DefaultStreakModel
-from pulse2percept.units import (DimensionMismatchError, Quantity, mm, ms, s,
-                                 uA, um)
+from pulse2percept.units import (DimensionMismatchError, Quantity,
+                                 dimensionless, mm, ms, s, uA, um)
 from pulse2percept.utils.base import FreezeError
 from pulse2percept.utils.testing import assert_warns_msg
 
@@ -682,7 +682,14 @@ def test_BiphasicAxonMap_dimension_before_waveform():
     complaint, which is about a stimulus it never had.
     """
     img = ImageStimulus(np.linspace(0, 1, 16).reshape((4, 4)))
-    implant = ArgusII(preprocess=False, stim=img)
+
+    # An ordinary implant refuses the picture outright (see
+    # `ProsthesisSystem.stimulus_unit`); one that delivers something else is
+    # what carries it as far as the model:
+    class Projector(ArgusII):
+        stimulus_unit = dimensionless
+
+    implant = Projector(preprocess=False, stim=img)
     for model in (BiphasicAxonMapSpatial(step=2).build(),
                   BiphasicAxonMapModel(step=2).build()):
         with pytest.raises(DimensionMismatchError) as excinfo:

--- a/pulse2percept/models/tests/test_temporal.py
+++ b/pulse2percept/models/tests/test_temporal.py
@@ -472,7 +472,7 @@ def test_FadingTemporal_reduce_limits():
     # two settings have nothing to disagree about.
     rising = Stimulus(np.full((4, 2), -20.0), time=[0.0, 500.0])
     rising.metadata['encoder'] = {'frame_time': np.arange(10) * 50.0,
-                                  'frame_dur': 50.0, 'n_frames': 10}
+                                  'frame_dur': 50.0}
     peak = FadingTemporal(tau=100).build().predict_percept(rising)
     last = FadingTemporal(tau=100, reduce='last').build().predict_percept(
         rising)
@@ -482,7 +482,7 @@ def test_FadingTemporal_reduce_limits():
     # A pulse train is the case they were built to disagree about:
     train = BiphasicPulseTrain(20, -50, 0.46, stim_dur=500)
     train.metadata['encoder'] = {'frame_time': np.arange(10) * 50.0,
-                                 'frame_dur': 50.0, 'n_frames': 10}
+                                 'frame_dur': 50.0}
     peak = FadingTemporal(tau=100).build().predict_percept(train)
     last = FadingTemporal(tau=100, reduce='last').build().predict_percept(
         train)

--- a/pulse2percept/percepts/base.py
+++ b/pulse2percept/percepts/base.py
@@ -10,7 +10,7 @@ import logging
 from skimage import img_as_ubyte
 from skimage.transform import resize
 
-from ..units import DimensionMismatchError, Quantity, Unit, as_value, ms
+from ..units import DimensionMismatchError, Hz, Quantity, Unit, as_value, ms
 from ..utils import Data, HTMLAnimation, frame_interval, sample
 from ..utils.constants import VIDEO_BLOCK_SIZE
 
@@ -359,7 +359,9 @@ class Percept(Data):
         ----------
         fps : float or None
             If None, uses the percept's time axis. Not supported for
-            non-homogeneous time axis.
+            non-homogeneous time axis. May be given as a plain number of hertz
+            or as a unitful frequency (e.g. ``30 * Hz``, ``0.03 * kHz``); see
+            :py:mod:`pulse2percept.units`.
         repeat : bool, optional
             Whether the animation should repeat when the sequence of frames is
             completed.
@@ -470,7 +472,9 @@ class Percept(Data):
             inferred accordingly.
         fps : float or None
             If None, uses the percept's time axis. Not supported for
-            non-homogeneous time axis.
+            non-homogeneous time axis. May be given as a plain number of hertz
+            or as a unitful frequency (e.g. ``30 * Hz``, ``0.03 * kHz``); see
+            :py:mod:`pulse2percept.units`.
 
         Notes
         -----
@@ -478,6 +482,10 @@ class Percept(Data):
             of 16 to ensure compatibility with most codecs and players.
 
         """
+        # This path hands `fps` to imageio rather than to `frame_interval`, so
+        # it is its own boundary: a frame rate is a frequency, and imageio
+        # takes a plain number of hertz.
+        fps = as_value(fps, Hz, 'fps')
         data = self.data - self.data.min()
         if not isclose(np.max(data), 0):
             data = data / np.max(data)

--- a/pulse2percept/percepts/tests/test_base.py
+++ b/pulse2percept/percepts/tests/test_base.py
@@ -1,6 +1,7 @@
 from pulse2percept.topography import Grid2D
 from pulse2percept.percepts import Percept
-from pulse2percept.units import DimensionMismatchError, ms, s, um, us
+from pulse2percept.units import (DimensionMismatchError, Hz, kHz, ms, s, uA,
+                                 um, us)
 from skimage.io import imread
 from skimage import img_as_float
 import imageio
@@ -9,6 +10,7 @@ from matplotlib.animation import FuncAnimation
 from matplotlib.axes import Subplot
 import matplotlib.pyplot as plt
 import os
+import re
 import numpy as np
 import pytest
 import numpy.testing as npt
@@ -234,6 +236,39 @@ def test_Percept_save_single_frame(tmp_path):
     fname = str(tmp_path / 'fps.mp4')
     percept.save(fname, fps=12)
     npt.assert_equal(len(mimread(fname)), 1)
+
+
+def test_Percept_fps_units(tmp_path):
+    """A frame rate is a frequency, however it is spelled
+
+    .. versionadded:: 0.10.0
+    """
+    percept = Percept(np.random.rand(8, 8, 4))
+
+    def interval(**kwargs):
+        """The frame delay (ms) the HTML player was configured with"""
+        html = percept.play(**kwargs).to_jshtml()
+        return float(re.search(r'"interval": ([0-9.]+)', html).group(1))
+
+    # 33.33 ms, which is what 30 frames per second asks for:
+    npt.assert_almost_equal(interval(fps=30), 1000 / 30, decimal=6)
+    for spelling in (30 * Hz, 0.03 * kHz):
+        npt.assert_almost_equal(interval(fps=spelling), interval(fps=30),
+                                decimal=12)
+
+    # ... and the same on the way out to a file:
+    fname = str(tmp_path / 'fps.mp4')
+    percept.save(fname, fps=30 * Hz)
+    npt.assert_equal(len(mimread(fname)), 4)
+    percept.save(fname, fps=0.03 * kHz)
+    npt.assert_equal(len(mimread(fname)), 4)
+
+    # Nothing else is a frame rate:
+    for wrong in (30 * ms, 30 * uA):
+        with pytest.raises(DimensionMismatchError):
+            percept.play(fps=wrong)
+        with pytest.raises(DimensionMismatchError):
+            percept.save(fname, fps=wrong)
 
 
 def test_Percept_units():

--- a/pulse2percept/stimuli/__init__.py
+++ b/pulse2percept/stimuli/__init__.py
@@ -25,8 +25,18 @@ from .pulse_trains import (PulseTrain, BiphasicPulseTrain,
                            BiphasicTripletTrain, AsymmetricBiphasicPulseTrain)
 from .images import ImageStimulus, LogoBVL, LogoUCSB, SnellenChart
 from .videos import VideoStimulus, BostonTrain, GirlPool
-from .encoders import Encoder, AmplitudeEncoder, FrequencyEncoder
+from .encoders import StimulusEncoder, AmplitudeEncoder, FrequencyEncoder
 from .psychophysics import BarStimulus, GratingStimulus
+from ..utils import deprecated_names
+
+#: ``StimulusEncoder`` was called ``Encoder`` in 0.10.0. The old name is
+#: deliberately *not* imported above: a module-level ``__getattr__`` is only
+#: consulted for names the module does not already have, and that hook is what
+#: lets ``from pulse2percept.stimuli import Encoder`` warn while still handing
+#: back ``StimulusEncoder`` itself.
+__getattr__ = deprecated_names(globals(), {'Encoder': 'StimulusEncoder'},
+                               deprecated_version='0.10.0',
+                               removed_version='0.11.0')
 
 __all__ = [
     'AmplitudeEncoder',
@@ -38,6 +48,8 @@ __all__ = [
     'BiphasicTripletTrain',
     'BostonTrain',
     'ElectrodeNames',
+    # Deprecated alias for `StimulusEncoder`, kept until 0.11.0 so that
+    # ``from pulse2percept.stimuli import *`` does not break:
     'Encoder',
     'FrequencyEncoder',
     'GirlPool',
@@ -49,5 +61,6 @@ __all__ = [
     'PulseTrain',
     'SnellenChart',
     'Stimulus',
+    'StimulusEncoder',
     'VideoStimulus'
 ]

--- a/pulse2percept/stimuli/__init__.py
+++ b/pulse2percept/stimuli/__init__.py
@@ -27,16 +27,6 @@ from .images import ImageStimulus, LogoBVL, LogoUCSB, SnellenChart
 from .videos import VideoStimulus, BostonTrain, GirlPool
 from .encoders import StimulusEncoder, AmplitudeEncoder, FrequencyEncoder
 from .psychophysics import BarStimulus, GratingStimulus
-from ..utils import deprecated_names
-
-#: ``StimulusEncoder`` was called ``Encoder`` in 0.10.0. The old name is
-#: deliberately *not* imported above: a module-level ``__getattr__`` is only
-#: consulted for names the module does not already have, and that hook is what
-#: lets ``from pulse2percept.stimuli import Encoder`` warn while still handing
-#: back ``StimulusEncoder`` itself.
-__getattr__ = deprecated_names(globals(), {'Encoder': 'StimulusEncoder'},
-                               deprecated_version='0.10.0',
-                               removed_version='0.11.0')
 
 __all__ = [
     'AmplitudeEncoder',
@@ -48,9 +38,6 @@ __all__ = [
     'BiphasicTripletTrain',
     'BostonTrain',
     'ElectrodeNames',
-    # Deprecated alias for `StimulusEncoder`, kept until 0.11.0 so that
-    # ``from pulse2percept.stimuli import *`` does not break:
-    'Encoder',
     'FrequencyEncoder',
     'GirlPool',
     'GratingStimulus',

--- a/pulse2percept/stimuli/encoders.py
+++ b/pulse2percept/stimuli/encoders.py
@@ -104,16 +104,16 @@ class StimulusEncoder(PrettyPrint, metaclass=ABCMeta):
         frame -- sampled at the electrode locations, if :py:meth:`encode` was
         given an ``implant`` -- and map those gray levels onto the amplitude
         and frequency each electrode is to run at (``_modulate``). Nothing
-        here is time-resolved. :py:meth:`encode_spatial` stops at this point.
+        here is time-resolved.
     2.  **Realization.** Turn those parameters into an actual train of pulses
         (``_assemble``), which is where the pulse shape, the pulse clock and
-        the raster come in. :py:meth:`encode` runs both steps.
+        the raster come in.
 
-    The split is not an implementation detail: what the two halves produce are
-    two different things a reader may want. A model with a temporal component
-    integrates pulses and must have the train; one without a temporal
-    component has no way to express a pulse train at all, and reads the
-    modulation instead.
+    :py:meth:`encode` runs both steps and hands back the train. The seam is
+    not only an implementation detail, though: a model with no temporal
+    component has no way to express a pulse train, and reads what came out of
+    the first step instead (see
+    :py:meth:`~pulse2percept.models.SpatialModel.predict_percept`).
 
     An encoder describes a *modulation scheme*, not a device: it holds no
     implant of its own, and the implant it encodes for is named at
@@ -761,7 +761,6 @@ class StimulusEncoder(PrettyPrint, metaclass=ABCMeta):
         time[-1] = total
         stim = Stimulus(data, electrodes=electrodes, time=time)
         stim.metadata['encoder'] = {'kind': type(self).__name__,
-                                    'modulation': False,
                                     'frame_dur': frame_dur,
                                     'n_frames': n_frames,
                                     'frame_time': frame_time,
@@ -812,13 +811,13 @@ class StimulusEncoder(PrettyPrint, metaclass=ABCMeta):
         zero frequency reads as zero amplitude here however high an amplitude
         it was handed. Past that, rate does not survive into this
         representation: what a rate means is a fact about time, and a reader
-        with no clock of its own has no way to express it. It is recorded in
-        the metadata for readers that do.
+        with no clock of its own has no way to express it. So frequency
+        modulation collapses to on/off here, which is the least misleading
+        thing it can do.
         """
         shape = (len(electrodes), frame_time.size)
         amp = np.broadcast_to(np.asarray(amp, dtype=np.float32), shape)
-        freq = np.ascontiguousarray(
-            np.broadcast_to(np.asarray(freq, dtype=np.float64), shape))
+        freq = np.broadcast_to(np.asarray(freq, dtype=np.float64), shape)
         data = np.where(freq > 0, amp, np.float32(0)).astype(np.float32)
         # A source with a single frame has no time axis of its own, and gets
         # none here either: what it asks for is one steady thing, and saying so
@@ -831,61 +830,21 @@ class StimulusEncoder(PrettyPrint, metaclass=ABCMeta):
         else:
             stim = Stimulus(data.ravel(), electrodes=electrodes)
         stim.metadata['encoder'] = {'kind': type(self).__name__,
-                                    'modulation': True,
                                     'frame_dur': frame_dur,
                                     'n_frames': int(frame_time.size),
-                                    'frame_time': frame_time,
-                                    'freq': freq}
+                                    'frame_time': frame_time}
         return stim
 
     def _encode_both(self, source, implant=None):
-        """Both representations of one source, sharing the modulation step
+        """Both descriptions of one source, sharing the modulation step
 
-        What an implant wants when a picture is assigned to it: sampling the
-        source at the electrodes is the expensive half of encoding, and doing
-        it once for :py:meth:`encode` and again for :py:meth:`encode_spatial`
-        would be paying for it twice.
+        What an implant needs when a picture is assigned to it: the modulation
+        the source asks for and the pulse train realizing it. Sampling the
+        source at the electrodes is the expensive half of encoding, so the two
+        are built from one pass over it rather than two.
         """
         mod = self._modulation(source, implant)
         return self._as_spatial(*mod), self._assemble(*mod, implant=implant)
-
-    def encode_spatial(self, source, implant=None):
-        """Encode an image or a video as the modulation it asks each electrode
-        for
-
-        The *spatial* half of :py:meth:`encode`: one amplitude per electrode
-        per frame of the source, and no pulse train. Nothing that belongs to
-        the device's timing is in it -- no pulse shape, no pulse clock, no
-        raster -- because none of those can be read by anything that has no
-        clock of its own.
-
-        This is what a purely spatial model consumes (see
-        :py:meth:`~pulse2percept.models.SpatialModel.predict_percept`). Handing
-        such a model the delivered pulse train instead would have it report the
-        stimulus one raster slot at a time, which is a picture of the schedule
-        rather than of the image.
-
-        Parameters
-        ----------
-        source : :py:class:`~pulse2percept.stimuli.Stimulus`
-            The image or video to encode; see :py:meth:`encode`.
-        implant : :py:class:`~pulse2percept.implants.ProsthesisSystem`, optional
-            The implant to encode for; see :py:meth:`encode`. Its raster plays
-            no part here, since a raster is a fact about time.
-
-        Returns
-        -------
-        stim : :py:class:`~pulse2percept.stimuli.Stimulus`
-            One row per electrode and one column per frame, in microamps. A
-            single-frame source (an image) comes back without a time axis. The
-            per-electrode pulse frequency is recorded under
-            ``metadata['encoder']['freq']``, for readers that can express a
-            rate.
-
-        .. versionadded:: 0.10.0
-
-        """
-        return self._as_spatial(*self._modulation(source, implant))
 
     def encode(self, source, implant=None):
         """Encode an image or a video as a train of electrical pulses
@@ -925,11 +884,6 @@ class StimulusEncoder(PrettyPrint, metaclass=ABCMeta):
         ------
         :py:class:`~pulse2percept.units.DimensionMismatchError`
             If ``source`` is not dimensionless.
-
-        See Also
-        --------
-        encode_spatial : the same source as the modulation it asks for, with
-                         none of the device's timing in it.
 
         """
         return self._assemble(*self._modulation(source, implant),

--- a/pulse2percept/stimuli/encoders.py
+++ b/pulse2percept/stimuli/encoders.py
@@ -99,12 +99,20 @@ class StimulusEncoder(PrettyPrint, metaclass=ABCMeta):
 
     All encoders share the same two-step structure:
 
-    1.  Reduce the source to one gray level per electrode per frame. If the
-        encoder was given an ``implant``, the source is first sampled at the
-        electrode locations, so that everything downstream works at electrode
-        resolution.
+    1.  Reduce the source to one gray level per electrode per frame. If
+        :py:meth:`encode` was given an ``implant``, the source is first sampled
+        at the electrode locations, so that everything downstream works at
+        electrode resolution.
     2.  Map those gray levels onto pulse train parameters (``_modulate``),
         then assemble the pulse trains (``_assemble``).
+
+    An encoder describes a *modulation scheme*, not a device: it holds no
+    implant of its own, and the implant it encodes for is named at
+    :py:meth:`encode` time (or, more usually, by assigning the encoder to
+    :py:attr:`~pulse2percept.implants.ProsthesisSystem.encoder` and letting the
+    implant do it). Everything about the device -- which electrodes there are,
+    where they sit, and how they take turns -- therefore comes from that one
+    implant, including the :py:class:`~pulse2percept.implants.Raster`.
 
     Subclasses only implement ``_modulate``; everything else is provided here.
 
@@ -112,10 +120,6 @@ class StimulusEncoder(PrettyPrint, metaclass=ABCMeta):
 
     Parameters
     ----------
-    implant : :py:class:`~pulse2percept.implants.ProsthesisSystem`, optional
-        The implant to encode for. Its electrode locations are used to sample
-        the source, and its electrode names label the resulting stimulus.
-        If None, every pixel of the source is treated as its own electrode.
     phase_dur : float, optional
         Duration (ms) of the cathodic/anodic phase of each pulse.
     interphase_dur : float, optional
@@ -157,15 +161,6 @@ class StimulusEncoder(PrettyPrint, metaclass=ABCMeta):
         resolution of the device's input stage. Gray levels are rounded onto
         ``n_levels`` values evenly spaced over [0, 1] before being modulated.
         If None, they are taken at full precision.
-    raster : :py:class:`~pulse2percept.implants.Raster`, optional
-        How the stimulator takes turns between electrodes it cannot drive at
-        the same time. Each group starts its pulse a fixed ``group_dur`` behind
-        the group before it, so no two groups are ever active at once. Where
-        electrodes run at *differing* rates they would drift into one another,
-        so there their periods are pinned to whole sweeps; electrodes sharing
-        one rate cannot drift and keep their period exactly. If None, the
-        ``implant``'s own raster is used, and failing that every electrode
-        fires on the same schedule.
     frame_dur : float, optional
         Duration (ms) of a single frame. If None, it is inferred from the
         source's frame rate (or, failing that, from its time axis). A source
@@ -197,13 +192,12 @@ class StimulusEncoder(PrettyPrint, metaclass=ABCMeta):
        does not matter. A dimensionless waveform is a perfectly good template.
 
     """
-    __slots__ = ('implant', 'phase_dur', 'interphase_dur', 'cathodic_first',
-                 'pulse', 'clock', 'n_levels', 'raster', 'frame_dur',
-                 'stretch')
+    __slots__ = ('phase_dur', 'interphase_dur', 'cathodic_first', 'pulse',
+                 'clock', 'n_levels', 'frame_dur', 'stretch')
 
-    def __init__(self, implant=None, phase_dur=0.46, interphase_dur=0,
+    def __init__(self, phase_dur=0.46, interphase_dur=0,
                  cathodic_first=True, pulse=None, clock=None, n_levels=None,
-                 raster=None, frame_dur=None, stretch=False):
+                 frame_dur=None, stretch=False):
         # Strip the units first; every schedule computed below is in plain
         # milliseconds, as it has always been. `pulse` is deliberately not
         # checked: only its shape is borrowed, and its amplitude is normalized
@@ -248,25 +242,22 @@ class StimulusEncoder(PrettyPrint, metaclass=ABCMeta):
             _finite('frame_dur', frame_dur)
             if frame_dur <= 0:
                 raise ValueError("'frame_dur' must be positive.")
-        self.implant = implant
         self.phase_dur = phase_dur
         self.interphase_dur = interphase_dur
         self.cathodic_first = cathodic_first
         self.pulse = pulse
         self.clock = clock
         self.n_levels = n_levels
-        self.raster = raster
         self.frame_dur = frame_dur
         self.stretch = stretch
 
     def _pprint_params(self):
         """Return a dict of class arguments to pretty-print"""
-        return {'implant': self.implant, 'phase_dur': self.phase_dur,
+        return {'phase_dur': self.phase_dur,
                 'interphase_dur': self.interphase_dur,
                 'cathodic_first': self.cathodic_first, 'pulse': self.pulse,
                 'clock': self.clock, 'n_levels': self.n_levels,
-                'raster': self.raster, 'frame_dur': self.frame_dur,
-                'stretch': self.stretch}
+                'frame_dur': self.frame_dur, 'stretch': self.stretch}
 
     @abstractmethod
     def _modulate(self, gray):
@@ -288,7 +279,7 @@ class StimulusEncoder(PrettyPrint, metaclass=ABCMeta):
         """
         raise NotImplementedError
 
-    def _as_frames(self, source):
+    def _as_frames(self, source, implant=None):
         """Reduce the source to one gray level per electrode per frame
 
         Returns
@@ -321,7 +312,7 @@ class StimulusEncoder(PrettyPrint, metaclass=ABCMeta):
         # does not necessarily carry it along.
         fps = _fps(source.metadata)
         stim = source
-        if (self.implant is not None and
+        if (implant is not None and
                 isinstance(stim, (ImageStimulus, VideoStimulus))):
             # Sample the source at the electrode locations. This is the same
             # step that assigning an image or a video to `implant.stim` would
@@ -329,7 +320,7 @@ class StimulusEncoder(PrettyPrint, metaclass=ABCMeta):
             # electrode resolution rather than at pixel resolution. It is also
             # where RGB becomes gray. Row count is not a usable test of whether
             # a source is already in electrode coordinates, so always reshape:
-            stim = self.implant.reshape_stim(stim)
+            stim = implant.reshape_stim(stim)
         # `values` rather than `data`, to say out loud that these are the
         # dimensionless numbers the modulation below is a function of:
         gray = np.clip(np.asarray(stim.values(dimensionless),
@@ -441,7 +432,7 @@ class StimulusEncoder(PrettyPrint, metaclass=ABCMeta):
                              f"or lower the frequency.")
         return firing, period
 
-    def _raster_grid(self, electrodes, period, firing, pulse_len):
+    def _raster_grid(self, electrodes, period, firing, pulse_len, raster):
         """The slot each electrode may pulse in, and the raster sweep
 
         The sweep has to fit inside the shortest pulse period anyone asked for.
@@ -460,11 +451,6 @@ class StimulusEncoder(PrettyPrint, metaclass=ABCMeta):
             when there is nothing to multiplex.
 
         """
-        # An explicit raster wins over the implant's own, so that a raster can
-        # be tried out without modifying the implant:
-        raster = self.raster
-        if raster is None:
-            raster = getattr(self.implant, 'raster', None)
         zero = np.zeros(len(electrodes), dtype=np.float64)
         if raster is None or raster.n_groups < 2 or not np.any(firing):
             return zero, None
@@ -643,7 +629,8 @@ class StimulusEncoder(PrettyPrint, metaclass=ABCMeta):
         t, keep = np.unique(t, return_index=True)
         return np.interp(ticks, t, v[keep])
 
-    def _assemble(self, amp, freq, electrodes, frame_time, frame_dur):
+    def _assemble(self, amp, freq, electrodes, frame_time, frame_dur,
+                  implant=None):
         """Build the pulse trains for every electrode and frame
 
         Electrodes that pulse at the same times share the shape of their
@@ -681,7 +668,10 @@ class StimulusEncoder(PrettyPrint, metaclass=ABCMeta):
         # keeps running ("firing"), so it stays in phase with its neighbors,
         # but it costs no pulses and no time points:
         active = firing & (amp != 0)
-        offset, cycle = self._raster_grid(electrodes, period, firing, pulse_len)
+        # The implant is the one source of truth for how the device schedules
+        # its electrodes:
+        offset, cycle = self._raster_grid(electrodes, period, firing, pulse_len,
+                                          getattr(implant, 'raster', None))
         if cycle is not None and not _all_equal(period[firing]):
             # Electrodes on different periods drift relative to one another,
             # and two groups would eventually land on the same instant. Pinning
@@ -739,7 +729,7 @@ class StimulusEncoder(PrettyPrint, metaclass=ABCMeta):
                 f"less on its own, because two electrodes on the same gray "
                 f"level still pulse at different times.",
                 category=UserWarning)
-        if n_el * n_time > _BIG_STIM and self.implant is None:
+        if n_el * n_time > _BIG_STIM and implant is None:
             _warn_external(
                 f"Encoding {n_el} electrodes x {n_time} time points will "
                 f"allocate {n_el * n_time * 4 / 1e9:.1f} GB. Pass 'implant' "
@@ -770,7 +760,7 @@ class StimulusEncoder(PrettyPrint, metaclass=ABCMeta):
                                     'n_schedules': len(uniq)}
         return stim
 
-    def encode(self, source):
+    def encode(self, source, implant=None):
         """Encode an image or a video as a train of electrical pulses
 
         Parameters
@@ -782,6 +772,19 @@ class StimulusEncoder(PrettyPrint, metaclass=ABCMeta):
             be dimensionless: this method is the boundary at which a picture
             becomes stimulation, so an electrical stimulus is not a valid
             source for it.
+        implant : :py:class:`~pulse2percept.implants.ProsthesisSystem`, optional
+            The implant to encode for. Its electrode locations are used to
+            sample the source, its electrode names label the resulting
+            stimulus, and its
+            :py:attr:`~pulse2percept.implants.ProsthesisSystem.raster` decides
+            which electrodes may pulse when. If None, every pixel of the source
+            is treated as its own electrode and every electrode fires on the
+            same schedule.
+
+            .. versionchanged:: 0.10.0
+                The implant is named here rather than owned by the encoder, so
+                that one encoder can be used for several implants and so that
+                the implant is the only place device scheduling is described.
 
         Returns
         -------
@@ -797,7 +800,8 @@ class StimulusEncoder(PrettyPrint, metaclass=ABCMeta):
             If ``source`` is not dimensionless.
 
         """
-        gray, electrodes, frame_time, frame_dur = self._as_frames(source)
+        gray, electrodes, frame_time, frame_dur = self._as_frames(source,
+                                                                 implant)
         if self.stretch:
             gray = gray - gray.min()
             peak = gray.max()
@@ -809,7 +813,8 @@ class StimulusEncoder(PrettyPrint, metaclass=ABCMeta):
             steps = self.n_levels - 1
             gray = np.round(gray * steps) / steps
         amp, freq = self._modulate(gray)
-        return self._assemble(amp, freq, electrodes, frame_time, frame_dur)
+        return self._assemble(amp, freq, electrodes, frame_time, frame_dur,
+                              implant)
 
 
 class AmplitudeEncoder(StimulusEncoder):
@@ -831,9 +836,6 @@ class AmplitudeEncoder(StimulusEncoder):
 
     Parameters
     ----------
-    implant : :py:class:`~pulse2percept.implants.ProsthesisSystem`, optional
-        The implant to encode for; see
-        :py:class:`~pulse2percept.stimuli.StimulusEncoder`.
     amp_range : (min_amp, max_amp), optional
         Range of pulse amplitudes (uA). A gray level of 0 maps onto
         ``min_amp`` and a gray level of 1 onto ``max_amp``.
@@ -867,14 +869,19 @@ class AmplitudeEncoder(StimulusEncoder):
 
     >>> import pulse2percept as p2p
     >>> implant = p2p.implants.ArgusII()
-    >>> encoder = p2p.stimuli.AmplitudeEncoder(implant, amp_range=(0, 50))
-    >>> implant.stim = encoder.encode(p2p.stimuli.BostonTrain())
+    >>> implant.encoder = p2p.stimuli.AmplitudeEncoder(amp_range=(0, 50))
+    >>> implant.stim = p2p.stimuli.BostonTrain()
+
+    The same thing spelled out, for an implant that is not to keep the encoder:
+
+    >>> encoder = p2p.stimuli.AmplitudeEncoder(amp_range=(0, 50))
+    >>> stim = encoder.encode(p2p.stimuli.BostonTrain(), implant=implant)
 
     """
     __slots__ = ('amp_range', 'freq')
 
-    def __init__(self, implant=None, amp_range=(0, 50), freq=20, **kwargs):
-        super().__init__(implant=implant, **kwargs)
+    def __init__(self, amp_range=(0, 50), freq=20, **kwargs):
+        super().__init__(**kwargs)
         # See `StimulusEncoder.__init__`. `amp_range` is converted element by
         # element, so its two endpoints may be given in different units:
         amp_range = as_value(amp_range, uA, 'amp_range')
@@ -954,9 +961,6 @@ class FrequencyEncoder(StimulusEncoder):
 
     Parameters
     ----------
-    implant : :py:class:`~pulse2percept.implants.ProsthesisSystem`, optional
-        The implant to encode for; see
-        :py:class:`~pulse2percept.stimuli.StimulusEncoder`.
     freq_range : (min_freq, max_freq), optional
         Range of pulse train frequencies (Hz). A gray level of 0 maps onto
         ``min_freq`` and a gray level of 1 onto ``max_freq``. A frequency of 0
@@ -1000,19 +1004,21 @@ frame_dur, stretch
     Examples
     --------
     Encode a movie for Argus II at 50 uA, mapping gray levels onto 0-300 Hz on
-    a 1 ms stimulator clock:
+    a 1 ms stimulator clock. A 300 Hz period is 3.3 ms, which Argus II's own
+    six-group 2 ms raster sweep does not fit into, so this device drives every
+    electrode at once:
 
     >>> import pulse2percept as p2p
-    >>> implant = p2p.implants.ArgusII()
-    >>> encoder = p2p.stimuli.FrequencyEncoder(implant, freq_range=(0, 300),
-    ...                                        amp=50, clock=1)
-    >>> implant.stim = encoder.encode(p2p.stimuli.BostonTrain())
+    >>> implant = p2p.implants.ArgusII(raster=None)
+    >>> implant.encoder = p2p.stimuli.FrequencyEncoder(freq_range=(0, 300),
+    ...                                                amp=50, clock=1)
+    >>> implant.stim = p2p.stimuli.BostonTrain()
 
     """
     __slots__ = ('freq_range', 'amp')
 
-    def __init__(self, implant=None, freq_range=(0, 300), amp=50, **kwargs):
-        super().__init__(implant=implant, **kwargs)
+    def __init__(self, freq_range=(0, 300), amp=50, **kwargs):
+        super().__init__(**kwargs)
         # See `StimulusEncoder.__init__`:
         freq_range = as_value(freq_range, Hz, 'freq_range')
         amp = as_value(amp, uA, 'amp')

--- a/pulse2percept/stimuli/encoders.py
+++ b/pulse2percept/stimuli/encoders.py
@@ -760,13 +760,13 @@ class StimulusEncoder(PrettyPrint, metaclass=ABCMeta):
         time = ticks * DT
         time[-1] = total
         stim = Stimulus(data, electrodes=electrodes, time=time)
-        stim.metadata['encoder'] = {'kind': type(self).__name__,
+        # The frame clock, which is what decides when a percept is worth
+        # reporting (see `pulse2percept.models.base._frame_clock`), and the
+        # raster sweep the schedule was actually realized on:
+        stim.metadata['encoder'] = {'frame_time': frame_time,
                                     'frame_dur': frame_dur,
-                                    'n_frames': n_frames,
-                                    'frame_time': frame_time,
                                     'cycle': None if cycle is None else
-                                    cycle * DT,
-                                    'n_schedules': len(uniq)}
+                                    cycle * DT}
         return stim
 
     def _modulation(self, source, implant=None):
@@ -829,10 +829,10 @@ class StimulusEncoder(PrettyPrint, metaclass=ABCMeta):
             stim = Stimulus(data, electrodes=electrodes, time=frame_time)
         else:
             stim = Stimulus(data.ravel(), electrodes=electrodes)
-        stim.metadata['encoder'] = {'kind': type(self).__name__,
-                                    'frame_dur': frame_dur,
-                                    'n_frames': int(frame_time.size),
-                                    'frame_time': frame_time}
+        # The frame clock and nothing else: there is no schedule here to
+        # record, which is the whole point of this representation.
+        stim.metadata['encoder'] = {'frame_time': frame_time,
+                                    'frame_dur': frame_dur}
         return stim
 
     def _encode_both(self, source, implant=None):

--- a/pulse2percept/stimuli/encoders.py
+++ b/pulse2percept/stimuli/encoders.py
@@ -10,7 +10,7 @@ from .pulses import BiphasicPulse
 from .videos import VideoStimulus
 from ..units import (DimensionMismatchError, Hz, as_value, dimensionless, ms,
                      uA)
-from ..utils import PrettyPrint, deprecated_names, frame_interval
+from ..utils import PrettyPrint, frame_interval
 # Every warning below is about the *caller's* choice of source, frequency, or
 # implant, so it has to point at their line rather than at this file:
 from ..utils.deprecation import _warn_external
@@ -1040,11 +1040,3 @@ frame_dur, stretch
         """Gray level in [0, 1] -> frequency in ``freq_range``"""
         freq_lo, freq_hi = self.freq_range
         return self.amp, freq_lo + gray * (freq_hi - freq_lo)
-
-
-#: ``StimulusEncoder`` was called ``Encoder`` in 0.10.0. The old name still
-#: resolves -- to the very same class object, so that ``isinstance`` and
-#: ``issubclass`` keep answering what they always did -- and warns:
-__getattr__ = deprecated_names(globals(), {'Encoder': 'StimulusEncoder'},
-                               deprecated_version='0.10.0',
-                               removed_version='0.11.0')

--- a/pulse2percept/stimuli/encoders.py
+++ b/pulse2percept/stimuli/encoders.py
@@ -97,14 +97,23 @@ class StimulusEncoder(PrettyPrint, metaclass=ABCMeta):
        may pulse when, so that no two raster groups are ever active at the same
        instant.
 
-    All encoders share the same two-step structure:
+    All encoders share the same two-step structure, and the seam between the
+    steps is where time enters:
 
-    1.  Reduce the source to one gray level per electrode per frame. If
-        :py:meth:`encode` was given an ``implant``, the source is first sampled
-        at the electrode locations, so that everything downstream works at
-        electrode resolution.
-    2.  Map those gray levels onto pulse train parameters (``_modulate``),
-        then assemble the pulse trains (``_assemble``).
+    1.  **Modulation.** Reduce the source to one gray level per electrode per
+        frame -- sampled at the electrode locations, if :py:meth:`encode` was
+        given an ``implant`` -- and map those gray levels onto the amplitude
+        and frequency each electrode is to run at (``_modulate``). Nothing
+        here is time-resolved. :py:meth:`encode_spatial` stops at this point.
+    2.  **Realization.** Turn those parameters into an actual train of pulses
+        (``_assemble``), which is where the pulse shape, the pulse clock and
+        the raster come in. :py:meth:`encode` runs both steps.
+
+    The split is not an implementation detail: what the two halves produce are
+    two different things a reader may want. A model with a temporal component
+    integrates pulses and must have the train; one without a temporal
+    component has no way to express a pulse train at all, and reads the
+    modulation instead.
 
     An encoder describes a *modulation scheme*, not a device: it holds no
     implant of its own, and the implant it encodes for is named at
@@ -752,6 +761,7 @@ class StimulusEncoder(PrettyPrint, metaclass=ABCMeta):
         time[-1] = total
         stim = Stimulus(data, electrodes=electrodes, time=time)
         stim.metadata['encoder'] = {'kind': type(self).__name__,
+                                    'modulation': False,
                                     'frame_dur': frame_dur,
                                     'n_frames': n_frames,
                                     'frame_time': frame_time,
@@ -759,6 +769,123 @@ class StimulusEncoder(PrettyPrint, metaclass=ABCMeta):
                                     cycle * DT,
                                     'n_schedules': len(uniq)}
         return stim
+
+    def _modulation(self, source, implant=None):
+        """What the source asks each electrode for, frame by frame
+
+        The first half of encoding, and the half with no time resolution in
+        it: the source is reduced to one gray level per electrode per frame,
+        stretched and quantized as asked, and ``_modulate`` turns those gray
+        levels into the amplitude and frequency each electrode is to run at.
+        There is no waveform here, no pulse clock and no raster -- those are
+        :py:meth:`_assemble`, and they are what makes the result a *train*
+        rather than a description of one.
+
+        Returns the arguments both halves of the split take, in the order
+        :py:meth:`_assemble` and :py:meth:`_as_spatial` accept them.
+        """
+        gray, electrodes, frame_time, frame_dur = self._as_frames(source,
+                                                                  implant)
+        if self.stretch:
+            gray = gray - gray.min()
+            peak = gray.max()
+            if peak > 0:
+                gray = gray / peak
+        if self.n_levels is not None:
+            # Quantize before modulating rather than after, so that the same
+            # parameter means the same thing however a subclass modulates:
+            steps = self.n_levels - 1
+            gray = np.round(gray * steps) / steps
+        amp, freq = self._modulate(gray)
+        return amp, freq, electrodes, frame_time, frame_dur
+
+    def _as_spatial(self, amp, freq, electrodes, frame_time, frame_dur):
+        """The modulation parameters as a Stimulus, with no waveform in them
+
+        One column per frame of the source and one row per electrode, holding
+        the current that electrode is modulated to over that frame. It is what
+        the encoder *asks the device for*, before the device's own timing --
+        the pulse shape, the pulse clock, the raster -- settles when any of it
+        is actually delivered.
+
+        An electrode whose train never fires delivers no current at all, so a
+        zero frequency reads as zero amplitude here however high an amplitude
+        it was handed. Past that, rate does not survive into this
+        representation: what a rate means is a fact about time, and a reader
+        with no clock of its own has no way to express it. It is recorded in
+        the metadata for readers that do.
+        """
+        shape = (len(electrodes), frame_time.size)
+        amp = np.broadcast_to(np.asarray(amp, dtype=np.float32), shape)
+        freq = np.ascontiguousarray(
+            np.broadcast_to(np.asarray(freq, dtype=np.float64), shape))
+        data = np.where(freq > 0, amp, np.float32(0)).astype(np.float32)
+        # A source with a single frame has no time axis of its own, and gets
+        # none here either: what it asks for is one steady thing, and saying so
+        # is what lets a spatial model report a single picture rather than a
+        # sequence of one. Flattened, because that is how `Stimulus` is told
+        # a stimulus has no time component -- an (n, 1) container with
+        # `time=None` is given a time axis of [0] instead.
+        if frame_time.size > 1:
+            stim = Stimulus(data, electrodes=electrodes, time=frame_time)
+        else:
+            stim = Stimulus(data.ravel(), electrodes=electrodes)
+        stim.metadata['encoder'] = {'kind': type(self).__name__,
+                                    'modulation': True,
+                                    'frame_dur': frame_dur,
+                                    'n_frames': int(frame_time.size),
+                                    'frame_time': frame_time,
+                                    'freq': freq}
+        return stim
+
+    def _encode_both(self, source, implant=None):
+        """Both representations of one source, sharing the modulation step
+
+        What an implant wants when a picture is assigned to it: sampling the
+        source at the electrodes is the expensive half of encoding, and doing
+        it once for :py:meth:`encode` and again for :py:meth:`encode_spatial`
+        would be paying for it twice.
+        """
+        mod = self._modulation(source, implant)
+        return self._as_spatial(*mod), self._assemble(*mod, implant=implant)
+
+    def encode_spatial(self, source, implant=None):
+        """Encode an image or a video as the modulation it asks each electrode
+        for
+
+        The *spatial* half of :py:meth:`encode`: one amplitude per electrode
+        per frame of the source, and no pulse train. Nothing that belongs to
+        the device's timing is in it -- no pulse shape, no pulse clock, no
+        raster -- because none of those can be read by anything that has no
+        clock of its own.
+
+        This is what a purely spatial model consumes (see
+        :py:meth:`~pulse2percept.models.SpatialModel.predict_percept`). Handing
+        such a model the delivered pulse train instead would have it report the
+        stimulus one raster slot at a time, which is a picture of the schedule
+        rather than of the image.
+
+        Parameters
+        ----------
+        source : :py:class:`~pulse2percept.stimuli.Stimulus`
+            The image or video to encode; see :py:meth:`encode`.
+        implant : :py:class:`~pulse2percept.implants.ProsthesisSystem`, optional
+            The implant to encode for; see :py:meth:`encode`. Its raster plays
+            no part here, since a raster is a fact about time.
+
+        Returns
+        -------
+        stim : :py:class:`~pulse2percept.stimuli.Stimulus`
+            One row per electrode and one column per frame, in microamps. A
+            single-frame source (an image) comes back without a time axis. The
+            per-electrode pulse frequency is recorded under
+            ``metadata['encoder']['freq']``, for readers that can express a
+            rate.
+
+        .. versionadded:: 0.10.0
+
+        """
+        return self._as_spatial(*self._modulation(source, implant))
 
     def encode(self, source, implant=None):
         """Encode an image or a video as a train of electrical pulses
@@ -799,22 +926,14 @@ class StimulusEncoder(PrettyPrint, metaclass=ABCMeta):
         :py:class:`~pulse2percept.units.DimensionMismatchError`
             If ``source`` is not dimensionless.
 
+        See Also
+        --------
+        encode_spatial : the same source as the modulation it asks for, with
+                         none of the device's timing in it.
+
         """
-        gray, electrodes, frame_time, frame_dur = self._as_frames(source,
-                                                                 implant)
-        if self.stretch:
-            gray = gray - gray.min()
-            peak = gray.max()
-            if peak > 0:
-                gray = gray / peak
-        if self.n_levels is not None:
-            # Quantize before modulating rather than after, so that the same
-            # parameter means the same thing however a subclass modulates:
-            steps = self.n_levels - 1
-            gray = np.round(gray * steps) / steps
-        amp, freq = self._modulate(gray)
-        return self._assemble(amp, freq, electrodes, frame_time, frame_dur,
-                              implant)
+        return self._assemble(*self._modulation(source, implant),
+                              implant=implant)
 
 
 class AmplitudeEncoder(StimulusEncoder):

--- a/pulse2percept/stimuli/encoders.py
+++ b/pulse2percept/stimuli/encoders.py
@@ -1,8 +1,7 @@
-""":py:class:`~pulse2percept.stimuli.Encoder`,
+""":py:class:`~pulse2percept.stimuli.StimulusEncoder`,
    :py:class:`~pulse2percept.stimuli.AmplitudeEncoder`,
    :py:class:`~pulse2percept.stimuli.FrequencyEncoder`"""
 from abc import ABCMeta, abstractmethod
-import warnings
 import numpy as np
 
 from .base import Stimulus
@@ -11,7 +10,10 @@ from .pulses import BiphasicPulse
 from .videos import VideoStimulus
 from ..units import (DimensionMismatchError, Hz, as_value, dimensionless, ms,
                      uA)
-from ..utils import PrettyPrint, frame_interval
+from ..utils import PrettyPrint, deprecated_names, frame_interval
+# Every warning below is about the *caller's* choice of source, frequency, or
+# implant, so it has to point at their line rather than at this file:
+from ..utils.deprecation import _warn_external
 from ..utils.constants import DT, MS_PER_S
 
 # Encoding a source that still has one row per *pixel* rather than one per
@@ -59,7 +61,7 @@ def _fps(metadata):
     return user.get('fps') if isinstance(user, dict) else None
 
 
-class Encoder(PrettyPrint, metaclass=ABCMeta):
+class StimulusEncoder(PrettyPrint, metaclass=ABCMeta):
     """Abstract base class for all stimulus encoders
 
     An encoder translates the gray levels of an image or a video into the
@@ -717,10 +719,11 @@ class Encoder(PrettyPrint, metaclass=ABCMeta):
         missed = np.count_nonzero(~hit & active.any(axis=0))
         if missed:
             fps = MS_PER_S / frame_dur
-            warnings.warn(f"{missed} of {n_frames} frames deliver no pulse at "
-                          f"all, because the pulse period is longer than a "
-                          f"frame ({fps:.2f} fps). Their gray levels are "
-                          f"never sampled; raise the frequency to see them.")
+            _warn_external(
+                f"{missed} of {n_frames} frames deliver no pulse at all, "
+                f"because the pulse period is longer than a frame "
+                f"({fps:.2f} fps). Their gray levels are never sampled; "
+                f"raise the frequency to see them.", category=UserWarning)
 
         ticks = np.unique(np.concatenate(
             [np.array([0, end], dtype=np.int64)] +
@@ -728,18 +731,20 @@ class Encoder(PrettyPrint, metaclass=ABCMeta):
              for o in onsets if o.size]))
         n_time = ticks.size
         if n_time > _BIG_TIME:
-            warnings.warn(f"This stimulus has {n_time} time points, which "
-                          f"every model downstream will pay for. Coarsening "
-                          f"'clock' is the lever that helps most, since it "
-                          f"confines every pulse onset to the same grid; a "
-                          f"'raster' does the same. 'n_levels' helps far less "
-                          f"on its own, because two electrodes on the same "
-                          f"gray level still pulse at different times.")
+            _warn_external(
+                f"This stimulus has {n_time} time points, which every model "
+                f"downstream will pay for. Coarsening 'clock' is the lever "
+                f"that helps most, since it confines every pulse onset to the "
+                f"same grid; a 'raster' does the same. 'n_levels' helps far "
+                f"less on its own, because two electrodes on the same gray "
+                f"level still pulse at different times.",
+                category=UserWarning)
         if n_el * n_time > _BIG_STIM and self.implant is None:
-            warnings.warn(f"Encoding {n_el} electrodes x {n_time} time points "
-                          f"will allocate {n_el * n_time * 4 / 1e9:.1f} GB. "
-                          f"Pass 'implant' to encode at electrode resolution "
-                          f"instead.")
+            _warn_external(
+                f"Encoding {n_el} electrodes x {n_time} time points will "
+                f"allocate {n_el * n_time * 4 / 1e9:.1f} GB. Pass 'implant' "
+                f"to encode at electrode resolution instead.",
+                category=UserWarning)
 
         # One unit-amplitude waveform per schedule, scaled by the amplitude of
         # whichever frame each pulse belongs to:
@@ -807,7 +812,7 @@ class Encoder(PrettyPrint, metaclass=ABCMeta):
         return self._assemble(amp, freq, electrodes, frame_time, frame_dur)
 
 
-class AmplitudeEncoder(Encoder):
+class AmplitudeEncoder(StimulusEncoder):
     """Encode gray levels as pulse amplitudes
 
     Every electrode emits a pulse train of the same fixed frequency, and the
@@ -828,7 +833,7 @@ class AmplitudeEncoder(Encoder):
     ----------
     implant : :py:class:`~pulse2percept.implants.ProsthesisSystem`, optional
         The implant to encode for; see
-        :py:class:`~pulse2percept.stimuli.Encoder`.
+        :py:class:`~pulse2percept.stimuli.StimulusEncoder`.
     amp_range : (min_amp, max_amp), optional
         Range of pulse amplitudes (uA). A gray level of 0 maps onto
         ``min_amp`` and a gray level of 1 onto ``max_amp``.
@@ -847,7 +852,7 @@ class AmplitudeEncoder(Encoder):
            delivered. Encoding warns when this happens.
 
     phase_dur, interphase_dur, cathodic_first, frame_dur, stretch
-        See :py:class:`~pulse2percept.stimuli.Encoder`.
+        See :py:class:`~pulse2percept.stimuli.StimulusEncoder`.
 
     Notes
     -----
@@ -870,8 +875,8 @@ class AmplitudeEncoder(Encoder):
 
     def __init__(self, implant=None, amp_range=(0, 50), freq=20, **kwargs):
         super().__init__(implant=implant, **kwargs)
-        # See `Encoder.__init__`. `amp_range` is converted element by element,
-        # so its two endpoints may be given in different units:
+        # See `StimulusEncoder.__init__`. `amp_range` is converted element by
+        # element, so its two endpoints may be given in different units:
         amp_range = as_value(amp_range, uA, 'amp_range')
         freq = as_value(freq, Hz, 'freq')
         if np.size(amp_range) != 2:
@@ -900,7 +905,7 @@ class AmplitudeEncoder(Encoder):
         return amp_lo + gray * (amp_hi - amp_lo), self.freq
 
 
-class FrequencyEncoder(Encoder):
+class FrequencyEncoder(StimulusEncoder):
     """Encode gray levels as pulse train frequencies
 
     Every electrode emits pulses of the same fixed amplitude, and the gray
@@ -951,7 +956,7 @@ class FrequencyEncoder(Encoder):
     ----------
     implant : :py:class:`~pulse2percept.implants.ProsthesisSystem`, optional
         The implant to encode for; see
-        :py:class:`~pulse2percept.stimuli.Encoder`.
+        :py:class:`~pulse2percept.stimuli.StimulusEncoder`.
     freq_range : (min_freq, max_freq), optional
         Range of pulse train frequencies (Hz). A gray level of 0 maps onto
         ``min_freq`` and a gray level of 1 onto ``max_freq``. A frequency of 0
@@ -983,7 +988,7 @@ class FrequencyEncoder(Encoder):
         Pulse amplitude (uA), the same for every electrode.
     phase_dur, interphase_dur, cathodic_first, pulse, clock, n_levels, \
 frame_dur, stretch
-        See :py:class:`~pulse2percept.stimuli.Encoder`.
+        See :py:class:`~pulse2percept.stimuli.StimulusEncoder`.
 
     Notes
     -----
@@ -1008,7 +1013,7 @@ frame_dur, stretch
 
     def __init__(self, implant=None, freq_range=(0, 300), amp=50, **kwargs):
         super().__init__(implant=implant, **kwargs)
-        # See `Encoder.__init__`:
+        # See `StimulusEncoder.__init__`:
         freq_range = as_value(freq_range, Hz, 'freq_range')
         amp = as_value(amp, uA, 'amp')
         if np.size(freq_range) != 2:
@@ -1035,3 +1040,11 @@ frame_dur, stretch
         """Gray level in [0, 1] -> frequency in ``freq_range``"""
         freq_lo, freq_hi = self.freq_range
         return self.amp, freq_lo + gray * (freq_hi - freq_lo)
+
+
+#: ``StimulusEncoder`` was called ``Encoder`` in 0.10.0. The old name still
+#: resolves -- to the very same class object, so that ``isinstance`` and
+#: ``issubclass`` keep answering what they always did -- and warns:
+__getattr__ = deprecated_names(globals(), {'Encoder': 'StimulusEncoder'},
+                               deprecated_version='0.10.0',
+                               removed_version='0.11.0')

--- a/pulse2percept/stimuli/images.py
+++ b/pulse2percept/stimuli/images.py
@@ -655,8 +655,8 @@ class ImageStimulus(Stimulus):
         """
         # Imported here because `encoders` imports this module:
         from .encoders import AmplitudeEncoder
-        return AmplitudeEncoder(implant=implant, amp_range=amp_range,
-                                freq=freq, **kwargs).encode(self)
+        return AmplitudeEncoder(amp_range=amp_range, freq=freq,
+                                **kwargs).encode(self, implant=implant)
 
     def plot(self, ax=None, **kwargs):
         """Plot the stimulus

--- a/pulse2percept/stimuli/tests/test_encoders.py
+++ b/pulse2percept/stimuli/tests/test_encoders.py
@@ -872,14 +872,16 @@ def test_StimulusEncoder_implant_reshape():
         npt.assert_equal(list(enc.electrodes), list(implant.electrode_names))
 
 
-def test_StimulusEncoder_encode_spatial():
+def test_StimulusEncoder_encode_both():
     """The modulation half of encoding, with none of the device's timing in it
     """
     img = ImageStimulus(np.linspace(0, 1, 16).reshape((4, 4)))
     implant = pixel_implant((4, 4), SequentialRaster(4, interleave=True))
     enc = AmplitudeEncoder(amp_range=(0, 50), freq=100, frame_dur=100)
-    spatial = enc.encode_spatial(img, implant=implant)
-    delivered = enc.encode(img, implant=implant)
+    spatial, delivered = enc._encode_both(img, implant=implant)
+    # The delivered half is exactly what `encode` gives on its own:
+    npt.assert_array_equal(delivered.data, enc.encode(img,
+                                                      implant=implant).data)
 
     # One row per electrode, one column per frame of the source -- and an
     # image is one frame, so there is no time axis at all:
@@ -899,8 +901,7 @@ def test_StimulusEncoder_encode_spatial():
     # The delivered train has 4 raster groups and hundreds of time points.
     npt.assert_equal(delivered.time.size > 100, True)
     npt.assert_equal('cycle' in spatial.metadata['encoder'], False)
-    npt.assert_equal(spatial.metadata['encoder']['modulation'], True)
-    npt.assert_equal(delivered.metadata['encoder']['modulation'], False)
+    npt.assert_equal('n_schedules' in spatial.metadata['encoder'], False)
     # The frame clock is a fact about the source, so it does survive:
     for key in ('kind', 'frame_dur', 'n_frames'):
         npt.assert_equal(spatial.metadata['encoder'][key],
@@ -911,35 +912,32 @@ def test_StimulusEncoder_encode_spatial():
     # `encode`):
     vid = VideoStimulus(np.random.default_rng(0).random((4, 4, 5)),
                         metadata={'fps': 20})
-    spatial = enc.encode_spatial(vid, implant=implant)
+    spatial = enc._encode_both(vid, implant=implant)[0]
     npt.assert_equal(spatial.shape, (16, 5))
     npt.assert_almost_equal(spatial.time, np.arange(5) * 100.0)
 
     # Encoding for no implant at all works the same way, at pixel resolution:
-    bare = enc.encode_spatial(img)
+    bare = enc._encode_both(img)[0]
     npt.assert_equal(bare.shape, (16, 1))
     npt.assert_almost_equal(bare.data.ravel(), np.linspace(0, 1, 16) * 50,
                             decimal=4)
     # ... and a source that is not a picture is refused here too:
     with pytest.raises(DimensionMismatchError):
-        enc.encode_spatial(Stimulus([0.5]))
+        enc._encode_both(Stimulus([0.5]))
 
 
-def test_FrequencyEncoder_encode_spatial():
+def test_FrequencyEncoder_encode_both():
     """A spatial reading of rate coding says what it can and no more"""
     grays = np.array([[0.0, 0.5], [0.75, 1.0]])
     img = ImageStimulus(grays)
     enc = FrequencyEncoder(freq_range=(0, 200), amp=30, frame_dur=100)
-    spatial = enc.encode_spatial(img)
+    spatial, delivered = enc._encode_both(img)
     # Every electrode that pulses at all pulses at the same amplitude, which
-    # is all a reader with no clock can be told. An electrode at 0 Hz never
-    # pulses, so it delivers no current -- that much is not about time:
+    # is all a reader with no clock can be told, so rate collapses to on/off.
+    # An electrode at 0 Hz never pulses, so it delivers no current -- that
+    # much is not about time:
     npt.assert_almost_equal(spatial.data.ravel(), [0, 30, 30, 30], decimal=4)
-    # The rate is recorded for readers that can express it:
-    npt.assert_almost_equal(spatial.metadata['encoder']['freq'].ravel(),
-                            grays.ravel() * 200, decimal=4)
     # The delivered train is where rate becomes visible, as pulse count:
-    delivered = enc.encode(img)
     counts = [n_pulses_of(delivered, e, peak=30) for e in range(4)]
     npt.assert_equal(counts[0], 0)
     npt.assert_equal(np.all(np.diff(counts) > 0), True)

--- a/pulse2percept/stimuli/tests/test_encoders.py
+++ b/pulse2percept/stimuli/tests/test_encoders.py
@@ -872,6 +872,79 @@ def test_StimulusEncoder_implant_reshape():
         npt.assert_equal(list(enc.electrodes), list(implant.electrode_names))
 
 
+def test_StimulusEncoder_encode_spatial():
+    """The modulation half of encoding, with none of the device's timing in it
+    """
+    img = ImageStimulus(np.linspace(0, 1, 16).reshape((4, 4)))
+    implant = pixel_implant((4, 4), SequentialRaster(4, interleave=True))
+    enc = AmplitudeEncoder(amp_range=(0, 50), freq=100, frame_dur=100)
+    spatial = enc.encode_spatial(img, implant=implant)
+    delivered = enc.encode(img, implant=implant)
+
+    # One row per electrode, one column per frame of the source -- and an
+    # image is one frame, so there is no time axis at all:
+    npt.assert_equal(spatial.shape, (16, 1))
+    npt.assert_equal(spatial.time, None)
+    npt.assert_equal(list(spatial.electrodes), list(delivered.electrodes))
+    npt.assert_equal(spatial.unit, uA)
+    # Gray level maps onto the amplitude range, and that is the whole content:
+    npt.assert_almost_equal(spatial.data.ravel(),
+                            np.linspace(0, 1, 16) * 50, decimal=4)
+    # Which is exactly the peak each electrode reaches in the pulse train the
+    # same parameters were assembled into -- the two are descriptions of one
+    # stimulus, not two different stimuli:
+    npt.assert_almost_equal(np.abs(delivered.data).max(axis=1),
+                            spatial.data.ravel(), decimal=4)
+    # None of the timing survives: no waveform, no pulse clock, no raster.
+    # The delivered train has 4 raster groups and hundreds of time points.
+    npt.assert_equal(delivered.time.size > 100, True)
+    npt.assert_equal('cycle' in spatial.metadata['encoder'], False)
+    npt.assert_equal(spatial.metadata['encoder']['modulation'], True)
+    npt.assert_equal(delivered.metadata['encoder']['modulation'], False)
+    # The frame clock is a fact about the source, so it does survive:
+    for key in ('kind', 'frame_dur', 'n_frames'):
+        npt.assert_equal(spatial.metadata['encoder'][key],
+                         delivered.metadata['encoder'][key])
+
+    # A video keeps one column per frame, and a time axis to say when each of
+    # them starts (here `frame_dur=100` re-times the source, as it does for
+    # `encode`):
+    vid = VideoStimulus(np.random.default_rng(0).random((4, 4, 5)),
+                        metadata={'fps': 20})
+    spatial = enc.encode_spatial(vid, implant=implant)
+    npt.assert_equal(spatial.shape, (16, 5))
+    npt.assert_almost_equal(spatial.time, np.arange(5) * 100.0)
+
+    # Encoding for no implant at all works the same way, at pixel resolution:
+    bare = enc.encode_spatial(img)
+    npt.assert_equal(bare.shape, (16, 1))
+    npt.assert_almost_equal(bare.data.ravel(), np.linspace(0, 1, 16) * 50,
+                            decimal=4)
+    # ... and a source that is not a picture is refused here too:
+    with pytest.raises(DimensionMismatchError):
+        enc.encode_spatial(Stimulus([0.5]))
+
+
+def test_FrequencyEncoder_encode_spatial():
+    """A spatial reading of rate coding says what it can and no more"""
+    grays = np.array([[0.0, 0.5], [0.75, 1.0]])
+    img = ImageStimulus(grays)
+    enc = FrequencyEncoder(freq_range=(0, 200), amp=30, frame_dur=100)
+    spatial = enc.encode_spatial(img)
+    # Every electrode that pulses at all pulses at the same amplitude, which
+    # is all a reader with no clock can be told. An electrode at 0 Hz never
+    # pulses, so it delivers no current -- that much is not about time:
+    npt.assert_almost_equal(spatial.data.ravel(), [0, 30, 30, 30], decimal=4)
+    # The rate is recorded for readers that can express it:
+    npt.assert_almost_equal(spatial.metadata['encoder']['freq'].ravel(),
+                            grays.ravel() * 200, decimal=4)
+    # The delivered train is where rate becomes visible, as pulse count:
+    delivered = enc.encode(img)
+    counts = [n_pulses_of(delivered, e, peak=30) for e in range(4)]
+    npt.assert_equal(counts[0], 0)
+    npt.assert_equal(np.all(np.diff(counts) > 0), True)
+
+
 def test_StimulusEncoder_metadata():
     enc = AmplitudeEncoder(freq=50).encode(ImageStimulus(np.ones((2, 2))))
     npt.assert_equal(enc.metadata['encoder']['kind'], 'AmplitudeEncoder')

--- a/pulse2percept/stimuli/tests/test_encoders.py
+++ b/pulse2percept/stimuli/tests/test_encoders.py
@@ -1,3 +1,4 @@
+import importlib
 import warnings
 
 import numpy as np
@@ -7,9 +8,10 @@ from scipy.integrate import trapezoid
 
 from pulse2percept.implants import ArgusII, CustomRaster, SequentialRaster
 from pulse2percept.stimuli import (AmplitudeEncoder, BiphasicPulse,
-                                   BiphasicPulseTrain, BostonTrain, Encoder,
+                                   BiphasicPulseTrain, BostonTrain,
                                    FrequencyEncoder, ImageStimulus,
-                                   MonophasicPulse, Stimulus, VideoStimulus)
+                                   MonophasicPulse, Stimulus, StimulusEncoder,
+                                   VideoStimulus)
 from pulse2percept.stimuli import encoders
 from pulse2percept.utils.constants import DT
 from pulse2percept.units import (DimensionMismatchError, Hz, Quantity,
@@ -28,12 +30,79 @@ def n_pulses_of(stim, electrode=0, peak=None):
     return np.count_nonzero(np.diff(firing.astype(int)) > 0) // 2
 
 
-def test_Encoder_is_abstract():
+def test_StimulusEncoder_is_abstract():
     with pytest.raises(TypeError):
-        Encoder()
+        StimulusEncoder()
 
 
-def test_Encoder_source():
+def test_StimulusEncoder_deprecated_name():
+    """``Encoder`` still resolves, to the very same class object
+
+    The old name is served by a module-level ``__getattr__`` rather than by a
+    subclass, so it is not merely compatible but identical: every
+    ``isinstance`` and ``issubclass`` check written against it keeps answering
+    what it answered before the rename.
+    """
+    for module in ('pulse2percept.stimuli', 'pulse2percept.stimuli.encoders'):
+        with pytest.warns(DeprecationWarning, match='StimulusEncoder'):
+            Encoder = getattr(importlib.import_module(module), 'Encoder')
+        npt.assert_equal(Encoder is StimulusEncoder, True)
+        npt.assert_equal(issubclass(AmplitudeEncoder, Encoder), True)
+        npt.assert_equal(issubclass(FrequencyEncoder, Encoder), True)
+        npt.assert_equal(isinstance(AmplitudeEncoder(), Encoder), True)
+
+    with pytest.warns(DeprecationWarning) as record:
+        from pulse2percept.stimuli import Encoder
+    npt.assert_equal('0.11.0' in str(record[0].message), True)
+    # The warning blames the line that used the deprecated name, not the
+    # module that serves it:
+    npt.assert_equal(record[0].filename, __file__)
+
+    # A user-defined subclass through the old name is a subclass of the new
+    # one, and works:
+    class MyEncoder(Encoder):
+        def _modulate(self, gray):
+            return 10 + 30 * gray, 20
+
+    npt.assert_equal(issubclass(MyEncoder, StimulusEncoder), True)
+    stim = MyEncoder(frame_dur=100).encode(
+        ImageStimulus(np.linspace(0, 1, 16).reshape((4, 4))))
+    npt.assert_almost_equal(np.abs(stim.data).max(), 40)
+
+    # A name that was never ours is still an ordinary AttributeError:
+    with pytest.raises(AttributeError):
+        encoders.NotAThing
+
+
+def test_StimulusEncoder_warnings_point_at_the_caller(monkeypatch):
+    """A warning is only actionable if it names the line that caused it
+
+    All three of these are about the caller's own choice of source, frequency
+    or implant, so blaming ``encoders.py`` (which is what a bare
+    ``warnings.warn`` does) puts an unhelpful line of p2p's internals in front
+    of them.
+    """
+    monkeypatch.setattr(encoders, '_BIG_STIM', 100)
+    monkeypatch.setattr(encoders, '_BIG_TIME', 100)
+    vid = VideoStimulus(np.random.rand(8, 8, 4), time=[0, 100, 200, 300])
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter('always')
+        AmplitudeEncoder(freq=1000).encode(vid)
+    npt.assert_equal(len(caught) > 0, True)
+    for warning in caught:
+        npt.assert_equal(warning.category, UserWarning)
+        npt.assert_equal(warning.filename, __file__)
+
+    # ... including the one about frames that never get a pulse:
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter('always')
+        AmplitudeEncoder(ArgusII(), freq=2).encode(vid)
+    npt.assert_equal([w.filename for w in caught], [__file__] * len(caught))
+    npt.assert_equal(any('deliver no pulse' in str(w.message)
+                         for w in caught), True)
+
+
+def test_StimulusEncoder_source():
     enc = AmplitudeEncoder()
     with pytest.raises(TypeError):
         enc.encode(np.random.rand(4, 5))
@@ -41,7 +110,7 @@ def test_Encoder_source():
         enc.encode('not-a-stimulus')
 
 
-def test_Encoder_params():
+def test_StimulusEncoder_params():
     with pytest.raises(ValueError):
         AmplitudeEncoder(phase_dur=DT / 2)
     with pytest.raises(ValueError):
@@ -329,7 +398,7 @@ def test_FrequencyEncoder_whole_pulses():
     npt.assert_equal(n_pulses_of(am), whole_pulses(60, frame_dur))
 
 
-def test_Encoder_clock():
+def test_StimulusEncoder_clock():
     # A clock rounds the pulse period onto a whole number of cycles, so
     # frequencies that differ by less than that collapse onto one schedule:
     img = ImageStimulus(np.linspace(0.5, 1, 16).reshape((4, 4)))
@@ -351,7 +420,7 @@ def test_Encoder_clock():
         FrequencyEncoder(clock=DT / 10)
 
 
-def test_Encoder_n_levels():
+def test_StimulusEncoder_n_levels():
     # Quantizing the gray levels quantizes whatever they are modulated onto:
     img = ImageStimulus(np.linspace(0, 1, 64).reshape((8, 8)))
     am = AmplitudeEncoder(amp_range=(0, 50), n_levels=4).encode(img)
@@ -365,7 +434,7 @@ def test_Encoder_n_levels():
     npt.assert_equal(fm4.shape[1] < fm.shape[1], True)
 
 
-def test_Encoder_big_time_warning(monkeypatch):
+def test_StimulusEncoder_big_time_warning(monkeypatch):
     monkeypatch.setattr(encoders, '_BIG_TIME', 100)
     img = ImageStimulus(np.linspace(0, 1, 16).reshape((4, 4)))
     with pytest.warns(UserWarning, match='time points'):
@@ -387,7 +456,7 @@ def test_FrequencyEncoder_implant():
     npt.assert_equal(enc.shape[1] < unclocked.shape[1] / 5, True)
 
 
-def test_Encoder_raster():
+def test_StimulusEncoder_raster():
     img = ImageStimulus(np.ones((2, 2)))
     raster = SequentialRaster(2, interleave=True)
     enc = AmplitudeEncoder(freq=100, frame_dur=100,
@@ -447,7 +516,7 @@ def test_Encoder_raster():
                              group_dur=5.1)).encode(img)
 
 
-def test_Encoder_raster_frequency_modulation():
+def test_StimulusEncoder_raster_frequency_modulation():
     # Under frequency modulation electrodes want different periods, so they
     # can only be kept apart by quantizing every period onto a common raster
     # cycle. The fastest electrode pulses once per cycle, slower ones every
@@ -471,7 +540,7 @@ def test_Encoder_raster_frequency_modulation():
                          raster=SequentialRaster(6)).encode(img)
 
 
-def test_Encoder_raster_from_implant():
+def test_StimulusEncoder_raster_from_implant():
     implant = ArgusII()
     implant.raster = SequentialRaster(6)
     vid = VideoStimulus(np.ones((6, 10, 2)), metadata={'fps': 30})
@@ -491,7 +560,7 @@ def test_Encoder_raster_from_implant():
     npt.assert_equal(enc.metadata['encoder']['n_schedules'], 1)
 
 
-def test_Encoder_raster_current_limit():
+def test_StimulusEncoder_raster_current_limit():
     # 60 electrodes at 50 uA is 3000 uA if they all fire at once, but only
     # 500 uA if they take turns ten at a time:
     implant = ArgusII()
@@ -525,7 +594,7 @@ def test_Encoder_raster_current_limit():
 
 @pytest.mark.parametrize('fps', [29.97, 30, 24, 59.94])
 @pytest.mark.parametrize('freq', [50, 100])
-def test_Encoder_freq_is_actual_freq(fps, freq):
+def test_StimulusEncoder_freq_is_actual_freq(fps, freq):
     # The pulse clock runs independently of the frame clock, so the requested
     # frequency is the frequency delivered -- whatever the frame rate is, and
     # whether or not a frame holds a whole number of periods. Before, each
@@ -594,7 +663,7 @@ def test_FrequencyEncoder_rate_changes_between_frames():
                             [0, 10, 20, 30, 40, 50, 70, 90, 120], decimal=3)
 
 
-def test_Encoder_raster_slots_land_on_the_clock():
+def test_StimulusEncoder_raster_slots_land_on_the_clock():
     # A stimulator can only start a pulse on a clock edge, so splitting a
     # period evenly between the groups has to be resolved onto that grid.
     # Rounding each group's offset independently could land two of them on the
@@ -619,7 +688,7 @@ def test_Encoder_raster_slots_land_on_the_clock():
     npt.assert_almost_equal(np.abs(enc.data).sum(axis=0).max(), 100)
 
 
-def test_Encoder_raster_short_slot_keeps_the_rate():
+def test_StimulusEncoder_raster_short_slot_keeps_the_rate():
     # A short explicit slot packs the groups into the start of each period.
     # That must not change the rate: when every electrode is on the same
     # period -- which is what amplitude modulation always produces -- two
@@ -697,7 +766,7 @@ def test_FrequencyEncoder_rate_changes_with_raster_offset():
             npt.assert_equal(vid.data[e, int(t // 20)] > 0, True)
 
 
-def test_Encoder_clock_never_speeds_up():
+def test_StimulusEncoder_clock_never_speeds_up():
     # Same invariant as the raster, for the stimulator's own time base: a
     # timing constraint may lower the rate an electrode ends up on, never raise
     # it, since raising it delivers more charge than was asked for. Realizable
@@ -738,7 +807,7 @@ def test_FrequencyEncoder_raster_never_speeds_up():
     npt.assert_almost_equal(np.diff(pulse_onsets(enc, 0)), 10, decimal=3)
 
 
-def test_Encoder_pulse_offset():
+def test_StimulusEncoder_pulse_offset():
     # `Stimulus` only requires a time axis to be ordered, not to start at zero.
     # What an encoder borrows from a supplied pulse is its *shape*, so a pulse
     # whose time axis is shifted has to encode exactly like an unshifted one.
@@ -759,7 +828,7 @@ def test_Encoder_pulse_offset():
     npt.assert_almost_equal(shifted.time, [5, 5.01, 6, 6.01])
 
 
-def test_Encoder_zero_amp():
+def test_StimulusEncoder_zero_amp():
     # An electrode delivering no current has nothing to schedule, so a dark
     # frame costs no pulses and no time points -- it used to build a full pulse
     # train and then multiply it by zero:
@@ -803,7 +872,7 @@ def test_Encoder_zero_amp():
     npt.assert_equal(enc.shape[1], 2)
 
 
-def test_Encoder_implant_reshape():
+def test_StimulusEncoder_implant_reshape():
     # Passing an implant means "sample the source at the electrode locations".
     # Row count is not a usable test of whether that already happened: a 10x6
     # image and an RGB 4x5 image both have exactly as many rows as Argus II has
@@ -822,7 +891,7 @@ def test_Encoder_implant_reshape():
         npt.assert_equal(list(enc.electrodes), list(implant.electrode_names))
 
 
-def test_Encoder_metadata():
+def test_StimulusEncoder_metadata():
     enc = AmplitudeEncoder(freq=50).encode(ImageStimulus(np.ones((2, 2))))
     npt.assert_equal(enc.metadata['encoder']['kind'], 'AmplitudeEncoder')
     npt.assert_almost_equal(enc.metadata['encoder']['frame_dur'], 500)
@@ -837,7 +906,7 @@ def test_Encoder_metadata():
     npt.assert_equal(fm.metadata['encoder']['n_schedules'], 4)
 
 
-def test_Encoder_degenerate_raster_is_no_raster():
+def test_StimulusEncoder_degenerate_raster_is_no_raster():
     """A raster with one group has nothing to multiplex, so it changes nothing.
 
     This is the limiting case that says a raster only ever *staggers* onsets:
@@ -869,7 +938,7 @@ def test_Encoder_degenerate_raster_is_no_raster():
                                 np.abs(plain.data).sum(axis=0).max())
 
 
-def test_Encoder_degenerate_ranges():
+def test_StimulusEncoder_degenerate_ranges():
     """A modulation range of zero width stops the gray levels mattering."""
     implant = ArgusII()
     img = ImageStimulus(np.random.default_rng(1).random((6, 10)))
@@ -896,7 +965,7 @@ def test_Encoder_degenerate_ranges():
         npt.assert_equal(np.any(enc.encode(black).data), False)
 
 
-def test_Encoder_n_levels_converges():
+def test_StimulusEncoder_n_levels_converges():
     """Quantizing onto enough gray levels is the same as not quantizing."""
     implant = ArgusII()
     img = ImageStimulus(np.random.default_rng(2).random((6, 10)))
@@ -914,7 +983,7 @@ def test_Encoder_n_levels_converges():
     npt.assert_array_equal(np.unique(np.abs(two.data).max(axis=1)), [0.0, 50.0])
 
 
-def test_Encoder_frame_rate_does_not_move_the_pulses():
+def test_StimulusEncoder_frame_rate_does_not_move_the_pulses():
     """The pulse clock is independent of the frame clock.
 
     Re-timing the same frames only changes how long the stimulus lasts and

--- a/pulse2percept/stimuli/tests/test_encoders.py
+++ b/pulse2percept/stimuli/tests/test_encoders.py
@@ -43,6 +43,17 @@ def pixel_implant(shape, raster=None):
     return implant
 
 
+def n_schedules_of(stim):
+    """How many distinct schedules the electrodes of a stimulus are split over
+
+    Two electrodes share a schedule when current flows on them at the same
+    times, whatever amplitude it flows at. That is what a raster splits
+    electrodes into, and what frequency modulation multiplies. Electrodes
+    delivering nothing at all share the empty schedule.
+    """
+    return len(np.unique(np.abs(stim.data) > 0, axis=0))
+
+
 def test_StimulusEncoder_is_abstract():
     with pytest.raises(TypeError):
         StimulusEncoder()
@@ -383,8 +394,8 @@ def test_StimulusEncoder_clock():
     fine = FrequencyEncoder(freq_range=(0, 300), frame_dur=100).encode(img)
     coarse = FrequencyEncoder(freq_range=(0, 300), frame_dur=100,
                               clock=1).encode(img)
-    npt.assert_equal(fine.metadata['encoder']['n_schedules'], 16)
-    npt.assert_equal(coarse.metadata['encoder']['n_schedules'] < 16, True)
+    npt.assert_equal(n_schedules_of(fine), 16)
+    npt.assert_equal(n_schedules_of(coarse) < 16, True)
     # ... which is the whole point: far fewer time points to simulate:
     npt.assert_equal(coarse.shape[1] < fine.shape[1] / 2, True)
     # Every pulse still lands on the clock grid, and the fine one does not:
@@ -408,7 +419,7 @@ def test_StimulusEncoder_n_levels():
     fm = FrequencyEncoder(freq_range=(0, 300), frame_dur=100).encode(img)
     fm4 = FrequencyEncoder(freq_range=(0, 300), frame_dur=100,
                            n_levels=4).encode(img)
-    npt.assert_equal(fm4.metadata['encoder']['n_schedules'], 4)
+    npt.assert_equal(n_schedules_of(fm4), 4)
     npt.assert_equal(fm4.shape[1] < fm.shape[1], True)
 
 
@@ -444,7 +455,7 @@ def test_StimulusEncoder_raster():
     # Rastering splits the electrodes across two pulse schedules. The cycle a
     # raster has to get through is the pulse *period*, not the frame, so the
     # two groups are offset by half a period:
-    npt.assert_equal(enc.metadata['encoder']['n_schedules'], 2)
+    npt.assert_equal(n_schedules_of(enc), 2)
     npt.assert_almost_equal(enc.metadata['encoder']['cycle'], 10)
     onsets = [pulse_onsets(enc, e) for e in (0, 1)]
     npt.assert_almost_equal(onsets[0][0], 0, decimal=3)
@@ -523,21 +534,21 @@ def test_StimulusEncoder_raster_from_implant():
     implant.raster = SequentialRaster(6)
     vid = VideoStimulus(np.ones((6, 10, 2)), metadata={'fps': 30})
     enc = AmplitudeEncoder(freq=30).encode(vid, implant=implant)
-    npt.assert_equal(enc.metadata['encoder']['n_schedules'], 6)
+    npt.assert_equal(n_schedules_of(enc), 6)
     delays = [pulse_onsets(enc, e)[0] for e in (0, 10, 20, 30, 40, 50)]
     npt.assert_almost_equal(delays, np.arange(6) * 1000 / 30 / 6, decimal=2)
     # Trying another one out is a matter of giving it to the implant:
     implant.raster = SequentialRaster(2)
     enc = AmplitudeEncoder(freq=30).encode(vid, implant=implant)
-    npt.assert_equal(enc.metadata['encoder']['n_schedules'], 2)
+    npt.assert_equal(n_schedules_of(enc), 2)
     # And no raster means every electrode fires at frame onset:
     implant.raster = None
     enc = AmplitudeEncoder(freq=30).encode(vid, implant=implant)
-    npt.assert_equal(enc.metadata['encoder']['n_schedules'], 1)
+    npt.assert_equal(n_schedules_of(enc), 1)
     # Encoding for no implant at all is pixel resolution and no raster, even
     # though this encoder just encoded for a rastered device:
     bare = AmplitudeEncoder(freq=30).encode(vid)
-    npt.assert_equal(bare.metadata['encoder']['n_schedules'], 1)
+    npt.assert_equal(n_schedules_of(bare), 1)
 
 
 def test_StimulusEncoder_raster_current_limit():
@@ -568,7 +579,7 @@ def test_StimulusEncoder_raster_current_limit():
     # Halving the phase duration makes it fit:
     enc = AmplitudeEncoder(freq=30, phase_dur=0.2).encode(vid,
                                                           implant=implant)
-    npt.assert_equal(enc.metadata['encoder']['n_schedules'], 60)
+    npt.assert_equal(n_schedules_of(enc), 60)
     npt.assert_almost_equal(np.abs(enc.data).sum(axis=0).max(), 50)
 
 
@@ -900,12 +911,16 @@ def test_StimulusEncoder_encode_both():
     # None of the timing survives: no waveform, no pulse clock, no raster.
     # The delivered train has 4 raster groups and hundreds of time points.
     npt.assert_equal(delivered.time.size > 100, True)
+    # Four raster groups, plus the black pixel that delivers nothing:
+    npt.assert_equal(n_schedules_of(delivered), 5)
+    # The modulation is one column per frame, so there is no schedule in it for
+    # the electrodes to be split across -- which is the one thing it does not
+    # record. The frame clock is a fact about the source, so it does survive:
     npt.assert_equal('cycle' in spatial.metadata['encoder'], False)
-    npt.assert_equal('n_schedules' in spatial.metadata['encoder'], False)
-    # The frame clock is a fact about the source, so it does survive:
-    for key in ('kind', 'frame_dur', 'n_frames'):
-        npt.assert_equal(spatial.metadata['encoder'][key],
-                         delivered.metadata['encoder'][key])
+    npt.assert_equal(spatial.metadata['encoder']['frame_dur'],
+                     delivered.metadata['encoder']['frame_dur'])
+    npt.assert_array_equal(spatial.metadata['encoder']['frame_time'],
+                           delivered.metadata['encoder']['frame_time'])
 
     # A video keeps one column per frame, and a time axis to say when each of
     # them starts (here `frame_dur=100` re-times the source, as it does for
@@ -945,17 +960,15 @@ def test_FrequencyEncoder_encode_both():
 
 def test_StimulusEncoder_metadata():
     enc = AmplitudeEncoder(freq=50).encode(ImageStimulus(np.ones((2, 2))))
-    npt.assert_equal(enc.metadata['encoder']['kind'], 'AmplitudeEncoder')
     npt.assert_almost_equal(enc.metadata['encoder']['frame_dur'], 500)
-    npt.assert_equal(enc.metadata['encoder']['n_frames'], 1)
+    npt.assert_almost_equal(enc.metadata['encoder']['frame_time'], [0])
     # Amplitude modulation puts every electrode on one schedule; frequency
     # modulation is what makes that number grow:
-    npt.assert_equal(enc.metadata['encoder']['n_schedules'], 1)
+    npt.assert_equal(n_schedules_of(enc), 1)
     fm = FrequencyEncoder(freq_range=(10, 100), n_levels=4,
                           clock=1).encode(ImageStimulus(np.linspace(
                               0, 1, 16).reshape((4, 4))))
-    npt.assert_equal(fm.metadata['encoder']['kind'], 'FrequencyEncoder')
-    npt.assert_equal(fm.metadata['encoder']['n_schedules'], 4)
+    npt.assert_equal(n_schedules_of(fm), 4)
 
 
 def test_StimulusEncoder_degenerate_raster_is_no_raster():
@@ -1008,7 +1021,7 @@ def test_StimulusEncoder_degenerate_ranges():
                             **kwargs).encode(img, implant=implant)
     npt.assert_array_equal(same.data, flat.data)
     npt.assert_array_equal(same.time, flat.time)
-    npt.assert_equal(same.metadata['encoder']['n_schedules'], 1)
+    npt.assert_equal(n_schedules_of(same), 1)
 
     # A black image asks for no current at all, at either end of the range:
     black = ImageStimulus(np.zeros((6, 10)))

--- a/pulse2percept/stimuli/tests/test_encoders.py
+++ b/pulse2percept/stimuli/tests/test_encoders.py
@@ -1,4 +1,3 @@
-import importlib
 import warnings
 
 import numpy as np
@@ -33,45 +32,6 @@ def n_pulses_of(stim, electrode=0, peak=None):
 def test_StimulusEncoder_is_abstract():
     with pytest.raises(TypeError):
         StimulusEncoder()
-
-
-def test_StimulusEncoder_deprecated_name():
-    """``Encoder`` still resolves, to the very same class object
-
-    The old name is served by a module-level ``__getattr__`` rather than by a
-    subclass, so it is not merely compatible but identical: every
-    ``isinstance`` and ``issubclass`` check written against it keeps answering
-    what it answered before the rename.
-    """
-    for module in ('pulse2percept.stimuli', 'pulse2percept.stimuli.encoders'):
-        with pytest.warns(DeprecationWarning, match='StimulusEncoder'):
-            Encoder = getattr(importlib.import_module(module), 'Encoder')
-        npt.assert_equal(Encoder is StimulusEncoder, True)
-        npt.assert_equal(issubclass(AmplitudeEncoder, Encoder), True)
-        npt.assert_equal(issubclass(FrequencyEncoder, Encoder), True)
-        npt.assert_equal(isinstance(AmplitudeEncoder(), Encoder), True)
-
-    with pytest.warns(DeprecationWarning) as record:
-        from pulse2percept.stimuli import Encoder
-    npt.assert_equal('0.11.0' in str(record[0].message), True)
-    # The warning blames the line that used the deprecated name, not the
-    # module that serves it:
-    npt.assert_equal(record[0].filename, __file__)
-
-    # A user-defined subclass through the old name is a subclass of the new
-    # one, and works:
-    class MyEncoder(Encoder):
-        def _modulate(self, gray):
-            return 10 + 30 * gray, 20
-
-    npt.assert_equal(issubclass(MyEncoder, StimulusEncoder), True)
-    stim = MyEncoder(frame_dur=100).encode(
-        ImageStimulus(np.linspace(0, 1, 16).reshape((4, 4))))
-    npt.assert_almost_equal(np.abs(stim.data).max(), 40)
-
-    # A name that was never ours is still an ordinary AttributeError:
-    with pytest.raises(AttributeError):
-        encoders.NotAThing
 
 
 def test_StimulusEncoder_warnings_point_at_the_caller(monkeypatch):

--- a/pulse2percept/stimuli/tests/test_encoders.py
+++ b/pulse2percept/stimuli/tests/test_encoders.py
@@ -5,7 +5,8 @@ import numpy.testing as npt
 import pytest
 from scipy.integrate import trapezoid
 
-from pulse2percept.implants import ArgusII, CustomRaster, SequentialRaster
+from pulse2percept.implants import (ArgusII, CustomRaster, RectangleImplant,
+                                     SequentialRaster)
 from pulse2percept.stimuli import (AmplitudeEncoder, BiphasicPulse,
                                    BiphasicPulseTrain, BostonTrain,
                                    FrequencyEncoder, ImageStimulus,
@@ -27,6 +28,19 @@ def n_pulses_of(stim, electrode=0, peak=None):
     firing = np.abs(row) >= 0.99 * peak
     # Each pulse has a leading and a trailing phase, both at full amplitude:
     return np.count_nonzero(np.diff(firing.astype(int)) > 0) // 2
+
+
+def pixel_implant(shape, raster=None):
+    """An implant with one electrode per pixel of a ``shape`` image
+
+    A raster describes how one particular device takes turns between its
+    electrodes, so trying one out means having a device to try it on. This
+    implant's electrodes sit exactly on the pixels of a ``shape`` image, so
+    sampling one at the other changes nothing about what gets encoded.
+    """
+    implant = RectangleImplant(shape=shape, spacing=200, r=50)
+    implant.raster = raster
+    return implant
 
 
 def test_StimulusEncoder_is_abstract():
@@ -56,7 +70,7 @@ def test_StimulusEncoder_warnings_point_at_the_caller(monkeypatch):
     # ... including the one about frames that never get a pulse:
     with warnings.catch_warnings(record=True) as caught:
         warnings.simplefilter('always')
-        AmplitudeEncoder(ArgusII(), freq=2).encode(vid)
+        AmplitudeEncoder(freq=2).encode(vid, implant=ArgusII())
     npt.assert_equal([w.filename for w in caught], [__file__] * len(caught))
     npt.assert_equal(any('deliver no pulse' in str(w.message)
                          for w in caught), True)
@@ -250,9 +264,12 @@ def test_AmplitudeEncoder_image():
 
 
 def test_AmplitudeEncoder_implant():
-    implant = ArgusII()
+    # No raster here: what is being checked is the sampling, and a raster would
+    # stagger the onsets away from the pixel-resolution encoding compared with
+    # at the end.
+    implant = ArgusII(raster=None)
     vid = BostonTrain()
-    enc = AmplitudeEncoder(implant, amp_range=(0, 50)).encode(vid)
+    enc = AmplitudeEncoder(amp_range=(0, 50)).encode(vid, implant=implant)
     # The video is sampled at the electrode locations, so the stimulus has one
     # row per electrode rather than one per pixel:
     npt.assert_equal(enc.shape[0], implant.n_electrodes)
@@ -283,7 +300,8 @@ def test_AmplitudeEncoder_big_stim_warning(monkeypatch):
     # Passing an implant is the way out, so it does not warn:
     with warnings.catch_warnings():
         warnings.simplefilter('error')
-        AmplitudeEncoder(ArgusII(), freq=1000).encode(vid)
+        AmplitudeEncoder(freq=1000).encode(vid,
+                                          implant=ArgusII(raster=None))
 
 
 def whole_pulses(freq, frame_dur, pulse_dur=0.92):
@@ -402,25 +420,27 @@ def test_StimulusEncoder_big_time_warning(monkeypatch):
 
 
 def test_FrequencyEncoder_implant():
-    implant = ArgusII()
-    enc = FrequencyEncoder(implant, freq_range=(0, 300), amp=50,
-                           clock=1).encode(BostonTrain())
+    # A 300 Hz period is 3.3 ms, which Argus II's own six-group 2 ms raster
+    # sweep does not fit into, so this device drives every electrode at once:
+    implant = ArgusII(raster=None)
+    enc = FrequencyEncoder(freq_range=(0, 300), amp=50, clock=1).encode(
+        BostonTrain(), implant=implant)
     npt.assert_equal(enc.shape[0], implant.n_electrodes)
     npt.assert_almost_equal(np.abs(enc.data).max(), 50)
     implant.stim = enc
     npt.assert_equal(implant.stim.shape, enc.shape)
     # The clock is what makes this tractable at all: without one, the same
     # clip needs several times as many time points:
-    unclocked = FrequencyEncoder(implant, freq_range=(0, 300),
-                                 amp=50).encode(BostonTrain())
+    unclocked = FrequencyEncoder(freq_range=(0, 300), amp=50).encode(
+        BostonTrain(), implant=implant)
     npt.assert_equal(enc.shape[1] < unclocked.shape[1] / 5, True)
 
 
 def test_StimulusEncoder_raster():
     img = ImageStimulus(np.ones((2, 2)))
-    raster = SequentialRaster(2, interleave=True)
-    enc = AmplitudeEncoder(freq=100, frame_dur=100,
-                           raster=raster).encode(img)
+    implant = pixel_implant((2, 2), SequentialRaster(2, interleave=True))
+    enc = AmplitudeEncoder(freq=100, frame_dur=100).encode(img,
+                                                           implant=implant)
     # Rastering splits the electrodes across two pulse schedules. The cycle a
     # raster has to get through is the pulse *period*, not the frame, so the
     # two groups are offset by half a period:
@@ -452,28 +472,23 @@ def test_StimulusEncoder_raster():
     # a 10 ms cycle -- which here still holds the requested 100 Hz exactly.
     # Rounding each offset and the total cycle independently instead would give
     # a 9 ms cycle made of a 5 ms and a 4 ms turn, and 111 Hz:
-    enc = AmplitudeEncoder(freq=100, frame_dur=100, clock=1,
-                           raster=SequentialRaster(
-                               2, interleave=True,
-                               group_dur=4.6)).encode(img)
+    implant.raster = SequentialRaster(2, interleave=True, group_dur=4.6)
+    enc = AmplitudeEncoder(freq=100, frame_dur=100, clock=1).encode(
+        img, implant=implant)
     npt.assert_almost_equal(pulse_onsets(enc, 1)[0], 5, decimal=3)
     npt.assert_almost_equal(np.diff(pulse_onsets(enc, 1)), 10, decimal=3)
     npt.assert_almost_equal(enc.metadata['encoder']['cycle'], 10)
     # Whether the groups fit is decided on the slot the hardware will actually
     # use. Two 5.1 ms slots do not fit into a 10 ms period, but on a 1 ms clock
     # they are 5 ms slots, and two of those fit exactly:
-    enc = AmplitudeEncoder(freq=100, frame_dur=100, clock=1,
-                           raster=SequentialRaster(
-                               2, interleave=True,
-                               group_dur=5.1)).encode(img)
+    implant.raster = SequentialRaster(2, interleave=True, group_dur=5.1)
+    enc = AmplitudeEncoder(freq=100, frame_dur=100, clock=1).encode(
+        img, implant=implant)
     npt.assert_almost_equal(enc.metadata['encoder']['cycle'], 10)
     npt.assert_almost_equal(pulse_onsets(enc, 1)[0], 5, decimal=3)
     # Without a clock to round it there is nothing to round, and it is an error:
     with pytest.raises(ValueError):
-        AmplitudeEncoder(freq=100, frame_dur=100,
-                         raster=SequentialRaster(
-                             2, interleave=True,
-                             group_dur=5.1)).encode(img)
+        AmplitudeEncoder(freq=100, frame_dur=100).encode(img, implant=implant)
 
 
 def test_StimulusEncoder_raster_frequency_modulation():
@@ -482,8 +497,9 @@ def test_StimulusEncoder_raster_frequency_modulation():
     # cycle. The fastest electrode pulses once per cycle, slower ones every
     # m-th cycle, and no two groups ever coincide:
     img = ImageStimulus(np.linspace(0.25, 1, 16).reshape((4, 4)))
-    enc = FrequencyEncoder(freq_range=(0, 120), amp=10, frame_dur=200,
-                           raster=SequentialRaster(4, interleave=True)).encode(img)
+    implant = pixel_implant((4, 4), SequentialRaster(4, interleave=True))
+    enc = FrequencyEncoder(freq_range=(0, 120), amp=10,
+                           frame_dur=200).encode(img, implant=implant)
     cycle = enc.metadata['encoder']['cycle']
     npt.assert_almost_equal(cycle, 1000 / 120)
     for e in range(16):
@@ -496,58 +512,62 @@ def test_StimulusEncoder_raster_frequency_modulation():
     # Multiplexing a fast train across many groups asks more of a stimulator
     # than it can give, and that is an error rather than a silent collision:
     with pytest.raises(ValueError, match='no room'):
-        FrequencyEncoder(freq_range=(0, 300), amp=10, frame_dur=200,
-                         raster=SequentialRaster(6)).encode(img)
+        FrequencyEncoder(freq_range=(0, 300), amp=10, frame_dur=200).encode(
+            img, implant=pixel_implant((4, 4), SequentialRaster(6)))
 
 
 def test_StimulusEncoder_raster_from_implant():
+    # The implant is the one place device scheduling is described, so the
+    # encoder holds no raster of its own and reads the implant's:
     implant = ArgusII()
     implant.raster = SequentialRaster(6)
     vid = VideoStimulus(np.ones((6, 10, 2)), metadata={'fps': 30})
-    # The encoder picks up the implant's raster without being told:
-    enc = AmplitudeEncoder(implant, freq=30).encode(vid)
+    enc = AmplitudeEncoder(freq=30).encode(vid, implant=implant)
     npt.assert_equal(enc.metadata['encoder']['n_schedules'], 6)
     delays = [pulse_onsets(enc, e)[0] for e in (0, 10, 20, 30, 40, 50)]
     npt.assert_almost_equal(delays, np.arange(6) * 1000 / 30 / 6, decimal=2)
-    # An explicit raster on the encoder wins, so one can be tried out without
-    # modifying the implant:
-    enc = AmplitudeEncoder(implant, freq=30,
-                           raster=SequentialRaster(2)).encode(vid)
+    # Trying another one out is a matter of giving it to the implant:
+    implant.raster = SequentialRaster(2)
+    enc = AmplitudeEncoder(freq=30).encode(vid, implant=implant)
     npt.assert_equal(enc.metadata['encoder']['n_schedules'], 2)
-    # And no raster anywhere means every electrode fires at frame onset:
+    # And no raster means every electrode fires at frame onset:
     implant.raster = None
-    enc = AmplitudeEncoder(implant, freq=30).encode(vid)
+    enc = AmplitudeEncoder(freq=30).encode(vid, implant=implant)
     npt.assert_equal(enc.metadata['encoder']['n_schedules'], 1)
+    # Encoding for no implant at all is pixel resolution and no raster, even
+    # though this encoder just encoded for a rastered device:
+    bare = AmplitudeEncoder(freq=30).encode(vid)
+    npt.assert_equal(bare.metadata['encoder']['n_schedules'], 1)
 
 
 def test_StimulusEncoder_raster_current_limit():
     # 60 electrodes at 50 uA is 3000 uA if they all fire at once, but only
     # 500 uA if they take turns ten at a time:
-    implant = ArgusII()
+    implant = ArgusII(raster=None)
     implant.max_current = 1000
     vid = VideoStimulus(np.ones((6, 10, 3)), metadata={'fps': 30})
     with pytest.raises(ValueError, match='raster'):
-        implant.stim = AmplitudeEncoder(implant, amp_range=(50, 50),
-                                        freq=30).encode(vid)
+        implant.stim = AmplitudeEncoder(amp_range=(50, 50), freq=30).encode(
+            vid, implant=implant)
     implant.raster = SequentialRaster(6)
-    implant.stim = AmplitudeEncoder(implant, amp_range=(50, 50),
-                                    freq=30).encode(vid)
+    implant.stim = AmplitudeEncoder(amp_range=(50, 50), freq=30).encode(
+        vid, implant=implant)
     npt.assert_almost_equal(np.abs(implant.stim.data).sum(axis=0).max(), 500)
     # A raster that cannot get through all its groups within a frame is not a
     # usable schedule:
+    implant.raster = SequentialRaster(6, group_dur=20)
     with pytest.raises(ValueError):
-        AmplitudeEncoder(implant, freq=30,
-                         raster=SequentialRaster(6, group_dur=20)).encode(vid)
+        AmplitudeEncoder(freq=30).encode(vid, implant=implant)
     # Neither is one whose groups get a turn too short to pulse in. Sixty
     # 0.92 ms pulses take 55 ms, which does not fit into a 33 ms frame, so
     # electrode-at-a-time rastering is impossible here rather than merely
     # dropping the electrodes that come last:
+    implant.raster = SequentialRaster(60)
     with pytest.raises(ValueError, match='no room'):
-        AmplitudeEncoder(implant, freq=30,
-                         raster=SequentialRaster(60)).encode(vid)
+        AmplitudeEncoder(freq=30).encode(vid, implant=implant)
     # Halving the phase duration makes it fit:
-    enc = AmplitudeEncoder(implant, freq=30, phase_dur=0.2,
-                           raster=SequentialRaster(60)).encode(vid)
+    enc = AmplitudeEncoder(freq=30, phase_dur=0.2).encode(vid,
+                                                          implant=implant)
     npt.assert_equal(enc.metadata['encoder']['n_schedules'], 60)
     npt.assert_almost_equal(np.abs(enc.data).sum(axis=0).max(), 50)
 
@@ -631,13 +651,14 @@ def test_StimulusEncoder_raster_slots_land_on_the_clock():
     # five edges to go round -- and they would then pulse together, which is
     # the one thing a raster exists to prevent.
     img = ImageStimulus(np.ones((6, 2)))
+    implant = pixel_implant((6, 2), SequentialRaster(6))
     with pytest.raises(ValueError, match='clock'):
-        AmplitudeEncoder(freq=200, frame_dur=100, clock=1,
-                         raster=SequentialRaster(6)).encode(img)
+        AmplitudeEncoder(freq=200, frame_dur=100, clock=1).encode(
+            img, implant=implant)
     # Given room, every group gets its own whole number of clock cycles, and
     # the turns come out evenly spaced rather than jittered onto nearby edges:
-    enc = AmplitudeEncoder(freq=20, frame_dur=200, clock=1,
-                           raster=SequentialRaster(6)).encode(img)
+    enc = AmplitudeEncoder(freq=20, frame_dur=200, clock=1).encode(
+        img, implant=implant)
     starts = np.array([pulse_onsets(enc, e)[0] for e in range(0, 12, 2)])
     npt.assert_almost_equal(starts, np.arange(6) * 8.0, decimal=3)
     npt.assert_equal(np.unique(starts).size, 6)
@@ -656,12 +677,12 @@ def test_StimulusEncoder_raster_short_slot_keeps_the_rate():
     # quantize away. Pinning the period to the cycle anyway turned a requested
     # 20 Hz into 18.5 Hz on Argus II with a 1 ms slot.
     img = ImageStimulus(np.ones((2, 2)))
+    implant = pixel_implant((2, 2), SequentialRaster(2, interleave=True,
+                                                     group_dur=1.5))
     # 10 ms period against a 2 x 1.5 = 3 ms cycle: quantizing would round the
     # period up to 12 ms (83 Hz):
-    enc = AmplitudeEncoder(freq=100, frame_dur=200,
-                           raster=SequentialRaster(
-                               2, interleave=True,
-                               group_dur=1.5)).encode(img)
+    enc = AmplitudeEncoder(freq=100, frame_dur=200).encode(img,
+                                                           implant=implant)
     npt.assert_almost_equal(enc.metadata['encoder']['cycle'], 3)
     for e, offset in enumerate([0, 1.5, 0, 1.5]):
         npt.assert_almost_equal(pulse_onsets(enc, e)[0], offset, decimal=3)
@@ -673,12 +694,11 @@ def test_StimulusEncoder_raster_short_slot_keeps_the_rate():
     npt.assert_almost_equal(np.abs(enc.data).sum(axis=0).max(), 100)
     # Frequency modulation still has to quantize, because electrodes on
     # different periods do drift onto each other:
-    fm = FrequencyEncoder(freq_range=(50, 100), amp=10, frame_dur=200,
-                          raster=SequentialRaster(
-                              2, interleave=True,
-                              group_dur=1.5)).encode(
-                                  ImageStimulus(np.array([[1.0, 0.0],
-                                                          [1.0, 0.0]])))
+    fm = FrequencyEncoder(freq_range=(50, 100), amp=10,
+                          frame_dur=200).encode(
+                              ImageStimulus(np.array([[1.0, 0.0],
+                                                      [1.0, 0.0]])),
+                              implant=implant)
     for e in range(4):
         period = np.diff(pulse_onsets(fm, e))
         npt.assert_allclose(period / 3, np.round(period / 3), atol=1e-3)
@@ -692,13 +712,14 @@ def test_FrequencyEncoder_rate_changes_with_raster_offset():
     # to an earlier frame boundary.
     # 20 ms frames; the top of the range is 10 Hz, so the raster cycle is
     # 100 ms and the second of two groups may only pulse at 50, 150, ... ms:
+    implant = pixel_implant((2, 2), SequentialRaster(2, interleave=True))
     vid = VideoStimulus(np.tile(np.array([0, 1, 0, 0, 0, 0], dtype=float),
-                                (1, 2, 1)).reshape(1, 2, 6),
+                                (2, 2, 1)).reshape(2, 2, 6),
                         metadata={'fps': 50})
     with warnings.catch_warnings():
         warnings.simplefilter('ignore')
-        enc = FrequencyEncoder(freq_range=(0, 10), amp=10,
-                               raster=SequentialRaster(2)).encode(vid)
+        enc = FrequencyEncoder(freq_range=(0, 10), amp=10).encode(
+            vid, implant=implant)
     npt.assert_almost_equal(enc.metadata['encoder']['cycle'], 100)
     # Only the 20-40 ms frame asks for stimulation, and neither group has a
     # legal slot inside it -- group 0's fall on 0 and 100 ms, group 1's on 50
@@ -712,12 +733,12 @@ def test_FrequencyEncoder_rate_changes_with_raster_offset():
     # in their own slots, a cycle apart:
     vid = VideoStimulus(np.tile(np.array([1, 1, 1, 0, 0, 1, 1, 1, 1, 1],
                                          dtype=float),
-                                (1, 2, 1)).reshape(1, 2, 10),
+                                (2, 2, 1)).reshape(2, 2, 10),
                         metadata={'fps': 50})
     with warnings.catch_warnings():
         warnings.simplefilter('ignore')
-        enc = FrequencyEncoder(freq_range=(0, 10), amp=10,
-                               raster=SequentialRaster(2)).encode(vid)
+        enc = FrequencyEncoder(freq_range=(0, 10), amp=10).encode(
+            vid, implant=implant)
     npt.assert_almost_equal(pulse_onsets(enc, 0), [0], decimal=3)
     npt.assert_almost_equal(pulse_onsets(enc, 1), [50], decimal=3)
     # A pulse is never delivered into a frame that asked for silence:
@@ -752,8 +773,9 @@ def test_FrequencyEncoder_raster_never_speeds_up():
     # becomes 50 Hz rather than 100 Hz.
     grays = np.array([1.0, 0.67, 0.4, 0.2])
     img = ImageStimulus(grays.reshape((2, 2)))
-    enc = FrequencyEncoder(freq_range=(0, 100), amp=10, frame_dur=200,
-                           raster=SequentialRaster(4)).encode(img)
+    implant = pixel_implant((2, 2), SequentialRaster(4))
+    enc = FrequencyEncoder(freq_range=(0, 100), amp=10, frame_dur=200).encode(
+        img, implant=implant)
     cycle = enc.metadata['encoder']['cycle']
     npt.assert_almost_equal(cycle, 10)
     for e, gray in enumerate(grays):
@@ -820,14 +842,13 @@ def test_StimulusEncoder_zero_amp():
     npt.assert_almost_equal(onsets[[0, -1]], [0, 70], decimal=3)
     # A raster that a stimulus cannot possibly satisfy is a property of the
     # device, not of how bright today's video is, so it is reported either way:
-    implant = ArgusII()
+    implant = ArgusII(raster=SequentialRaster(60))
     dark = VideoStimulus(np.zeros((6, 10, 3)), metadata={'fps': 30})
     with pytest.raises(ValueError, match='no room'):
-        AmplitudeEncoder(implant, freq=30,
-                         raster=SequentialRaster(60)).encode(dark)
+        AmplitudeEncoder(freq=30).encode(dark, implant=implant)
     # ... and a workable one costs a dark video nothing:
-    enc = AmplitudeEncoder(implant, amp_range=(0, 50), freq=30, phase_dur=0.2,
-                           raster=SequentialRaster(60)).encode(dark)
+    enc = AmplitudeEncoder(amp_range=(0, 50), freq=30, phase_dur=0.2).encode(
+        dark, implant=implant)
     npt.assert_equal(np.all(enc.data == 0), True)
     npt.assert_equal(enc.shape[1], 2)
 
@@ -838,13 +859,13 @@ def test_StimulusEncoder_implant_reshape():
     # image and an RGB 4x5 image both have exactly as many rows as Argus II has
     # electrodes, and both used to skip sampling (and, for RGB, `rgb2gray`)
     # while still being labeled with electrode names.
-    implant = ArgusII()
+    implant = ArgusII(raster=None)
     for src in [ImageStimulus(np.random.rand(10, 6)),
                 ImageStimulus(np.random.rand(4, 5, 3)),
                 ImageStimulus(np.random.rand(6, 10)),
                 VideoStimulus(np.random.rand(10, 6, 2))]:
         npt.assert_equal(src.data.shape[0], implant.n_electrodes)
-        enc = AmplitudeEncoder(implant, amp_range=(0, 50)).encode(src)
+        enc = AmplitudeEncoder(amp_range=(0, 50)).encode(src, implant=implant)
         direct = AmplitudeEncoder(amp_range=(0, 50)).encode(
             implant.reshape_stim(src))
         npt.assert_almost_equal(enc.data, direct.data, decimal=4)
@@ -875,10 +896,10 @@ def test_StimulusEncoder_degenerate_raster_is_no_raster():
     That holds even with an explicit ``group_dur``, which would otherwise set
     the sweep length.
     """
-    implant = ArgusII()
+    implant = ArgusII(raster=None)
     img = ImageStimulus(np.random.default_rng(0).random((6, 10)))
     kwargs = dict(amp_range=(0, 50), freq=20, frame_dur=200)
-    plain = AmplitudeEncoder(implant, **kwargs).encode(img)
+    plain = AmplitudeEncoder(**kwargs).encode(img, implant=implant)
     npt.assert_equal(plain.metadata['encoder']['cycle'], None)
 
     names = list(implant.electrode_names)
@@ -888,7 +909,8 @@ def test_StimulusEncoder_degenerate_raster_is_no_raster():
                    CustomRaster([names]),
                    CustomRaster({n: 0 for n in names})):
         npt.assert_equal(raster.n_groups, 1)
-        got = AmplitudeEncoder(implant, raster=raster, **kwargs).encode(img)
+        implant.raster = raster
+        got = AmplitudeEncoder(**kwargs).encode(img, implant=implant)
         npt.assert_array_equal(got.data, plain.data)
         npt.assert_array_equal(got.time, plain.time)
         npt.assert_equal(got.metadata['encoder']['cycle'], None)
@@ -900,29 +922,29 @@ def test_StimulusEncoder_degenerate_raster_is_no_raster():
 
 def test_StimulusEncoder_degenerate_ranges():
     """A modulation range of zero width stops the gray levels mattering."""
-    implant = ArgusII()
+    implant = ArgusII(raster=None)
     img = ImageStimulus(np.random.default_rng(1).random((6, 10)))
     kwargs = dict(frame_dur=200)
 
     # One amplitude for every gray level is a constant-amplitude train...
-    flat = AmplitudeEncoder(implant, amp_range=(30, 30), freq=20,
-                            **kwargs).encode(img)
+    flat = AmplitudeEncoder(amp_range=(30, 30), freq=20,
+                            **kwargs).encode(img, implant=implant)
     npt.assert_almost_equal(np.abs(flat.data).max(axis=1), 30.0, decimal=4)
     # ... and one frequency for every gray level is the very same stimulus,
     # since frequency modulation at a constant rate *is* amplitude modulation
     # at a constant amplitude:
-    same = FrequencyEncoder(implant, freq_range=(20, 20), amp=30,
-                            **kwargs).encode(img)
+    same = FrequencyEncoder(freq_range=(20, 20), amp=30,
+                            **kwargs).encode(img, implant=implant)
     npt.assert_array_equal(same.data, flat.data)
     npt.assert_array_equal(same.time, flat.time)
     npt.assert_equal(same.metadata['encoder']['n_schedules'], 1)
 
     # A black image asks for no current at all, at either end of the range:
     black = ImageStimulus(np.zeros((6, 10)))
-    for enc in (AmplitudeEncoder(implant, amp_range=(0, 50), **kwargs),
-                FrequencyEncoder(implant, freq_range=(0, 200), amp=50,
-                                 **kwargs)):
-        npt.assert_equal(np.any(enc.encode(black).data), False)
+    for enc in (AmplitudeEncoder(amp_range=(0, 50), **kwargs),
+                FrequencyEncoder(freq_range=(0, 200), amp=50, **kwargs)):
+        npt.assert_equal(np.any(enc.encode(black, implant=implant).data),
+                         False)
 
 
 def test_StimulusEncoder_n_levels_converges():
@@ -930,16 +952,17 @@ def test_StimulusEncoder_n_levels_converges():
     implant = ArgusII()
     img = ImageStimulus(np.random.default_rng(2).random((6, 10)))
     kwargs = dict(amp_range=(0, 50), freq=20, frame_dur=200)
-    ref = AmplitudeEncoder(implant, **kwargs).encode(img)
-    err = [np.abs(AmplitudeEncoder(implant, n_levels=n,
-                                   **kwargs).encode(img).data - ref.data).max()
+    ref = AmplitudeEncoder(**kwargs).encode(img, implant=implant)
+    err = [np.abs(AmplitudeEncoder(n_levels=n, **kwargs).encode(
+               img, implant=implant).data - ref.data).max()
            for n in (4, 16, 256, 1 << 16)]
     # Each step of 4x in the level count is a step of ~4x in accuracy, and the
     # finest is close enough to be irrelevant next to a 50 uA range:
     npt.assert_equal(np.all(np.diff(err) < 0), True)
     npt.assert_array_less(err[-1], 1e-2)
     # Two levels is the coarsest allowed, and it is a black-or-white encoding:
-    two = AmplitudeEncoder(implant, n_levels=2, **kwargs).encode(img)
+    two = AmplitudeEncoder(n_levels=2, **kwargs).encode(img,
+                                                        implant=implant)
     npt.assert_array_equal(np.unique(np.abs(two.data).max(axis=1)), [0.0, 50.0])
 
 
@@ -959,8 +982,9 @@ def test_StimulusEncoder_frame_rate_does_not_move_the_pulses():
     for frame_dur in (100.0, 50.0, 25.0):
         with warnings.catch_warnings():
             warnings.simplefilter('ignore')
-            stim = AmplitudeEncoder(implant, amp_range=(50, 50), freq=20,
-                                    frame_dur=frame_dur).encode(vid)
+            stim = AmplitudeEncoder(amp_range=(50, 50), freq=20,
+                                    frame_dur=frame_dur).encode(
+                                        vid, implant=implant)
         npt.assert_almost_equal(stim.time[-1], 4 * frame_dur)
         neg = stim.data[0] < 0
         onsets.append(stim.time[neg & ~np.concatenate(([False], neg[:-1]))])
@@ -1046,8 +1070,8 @@ def test_encoder_source_must_be_dimensionless():
     npt.assert_equal(sampled.unit, dimensionless)
     npt.assert_equal(enc.encode(sampled).unit, uA)
     # ... and the implant path inside the encoder gives the same answer:
-    npt.assert_equal(AmplitudeEncoder(implant,
-                                      amp_range=(0, 50)).encode(img).unit, uA)
+    npt.assert_equal(AmplitudeEncoder(amp_range=(0, 50)).encode(
+        img, implant=implant).unit, uA)
     # An electrical stimulus, no: `Stimulus([0.5])` is half a microamp, and
     # reading it as a gray level would clip and re-modulate it silently.
     with pytest.raises(DimensionMismatchError) as excinfo:

--- a/pulse2percept/stimuli/tests/test_videos.py
+++ b/pulse2percept/stimuli/tests/test_videos.py
@@ -1,9 +1,11 @@
 from pulse2percept.stimuli import (AmplitudeEncoder, VideoStimulus,
                                    BostonTrain, GirlPool)
+from pulse2percept.units import DimensionMismatchError, Hz, kHz, ms, uA
 from skimage.color import rgb2gray
 from skimage.io import imsave
 from skimage.transform import resize as vid_resize
 from matplotlib.animation import FuncAnimation
+import re
 import numpy as np
 import numpy.testing as npt
 import pytest
@@ -438,6 +440,26 @@ def test_VideoStimulus_play(n_frames):
     # Color videos are played back in color:
     rgb = VideoStimulus(np.random.rand(2, 4, 3, n_frames))
     npt.assert_equal('p2p-anim' in rgb.play().to_jshtml(), True)
+
+
+def test_VideoStimulus_play_fps_units():
+    """A frame rate is a frequency, however it is spelled
+
+    .. versionadded:: 0.10.0
+    """
+    video = VideoStimulus(np.random.rand(2, 4, 5))
+
+    def interval(fps):
+        """The frame delay (ms) the HTML player was configured with"""
+        html = video.play(fps=fps).to_jshtml()
+        return float(re.search(r'"interval": ([0-9.]+)', html).group(1))
+
+    npt.assert_almost_equal(interval(30), 1000 / 30, decimal=6)
+    for spelling in (30 * Hz, 0.03 * kHz):
+        npt.assert_almost_equal(interval(spelling), interval(30), decimal=12)
+    for wrong in (30 * ms, 30 * uA):
+        with pytest.raises(DimensionMismatchError):
+            video.play(fps=wrong)
 
 
 def test_VideoStimulus_play_compressed():

--- a/pulse2percept/stimuli/videos.py
+++ b/pulse2percept/stimuli/videos.py
@@ -722,7 +722,9 @@ class VideoStimulus(Stimulus):
         ----------
         fps : float or None
             If None, uses the video's time axis. Not supported for
-            non-homogeneous time axis.
+            non-homogeneous time axis. May be given as a plain number of hertz
+            or as a unitful frequency (e.g. ``30 * Hz``, ``0.03 * kHz``); see
+            :py:mod:`pulse2percept.units`.
         repeat : bool, optional
             Whether the animation should repeat when the sequence of frames is
             completed.

--- a/pulse2percept/stimuli/videos.py
+++ b/pulse2percept/stimuli/videos.py
@@ -691,8 +691,8 @@ class VideoStimulus(Stimulus):
         """
         # Imported here because `encoders` imports this module:
         from .encoders import AmplitudeEncoder
-        return AmplitudeEncoder(implant=implant, amp_range=amp_range,
-                                freq=freq, **kwargs).encode(self)
+        return AmplitudeEncoder(amp_range=amp_range, freq=freq,
+                                **kwargs).encode(self, implant=implant)
 
     def __iter__(self):
         """Iterate over all frames in self.data"""

--- a/pulse2percept/topography/__init__.py
+++ b/pulse2percept/topography/__init__.py
@@ -20,7 +20,7 @@ __all__ = [
     'CorticalMap',
     'Curcio1990Map',
     'Grid2D',
-    'RetinalMap'
+    'RetinalMap',
     'VisualFieldMap',
     'Watson2014DisplaceMap',
     'Watson2014Map',

--- a/pulse2percept/units/base.py
+++ b/pulse2percept/units/base.py
@@ -27,12 +27,18 @@ _BASE_LABELS = {
     'visual_angle': 'visual angle',
 }
 
-# Names for the handful of derived dimensions that have one:
+# Names for the handful of derived dimensions that have one. A dimension earns
+# an entry here when p2p actually talks about it -- these names are what error
+# messages say, and "expected charge density, got time * electric current /
+# length^2" is the difference between a diagnostic and a puzzle. Power and
+# energy are deliberately absent: the algebra derives them from voltage and
+# current already, but no p2p API takes them yet.
 _DERIVED_LABELS = {
     (0, 0, 0, 0, 0): 'dimensionless',
     (-1, 0, 0, 0, 0): 'frequency',
     (1, 0, 1, 0, 0): 'charge',
     (0, -2, 1, 0, 0): 'current density',
+    (1, -2, 1, 0, 0): 'charge density',
 }
 
 
@@ -255,6 +261,11 @@ class Dimension(object):
 #: The dimension of a plain number
 DIMENSIONLESS = Dimension()
 
+#: Canonical display symbols, keyed by the ``(dimension, scale)`` pair that
+#: :py:meth:`Unit.__eq__` compares. Filled in at the bottom of this module,
+#: once the predefined units exist.
+_CANONICAL_SYMBOLS = {}
+
 
 def _symbol_mul(a, b):
     """Compose the symbol of a product of two units"""
@@ -288,6 +299,12 @@ class Unit(object):
     exponentiating units produces another unit, so derived units such as
     ``uA / mm ** 2`` need not be predefined.
 
+    A composed unit that is exactly a predefined one is displayed as that unit,
+    since ``uA * ms`` and ``nC`` are the same unit rather than convertible
+    ones. This is a spelling choice applied at display time; it never rescales
+    a magnitude, so a composed unit that is *not* exactly a predefined one
+    keeps its composed symbol. Use :py:meth:`Quantity.to` to change scale.
+
     Units are immutable. p2p does not maintain a unit registry, parse unit
     strings, or generate SI prefixes automatically: the vocabulary exported by
     :py:mod:`pulse2percept.units` is the whole of it.
@@ -312,6 +329,10 @@ class Unit(object):
     uA/mm^2
     >>> 50 * uA
     50 uA
+    >>> uA * ms
+    nC
+    >>> uA * ms / mm ** 2
+    uA*ms/mm^2
 
     """
     __slots__ = ('_dimension', '_scale', '_symbol')
@@ -352,8 +373,27 @@ class Unit(object):
 
     @property
     def symbol(self):
-        """Short symbol used for display"""
+        """Short symbol this unit was built with, e.g. ``'uA*ms'``"""
         return self._symbol
+
+    @property
+    def _display_symbol(self):
+        """The symbol to print, preferring a predefined unit's spelling
+
+        A composed unit that lands *exactly* on a predefined one is printed as
+        that unit: ``uA * ms`` prints as ``nC`` because the two are the same
+        unit, not merely convertible ones. `_snap_scale` has already made their
+        scales the same float, so this is a dict hit on the pair that
+        :py:meth:`__eq__` and :py:meth:`__hash__` already agree on.
+
+        It is a spelling choice and nothing more. It never touches a magnitude
+        and never picks a different scale, so ``uA * ms / um ** 2`` keeps its
+        composed symbol: no predefined unit is that size, and printing it as
+        ``uC/mm^2`` would mean silently rescaling 0.00225 to 2.25. Choosing a
+        different scale is what :py:meth:`Quantity.to` is for.
+        """
+        return _CANONICAL_SYMBOLS.get((self._dimension, self._scale),
+                                      self._symbol)
 
     def __mul__(self, other):
         if isinstance(other, Unit):
@@ -426,10 +466,10 @@ class Unit(object):
             object.__setattr__(self, key, value)
 
     def __str__(self):
-        return self.symbol
+        return self._display_symbol
 
     def __repr__(self):
-        return self.symbol if self.symbol else 'dimensionless'
+        return self._display_symbol if self._display_symbol else 'dimensionless'
 
 
 class Quantity(object):
@@ -567,12 +607,20 @@ class Quantity(object):
                 f"Cannot {verb} {self.unit.dimension.name} ({self.unit}) and "
                 f"{other.unit.dimension.name} ({other.unit}).")
 
+    # A bare number combined with a dimensionless quantity is a quantity in the
+    # canonical `dimensionless` unit -- not "the magnitude in whatever compound
+    # dimensionless unit this one happens to carry". The distinction is invisible
+    # for `dimensionless` itself (scale 1) and decisive for anything composed:
+    # a duty cycle of ``0.45 * ms * 50 * Hz`` is 0.0225, though its ms*Hz
+    # magnitude reads 22.5. So these branches rescale before they touch a
+    # number, and hand back a result in `dimensionless`.
     def __add__(self, other):
         if isinstance(other, Unit):
             other = Quantity(1, other)
         if not isinstance(other, Quantity):
             if self.dimension.is_dimensionless:
-                return Quantity(self.magnitude + other, self.unit)
+                return Quantity(self.to_value(dimensionless) + other,
+                                dimensionless)
             return NotImplemented
         self._check_compatible(other, 'add')
         return Quantity(self.magnitude + other.to_value(self.unit), self.unit)
@@ -585,7 +633,8 @@ class Quantity(object):
             other = Quantity(1, other)
         if not isinstance(other, Quantity):
             if self.dimension.is_dimensionless:
-                return Quantity(self.magnitude - other, self.unit)
+                return Quantity(self.to_value(dimensionless) - other,
+                                dimensionless)
             return NotImplemented
         self._check_compatible(other, 'subtract')
         return Quantity(self.magnitude - other.to_value(self.unit), self.unit)
@@ -636,7 +685,7 @@ class Quantity(object):
             other = Quantity(1, other)
         if not isinstance(other, Quantity):
             if self.dimension.is_dimensionless:
-                return op(self.magnitude, other)
+                return op(self.to_value(dimensionless), other)
             raise DimensionMismatchError(
                 f"Cannot {verb} {self.unit.dimension.name} ({self.unit}) and "
                 f"a plain number. Multiply the number by a unit first.")
@@ -663,7 +712,7 @@ class Quantity(object):
             other = Quantity(1, other)
         if not isinstance(other, Quantity):
             if self.dimension.is_dimensionless:
-                return _isclose(self.magnitude, other)
+                return _isclose(self.to_value(dimensionless), other)
             # Equality must not raise: a quantity simply is not equal to a
             # bare number of a different dimension.
             return NotImplemented
@@ -697,9 +746,10 @@ class Quantity(object):
             object.__setattr__(self, key, value)
 
     def __str__(self):
-        if not self.unit.symbol:
+        symbol = self.unit._display_symbol
+        if not symbol:
             return f'{self.magnitude}'
-        return f'{self.magnitude} {self.unit.symbol}'
+        return f'{self.magnitude} {symbol}'
 
     def __repr__(self):
         return self.__str__()
@@ -845,3 +895,31 @@ nC = Unit(CHARGE, 1e-9, 'nC')
 #: Degree of visual angle. Not an ordinary angle: converting dva to a distance
 #: on the retina or cortex requires a visual field map, not a scale factor.
 dva = Unit(VISUAL_ANGLE, 1, 'dva')
+
+
+# The canonical spelling of each predefined unit, for `Unit._display_symbol`.
+# Written out here rather than harvested from this module's namespace: should
+# two units ever share a (dimension, scale) -- an alias such as ``sec`` for
+# ``s`` -- the one listed here is the one that wins, and that ought to be a
+# decision rather than an accident of declaration order. An alias simply does
+# not go in this tuple; listing both is a mistake, so it raises rather than
+# letting declaration order pick a winner.
+_CANONICAL_UNITS = (dimensionless,
+                    s, ms, us, ns,
+                    Hz, kHz,
+                    m, cm, mm, um, nm,
+                    A, mA, uA, nA,
+                    V, mV, uV,
+                    C, mC, uC, nC,
+                    dva)
+
+for _unit in _CANONICAL_UNITS:
+    _key = (_unit.dimension, _unit.scale)
+    if _key in _CANONICAL_SYMBOLS:
+        raise RuntimeError(
+            f"Two canonical units claim {_unit.dimension.name} at scale "
+            f"{_unit.scale:g}: '{_CANONICAL_SYMBOLS[_key]}' and "
+            f"'{_unit.symbol}'. Only one spelling can be canonical: drop the "
+            f"alias from _CANONICAL_UNITS.")
+    _CANONICAL_SYMBOLS[_key] = _unit.symbol
+del _unit, _key

--- a/pulse2percept/units/tests/test_integration.py
+++ b/pulse2percept/units/tests/test_integration.py
@@ -17,13 +17,16 @@ from pulse2percept.implants import (ArgusII, DiskElectrode, ElectrodeGrid,
 from pulse2percept.implants.cortex import Cortivis
 from pulse2percept.models import (AxonMapSpatial, FadingTemporal, Model,
                                   ScoreboardSpatial)
+from pulse2percept.models.cortex import (ScoreboardSpatial as
+                                         CortexScoreboardSpatial)
 from pulse2percept.percepts import Percept
 from pulse2percept.stimuli import (AmplitudeEncoder, BiphasicPulse,
                                    BiphasicPulseTrain, ImageStimulus,
                                    Stimulus)
 from pulse2percept.topography import Grid2D, Polimeni2006Map, Watson2014Map
 from pulse2percept.units import (DimensionMismatchError, Quantity, Unit, cm,
-                                 dva, mA, mm, ms, nA, s, uA, um, us)
+                                 dimensionless, dva, mA, mm, ms, nA, s, uA, um,
+                                 us)
 
 # The same physical quantity, spelled every awkward way the unit system
 # allows. Each row is (bare, [equivalent unitful spellings]).
@@ -218,9 +221,19 @@ def test_the_whole_rejection_matrix():
     current = Stimulus({'A1': BiphasicPulseTrain(20, 50, 0.45, stim_dur=100)})
     model = ScoreboardSpatial(xrange=(-2, 2), yrange=(-2, 2), step=1).build()
 
-    # dimensionless -> model: gray levels are not small currents.
+    # dimensionless -> implant: an implant delivers current, so a picture is
+    # refused where it is assigned rather than where it is eventually read.
     with pytest.raises(DimensionMismatchError):
-        model.predict_percept(ArgusII(preprocess=False, stim=img))
+        ArgusII(preprocess=False, stim=img)
+
+    # dimensionless -> model: gray levels are not small currents. The implant
+    # above is the outer boundary; this is the one behind it, so it is reached
+    # through an implant that claims to deliver something else.
+    class Projector(ArgusII):
+        stimulus_unit = dimensionless
+
+    with pytest.raises(DimensionMismatchError):
+        model.predict_percept(Projector(preprocess=False, stim=img))
 
     # current -> encoder: an encoder is what *makes* current out of pictures.
     with pytest.raises(DimensionMismatchError):
@@ -238,9 +251,14 @@ def test_the_whole_rejection_matrix():
     with pytest.raises(DimensionMismatchError):
         Grid2D((-2 * mm, 2 * mm), (-2, 2))
     with pytest.raises(DimensionMismatchError):
-        ScoreboardSpatial(xrange=(-2 * mm, 2 * mm))
-    with pytest.raises(DimensionMismatchError):
         Watson2014Map().dva_to_ret(575 * um, 575 * um)
+    # A retinal model does resolve a physical `xrange` through its own map
+    # (see `SpatialModel._retinal_range_to_dva`), but that is shorthand for a
+    # visual field extent, not a conversion, and it is offered nowhere else:
+    with pytest.raises(DimensionMismatchError):
+        ScoreboardSpatial(step=100 * um)
+    with pytest.raises(DimensionMismatchError):
+        CortexScoreboardSpatial(xrange=(-2 * mm, 2 * mm))
 
     # current -> time, and time -> current.
     with pytest.raises(DimensionMismatchError):

--- a/pulse2percept/units/tests/test_integration.py
+++ b/pulse2percept/units/tests/test_integration.py
@@ -128,8 +128,9 @@ def test_every_spelling_builds_the_same_object():
           'Stimulus', rtol=1e-6)
     _same(lambda a: ProsthesisSystem(ArgusII().earray, max_current=a),
           amp, amps, lambda p: p.max_current, 'ProsthesisSystem.max_current')
-    _same(lambda a: AmplitudeEncoder(ArgusII(), amp_range=(0, a), freq=20)
-          .encode(ImageStimulus(np.linspace(0, 1, 36).reshape((6, 6)))),
+    _same(lambda a: AmplitudeEncoder(amp_range=(0, a), freq=20).encode(
+              ImageStimulus(np.linspace(0, 1, 36).reshape((6, 6))),
+              implant=ArgusII()),
           amp, amps, lambda s: s.data, 'AmplitudeEncoder.amp_range',
           rtol=1e-6)
 
@@ -223,8 +224,10 @@ def test_the_whole_rejection_matrix():
 
     # dimensionless -> implant: an implant delivers current, so a picture is
     # refused where it is assigned rather than where it is eventually read.
+    # (Argus II ships with an encoder, which would otherwise turn the picture
+    # into the current the implant does deliver.)
     with pytest.raises(DimensionMismatchError):
-        ArgusII(preprocess=False, stim=img)
+        ArgusII(preprocess=False, encoder=None, stim=img)
 
     # dimensionless -> model: gray levels are not small currents. The implant
     # above is the outer boundary; this is the one behind it, so it is reached
@@ -237,7 +240,7 @@ def test_the_whole_rejection_matrix():
 
     # current -> encoder: an encoder is what *makes* current out of pictures.
     with pytest.raises(DimensionMismatchError):
-        AmplitudeEncoder(ArgusII(), amp_range=(0, 50)).encode(current)
+        AmplitudeEncoder(amp_range=(0, 50)).encode(current, implant=ArgusII())
 
     # visual angle -> physical coordinate: retinotopy is a map, not a factor.
     with pytest.raises(DimensionMismatchError):

--- a/pulse2percept/units/tests/test_units.py
+++ b/pulse2percept/units/tests/test_units.py
@@ -10,7 +10,8 @@ from pulse2percept.units import (Dimension, Unit, Quantity,
                                  dimensionless,
                                  s, ms, us, ns, Hz, kHz, m, cm, mm, um, nm,
                                  A, mA, uA, nA, V, mV, uV, C, mC, uC, nC, dva)
-from pulse2percept.units.base import TIME
+from pulse2percept.units.base import (TIME, _CANONICAL_SYMBOLS,
+                                      _CANONICAL_UNITS)
 
 
 def test_Dimension():
@@ -35,6 +36,8 @@ def test_Dimension():
     npt.assert_equal(Dimension(time=-1).name, 'frequency')
     npt.assert_equal(Dimension(current=1, time=1).name, 'charge')
     npt.assert_equal(Dimension(current=1, length=-2).name, 'current density')
+    npt.assert_equal(Dimension(current=1, time=1, length=-2).name,
+                     'charge density')
     npt.assert_equal(Dimension().name, 'dimensionless')
     npt.assert_equal(Dimension(voltage=1, time=2).name, 'time^2 * voltage')
     # Immutable:
@@ -54,7 +57,7 @@ def test_Unit():
     npt.assert_equal(ms.scale, 1e-3)
     npt.assert_equal(ms.symbol, 'ms')
     npt.assert_equal(str(uA / mm ** 2), 'uA/mm^2')
-    npt.assert_equal(str(uA * ms), 'uA*ms')
+    npt.assert_equal(str(uA * ms), 'nC')  # exactly nC; see test_canonical_display
     npt.assert_equal(str(mm ** 2), 'mm^2')
     npt.assert_equal(str(ms / (uA * ms)), 'ms/(uA*ms)')
     # Unit algebra produces units, not quantities:
@@ -86,6 +89,48 @@ def test_Unit():
     for bad_scale in (0, -1, np.nan, np.inf, -np.inf):
         with pytest.raises(ValueError):
             Unit(TIME, bad_scale, 'bad')
+
+
+def test_canonical_display():
+    # A composed unit that is EXACTLY a predefined one is spelled that way,
+    # because it is that unit and not merely convertible to it:
+    npt.assert_equal(str(uA * ms), 'nC')
+    npt.assert_equal(repr(uA * ms), 'nC')
+    npt.assert_equal(str(200 * uA * 0.45 * ms), '90.0 nC')
+    npt.assert_equal(repr(1 / ms), '1 kHz')
+    npt.assert_equal(str(mA * s), 'mC')
+    npt.assert_equal(str(s ** -1), 'Hz')
+    npt.assert_equal(str(1 * ms / ms), '1')  # dimensionless has no symbol
+    # ... and the magnitude is never touched, so a composed unit that is not
+    # exactly a predefined one keeps its composed spelling rather than being
+    # rescaled into one. `.to()` is the only thing that changes scale.
+    # Canonicalization happens at display time, so the pieces a compound symbol
+    # is built from are the ones it was composed from, not their canonical
+    # spellings: uA*ms/um^2, not nC/um^2.
+    charge_density = (200 * uA * 0.45 * ms) / (200 * um) ** 2
+    npt.assert_equal(str(charge_density), '0.00225 uA*ms/um^2')
+    npt.assert_equal(str(charge_density.to(uC / mm ** 2)), '2.25 uC/mm^2')
+    npt.assert_equal(str(uA / mm ** 2), 'uA/mm^2')
+    npt.assert_equal(str(uA * ms / mm ** 2), 'uA*ms/mm^2')
+    # The lookup is on the same (dimension, scale) pair that __eq__ compares,
+    # so display agrees with equality:
+    for composed, predefined in [(uA * ms, nC), (s ** -1, Hz), (mA * s, mC),
+                                 (ms ** -1, kHz), (A / A, dimensionless)]:
+        npt.assert_equal(composed == predefined, True)
+        npt.assert_equal(str(composed), str(predefined))
+    # `symbol` still reports how the unit was built; only display is canonical:
+    npt.assert_equal((uA * ms).symbol, 'uA*ms')
+    # An alias is not canonical unless it is listed as such:
+    npt.assert_equal(str(Unit(TIME, 1e-3, 'msec')), 'ms')
+
+
+def test_canonical_units_are_unambiguous():
+    # Each canonical unit claims a distinct (dimension, scale), so no predefined
+    # unit's spelling is decided by declaration order:
+    npt.assert_equal(len(_CANONICAL_SYMBOLS), len(_CANONICAL_UNITS))
+    for unit in _CANONICAL_UNITS:
+        npt.assert_equal(_CANONICAL_SYMBOLS[(unit.dimension, unit.scale)],
+                         unit.symbol)
 
 
 def test_snap_scale():
@@ -238,6 +283,44 @@ def test_Quantity_comparison():
         (5 * uA) < (2 * ms)
     with pytest.raises(DimensionMismatchError):
         (5 * uA) < 2
+
+
+def test_dimensionless_compound_units():
+    # A bare number combined with a dimensionless quantity means a quantity in
+    # the canonical `dimensionless` unit -- NOT the magnitude in whatever
+    # compound dimensionless unit the quantity happens to carry. The two differ
+    # for every compound whose scale is not 1, which is most of them, and
+    # `5 * dimensionless` is exactly the case that hides the difference.
+    duty = 0.45 * ms * 50 * Hz  # a duty cycle: 0.0225, spelled 22.5 ms*Hz
+    npt.assert_equal(duty.magnitude, 22.5)
+    npt.assert_equal(duty.to_value(dimensionless), 0.0225)
+    npt.assert_equal(duty == 0.0225, True)
+    npt.assert_equal(duty == 22.5, False)
+    npt.assert_equal(duty < 0.05, True)
+    npt.assert_equal(duty > 1.0, False)
+    npt.assert_equal(duty <= 0.0225, True)
+    npt.assert_equal(duty >= 0.0225, True)
+    npt.assert_equal(duty != 0.0225, False)
+    npt.assert_equal(duty + 1 == 1.0225, True)
+    npt.assert_equal(1 + duty == 1.0225, True)
+    npt.assert_equal(duty - 1 == -0.9775, True)
+    npt.assert_equal(1 - duty == 0.9775, True)  # __rsub__ takes its own path
+    ratio = (1 * s) / ms
+    npt.assert_equal(ratio.magnitude, 1)
+    npt.assert_equal(ratio == 1000, True)
+    npt.assert_equal(ratio > 999, True)
+    npt.assert_equal(ratio < 1001, True)
+    npt.assert_equal(ratio + 1 == 1001, True)
+    npt.assert_equal(1 + ratio == 1001, True)
+    npt.assert_equal(ratio - 1 == 999, True)
+    npt.assert_equal(1 - ratio == -999, True)
+    # The result of mixing in a bare number is in `dimensionless`, so it does
+    # not silently inherit a compound spelling:
+    npt.assert_equal((duty + 1).unit, dimensionless)
+    npt.assert_equal((1 - duty).unit, dimensionless)
+    # Quantity-to-quantity comparison already converted, and still does:
+    npt.assert_equal(duty == 0.0225 * dimensionless, True)
+    npt.assert_equal(ratio == 1000 * dimensionless, True)
 
 
 def test_Quantity_arrays():

--- a/pulse2percept/utils/__init__.py
+++ b/pulse2percept/utils/__init__.py
@@ -26,8 +26,8 @@ from .convolution import center_vector, conv
 from .optimize import bisect
 from .stats import r2_score, circ_r2_score
 from .deprecation import (deprecated, deprecate_parameter, deprecated_alias,
-                          rename_parameter, warn_deprecated_params,
-                          rename_deprecated_params)
+                          deprecated_names, rename_parameter,
+                          warn_deprecated_params, rename_deprecated_params)
 from .three_dim import parse_3d_orient
 
 __all__ = [
@@ -44,6 +44,7 @@ __all__ = [
     'deprecate_parameter',
     'deprecated',
     'deprecated_alias',
+    'deprecated_names',
     'frame_interval',
     'FreezeError',
     'Frozen',

--- a/pulse2percept/utils/__init__.py
+++ b/pulse2percept/utils/__init__.py
@@ -26,8 +26,8 @@ from .convolution import center_vector, conv
 from .optimize import bisect
 from .stats import r2_score, circ_r2_score
 from .deprecation import (deprecated, deprecate_parameter, deprecated_alias,
-                          deprecated_names, rename_parameter,
-                          warn_deprecated_params, rename_deprecated_params)
+                          rename_parameter, warn_deprecated_params,
+                          rename_deprecated_params)
 from .three_dim import parse_3d_orient
 
 __all__ = [
@@ -44,7 +44,6 @@ __all__ = [
     'deprecate_parameter',
     'deprecated',
     'deprecated_alias',
-    'deprecated_names',
     'frame_interval',
     'FreezeError',
     'Frozen',

--- a/pulse2percept/utils/animation.py
+++ b/pulse2percept/utils/animation.py
@@ -21,6 +21,8 @@ from matplotlib.animation import FuncAnimation
 from matplotlib.colors import to_hex, to_rgba
 from PIL import Image
 
+from ..units import Hz, as_value
+
 __all__ = ['HTMLAnimation', 'frame_interval']
 
 # Frames are packed into a single sprite sheet. Browsers put a cap on the size
@@ -80,6 +82,9 @@ def frame_interval(time, fps=None, tol=1e-2):
     fps : float or None
         Frames per second. If None, the interval is inferred from ``time``,
         which is not supported for a non-homogeneous time axis.
+
+        May be given as a plain number of hertz or as a unitful frequency
+        (e.g. ``0.03 * kHz``); see :py:mod:`pulse2percept.units`.
     tol : float, optional
         Tolerance within which two time steps count as equal
 
@@ -90,6 +95,11 @@ def frame_interval(time, fps=None, tol=1e-2):
         time step of its own and falls back on ``SINGLE_FRAME_INTERVAL``.
 
     """
+    # Every ``play`` in p2p ends up here for its frame timing, so this is the
+    # one place a frame rate has to be turned into a plain number of hertz. A
+    # rate is a frequency, so `30 * Hz` and `0.03 * kHz` are the same argument
+    # as `30`, and `30 * ms` is not an argument at all:
+    fps = as_value(fps, Hz, 'fps')
     if fps is not None:
         return 1000.0 / fps
     interval = np.diff(np.asarray(time, dtype=np.float64))
@@ -618,13 +628,18 @@ class HTMLAnimation(FuncAnimation):
         Parameters
         ----------
         fps : float or None
-            Frames per second. If None, uses the animation's interval.
+            Frames per second. If None, uses the animation's interval. May be
+            given as a unitful frequency (e.g. ``30 * Hz``); see
+            :py:mod:`pulse2percept.units`.
         embed_frames : bool
             Unused; frames are always embedded.
         default_mode : {'loop', 'once', 'reflect'} or None
             What the animation should do once it has played through. If None,
             uses 'loop' or 'once', depending on ``repeat``.
         """
+        # Before the fallback below: Matplotlib takes a plain number of hertz,
+        # so a quantity has to be converted whichever player renders it.
+        fps = as_value(fps, Hz, 'fps')
         if self._image is None or self._frame_data is None:
             # Nothing to accelerate, fall back on Matplotlib:
             return super().to_jshtml(fps=fps, embed_frames=embed_frames,

--- a/pulse2percept/utils/base.py
+++ b/pulse2percept/utils/base.py
@@ -150,7 +150,8 @@ def freeze_class(set, normalize=None):
     normalize : callable, optional
         ``normalize(self, name, value)``, called before the assignment when
         ``value`` carries a physical unit, and returning the value to store.
-        See ``_normalize_param``.
+        See ``_normalize_param``, which dispatches to the object's own
+        ``_normalize_param_value``.
 
         This is a parameter rather than a wrapper around ``set_attr`` on
         purpose: both this function and
@@ -201,25 +202,14 @@ class Frozen(object):
 
 
 def _normalize_param(obj, name, value):
-    """Convert a unitful value into the unit its parameter is stored in
+    """Hand a unitful value to the object's own normalization hook
 
-    Model equations operate on ordinary numbers, so a
-    :py:class:`~pulse2percept.units.Quantity` must never survive into a
-    parameter. Which unit a parameter is stored in is declared by
-    ``get_param_units``; a parameter that declares none takes a plain number,
-    and saying so is more useful than storing an object the equations cannot
-    use.
-
-    Attributes that are not user-settable parameters at all are left alone: it
-    is the parameter contract this enforces, not a rule about what a
-    ``Parametrized`` object may hold.
+    Kept as a module-level function because ``freeze_class`` takes the
+    normalizer as an argument rather than looking it up on the class; see
+    :py:meth:`~pulse2percept.utils.Parametrized._normalize_param_value` for
+    what actually happens to the value, and for how a subclass extends it.
     """
-    units = obj.get_param_units()
-    if name in units:
-        return as_value(value, units[name], name=name)
-    if name in obj.get_default_params():
-        return as_value(value, dimensionless, name=name)
-    return value
+    return obj._normalize_param_value(name, value)
 
 
 class Parametrized(Frozen, PrettyPrint, metaclass=abc.ABCMeta):
@@ -286,6 +276,61 @@ class Parametrized(Frozen, PrettyPrint, metaclass=abc.ABCMeta):
     def get_default_params(self):
         """Return a dict of user-settable parameters"""
         raise NotImplementedError
+
+    def _normalize_param_value(self, name, value):
+        """Convert a unitful value into the unit its parameter is stored in
+
+        Called on the way into every attribute assignment whose value carries
+        a physical unit -- from the constructor, ``set_params``, ``build``, a
+        direct assignment, or a composite
+        :py:class:`~pulse2percept.models.Model` forwarding one to its
+        sub-models -- and returns the value to store.
+
+        Model equations operate on ordinary numbers, so a
+        :py:class:`~pulse2percept.units.Quantity` must never survive into a
+        parameter. Which unit a parameter is stored in is declared by
+        ``get_param_units``; a parameter that declares none takes a plain
+        number, and saying so is more useful than storing an object the
+        equations cannot use.
+
+        Attributes that are not user-settable parameters at all are left
+        alone: it is the parameter contract this enforces, not a rule about
+        what a ``Parametrized`` object may hold.
+
+        This is the extension point for a parameter whose unit is not the
+        whole story. ``SpatialModel`` overrides it so that a retinal *length*
+        assigned to ``xrange``/``yrange`` is resolved through the model's
+        visual field map into the degrees of visual angle the parameter is
+        actually stored in -- a conversion that needs the object, not just the
+        unit, and so cannot live in ``get_param_units``. An override handles
+        the names it knows about and defers the rest::
+
+            def _normalize_param_value(self, name, value):
+                if name == 'mine' and ...:
+                    return ...
+                return super()._normalize_param_value(name, value)
+
+        .. versionadded:: 0.10.0
+
+        Parameters
+        ----------
+        name : str
+            Name of the attribute being assigned.
+        value : Quantity, Unit, or sequence of them
+            The value being assigned. Only unitful values reach this method.
+
+        Returns
+        -------
+        value : float, np.ndarray, or tuple
+            The plain numerical value to store.
+
+        """
+        units = self.get_param_units()
+        if name in units:
+            return as_value(value, units[name], name=name)
+        if name in self.get_default_params():
+            return as_value(value, dimensionless, name=name)
+        return value
 
     def get_param_units(self):
         """Return a dict of the units that parameters are stored in

--- a/pulse2percept/utils/deprecation.py
+++ b/pulse2percept/utils/deprecation.py
@@ -1,7 +1,6 @@
 """:py:class:`~pulse2percept.utils.deprecated`,
    :py:class:`~pulse2percept.utils.deprecate_parameter`,
    :py:class:`~pulse2percept.utils.deprecated_alias`,
-   :py:class:`~pulse2percept.utils.deprecated_names`,
    :py:class:`~pulse2percept.utils.rename_parameter`,
    :py:class:`~pulse2percept.utils.is_deprecated`"""
 
@@ -78,81 +77,6 @@ def _warn_external(message, category=DeprecationWarning):
         frame = frame.f_back
         stacklevel += 1
     warnings.warn(message, category=category, stacklevel=stacklevel)
-
-
-def deprecated_names(namespace, aliases, deprecated_version=None,
-                     removed_version=None):
-    """Build a module-level ``__getattr__`` that serves renamed objects
-
-    Use this to keep the *old* name of a public class or function importable
-    after it has been renamed. Assign the result to ``__getattr__`` in the
-    module that owns the object (and in any package that re-exports it)::
-
-        class StimulusEncoder:
-            ...
-
-        __getattr__ = deprecated_names(globals(),
-                                       {'Encoder': 'StimulusEncoder'},
-                                       deprecated_version='0.10.0',
-                                       removed_version='0.11.0')
-
-    Reading ``module.Encoder``, or importing it, then raises a
-    ``DeprecationWarning`` and hands back
-    :py:class:`~pulse2percept.stimuli.StimulusEncoder` **itself** rather than a
-    subclass of it (see PEP 562). That distinction is the reason to prefer this
-    over ``class Encoder(StimulusEncoder)``: the two names stay the same
-    object, so ``issubclass(AmplitudeEncoder, Encoder)``, ``isinstance`` and
-    ``type(obj) is Encoder`` all keep answering what they answered before the
-    rename.
-
-    A module-level ``__getattr__`` is only consulted for names that are *not*
-    in the module's namespace, so the deprecated name must not also be
-    imported or defined there. It may still be listed in ``__all__``, which is
-    what keeps ``from module import *`` working (with a warning) during the
-    deprecation window.
-
-    .. versionadded:: 0.10.0
-
-    .. note::
-
-        Renaming a *parameter* is a different job; see
-        :py:class:`~pulse2percept.utils.rename_parameter` and
-        :py:class:`~pulse2percept.utils.deprecated_alias`.
-
-    Parameters
-    ----------
-    namespace : dict
-        The module's own ``globals()``, which is where the new names are
-        looked up when a deprecated one is read.
-    aliases : dict
-        Maps each deprecated name to the name that replaces it.
-    deprecated_version : float or str
-        The package version in which the old name was first marked as
-        deprecated.
-    removed_version : float or str
-        The package version in which the old name will stop working.
-
-    Returns
-    -------
-    __getattr__ : callable
-        The module-level attribute hook to assign to ``__getattr__``.
-
-    """
-    clause = _version_clause(deprecated_version, removed_version)
-
-    def __getattr__(name):
-        new_name = aliases.get(name)
-        if new_name is None:
-            # Not ours: answer the way an ordinary module would, so that a
-            # typo still reads as a typo:
-            raise AttributeError(f"module "
-                                 f"{namespace.get('__name__')!r} has no "
-                                 f"attribute {name!r}")
-        _warn_external(f"{name} is deprecated{clause}. Use {new_name} "
-                       f"instead.")
-        return namespace[new_name]
-
-    return __getattr__
 
 
 class deprecated:

--- a/pulse2percept/utils/deprecation.py
+++ b/pulse2percept/utils/deprecation.py
@@ -1,6 +1,7 @@
 """:py:class:`~pulse2percept.utils.deprecated`,
    :py:class:`~pulse2percept.utils.deprecate_parameter`,
    :py:class:`~pulse2percept.utils.deprecated_alias`,
+   :py:class:`~pulse2percept.utils.deprecated_names`,
    :py:class:`~pulse2percept.utils.rename_parameter`,
    :py:class:`~pulse2percept.utils.is_deprecated`"""
 
@@ -77,6 +78,81 @@ def _warn_external(message, category=DeprecationWarning):
         frame = frame.f_back
         stacklevel += 1
     warnings.warn(message, category=category, stacklevel=stacklevel)
+
+
+def deprecated_names(namespace, aliases, deprecated_version=None,
+                     removed_version=None):
+    """Build a module-level ``__getattr__`` that serves renamed objects
+
+    Use this to keep the *old* name of a public class or function importable
+    after it has been renamed. Assign the result to ``__getattr__`` in the
+    module that owns the object (and in any package that re-exports it)::
+
+        class StimulusEncoder:
+            ...
+
+        __getattr__ = deprecated_names(globals(),
+                                       {'Encoder': 'StimulusEncoder'},
+                                       deprecated_version='0.10.0',
+                                       removed_version='0.11.0')
+
+    Reading ``module.Encoder``, or importing it, then raises a
+    ``DeprecationWarning`` and hands back
+    :py:class:`~pulse2percept.stimuli.StimulusEncoder` **itself** rather than a
+    subclass of it (see PEP 562). That distinction is the reason to prefer this
+    over ``class Encoder(StimulusEncoder)``: the two names stay the same
+    object, so ``issubclass(AmplitudeEncoder, Encoder)``, ``isinstance`` and
+    ``type(obj) is Encoder`` all keep answering what they answered before the
+    rename.
+
+    A module-level ``__getattr__`` is only consulted for names that are *not*
+    in the module's namespace, so the deprecated name must not also be
+    imported or defined there. It may still be listed in ``__all__``, which is
+    what keeps ``from module import *`` working (with a warning) during the
+    deprecation window.
+
+    .. versionadded:: 0.10.0
+
+    .. note::
+
+        Renaming a *parameter* is a different job; see
+        :py:class:`~pulse2percept.utils.rename_parameter` and
+        :py:class:`~pulse2percept.utils.deprecated_alias`.
+
+    Parameters
+    ----------
+    namespace : dict
+        The module's own ``globals()``, which is where the new names are
+        looked up when a deprecated one is read.
+    aliases : dict
+        Maps each deprecated name to the name that replaces it.
+    deprecated_version : float or str
+        The package version in which the old name was first marked as
+        deprecated.
+    removed_version : float or str
+        The package version in which the old name will stop working.
+
+    Returns
+    -------
+    __getattr__ : callable
+        The module-level attribute hook to assign to ``__getattr__``.
+
+    """
+    clause = _version_clause(deprecated_version, removed_version)
+
+    def __getattr__(name):
+        new_name = aliases.get(name)
+        if new_name is None:
+            # Not ours: answer the way an ordinary module would, so that a
+            # typo still reads as a typo:
+            raise AttributeError(f"module "
+                                 f"{namespace.get('__name__')!r} has no "
+                                 f"attribute {name!r}")
+        _warn_external(f"{name} is deprecated{clause}. Use {new_name} "
+                       f"instead.")
+        return namespace[new_name]
+
+    return __getattr__
 
 
 class deprecated:

--- a/pulse2percept/utils/tests/test_animation.py
+++ b/pulse2percept/utils/tests/test_animation.py
@@ -11,6 +11,7 @@ import matplotlib.pyplot as plt
 from matplotlib.animation import FuncAnimation
 from PIL import Image
 
+from pulse2percept.units import (DimensionMismatchError, Hz, dva, kHz, ms, uA)
 from pulse2percept.utils import HTMLAnimation, frame_interval
 from pulse2percept.utils.animation import (MAX_SPRITE_PX,
                                            SINGLE_FRAME_INTERVAL,
@@ -116,6 +117,18 @@ def test_frame_interval():
     npt.assert_almost_equal(frame_interval([0, 10, 20.005], tol=1), 10)
     with pytest.raises(NotImplementedError):
         frame_interval([0, 10, 20.005], tol=1e-6)
+
+
+def test_frame_interval_fps_units():
+    """A frame rate is a frequency, however it is spelled"""
+    bare = frame_interval([0, 10, 20], fps=25)
+    for spelling in (25 * Hz, 0.025 * kHz):
+        npt.assert_allclose(frame_interval([0, 10, 20], fps=spelling), bare,
+                            rtol=1e-12)
+    # ... and nothing else is a frame rate:
+    for wrong in (30 * ms, 30 * uA, 30 * dva):
+        with pytest.raises(DimensionMismatchError):
+            frame_interval([0, 10, 20], fps=wrong)
 
 
 @pytest.mark.parametrize('n_frames', (1, 2, 5, 17))

--- a/pulse2percept/utils/tests/test_deprecation.py
+++ b/pulse2percept/utils/tests/test_deprecation.py
@@ -3,6 +3,7 @@ import numpy.testing as npt
 import pytest
 from pulse2percept.utils.deprecation import (deprecated, deprecate_parameter,
                                              deprecated_alias,
+                                             deprecated_names,
                                              rename_parameter,
                                              rename_deprecated_params,
                                              is_deprecated)
@@ -341,3 +342,31 @@ def test_rename_deprecated_params_both_names():
         warnings.simplefilter("error", DeprecationWarning)
         with pytest.raises(TypeError):
             rename_deprecated_params('MyModel', {'old': 1, 'new': 2}, specs)
+
+
+class NewName:
+    """Stand-in for a class that used to be called something else"""
+
+
+#: What a module assigns to serve the old name (see `deprecated_names`):
+__getattr__ = deprecated_names(globals(), {'OldName': 'NewName'},
+                               deprecated_version='0.10.0',
+                               removed_version='0.11.0')
+
+
+def test_deprecated_names():
+    # The old name warns, and answers with the very same object -- not a
+    # subclass of it, which is what would quietly change `issubclass`:
+    assert_warns_msg(DeprecationWarning, __getattr__,
+                     "OldName is deprecated since version 0.10.0, and will be "
+                     "removed in version 0.11.0. Use NewName instead.",
+                     'OldName')
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        npt.assert_equal(__getattr__('OldName') is NewName, True)
+    # A name that was never deprecated is an ordinary AttributeError, so a
+    # typo still reads as a typo:
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", DeprecationWarning)
+        with pytest.raises(AttributeError):
+            __getattr__('NeverExisted')

--- a/pulse2percept/utils/tests/test_deprecation.py
+++ b/pulse2percept/utils/tests/test_deprecation.py
@@ -3,7 +3,6 @@ import numpy.testing as npt
 import pytest
 from pulse2percept.utils.deprecation import (deprecated, deprecate_parameter,
                                              deprecated_alias,
-                                             deprecated_names,
                                              rename_parameter,
                                              rename_deprecated_params,
                                              is_deprecated)
@@ -342,31 +341,3 @@ def test_rename_deprecated_params_both_names():
         warnings.simplefilter("error", DeprecationWarning)
         with pytest.raises(TypeError):
             rename_deprecated_params('MyModel', {'old': 1, 'new': 2}, specs)
-
-
-class NewName:
-    """Stand-in for a class that used to be called something else"""
-
-
-#: What a module assigns to serve the old name (see `deprecated_names`):
-__getattr__ = deprecated_names(globals(), {'OldName': 'NewName'},
-                               deprecated_version='0.10.0',
-                               removed_version='0.11.0')
-
-
-def test_deprecated_names():
-    # The old name warns, and answers with the very same object -- not a
-    # subclass of it, which is what would quietly change `issubclass`:
-    assert_warns_msg(DeprecationWarning, __getattr__,
-                     "OldName is deprecated since version 0.10.0, and will be "
-                     "removed in version 0.11.0. Use NewName instead.",
-                     'OldName')
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore", DeprecationWarning)
-        npt.assert_equal(__getattr__('OldName') is NewName, True)
-    # A name that was never deprecated is an ordinary AttributeError, so a
-    # typo still reads as a typo:
-    with warnings.catch_warnings():
-        warnings.simplefilter("error", DeprecationWarning)
-        with pytest.raises(AttributeError):
-            __getattr__('NeverExisted')


### PR DESCRIPTION
This PR cleans up the interaction between the recently added stim encoders/rasters, implants, and units API.

The main goal is to restore a simple high-level workflow while keeping the physical meaning of stimulation explicit:

```
implant = p2p.implants.ArgusII(stim=p2p.stimuli.LogoBVL())
percept = p2p.models.AxonMapModel().build().predict_percept(implant)
```

or as a one-liner:

```
p2p.models.AxonMapModel().build().predict_percept(p2p.implants.ArgusII(stim=p2p.stimuli.LogoBVL())).plot()
```

Real implants have an in-house encoding method and raster strategy (e.g., Argus II: 6 Hz amp modulation, 2 ms raster), and this is now captured using default `implant.encoder` and `implant.raster` attributes. They can of course be overwritten by the user.

In sum:
- [x] Add `implant.encoder` and `implant.raster`; make sure they're only applied to temporal models
- [x] Give Argus encoding/raster defaults
- [x] Refactor `StimulusEncoder` so it no longer owns an implant or raster. The implant is supplied at encoding time, and device scheduling comes from `implant.raster`
- [x] Bind `Raster` objects to implants so geometry-dependent raster patterns can derive their layout from the electrode array
- [x] Encode dimensionless image/video input when it is assigned to an implant. Electrical stimuli bypass the encoder
- [x] Reject dimensionless stimuli at the implant/model boundary rather than silently interpreting gray levels as current
- [x] Preserve a frame-level modulation representation for spatial-only models while temporal models operate on the delivered electrical pulse train
- [x] Allow retinal spatial-model `xrange`/`yrange` to be specified as retinal distances and resolve them through the model's visual-field map
- [x] Improve unit handling across several API boundaries (fps accepts Hz, current/charge conversions, dimensionless scaling)