### PR TITLE
[ENH] Percept indexing by time, vmin/vmax on play()/save(), and Percept.load()

### DIFF
--- a/doc/users/release_notes.rst
+++ b/doc/users/release_notes.rst
@@ -10,42 +10,26 @@ v0.10.0 Encoders (unreleased)
 Highlights:
 
 *  New :py:class:`~pulse2percept.stimuli.StimulusEncoder` classes translate
-   images and videos into electrical stimulation. Amplitude and frequency
-   modulation are supported, including stimulator timing, input resolution,
-   and electrode multiplexing. An implant carries its own encoder, so
-   ``implant.stim = image`` encodes on assignment::
-
-       implant = p2p.implants.ArgusII(stim=p2p.stimuli.BostonTrain())
-       percept = p2p.models.AxonMapModel().build().predict_percept(implant)
-       percept.play()
-
-*  Spatial models read modulation frames; temporal models read electrical
-   events. An implant that encodes a picture keeps two descriptions of it: the
-   pulse train the device delivers (``implant.stim``) and the modulation the
-   encoder asked for -- one amplitude per electrode per frame, with no
-   waveform, pulse clock or raster in it. A model with no temporal component
-   reads the latter, since a pulse train is a statement about time that it has
-   no way to express; otherwise an encoded image would come back as a sequence
-   of raster slots rather than as the image. So
-   :py:meth:`~pulse2percept.models.SpatialModel.predict_percept` reports one
-   percept frame per video frame, and one frame for an image.
+   images and videos into electrical stimulation using amplitude or frequency
+   modulation.
 
 *  New :py:class:`~pulse2percept.implants.Raster` classes describe how
-   stimulators multiplex electrodes that cannot be driven simultaneously. Each
-   group starts its pulse a fixed ``group_dur`` behind the one before it.
+   stimulators multiplex electrodes that cannot be driven simultaneously.
    :py:class:`~pulse2percept.implants.CheckerboardRaster` implements the
-   checkerboard pattern of [Kasowski2025]_.
+   checkerboard pattern of [Kasowski2025]_ in a generalized form.
+
+*  New :py:mod:`~pulse2percept.units` module support using physical quantities
+   (``50 * uA``, ``450 * us``, ``15 * mm``, ``2 * dva``), which are
+   dimension-checked and converted to the unit the code expects. Bare numbers
+   keep working and keep their documented meaning everywhere.
+   See :ref:`Physical Units <topics-units>`.
 
 * :py:meth:`~pulse2percept.percepts.Percept.play` and
   :py:meth:`~pulse2percept.stimuli.VideoStimulus.play` are roughly 100x faster
   and produce much smaller notebooks and documentation pages.
 
-*  New :py:mod:`~pulse2percept.units` module. Arguments at pulse2percept's
-   public API boundaries may now be given as physical quantities
-   (``50 * uA``, ``450 * us``, ``15 * mm``, ``2 * dva``), which are
-   dimension-checked and converted to the unit the code expects. Bare numbers
-   keep working and keep their documented meaning everywhere, and are never
-   warned about. See :ref:`Physical Units <topics-units>`.
+* New :py:meth:`~pulse2percept.percepts.Percept.load` reads a percept back
+  from an image, GIF, or movie file.
 
 * Python 3.14 is now supported. Python 3.11 and NumPy 2 are now required.
 
@@ -57,57 +41,23 @@ API changes:
   In addition, ``FadingTemporal`` now enforces ``tau >= dt``.
 
 * The grid-spacing parameter ``xystep`` was renamed to ``step`` across spatial
-  models and implant-grid factory methods. The old name remains supported with 
-  a ``DeprecationWarning`` and will be removed in v0.11.0. The axon-map
-  parameter ``axlambda`` was similarly renamed to ``lam``.
+  models and implant-grid factory methods. The axon-map parameter ``axlambda``
+  was similarly renamed to ``lam``.
 
 * Temporal models gained a ``reduce`` parameter. When ``predict_percept`` picks
   the output times itself (``t_percept=None``), ``reduce='peak'`` makes each
   point report the highest brightness reached over the interval leading up to
-  it rather than the brightness at the instant it ends. Naming ``t_percept``
-  still asks for those instants.
-
-* :py:meth:`~pulse2percept.stimuli.ImageStimulus.encode` and
-  :py:meth:`~pulse2percept.stimuli.VideoStimulus.encode` now use
-  :py:class:`~pulse2percept.stimuli.AmplitudeEncoder`. Most importantly, gray
-  levels map to ``amp_range`` absolutely rather than being stretched to fill
-  it, and each frame now produces a pulse train rather than a single pulse.
-  Pass ``stretch=True`` for the old gray-level mapping.
-
-* :py:class:`~pulse2percept.stimuli.BiphasicPulseTrain` now records ``amp`` in
-  its metadata as a magnitude.
+  it rather than the brightness at the instant it ends.
 
 * :py:class:`~pulse2percept.implants.ProsthesisSystem` now exposes ``encoder``,
   ``raster`` and ``max_current``. A raster is bound to the implant it is
-  assigned to (:py:meth:`~pulse2percept.implants.Raster.bind`), so
-  ``CheckerboardRaster`` works its pattern out from that implant's electrode
-  geometry and ``implant.raster.plot()`` needs no argument.
-  :py:class:`~pulse2percept.implants.ArgusII` defaults to an
-  :py:class:`~pulse2percept.stimuli.AmplitudeEncoder` at 6 Hz and a
-  :py:class:`~pulse2percept.implants.SequentialRaster` of six groups 2 ms
-  apart; pass ``encoder=None`` or ``raster=None`` to switch either off.
+  assigned to (:py:meth:`~pulse2percept.implants.Raster.bind`).
 
-* ``play`` gained a ``fmt`` argument (defaulting to JPEG in
+* :py:meth:`~pulse2percept.percepts.Percept.play` and
+  :py:meth:`~pulse2percept.percepts.Percept.save` gained ``vmin`` and
+  ``vmax``. ``play`` also gained a ``fmt`` argument (defaulting to JPEG in
   :py:meth:`~pulse2percept.stimuli.VideoStimulus.play` and PNG in
-  :py:meth:`~pulse2percept.percepts.Percept.play`), now supports nonuniform
-  time axes, and plays percepts according to their recorded timing.
-  ``fps`` now controls the display/export sampling rate without changing
-  playback speed: a percept keeps its wall-clock duration, to within one
-  frame of the requested rate. Saving a percept with a nonuniform time axis
-  still requires an explicit ``fps``.
-
-* Objects now record what their numbers mean:
-  :py:attr:`~pulse2percept.stimuli.Stimulus.unit`,
-  :py:attr:`~pulse2percept.stimuli.Stimulus.time_unit`,
-  :py:meth:`~pulse2percept.stimuli.Stimulus.values`,
-  :py:meth:`~pulse2percept.stimuli.Stimulus.times`,
-  :py:meth:`~pulse2percept.implants.ElectrodeArray.coordinates`,
-  :py:attr:`~pulse2percept.percepts.Percept.time_unit`,
-  :py:meth:`~pulse2percept.percepts.Percept.times`, and
-  :py:meth:`~pulse2percept.utils.Parametrized.get_param_units`. Models declare
-  ``stimulus_unit``, ``space_unit`` and ``time_unit``; visual field maps
-  declare ``visual_unit`` and ``tissue_unit``. Storage is unchanged: these
-  report the unit, they do not convert what is stored.
+  :py:meth:`~pulse2percept.percepts.Percept.play`).
 
 * ``predict_percept`` now raises ``DimensionMismatchError`` when the stimulus
   is not the physical quantity the model reads. Assigning an
@@ -116,62 +66,16 @@ API changes:
   previously had its gray levels silently treated as microamps. The same check
   guards the ``safe_mode`` and ``max_current`` safety checks.
 
-* :py:class:`~pulse2percept.implants.ProsthesisSystem` now declares
-  ``stimulus_unit`` (microamps) and never stores a stimulus of another
-  dimension. A picture assigned to an implant that has an ``encoder`` is
-  encoded on the way in; one assigned to an implant without an encoder raises,
-  rather than letting it through to fail in the model. Preprocessing still runs
-  first, so an implant whose ``preprocess`` turns pictures into current is
-  unaffected, and its output is not encoded a second time.
-
-* A :py:class:`~pulse2percept.stimuli.StimulusEncoder` no longer holds an
-  implant or a raster of its own. The implant is named where the encoding
-  happens -- ``encoder.encode(source, implant=implant)`` -- and the raster
-  comes from that implant, so device scheduling is described in exactly one
-  place. :py:class:`~pulse2percept.implants.CheckerboardRaster` likewise takes
-  ``n_groups`` alone and learns its geometry when it is bound.
-
-* ``fps`` arguments (:py:meth:`~pulse2percept.percepts.Percept.play`,
-  :py:meth:`~pulse2percept.percepts.Percept.save`,
-  :py:meth:`~pulse2percept.stimuli.VideoStimulus.play`,
-  :py:func:`~pulse2percept.utils.frame_interval`) accept a frequency
-  quantity (``30 * Hz``, ``0.03 * kHz``) as well as a plain number of hertz.
-
-* ``xrange`` and ``yrange`` on a retinal spatial model accept a physical
-  extent (``xrange=(-4 * mm, 4 * mm)``), which the model's ``vfmap`` resolves
-  into the visual field range that piece of retina covers, each range along
-  its own retinal meridian. The range is stored in degrees of visual angle and
-  the grid stays uniform in dva, exactly as before. This is shorthand for a
-  visual field extent rather than a unit conversion, so it is not offered for
-  ``step`` and not offered on cortical models.
-
-* Warnings raised while encoding (missed frames, large time axes, large
-  allocations) now point at the calling line rather than at ``encoders.py``.
-
-* :py:attr:`~pulse2percept.stimuli.Stimulus.is_charge_balanced` returns None
-  for a stimulus that is not a current, rather than answering a question that
-  does not apply to it.
-
-* :py:meth:`~pulse2percept.implants.EnsembleImplant.from_coords` requires
-  ``xrange``, ``yrange`` and ``step`` together when ``locs`` is not given.
-  They previously defaulted to a visual-field range, which placed implants at
-  coordinates that were never meant to be microns.
-
 * Minimum dependency versions were raised for NumPy 2 compatibility. NumPy 1.x
   users should remain on v0.9.1.
 
 Bug fixes:
 
-* :py:class:`~pulse2percept.stimuli.PulseTrain` no longer ends on partial,
-  unbalanced pulses when its frequency does not divide ``stim_dur``.
-
 * Stimulus time axes now use float64 precision, fixing false
   :py:attr:`~pulse2percept.stimuli.Stimulus.is_charge_balanced` failures for
   longer pulse trains and improving frequency-modulation accuracy.
 
-* :py:class:`~pulse2percept.implants.EnsembleImplant` now merges nearly
-  identical time points using the same tolerance as
-  :py:class:`~pulse2percept.stimuli.Stimulus`.
+* Stimulus metadata now survives ``predict_percept`` and other transformations.
 
 * Various fixes for :py:class:`~pulse2percept.stimuli.ImageStimulus`:
   keyword arguments are passed on to scikit-image; inputs are no longer
@@ -184,27 +88,9 @@ Bug fixes:
   :py:meth:`~pulse2percept.percepts.Percept.save` now handle single-frame
   inputs correctly and give a useful error for nonuniform time axes.
 
-* :py:attr:`~pulse2percept.stimuli.VideoStimulus.vid_shape` now reports the
-  number of frames the stimulus actually has, rather than the number the source
-  video had before ``compress=True`` dropped the redundant time points. This
-  fixes :py:meth:`~pulse2percept.stimuli.VideoStimulus.play` and every other
-  operation that reshapes ``data`` back into frames. Playing a video that was
-  compressed in *space* raises an explanatory error instead of a reshape error.
-
-* A four-channel :py:class:`~pulse2percept.stimuli.VideoStimulus` is played
-  back as RGBA, as documented: the alpha channel is preserved for ``fmt='png'``
-  and composited onto the axes background for ``fmt='jpg'``, which cannot carry
-  it. Previously the four channels were reinterpreted as RGB, which sheared the
-  color channels across every row.
-
-* Stimulus metadata now survives ``predict_percept`` and other transformations.
-
-* When a temporal model picks its own output times, the last one no longer
-  falls after the end of the stimulus. The end of the range was nudged by one
-  millisecond to make it inclusive, which added a frame wherever the frame
-  interval did not divide that millisecond -- most visibly in
-  :py:class:`~pulse2percept.models.cortex.DynaphosModel` with ``dt`` finer than
-  1 ms.
+* :py:class:`~pulse2percept.implants.EnsembleImplant` now merges nearly
+  identical time points using the same tolerance as
+  :py:class:`~pulse2percept.stimuli.Stimulus`.
 
 * Visual-field-map equality now handles array-valued attributes correctly,
   maps are hashable again, and maps of different classes no longer compare
@@ -212,13 +98,10 @@ Bug fixes:
 
 * :py:meth:`~pulse2percept.topography.NeuropythyMap.cortex_to_dva` (and the
   ``v1_to_dva``, ``v2_to_dva``, ``v3_to_dva`` methods that call it) now returns
-  coordinates with the same shape as its input. Previously NaN inputs were
-  dropped rather than mapped to NaN outputs, which silently shifted every point
-  after them into the wrong slot, and multidimensional inputs came back
-  flattened. Cortical points that land exactly on a mesh vertex now map to that
-  vertex instead of dividing by zero and returning NaN. The docstrings said the
-  cortical coordinates were in mm; they are in um, as the code always
-  assumed.
+  coordinates with the same shape as its input. Cortical points that land
+  exactly on a mesh vertex now map to that vertex instead of dividing by zero
+  and returning NaN. The docstrings said the cortical coordinates were in mm;
+  they are in um, as the code always assumed.
 
 v0.9.1 (2026-08-06)
 -------------------

--- a/pulse2percept/percepts/base.py
+++ b/pulse2percept/percepts/base.py
@@ -78,17 +78,38 @@ def _media_range(fname):
     return None, None
 
 
-def _media_fps(fname):
+def _frame_durations(fname, n_frames):
+    """How long each frame of a Pillow-readable file stays up (in ms)"""
+    durations = []
+    for index in range(n_frames):
+        try:
+            meta = iio.immeta(fname, plugin='pillow', index=index)
+        except Exception:
+            return None
+        if 'duration' not in meta:
+            return None
+        durations.append(float(meta['duration']))
+    return durations
+
+
+def _media_fps(fname, n_frames):
     """The frame rate (in Hz) a media file records, or None"""
     for meta in _media_metadata(fname):
         if meta.get('fps'):
+            # FFMPEG reports the rate directly:
             return float(meta['fps'])
-        if 'fps' not in meta and meta.get('duration'):
-            # Pillow counts milliseconds per frame rather than frames per
-            # second. FFMPEG's 'duration' is the length of the whole movie
-            # instead, so only a backend that reports no 'fps' at all gets
-            # read this way:
+        if 'fps' in meta or not meta.get('duration'):
+            continue
+        # Pillow counts milliseconds per frame:
+        durations = _frame_durations(fname, n_frames)
+        if durations is None:
             return 1000.0 / float(meta['duration'])
