### PR TITLE
[FIX] v*-to-dva transforms

### DIFF
--- a/pulse2percept/topography/cortex.py
+++ b/pulse2percept/topography/cortex.py
@@ -12,14 +12,8 @@ from ..utils.constants import UM_PER_MM
 import matplotlib.pyplot as plt
 
 
-def _elementwise(dtype):
-    """Make a coordinate transform elementwise over scalars and arrays alike
-
-    The transforms below index with boolean masks and divide in place, neither
-    of which a scalar (or a 0-d, or an integer, array) supports. Coordinates
-    therefore enter as float arrays of at least one dimension; a call made
-    with two scalars gets scalars back.
-    """
+def _scalar_safe(dtype):
+    """Normalize transform inputs to arrays and restore scalar outputs."""
     def decorator(func):
         @wraps(func)
         def wrapper(self, x, y):
@@ -180,7 +174,7 @@ class Polimeni2006Map(CorticalMap):
         x[idx_nan], y[idx_nan] = np.nan, np.nan
         return x, y
 
-    @_elementwise('float32')
+    @_scalar_safe('float32')
     def dva_to_v1(self, x, y):
         if self.jitter_boundary:
             # remove and discontinuities across x axis
@@ -198,7 +192,7 @@ class Polimeni2006Map(CorticalMap):
         yV1 *= 1000
         return self._invert_left_cart(xV1, yV1, ~inverted)[:2]
 
-    @_elementwise('float32')
+    @_scalar_safe('float32')
     def dva_to_v2(self, x, y):
         if self.jitter_boundary:
             # remove and discontinuities across x and y axis
@@ -219,7 +213,7 @@ class Polimeni2006Map(CorticalMap):
         yV2 *= 1000
         return self._invert_left_cart(xV2, yV2, ~inverted)[:2]
 
-    @_elementwise('float32')
+    @_scalar_safe('float32')
     def dva_to_v3(self, x, y):
         if self.jitter_boundary:
             # remove and discontinuities across x and y axis
@@ -240,11 +234,11 @@ class Polimeni2006Map(CorticalMap):
         yV3 *= 1000
         return self._invert_left_cart(xV3, yV3, ~inverted)[:2]
 
-    @_elementwise('float64')
+    @_scalar_safe(None)
     def v1_to_dva(self, x, y):
         x, y, inverted = self._invert_left_cart(x, y, boundary=self.left_offset/2)
-        x /= 1000
-        y /= 1000
+        x = x / 1000
+        y = y / 1000
         w = x + y*1j
         z = (self.a - self.a * np.exp(w/self.k)) / (self.a/self.b * np.exp(w/self.k) - 1)
         z = z.astype('complex64')
@@ -255,11 +249,11 @@ class Polimeni2006Map(CorticalMap):
         theta = thetav1 / self.alpha1
         return pol2cart(*self._invert_left_pol(theta, r, ~inverted)[:2])
 
-    @_elementwise('float64')
+    @_scalar_safe(None)
     def v2_to_dva(self, x, y):
         x, y, inverted = self._invert_left_cart(x, y, boundary=self.left_offset/2)
-        x /= 1000
-        y /= 1000
+        x = x / 1000
+        y = y / 1000
         w = x + y * 1j
         z = (self.a - self.a*np.exp(w / self.k)) / (self.a/self.b * np.exp(w/self.k) - 1)
         z = z.astype('complex64')
@@ -273,11 +267,11 @@ class Polimeni2006Map(CorticalMap):
         theta = (thetav2 - (np.sign(y) * (phi1 + phi2))) / self.alpha2
         return pol2cart(*self._invert_left_pol(theta, r, ~inverted)[:2])
 
-    @_elementwise('float64')
+    @_scalar_safe(None)
     def v3_to_dva(self, x, y):
         x, y, inverted = self._invert_left_cart(x, y, boundary=self.left_offset/2)
-        x /= 1000
-        y /= 1000
+        x = x / 1000
+        y = y / 1000
         w = x + y * 1j
         z = (self.a - self.a * np.exp(w/self.k)) / (self.a/self.b * np.exp(w/self.k) - 1)
         z = z.astype('complex64')