+        if max(durations) - min(durations) > 1e-6:
+            raise ValueError(
+                f"The frames of '{fname}' are not all the same length "
+                f"({min(durations):g} to {max(durations):g} ms), so it "
+                f"has no one frame rate. Pass 'time' instead.")
+        return 1000.0 / durations[0]
     return None
 
 
@@ -184,7 +205,8 @@ class Percept(Data):
     *  ``percept[..., [0, 10]]``, ``percept[..., 0:50:10]``: several frames
     *  ``percept[..., percept.time < 20]``: the stored frames before t=20
 
-    The ``fps`` of :py:meth:`~pulse2percept.percepts.Percept.play` and
+    One time point selects a frame and drops the time axis; a list or slice of
+    them keeps it. The ``fps`` of :py:meth:`~pulse2percept.percepts.Percept.play` and
     :py:meth:`~pulse2percept.percepts.Percept.save` is a rendering clock
     rather than an interpolation: it chooses which stored frame to show when,
     and never invents one in between.
@@ -289,6 +311,9 @@ class Percept(Data):
         *  ``percept[..., percept.time < 20]``: the stored frames before t=20
         *  ``percept[0, 1, 12.5]``: one interpolated pixel, as a scalar
 
+        One time point selects a frame and drops the time axis, the way a
+        scalar index does on any other axis; a list or slice of them keeps it.
+
         With ``time=None`` there is no time axis to name, and indexing is
         ordinary NumPy indexing throughout.
 
@@ -304,10 +329,11 @@ class Percept(Data):
         space, time = item, None
         if self.time is not None and isinstance(item, tuple) and len(item) > 1:
             head = item[:-1]
-            if (any(idx is Ellipsis for idx in head)
-                    or len(head) == self.data.ndim - 1):
+            if (any(idx is Ellipsis for idx in head) or
+                    len(head) == self.data.ndim - 1):
                 space, time = head, item[-1]
         # STEP 2: AVOID CONFUSING TIME POINTS WITH FRAME INDICES
+        scalar_time = False
         if isinstance(time, slice):
             sliced = _slice_times(time, self.time, self.time_unit)
             if sliced is not None:
@@ -322,6 +348,7 @@ class Percept(Data):
             # boolean mask selects stored frames and must stay boolean):
             if np.asarray(time).dtype != bool:
                 time = np.float64(time)
+                scalar_time = time.ndim == 0
         # STEP 3: NUMPY HANDLES MOST INDEXING AND SLICING
         try:
             return self.data[space if time is None else (*space, time)]
@@ -332,15 +359,18 @@ class Percept(Data):
                 raise
         # STEP 4: INTERPOLATE TIME
         frames = self.data[space]
-        time = np.array([time], dtype=np.float64).ravel()
+        times = np.array([time], dtype=np.float64).ravel()
         # ``_interp_rows`` works on rows; a percept has one time series per
         # pixel rather than per electrode, so flatten space and put it back:
-        data = _interp_rows(time, self.time,
+        data = _interp_rows(times, self.time,
                             frames.reshape((-1, len(self.time))))
-        data = data.astype(np.float32).reshape(frames.shape[:-1] + time.shape)
-        if data.size == 1:
-            # Return a single element as a scalar:
-            return data.ravel()[0].item()
+        data = data.reshape(frames.shape[:-1] + times.shape)
+        if scalar_time:
+            # One time point picks a frame out rather than slicing a one-frame
+            # stack out, exactly as a scalar index does on any other axis:
+            data = data[..., 0]
+        if data.ndim == 0:
+            return data.item()
         return data
 
     @property
@@ -668,7 +698,7 @@ class Percept(Data):
                              fmt=fmt)
 
     def save(self, fname, shape=None, fps=None, vmin=None, vmax=None):
-        """Save the percept as an MP4 or GIF
+        """Save the percept to an image or video file
 
         Parameters
         ----------
@@ -723,7 +753,8 @@ class Percept(Data):
         if vmin is None and vmax is None:
             warnings.warn("Normalizing the percept to its own brightness "
                           "range, so percepts saved separately do not share a "
-                          "scale. Pass 'vmin' and 'vmax' to fix the range.")
+                          "scale. Pass 'vmin' and 'vmax' to fix the range.",
+                          stacklevel=2)
         # Resolve the range before any frame is dropped below, so that the
         # export rate cannot change how bright the movie comes out:
         vmin, vmax = _resolve_clim(self.data, vmin, vmax,
@@ -826,7 +857,9 @@ class Percept(Data):
             quantity. Overrides both ``fps`` and the file's own timing.
         fps : float or None
             The frame rate to read the file at, in Hz, overriding the rate the
-            file records. May be given as a unitful frequency.
+            file records. May be given as a unitful frequency. A GIF may hold
+            a different duration for every frame, and one that does has no
+            single rate to be read at: pass ``time`` for it.
         vmin, vmax : float, optional
             The brightness range the file's gray levels stand for. See the
             notes below.
@@ -880,7 +913,7 @@ class Percept(Data):
         if time is None:
             fps = as_value(fps, Hz, 'fps')
             if fps is None and data.shape[-1] > 1:
-                fps = _media_fps(fname)
+                fps = _media_fps(fname, data.shape[-1])
                 if fps is None:
                     raise ValueError(f"Cannot infer the frame rate of "
                                      f"'{fname}'. Pass 'fps' or 'time'.")
@@ -903,7 +936,7 @@ class Percept(Data):
         if vmin is None or vmax is None:
             warnings.warn(f"The brightness range of '{fname}' is unknown, so "
                           f"the data is left normalized to [0, 1]. Pass "
-                          f"'vmin' and 'vmax' if you know it.")
+                          f"'vmin' and 'vmax' if you know it.", stacklevel=2)
         else:
             _check_clim(vmin, vmax)
             data = vmin + data * (vmax - vmin)

--- a/pulse2percept/percepts/base.py
+++ b/pulse2percept/percepts/base.py
@@ -47,6 +47,21 @@ def _parse_range_tag(text):
                  for val in match.group('vmin', 'vmax'))
 
 
+def _range_tagged_path(fname, vmin, vmax):
+    """``fname`` with the brightness range written into its own name
+
+    The fallback for the containers :py:func:`_metadata_kwargs` cannot record
+    a range in. A name that already carries a tag has it replaced rather than
+    added to, so that no file is left named for a range it was not written
+    with.
+    """
+    head, tail = os.path.split(os.fspath(fname))
+    root, ext = os.path.splitext(tail)
+    tag = _range_tag(vmin, vmax)
+    root, n_replaced = _P2P_RANGE_RE.subn(lambda match: tag, root, count=1)
+    return os.path.join(head, (root if n_replaced else root + tag) + ext)
+
+
 def _media_metadata(fname):
     """Whatever metadata imageio can read off a media file
 
@@ -134,6 +149,12 @@ def _metadata_kwargs(fname, tag):
     return {}
 
 
+# The containers that hold one image and no more, so that a percept with a
+# time axis has to go somewhere else:
+_STILL_EXTENSIONS = ('.jpg', '.jpeg', '.bmp', '.png', '.tif', '.tiff', '.jif',
+                     '.jfif')
+
+
 def _check_clim(vmin, vmax):
     """Reject a brightness range that cannot be mapped onto a color scale"""
     if not np.all(np.isfinite([vmin, vmax])) or vmax < vmin:
@@ -156,93 +177,40 @@ def _resolve_clim(data, vmin, vmax, auto_vmin):
 
 
 class Percept(Data):
-    """Visual percept
+    """Visual percept in space and time.
 
-    A visual percept in space and time (optional). Typically the output of a
-    computational model.
+    Percepts are typically produced by computational models. Data are stored
+    as perceived brightness in arbitrary units with shape (Y, X, T).
 
     .. versionadded:: 0.6
 
     Parameters
     ----------
-    data : 3D NumPy array
-        A NumPy array specifying the percept in (Y, X, T) dimensions
+    data : 3D array_like
+        Percept data in (Y, X, T) dimensions.
     space : :py:class:`~pulse2percept.topography.Grid2D`, optional
-        A grid object specifying the (x,y) coordinates in space
-    time : 1D array, optional
-        A list of time points, expressed in ``time_unit``. May be given as a
-        unitful quantity (e.g. ``[0, 0.01] * s``), which is converted into
-        ``time_unit`` rather than changing it.
+        Spatial coordinates of the percept.
+    time : 1D array_like, optional
+        Time points corresponding to the frames. Bare values are expressed in
+        ``time_unit``; unitful values are converted to it.
     metadata : dict, optional
-        Additional stimulus metadata can be stored in a dictionary.
+        Additional percept metadata.
     n_gray : int, optional
-        The number of gray levels to use. If an integer is given, k-means
-        clustering is used to compress the color space of the percept into
-        ``n_gray`` bins. If None, no compression is performed.
+        Number of gray levels. If specified, k-means clustering is used to
+        reduce the percept to ``n_gray`` levels.
     noise : float or int, optional
-        Adds salt-and-pepper noise to each percept frame. An integer will be
-        interpreted as the number of pixels to subject to noise in each frame.
-        A float between 0 and 1 will be interpreted as a ratio of pixels to
-        subject to noise in each frame.
+        Amount of salt-and-pepper noise per frame. Integers specify a number
+        of pixels; floats in [0, 1] specify a fraction of pixels.
     time_unit : :py:class:`~pulse2percept.units.Unit`, optional
-        The unit ``time`` is stored in. Bare numbers passed as ``time`` are
-        assumed to already be expressed in this unit; unitful ones are
-        converted into it. A model-created percept records the model's own
-        :py:attr:`~pulse2percept.models.BaseModel.time_unit` here, which is
-        what lets its time axis cross into another model correctly.
+        Unit in which ``time`` is stored.
 
         .. versionadded:: 0.10.0
 
     Notes
     -----
-    Space is indexed the NumPy way, but a number that reaches the time axis is
-    a *time*, not a frame number, and is linearly interpolated between the two
-    frames on either side of it:
-
-    *  ``percept[0, 1]``: the time series of pixel (0, 1)
-    *  ``percept[..., 12.5]``: the frame at t=12.5, interpolated
-    *  ``percept[..., 0.02 * s]``: that same frame in another unit
-    *  ``percept[..., [0, 10]]``, ``percept[..., 0:50:10]``: several frames
-    *  ``percept[..., percept.time < 20]``: the stored frames before t=20
-
-    Bare numbers are read in the percept's
-    :py:attr:`~pulse2percept.percepts.Percept.time_unit`. One time point
-    selects a frame and drops the time axis, the way a scalar index does on
-    any other axis; a list, slice, or mask of them keeps it. With
-    ``time=None`` there is no time axis to name, and indexing is ordinary
-    NumPy indexing throughout.
-
-    The ``fps`` of :py:meth:`~pulse2percept.percepts.Percept.play` and
-    :py:meth:`~pulse2percept.percepts.Percept.save` is a rendering clock
-    rather than an interpolation: it chooses which stored frame to show when,
-    and never invents one in between.
-
-    .. versionchanged:: 0.10.0
-
-        The time axis is unit-aware (see ``time_unit`` above). ``data`` is
-        not: a percept is perceived brightness in arbitrary units, which is
-        model output rather than a physical quantity.
-
-    Examples
-    --------
-    A time axis given in seconds is stored in the percept's own unit, so
-    these two are the same percept:
-
-    >>> import numpy as np
-    >>> from pulse2percept.percepts import Percept
-    >>> from pulse2percept.units import s
-    >>> data = np.zeros((3, 3, 2))
-    >>> Percept(data, time=[0.0, 10.0]).time
-    array([ 0., 10.])
-    >>> Percept(data, time=[0, 0.01] * s).time
-    array([ 0., 10.])
-
-    Read the percept halfway between its two frames:
-
-    >>> Percept(np.dstack([np.zeros((3, 3)), np.ones((3, 3))]),
-    ...         time=[0.0, 10.0])[0, 0, 5.0]
-    0.5
-
+    Spatial dimensions use standard NumPy indexing. When a time axis exists,
+    values indexing the last dimension are interpreted as time points and may
+    be interpolated; see :py:meth:`Percept.__getitem__`.
     """
 
     def __init__(self, data, space=None, time=None, metadata=None, n_gray=None,
@@ -578,65 +546,44 @@ class Percept(Data):
         return ax
 
     def play(self, fps=None, repeat=True, annotate_time=True, ax=None,
-             colorbar=True, fmt='png', vmin=None, vmax=None):
-        """Animate the percept as HTML with JavaScript
-
-        The percept will be played in an interactive player in IPython or
-        Jupyter Notebook.
+            colorbar=True, fmt='png', vmin=None, vmax=None):
+        """Animate the percept in an interactive HTML player.
 
         Parameters
         ----------
-        fps : float or None
-            Display sampling rate in Hz. If None, show every percept frame using
-            its recorded timing. Otherwise resample onto a regular display clock
-            using zero-order hold. Playback duration is preserved to within one
-            display frame. May also be given as a unitful frequency.
+        fps : float, optional
+            Display frame rate in Hz. If None, use the percept's recorded timing.
         repeat : bool, optional
-            Whether the animation should repeat when the sequence of frames is
-            completed.
+            Whether to repeat the animation.
         annotate_time : bool, optional
-            If True, the time of the frame will be shown as t = X in the title
-            of the panel, in the percept's
-            :py:attr:`~pulse2percept.percepts.Percept.time_unit`.
-        ax : matplotlib.axes.AxesSubplot, optional
-            A Matplotlib axes object. If None, will create a new Axes object
-        colorbar : {True, False}
-            Whether to show the colorbar
+            Whether to show the current time above each frame.
+        ax : matplotlib.axes.Axes, optional
+            Axes on which to draw the animation.
+        colorbar : bool, optional
+            Whether to show a colorbar.
         fmt : {'png', 'jpg'}, optional
-            The image format used to embed the frames. Prefer 'jpg' only if
-            size matters more than pixel-exact frames.
+            Image format used to encode animation frames.
 
             .. versionadded:: 0.10.0
         vmin, vmax : float, optional
-            The brightness range the color scale spans, in the percept's own
-            arbitrary units. Omitted limits are resolved from the whole
-            percept (0 and its brightest pixel), never from the frames the
-            display clock happens to sample, so ``fps`` cannot change how
-            bright the percept looks. Pass both to put two percepts on a
-            common scale.
+            Brightness limits. By default, ``vmin=0`` and ``vmax`` is the maximum
+            brightness across the percept.
 
             .. versionadded:: 0.10.0
 
         Returns
         -------
-        ani : pulse2percept.utils.HTMLAnimation
-            A Matplotlib animation object that will play the percept
-            frame-by-frame.
+        pulse2percept.utils.HTMLAnimation
+            The animation.
 
         Notes
         -----
+        ``fps`` controls display sampling, not interpolation. Use
+        ``percept[..., t]`` to interpolate the percept at an arbitrary time.
+
         .. versionchanged:: 0.10.0
-
-            The HTML player is now generated by
-            :py:class:`~pulse2percept.utils.HTMLAnimation`, which renders the
-            figure once and ships all frames as a single sprite sheet.
-
-            ``fps`` now controls display sampling rather than playback speed, and
-            nonuniform time axes are supported. It is a display clock, not an
-            interpolation: use ``percept[..., t]`` to read the percept at a
-            time point that was not recorded.
-
-            ``vmin`` and ``vmax`` were added.
+            Added support for irregular timing, ``fps`` display sampling, and
+            ``vmin``/``vmax``.
         """
         if self.time is None:
             raise ValueError("Cannot animate a percept with time=None. Use "
@@ -686,59 +633,53 @@ class Percept(Data):
                              fmt=fmt)
 
     def save(self, fname, shape=None, fps=None, vmin=None, vmax=None):
-        """Save the percept to an image or video file
+        """Save the percept to an image or video file.
 
         Parameters
         ----------
         fname : str
-            The filename to be created, with the file extension indicating the
-            file type. Percepts with time=None can be saved as images (e.g.,
-            '.jpg', '.png', '.gif'). Multi-frame percepts can be saved as
-            movies (e.g., '.mp4', '.avi', '.mov') or '.gif'.
-        shape : (height, width) or None, optional
-            The desired width x height of the resulting image/video.
-            Use (h, None) to use a specified height and automatically infer the
-            width from the percept's aspect ratio.
-            Analogously, use (None, w) to use a specified width.
-            If shape is None, width will be set to 320px and height will be
-            inferred accordingly.
-        fps : float or None
-            Movie frame rate in Hz. If None, use the percept's native rate,
-            which requires a homogeneous time axis. Otherwise resample using
-            zero-order hold. Movie duration is preserved to within one frame.
-            May also be given as a unitful frequency.
+            Output filename. The extension determines the file format.
+        shape : (height, width), optional
+            Output size in pixels. Either dimension may be ``None`` to preserve
+            the percept's aspect ratio.
+        fps : float, optional
+            Movie frame rate in Hz. If None, use the percept's recorded timing.
         vmin, vmax : float, optional
-            The brightness range that is mapped onto the file's gray levels,
-            in the percept's own arbitrary units. Values outside it are
-            clipped. Omitted limits are resolved from the whole percept (its
-            darkest and brightest pixel), never from the frames the export
-            clock happens to sample, so ``fps`` cannot change how bright the
-            movie looks. Pass both to put two percepts on a common scale;
-            leaving both out normalizes this percept alone and warns.
+            Brightness limits mapped to the file's gray levels. Values outside
+            this range are clipped. If either limit is given, the resolved range
+            is stored so that :meth:`Percept.load` can restore it.
 
             .. versionadded:: 0.10.0
 
+        Returns
+        -------
+        str
+            Path of the file that was written.
+
         Notes
         -----
-        *  ``shape`` will be adjusted so that width and height are multiples
-            of 16 to ensure compatibility with most codecs and players.
-        *  PNG and GIF files record the range in their own metadata, so that
-            :py:meth:`~pulse2percept.percepts.Percept.load` can undo the
-            scaling. Other containers have nowhere to put it; naming the file
-            ``'foo__p2p_vmin=0.0_vmax=20.0.mp4'`` tells ``load`` the same
-            thing.
+        If the output format cannot store the brightness range in metadata,
+        ``save`` adds it to the filename.
+
+        Movie dimensions may be adjusted for codec compatibility.
 
         .. versionchanged:: 0.10.0
-
-            ``fps`` now changes the export sampling rate rather than movie
-            duration. ``vmin`` and ``vmax`` were added.
-
+            Added ``vmin``/``vmax`` and return of the output filename.
         """
+        fname = os.fspath(fname)
         # This path hands `fps` to imageio rather than to `frame_timeline`, so
         # it is its own boundary too: a frame rate is a frequency, and imageio
         # takes a plain number of hertz.
         fps = as_value(fps, Hz, 'fps')
-        if vmin is None and vmax is None:
+        if self.time is not None:
+            # A movie needs a container that can hold more than one frame:
+            if os.path.splitext(fname)[1].lower() in _STILL_EXTENSIONS:
+                raise ValueError(f"Cannot save multi-frame percept as a "
+                                 f"static image: {fname}")
+        # Either limit says that the scale matters, which is what allows the
+        # file name to be changed below:
+        fixed_clim = vmin is not None or vmax is not None
+        if not fixed_clim:
             warnings.warn("Normalizing the percept to its own brightness "
                           "range, so percepts saved separately do not share a "
                           "scale. Pass 'vmin' and 'vmax' to fix the range.",
@@ -771,19 +712,21 @@ class Percept(Data):
         # Rescale percept to desired shape:
         data = resize(data, (np.int32(height), np.int32(width)))
 
-        # Record the range in the file itself where the container has room
-        # for it, so that `load` can put the gray levels back on this scale:
+        # Record the resolved range so that `load` can put the gray levels
+        # back on this scale. A container with metadata of its own always gets
+        # it; one without has only its name, which is the caller's to choose
+        # and so is rewritten only when the caller asked for a range -- or
+        # when the name already claims one, which it must not go on claiming.
         meta_kwargs = _metadata_kwargs(fname, _range_tag(vmin, vmax))
+        if (fixed_clim and not meta_kwargs) or _P2P_RANGE_RE.search(
+                os.path.basename(fname)) is not None:
+            fname = _range_tagged_path(fname, vmin, vmax)
         if self.time is None:
             # No time component, store as an image. imwrite will automatically
             # scale the gray levels:
             imageio.imwrite(fname, img_as_ubyte(data).squeeze(2),
                             **meta_kwargs)
         else:
-            # Throw error if we try to save as a static image
-            for ext in ['.jpg','.jpeg','.bmp','.png','.tif','.tiff','.jif','.jfif']:
-                if fname.endswith(ext):
-                    raise ValueError(f"Cannot save multi-frame percept as a static image: {fname}")
             # With time component, store as a movie. A single-frame percept
             # has no frame rate of its own, but can still be written out:
             if fps is None:
@@ -819,64 +762,39 @@ class Percept(Data):
                 imageio.mimwrite(fname, data.transpose((2, 0, 1)),
                                  duration=1000/fps, **meta_kwargs)
         logging.getLogger(__name__).info(f'Created {fname}.')
+        return fname
 
     @classmethod
     def load(cls, fname, space=None, time=None, fps=None, vmin=None,
-             vmax=None):
-        """Load a percept from an image, GIF, or movie file
-
-        The counterpart to :py:meth:`~pulse2percept.percepts.Percept.save`,
-        for the image and video formats imageio can read. A static image
-        becomes a (Y, X, 1) percept with ``time=None``; a GIF or movie becomes
-        a (Y, X, T) one. Color input is converted to grayscale, because a
-        percept is a single perceived brightness per pixel.
+            vmax=None):
+        """Load a percept from an image or video file.
 
         .. versionadded:: 0.10.0
 
         Parameters
         ----------
         fname : str
-            The file to read. The file type is inferred from its extension.
+            File to load.
         space : :py:class:`~pulse2percept.topography.Grid2D`, optional
-            The (x, y) coordinates the pixels sit at. A media file does not
-            record them; without a grid the percept is indexed in pixels.
-        time : 1D array, optional
-            The time points of the frames, in milliseconds or as a unitful
-            quantity. Overrides both ``fps`` and the file's own timing.
-        fps : float or None
-            The frame rate to read the file at, in Hz, overriding the rate the
-            file records. May be given as a unitful frequency. A GIF may hold
-            a different duration for every frame, and one that does has no
-            single rate to be read at: pass ``time`` for it.
+            Spatial coordinates of the percept.
+        time : 1D array_like, optional
+            Frame times. Overrides ``fps`` and timing stored in the file.
+        fps : float, optional
+            Frame rate in Hz. Overrides the frame rate stored in the file.
         vmin, vmax : float, optional
-            The brightness range the file's gray levels stand for. See the
-            notes below.
+            Brightness limits represented by the file. Explicit values override
+            any range stored in the file metadata or filename.
 
         Returns
         -------
-        percept : :py:class:`~pulse2percept.percepts.Percept`
+        Percept
+            Loaded percept.
 
         Notes
         -----
-        A media file holds quantized pixel values, not brightness, so the
-        scale the percept was saved on has to be recovered separately.
-        ``vmin`` and ``vmax`` are resolved independently, in this order:
-
-        1.  the arguments given here;
-        2.  the pulse2percept metadata
-            :py:meth:`~pulse2percept.percepts.Percept.save` writes into a PNG
-            or GIF;
-        3.  a ``'foo__p2p_vmin=0.0_vmax=20.0.png'`` file name.
-
-        With both bounds known, the decoded intensities are mapped back onto
-        that range. Otherwise the data is left normalized to [0, 1] and a
-        warning says so.
-
-        Recovering the range restores the brightness *scale* that was encoded,
-        not the original percept: clipping, quantization to 256 gray levels,
-        resizing, and lossy video compression all happened on the way out and
-        cannot be undone.
-
+        Color images are converted to grayscale. If the brightness range cannot
+        be recovered, values remain on the encoded [0, 1] scale and a warning is
+        issued.
         """
         # `index=...` reads every format the same way, as a stack of frames,
         # so a three-channel image is never mistaken for three frames:
@@ -921,10 +839,21 @@ class Percept(Data):
             vmin = file_vmin if file_vmin is not None else name_vmin
         if vmax is None:
             vmax = file_vmax if file_vmax is not None else name_vmax
-        if vmin is None or vmax is None:
+        if vmin is None and vmax is None:
             warnings.warn(f"The brightness range of '{fname}' is unknown, so "
-                          f"the data is left normalized to [0, 1]. Pass "
-                          f"'vmin' and 'vmax' if you know it.", stacklevel=2)
+                          f"the data is left on the encoded [0, 1] scale. "
+                          f"Pass 'vmin' and 'vmax' if you know it.",
+                          stacklevel=2)
+        elif vmin is None or vmax is None:
+            # Half a range is no range: the other end cannot be read off the
+            # encoded pixels without inventing it, and silently dropping what
+            # the caller did pass would be worse than saying so.
+            missing, known = (('vmin', f'vmax={vmax}') if vmin is None
+                              else ('vmax', f'vmin={vmin}'))
+            raise ValueError(f"Cannot restore the brightness scale of "
+                             f"'{fname}' from {known} alone, because "
+                             f"'{missing}' is unknown and the file does not "
+                             f"record it. Pass '{missing}' as well.")
         else:
             _check_clim(vmin, vmax)
             data = vmin + data * (vmax - vmin)

--- a/pulse2percept/percepts/base.py
+++ b/pulse2percept/percepts/base.py
@@ -1,19 +1,137 @@
 """:py:class:`~pulse2percept.percepts.Percept`"""
 import numpy as np
+import os
+import re
+import warnings
 from copy import deepcopy
 import matplotlib.pyplot as plt
 from matplotlib.axes import Subplot
-from math import isclose
 from scipy.cluster.vq import kmeans2
 import imageio
+import imageio.v3 as iio
 import logging
-from skimage import img_as_ubyte
+from skimage import img_as_float32, img_as_ubyte
+from skimage.color import rgb2gray, rgba2rgb
 from skimage.transform import resize
 
 from ..units import DimensionMismatchError, Hz, Quantity, Unit, as_value, ms
 from ..utils import Data, HTMLAnimation, frame_interval, sample
 from ..utils.animation import _frame_timeline
+from ..utils.array import _interp_rows, _slice_times
 from ..utils.constants import VIDEO_BLOCK_SIZE
+
+# A number as it may appear in a brightness-range tag:
+_NUM = r'[-+]?(?:\d+\.?\d*|\.\d+)(?:[eE][-+]?\d+)?'
+
+# The brightness range a percept was saved with, as it appears both in media
+# metadata and in a file name ('foo__p2p_vmin=0.0_vmax=20.0.png'). The
+# ``__p2p_`` prefix is what keeps metadata and file names written by other
+# tools from being read as pulse2percept information.
+_P2P_RANGE_RE = re.compile(rf'__p2p_(?:vmin=(?P<vmin>{_NUM}))?_?'
+                           rf'(?:vmax=(?P<vmax>{_NUM}))?')
+
+
+def _range_tag(vmin, vmax):
+    """The namespaced tag that records a brightness range"""
+    return f'__p2p_vmin={float(vmin)!r}_vmax={float(vmax)!r}'
+
+
+def _parse_range_tag(text):
+    """The (vmin, vmax) a namespaced tag records, either one None if absent"""
+    if not isinstance(text, str):
+        return None, None
+    match = _P2P_RANGE_RE.search(text)
+    if match is None:
+        return None, None
+    return tuple(None if val is None else float(val)
+                 for val in match.group('vmin', 'vmax'))
+
+
+def _media_metadata(fname):
+    """Whatever metadata imageio can read off a media file
+
+    Pillow carries the text chunks and comments that
+    :py:meth:`~pulse2percept.percepts.Percept.save` writes, but cannot open a
+    video; FFMPEG can, and reports the frame rate. Whichever opens the file
+    wins, so this yields at most one dictionary per backend that can read it.
+    """
+    for kwargs in ({'plugin': 'pillow'}, {}):
+        try:
+            yield dict(iio.immeta(fname, **kwargs))
+        except Exception:
+            # Any backend may decline any file; the caller falls back on the
+            # next one, and ultimately on knowing nothing about the file:
+            continue
+
+
+def _media_range(fname):
+    """The (vmin, vmax) a media file records in its own metadata"""
+    for meta in _media_metadata(fname):
+        for key, value in meta.items():
+            if str(key).lower() != 'comment':
+                continue
+            if isinstance(value, bytes):
+                value = value.decode('utf-8', 'replace')
+            vmin, vmax = _parse_range_tag(value)
+            if vmin is not None or vmax is not None:
+                return vmin, vmax
+    return None, None
+
+
+def _media_fps(fname):
+    """The frame rate (in Hz) a media file records, or None"""
+    for meta in _media_metadata(fname):
+        if meta.get('fps'):
+            return float(meta['fps'])
+        if 'fps' not in meta and meta.get('duration'):
+            # Pillow counts milliseconds per frame rather than frames per
+            # second. FFMPEG's 'duration' is the length of the whole movie
+            # instead, so only a backend that reports no 'fps' at all gets
+            # read this way:
+            return 1000.0 / float(meta['duration'])
+    return None
+
+
+def _metadata_kwargs(fname, tag):
+    """Writer arguments that record ``tag`` in the file's own metadata
+
+    Only for the containers whose writer already has a comment field to put it
+    in. A percept saved in any other format can still carry its range in the
+    file name, which is the caller's to choose.
+    """
+    ext = os.path.splitext(os.fspath(fname))[1].lower()
+    if ext == '.png':
+        try:
+            from PIL.PngImagePlugin import PngInfo
+        except ImportError:
+            return {}
+        info = PngInfo()
+        info.add_text('Comment', tag)
+        return {'pnginfo': info}
+    if ext == '.gif':
+        return {'comment': tag.encode('utf-8')}
+    return {}
+
+
+def _check_clim(vmin, vmax):
+    """Reject a brightness range that cannot be mapped onto a color scale"""
+    if not np.all(np.isfinite([vmin, vmax])) or vmax < vmin:
+        raise ValueError(f"'vmin' ({vmin}) and 'vmax' ({vmax}) must be finite "
+                         f"with 'vmin' <= 'vmax'.")
+
+
+def _resolve_clim(data, vmin, vmax, auto_vmin):
+    """Fill omitted display limits in from the whole percept
+
+    Resolving against all of ``data`` rather than against the frames a display
+    or export clock happens to sample is what keeps the brightness scale
+    independent of ``fps``.
+    """
+    vmin = auto_vmin if vmin is None else vmin
+    vmax = np.max(data) if vmax is None else vmax
+    vmin, vmax = float(vmin), float(vmax)
+    _check_clim(vmin, vmax)
+    return vmin, vmax
 
 
 class Percept(Data):
@@ -56,6 +174,21 @@ class Percept(Data):
 
     Notes
     -----
+    Space is indexed the NumPy way, but a number that reaches the time axis is
+    a *time*, not a frame number, and is linearly interpolated between the two
+    frames on either side of it:
+
+    *  ``percept[0, 1]``: the time series of pixel (0, 1)
+    *  ``percept[..., 12.5]``: the frame at t=12.5, interpolated
+    *  ``percept[..., 0.02 * s]``: that same frame in another unit
+    *  ``percept[..., [0, 10]]``, ``percept[..., 0:50:10]``: several frames
+    *  ``percept[..., percept.time < 20]``: the stored frames before t=20
+
+    The ``fps`` of :py:meth:`~pulse2percept.percepts.Percept.play` and
+    :py:meth:`~pulse2percept.percepts.Percept.save` is a rendering clock
+    rather than an interpolation: it chooses which stored frame to show when,
+    and never invents one in between.
+
     .. versionchanged:: 0.10.0
 
         The time axis is unit-aware (see ``time_unit`` above). ``data`` is
@@ -75,6 +208,12 @@ class Percept(Data):
     array([ 0., 10.])
     >>> Percept(data, time=[0, 0.01] * s).time
     array([ 0., 10.])
+
+    Read the percept halfway between its two frames:
+
+    >>> Percept(np.dstack([np.zeros((3, 3)), np.ones((3, 3))]),
+    ...         time=[0.0, 10.0])[0, 0, 5.0]
+    0.5
 
     """
 
@@ -130,8 +269,79 @@ class Percept(Data):
             'metadata': metadata
         }
 
-    def __get_item__(self, key):
-        return self.data[key]
+    def __getitem__(self, item):
+        """Return percept data, interpolated in time where necessary
+
+        Space is indexed the NumPy way, but -- as in
+        :py:class:`~pulse2percept.stimuli.Stimulus` -- a number that reaches
+        the time axis is a *time*, not a frame index, and is linearly
+        interpolated between the two frames on either side of it. Bare numbers
+        are read in the percept's
+        :py:attr:`~pulse2percept.percepts.Percept.time_unit`; unitful ones are
+        converted into it.
+
+        *  ``percept[0, 1]``: the time series of pixel (0, 1)
+        *  ``percept[..., 12.5]``: the frame at t=12.5, interpolated
+        *  ``percept[..., 20 * ms]``, ``percept[..., 0.02 * s]``: that same
+           frame, asked for in another unit
+        *  ``percept[:, :, [0, 10]]``: the frames at t=0 and t=10
+        *  ``percept[..., 0:50:10]``: every 10 time units from t=0 to t=50
+        *  ``percept[..., percept.time < 20]``: the stored frames before t=20
+        *  ``percept[0, 1, 12.5]``: one interpolated pixel, as a scalar
+
+        With ``time=None`` there is no time axis to name, and indexing is
+        ordinary NumPy indexing throughout.
+
+        Returns a NumPy array or a scalar, never a new
+        :py:class:`~pulse2percept.percepts.Percept`.
+
+        .. versionadded:: 0.10.0
+
+        """
+        # STEP 1: DOES THE INDEX REACH THE TIME AXIS?
+        # ``percept[0, 1]`` asks for the time series of a pixel, so only an
+        # index that reaches the last axis can be naming a time point:
+        space, time = item, None
+        if self.time is not None and isinstance(item, tuple) and len(item) > 1:
+            head = item[:-1]
+            if (any(idx is Ellipsis for idx in head)
+                    or len(head) == self.data.ndim - 1):
+                space, time = head, item[-1]
+        # STEP 2: AVOID CONFUSING TIME POINTS WITH FRAME INDICES
+        if isinstance(time, slice):
+            sliced = _slice_times(time, self.time, self.time_unit)
+            if sliced is not None:
+                time = sliced
+            # Otherwise the slice stays what it is, and NumPy takes the frames
+            # it names below.
+        elif time is not None and time is not Ellipsis:
+            # A requested time point (or a list of them) may be unitful; after
+            # this it is an ordinary number:
+            time = as_value(time, self.time_unit, 'time')
+            # Convert to float so time is not mistaken for a frame index (a
+            # boolean mask selects stored frames and must stay boolean):
+            if np.asarray(time).dtype != bool:
+                time = np.float64(time)
+        # STEP 3: NUMPY HANDLES MOST INDEXING AND SLICING
+        try:
+            return self.data[space if time is None else (*space, time)]
+        except IndexError:
+            # An IndexError must still be thrown unless the index named a time
+            # point, in which case NumPy refused a float and we interpolate:
+            if time is None:
+                raise
+        # STEP 4: INTERPOLATE TIME
+        frames = self.data[space]
+        time = np.array([time], dtype=np.float64).ravel()
+        # ``_interp_rows`` works on rows; a percept has one time series per
+        # pixel rather than per electrode, so flatten space and put it back:
+        data = _interp_rows(time, self.time,
+                            frames.reshape((-1, len(self.time))))
+        data = data.astype(np.float32).reshape(frames.shape[:-1] + time.shape)
+        if data.size == 1:
+            # Return a single element as a scalar:
+            return data.ravel()[0].item()
+        return data
 
     @property
     def time_unit(self):
@@ -350,7 +560,7 @@ class Percept(Data):
         return ax
 
     def play(self, fps=None, repeat=True, annotate_time=True, ax=None,
-             colorbar=True, fmt='png'):
+             colorbar=True, fmt='png', vmin=None, vmax=None):
         """Animate the percept as HTML with JavaScript
 
         The percept will be played in an interactive player in IPython or
@@ -379,6 +589,15 @@ class Percept(Data):
             size matters more than pixel-exact frames.
 
             .. versionadded:: 0.10.0
+        vmin, vmax : float, optional
+            The brightness range the color scale spans, in the percept's own
+            arbitrary units. Omitted limits are resolved from the whole
+            percept (0 and its brightest pixel), never from the frames the
+            display clock happens to sample, so ``fps`` cannot change how
+            bright the percept looks. Pass both to put two percepts on a
+            common scale.
+
+            .. versionadded:: 0.10.0
 
         Returns
         -------
@@ -395,7 +614,11 @@ class Percept(Data):
             figure once and ships all frames as a single sprite sheet.
 
             ``fps`` now controls display sampling rather than playback speed, and
-            nonuniform time axes are supported.
+            nonuniform time axes are supported. It is a display clock, not an
+            interpolation: use ``percept[..., t]`` to read the percept at a
+            time point that was not recorded.
+
+            ``vmin`` and ``vmax`` were added.
         """
         if self.time is None:
             raise ValueError("Cannot animate a percept with time=None. Use "
@@ -425,8 +648,9 @@ class Percept(Data):
             fig = ax.figure
         # Show an empty frame. The color scale spans the whole percept, so
         # that it does not shift with the display rate:
+        vmin, vmax = _resolve_clim(self.data, vmin, vmax, auto_vmin=0)
         mat = ax.imshow(np.zeros_like(self.data[..., 0]), cmap='gray',
-                        vmin=0, vmax=self.data.max())
+                        vmin=vmin, vmax=vmax)
         if colorbar:
             cbar = fig.colorbar(mat)
             cbar.ax.set_ylabel('Phosphene brightness (a.u.)', rotation=-90,
@@ -443,7 +667,7 @@ class Percept(Data):
                              frame_data=self.data[..., idx], labels=labels,
                              fmt=fmt)
 