--- a/pulse2percept/topography/cortex.py
+++ b/pulse2percept/topography/cortex.py
@@ -3,12 +3,33 @@
 """
 import numpy as np
 from abc import abstractmethod
+from functools import wraps
 
 from .base import VisualFieldMap
 from ..units import dva, mm, um
 from ..utils import pol2cart, cart2pol
 from ..utils.constants import UM_PER_MM
 import matplotlib.pyplot as plt
+
+
+def _elementwise(dtype):
+    """Make a coordinate transform elementwise over scalars and arrays alike
+
+    The transforms below index with boolean masks and divide in place, neither
+    of which a scalar (or a 0-d, or an integer, array) supports. Coordinates
+    therefore enter as float arrays of at least one dimension; a call made
+    with two scalars gets scalars back.
+    """
+    def decorator(func):
+        @wraps(func)
+        def wrapper(self, x, y):
+            # np.array copies, so the caller's arrays are never written to:
+            x, y = np.array(x, dtype=dtype), np.array(y, dtype=dtype)
+            scalar = x.ndim == 0 and y.ndim == 0
+            x, y = func(self, np.atleast_1d(x), np.atleast_1d(y))
+            return (x[0], y[0]) if scalar else (x, y)
+        return wrapper
+    return decorator
 
 
 class CorticalMap(VisualFieldMap):
@@ -159,9 +180,8 @@ class Polimeni2006Map(CorticalMap):
         x[idx_nan], y[idx_nan] = np.nan, np.nan
         return x, y
 
+    @_elementwise('float32')
     def dva_to_v1(self, x, y):
-        x = np.array(x, dtype='float32')
-        y = np.array(y, dtype='float32')
         if self.jitter_boundary:
             # remove and discontinuities across x axis
             # shift to the same side as existing points
@@ -178,9 +198,8 @@ class Polimeni2006Map(CorticalMap):
         yV1 *= 1000
         return self._invert_left_cart(xV1, yV1, ~inverted)[:2]
 
+    @_elementwise('float32')
     def dva_to_v2(self, x, y):
-        x = np.array(x, dtype='float32')
-        y = np.array(y, dtype='float32')
         if self.jitter_boundary:
             # remove and discontinuities across x and y axis
             # shift to the same side as existing points
@@ -200,9 +219,8 @@ class Polimeni2006Map(CorticalMap):
         yV2 *= 1000
         return self._invert_left_cart(xV2, yV2, ~inverted)[:2]
 
+    @_elementwise('float32')
     def dva_to_v3(self, x, y):
-        x = np.array(x, dtype='float32')
-        y = np.array(y, dtype='float32')
         if self.jitter_boundary:
             # remove and discontinuities across x and y axis
             # shift to the same side as existing points
@@ -222,9 +240,8 @@ class Polimeni2006Map(CorticalMap):
         yV3 *= 1000
         return self._invert_left_cart(xV3, yV3, ~inverted)[:2]
 
+    @_elementwise('float64')
     def v1_to_dva(self, x, y):
-        x = np.array(x)
-        y = np.array(y)
         x, y, inverted = self._invert_left_cart(x, y, boundary=self.left_offset/2)
         x /= 1000
         y /= 1000
@@ -238,9 +255,8 @@ class Polimeni2006Map(CorticalMap):
         theta = thetav1 / self.alpha1
         return pol2cart(*self._invert_left_pol(theta, r, ~inverted)[:2])
 
+    @_elementwise('float64')
     def v2_to_dva(self, x, y):
-        x = np.array(x)
-        y = np.array(y)
         x, y, inverted = self._invert_left_cart(x, y, boundary=self.left_offset/2)
         x /= 1000
         y /= 1000
@@ -257,9 +273,8 @@ class Polimeni2006Map(CorticalMap):
         theta = (thetav2 - (np.sign(y) * (phi1 + phi2))) / self.alpha2
         return pol2cart(*self._invert_left_pol(theta, r, ~inverted)[:2])
 
+    @_elementwise('float64')
     def v3_to_dva(self, x, y):
-        x = np.array(x)
-        y = np.array(y)
         x, y, inverted = self._invert_left_cart(x, y, boundary=self.left_offset/2)
         x /= 1000
         y /= 1000

--- a/pulse2percept/topography/tests/test_cortex.py
+++ b/pulse2percept/topography/tests/test_cortex.py
@@ -198,3 +198,22 @@ def test_cortical_map_units():
             to_tissue(xdva * um, ydva)
         with pytest.raises(DimensionMismatchError):
             to_visual(x_um * dva, y_um)
+
+
+def test_polimeni_scalars():
+    """A scalar coordinate transforms like a one-element array"""
+    map = Polimeni2006Map(regions=['v1', 'v2', 'v3'])
+    for region in ('v1', 'v2', 'v3'):
+        to_tissue = getattr(map, f'dva_to_{region}')
+        to_visual = getattr(map, f'{region}_to_dva')
+        x_um, y_um = to_tissue(5, -2)
+        npt.assert_equal(np.isscalar(x_um) or np.ndim(x_um) == 0, True)
+        npt.assert_almost_equal([x_um, y_um], np.ravel(to_tissue([5.], [-2.])),
+                                err_msg=region)
+        # Integers must survive the inverse, too (it divides in place):
+        back = to_visual(int(x_um), int(y_um))
+        npt.assert_almost_equal(back, np.ravel(to_visual([float(x_um)],
+                                                         [float(y_um)])), 3,
+                                err_msg=region)
+        # Points outside the mapped eccentricity are NaN, not an error:
+        npt.assert_equal(np.isnan(to_tissue(100, 0)), True)

--- a/pulse2percept/topography/tests/test_cortex.py
+++ b/pulse2percept/topography/tests/test_cortex.py
@@ -210,10 +210,10 @@ def test_polimeni_scalars():
         npt.assert_equal(np.isscalar(x_um) or np.ndim(x_um) == 0, True)
         npt.assert_almost_equal([x_um, y_um], np.ravel(to_tissue([5.], [-2.])),
                                 err_msg=region)
-        # Integers must survive the inverse, too (it divides in place):
-        back = to_visual(int(x_um), int(y_um))
-        npt.assert_almost_equal(back, np.ravel(to_visual([float(x_um)],
-                                                         [float(y_um)])), 3,
+        # Integers must survive the inverse, too (it divides coordinates):
+        xi, yi = int(x_um), int(y_um)
+        npt.assert_almost_equal(to_visual(xi, yi),
+                                to_visual(float(xi), float(yi)),
                                 err_msg=region)
         # Points outside the mapped eccentricity are NaN, not an error:
         npt.assert_equal(np.isnan(to_tissue(100, 0)), True)


### PR DESCRIPTION
Closes #827.

Cause: the six transforms are written for arrays, which index with boolean masks (`x[idx_nan] = np.nan`) and divide in place (`x /= 1000`). A scalar became a 0-d array, whose `np.real` is a NumPy scalar with no `__setitem__`. Integer coordinates broke the inverse direction the same way (`UFuncTypeError` on in-place divide).

Fix: one `_elementwise(dtype)` decorator handles coordinates entering as float arrays and returns two scalars.

Example: `Polimeni2006Map.dva_to_v1(5, -2)` now returns `(np.float32(-51606.777), np.float32(4717.199))`.