-    def save(self, fname, shape=None, fps=None):
+    def save(self, fname, shape=None, fps=None, vmin=None, vmax=None):
         """Save the percept as an MP4 or GIF
 
         Parameters
@@ -465,25 +689,52 @@ class Percept(Data):
             which requires a homogeneous time axis. Otherwise resample using
             zero-order hold. Movie duration is preserved to within one frame.
             May also be given as a unitful frequency.
+        vmin, vmax : float, optional
+            The brightness range that is mapped onto the file's gray levels,
+            in the percept's own arbitrary units. Values outside it are
+            clipped. Omitted limits are resolved from the whole percept (its
+            darkest and brightest pixel), never from the frames the export
+            clock happens to sample, so ``fps`` cannot change how bright the
+            movie looks. Pass both to put two percepts on a common scale;
+            leaving both out normalizes this percept alone and warns.
+
+            .. versionadded:: 0.10.0
 
         Notes
         -----
         *  ``shape`` will be adjusted so that width and height are multiples
             of 16 to ensure compatibility with most codecs and players.
+        *  PNG and GIF files record the range in their own metadata, so that
+            :py:meth:`~pulse2percept.percepts.Percept.load` can undo the
+            scaling. Other containers have nowhere to put it; naming the file
+            ``'foo__p2p_vmin=0.0_vmax=20.0.mp4'`` tells ``load`` the same
+            thing.
 
         .. versionchanged:: 0.10.0
 
             ``fps`` now changes the export sampling rate rather than movie
-            duration.
+            duration. ``vmin`` and ``vmax`` were added.
 
         """
         # This path hands `fps` to imageio rather than to `frame_timeline`, so
         # it is its own boundary too: a frame rate is a frequency, and imageio
         # takes a plain number of hertz.
         fps = as_value(fps, Hz, 'fps')
-        data = self.data - self.data.min()
-        if not isclose(np.max(data), 0):
-            data = data / np.max(data)
+        if vmin is None and vmax is None:
+            warnings.warn("Normalizing the percept to its own brightness "
+                          "range, so percepts saved separately do not share a "
+                          "scale. Pass 'vmin' and 'vmax' to fix the range.")
+        # Resolve the range before any frame is dropped below, so that the
+        # export rate cannot change how bright the movie comes out:
+        vmin, vmax = _resolve_clim(self.data, vmin, vmax,
+                                   auto_vmin=self.data.min())
+        span = vmax - vmin
+        if span > 0:
+            data = np.clip((self.data - vmin) / span, 0, 1)
+        else:
+            # A constant percept spans no range to stretch, and comes out
+            # uniformly black rather than dividing by zero:
+            data = np.zeros(self.data.shape, dtype=np.float64)
         data = img_as_ubyte(data)
 
         if shape is None:
@@ -501,10 +752,14 @@ class Percept(Data):
         # Rescale percept to desired shape:
         data = resize(data, (np.int32(height), np.int32(width)))
 
+        # Record the range in the file itself where the container has room
+        # for it, so that `load` can put the gray levels back on this scale:
+        meta_kwargs = _metadata_kwargs(fname, _range_tag(vmin, vmax))
         if self.time is None:
             # No time component, store as an image. imwrite will automatically
             # scale the gray levels:
-            imageio.imwrite(fname, img_as_ubyte(data).squeeze(2))
+            imageio.imwrite(fname, img_as_ubyte(data).squeeze(2),
+                            **meta_kwargs)
         else:
             # Throw error if we try to save as a static image
             for ext in ['.jpg','.jpeg','.bmp','.png','.tif','.tiff','.jif','.jfif']:
@@ -539,7 +794,119 @@ class Percept(Data):
                     data = resize(data, (out_h, out_w))
             data = img_as_ubyte(data)
             try:
-                imageio.mimwrite(fname, data.transpose((2, 0, 1)), fps=float(fps))
+                imageio.mimwrite(fname, data.transpose((2, 0, 1)),
+                                 fps=float(fps), **meta_kwargs)
             except TypeError:
-                imageio.mimwrite(fname, data.transpose((2, 0, 1)), duration=1000/fps)
+                imageio.mimwrite(fname, data.transpose((2, 0, 1)),
+                                 duration=1000/fps, **meta_kwargs)
         logging.getLogger(__name__).info(f'Created {fname}.')
+
+    @classmethod
+    def load(cls, fname, space=None, time=None, fps=None, vmin=None,
+             vmax=None):
+        """Load a percept from an image, GIF, or movie file
+
+        The counterpart to :py:meth:`~pulse2percept.percepts.Percept.save`,
+        for the image and video formats imageio can read. A static image
+        becomes a (Y, X, 1) percept with ``time=None``; a GIF or movie becomes
+        a (Y, X, T) one. Color input is converted to grayscale, because a
+        percept is a single perceived brightness per pixel.
+
+        .. versionadded:: 0.10.0
+
+        Parameters
+        ----------
+        fname : str
+            The file to read. The file type is inferred from its extension.
+        space : :py:class:`~pulse2percept.topography.Grid2D`, optional
+            The (x, y) coordinates the pixels sit at. A media file does not
+            record them; without a grid the percept is indexed in pixels.
+        time : 1D array, optional
+            The time points of the frames, in milliseconds or as a unitful
+            quantity. Overrides both ``fps`` and the file's own timing.
+        fps : float or None
+            The frame rate to read the file at, in Hz, overriding the rate the
+            file records. May be given as a unitful frequency.
+        vmin, vmax : float, optional
+            The brightness range the file's gray levels stand for. See the
+            notes below.
+
+        Returns
+        -------
+        percept : :py:class:`~pulse2percept.percepts.Percept`
+
+        Notes
+        -----
+        A media file holds quantized pixel values, not brightness, so the
+        scale the percept was saved on has to be recovered separately.
+        ``vmin`` and ``vmax`` are resolved independently, in this order:
+
+        1.  the arguments given here;
+        2.  the pulse2percept metadata
+            :py:meth:`~pulse2percept.percepts.Percept.save` writes into a PNG
+            or GIF;
+        3.  a ``'foo__p2p_vmin=0.0_vmax=20.0.png'`` file name.
+
+        With both bounds known, the decoded intensities are mapped back onto
+        that range. Otherwise the data is left normalized to [0, 1] and a
+        warning says so.
+
+        Recovering the range restores the brightness *scale* that was encoded,
+        not the original percept: clipping, quantization to 256 gray levels,
+        resizing, and lossy video compression all happened on the way out and
+        cannot be undone.
+
+        """
+        # `index=...` reads every format the same way, as a stack of frames,
+        # so a three-channel image is never mistaken for three frames:
+        frames = iio.imread(fname, index=...)
+        if frames.ndim == 4:
+            if frames.shape[-1] == 4:
+                # As elsewhere in p2p, alpha is blended against black:
+                frames = rgba2rgb(frames, background=(0, 0, 0))
+            if frames.shape[-1] == 3:
+                frames = rgb2gray(frames)
+            else:
+                frames = frames[..., 0]
+        if frames.ndim != 3:
+            raise ValueError(f"Expected a 2-D image or a stack of them in "
+                             f"'{fname}', not an array of shape "
+                             f"{frames.shape}.")
+        # Encoded pixels become floating-point data in [0, 1], and the frame
+        # axis moves to the back, where a percept keeps it:
+        data = np.moveaxis(img_as_float32(frames), 0, -1)
+
+        # STEP 1: WHEN THE FRAMES HAPPEN
+        if time is None:
+            fps = as_value(fps, Hz, 'fps')
+            if fps is None and data.shape[-1] > 1:
+                fps = _media_fps(fname)
+                if fps is None:
+                    raise ValueError(f"Cannot infer the frame rate of "
+                                     f"'{fname}'. Pass 'fps' or 'time'.")
+            if fps is not None:
+                if fps <= 0:
+                    raise ValueError(f"'fps' must be greater than zero, not "
+                                     f"{fps}.")
+                # Frames per second is a wall-clock rate; a percept counts
+                # milliseconds:
+                time = np.arange(data.shape[-1]) * 1000.0 / fps
+
+        # STEP 2: WHAT THE GRAY LEVELS MEAN
+        file_vmin, file_vmax = _media_range(fname)
+        name_vmin, name_vmax = _parse_range_tag(
+            os.path.splitext(os.path.basename(os.fspath(fname)))[0])
+        if vmin is None:
+            vmin = file_vmin if file_vmin is not None else name_vmin
+        if vmax is None:
+            vmax = file_vmax if file_vmax is not None else name_vmax
+        if vmin is None or vmax is None:
+            warnings.warn(f"The brightness range of '{fname}' is unknown, so "
+                          f"the data is left normalized to [0, 1]. Pass "
+                          f"'vmin' and 'vmax' if you know it.")
+        else:
+            _check_clim(vmin, vmax)
+            data = vmin + data * (vmax - vmin)
+        return cls(data, space=space, time=time,
+                   metadata={'source': os.fspath(fname), 'vmin': vmin,
+                             'vmax': vmax})

--- a/pulse2percept/percepts/base.py
+++ b/pulse2percept/percepts/base.py
@@ -205,8 +205,14 @@ class Percept(Data):
     *  ``percept[..., [0, 10]]``, ``percept[..., 0:50:10]``: several frames
     *  ``percept[..., percept.time < 20]``: the stored frames before t=20
 
-    One time point selects a frame and drops the time axis; a list or slice of
-    them keeps it. The ``fps`` of :py:meth:`~pulse2percept.percepts.Percept.play` and
+    Bare numbers are read in the percept's
+    :py:attr:`~pulse2percept.percepts.Percept.time_unit`. One time point
+    selects a frame and drops the time axis, the way a scalar index does on
+    any other axis; a list, slice, or mask of them keeps it. With
+    ``time=None`` there is no time axis to name, and indexing is ordinary
+    NumPy indexing throughout.
+
+    The ``fps`` of :py:meth:`~pulse2percept.percepts.Percept.play` and
     :py:meth:`~pulse2percept.percepts.Percept.save` is a rendering clock
     rather than an interpolation: it chooses which stored frame to show when,
     and never invents one in between.
@@ -294,31 +300,10 @@ class Percept(Data):
     def __getitem__(self, item):
         """Return percept data, interpolated in time where necessary
 
-        Space is indexed the NumPy way, but -- as in
-        :py:class:`~pulse2percept.stimuli.Stimulus` -- a number that reaches
-        the time axis is a *time*, not a frame index, and is linearly
-        interpolated between the two frames on either side of it. Bare numbers
-        are read in the percept's
-        :py:attr:`~pulse2percept.percepts.Percept.time_unit`; unitful ones are
-        converted into it.
-
-        *  ``percept[0, 1]``: the time series of pixel (0, 1)
-        *  ``percept[..., 12.5]``: the frame at t=12.5, interpolated
-        *  ``percept[..., 20 * ms]``, ``percept[..., 0.02 * s]``: that same
-           frame, asked for in another unit
-        *  ``percept[:, :, [0, 10]]``: the frames at t=0 and t=10
-        *  ``percept[..., 0:50:10]``: every 10 time units from t=0 to t=50
-        *  ``percept[..., percept.time < 20]``: the stored frames before t=20
-        *  ``percept[0, 1, 12.5]``: one interpolated pixel, as a scalar
-
-        One time point selects a frame and drops the time axis, the way a
-        scalar index does on any other axis; a list or slice of them keeps it.
-
-        With ``time=None`` there is no time axis to name, and indexing is
-        ordinary NumPy indexing throughout.
-
-        Returns a NumPy array or a scalar, never a new
-        :py:class:`~pulse2percept.percepts.Percept`.
+        Space is indexed the NumPy way, but a number that reaches the time
+        axis is a *time* rather than a frame index; see the class docstring
+        for the forms that takes. Returns a NumPy array or a scalar, never a
+        new :py:class:`~pulse2percept.percepts.Percept`.
 
         .. versionadded:: 0.10.0
 
@@ -333,7 +318,7 @@ class Percept(Data):
                     len(head) == self.data.ndim - 1):
                 space, time = head, item[-1]
         # STEP 2: AVOID CONFUSING TIME POINTS WITH FRAME INDICES
-        scalar_time = False
+        scalar_time = mask_time = False
         if isinstance(time, slice):
             sliced = _slice_times(time, self.time, self.time_unit)
             if sliced is not None:
@@ -344,30 +329,33 @@ class Percept(Data):
             # A requested time point (or a list of them) may be unitful; after
             # this it is an ordinary number:
             time = as_value(time, self.time_unit, 'time')
-            # Convert to float so time is not mistaken for a frame index (a
-            # boolean mask selects stored frames and must stay boolean):
-            if np.asarray(time).dtype != bool:
+            if np.asarray(time).dtype == bool:
+                # A mask selects stored frames and is not a time at all:
+                mask_time = True
+            else:
+                # Convert to float so time is not mistaken for a frame index:
                 time = np.float64(time)
                 scalar_time = time.ndim == 0
         # STEP 3: NUMPY HANDLES MOST INDEXING AND SLICING
         try:
             return self.data[space if time is None else (*space, time)]
         except IndexError:
-            # An IndexError must still be thrown unless the index named a time
-            # point, in which case NumPy refused a float and we interpolate:
-            if time is None:
+            # NumPy refusing a float is how we find out that the index named a
+            # time point. A mask it refuses is the wrong length, and reading
+            # its True/False as times t=1 and t=0 would answer a broken
+            # question instead of raising:
+            if time is None or mask_time:
                 raise
         # STEP 4: INTERPOLATE TIME
         frames = self.data[space]
         times = np.array([time], dtype=np.float64).ravel()
-        # ``_interp_rows`` works on rows; a percept has one time series per
-        # pixel rather than per electrode, so flatten space and put it back:
+        # ``_interp_rows`` interpolates rows, and a percept's rows are its
+        # pixels rather than a stimulus's electrodes:
         data = _interp_rows(times, self.time,
                             frames.reshape((-1, len(self.time))))
         data = data.reshape(frames.shape[:-1] + times.shape)
         if scalar_time:
-            # One time point picks a frame out rather than slicing a one-frame
-            # stack out, exactly as a scalar index does on any other axis:
+            # A scalar index drops the axis it indexes:
             data = data[..., 0]
         if data.ndim == 0:
             return data.item()
@@ -918,9 +906,9 @@ class Percept(Data):
                     raise ValueError(f"Cannot infer the frame rate of "
                                      f"'{fname}'. Pass 'fps' or 'time'.")
             if fps is not None:
-                if fps <= 0:
-                    raise ValueError(f"'fps' must be greater than zero, not "
-                                     f"{fps}.")
+                if not np.isfinite(fps) or fps <= 0:
+                    raise ValueError(f"'fps' must be a finite number greater "
+                                     f"than zero, not {fps}.")
                 # Frames per second is a wall-clock rate; a percept counts
                 # milliseconds:
                 time = np.arange(data.shape[-1]) * 1000.0 / fps

--- a/pulse2percept/percepts/tests/test_base.py
+++ b/pulse2percept/percepts/tests/test_base.py
@@ -11,6 +11,7 @@ from matplotlib.axes import Subplot
 import matplotlib.pyplot as plt
 import json
 import os
+import warnings
 import re
 import numpy as np
 import pytest
@@ -571,3 +572,269 @@ def test_Percept_play_units_equivalent():
         npt.assert_equal(milli_cfg['n'], second_cfg['n'])
         npt.assert_almost_equal(milli_cfg['intervals'],
                                 second_cfg['intervals'], decimal=6)
+
+
+def test_Percept_getitem_time():
+    """A number on the time axis is a time, not a frame index"""
+    data = np.arange(24, dtype=float).reshape((2, 3, 4))
+    percept = Percept(data, time=[0.0, 10.0, 20.0, 30.0])
+    # A stored time point comes back verbatim ...
+    npt.assert_almost_equal(percept[..., 10.0].squeeze(), data[..., 1])
+    # ... one in between is interpolated between its neighbors:
+    npt.assert_almost_equal(percept[..., 5.0].squeeze(),
+                            (data[..., 0] + data[..., 1]) / 2)
+    # A fully specified index returns a scalar:
+    npt.assert_almost_equal(percept[0, 1, 5.0],
+                            (data[0, 1, 0] + data[0, 1, 1]) / 2)
+    # Beyond the ends, the closest stored frame is held:
+    npt.assert_almost_equal(percept[..., -5.0].squeeze(), data[..., 0])
+    npt.assert_almost_equal(percept[..., 99.0].squeeze(), data[..., -1])
+    # Space is indexed the NumPy way, and an index that stops short of the
+    # time axis returns the whole time series:
+    npt.assert_almost_equal(percept[0, 1], data[0, 1])
+    npt.assert_almost_equal(percept[0], data[0])
+
+
+def test_Percept_getitem_multiple_times():
+    """Lists, slices and masks of time points"""
+    data = np.arange(24, dtype=float).reshape((2, 3, 4))
+    percept = Percept(data, time=[0.0, 10.0, 20.0, 30.0])
+    # A list of time points is interpolated onto:
+    npt.assert_almost_equal(percept[..., [5.0, 15.0]],
+                            np.stack([(data[..., 0] + data[..., 1]) / 2,
+                                      (data[..., 1] + data[..., 2]) / 2],
+                                     axis=-1))
+    # A stepped slice is a time range, not a range of frame indices:
+    npt.assert_equal(percept[..., 0:30:5].shape, (2, 3, 6))
+    npt.assert_almost_equal(percept[0, 0, 0:30:10], data[0, 0, :3])
+    # A stepless slice takes the stored frames by position:
+    npt.assert_almost_equal(percept[..., :], data)
+    with pytest.raises(ValueError):
+        percept[..., 0:20]
+    # A boolean mask selects stored frames without interpolating:
+    npt.assert_almost_equal(percept[..., percept.time < 20], data[..., :2])
+
+
+def test_Percept_getitem_irregular_time():
+    """Interpolation follows the recorded times, however unevenly spaced"""
+    data = np.arange(8, dtype=float).reshape((2, 1, 4))
+    percept = Percept(data, time=[0.0, 1.0, 10.0, 100.0])
+    npt.assert_almost_equal(
+        percept[0, 0, 5.5],
+        data[0, 0, 1] + 0.5 * (data[0, 0, 2] - data[0, 0, 1]))
+    npt.assert_almost_equal(percept[0, 0, 1.0], data[0, 0, 1])
+
+
+def test_Percept_getitem_units():
+    """A time point may be bare or unitful"""
+    data = np.arange(24, dtype=float).reshape((2, 3, 4))
+    percept = Percept(data, time=[0.0, 10.0, 20.0, 30.0])
+    npt.assert_almost_equal(percept[..., 15 * ms], percept[..., 15.0])
+    npt.assert_almost_equal(percept[..., 0.015 * s], percept[..., 15.0])
+    # A percept that counts seconds reads bare numbers as seconds:
+    in_s = Percept(data, time=[0.0, 0.01, 0.02, 0.03], time_unit=s)
+    npt.assert_almost_equal(in_s[..., 0.015], percept[..., 15.0])
+    npt.assert_almost_equal(in_s[..., 15 * ms], percept[..., 15.0])
+    with pytest.raises(DimensionMismatchError):
+        percept[..., 15 * uA]
+
+
+def test_Percept_getitem_no_time():
+    """Without a time axis, indexing is ordinary NumPy indexing"""
+    data = np.arange(6, dtype=float).reshape((2, 3, 1))
+    percept = Percept(data)
+    npt.assert_equal(percept.time, None)
+    npt.assert_almost_equal(percept[..., 0], data[..., 0])
+    npt.assert_almost_equal(percept[0, 1, 0], data[0, 1, 0])
+    npt.assert_almost_equal(percept[:, :, 0:1], data[:, :, 0:1])
+    with pytest.raises(IndexError):
+        percept[..., 1.5]
+    # A time axis that was filled in automatically is still a time axis:
+    auto = Percept(np.arange(24, dtype=float).reshape((2, 3, 4)))
+    npt.assert_almost_equal(auto.time, [0, 1, 2, 3])
+    npt.assert_almost_equal(auto[0, 0, 1.5], 1.5)
+
+
+def test_Percept_play_clim():
+    """Explicit limits set the color scale and leave the timeline alone"""
+    percept = Percept(np.random.rand(4, 4, 10) * 20,
+                      time=np.arange(10) * 10.0)
+    auto = percept.play()
+    npt.assert_almost_equal(auto._image.get_clim(), (0, percept.data.max()))
+    fixed = percept.play(vmin=-1, vmax=50)
+    npt.assert_almost_equal(fixed._image.get_clim(), (-1, 50))
+    npt.assert_almost_equal(player(fixed)['intervals'],
+                            player(auto)['intervals'])
+    npt.assert_equal(fixed._frame_data.shape, auto._frame_data.shape)
+    with pytest.raises(ValueError):
+        percept.play(vmin=1, vmax=0)
+
+
+def test_Percept_play_clim_ignores_fps():
+    """The color scale spans the percept, not the frames the display samples"""
+    data = np.zeros((4, 4, 10))
+    data[..., 1] = 20.0
+    percept = Percept(data, time=np.arange(10) * 10.0)
+    # 20 fps samples t = 0 and 50 ms, missing the flash at t = 10 ms ...
+    npt.assert_equal(percept.play(fps=20)._frame_data.max(), 0)
+    # ... but the brightness scale still knows about it:
+    npt.assert_almost_equal(percept.play(fps=20)._image.get_clim(), (0, 20))
+    npt.assert_almost_equal(percept.play()._image.get_clim(), (0, 20))
+
+
+def test_Percept_save_common_clim(tmp_path):
+    """Two percepts saved on a common range come back on a common scale"""
+    dim = Percept(np.linspace(0, 5, 256).reshape((16, 16, 1)))
+    bright = Percept(np.linspace(0, 20, 256).reshape((16, 16, 1)))
+    for percept, name in ((dim, 'dim.png'), (bright, 'bright.png')):
+        percept.save(str(tmp_path / name), shape=(16, 16), vmin=0, vmax=20)
+        loaded = Percept.load(str(tmp_path / name))
+        # 8 bits of gray spread over a range of 20:
+        npt.assert_allclose(loaded.data, percept.data, atol=20 / 255)
+    # The dim percept does not get stretched to fill the gray levels:
+    npt.assert_equal(imread(str(tmp_path / 'dim.png')).max() < 255, True)
+    npt.assert_equal(imread(str(tmp_path / 'bright.png')).max(), 255)
+
+
+def test_Percept_save_clim_edge_cases(tmp_path):
+    """Clipping, negative values, constant data, and nonsensical ranges"""
+    percept = Percept(np.linspace(-5, 5, 256).reshape((16, 16, 1)))
+    # Negative values are just the bottom of the range:
+    fname = str(tmp_path / 'signed.png')
+    percept.save(fname, shape=(16, 16), vmin=-5, vmax=5)
+    npt.assert_allclose([Percept.load(fname).data.min(),
+                         Percept.load(fname).data.max()], [-5, 5], atol=0.05)
+    # Everything below vmin is clipped to it:
+    fname = str(tmp_path / 'clipped.png')
+    percept.save(fname, shape=(16, 16), vmin=0, vmax=5)
+    npt.assert_almost_equal(Percept.load(fname).data.min(), 0)
+    npt.assert_equal(np.mean(Percept.load(fname).data == 0) > 0.4, True)
+    # A constant percept has no range to stretch, and does not divide by zero:
+    fname = str(tmp_path / 'constant.png')
+    with pytest.warns(UserWarning):
+        Percept(np.full((16, 16, 1), 3.0)).save(fname, shape=(16, 16))
+    npt.assert_almost_equal(Percept.load(fname).data, 3.0)
+    with pytest.raises(ValueError):
+        percept.save(str(tmp_path / 'bad.png'), vmin=5, vmax=0)
+
+
+def test_Percept_save_clim_ignores_fps(tmp_path):
+    """Export rate cannot change how bright the movie comes out"""
+    data = np.zeros((16, 16, 10))
+    data[..., :] = np.linspace(0, 1, 10)
+    # A flash that only the faster export rate samples:
+    data[..., 1] = 10.0
+    percept = Percept(data, time=np.arange(10) * 10.0)
+    with pytest.warns(UserWarning):
+        percept.save(str(tmp_path / 'slow.gif'), shape=(16, 16), fps=20)
+    with pytest.warns(UserWarning):
+        percept.save(str(tmp_path / 'fast.gif'), shape=(16, 16), fps=100)
+    slow, fast = (mimread(str(tmp_path / n)) for n in ('slow.gif', 'fast.gif'))
+    npt.assert_equal((len(slow), len(fast)), (2, 10))
+    # Same percept frame, same gray levels:
+    npt.assert_array_equal(slow[1], fast[5])
+
+
+def test_Percept_save_warns_without_clim(tmp_path):
+    """Automatic normalization is not a shared scale, and says so"""
+    percept = Percept(np.random.rand(16, 16, 1))
+    with pytest.warns(UserWarning, match='Pass'):
+        percept.save(str(tmp_path / 'auto.png'), shape=(16, 16))
+    with warnings.catch_warnings():
+        warnings.simplefilter('error')
+        percept.save(str(tmp_path / 'fixed.png'), shape=(16, 16), vmin=0,
+                     vmax=1)
+
+
+def test_Percept_load_image(tmp_path):
+    """A static image is a single-frame percept with no time axis"""
+    fname = str(tmp_path / 'p.png')
+    percept = Percept(np.linspace(0, 20, 256).reshape((16, 16, 1)))
+    percept.save(fname, shape=(16, 16), vmin=0, vmax=20)
+    loaded = Percept.load(fname)
+    npt.assert_equal(loaded.shape, (16, 16, 1))
+    npt.assert_equal(loaded.time, None)
+    npt.assert_allclose(loaded.data, percept.data, atol=20 / 255)
+    # A media file does not record where the pixels sit:
+    npt.assert_almost_equal(loaded.xdva, np.arange(16))
+    grid = Grid2D((-1, 1), (-1, 1), step=2 / 15)
+    npt.assert_almost_equal(Percept.load(fname, space=grid).xdva, grid._xflat)
+
+
+@pytest.mark.parametrize('ext', ('.gif', '.mp4'))
+def test_Percept_load_video(ext, tmp_path):
+    """A GIF or movie is a multi-frame percept, timed by its frame rate"""
+    fname = str(tmp_path / f'p{ext}')
+    data = np.zeros((16, 16, 5))
+    data[..., :] = np.linspace(0, 20, 5)
+    percept = Percept(data, time=np.arange(5) * 100.0)
+    percept.save(fname, shape=(32, 32), vmin=0, vmax=20)
+    loaded = Percept.load(fname, vmin=0, vmax=20)
+    npt.assert_equal(loaded.shape[-1], 5)
+    npt.assert_almost_equal(loaded.time, percept.time)
+    # Quantization and, for a movie, the codec cost a fraction of a gray level:
+    npt.assert_allclose([loaded.data[..., i].mean() for i in range(5)],
+                        np.linspace(0, 20, 5), atol=0.5)
+
+
+def test_Percept_load_timing(tmp_path):
+    """Explicit timing overrides what the file records"""
+    fname = str(tmp_path / 'p.gif')
+    percept = Percept(np.random.rand(16, 16, 4), time=np.arange(4) * 100.0)
+    percept.save(fname, shape=(16, 16), vmin=0, vmax=1)
+    npt.assert_almost_equal(Percept.load(fname).time, [0, 100, 200, 300])
+    npt.assert_almost_equal(Percept.load(fname, fps=50).time, [0, 20, 40, 60])
+    npt.assert_almost_equal(Percept.load(fname, fps=50 * Hz).time,
+                            [0, 20, 40, 60])
+    npt.assert_almost_equal(Percept.load(fname, time=[0, 1, 2, 3]).time,
+                            [0, 1, 2, 3])
+    npt.assert_almost_equal(
+        Percept.load(fname, time=np.arange(4) / 1000 * s).time, [0, 1, 2, 3])
+
+
+def test_Percept_load_grayscale(tmp_path):
+    """Color input is reduced to one brightness per pixel"""
+    rgb = np.zeros((8, 8, 3), dtype=np.uint8)
+    rgb[..., 0] = 255
+    imageio.imwrite(str(tmp_path / 'rgb.png'), rgb)
+    with pytest.warns(UserWarning):
+        loaded = Percept.load(str(tmp_path / 'rgb.png'))
+    npt.assert_equal(loaded.shape, (8, 8, 1))
+    # The luminance of pure red:
+    npt.assert_allclose(loaded.data, 0.2125, atol=1e-3)
+    # Alpha is blended against black, as elsewhere in p2p:
+    rgba = np.full((8, 8, 4), 255, dtype=np.uint8)
+    rgba[..., 3] = 128
+    imageio.imwrite(str(tmp_path / 'rgba.png'), rgba)
+    with pytest.warns(UserWarning):
+        loaded = Percept.load(str(tmp_path / 'rgba.png'))
+    npt.assert_allclose(loaded.data, 128 / 255, atol=0.01)
+
+
+def test_Percept_load_range_precedence(tmp_path):
+    """Explicit limits beat file metadata, which beats the file name"""
+    percept = Percept(np.linspace(0, 20, 256).reshape((16, 16, 1)))
+    # Metadata says [0, 20] and the file name says [0, 5]:
+    fname = str(tmp_path / 'p__p2p_vmin=0.0_vmax=5.0.png')
+    percept.save(fname, shape=(16, 16), vmin=0, vmax=20)
+    npt.assert_allclose(Percept.load(fname).data.max(), 20, atol=0.1)
+    npt.assert_allclose(Percept.load(fname, vmax=100).data.max(), 100,
+                        atol=0.5)
+    # A BMP has nowhere to record the range, so the file name is what is left:
+    named = str(tmp_path / 'q__p2p_vmin=0.0_vmax=5.0.bmp')
+    percept.save(named, shape=(16, 16), vmin=0, vmax=20)
+    npt.assert_allclose(Percept.load(named).data.max(), 5, atol=0.05)
+
+
+def test_Percept_load_unknown_range_warns(tmp_path):
+    """An unrecoverable range leaves the data normalized, and says so"""
+    fname = str(tmp_path / 'plain.bmp')
+    percept = Percept(np.linspace(0, 20, 256).reshape((16, 16, 1)))
+    percept.save(fname, shape=(16, 16), vmin=0, vmax=20)
+    with pytest.warns(UserWarning, match='brightness range'):
+        loaded = Percept.load(fname)
+    npt.assert_almost_equal([loaded.data.min(), loaded.data.max()], [0, 1])
+    with warnings.catch_warnings():
+        warnings.simplefilter('error')
+        recovered = Percept.load(fname, vmin=0, vmax=20)
+    npt.assert_allclose(recovered.data, percept.data, atol=20 / 255)

--- a/pulse2percept/percepts/tests/test_base.py
+++ b/pulse2percept/percepts/tests/test_base.py
@@ -209,8 +209,7 @@ def test_Percept_save(dtype, tmp_path):
 
     # Save multiple frames as a gif or movie:
     for name in ['test.mp4', 'test.avi', 'test.mov', 'test.wmv', 'test.gif']:
-        fname = str(tmp_path / name)
-        percept.save(fname, vmin=0, vmax=255)
+        fname = percept.save(str(tmp_path / name), vmin=0, vmax=255)
         npt.assert_equal(os.path.isfile(fname), True)
         # Normalized to [0, 255] with some loss of precision:
         for mov in mimread(fname):
@@ -225,8 +224,7 @@ def test_Percept_save(dtype, tmp_path):
     # But, can save single frame as image:
     percept = Percept(ndarray[..., :1])
     for name in ['test.jpg', 'test.png', 'test.tif', 'test.gif']:
-        fname = str(tmp_path / name)
-        percept.save(fname, vmin=0, vmax=255)
+        fname = percept.save(str(tmp_path / name), vmin=0, vmax=255)
         npt.assert_equal(os.path.isfile(fname), True)
         img = img_as_float(imread(fname))
         npt.assert_almost_equal(np.min(img), 0, decimal=3)
@@ -237,12 +235,10 @@ def test_Percept_save_single_frame(tmp_path):
     """A percept with a single time point has no frame rate of its own"""
     percept = Percept(np.random.rand(16, 16, 1), time=[3.5])
     for name in ['test.mp4', 'test.avi', 'test.gif']:
-        fname = str(tmp_path / name)
-        percept.save(fname, vmin=0, vmax=1)
+        fname = percept.save(str(tmp_path / name), vmin=0, vmax=1)
         npt.assert_equal(len(mimread(fname)), 1)
     # An explicit frame rate is still honored:
-    fname = str(tmp_path / 'fps.mp4')
-    percept.save(fname, fps=12, vmin=0, vmax=1)
+    fname = percept.save(str(tmp_path / 'fps.mp4'), fps=12, vmin=0, vmax=1)
     npt.assert_equal(len(mimread(fname)), 1)
 
 
@@ -267,10 +263,10 @@ def test_Percept_fps_units(tmp_path):
 
     # ... and the same on the way out to a file:
     fname = str(tmp_path / 'fps.mp4')
-    percept.save(fname, fps=30 * Hz, vmin=0, vmax=1)
-    npt.assert_equal(len(mimread(fname)), 30)
-    percept.save(fname, fps=0.03 * kHz, vmin=0, vmax=1)
-    npt.assert_equal(len(mimread(fname)), 30)
+    npt.assert_equal(
+        len(mimread(percept.save(fname, fps=30 * Hz, vmin=0, vmax=1))), 30)
+    npt.assert_equal(
+        len(mimread(percept.save(fname, fps=0.03 * kHz, vmin=0, vmax=1))), 30)
 
     # Nothing else is a frame rate:
     for wrong in (30 * ms, 30 * uA):
@@ -759,6 +755,59 @@ def test_Percept_save_warns_without_clim(tmp_path):
                      vmax=1)
 
 
+def test_Percept_save_keeps_an_explicit_clim(tmp_path):
+    """A movie cannot hold the scale it was written on, but its name can
+
+    The round trip a fixed ``vmax`` promises: the file comes back on the
+    brightness scale the percept was on, not on the one it was encoded with.
+    """
+    data = np.zeros((16, 16, 5))
+    data[..., :] = np.linspace(0, 0.35, 5)
+    percept = Percept(data, time=np.arange(5) * 100.0)
+    fname = percept.save(str(tmp_path / 'percept.mp4'), shape=(32, 32),
+                         vmax=0.5)
+    # The range `save` resolved, both bounds of it, is in the name it returns:
+    npt.assert_equal(os.path.basename(fname),
+                     'percept__p2p_vmin=0.0_vmax=0.5.mp4')
+    npt.assert_equal(os.path.isfile(fname), True)
+    # Loading it needs no arguments and has nothing to warn about...
+    with warnings.catch_warnings():
+        warnings.simplefilter('error')
+        loaded = Percept.load(fname)
+    # ... and `vmax=0.5` was the scale the movie was encoded on, not the
+    # brightness the percept comes back with:
+    npt.assert_allclose(loaded.data.max(), 0.35, atol=0.02)
+    npt.assert_allclose([loaded.data[..., i].mean() for i in range(5)],
+                        np.linspace(0, 0.35, 5), atol=0.02)
+
+
+def test_Percept_save_range_tag(tmp_path):
+    """The file name records the range only where the file itself cannot"""
+    percept = Percept(np.linspace(0, 20, 256).reshape((16, 16, 1)))
+    # A PNG has metadata to hold the range, so its name is left alone:
+    fname = percept.save(str(tmp_path / 'p.png'), shape=(16, 16), vmin=0,
+                         vmax=20)
+    npt.assert_equal(os.path.basename(fname), 'p.png')
+    npt.assert_allclose(Percept.load(fname).data.max(), 20, atol=0.1)
+    # Automatic normalization claims no scale, so it renames nothing:
+    with pytest.warns(UserWarning):
+        auto = percept.save(str(tmp_path / 'auto.bmp'), shape=(16, 16))
+    npt.assert_equal(os.path.basename(auto), 'auto.bmp')
+    # A name that already claims a range has it rewritten, not appended to,
+    # so that it cannot end up naming a range the file was not written with:
+    stale = str(tmp_path / 'stale__p2p_vmin=0.0_vmax=1.0.bmp')
+    tagged = percept.save(stale, shape=(16, 16), vmin=0, vmax=20)
+    npt.assert_equal(os.path.basename(tagged),
+                     'stale__p2p_vmin=0.0_vmax=20.0.bmp')
+    npt.assert_equal(os.path.isfile(stale), False)
+    npt.assert_allclose(Percept.load(tagged).data.max(), 20, atol=0.1)
+    # ... including when the range was resolved rather than asked for:
+    with pytest.warns(UserWarning):
+        redone = percept.save(tagged, shape=(16, 16))
+    npt.assert_equal(os.path.basename(redone),
+                     'stale__p2p_vmin=0.0_vmax=20.0.bmp')
+
+
 def test_Percept_load_image(tmp_path):
     """A static image is a single-frame percept with no time axis"""
     fname = str(tmp_path / 'p.png')
@@ -777,11 +826,11 @@ def test_Percept_load_image(tmp_path):
 @pytest.mark.parametrize('ext', ('.gif', '.mp4'))
 def test_Percept_load_video(ext, tmp_path):
     """A GIF or movie is a multi-frame percept, timed by its frame rate"""
-    fname = str(tmp_path / f'p{ext}')
     data = np.zeros((16, 16, 5))
     data[..., :] = np.linspace(0, 20, 5)
     percept = Percept(data, time=np.arange(5) * 100.0)
-    percept.save(fname, shape=(32, 32), vmin=0, vmax=20)
+    fname = percept.save(str(tmp_path / f'p{ext}'), shape=(32, 32), vmin=0,
+                         vmax=20)
     loaded = Percept.load(fname, vmin=0, vmax=20)
     npt.assert_equal(loaded.shape[-1], 5)
     npt.assert_almost_equal(loaded.time, percept.time)
@@ -853,28 +902,52 @@ def test_Percept_load_grayscale(tmp_path):
 
 def test_Percept_load_range_precedence(tmp_path):
     """Explicit limits beat file metadata, which beats the file name"""
-    percept = Percept(np.linspace(0, 20, 256).reshape((16, 16, 1)))
-    # Metadata says [0, 20] and the file name says [0, 5]:
+    from PIL.PngImagePlugin import PngInfo
+    gray = np.linspace(0, 255, 256).astype(np.uint8).reshape((16, 16))
+    # `save` keeps a file's metadata and its name in step, so a file that
+    # disagrees with itself has to be written by hand. Metadata says [0, 20]
+    # and the name says [0, 5]:
+    info = PngInfo()
+    info.add_text('Comment', '__p2p_vmin=0.0_vmax=20.0')
     fname = str(tmp_path / 'p__p2p_vmin=0.0_vmax=5.0.png')
-    percept.save(fname, shape=(16, 16), vmin=0, vmax=20)
+    imageio.imwrite(fname, gray, pnginfo=info)
     npt.assert_allclose(Percept.load(fname).data.max(), 20, atol=0.1)
     npt.assert_allclose(Percept.load(fname, vmax=100).data.max(), 100,
                         atol=0.5)
     # A BMP has nowhere to record the range, so the file name is what is left:
     named = str(tmp_path / 'q__p2p_vmin=0.0_vmax=5.0.bmp')
-    percept.save(named, shape=(16, 16), vmin=0, vmax=20)
+    imageio.imwrite(named, gray)
     npt.assert_allclose(Percept.load(named).data.max(), 5, atol=0.05)
 
 
 def test_Percept_load_unknown_range_warns(tmp_path):
-    """An unrecoverable range leaves the data normalized, and says so"""
-    fname = str(tmp_path / 'plain.bmp')
+    """An unrecoverable range leaves the encoded values alone, and says so"""
     percept = Percept(np.linspace(0, 20, 256).reshape((16, 16, 1)))
-    percept.save(fname, shape=(16, 16), vmin=0, vmax=20)
-    with pytest.warns(UserWarning, match='brightness range'):
+    # Nothing was said about the scale, so nothing is recorded and the file
+    # keeps the name it was given:
+    with pytest.warns(UserWarning, match='Normalizing'):
+        fname = percept.save(str(tmp_path / 'plain.bmp'), shape=(16, 16))
+    npt.assert_equal(fname, str(tmp_path / 'plain.bmp'))
+    with pytest.warns(UserWarning, match='encoded'):
         loaded = Percept.load(fname)
     npt.assert_almost_equal([loaded.data.min(), loaded.data.max()], [0, 1])
     with warnings.catch_warnings():
         warnings.simplefilter('error')
         recovered = Percept.load(fname, vmin=0, vmax=20)
     npt.assert_allclose(recovered.data, percept.data, atol=20 / 255)
+
+
+def test_Percept_load_half_a_range_raises(tmp_path):
+    """One bound cannot place the other, and is not quietly dropped"""
+    percept = Percept(np.linspace(0, 20, 256).reshape((16, 16, 1)))
+    with pytest.warns(UserWarning):
+        fname = percept.save(str(tmp_path / 'plain.bmp'), shape=(16, 16))
+    with pytest.raises(ValueError, match="'vmin' is unknown"):
+        Percept.load(fname, vmax=20)
+    with pytest.raises(ValueError, match="'vmax' is unknown"):
+        Percept.load(fname, vmin=0)
+    # Saying what the other end is, is what the error asks for:
+    with warnings.catch_warnings():
+        warnings.simplefilter('error')
+        npt.assert_allclose(Percept.load(fname, vmin=0, vmax=20).data,
+                            percept.data, atol=20 / 255)

--- a/pulse2percept/percepts/tests/test_base.py
+++ b/pulse2percept/percepts/tests/test_base.py
@@ -622,6 +622,10 @@ def test_Percept_getitem_multiple_times():
         percept[..., 0:20]
     # A boolean mask selects stored frames without interpolating:
     npt.assert_almost_equal(percept[..., percept.time < 20], data[..., :2])
+    # One of the wrong length is a shape error. It must not be read as the
+    # times t=1 and t=0, which is what its True and False would interpolate to:
+    with pytest.raises(IndexError):
+        percept[..., np.array([True, False])]
 
 
 def test_Percept_getitem_irregular_time():
@@ -812,6 +816,20 @@ def test_Percept_load_variable_frame_durations(tmp_path):
     with pytest.warns(UserWarning):
         loaded = Percept.load(fname, time=[0, 100, 400, 450])
     npt.assert_almost_equal(loaded.time, [0, 100, 400, 450])
+
+
+@pytest.mark.parametrize('fps', (0, -30, np.nan, np.inf))
+def test_Percept_load_rejects_bad_fps(fps, tmp_path):
+    """A frame rate that is not a finite positive number is not a frame rate
+
+    ``nan`` would give the percept a nan time axis and ``inf`` an all-zero
+    one, neither of which announces itself later.
+    """
+    fname = str(tmp_path / 'p.gif')
+    percept = Percept(np.random.rand(16, 16, 4), time=np.arange(4) * 100.0)
+    percept.save(fname, shape=(16, 16), vmin=0, vmax=1)
+    with pytest.raises(ValueError):
+        Percept.load(fname, fps=fps)
 
 
 def test_Percept_load_grayscale(tmp_path):

--- a/pulse2percept/percepts/tests/test_base.py
+++ b/pulse2percept/percepts/tests/test_base.py
@@ -210,7 +210,7 @@ def test_Percept_save(dtype, tmp_path):
     # Save multiple frames as a gif or movie:
     for name in ['test.mp4', 'test.avi', 'test.mov', 'test.wmv', 'test.gif']:
         fname = str(tmp_path / name)
-        percept.save(fname)
+        percept.save(fname, vmin=0, vmax=255)
         npt.assert_equal(os.path.isfile(fname), True)
         # Normalized to [0, 255] with some loss of precision:
         for mov in mimread(fname):
@@ -220,13 +220,13 @@ def test_Percept_save(dtype, tmp_path):
     # Cannot save multiple frames image:
     fname = str(tmp_path / 'test.jpg')
     with pytest.raises(ValueError):
-        percept.save(fname)
+        percept.save(fname, vmin=0, vmax=255)
 
     # But, can save single frame as image:
     percept = Percept(ndarray[..., :1])
     for name in ['test.jpg', 'test.png', 'test.tif', 'test.gif']:
         fname = str(tmp_path / name)
-        percept.save(fname)
+        percept.save(fname, vmin=0, vmax=255)
         npt.assert_equal(os.path.isfile(fname), True)
         img = img_as_float(imread(fname))
         npt.assert_almost_equal(np.min(img), 0, decimal=3)
@@ -238,11 +238,11 @@ def test_Percept_save_single_frame(tmp_path):
     percept = Percept(np.random.rand(16, 16, 1), time=[3.5])
     for name in ['test.mp4', 'test.avi', 'test.gif']:
         fname = str(tmp_path / name)
-        percept.save(fname)
+        percept.save(fname, vmin=0, vmax=1)
         npt.assert_equal(len(mimread(fname)), 1)
     # An explicit frame rate is still honored:
     fname = str(tmp_path / 'fps.mp4')
-    percept.save(fname, fps=12)
+    percept.save(fname, fps=12, vmin=0, vmax=1)
     npt.assert_equal(len(mimread(fname)), 1)
 
 
@@ -267,9 +267,9 @@ def test_Percept_fps_units(tmp_path):
 
     # ... and the same on the way out to a file:
     fname = str(tmp_path / 'fps.mp4')
-    percept.save(fname, fps=30 * Hz)
+    percept.save(fname, fps=30 * Hz, vmin=0, vmax=1)
     npt.assert_equal(len(mimread(fname)), 30)
-    percept.save(fname, fps=0.03 * kHz)
+    percept.save(fname, fps=0.03 * kHz, vmin=0, vmax=1)
     npt.assert_equal(len(mimread(fname)), 30)
 
     # Nothing else is a frame rate:
@@ -363,7 +363,7 @@ def test_Percept_animates_in_wall_clock_time(tmp_path, monkeypatch):
     monkeypatch.setattr(imageio, 'mimwrite',
                         lambda fname, data, **kwargs: seen.append(kwargs))
     for percept in (milli, second):
-        percept.save(str(tmp_path / 'test.mp4'))
+        percept.save(str(tmp_path / 'test.mp4'), vmin=0, vmax=1)
     npt.assert_equal(len(seen), 2)
     npt.assert_almost_equal(seen[0]['fps'], 50)
     npt.assert_almost_equal(seen[1]['fps'], 50)
@@ -375,7 +375,7 @@ def test_Percept_animates_in_wall_clock_time(tmp_path, monkeypatch):
     npt.assert_almost_equal(player(ragged.play())['intervals'], [20, 30, 30])
     # A movie file runs at a single frame rate, so this one needs an `fps`:
     with pytest.raises(NotImplementedError):
-        ragged.save(str(tmp_path / 'ragged.mp4'))
+        ragged.save(str(tmp_path / 'ragged.mp4'), vmin=0, vmax=1)
 
 
 def pulse_train_percept(n_pulses=3, period=1000.0 / 6):
@@ -498,7 +498,7 @@ def test_Percept_save_fps_resamples(tmp_path, monkeypatch):
     # One second of percept, sampled at 100 Hz:
     percept = Percept(np.random.rand(16, 16, 100), time=np.arange(0, 1000, 10))
     for fps in (15, 30, 60, None):
-        percept.save(str(tmp_path / 'test.mp4'), fps=fps)
+        percept.save(str(tmp_path / 'test.mp4'), fps=fps, vmin=0, vmax=1)
     for (data, kwargs), fps in zip(seen, (15, 30, 60, 100)):
         n_frames = fps if fps != 100 else 100
         npt.assert_equal(len(data), n_frames)
@@ -511,7 +511,7 @@ def test_Percept_save_fps_resamples(tmp_path, monkeypatch):
     seen.clear()
     percept = pulse_train_percept(n_pulses=3, period=1000.0 / 6)
     duration = (percept.time[-1] - percept.time[0] + 0.45) / 1000.0
-    percept.save(str(tmp_path / 'pulses.mp4'), fps=30)
+    percept.save(str(tmp_path / 'pulses.mp4'), fps=30, vmin=0, vmax=1)
     npt.assert_equal(len(seen[0][0]), 10)
     npt.assert_array_less(abs(len(seen[0][0]) / 30.0 - duration), 1 / 30.0)
 
@@ -546,7 +546,7 @@ def test_Percept_play_rejects_unordered_time(tmp_path):
         with pytest.raises(ValueError):
             percept.play(fps=fps)
     with pytest.raises(ValueError):
-        percept.save(str(tmp_path / 'test.mp4'), fps=30)
+        percept.save(str(tmp_path / 'test.mp4'), fps=30, vmin=0, vmax=1)
 
 
 def test_Percept_play_save_do_not_mutate(tmp_path):
@@ -555,7 +555,7 @@ def test_Percept_play_save_do_not_mutate(tmp_path):
     data, time = percept.data.copy(), percept.time.copy()
     for fps in (None, 10, 1000):
         percept.play(fps=fps).to_jshtml()
-    percept.save(str(tmp_path / 'test.mp4'), fps=30)
+    percept.save(str(tmp_path / 'test.mp4'), fps=30, vmin=0, vmax=1)
     npt.assert_almost_equal(percept.data, data)
     npt.assert_almost_equal(percept.time, time)
 
@@ -578,21 +578,27 @@ def test_Percept_getitem_time():
     """A number on the time axis is a time, not a frame index"""
     data = np.arange(24, dtype=float).reshape((2, 3, 4))
     percept = Percept(data, time=[0.0, 10.0, 20.0, 30.0])
-    # A stored time point comes back verbatim ...
-    npt.assert_almost_equal(percept[..., 10.0].squeeze(), data[..., 1])
-    # ... one in between is interpolated between its neighbors:
-    npt.assert_almost_equal(percept[..., 5.0].squeeze(),
+    # One time point drops the time axis, the way a scalar index does on any
+    # other axis ...
+    npt.assert_equal(percept[..., 10.0].shape, (2, 3))
+    npt.assert_equal(percept[:, 0, 10.0].shape, (2,))
+    npt.assert_equal(np.isscalar(percept[0, 1, 10.0]), True)
+    # ... and a stored time point comes back verbatim:
+    npt.assert_almost_equal(percept[..., 10.0], data[..., 1])
+    # One in between is interpolated between its neighbors:
+    npt.assert_almost_equal(percept[..., 5.0],
                             (data[..., 0] + data[..., 1]) / 2)
-    # A fully specified index returns a scalar:
     npt.assert_almost_equal(percept[0, 1, 5.0],
                             (data[0, 1, 0] + data[0, 1, 1]) / 2)
     # Beyond the ends, the closest stored frame is held:
-    npt.assert_almost_equal(percept[..., -5.0].squeeze(), data[..., 0])
-    npt.assert_almost_equal(percept[..., 99.0].squeeze(), data[..., -1])
+    npt.assert_almost_equal(percept[..., -5.0], data[..., 0])
+    npt.assert_almost_equal(percept[..., 99.0], data[..., -1])
     # Space is indexed the NumPy way, and an index that stops short of the
     # time axis returns the whole time series:
     npt.assert_almost_equal(percept[0, 1], data[0, 1])
     npt.assert_almost_equal(percept[0], data[0])
+    # A float64 percept is not interpolated down to float32:
+    npt.assert_equal(percept[..., 5.0].dtype, np.float64)
 
 
 def test_Percept_getitem_multiple_times():
@@ -604,6 +610,9 @@ def test_Percept_getitem_multiple_times():
                             np.stack([(data[..., 0] + data[..., 1]) / 2,
                                       (data[..., 1] + data[..., 2]) / 2],
                                      axis=-1))
+    # One requested time point is still a time axis when asked for as a list:
+    npt.assert_equal(percept[..., [5.0]].shape, (2, 3, 1))
+    npt.assert_equal(percept[0, 0, [5.0]].shape, (1,))
     # A stepped slice is a time range, not a range of frame indices:
     npt.assert_equal(percept[..., 0:30:5].shape, (2, 3, 6))
     npt.assert_almost_equal(percept[0, 0, 0:30:10], data[0, 0, :3])
@@ -790,6 +799,19 @@ def test_Percept_load_timing(tmp_path):
                             [0, 1, 2, 3])
     npt.assert_almost_equal(
         Percept.load(fname, time=np.arange(4) / 1000 * s).time, [0, 1, 2, 3])
+
+
+def test_Percept_load_variable_frame_durations(tmp_path):
+    """A GIF that holds a different duration per frame has no frame rate"""
+    fname = str(tmp_path / 'ragged.gif')
+    frames = [np.full((16, 16), level, dtype=np.uint8) for level in range(4)]
+    imageio.mimwrite(fname, frames, duration=[100, 300, 50, 200])
+    with pytest.raises(ValueError):
+        Percept.load(fname)
+    # Saying when the frames happen is what the error asks for:
+    with pytest.warns(UserWarning):
+        loaded = Percept.load(fname, time=[0, 100, 400, 450])
+    npt.assert_almost_equal(loaded.time, [0, 100, 400, 450])
 
 
 def test_Percept_load_grayscale(tmp_path):

--- a/pulse2percept/stimuli/base.py
+++ b/pulse2percept/stimuli/base.py
@@ -5,6 +5,7 @@ from ..units import (DimensionMismatchError, Quantity, Unit, as_value,
                      dimensionless, ms, uA)
 from ..units.base import has_units
 from ..utils import PrettyPrint, is_strictly_increasing
+from ..utils.array import _interp_rows, _slice_times
 from ..utils.constants import DT, MIN_AMP
 from ._base import fast_compress_space, fast_compress_time
 from .names import ElectrodeNames
@@ -16,94 +17,6 @@ import operator as ops
 from math import isclose
 from scipy.integrate import trapezoid
 import numpy as np
-
-
-def _interp_rows(x, xp, fp):
-    """Linearly interpolate every row of ``fp`` at the time points ``x``
-
-    Vectorized equivalent of ``[np.interp(x, xp, row) for row in fp]``, which
-    is otherwise a Python-level loop over (potentially many thousands of)
-    electrodes.
-
-    The arithmetic is deliberately carried out in double precision and in the
-    same order as ``np.interp``'s C loop, because temporal models resolve
-    stimulus edges on a fixed simulation grid.
-
-    Agreement with ``np.interp`` is exact wherever no arithmetic is needed:
-    on a knot, or beyond the end points, where the stored value is assigned
-    verbatim. For interior points it is exact to within one rounding - a C
-    compiler may contract ``slope * dx + y0`` into a single fused
-    multiply-add (it does on arm64), whereas the NumPy expression below
-    always rounds twice. That is at most a few ULP of float64, well below the
-    float32 that the caller ends up storing.
-
-    Parameters
-    ----------
-    x : 1-D array
-        Time points at which to interpolate.
-    xp : 1-D array
-        The stimulus time axis.
-    fp : 2-D array
-        The stimulus data, one row per electrode.
-
-    Returns
-    -------
-    data : 2-D array
-        Interpolated data, of shape ``(len(fp), len(x))``.
-    """
-    x = np.asarray(x, dtype=np.float64)
-    xp = np.asarray(xp, dtype=np.float64)
-    fp = np.asarray(fp)
-    # np.interp's C loop is hard to beat per element; what the vectorized path
-    # saves is one Python-level call per electrode. That only pays off with
-    # enough electrodes to amortize its setup, and only while the result stays
-    # small enough that the extra passes over it are cheaper than those calls.
-    # Outside that regime (and for a non-monotonic time axis, where
-    # np.interp's guess-based bracket search cannot be reproduced in a
-    # vectorized way because its result depends on the preceding query point),
-    # defer to np.interp itself:
-    if (fp.shape[0] < 32 or x.size > 256 or xp.size < 2 or
-            not np.all(np.diff(xp) > 0)):
-        return np.array([np.interp(x, xp, row)
-                         for row in fp]).reshape((-1, x.size))
-    # Bracket index j such that xp[j] <= x < xp[j+1], as np.interp does. Note
-    # that `j`, `x0` and `x1` are all 1-D (one entry per requested time point):
-    j = np.clip(np.searchsorted(xp, x, side='right') - 1, 0, xp.size - 2)
-    x0, x1 = xp[j], xp[j + 1]
-    # Gather first and widen afterwards: upcasting all of `fp` would touch the
-    # whole (potentially large) data container instead of just two columns
-    # per requested time point:
-    y0 = fp[:, j].astype(np.float64)
-    y1 = fp[:, j + 1].astype(np.float64)
-    with np.errstate(invalid='ignore', divide='ignore'):
-        out = (y1 - y0) / (x1 - x0)     # slope; reused in place below
-        out *= x - x0
-        out += y0
-        # np.interp retries from the right end of the interval if that gave a
-        # NaN (which happens for infinite slopes), then gives up:
-        nan = np.isnan(out)
-        if nan.any():
-            slope = (y1 - y0) / (x1 - x0)
-            out = np.where(nan, slope * (x - x1) + y1, out)
-            out = np.where(np.isnan(out) & (y0 == y1), y0, out)
-    # The remaining corrections all select whole columns, so build the masks
-    # on the 1-D time axis and write in place rather than allocating another
-    # full-size array per correction:
-    exact = x == x0
-    if exact.any():
-        # Exact hits on a knot return the stored value verbatim:
-        out[:, exact] = y0[:, exact]
-    # Beyond the end points, the value of the closest end point is returned:
-    below = x <= xp[0]
-    if below.any():
-        out[:, below] = fp[:, :1]
-    above = x >= xp[-1]
-    if above.any():
-        out[:, above] = fp[:, -1:]
-    undefined = np.isnan(x)
-    if undefined.any():
-        out[:, undefined] = x[undefined]
-    return out
 
 
 def _as_scalar_column(source):
@@ -1395,31 +1308,10 @@ class Stimulus(PrettyPrint):
     def _slice_times(self, time):
         """The time points a slice of the time axis asks for
 
-        Slicing the time axis asks for a time *range*, not for a range of
-        column indices: ``stim[:, 0:10:0.5]`` is the stimulus every 0.5 ms
-        from 0 to 10 ms. All three of ``start``, ``stop`` and ``step`` are
-        therefore times, and may be given as quantities.
-
-        A slice without a step has no such reading -- there is nothing to
-        interpolate onto -- and stands for the stored samples themselves.
-        Returns None in that case, so the caller can keep taking the cheap
-        positional path. Everything that slices the time axis goes through
-        here, so that a plot and the data it plots cannot disagree about what
-        a slice meant.
+        See :py:func:`~pulse2percept.utils.array._slice_times`, which
+        :py:class:`~pulse2percept.percepts.Percept` indexing shares.
         """
-        if not time.step:
-            # We can't interpolate if we don't know the step size, so the only
-            # allowed option is slice(None, None, None), i.e. ':'
-            if time.start or time.stop:
-                raise ValueError("You must provide a step size when slicing "
-                                 "the time axis.")
-            return None
-        start = self._as_time(time.start)
-        stop = self._as_time(time.stop)
-        step = self._as_time(time.step)
-        start = self.time[0] if start is None else start
-        stop = self.time[-1] if stop is None else stop
-        return np.arange(start, stop, step, dtype=np.float64)
+        return _slice_times(time, self.time, self.time_unit)
 
     def __add__(self, scalar):
         """Add a scalar to every data point in the stimulus"""

--- a/pulse2percept/utils/animation.py
+++ b/pulse2percept/utils/animation.py
@@ -629,8 +629,9 @@ class HTMLAnimation(FuncAnimation):
         Whether to encode the frames as JPEG or PNG. JPEG is typically an
         order of magnitude smaller, PNG is lossless
     intervals : array_like or None, optional
-        Duration of each frame in ms. If None, use ``interval`` for every
-        frame.
+        How long each frame stays up (in ms), one value per frame. If None,
+        every frame is shown for ``interval`` ms. Frames of unequal duration
+        are what lets an animation follow an irregular time axis.
 
         .. versionadded:: 0.10.0
 

--- a/pulse2percept/utils/animation.py
+++ b/pulse2percept/utils/animation.py
@@ -616,7 +616,7 @@ class HTMLAnimation(FuncAnimation):
     Parameters
     ----------
     fig, func, frames, *args, **kwargs :
-        Passed to :py:class:`~matplotlib.animation.FuncAnimatgition`
+        Passed to :py:class:`~matplotlib.animation.FuncAnimation`
     image : matplotlib.image.AxesImage
         The image artist that is updated by ``func``. Its position, colormap,
         and normalization determine how the frames are drawn

--- a/pulse2percept/utils/animation.py
+++ b/pulse2percept/utils/animation.py
@@ -616,7 +616,7 @@ class HTMLAnimation(FuncAnimation):
     Parameters
     ----------
     fig, func, frames, *args, **kwargs :
-        Passed to :py:class:`~matplotlib.animation.FuncAnimation`
+        Passed to :py:class:`~matplotlib.animation.FuncAnimatgition`
     image : matplotlib.image.AxesImage
         The image artist that is updated by ``func``. Its position, colormap,
         and normalization determine how the frames are drawn
@@ -629,9 +629,8 @@ class HTMLAnimation(FuncAnimation):
         Whether to encode the frames as JPEG or PNG. JPEG is typically an
         order of magnitude smaller, PNG is lossless
     intervals : array_like or None, optional
-        How long each frame stays up (in ms), one value per frame. If None,
-        every frame is shown for ``interval`` ms. Frames of unequal duration
-        are what lets an animation follow an irregular time axis.
+        Duration of each frame in ms. If None, use ``interval`` for every
+        frame.
 
         .. versionadded:: 0.10.0
 

--- a/pulse2percept/utils/array.py
+++ b/pulse2percept/utils/array.py
@@ -4,6 +4,7 @@
    :py:class:`~pulse2percept.utils.radial_mask`"""
 
 from ._fast_array import fast_is_strictly_increasing
+from ..units import as_value
 import numpy as np
 
 
@@ -95,3 +96,114 @@ def radial_mask(shape, mask='gauss', sd=3):
         raise ValueError(f'Unknown mask "{mask}". Choose either "circle" or '
                          f'"gauss".')
     return intensity
+
+
+def _interp_rows(x, xp, fp):
+    """Linearly interpolate every row of ``fp`` at the time points ``x``
+
+    Vectorized equivalent of ``[np.interp(x, xp, row) for row in fp]``, which
+    is otherwise a Python-level loop over (potentially many thousands of)
+    electrodes.
+
+    The arithmetic is deliberately carried out in double precision and in the
+    same order as ``np.interp``'s C loop, because temporal models resolve
+    stimulus edges on a fixed simulation grid.
+
+    Parameters
+    ----------
+    x : 1-D array
+        Time points at which to interpolate.
+    xp : 1-D array
+        The stimulus time axis.
+    fp : 2-D array
+        The stimulus data, one row per electrode.
+
+    Returns
+    -------
+    data : 2-D array
+        Interpolated data, of shape ``(len(fp), len(x))``.
+    """
+    x = np.asarray(x, dtype=np.float64)
+    xp = np.asarray(xp, dtype=np.float64)
+    fp = np.asarray(fp)
+    # np.interp's C loop is hard to beat per element; what the vectorized path
+    # saves is one Python-level call per electrode:
+    if (fp.shape[0] < 32 or x.size > 256 or xp.size < 2 or
+            not np.all(np.diff(xp) > 0)):
+        return np.array([np.interp(x, xp, row)
+                         for row in fp]).reshape((-1, x.size))
+    # Bracket index j such that xp[j] <= x < xp[j+1], as np.interp does. Note
+    # that `j`, `x0` and `x1` are all 1-D (one entry per requested time point):
+    j = np.clip(np.searchsorted(xp, x, side='right') - 1, 0, xp.size - 2)
+    x0, x1 = xp[j], xp[j + 1]
+    # Gather first and widen afterwards: upcasting all of `fp` would touch the
+    # whole (potentially large) data container instead of just two columns
+    # per requested time point:
+    y0 = fp[:, j].astype(np.float64)
+    y1 = fp[:, j + 1].astype(np.float64)
+    with np.errstate(invalid='ignore', divide='ignore'):
+        out = (y1 - y0) / (x1 - x0)     # slope; reused in place below
+        out *= x - x0
+        out += y0
+        # np.interp retries from the right end of the interval if that gave a
+        # NaN (which happens for infinite slopes), then gives up:
+        nan = np.isnan(out)
+        if nan.any():
+            slope = (y1 - y0) / (x1 - x0)
+            out = np.where(nan, slope * (x - x1) + y1, out)
+            out = np.where(np.isnan(out) & (y0 == y1), y0, out)
+    # The remaining corrections all select whole columns, so build the masks
+    # on the 1-D time axis and write in place rather than allocating another
+    # full-size array per correction:
+    exact = x == x0
+    if exact.any():
+        # Exact hits on a knot return the stored value verbatim:
+        out[:, exact] = y0[:, exact]
+    # Beyond the end points, the value of the closest end point is returned:
+    below = x <= xp[0]
+    if below.any():
+        out[:, below] = fp[:, :1]
+    above = x >= xp[-1]
+    if above.any():
+        out[:, above] = fp[:, -1:]
+    undefined = np.isnan(x)
+    if undefined.any():
+        out[:, undefined] = x[undefined]
+    return out
+
+
+def _slice_times(sl, time, time_unit):
+    """The time points a slice of a time axis asks for
+
+    Slicing a time axis asks for a time *range*, not for a range of column
+    indices: ``stim[:, 0:10:0.5]`` is the stimulus every 0.5 ms from 0 to
+    10 ms. All three of ``start``, ``stop`` and ``step`` are therefore times,
+    and may be given as quantities.
+
+    Parameters
+    ----------
+    sl : slice
+        The slice to resolve.
+    time : 1-D array
+        The stored time axis, in ``time_unit``.
+    time_unit : :py:class:`~pulse2percept.units.Unit`
+        The unit the slice endpoints are read in.
+
+    Returns
+    -------
+    times : 1-D array or None
+        The requested time points, or None for a stepless slice.
+    """
+    if not sl.step:
+        # We can't interpolate if we don't know the step size, so the only
+        # allowed option is slice(None, None, None), i.e. ':'
+        if sl.start or sl.stop:
+            raise ValueError("You must provide a step size when slicing the "
+                             "time axis.")
+        return None
+    start = as_value(sl.start, time_unit, 'time')
+    stop = as_value(sl.stop, time_unit, 'time')
+    step = as_value(sl.step, time_unit, 'time')
+    start = time[0] if start is None else start
+    stop = time[-1] if stop is None else stop
+    return np.arange(start, stop, step, dtype=np.float64)


### PR DESCRIPTION
Closes #690. Closes #207.

This PR rounds out `Percept` so it is as complete as `Stimulus` and internally consistent about brightness.

- [x] `__get_item__` was a typo and replaced with a real `__getitem__` that follows the existing `Stimulus` convention
- [x] `play()` and `save()` now have `vmin` and `vmax`
- [x] Add `Percept.load()`, which reads a percept back from an image, GIF, or movie
- [x] `_interp_rows` moved from `stimuli/base.py` to `utils/array.py`