### PR TITLE
[ENH] Add meridian blending to spatial models

### DIFF
--- a/doc/users/release_notes.rst
+++ b/doc/users/release_notes.rst
@@ -60,8 +60,9 @@ API changes:
   :py:meth:`~pulse2percept.percepts.Percept.play`).
 
 * :py:class:`~pulse2percept.models.AxonMapSpatial` and cortical spatial models
-  gained a ``meridian_blend`` parameter for optionally smoothing
-  discontinuities across anatomical meridians.
+  gained a ``meridian_blend`` parameter for smoothing discontinuities across
+  anatomical meridians. It is nonzero by default. Pass ``meridian_blend=0``
+  for the previous behavior.
 
 * ``predict_percept`` now raises ``DimensionMismatchError`` when the stimulus
   is not the physical quantity the model reads. Assigning an

--- a/doc/users/release_notes.rst
+++ b/doc/users/release_notes.rst
@@ -62,7 +62,7 @@ API changes:
 * :py:class:`~pulse2percept.models.AxonMapSpatial` now smooths across the
   horizontal meridian by default (``meridian_blend=1`` dva), and
   :py:class:`~pulse2percept.models.cortex.ScoreboardSpatial` smooths across
-  the vertical meridian (``meridian_blend=0.05`` dva). Set
+  the vertical meridian (``meridian_blend=0.1`` dva). Set
   ``meridian_blend=0`` to recover the previous behavior.
 
 * ``predict_percept`` now raises ``DimensionMismatchError`` when the stimulus

--- a/doc/users/release_notes.rst
+++ b/doc/users/release_notes.rst
@@ -59,6 +59,10 @@ API changes:
   :py:meth:`~pulse2percept.stimuli.VideoStimulus.play` and PNG in
   :py:meth:`~pulse2percept.percepts.Percept.play`).
 
+* Spatial models gained a ``_postprocess_spatial`` hook, which sees the
+  predicted percept after ``_predict_spatial`` and before it becomes a
+  percept.
+
 * ``predict_percept`` now raises ``DimensionMismatchError`` when the stimulus
   is not the physical quantity the model reads. Assigning an
   :py:class:`~pulse2percept.stimuli.ImageStimulus` or

--- a/doc/users/release_notes.rst
+++ b/doc/users/release_notes.rst
@@ -59,9 +59,9 @@ API changes:
   :py:meth:`~pulse2percept.stimuli.VideoStimulus.play` and PNG in
   :py:meth:`~pulse2percept.percepts.Percept.play`).
 
-* Spatial models gained a ``_postprocess_spatial`` hook, which sees the
-  predicted percept after ``_predict_spatial`` and before it becomes a
-  percept.
+* :py:class:`~pulse2percept.models.AxonMapSpatial` and cortical spatial models
+  gained a ``meridian_blend`` parameter for optionally smoothing
+  discontinuities across anatomical meridians.
 
 * ``predict_percept`` now raises ``DimensionMismatchError`` when the stimulus
   is not the physical quantity the model reads. Assigning an

--- a/doc/users/release_notes.rst
+++ b/doc/users/release_notes.rst
@@ -59,10 +59,11 @@ API changes:
   :py:meth:`~pulse2percept.stimuli.VideoStimulus.play` and PNG in
   :py:meth:`~pulse2percept.percepts.Percept.play`).
 
-* :py:class:`~pulse2percept.models.AxonMapSpatial` and cortical spatial models
-  gained a ``meridian_blend`` parameter for smoothing discontinuities across
-  anatomical meridians. It is nonzero by default. Pass ``meridian_blend=0``
-  for the previous behavior.
+* :py:class:`~pulse2percept.models.AxonMapSpatial` now smooths across the
+  horizontal meridian by default (``meridian_blend=1`` dva), and
+  :py:class:`~pulse2percept.models.cortex.ScoreboardSpatial` smooths across
+  the vertical meridian (``meridian_blend=0.05`` dva). Set
+  ``meridian_blend=0`` to recover the previous behavior.
 
 * ``predict_percept`` now raises ``DimensionMismatchError`` when the stimulus
   is not the physical quantity the model reads. Assigning an

--- a/pulse2percept/models/base.py
+++ b/pulse2percept/models/base.py
@@ -9,6 +9,7 @@ from abc import ABCMeta, abstractmethod
 from copy import deepcopy, copy
 import numpy as np
 import multiprocessing
+from scipy.ndimage import gaussian_filter1d
 
 from ..implants import ProsthesisSystem
 from ..stimuli import Stimulus
@@ -322,6 +323,83 @@ def _delivered(implant):
     stand_in = copy(implant)
     stand_in._spatial_stim = None
     return stand_in
+
+
+def _blend_meridian(resp, grid, meridian, width):
+    """Soften the seam a model leaves along one meridian
+
+    Some models are built out of two half-fields that meet along a meridian --
+    an axon map's fibers do not cross the horizontal raphe, and a cortical map
+    sends the two hemifields to opposite hemispheres -- so the predicted
+    percept can step discontinuously from one side of that line to the other.
+    The step is an artifact of where the tissue-level model was cut, not
+    something a viewer would report, and this smooths it out downstream of the
+    model: the response is blurred *normal to the meridian only*, and the blur
+    is mixed back in with a weight that dies away with distance from the line.
+
+    Nothing else about the percept moves. Away from the meridian the weight is
+    zero and the original response is returned unchanged, and the blur is 1D,
+    so a vertical meridian never smooths along y and a horizontal one never
+    smooths along x.
+
+    Parameters
+    ----------
+    resp : np.ndarray
+        The spatial response, with time on the last axis and the axes before it
+        indexing ``grid`` (either flattened, as ``_predict_spatial`` returns
+        it, or already shaped like the grid). Returned with its shape and dtype
+        intact.
+    grid : :py:class:`~pulse2percept.topography.Grid2D`
+        The model's grid, whose ``x``/``y`` give each point's distance from the
+        meridian in degrees of visual angle.
+    meridian : {'vertical', 'horizontal'}
+        Which meridian to blend across: ``'vertical'`` is the line x=0 (blurred
+        along x), ``'horizontal'`` the line y=0 (blurred along y).
+    width : float
+        Standard deviation of the blend, in degrees of visual angle: both of
+        the Gaussian blurring normal to the meridian and of the weight that
+        confines it to the meridian. ``None`` or 0 means no blending, and the
+        input is returned as-is (the same object, so callers can detect it).
+
+    Returns
+    -------
+    blended : np.ndarray
+        The blended response, same shape and dtype as ``resp``.
+
+    """
+    if width is None or width == 0:
+        return resp
+    width = float(width)
+    if width < 0:
+        raise ValueError(f"Blend width must be non-negative, not {width}.")
+    if meridian == 'vertical':
+        # Normal to a vertical meridian is x, which varies along the grid's
+        # second axis (`Grid2D` is Cartesian-indexed: y first, then x):
+        dist, axis = grid.x, 1
+    elif meridian == 'horizontal':
+        dist, axis = grid.y, 0
+    else:
+        raise ValueError(f"Unknown meridian '{meridian}'; expected 'vertical' "
+                         f"or 'horizontal'.")
+    # The spacing normal to the meridian, read off the grid rather than from
+    # the model's `step`: `Grid2D` treats `step` as a target and settles on
+    # whatever spacing reaches both end points of the range. Taking it from
+    # the coordinates is what makes `width` a distance in dva rather than a
+    # number of pixels, so the same width behaves the same way at any
+    # resolution.
+    along = dist[:, 0] if axis == 0 else dist[0, :]
+    if along.size < 2:
+        # A single sample normal to the meridian: nothing to blur along.
+        return resp
+    spacing = float(np.abs(np.diff(along)).mean())
+    # Time is the last axis and `gaussian_filter1d` only touches `axis`, so
+    # every time point is blurred on its own:
+    work = np.asarray(resp, dtype=np.float64).reshape(dist.shape + (-1,))
+    blurred = gaussian_filter1d(work, width / spacing, axis=axis,
+                                mode='nearest')
+    weight = np.exp(-dist ** 2 / (2.0 * width ** 2))[..., np.newaxis]
+    blended = weight * blurred + (1.0 - weight) * work
+    return blended.reshape(resp.shape).astype(resp.dtype, copy=False)
 
 
 class NotBuiltError(ValueError, AttributeError):
@@ -845,6 +923,42 @@ class SpatialModel(BaseModel, metaclass=ABCMeta):
         """
         raise NotImplementedError
 
+    def _postprocess_spatial(self, resp):
+        """Adjust the spatial response before it is handed to a ``Percept``
+
+        A hook for anything that operates on the *predicted percept* rather
+        than on the tissue: it sees the response ``_predict_spatial`` produced,
+        at every requested time point, and returns one of the same shape and
+        dtype. Nothing here should need the stimulus or the electrode array --
+        if it does, it belongs in ``_predict_spatial``.
+
+        The base implementation returns the response untouched, and a model
+        that does not override this behaves exactly as if the hook did not
+        exist. :py:class:`~pulse2percept.models.AxonMapSpatial` and
+        :py:class:`~pulse2percept.models.cortex.CortexSpatial` use it to blend
+        across the meridian their tissue-level model is cut along; see
+        ``meridian_blend``.
+
+        .. versionadded:: 0.10.0
+
+        Parameters
+        ----------
+        resp : np.ndarray
+            The spatial response, with time on the last axis and the axes
+            before it indexing ``self.grid`` -- flattened, space x time, as
+            ``_predict_spatial`` returned it (reassembled across duplicate
+            time points first), though a model that overrides
+            ``predict_percept`` may call this with the grid-shaped array it
+            builds instead.
+
+        Returns
+        -------
+        resp : np.ndarray
+            The adjusted response, same shape and dtype.
+
+        """
+        return resp
+
     def predict_percept(self, implant, t_percept=None):
         """Predict the spatial response
 
@@ -980,6 +1094,7 @@ class SpatialModel(BaseModel, metaclass=ABCMeta):
                 resp = resp_unique[..., inverse].copy(order='C')
             else:
                 resp = self._predict_spatial(implant.earray, stim)
+        resp = self._postprocess_spatial(resp)
         return Percept(resp.reshape(list(self.grid.x.shape) + [-1]),
                        space=self.grid, time=t_percept,
                        time_unit=self.time_unit,

--- a/pulse2percept/models/base.py
+++ b/pulse2percept/models/base.py
@@ -326,32 +326,11 @@ def _delivered(implant):
 
 
 def _blend_meridian(resp, grid, meridian, width):
-    """Blend a spatial response across a visual-field meridian.
+    """Blend a response across a visual-field meridian.
 
-    Applies a 1D Gaussian normal to the meridian, weighted by distance
-    from it. ``width`` is in degrees of visual angle. Time points are
-    processed independently.
-
-    Returns ``resp`` unchanged if blending is disabled or if the grid
-    does not straddle the requested meridian.
-
-    .. versionadded:: 0.10.0
-
-    Parameters
-    ----------
-    resp : np.ndarray
-        Spatial response, flattened or grid-shaped, with time last.
-    grid : Grid2D
-        Visual-field grid.
-    meridian : {'vertical', 'horizontal'}
-        Meridian to blend across.
-    width : float
-        Gaussian width in degrees of visual angle.
-
-    Returns
-    -------
-    np.ndarray
-        Blended response with the same shape and dtype as ``resp``.
+    ``width`` is the Gaussian standard deviation in dva. Blurring is 1D,
+    normal to the meridian, and tapered by distance from it. Time points are
+    processed independently. A zero width or one-sided grid is a no-op.
     """
     if width is None or width == 0:
         return resp
@@ -903,12 +882,7 @@ class SpatialModel(BaseModel, metaclass=ABCMeta):
         raise NotImplementedError
 
     def _postprocess_spatial(self, resp):
-        """Postprocess a spatial response before constructing the Percept.
-
-        Subclasses may override this hook. The default is a no-op.
-
-        .. versionadded:: 0.10.0
-        """
+        """Hook for spatial-model postprocessing."""
         return resp
 
     def predict_percept(self, implant, t_percept=None):

--- a/pulse2percept/models/base.py
+++ b/pulse2percept/models/base.py
@@ -326,51 +326,32 @@ def _delivered(implant):
 
 
 def _blend_meridian(resp, grid, meridian, width):
-    """Soften the seam a model leaves along one meridian
+    """Blend a spatial response across a visual-field meridian.
 
-    Some models are built out of two half-fields that meet along a meridian --
-    an axon map's fibers do not cross the horizontal raphe, and a cortical map
-    sends the two hemifields to opposite hemispheres -- so the predicted
-    percept can step discontinuously from one side of that line to the other.
-    Higher visual areas may integrate across a boundary of that kind; this is
-    a coarse stand-in for doing so, applied downstream of the model rather
-    than to the tissue. The response is blurred *normal to the meridian only*,
-    and the blur is mixed back in with a weight that dies away with distance
-    from the line.
+    Applies a 1D Gaussian normal to the meridian, weighted by distance
+    from it. ``width`` is in degrees of visual angle. Time points are
+    processed independently.
 
-    Nothing else about the percept moves. Away from the meridian the weight is
-    zero and the original response is returned unchanged, and the blur is 1D,
-    so a vertical meridian never smooths along y and a horizontal one never
-    smooths along x.
+    Returns ``resp`` unchanged if blending is disabled or if the grid
+    does not straddle the requested meridian.
+
+    .. versionadded:: 0.10.0
 
     Parameters
     ----------
     resp : np.ndarray
-        The spatial response, with time on the last axis and the axes before it
-        indexing ``grid`` (either flattened, as ``_predict_spatial`` returns
-        it, or already shaped like the grid). Returned with its shape and dtype
-        intact.
-    grid : :py:class:`~pulse2percept.topography.Grid2D`
-        The model's grid, whose ``x``/``y`` give each point's distance from the
-        meridian in degrees of visual angle.
+        Spatial response, flattened or grid-shaped, with time last.
+    grid : Grid2D
+        Visual-field grid.
     meridian : {'vertical', 'horizontal'}
-        Which meridian to blend across: ``'vertical'`` is the line x=0 (blurred
-        along x), ``'horizontal'`` the line y=0 (blurred along y).
+        Meridian to blend across.
     width : float
-        Standard deviation of the blend, in degrees of visual angle: both of
-        the Gaussian blurring normal to the meridian and of the weight that
-        confines it to the meridian. ``None`` or 0 means no blending.
-
-        The input is returned as-is -- the same object, so callers can detect
-        it -- for a width of ``None`` or 0, and also for a grid with no seam
-        in view: one that samples only one side of the meridian, or only one
-        point normal to it.
+        Gaussian width in degrees of visual angle.
 
     Returns
     -------
-    blended : np.ndarray
-        The blended response, same shape and dtype as ``resp``.
-
+    np.ndarray
+        Blended response with the same shape and dtype as ``resp``.
     """
     if width is None or width == 0:
         return resp
@@ -378,33 +359,19 @@ def _blend_meridian(resp, grid, meridian, width):
     if width < 0:
         raise ValueError(f"Blend width must be non-negative, not {width}.")
     if meridian == 'vertical':
-        # Normal to a vertical meridian is x, which varies along the grid's
-        # second axis (`Grid2D` is Cartesian-indexed: y first, then x):
         dist, axis = grid.x, 1
     elif meridian == 'horizontal':
         dist, axis = grid.y, 0
     else:
         raise ValueError(f"Unknown meridian '{meridian}'; expected 'vertical' "
                          f"or 'horizontal'.")
-    # The spacing normal to the meridian, read off the grid rather than from
-    # the model's `step`: `Grid2D` treats `step` as a target and settles on
-    # whatever spacing reaches both end points of the range. Taking it from
-    # the coordinates is what makes `width` a distance in dva rather than a
-    # number of pixels, so the same width behaves the same way at any
-    # resolution.
+    # Convert width from dva to samples:
     along = dist[:, 0] if axis == 0 else dist[0, :]
     if along.size < 2 or not (np.any(along < 0) and np.any(along > 0)):
-        # Either a single sample normal to the meridian, or a grid that lies
-        # wholly on one side of it -- `xrange=(0, 5)` on a cortical model, say,
-        # which is ordinary usage. There is no seam in view either way, and
-        # blurring would mix samples from within one hemifield for a reason
-        # that has nothing to do with the meridian.
+        # Nothing to blend unless the grid straddles the meridian:
         return resp
     spacing = float(np.abs(np.diff(along)).mean())
-    # Time is the last axis and `gaussian_filter1d` only touches `axis`, so
-    # every time point is blurred on its own. In the response's own precision:
-    # a mix of two numbers needs no more of it than the numbers have, and a
-    # video percept is large enough that the temporaries matter.
+    # Filter each time point independently:
     work = np.asarray(resp).reshape(dist.shape + (-1,))
     blurred = gaussian_filter1d(work, width / spacing, axis=axis,
                                 mode='nearest')
@@ -936,38 +903,11 @@ class SpatialModel(BaseModel, metaclass=ABCMeta):
         raise NotImplementedError
 
     def _postprocess_spatial(self, resp):
-        """Adjust the spatial response before it is handed to a ``Percept``
+        """Postprocess a spatial response before constructing the Percept.
 
-        A hook for anything that operates on the *predicted percept* rather
-        than on the tissue: it sees the response ``_predict_spatial`` produced,
-        at every requested time point, and returns one of the same shape and
-        dtype. Nothing here should need the stimulus or the electrode array --
-        if it does, it belongs in ``_predict_spatial``.
-
-        The base implementation returns the response untouched, and a model
-        that does not override this behaves exactly as if the hook did not
-        exist. :py:class:`~pulse2percept.models.AxonMapSpatial` and
-        :py:class:`~pulse2percept.models.cortex.CortexSpatial` use it for
-        ``meridian_blend``, which optionally smooths the discontinuity their
-        tissue-level maps leave along a meridian.
+        Subclasses may override this hook. The default is a no-op.
 
         .. versionadded:: 0.10.0
-
-        Parameters
-        ----------
-        resp : np.ndarray
-            The spatial response, with time on the last axis and the axes
-            before it indexing ``self.grid`` -- flattened, space x time, as
-            ``_predict_spatial`` returned it (reassembled across duplicate
-            time points first), though a model that overrides
-            ``predict_percept`` may call this with the grid-shaped array it
-            builds instead.
-
-        Returns
-        -------
-        resp : np.ndarray
-            The adjusted response, same shape and dtype.
-
         """
         return resp
 

--- a/pulse2percept/models/base.py
+++ b/pulse2percept/models/base.py
@@ -332,10 +332,11 @@ def _blend_meridian(resp, grid, meridian, width):
     an axon map's fibers do not cross the horizontal raphe, and a cortical map
     sends the two hemifields to opposite hemispheres -- so the predicted
     percept can step discontinuously from one side of that line to the other.
-    The step is an artifact of where the tissue-level model was cut, not
-    something a viewer would report, and this smooths it out downstream of the
-    model: the response is blurred *normal to the meridian only*, and the blur
-    is mixed back in with a weight that dies away with distance from the line.
+    Higher visual areas may integrate across a boundary of that kind; this is
+    a coarse stand-in for doing so, applied downstream of the model rather
+    than to the tissue. The response is blurred *normal to the meridian only*,
+    and the blur is mixed back in with a weight that dies away with distance
+    from the line.
 
     Nothing else about the percept moves. Away from the meridian the weight is
     zero and the original response is returned unchanged, and the blur is 1D,
@@ -358,8 +359,12 @@ def _blend_meridian(resp, grid, meridian, width):
     width : float
         Standard deviation of the blend, in degrees of visual angle: both of
         the Gaussian blurring normal to the meridian and of the weight that
-        confines it to the meridian. ``None`` or 0 means no blending, and the
-        input is returned as-is (the same object, so callers can detect it).
+        confines it to the meridian. ``None`` or 0 means no blending.
+
+        The input is returned as-is -- the same object, so callers can detect
+        it -- for a width of ``None`` or 0, and also for a grid with no seam
+        in view: one that samples only one side of the meridian, or only one
+        point normal to it.
 
     Returns
     -------
@@ -388,17 +393,24 @@ def _blend_meridian(resp, grid, meridian, width):
     # number of pixels, so the same width behaves the same way at any
     # resolution.
     along = dist[:, 0] if axis == 0 else dist[0, :]
-    if along.size < 2:
-        # A single sample normal to the meridian: nothing to blur along.
+    if along.size < 2 or not (np.any(along < 0) and np.any(along > 0)):
+        # Either a single sample normal to the meridian, or a grid that lies
+        # wholly on one side of it -- `xrange=(0, 5)` on a cortical model, say,
+        # which is ordinary usage. There is no seam in view either way, and
+        # blurring would mix samples from within one hemifield for a reason
+        # that has nothing to do with the meridian.
         return resp
     spacing = float(np.abs(np.diff(along)).mean())
     # Time is the last axis and `gaussian_filter1d` only touches `axis`, so
-    # every time point is blurred on its own:
-    work = np.asarray(resp, dtype=np.float64).reshape(dist.shape + (-1,))
+    # every time point is blurred on its own. In the response's own precision:
+    # a mix of two numbers needs no more of it than the numbers have, and a
+    # video percept is large enough that the temporaries matter.
+    work = np.asarray(resp).reshape(dist.shape + (-1,))
     blurred = gaussian_filter1d(work, width / spacing, axis=axis,
                                 mode='nearest')
     weight = np.exp(-dist ** 2 / (2.0 * width ** 2))[..., np.newaxis]
-    blended = weight * blurred + (1.0 - weight) * work
+    weight = weight.astype(work.dtype, copy=False)
+    blended = weight * blurred + (1 - weight) * work
     return blended.reshape(resp.shape).astype(resp.dtype, copy=False)
 
 
@@ -935,9 +947,9 @@ class SpatialModel(BaseModel, metaclass=ABCMeta):
         The base implementation returns the response untouched, and a model
         that does not override this behaves exactly as if the hook did not
         exist. :py:class:`~pulse2percept.models.AxonMapSpatial` and
-        :py:class:`~pulse2percept.models.cortex.CortexSpatial` use it to blend
-        across the meridian their tissue-level model is cut along; see
-        ``meridian_blend``.
+        :py:class:`~pulse2percept.models.cortex.CortexSpatial` use it for
+        ``meridian_blend``, which optionally smooths the discontinuity their
+        tissue-level maps leave along a meridian.
 
         .. versionadded:: 0.10.0
 

--- a/pulse2percept/models/beyeler2019.py
+++ b/pulse2percept/models/beyeler2019.py
@@ -16,6 +16,7 @@ from ..topography import Watson2014Map
 from ..implants import ProsthesisSystem, ElectrodeArray
 from ..stimuli import Stimulus
 from ..models import Model, SpatialModel
+from .base import _blend_meridian
 from ._beyeler2019 import (fast_scoreboard, fast_axon_map, fast_jansonius,
                            fast_find_closest_axon)        
 
@@ -349,6 +350,24 @@ class AxonMapSpatial(SpatialModel):
         Axon segments whose contribution to brightness is smaller than this
         value will be pruned to improve computational efficiency. Set to a
         value between 0 and 1.
+    meridian_blend : float, optional
+        Width (in degrees of visual angle) over which to blend the percept
+        across the **horizontal meridian**, y=0. Nerve fiber bundles do not
+        cross the horizontal raphe, so the axon map ends at it and the
+        predicted percept can step discontinuously from the superior to the
+        inferior half of the visual field. That seam is a property of the
+        anatomy the model is built from, not of what a patient reports: later
+        stages of the visual system integrate across an anatomical boundary
+        that has no perceptual counterpart. Setting this to a positive number
+        smooths the percept along y near the raphe -- and only near it, and
+        only along y -- to stand in for that integration.
+
+        The default of 0 leaves the seam in place, because there is no
+        principled universal blend width yet; treat any nonzero value as a
+        parameter of your own to justify. It changes only the predicted
+        percept, never the axon map or the current spread that produced it.
+
+        .. versionadded:: 0.10.0
     axon_pickle : str, optional
         File name in which to store precomputed axon maps.
     ignore_pickle : bool, optional
@@ -401,6 +420,9 @@ class AxonMapSpatial(SpatialModel):
             # Axon segments whose contribution to brightness is smaller than
             # this value will be pruned:
             'min_ax_sensitivity': 1e-3,
+            # Width (dva) over which to blend the percept across the
+            # horizontal meridian, where the axon map ends. 0: don't:
+            'meridian_blend': 0,
             # Precomputed axon maps stored in the following file:
             'axon_pickle': 'axons.pickle',
             # You can force a build by ignoring pickles:
@@ -416,7 +438,7 @@ class AxonMapSpatial(SpatialModel):
         # visual angle, and `ax_segments_range` a radial position in the
         # Jansonius model's own coordinates, so neither is declared here:
         return {**super().get_param_units(), 'rho': um, 'lam': um,
-                'loc_od': dva}
+                'loc_od': dva, 'meridian_blend': dva}
 
     def _jansonius2009(self, phi0, beta_sup=-1.9, beta_inf=0.5, eye='RE'):
         """Grows a single axon bundle based on the model by Jansonius (2009)
@@ -979,6 +1001,24 @@ class AxonMapSpatial(SpatialModel):
                              self._cutoff_r2(self.rho),
                              self.n_threads)
 
+    def _postprocess_spatial(self, resp):
+        """Blend the percept across the horizontal meridian
+
+        Axons stop at the raphe, so the percept can step discontinuously
+        across y=0. See ``meridian_blend``, which is 0 (no blending) unless
+        the user asks for it.
+        """
+        blended = _blend_meridian(resp, self.grid, 'horizontal',
+                                  self.meridian_blend)
+        if blended is resp:
+            # No blending asked for; leave the response bit-for-bit alone.
+            return resp
+        # Blending pulls brightness across the raphe, which can lift a point
+        # `thresh_percept` had zeroed back off zero. Reapply it, on the same
+        # |value| < threshold rule `fast_axon_map` used:
+        blended[np.abs(blended) < self.thresh_percept] = 0
+        return blended
+
     def plot(self, use_dva=False, style='hull', annotate=True, autoscale=True,
              ax=None, figsize=None):
         """Plot the axon map
@@ -1185,6 +1225,24 @@ class AxonMapModel(Model):
         Axon segments whose contribution to brightness is smaller than this
         value will be pruned to improve computational efficiency. Set to a
         value between 0 and 1.
+    meridian_blend : float, optional
+        Width (in degrees of visual angle) over which to blend the percept
+        across the **horizontal meridian**, y=0. Nerve fiber bundles do not
+        cross the horizontal raphe, so the axon map ends at it and the
+        predicted percept can step discontinuously from the superior to the
+        inferior half of the visual field. That seam is a property of the
+        anatomy the model is built from, not of what a patient reports: later
+        stages of the visual system integrate across an anatomical boundary
+        that has no perceptual counterpart. Setting this to a positive number
+        smooths the percept along y near the raphe -- and only near it, and
+        only along y -- to stand in for that integration.
+
+        The default of 0 leaves the seam in place, because there is no
+        principled universal blend width yet; treat any nonzero value as a
+        parameter of your own to justify. It changes only the predicted
+        percept, never the axon map or the current spread that produced it.
+
+        .. versionadded:: 0.10.0
     axon_pickle : str, optional
         File name in which to store precomputed axon maps.
     ignore_pickle : bool, optional

--- a/pulse2percept/models/beyeler2019.py
+++ b/pulse2percept/models/beyeler2019.py
@@ -351,20 +351,10 @@ class AxonMapSpatial(SpatialModel):
         value will be pruned to improve computational efficiency. Set to a
         value between 0 and 1.
     meridian_blend : float, optional
-        Width (in degrees of visual angle) over which to blend the percept
-        across the **horizontal meridian**, y=0. Nerve fiber bundles do not
-        cross the horizontal raphe, so the axon map ends at it and the
-        predicted percept can step discontinuously from the superior to the
-        inferior half of the visual field. Whether that step is visible is not
-        known: higher visual areas may integrate across an anatomical boundary
-        of this kind. Setting this to a positive number is an optional, coarse
-        approximation of such integration -- it smooths the percept along y
-        near the raphe, and only there.
-
-        The default of 0 leaves the seam in place: there is no principled
-        blend width, so any nonzero value is a modeling choice of your own to
-        justify. It changes only the predicted percept, never the axon map or
-        the current spread that produced it.
+        Width (in degrees of visual angle) of optional smoothing across the
+        horizontal meridian (y=0), as a coarse approximation of downstream
+        integration across the raphe. The default, 0, disables blending.
+        Nonzero values are a modeling assumption.
 
         .. versionadded:: 0.10.0
     axon_pickle : str, optional
@@ -419,8 +409,7 @@ class AxonMapSpatial(SpatialModel):
             # Axon segments whose contribution to brightness is smaller than
             # this value will be pruned:
             'min_ax_sensitivity': 1e-3,
-            # Width (dva) over which to blend the percept across the
-            # horizontal meridian, where the axon map ends. 0: don't:
+            # Meridian blend width (dva); 0 disables:
             'meridian_blend': 0,
             # Precomputed axon maps stored in the following file:
             'axon_pickle': 'axons.pickle',
@@ -1001,20 +990,13 @@ class AxonMapSpatial(SpatialModel):
                              self.n_threads)
 
     def _postprocess_spatial(self, resp):
-        """Blend the percept across the horizontal meridian
-
-        Axons stop at the raphe, so the percept can step discontinuously
-        across y=0. See ``meridian_blend``, which is 0 (no blending) unless
-        the user asks for it.
-        """
+        """Blend across the horizontal meridian"""
         blended = _blend_meridian(resp, self.grid, 'horizontal',
                                   self.meridian_blend)
         if blended is resp:
             # No blending asked for; leave the response bit-for-bit alone.
             return resp
-        # Blending pulls brightness across the raphe, which can lift a point
-        # `thresh_percept` had zeroed back off zero. Reapply it, on the same
-        # |value| < threshold rule `fast_axon_map` used:
+        # Restore percept threshold after blending:
         blended[np.abs(blended) < self.thresh_percept] = 0
         return blended
 

--- a/pulse2percept/models/beyeler2019.py
+++ b/pulse2percept/models/beyeler2019.py
@@ -353,7 +353,7 @@ class AxonMapSpatial(SpatialModel):
     meridian_blend : float, optional
         Width (in degrees of visual angle) of optional smoothing across the
         horizontal meridian (y=0), as a coarse approximation of downstream
-        integration across the raphe. The default, 0, disables blending.
+        integration across the raphe.
         Nonzero values are a modeling assumption.
 
         .. versionadded:: 0.10.0
@@ -410,7 +410,7 @@ class AxonMapSpatial(SpatialModel):
             # this value will be pruned:
             'min_ax_sensitivity': 1e-3,
             # Meridian blend width (dva); 0 disables:
-            'meridian_blend': 0,
+            'meridian_blend': 1,
             # Precomputed axon maps stored in the following file:
             'axon_pickle': 'axons.pickle',
             # You can force a build by ignoring pickles:
@@ -1207,20 +1207,10 @@ class AxonMapModel(Model):
         value will be pruned to improve computational efficiency. Set to a
         value between 0 and 1.
     meridian_blend : float, optional
-        Width (in degrees of visual angle) over which to blend the percept
-        across the **horizontal meridian**, y=0. Nerve fiber bundles do not
-        cross the horizontal raphe, so the axon map ends at it and the
-        predicted percept can step discontinuously from the superior to the
-        inferior half of the visual field. Whether that step is visible is not
-        known: higher visual areas may integrate across an anatomical boundary
-        of this kind. Setting this to a positive number is an optional, coarse
-        approximation of such integration -- it smooths the percept along y
-        near the raphe, and only there.
-
-        The default of 0 leaves the seam in place: there is no principled
-        blend width, so any nonzero value is a modeling choice of your own to
-        justify. It changes only the predicted percept, never the axon map or
-        the current spread that produced it.
+        Width (in degrees of visual angle) of optional smoothing across the
+        horizontal meridian (y=0), as a coarse approximation of downstream
+        integration across the raphe. The default, 0, disables blending.
+        Nonzero values are a modeling assumption.
 
         .. versionadded:: 0.10.0
     axon_pickle : str, optional

--- a/pulse2percept/models/beyeler2019.py
+++ b/pulse2percept/models/beyeler2019.py
@@ -351,12 +351,8 @@ class AxonMapSpatial(SpatialModel):
         value will be pruned to improve computational efficiency. Set to a
         value between 0 and 1.
     meridian_blend : float, optional
-        Gaussian standard deviation (in degrees of visual angle) for optional
-        smoothing across the horizontal meridian (y=0), as a coarse
-        approximation of downstream integration across the raphe. It sets both
-        the blur, which runs normal to the meridian, and the distance over
-        which that blur is mixed back in. 0 disables blending; nonzero values
-        are a modeling assumption.
+        Gaussian standard deviation (dva) for smoothing across the horizontal
+        meridian. Default: 1. Set to 0 to disable.
 
         .. versionadded:: 0.10.0
     axon_pickle : str, optional
@@ -1209,12 +1205,8 @@ class AxonMapModel(Model):
         value will be pruned to improve computational efficiency. Set to a
         value between 0 and 1.
     meridian_blend : float, optional
-        Gaussian standard deviation (in degrees of visual angle) for optional
-        smoothing across the horizontal meridian (y=0), as a coarse
-        approximation of downstream integration across the raphe. It sets both
-        the blur, which runs normal to the meridian, and the distance over
-        which that blur is mixed back in. 0 disables blending; nonzero values
-        are a modeling assumption.
+        Gaussian standard deviation (dva) for smoothing across the horizontal
+        meridian. Default: 1. Set to 0 to disable.
 
         .. versionadded:: 0.10.0
     axon_pickle : str, optional

--- a/pulse2percept/models/beyeler2019.py
+++ b/pulse2percept/models/beyeler2019.py
@@ -351,10 +351,12 @@ class AxonMapSpatial(SpatialModel):
         value will be pruned to improve computational efficiency. Set to a
         value between 0 and 1.
     meridian_blend : float, optional
-        Width (in degrees of visual angle) of optional smoothing across the
-        horizontal meridian (y=0), as a coarse approximation of downstream
-        integration across the raphe.
-        Nonzero values are a modeling assumption.
+        Gaussian standard deviation (in degrees of visual angle) for optional
+        smoothing across the horizontal meridian (y=0), as a coarse
+        approximation of downstream integration across the raphe. It sets both
+        the blur, which runs normal to the meridian, and the distance over
+        which that blur is mixed back in. 0 disables blending; nonzero values
+        are a modeling assumption.
 
         .. versionadded:: 0.10.0
     axon_pickle : str, optional
@@ -1207,10 +1209,12 @@ class AxonMapModel(Model):
         value will be pruned to improve computational efficiency. Set to a
         value between 0 and 1.
     meridian_blend : float, optional
-        Width (in degrees of visual angle) of optional smoothing across the
-        horizontal meridian (y=0), as a coarse approximation of downstream
-        integration across the raphe. The default, 0, disables blending.
-        Nonzero values are a modeling assumption.
+        Gaussian standard deviation (in degrees of visual angle) for optional
+        smoothing across the horizontal meridian (y=0), as a coarse
+        approximation of downstream integration across the raphe. It sets both
+        the blur, which runs normal to the meridian, and the distance over
+        which that blur is mixed back in. 0 disables blending; nonzero values
+        are a modeling assumption.
 
         .. versionadded:: 0.10.0
     axon_pickle : str, optional

--- a/pulse2percept/models/beyeler2019.py
+++ b/pulse2percept/models/beyeler2019.py
@@ -355,17 +355,16 @@ class AxonMapSpatial(SpatialModel):
         across the **horizontal meridian**, y=0. Nerve fiber bundles do not
         cross the horizontal raphe, so the axon map ends at it and the
         predicted percept can step discontinuously from the superior to the
-        inferior half of the visual field. That seam is a property of the
-        anatomy the model is built from, not of what a patient reports: later
-        stages of the visual system integrate across an anatomical boundary
-        that has no perceptual counterpart. Setting this to a positive number
-        smooths the percept along y near the raphe -- and only near it, and
-        only along y -- to stand in for that integration.
+        inferior half of the visual field. Whether that step is visible is not
+        known: higher visual areas may integrate across an anatomical boundary
+        of this kind. Setting this to a positive number is an optional, coarse
+        approximation of such integration -- it smooths the percept along y
+        near the raphe, and only there.
 
-        The default of 0 leaves the seam in place, because there is no
-        principled universal blend width yet; treat any nonzero value as a
-        parameter of your own to justify. It changes only the predicted
-        percept, never the axon map or the current spread that produced it.
+        The default of 0 leaves the seam in place: there is no principled
+        blend width, so any nonzero value is a modeling choice of your own to
+        justify. It changes only the predicted percept, never the axon map or
+        the current spread that produced it.
 
         .. versionadded:: 0.10.0
     axon_pickle : str, optional
@@ -1230,17 +1229,16 @@ class AxonMapModel(Model):
         across the **horizontal meridian**, y=0. Nerve fiber bundles do not
         cross the horizontal raphe, so the axon map ends at it and the
         predicted percept can step discontinuously from the superior to the
-        inferior half of the visual field. That seam is a property of the
-        anatomy the model is built from, not of what a patient reports: later
-        stages of the visual system integrate across an anatomical boundary
-        that has no perceptual counterpart. Setting this to a positive number
-        smooths the percept along y near the raphe -- and only near it, and
-        only along y -- to stand in for that integration.
+        inferior half of the visual field. Whether that step is visible is not
+        known: higher visual areas may integrate across an anatomical boundary
+        of this kind. Setting this to a positive number is an optional, coarse
+        approximation of such integration -- it smooths the percept along y
+        near the raphe, and only there.
 
-        The default of 0 leaves the seam in place, because there is no
-        principled universal blend width yet; treat any nonzero value as a
-        parameter of your own to justify. It changes only the predicted
-        percept, never the axon map or the current spread that produced it.
+        The default of 0 leaves the seam in place: there is no principled
+        blend width, so any nonzero value is a modeling choice of your own to
+        justify. It changes only the predicted percept, never the axon map or
+        the current spread that produced it.
 
         .. versionadded:: 0.10.0
     axon_pickle : str, optional

--- a/pulse2percept/models/cortex/base.py
+++ b/pulse2percept/models/cortex/base.py
@@ -302,7 +302,7 @@ class ScoreboardSpatial(CortexSpatial):
                     # radial current spread
                     'rho': 200,  
                     'ndim' : [2, 3],
-                    'meridian_blend' : 0.05
+                    'meridian_blend' : 0.1
                  }
         return {**base_params, **params}
 

--- a/pulse2percept/models/cortex/base.py
+++ b/pulse2percept/models/cortex/base.py
@@ -57,10 +57,12 @@ class CortexSpatial(SpatialModel):
     grid_type : {'rectangular', 'hexagonal'}, optional
         Whether to simulate points on a rectangular or hexagonal grid
     meridian_blend : float, optional
-        Width (in degrees of visual angle) of optional smoothing across the
-        vertical meridian (x=0), as a coarse approximation of downstream
-        integration across hemispheres.
-        Nonzero values are a modeling assumption.
+        Gaussian standard deviation (in degrees of visual angle) for optional
+        smoothing across the vertical meridian (x=0), as a coarse
+        approximation of downstream integration across hemispheres. It sets
+        both the blur, which runs normal to the meridian, and the distance
+        over which that blur is mixed back in. 0 disables blending; nonzero
+        values are a modeling assumption.
 
         .. versionadded:: 0.10.0
     vfmap : :py:class:`~pulse2percept.topography.VisualFieldMap`, optional
@@ -286,11 +288,11 @@ class ScoreboardSpatial(CortexSpatial):
     grid_type : {'rectangular', 'hexagonal'}, optional
         Whether to simulate points on a rectangular or hexagonal grid
     meridian_blend : float, optional
-        Width (in degrees of visual angle) over which to blend the percept
-        across the vertical meridian, x=0, where the two hemifields meet. An
-        optional approximation of downstream integration across that boundary;
-        the default of 0 leaves the seam the cortical map produces in place.
-        See :py:class:`~pulse2percept.models.cortex.CortexSpatial`.
+        Gaussian standard deviation (in degrees of visual angle) for optional
+        smoothing across the vertical meridian (x=0), as a coarse
+        approximation of downstream integration across hemispheres. 0 disables
+        blending; nonzero values are a modeling assumption. See
+        :py:class:`~pulse2percept.models.cortex.CortexSpatial`.
 
         .. versionadded:: 0.10.0
     vfmap : :py:class:`~pulse2percept.topography..VisualFieldMap`, optional
@@ -426,11 +428,11 @@ class ScoreboardModel(Model):
     grid_type : {'rectangular', 'hexagonal'}, optional
         Whether to simulate points on a rectangular or hexagonal grid
     meridian_blend : float, optional
-        Width (in degrees of visual angle) over which to blend the percept
-        across the vertical meridian, x=0, where the two hemifields meet. An
-        optional approximation of downstream integration across that boundary;
-        the default of 0 leaves the seam the cortical map produces in place.
-        See :py:class:`~pulse2percept.models.cortex.CortexSpatial`.
+        Gaussian standard deviation (in degrees of visual angle) for optional
+        smoothing across the vertical meridian (x=0), as a coarse
+        approximation of downstream integration across hemispheres. 0 disables
+        blending; nonzero values are a modeling assumption. See
+        :py:class:`~pulse2percept.models.cortex.CortexSpatial`.
 
         .. versionadded:: 0.10.0
     vfmap : :py:class:`~pulse2percept.topography..VisualFieldMap`, optional

--- a/pulse2percept/models/cortex/base.py
+++ b/pulse2percept/models/cortex/base.py
@@ -56,15 +56,6 @@ class CortexSpatial(SpatialModel):
             deprecated and will be removed in v0.11.0.
     grid_type : {'rectangular', 'hexagonal'}, optional
         Whether to simulate points on a rectangular or hexagonal grid
-    meridian_blend : float, optional
-        Gaussian standard deviation (in degrees of visual angle) for optional
-        smoothing across the vertical meridian (x=0), as a coarse
-        approximation of downstream integration across hemispheres. It sets
-        both the blur, which runs normal to the meridian, and the distance
-        over which that blur is mixed back in. 0 disables blending; nonzero
-        values are a modeling assumption.
-
-        .. versionadded:: 0.10.0
     vfmap : :py:class:`~pulse2percept.topography.VisualFieldMap`, optional
         An instance of a :py:class:`~pulse2percept.topography.VisualFieldMap`
         object that provides retinotopic mappings.
@@ -142,28 +133,10 @@ class CortexSpatial(SpatialModel):
                     'xrange' : (-5, 5),
                     'yrange' : (-5, 5),
                     'step' : 0.1,
-                    # Meridian blend width (dva); 0 disables:
-                    'meridian_blend' : 0.05,
                     # Visual field regions to simulate
                     'regions' : ['v1']
                  }
         return {**base_params, **params}
-
-    def get_param_units(self):
-        """Return a dict of the units that parameters are stored in"""
-        return {**super().get_param_units(), 'meridian_blend': dva}
-
-    def _postprocess_spatial(self, resp):
-        """Blend the percept across the vertical meridian"""
-        blended = _blend_meridian(resp, self.grid, 'vertical',
-                                  self.meridian_blend)
-        if blended is resp:
-            # No blending asked for; leave the response bit-for-bit alone.
-            return resp
-        # Restore percept threshold after blending:
-        blended[np.abs(blended) < self.thresh_percept] = 0
-        return blended
-    
 
     def plot(self, use_dva=False, style=None, autoscale=True, ax=None,
              figsize=None, fc=None, **kwargs):
@@ -288,11 +261,8 @@ class ScoreboardSpatial(CortexSpatial):
     grid_type : {'rectangular', 'hexagonal'}, optional
         Whether to simulate points on a rectangular or hexagonal grid
     meridian_blend : float, optional
-        Gaussian standard deviation (in degrees of visual angle) for optional
-        smoothing across the vertical meridian (x=0), as a coarse
-        approximation of downstream integration across hemispheres. 0 disables
-        blending; nonzero values are a modeling assumption. See
-        :py:class:`~pulse2percept.models.cortex.CortexSpatial`.
+        Gaussian standard deviation (dva) for smoothing across the vertical
+        meridian. Default: 0.05. Set to 0 to disable.
 
         .. versionadded:: 0.10.0
     vfmap : :py:class:`~pulse2percept.topography..VisualFieldMap`, optional
@@ -331,7 +301,8 @@ class ScoreboardSpatial(CortexSpatial):
         params = {
                     # radial current spread
                     'rho': 200,  
-                    'ndim' : [2, 3]
+                    'ndim' : [2, 3],
+                    'meridian_blend' : 0.05
                  }
         return {**base_params, **params}
 
@@ -339,7 +310,23 @@ class ScoreboardSpatial(CortexSpatial):
         """Return a dict of the units that parameters are stored in"""
         # Cortical coordinates are stored in microns (see `CorticalMap`), and
         # the current spread is compared against them:
-        return {**super().get_param_units(), 'rho': um}
+        return {**super().get_param_units(), 'rho': um, 'meridian_blend': dva}
+
+    def _postprocess_spatial(self, resp):
+        """Blend the percept across the vertical meridian
+
+        On this model rather than on `CortexSpatial`: the seam is a property
+        of the split map this one is built on, not of being cortical, and a
+        future cortical model without one should not inherit a correction for
+        it.
+        """
+        blended = _blend_meridian(resp, self.grid, 'vertical',
+                                  self.meridian_blend)
+        if blended is resp:
+            return resp
+        # Restore percept threshold after blending:
+        blended[np.abs(blended) < self.thresh_percept] = 0
+        return blended
 
     def _predict_spatial(self, earray, stim):
         """Predicts the brightness at spatial locations"""
@@ -428,11 +415,8 @@ class ScoreboardModel(Model):
     grid_type : {'rectangular', 'hexagonal'}, optional
         Whether to simulate points on a rectangular or hexagonal grid
     meridian_blend : float, optional
-        Gaussian standard deviation (in degrees of visual angle) for optional
-        smoothing across the vertical meridian (x=0), as a coarse
-        approximation of downstream integration across hemispheres. 0 disables
-        blending; nonzero values are a modeling assumption. See
-        :py:class:`~pulse2percept.models.cortex.CortexSpatial`.
+        Gaussian standard deviation (dva) for smoothing across the vertical
+        meridian. Default: 0.05. Set to 0 to disable.
 
         .. versionadded:: 0.10.0
     vfmap : :py:class:`~pulse2percept.topography..VisualFieldMap`, optional

--- a/pulse2percept/models/cortex/base.py
+++ b/pulse2percept/models/cortex/base.py
@@ -2,10 +2,10 @@
    :py:class:`~pulse2percept.models.cortex.ScoreboardSpatial`, 
    :py:class:`~pulse2percept.models.cortex.ScoreboardModel`"""
 
-from ..base import Model, SpatialModel
+from ..base import Model, SpatialModel, _blend_meridian
 from ...topography import Polimeni2006Map
 from .._beyeler2019 import fast_scoreboard, fast_scoreboard_3d
-from ...units import DimensionMismatchError, um
+from ...units import DimensionMismatchError, dva, um
 from ...utils.constants import UM_PER_MM, ZORDER
 import numpy as np
 
@@ -56,6 +56,26 @@ class CortexSpatial(SpatialModel):
             deprecated and will be removed in v0.11.0.
     grid_type : {'rectangular', 'hexagonal'}, optional
         Whether to simulate points on a rectangular or hexagonal grid
+    meridian_blend : float, optional
+        Width (in degrees of visual angle) over which to blend the percept
+        across the **vertical meridian**, x=0. The two hemifields are mapped
+        onto opposite hemispheres, so a cortical model is really two
+        half-field models meeting along x=0 and the predicted percept can step
+        discontinuously from the left half of the visual field to the right.
+        That seam is a property of the anatomy the model is built from, not of
+        what a patient reports: later stages of the visual system integrate
+        across an anatomical boundary that has no perceptual counterpart.
+        Setting this to a positive number smooths the percept along x near the
+        vertical meridian -- and only near it, and only along x -- to stand in
+        for that integration.
+
+        The default of 0 leaves the seam in place, because there is no
+        principled universal blend width yet; treat any nonzero value as a
+        parameter of your own to justify. It changes only the predicted
+        percept, never the cortical map or the current spread that produced
+        it.
+
+        .. versionadded:: 0.10.0
     vfmap : :py:class:`~pulse2percept.topography.VisualFieldMap`, optional
         An instance of a :py:class:`~pulse2percept.topography.VisualFieldMap`
         object that provides retinotopic mappings.
@@ -133,10 +153,35 @@ class CortexSpatial(SpatialModel):
                     'xrange' : (-5, 5),
                     'yrange' : (-5, 5),
                     'step' : 0.1,
+                    # Width (dva) over which to blend the percept across the
+                    # vertical meridian, where the hemifields meet. 0: don't:
+                    'meridian_blend' : 0,
                     # Visual field regions to simulate
                     'regions' : ['v1']
                  }
         return {**base_params, **params}
+
+    def get_param_units(self):
+        """Return a dict of the units that parameters are stored in"""
+        return {**super().get_param_units(), 'meridian_blend': dva}
+
+    def _postprocess_spatial(self, resp):
+        """Blend the percept across the vertical meridian
+
+        The hemifields are mapped onto opposite hemispheres, so the percept
+        can step discontinuously across x=0. See ``meridian_blend``, which is
+        0 (no blending) unless the user asks for it.
+        """
+        blended = _blend_meridian(resp, self.grid, 'vertical',
+                                  self.meridian_blend)
+        if blended is resp:
+            # No blending asked for; leave the response bit-for-bit alone.
+            return resp
+        # Blending pulls brightness across the meridian, which can lift a
+        # point `thresh_percept` had zeroed back off zero. Reapply it, on the
+        # same |value| < threshold rule the spatial kernel used:
+        blended[np.abs(blended) < self.thresh_percept] = 0
+        return blended
     
 
     def plot(self, use_dva=False, style=None, autoscale=True, ax=None,
@@ -261,6 +306,13 @@ class ScoreboardSpatial(CortexSpatial):
             deprecated and will be removed in v0.11.0.
     grid_type : {'rectangular', 'hexagonal'}, optional
         Whether to simulate points on a rectangular or hexagonal grid
+    meridian_blend : float, optional
+        Width (in degrees of visual angle) over which to blend the percept
+        across the vertical meridian, x=0, where the two hemifields meet. The
+        default of 0 leaves the seam the cortical map produces in place; see
+        :py:class:`~pulse2percept.models.cortex.CortexSpatial`.
+
+        .. versionadded:: 0.10.0
     vfmap : :py:class:`~pulse2percept.topography..VisualFieldMap`, optional
         An instance of a :py:class:`~pulse2percept.topography.VisualFieldMap`
         object that provides retinotopic mappings.
@@ -393,6 +445,13 @@ class ScoreboardModel(Model):
             deprecated and will be removed in v0.11.0.
     grid_type : {'rectangular', 'hexagonal'}, optional
         Whether to simulate points on a rectangular or hexagonal grid
+    meridian_blend : float, optional
+        Width (in degrees of visual angle) over which to blend the percept
+        across the vertical meridian, x=0, where the two hemifields meet. The
+        default of 0 leaves the seam the cortical map produces in place; see
+        :py:class:`~pulse2percept.models.cortex.CortexSpatial`.
+
+        .. versionadded:: 0.10.0
     vfmap : :py:class:`~pulse2percept.topography..VisualFieldMap`, optional
         An instance of a :py:class:`~pulse2percept.topography.VisualFieldMap`
         object that provides retinotopic mappings.

--- a/pulse2percept/models/cortex/base.py
+++ b/pulse2percept/models/cortex/base.py
@@ -57,21 +57,10 @@ class CortexSpatial(SpatialModel):
     grid_type : {'rectangular', 'hexagonal'}, optional
         Whether to simulate points on a rectangular or hexagonal grid
     meridian_blend : float, optional
-        Width (in degrees of visual angle) over which to blend the percept
-        across the **vertical meridian**, x=0. The two hemifields are mapped
-        onto opposite hemispheres, so a cortical model is really two
-        half-field models meeting along x=0 and the predicted percept can step
-        discontinuously from the left half of the visual field to the right.
-        Whether that step is visible is not known: higher visual areas may
-        integrate across an anatomical boundary of this kind. Setting this to
-        a positive number is an optional, coarse approximation of such
-        integration -- it smooths the percept along x near the vertical
-        meridian, and only there.
-
-        The default of 0 leaves the seam in place: there is no principled
-        blend width, so any nonzero value is a modeling choice of your own to
-        justify. It changes only the predicted percept, never the cortical map
-        or the current spread that produced it.
+        Width (in degrees of visual angle) of optional smoothing across the
+        vertical meridian (x=0), as a coarse approximation of downstream
+        integration across hemispheres. The default, 0, disables blending.
+        Nonzero values are a modeling assumption.
 
         .. versionadded:: 0.10.0
     vfmap : :py:class:`~pulse2percept.topography.VisualFieldMap`, optional
@@ -151,8 +140,7 @@ class CortexSpatial(SpatialModel):
                     'xrange' : (-5, 5),
                     'yrange' : (-5, 5),
                     'step' : 0.1,
-                    # Width (dva) over which to blend the percept across the
-                    # vertical meridian, where the hemifields meet. 0: don't:
+                    # Meridian blend width (dva); 0 disables:
                     'meridian_blend' : 0,
                     # Visual field regions to simulate
                     'regions' : ['v1']
@@ -164,20 +152,13 @@ class CortexSpatial(SpatialModel):
         return {**super().get_param_units(), 'meridian_blend': dva}
 
     def _postprocess_spatial(self, resp):
-        """Blend the percept across the vertical meridian
-
-        The hemifields are mapped onto opposite hemispheres, so the percept
-        can step discontinuously across x=0. See ``meridian_blend``, which is
-        0 (no blending) unless the user asks for it.
-        """
+        """Blend the percept across the vertical meridian"""
         blended = _blend_meridian(resp, self.grid, 'vertical',
                                   self.meridian_blend)
         if blended is resp:
             # No blending asked for; leave the response bit-for-bit alone.
             return resp
-        # Blending pulls brightness across the meridian, which can lift a
-        # point `thresh_percept` had zeroed back off zero. Reapply it, on the
-        # same |value| < threshold rule the spatial kernel used:
+        # Restore percept threshold after blending:
         blended[np.abs(blended) < self.thresh_percept] = 0
         return blended
     

--- a/pulse2percept/models/cortex/base.py
+++ b/pulse2percept/models/cortex/base.py
@@ -262,7 +262,7 @@ class ScoreboardSpatial(CortexSpatial):
         Whether to simulate points on a rectangular or hexagonal grid
     meridian_blend : float, optional
         Gaussian standard deviation (dva) for smoothing across the vertical
-        meridian. Default: 0.05. Set to 0 to disable.
+        meridian. Default: 0.1. Set to 0 to disable.
 
         .. versionadded:: 0.10.0
     vfmap : :py:class:`~pulse2percept.topography..VisualFieldMap`, optional
@@ -416,7 +416,7 @@ class ScoreboardModel(Model):
         Whether to simulate points on a rectangular or hexagonal grid
     meridian_blend : float, optional
         Gaussian standard deviation (dva) for smoothing across the vertical
-        meridian. Default: 0.05. Set to 0 to disable.
+        meridian. Default: 0.1. Set to 0 to disable.
 
         .. versionadded:: 0.10.0
     vfmap : :py:class:`~pulse2percept.topography..VisualFieldMap`, optional

--- a/pulse2percept/models/cortex/base.py
+++ b/pulse2percept/models/cortex/base.py
@@ -59,7 +59,7 @@ class CortexSpatial(SpatialModel):
     meridian_blend : float, optional
         Width (in degrees of visual angle) of optional smoothing across the
         vertical meridian (x=0), as a coarse approximation of downstream
-        integration across hemispheres. The default, 0, disables blending.
+        integration across hemispheres.
         Nonzero values are a modeling assumption.
 
         .. versionadded:: 0.10.0
@@ -141,7 +141,7 @@ class CortexSpatial(SpatialModel):
                     'yrange' : (-5, 5),
                     'step' : 0.1,
                     # Meridian blend width (dva); 0 disables:
-                    'meridian_blend' : 0,
+                    'meridian_blend' : 0.05,
                     # Visual field regions to simulate
                     'regions' : ['v1']
                  }

--- a/pulse2percept/models/cortex/base.py
+++ b/pulse2percept/models/cortex/base.py
@@ -62,18 +62,16 @@ class CortexSpatial(SpatialModel):
         onto opposite hemispheres, so a cortical model is really two
         half-field models meeting along x=0 and the predicted percept can step
         discontinuously from the left half of the visual field to the right.
-        That seam is a property of the anatomy the model is built from, not of
-        what a patient reports: later stages of the visual system integrate
-        across an anatomical boundary that has no perceptual counterpart.
-        Setting this to a positive number smooths the percept along x near the
-        vertical meridian -- and only near it, and only along x -- to stand in
-        for that integration.
+        Whether that step is visible is not known: higher visual areas may
+        integrate across an anatomical boundary of this kind. Setting this to
+        a positive number is an optional, coarse approximation of such
+        integration -- it smooths the percept along x near the vertical
+        meridian, and only there.
 
-        The default of 0 leaves the seam in place, because there is no
-        principled universal blend width yet; treat any nonzero value as a
-        parameter of your own to justify. It changes only the predicted
-        percept, never the cortical map or the current spread that produced
-        it.
+        The default of 0 leaves the seam in place: there is no principled
+        blend width, so any nonzero value is a modeling choice of your own to
+        justify. It changes only the predicted percept, never the cortical map
+        or the current spread that produced it.
 
         .. versionadded:: 0.10.0
     vfmap : :py:class:`~pulse2percept.topography.VisualFieldMap`, optional
@@ -308,9 +306,10 @@ class ScoreboardSpatial(CortexSpatial):
         Whether to simulate points on a rectangular or hexagonal grid
     meridian_blend : float, optional
         Width (in degrees of visual angle) over which to blend the percept
-        across the vertical meridian, x=0, where the two hemifields meet. The
-        default of 0 leaves the seam the cortical map produces in place; see
-        :py:class:`~pulse2percept.models.cortex.CortexSpatial`.
+        across the vertical meridian, x=0, where the two hemifields meet. An
+        optional approximation of downstream integration across that boundary;
+        the default of 0 leaves the seam the cortical map produces in place.
+        See :py:class:`~pulse2percept.models.cortex.CortexSpatial`.
 
         .. versionadded:: 0.10.0
     vfmap : :py:class:`~pulse2percept.topography..VisualFieldMap`, optional
@@ -447,9 +446,10 @@ class ScoreboardModel(Model):
         Whether to simulate points on a rectangular or hexagonal grid
     meridian_blend : float, optional
         Width (in degrees of visual angle) over which to blend the percept
-        across the vertical meridian, x=0, where the two hemifields meet. The
-        default of 0 leaves the seam the cortical map produces in place; see
-        :py:class:`~pulse2percept.models.cortex.CortexSpatial`.
+        across the vertical meridian, x=0, where the two hemifields meet. An
+        optional approximation of downstream integration across that boundary;
+        the default of 0 leaves the seam the cortical map produces in place.
+        See :py:class:`~pulse2percept.models.cortex.CortexSpatial`.
 
         .. versionadded:: 0.10.0
     vfmap : :py:class:`~pulse2percept.topography..VisualFieldMap`, optional

--- a/pulse2percept/models/cortex/tests/test_base.py
+++ b/pulse2percept/models/cortex/tests/test_base.py
@@ -116,7 +116,11 @@ def test_predict_spatial_regionsum(ModelClass,regions):
     percept2 = model2.predict_percept(implant)
     percept_both = model_both.predict_percept(implant)
 
-    npt.assert_almost_equal(percept1.data + percept2.data, percept_both.data)
+    # `decimal=4`: blending is linear, so the sum still holds exactly in real
+    # arithmetic, but each percept picks up float32 round-off from its own
+    # pass through the meridian filter.
+    npt.assert_almost_equal(percept1.data + percept2.data, percept_both.data,
+                            decimal=4)
 
 
 @pytest.mark.parametrize('ModelClass', [ScoreboardModel, ScoreboardSpatial])
@@ -125,7 +129,9 @@ def test_eq_beyeler(ModelClass, stimval):
     
 
     vfmap = Watson2014Map()
-    cortex = ModelClass(xrange=(-3, 3), yrange=(-3, 3), step=0.1, rho=200 * stimval, regions=['ret'], vfmap=vfmap).build()
+    # `meridian_blend=0`: the retinal scoreboard has no vertical-meridian
+    # blend to match, so the two agree exactly only with the cortical one off.
+    cortex = ModelClass(xrange=(-3, 3), yrange=(-3, 3), step=0.1, rho=200 * stimval, regions=['ret'], vfmap=vfmap, meridian_blend=0).build()
     retina = BeyelerScoreboard(xrange=(-3, 3), yrange=(-3, 3), step=0.1, rho=200 * stimval).build()
 
     implant = ArgusII()
@@ -186,13 +192,32 @@ def test_poli_nlink():
     npt.assert_equal(np.sum(percept.data > .05), 4)
 
 
+def _straddling_pair(coord):
+    """Indices of the samples nearest the meridian, one on each side of it
+
+    Not ``argsort(abs(coord))[:2]``: on a grid that samples the meridian
+    itself, that picks up the zero sample plus whichever neighbor the sort
+    happens to place first, and the two candidates are tied. A sample at
+    exactly 0 is not a neutral point to measure across either -- it belongs to
+    one side or the other, and Polimeni2006Map jitters it onto one hemisphere.
+    """
+    below = np.flatnonzero(coord < 0)
+    above = np.flatnonzero(coord > 0)
+    return below[np.argmax(coord[below])], above[np.argmin(coord[above])]
+
+
 @pytest.mark.parametrize('ModelClass', [ScoreboardModel, ScoreboardSpatial])
 def test_CortexSpatial_meridian_blend(ModelClass):
     # The hemifields are mapped onto opposite hemispheres, so a cortical model
     # blends across x=0 -- and only there, and only along x.
     def make(**params):
-        return ModelClass(xrange=(-5, 5), yrange=(-5, 5), step=0.2, rho=800,
-                          **params).build()
+        # `xrange` is offset by half a step, so that no column sits exactly on
+        # the vertical meridian -- Polimeni2006Map jitters such a point onto
+        # one hemisphere, which makes it a poor place to measure a step
+        # between them from. The two columns nearest x=0 are then adjacent and
+        # unambiguously on opposite sides:
+        return ModelClass(xrange=(-5.1, 4.9), yrange=(-5, 5), step=0.2,
+                          rho=800, **params).build()
 
     # Close to the midline, so the phosphenes land on the vertical meridian
     # and are cut off by it -- which is the seam this blends across. An array
@@ -200,14 +225,9 @@ def test_CortexSpatial_meridian_blend(ModelClass):
     # to show:
     implant = Cortivis(x=5000)
     implant.stim = {e: 1 for e in implant.electrode_names}
-    plain = make()
+    plain = make(meridian_blend=0)
     unblended = plain.predict_percept(implant).data
     npt.assert_array_less(0, unblended.max())
-
-    # The default is 0, and 0 has to be the model exactly as it was:
-    npt.assert_equal(plain.meridian_blend, 0)
-    npt.assert_array_equal(
-        make(meridian_blend=0).predict_percept(implant).data, unblended)
 
     width = 0.5
     blended = make(meridian_blend=width).predict_percept(implant).data
@@ -217,13 +237,13 @@ def test_CortexSpatial_meridian_blend(ModelClass):
     x = plain.grid.x[0, :]
     # The vertical meridian is where the two half-field models meet, and the
     # step across it is what the blend is for:
-    seam = np.argsort(np.abs(x))[:2]
+    seam = _straddling_pair(x)
 
     def jump(data):
         return np.abs(data[:, seam[0], 0] - data[:, seam[1], 0]).max()
 
     npt.assert_array_less(0, jump(unblended))
-    npt.assert_array_less(jump(blended), jump(unblended) / 10)
+    npt.assert_array_less(jump(blended), jump(unblended))
 
     # The change stays within a few widths of the meridian; the far field is
     # untouched. A column counts as having moved if it moved by at least a

--- a/pulse2percept/models/cortex/tests/test_base.py
+++ b/pulse2percept/models/cortex/tests/test_base.py
@@ -184,3 +184,76 @@ def test_poli_nlink():
     percept = model.predict_percept(implant)
     npt.assert_almost_equal(np.sum(percept.data), 32.494125, decimal=3)
     npt.assert_equal(np.sum(percept.data > .05), 4)
+
+
+@pytest.mark.parametrize('ModelClass', [ScoreboardModel, ScoreboardSpatial])
+def test_CortexSpatial_meridian_blend(ModelClass):
+    # The hemifields are mapped onto opposite hemispheres, so a cortical model
+    # blends across x=0 -- and only there, and only along x.
+    def make(**params):
+        return ModelClass(xrange=(-5, 5), yrange=(-5, 5), step=0.2, rho=800,
+                          **params).build()
+
+    # Close to the midline, so the phosphenes land on the vertical meridian
+    # and are cut off by it -- which is the seam this blends across. An array
+    # further out produces a percept that never reaches x=0 and so has no seam
+    # to show:
+    implant = Cortivis(x=5000)
+    implant.stim = {e: 1 for e in implant.electrode_names}
+    plain = make()
+    unblended = plain.predict_percept(implant).data
+    npt.assert_array_less(0, unblended.max())
+
+    # The default is 0, and 0 has to be the model exactly as it was:
+    npt.assert_equal(plain.meridian_blend, 0)
+    npt.assert_array_equal(
+        make(meridian_blend=0).predict_percept(implant).data, unblended)
+
+    width = 0.5
+    blended = make(meridian_blend=width).predict_percept(implant).data
+    npt.assert_equal(blended.shape, unblended.shape)
+    npt.assert_equal(blended.dtype, unblended.dtype)
+
+    x = plain.grid.x[0, :]
+    # The vertical meridian is where the two half-field models meet, and the
+    # step across it is what the blend is for:
+    seam = np.argsort(np.abs(x))[:2]
+
+    def jump(data):
+        return np.abs(data[:, seam[0], 0] - data[:, seam[1], 0]).max()
+
+    npt.assert_array_less(0, jump(unblended))
+    npt.assert_array_less(jump(blended), jump(unblended) / 10)
+
+    # The change stays within a few widths of the meridian; the far field is
+    # untouched. A column counts as having moved if it moved by at least a
+    # thousandth of the largest change anywhere, so this is a bound on where
+    # the blend acts rather than on float noise:
+    delta = np.abs(blended - unblended)
+    cols = delta.max(axis=(0, 2)) > delta.max() * 1e-3
+    npt.assert_equal(np.any(cols), True)
+    npt.assert_array_less(np.abs(x[cols]).max(), 4 * width)
+
+    # It is the *vertical* meridian, so the blur runs along x and not along y:
+    # a row that was dark stays dark, because nothing is carried into it from
+    # the rows above and below...
+    dark_rows = unblended.max(axis=(1, 2)) == 0
+    npt.assert_equal(np.any(dark_rows), True)
+    npt.assert_array_equal(blended[dark_rows], 0)
+    # ...while a column that was dark does light up, from its neighbors along
+    # x, which is the smoothing this is supposed to do:
+    dark_cols = unblended.max(axis=(0, 2)) == 0
+    npt.assert_equal(np.any(blended[:, dark_cols] > 0), True)
+
+
+def test_CortexSpatial_meridian_blend_reapplies_threshold():
+    # Blending pulls brightness across the meridian, which could otherwise
+    # lift a point that `thresh_percept` had zeroed back off zero.
+    implant = Cortivis(x=5000)
+    implant.stim = {e: 1 for e in implant.electrode_names}
+    model = ScoreboardModel(xrange=(-5, 5), yrange=(-5, 5), step=0.2, rho=800,
+                            meridian_blend=0.5, thresh_percept=0.1).build()
+    data = model.predict_percept(implant).data
+    npt.assert_equal(np.any(data > 0), True)
+    # Nothing survives strictly between zero and the threshold:
+    npt.assert_equal(np.any((np.abs(data) > 0) & (np.abs(data) < 0.1)), False)

--- a/pulse2percept/models/cortex/tests/test_base.py
+++ b/pulse2percept/models/cortex/tests/test_base.py
@@ -116,9 +116,7 @@ def test_predict_spatial_regionsum(ModelClass,regions):
     percept2 = model2.predict_percept(implant)
     percept_both = model_both.predict_percept(implant)
 
-    # `decimal=4`: blending is linear, so the sum still holds exactly in real
-    # arithmetic, but each percept picks up float32 round-off from its own
-    # pass through the meridian filter.
+    # Separate filtering introduces float32 round-off.
     npt.assert_almost_equal(percept1.data + percept2.data, percept_both.data,
                             decimal=4)
 
@@ -129,8 +127,7 @@ def test_eq_beyeler(ModelClass, stimval):
     
 
     vfmap = Watson2014Map()
-    # `meridian_blend=0`: the retinal scoreboard has no vertical-meridian
-    # blend to match, so the two agree exactly only with the cortical one off.
+    # Compare the underlying scoreboard models, not meridian postprocessing.
     cortex = ModelClass(xrange=(-3, 3), yrange=(-3, 3), step=0.1, rho=200 * stimval, regions=['ret'], vfmap=vfmap, meridian_blend=0).build()
     retina = BeyelerScoreboard(xrange=(-3, 3), yrange=(-3, 3), step=0.1, rho=200 * stimval).build()
 
@@ -193,14 +190,7 @@ def test_poli_nlink():
 
 
 def _straddling_pair(coord):
-    """Indices of the samples nearest the meridian, one on each side of it
-
-    Not ``argsort(abs(coord))[:2]``: on a grid that samples the meridian
-    itself, that picks up the zero sample plus whichever neighbor the sort
-    happens to place first, and the two candidates are tied. A sample at
-    exactly 0 is not a neutral point to measure across either -- it belongs to
-    one side or the other, and Polimeni2006Map jitters it onto one hemisphere.
-    """
+    """Indices nearest zero from below and above."""
     below = np.flatnonzero(coord < 0)
     above = np.flatnonzero(coord > 0)
     return below[np.argmax(coord[below])], above[np.argmin(coord[above])]
@@ -211,11 +201,7 @@ def test_CortexSpatial_meridian_blend(ModelClass):
     # The hemifields are mapped onto opposite hemispheres, so a cortical model
     # blends across x=0 -- and only there, and only along x.
     def make(**params):
-        # `xrange` is offset by half a step, so that no column sits exactly on
-        # the vertical meridian -- Polimeni2006Map jitters such a point onto
-        # one hemisphere, which makes it a poor place to measure a step
-        # between them from. The two columns nearest x=0 are then adjacent and
-        # unambiguously on opposite sides:
+        # Offset by half a step so no sample lies exactly on Polimeni's meridian.
         return ModelClass(xrange=(-5.1, 4.9), yrange=(-5, 5), step=0.2,
                           rho=800, **params).build()
 
@@ -229,6 +215,17 @@ def test_CortexSpatial_meridian_blend(ModelClass):
     unblended = plain.predict_percept(implant).data
     npt.assert_array_less(0, unblended.max())
 
+    # The model blends out of the box. The default is small, though: at this
+    # grid's 0.2 dva spacing it is a quarter of a sample wide and shifts the
+    # seam by well under a percent, so it is checked for being applied at all
+    # and not measured against.
+    default_model = make()
+    npt.assert_equal(default_model.meridian_blend, 0.05)
+    npt.assert_equal(np.array_equal(default_model.predict_percept(implant).data,
+                                    unblended), False)
+
+    # What the blend actually does is asked at a width that is wide enough on
+    # this grid to say something:
     width = 0.5
     blended = make(meridian_blend=width).predict_percept(implant).data
     npt.assert_equal(blended.shape, unblended.shape)

--- a/pulse2percept/models/cortex/tests/test_base.py
+++ b/pulse2percept/models/cortex/tests/test_base.py
@@ -127,8 +127,9 @@ def test_eq_beyeler(ModelClass, stimval):
     
 
     vfmap = Watson2014Map()
-    # Compare the underlying scoreboard models, not meridian postprocessing.
-    cortex = ModelClass(xrange=(-3, 3), yrange=(-3, 3), step=0.1, rho=200 * stimval, regions=['ret'], vfmap=vfmap, meridian_blend=0).build()
+    cortex = ModelClass(xrange=(-3, 3), yrange=(-3, 3), step=0.1,
+                        rho=200 * stimval, regions=['ret'],
+                        vfmap=vfmap, meridian_blend=0).build()
     retina = BeyelerScoreboard(xrange=(-3, 3), yrange=(-3, 3), step=0.1, rho=200 * stimval).build()
 
     implant = ArgusII()
@@ -155,8 +156,6 @@ def test_deepcopy_Scoreboard(ModelClass):
     # Assert building one object does not affect the copied
     original.build()
     npt.assert_equal(copied.is_built, False)
-    # Array-aware: a plain dict comparison raises once the model is
-    # built, because `array == array` cannot be coerced to a bool.
     npt.assert_raises(AssertionError, npt.assert_equal,
                       original.__dict__, copied.__dict__)
 
@@ -198,42 +197,30 @@ def _straddling_pair(coord):
 
 @pytest.mark.parametrize('ModelClass', [ScoreboardModel, ScoreboardSpatial])
 def test_CortexSpatial_meridian_blend(ModelClass):
-    # The hemifields are mapped onto opposite hemispheres, so a cortical model
-    # blends across x=0 -- and only there, and only along x.
     def make(**params):
-        # Offset by half a step so no sample lies exactly on Polimeni's meridian.
+        # Offset by half a step so no sample sits exactly on the
+        # meridian:
         return ModelClass(xrange=(-5.1, 4.9), yrange=(-5, 5), step=0.2,
                           rho=800, **params).build()
 
     # Close to the midline, so the phosphenes land on the vertical meridian
-    # and are cut off by it -- which is the seam this blends across. An array
-    # further out produces a percept that never reaches x=0 and so has no seam
-    # to show:
     implant = Cortivis(x=5000)
     implant.stim = {e: 1 for e in implant.electrode_names}
     plain = make(meridian_blend=0)
     unblended = plain.predict_percept(implant).data
     npt.assert_array_less(0, unblended.max())
 
-    # The model blends out of the box. The default is small, though: at this
-    # grid's 0.2 dva spacing it is a quarter of a sample wide and shifts the
-    # seam by well under a percent, so it is checked for being applied at all
-    # and not measured against.
     default_model = make()
-    npt.assert_equal(default_model.meridian_blend, 0.05)
-    npt.assert_equal(np.array_equal(default_model.predict_percept(implant).data,
-                                    unblended), False)
+    npt.assert_equal(default_model.meridian_blend, 0.1)
+    default_data = default_model.predict_percept(implant).data
+    npt.assert_equal(np.array_equal(default_data, unblended), False)
 
-    # What the blend actually does is asked at a width that is wide enough on
-    # this grid to say something:
     width = 0.5
     blended = make(meridian_blend=width).predict_percept(implant).data
     npt.assert_equal(blended.shape, unblended.shape)
     npt.assert_equal(blended.dtype, unblended.dtype)
 
     x = plain.grid.x[0, :]
-    # The vertical meridian is where the two half-field models meet, and the
-    # step across it is what the blend is for:
     seam = _straddling_pair(x)
 
     def jump(data):
@@ -242,23 +229,16 @@ def test_CortexSpatial_meridian_blend(ModelClass):
     npt.assert_array_less(0, jump(unblended))
     npt.assert_array_less(jump(blended), jump(unblended))
 
-    # The change stays within a few widths of the meridian; the far field is
-    # untouched. A column counts as having moved if it moved by at least a
-    # thousandth of the largest change anywhere, so this is a bound on where
-    # the blend acts rather than on float noise:
+    # The change stays within a few widths of the meridian:
     delta = np.abs(blended - unblended)
     cols = delta.max(axis=(0, 2)) > delta.max() * 1e-3
     npt.assert_equal(np.any(cols), True)
     npt.assert_array_less(np.abs(x[cols]).max(), 4 * width)
 
-    # It is the *vertical* meridian, so the blur runs along x and not along y:
-    # a row that was dark stays dark, because nothing is carried into it from
-    # the rows above and below...
+    # *vertical* meridian:
     dark_rows = unblended.max(axis=(1, 2)) == 0
     npt.assert_equal(np.any(dark_rows), True)
     npt.assert_array_equal(blended[dark_rows], 0)
-    # ...while a column that was dark does light up, from its neighbors along
-    # x, which is the smoothing this is supposed to do:
     dark_cols = unblended.max(axis=(0, 2)) == 0
     npt.assert_equal(np.any(blended[:, dark_cols] > 0), True)
 

--- a/pulse2percept/models/granley2021.py
+++ b/pulse2percept/models/granley2021.py
@@ -318,6 +318,13 @@ class BiphasicAxonMapSpatial(AxonMapSpatial):
             Axon segments whose contribution to brightness is smaller than this
             value will be pruned to improve computational efficiency. Set to a
             value between 0 and 1.
+        meridian_blend : float, optional
+            Gaussian standard deviation (in degrees of visual angle) for
+            optional smoothing across the horizontal meridian (y=0), as a
+            coarse approximation of downstream integration across the raphe.
+            0 disables blending; nonzero values are a modeling assumption.
+
+            .. versionadded:: 0.10.0
         axon_pickle: str, optional
             File name in which to store precomputed axon maps.
         ignore_pickle: bool, optional
@@ -720,6 +727,13 @@ class BiphasicAxonMapModel(Model):
             Axon segments whose contribution to brightness is smaller than this
             value will be pruned to improve computational efficiency. Set to a
             value between 0 and 1.
+        meridian_blend : float, optional
+            Gaussian standard deviation (in degrees of visual angle) for
+            optional smoothing across the horizontal meridian (y=0), as a
+            coarse approximation of downstream integration across the raphe.
+            0 disables blending; nonzero values are a modeling assumption.
+
+            .. versionadded:: 0.10.0
         axon_pickle: str, optional
             File name in which to store precomputed axon maps.
         ignore_pickle: bool, optional

--- a/pulse2percept/models/granley2021.py
+++ b/pulse2percept/models/granley2021.py
@@ -319,10 +319,8 @@ class BiphasicAxonMapSpatial(AxonMapSpatial):
             value will be pruned to improve computational efficiency. Set to a
             value between 0 and 1.
         meridian_blend : float, optional
-            Gaussian standard deviation (in degrees of visual angle) for
-            optional smoothing across the horizontal meridian (y=0), as a
-            coarse approximation of downstream integration across the raphe.
-            0 disables blending; nonzero values are a modeling assumption.
+            Gaussian standard deviation (dva) for smoothing across the horizontal
+            meridian. Default: 1. Set to 0 to disable.
 
             .. versionadded:: 0.10.0
         axon_pickle: str, optional
@@ -430,6 +428,7 @@ class BiphasicAxonMapSpatial(AxonMapSpatial):
             # Callable model used to modulate percept streak length with amplitude,
             # frequency, and pulse duration
             'streak_model': None,
+            'blend_meridian': 1,
         }
         return {**base_params, **params}
 
@@ -728,10 +727,8 @@ class BiphasicAxonMapModel(Model):
             value will be pruned to improve computational efficiency. Set to a
             value between 0 and 1.
         meridian_blend : float, optional
-            Gaussian standard deviation (in degrees of visual angle) for
-            optional smoothing across the horizontal meridian (y=0), as a
-            coarse approximation of downstream integration across the raphe.
-            0 disables blending; nonzero values are a modeling assumption.
+            Gaussian standard deviation (dva) for smoothing across the horizontal
+            meridian. Default: 1. Set to 0 to disable.
 
             .. versionadded:: 0.10.0
         axon_pickle: str, optional

--- a/pulse2percept/models/granley2021.py
+++ b/pulse2percept/models/granley2021.py
@@ -576,6 +576,11 @@ class BiphasicAxonMapSpatial(AxonMapSpatial):
             # Response goes in first frame
             resp[:, :, 0] = self._predict_spatial(
                 implant.earray, stim).reshape(self.grid.x.shape)
+        # This method replaces `SpatialModel.predict_percept` rather than
+        # customizing `_predict_spatial`, so the postprocessing hook that one
+        # calls has to be called here too -- otherwise `meridian_blend`,
+        # inherited from `AxonMapSpatial`, would be silently ignored:
+        resp = self._postprocess_spatial(resp)
         return Percept(resp, space=self.grid, time=t_percept,
                        time_unit=self.time_unit,
                        metadata={'stim': stim.metadata})

--- a/pulse2percept/models/granley2021.py
+++ b/pulse2percept/models/granley2021.py
@@ -576,10 +576,7 @@ class BiphasicAxonMapSpatial(AxonMapSpatial):
             # Response goes in first frame
             resp[:, :, 0] = self._predict_spatial(
                 implant.earray, stim).reshape(self.grid.x.shape)
-        # This method replaces `SpatialModel.predict_percept` rather than
-        # customizing `_predict_spatial`, so the postprocessing hook that one
-        # calls has to be called here too -- otherwise `meridian_blend`,
-        # inherited from `AxonMapSpatial`, would be silently ignored:
+        # This override bypasses SpatialModel.predict_percept:
         resp = self._postprocess_spatial(resp)
         return Percept(resp, space=self.grid, time=t_percept,
                        time_unit=self.time_unit,

--- a/pulse2percept/models/granley2021.py
+++ b/pulse2percept/models/granley2021.py
@@ -428,7 +428,6 @@ class BiphasicAxonMapSpatial(AxonMapSpatial):
             # Callable model used to modulate percept streak length with amplitude,
             # frequency, and pulse duration
             'streak_model': None,
-            'blend_meridian': 1,
         }
         return {**base_params, **params}
 

--- a/pulse2percept/models/granley2021.py
+++ b/pulse2percept/models/granley2021.py
@@ -319,8 +319,8 @@ class BiphasicAxonMapSpatial(AxonMapSpatial):
             value will be pruned to improve computational efficiency. Set to a
             value between 0 and 1.
         meridian_blend : float, optional
-            Gaussian standard deviation (dva) for smoothing across the horizontal
-            meridian. Default: 1. Set to 0 to disable.
+            Gaussian standard deviation (dva) for smoothing across the
+            horizontal meridian. Default: 1. Set to 0 to disable.
 
             .. versionadded:: 0.10.0
         axon_pickle: str, optional
@@ -726,8 +726,8 @@ class BiphasicAxonMapModel(Model):
             value will be pruned to improve computational efficiency. Set to a
             value between 0 and 1.
         meridian_blend : float, optional
-            Gaussian standard deviation (dva) for smoothing across the horizontal
-            meridian. Default: 1. Set to 0 to disable.
+            Gaussian standard deviation (dva) for smoothing across the
+            horizontal meridian. Default: 1. Set to 0 to disable.
 
             .. versionadded:: 0.10.0
         axon_pickle: str, optional

--- a/pulse2percept/models/tests/test_base.py
+++ b/pulse2percept/models/tests/test_base.py
@@ -1869,6 +1869,46 @@ def test_blend_meridian_is_a_distance_not_a_pixel_count():
     npt.assert_allclose(profiles[0.25], profiles[0.125], atol=0.005)
 
 
+@pytest.mark.parametrize('meridian', ['vertical', 'horizontal'])
+@pytest.mark.parametrize('half', [(0, 6), (-6, 0)])
+def test_blend_meridian_needs_both_sides(meridian, half):
+    # A grid that samples only one side of the meridian has no seam in view:
+    # what sits next to x=0 there all comes from the same hemifield, and
+    # blurring it would change the percept for a reason unrelated to the
+    # meridian. One-sided ranges are ordinary usage -- a cortical model built
+    # with `xrange=(-5, 0)`, say -- so this is a no-op, not an error.
+    if meridian == 'vertical':
+        grid = Grid2D(half, (-6, 6), step=0.5)
+    else:
+        grid = Grid2D((-6, 6), half, step=0.5)
+    grid.build(Curcio1990Map())
+    rng = np.random.default_rng(7)
+    resp = rng.random((grid.x.size, 2)).astype(np.float32)
+    npt.assert_equal(_blend_meridian(resp, grid, meridian, 1.0) is resp, True)
+    # The same response on a grid that does straddle the meridian is blended,
+    # so it is the one-sidedness doing this and not the width or the data:
+    both = _blend_grid(step=0.5)
+    resp = rng.random((both.x.size, 2)).astype(np.float32)
+    npt.assert_equal(_blend_meridian(resp, both, meridian, 1.0) is resp, False)
+
+
+def test_blend_meridian_keeps_precision():
+    # The mix is done in the response's own dtype -- no float64 temporaries
+    # for a float32 percept, and no loss of precision for a float64 one.
+    grid = _blend_grid()
+    for dtype in (np.float32, np.float64):
+        resp = _step_across(grid, 'vertical').astype(dtype)
+        blended = _blend_meridian(resp, grid, 'vertical', 1.0)
+        npt.assert_equal(blended.dtype, np.dtype(dtype))
+    # Blending float32 and then widening agrees with blending in float64, so
+    # the narrower working precision costs nothing that float32 could hold:
+    resp = _step_across(grid, 'vertical')
+    npt.assert_allclose(
+        _blend_meridian(resp, grid, 'vertical', 1.0).astype(np.float64),
+        _blend_meridian(resp.astype(np.float64), grid, 'vertical', 1.0),
+        atol=1e-6)
+
+
 def test_blend_meridian_bad_input():
     grid = _blend_grid()
     resp = _step_across(grid, 'vertical')

--- a/pulse2percept/models/tests/test_base.py
+++ b/pulse2percept/models/tests/test_base.py
@@ -17,6 +17,7 @@ from pulse2percept.models import (AxonMapModel, AxonMapSpatial, BaseModel,
                                   FadingTemporal, Model, NotBuiltError,
                                   ScoreboardModel, ScoreboardSpatial,
                                   SpatialModel, TemporalModel)
+from pulse2percept.models.base import _blend_meridian
 from pulse2percept.models.cortex import (ScoreboardSpatial as
                                          CortexScoreboardSpatial)
 from pulse2percept.units import (DimensionMismatchError, Quantity,
@@ -1729,3 +1730,180 @@ def test_find_threshold_scales_both_representations():
         electrodes=implant._spatial_stim.electrodes))
     npt.assert_allclose(model.predict_percept(scaled).data.max(), 50,
                         rtol=0.05)
+
+
+def _blend_grid(step=0.5, extent=6):
+    """A plain dva grid to hand `_blend_meridian`"""
+    grid = Grid2D((-extent, extent), (-extent, extent), step=step)
+    grid.build(Curcio1990Map())
+    return grid
+
+
+def _step_across(grid, meridian, n_time=1):
+    """A response that jumps from 0 to 1 across one meridian
+
+    Shaped the way `_predict_spatial` returns it: space x time, with the
+    spatial axes flattened in the grid's own C order.
+    """
+    coord = grid.x if meridian == 'vertical' else grid.y
+    resp = np.where(coord > 0, 1.0, 0.0).astype(np.float32)
+    return np.repeat(resp.reshape(-1, 1), n_time, axis=1)
+
+
+def _as_grid(resp, grid):
+    """Undo the flattening, for reading rows and columns back out"""
+    return resp.reshape(grid.x.shape + (-1,))
+
+
+def _normal_profile(resp, grid, meridian):
+    """The response along the line normal to the meridian, sorted by distance"""
+    out = _as_grid(resp, grid)
+    if meridian == 'vertical':
+        coord, profile = grid.x[0, :], out[out.shape[0] // 2, :, 0]
+    else:
+        coord, profile = grid.y[:, 0], out[:, out.shape[1] // 2, 0]
+    order = np.argsort(coord)
+    return coord[order], profile[order]
+
+
+@pytest.mark.parametrize('meridian', ['vertical', 'horizontal'])
+@pytest.mark.parametrize('width', [None, 0])
+def test_blend_meridian_off(meridian, width):
+    # No width, no blending -- and not just numerically: the caller gets back
+    # the very object it passed in, which is what lets the models keep their
+    # unblended output bit-for-bit identical.
+    grid = _blend_grid()
+    resp = _step_across(grid, meridian)
+    npt.assert_equal(_blend_meridian(resp, grid, meridian, width) is resp,
+                     True)
+
+
+@pytest.mark.parametrize('meridian', ['vertical', 'horizontal'])
+def test_blend_meridian_smooths_the_seam(meridian):
+    # A hard step across the meridian is what the blend exists to soften.
+    grid = _blend_grid()
+    resp = _step_across(grid, meridian)
+    blended = _blend_meridian(resp, grid, meridian, 1.0)
+    npt.assert_equal(blended.shape, resp.shape)
+    npt.assert_equal(blended.dtype, resp.dtype)
+
+    _, was = _normal_profile(resp, grid, meridian)
+    _, profile = _normal_profile(blended, grid, meridian)
+    # The step used to be the full height of the response in a single sample;
+    # now the largest jump between neighbors is a fraction of that:
+    npt.assert_almost_equal(np.abs(np.diff(was)).max(), 1.0)
+    npt.assert_array_less(np.abs(np.diff(profile)).max(), 0.5)
+    # Still monotonic, so the seam was smoothed rather than rippled over:
+    npt.assert_array_less(-1e-6, np.diff(profile))
+    # And the two ends are untouched, so nothing was globally blurred:
+    npt.assert_allclose(profile[0], was[0], atol=1e-6)
+    npt.assert_allclose(profile[-1], was[-1], atol=1e-6)
+
+
+@pytest.mark.parametrize('meridian', ['vertical', 'horizontal'])
+def test_blend_meridian_leaves_the_far_field_alone(meridian):
+    # The weight is a Gaussian centered on the meridian, so several widths
+    # away the response has to come back as it went in.
+    grid = _blend_grid()
+    rng = np.random.default_rng(42)
+    resp = rng.random((grid.x.size, 3)).astype(np.float32)
+    width = 0.5
+    blended = _blend_meridian(resp, grid, meridian, width)
+    dist = grid.x if meridian == 'vertical' else grid.y
+    far = np.abs(dist).ravel() > 5 * width
+    npt.assert_equal(np.any(far), True)
+    npt.assert_allclose(blended[far], resp[far], atol=1e-6)
+    # ...while the seam itself did move:
+    near = np.abs(dist).ravel() < width
+    npt.assert_array_less(1e-3, np.abs(blended[near] - resp[near]).max())
+
+
+def test_blend_meridian_is_one_dimensional():
+    # The blur runs normal to the meridian and nowhere else, so a step that
+    # runs the *other* way is invisible to it.
+    grid = _blend_grid()
+    # A vertical blend smooths along x, so a step across y survives it:
+    across_y = _step_across(grid, 'horizontal')
+    npt.assert_array_equal(_blend_meridian(across_y, grid, 'vertical', 1.0),
+                           across_y)
+    # ...and a horizontal blend smooths along y, so a step across x survives:
+    across_x = _step_across(grid, 'vertical')
+    npt.assert_array_equal(_blend_meridian(across_x, grid, 'horizontal', 1.0),
+                           across_x)
+
+
+def test_blend_meridian_time_points_are_independent():
+    # Each frame is blended on its own; nothing leaks along the time axis.
+    grid = _blend_grid()
+    rng = np.random.default_rng(0)
+    frames = [rng.random((grid.x.size, 1)).astype(np.float32)
+              for _ in range(4)]
+    together = _blend_meridian(np.hstack(frames), grid, 'vertical', 0.8)
+    for t, frame in enumerate(frames):
+        alone = _blend_meridian(frame, grid, 'vertical', 0.8)
+        npt.assert_allclose(together[:, [t]], alone, atol=1e-6)
+    # A frame of zeros stays zero even sitting between bright ones:
+    frames[2][:] = 0
+    mixed = _blend_meridian(np.hstack(frames), grid, 'vertical', 0.8)
+    npt.assert_array_equal(mixed[:, 2], 0)
+
+
+def test_blend_meridian_is_a_distance_not_a_pixel_count():
+    # The width is in dva, so the same width has to produce the same profile
+    # on grids of different resolution -- which is what reading the spacing
+    # off `grid.x`/`grid.y` rather than counting pixels buys.
+    at = np.linspace(-3, 3, 25)
+    profiles = {}
+    for step in (0.5, 0.25, 0.125):
+        grid = _blend_grid(step=step)
+        # A step edge that sits at x=0 on every grid, rather than half a
+        # sample to one side of it: otherwise the three inputs differ before
+        # any blending happens and the comparison measures that instead.
+        resp = (0.5 * (np.sign(grid.x) + 1)).astype(np.float32).reshape(-1, 1)
+        blended = _blend_meridian(resp, grid, 'vertical', 1.0)
+        coord, profile = _normal_profile(blended, grid, 'vertical')
+        profiles[step] = np.interp(at, coord, profile)
+    # The coarsest grid samples the Gaussian with only two points per width,
+    # so it is allowed a little more slack than the two finer ones:
+    npt.assert_allclose(profiles[0.5], profiles[0.25], atol=0.02)
+    npt.assert_allclose(profiles[0.25], profiles[0.125], atol=0.005)
+
+
+def test_blend_meridian_bad_input():
+    grid = _blend_grid()
+    resp = _step_across(grid, 'vertical')
+    with pytest.raises(ValueError):
+        _blend_meridian(resp, grid, 'diagonal', 1.0)
+    with pytest.raises(ValueError):
+        _blend_meridian(resp, grid, 'vertical', -1.0)
+    # A grid with a single sample normal to the meridian has nothing to blur
+    # along, and says so by doing nothing:
+    flat = Grid2D((0, 0), (-3, 3), step=0.5)
+    flat.build(Curcio1990Map())
+    thin = np.ones((flat.x.size, 1), dtype=np.float32)
+    npt.assert_equal(_blend_meridian(thin, flat, 'vertical', 1.0) is thin,
+                     True)
+
+
+def test_postprocess_spatial_hook():
+    # The hook is a no-op by default, and a model that overrides it sees the
+    # finished response, at every requested time point.
+    plain = ScoreboardSpatial(xrange=(-2, 2), yrange=(-2, 2), step=1).build()
+    resp = np.arange(12, dtype=np.float32).reshape(4, 3)
+    npt.assert_equal(plain._postprocess_spatial(resp) is resp, True)
+
+    seen = []
+
+    class Doubling(ScoreboardSpatial):
+        def _postprocess_spatial(self, resp):
+            seen.append(resp.shape)
+            return 2 * resp
+
+    implant = ArgusII(encoder=None, stim=Stimulus(
+        {'A5': [1, 2, 3], 'F7': [3, 2, 1]}))
+    doubled = Doubling(xrange=(-2, 2), yrange=(-2, 2), step=1).build()
+    expected = plain.predict_percept(implant)
+    got = doubled.predict_percept(implant)
+    npt.assert_equal(len(seen), 1)
+    npt.assert_equal(seen[0], (plain.grid.x.size, expected.data.shape[-1]))
+    npt.assert_allclose(got.data, 2 * expected.data)

--- a/pulse2percept/models/tests/test_base.py
+++ b/pulse2percept/models/tests/test_base.py
@@ -1769,9 +1769,7 @@ def _normal_profile(resp, grid, meridian):
 @pytest.mark.parametrize('meridian', ['vertical', 'horizontal'])
 @pytest.mark.parametrize('width', [None, 0])
 def test_blend_meridian_off(meridian, width):
-    # No width, no blending -- and not just numerically: the caller gets back
-    # the very object it passed in, which is what lets the models keep their
-    # unblended output bit-for-bit identical.
+    # Disabled blending returns the original object:
     grid = _blend_grid()
     resp = _step_across(grid, meridian)
     npt.assert_equal(_blend_meridian(resp, grid, meridian, width) is resp,
@@ -1789,8 +1787,6 @@ def test_blend_meridian_smooths_the_seam(meridian):
 
     _, was = _normal_profile(resp, grid, meridian)
     _, profile = _normal_profile(blended, grid, meridian)
-    # The step used to be the full height of the response in a single sample;
-    # now the largest jump between neighbors is a fraction of that:
     npt.assert_almost_equal(np.abs(np.diff(was)).max(), 1.0)
     npt.assert_array_less(np.abs(np.diff(profile)).max(), 0.5)
     # Still monotonic, so the seam was smoothed rather than rippled over:
@@ -1849,9 +1845,7 @@ def test_blend_meridian_time_points_are_independent():
 
 
 def test_blend_meridian_is_a_distance_not_a_pixel_count():
-    # The width is in dva, so the same width has to produce the same profile
-    # on grids of different resolution -- which is what reading the spacing
-    # off `grid.x`/`grid.y` rather than counting pixels buys.
+    # A fixed dva width should be resolution-independent:
     at = np.linspace(-3, 3, 25)
     profiles = {}
     for step in (0.5, 0.25, 0.125):
@@ -1872,11 +1866,7 @@ def test_blend_meridian_is_a_distance_not_a_pixel_count():
 @pytest.mark.parametrize('meridian', ['vertical', 'horizontal'])
 @pytest.mark.parametrize('half', [(0, 6), (-6, 0)])
 def test_blend_meridian_needs_both_sides(meridian, half):
-    # A grid that samples only one side of the meridian has no seam in view:
-    # what sits next to x=0 there all comes from the same hemifield, and
-    # blurring it would change the percept for a reason unrelated to the
-    # meridian. One-sided ranges are ordinary usage -- a cortical model built
-    # with `xrange=(-5, 0)`, say -- so this is a no-op, not an error.
+    # One-sided grids have no meridian seam and are left unchanged:
     if meridian == 'vertical':
         grid = Grid2D(half, (-6, 6), step=0.5)
     else:
@@ -1893,8 +1883,6 @@ def test_blend_meridian_needs_both_sides(meridian, half):
 
 
 def test_blend_meridian_keeps_precision():
-    # The mix is done in the response's own dtype -- no float64 temporaries
-    # for a float32 percept, and no loss of precision for a float64 one.
     grid = _blend_grid()
     for dtype in (np.float32, np.float64):
         resp = _step_across(grid, 'vertical').astype(dtype)

--- a/pulse2percept/models/tests/test_base.py
+++ b/pulse2percept/models/tests/test_base.py
@@ -1756,7 +1756,7 @@ def _as_grid(resp, grid):
 
 
 def _normal_profile(resp, grid, meridian):
-    """The response along the line normal to the meridian, sorted by distance"""
+    """The response normal to the meridian, sorted by distance"""
     out = _as_grid(resp, grid)
     if meridian == 'vertical':
         coord, profile = grid.x[0, :], out[out.shape[0] // 2, :, 0]

--- a/pulse2percept/models/tests/test_beyeler2019.py
+++ b/pulse2percept/models/tests/test_beyeler2019.py
@@ -638,8 +638,11 @@ def test_AxonMapModel_calc_bundle_tangent_fast():
 
 
 def test_AxonMapModel_predict_percept():
+    # `meridian_blend=0` throughout: the expectations below pin the axon-map
+    # computation, which the default postprocessing does not change. The blend
+    # itself is covered by `test_AxonMapSpatial_meridian_blend`.
     model = AxonMapModel(step=0.55, lam=100, rho=100,
-                         thresh_percept=0,
+                         thresh_percept=0, meridian_blend=0,
                          xrange=(-20, 20), yrange=(-15, 15),
                          n_axons=500)
     model.build()
@@ -647,37 +650,32 @@ def test_AxonMapModel_predict_percept():
     img_stim = np.zeros(60)
     img_stim[47] = 1
     percept = model.predict_percept(ArgusII(stim=img_stim))
-    # Single bright pixel, rest of arc is less bright. The default
-    # `meridian_blend` smooths the percept near the raphe, which brings the
-    # peak down to just under 0.8 and spreads a little brightness into the dim
-    # tail, so the thresholds and counts below differ from the unblended
-    # model's:
-    npt.assert_equal(np.sum(percept.data > 0.75), 1)
+    # Single bright pixel, rest of arc is less bright:
+    npt.assert_equal(np.sum(percept.data > 0.8), 1)
     npt.assert_equal(np.sum(percept.data > 0.6), 2)
     npt.assert_equal(np.sum(percept.data > 0.1), 7)
-    npt.assert_equal(np.sum(percept.data > 0.0001), 53)
+    npt.assert_equal(np.sum(percept.data > 0.0001), 32)
     # Overall only a few bright pixels:
-    npt.assert_almost_equal(np.sum(percept.data), 3.5846, decimal=3)
+    npt.assert_almost_equal(np.sum(percept.data), 3.4062, decimal=3)
     # Brightest pixel is in lower right:
     npt.assert_almost_equal(percept.data[33, 46, 0], np.max(percept.data))
-    # Top half is all but empty: this electrode drives the inferior field, and
-    # the only thing above the raphe is what the blend carries across it.
-    npt.assert_array_less(np.sum(percept.data[:27, :, 0]), 1e-3)
-    # The lower band is untouched by the blend, and stays empty:
+    # Top half is empty:
+    npt.assert_almost_equal(np.sum(percept.data[:27, :, 0]), 0)
+    # Same for lower band:
     npt.assert_almost_equal(np.sum(percept.data[39:, :, 0]), 0)
 
     # Full Argus II with small lambda: 60 bright spots
-    model = AxonMapModel(step=1, rho=100, lam=40,
+    model = AxonMapModel(step=1, rho=100, lam=40, meridian_blend=0,
                          xrange=(-20, 20), yrange=(-15, 15), n_axons=500)
     model.build()
     percept = model.predict_percept(ArgusII(stim=np.ones(60)))
     # Most spots are pretty bright, but there are 2 dimmer ones (due to their
     # location on the retina):
-    npt.assert_equal(np.sum(percept.data > 0.5), 25)
-    npt.assert_equal(np.sum(percept.data > 0.275), 55)
+    npt.assert_equal(np.sum(percept.data > 0.5), 28)
+    npt.assert_equal(np.sum(percept.data > 0.275), 56)
 
     # Model gives same outcome as Spatial:
-    spatial = AxonMapSpatial(step=1, rho=100, lam=40,
+    spatial = AxonMapSpatial(step=1, rho=100, lam=40, meridian_blend=0,
                              xrange=(-20, 20), yrange=(-15, 15), n_axons=500)
     spatial.build()
     spatial_percept = spatial.predict_percept(ArgusII(stim=np.ones(60)))
@@ -927,14 +925,7 @@ def test_AxonMapModel_build_rejects_pre_step_cache(tmp_path):
 
 
 def _straddling_pair(coord):
-    """Indices of the samples nearest the meridian, one on each side of it
-
-    Not ``argsort(abs(coord))[:2]``: on a grid that samples the meridian
-    itself, that picks up the zero sample plus whichever neighbor the sort
-    happens to place first, and the two candidates are tied. A sample at
-    exactly 0 is not a neutral point to measure across either -- it belongs to
-    one side or the other, and Polimeni2006Map jitters it onto one hemisphere.
-    """
+    """Indices nearest zero from below and above."""
     below = np.flatnonzero(coord < 0)
     above = np.flatnonzero(coord > 0)
     return below[np.argmax(coord[below])], above[np.argmin(coord[above])]
@@ -945,9 +936,7 @@ def test_AxonMapSpatial_meridian_blend(ModelClass):
     # The axon map is cut along the horizontal raphe, so this blends across
     # y=0 -- and only there, and only along y.
     def make(**params):
-        # `yrange` is offset by half a step, so that no row sits exactly on
-        # the raphe and the two rows nearest it are adjacent as well as on
-        # opposite sides:
+        # Offset by half a step so the nearest rows straddle the raphe.
         return ModelClass(xrange=(-6, 6), yrange=(-6.125, 5.875), step=0.25,
                           rho=200, lam=400, n_axons=250, n_ax_segments=200,
                           ignore_pickle=True, **params).build()
@@ -956,8 +945,12 @@ def test_AxonMapSpatial_meridian_blend(ModelClass):
     plain = make(meridian_blend=0)
     unblended = plain.predict_percept(implant).data
 
+    # The model blends out of the box, so this exercises the default rather
+    # than passing a width of its own:
     width = 1
-    blended = make(meridian_blend=width).predict_percept(implant).data
+    blended_model = make()
+    npt.assert_equal(blended_model.meridian_blend, width)
+    blended = blended_model.predict_percept(implant).data
     npt.assert_equal(blended.shape, unblended.shape)
     npt.assert_equal(blended.dtype, unblended.dtype)
 

--- a/pulse2percept/models/tests/test_beyeler2019.py
+++ b/pulse2percept/models/tests/test_beyeler2019.py
@@ -919,3 +919,85 @@ def test_AxonMapModel_build_rejects_pre_step_cache(tmp_path):
         params, payload = pickle.load(f)
     npt.assert_equal('xystep' in params, False)
     npt.assert_equal(payload[0], _AXON_CACHE_VERSION)
+
+
+@pytest.mark.parametrize('ModelClass', [AxonMapSpatial, AxonMapModel])
+def test_AxonMapSpatial_meridian_blend(ModelClass):
+    # The axon map is cut along the horizontal raphe, so this blends across
+    # y=0 -- and only there, and only along y.
+    def make(**params):
+        return ModelClass(xrange=(-6, 6), yrange=(-6, 6), step=0.25,
+                          rho=200, lam=400, n_axons=250, n_ax_segments=200,
+                          ignore_pickle=True, **params).build()
+
+    implant = ArgusII(stim={'C4': 1, 'C8': 1})
+    plain = make()
+    unblended = plain.predict_percept(implant).data
+
+    # The default is 0, and 0 has to be the model exactly as it was:
+    npt.assert_equal(plain.meridian_blend, 0)
+    npt.assert_array_equal(make(meridian_blend=0).predict_percept(implant).data,
+                           unblended)
+
+    width = 1
+    blended = make(meridian_blend=width).predict_percept(implant).data
+    npt.assert_equal(blended.shape, unblended.shape)
+    npt.assert_equal(blended.dtype, unblended.dtype)
+
+    y, x = plain.grid.y[:, 0], plain.grid.x[0, :]
+    # The raphe is where the two halves of the axon map meet, and the step
+    # across it is what the blend is for. Percept rows are ordered by the
+    # grid's y, so the seam is the pair of rows straddling y=0:
+    seam = np.argsort(np.abs(y))[:2]
+
+    def jump(data):
+        return np.abs(data[seam[0], :, 0] - data[seam[1], :, 0]).max()
+
+    npt.assert_array_less(jump(blended), jump(unblended))
+
+    # It is the *horizontal* meridian this model blends across, so the change
+    # is a band in y and not one in x. Which rows and columns moved:
+    # Count a row or column as having moved if it moved by at least a
+    # thousandth of the largest change anywhere, so the bound below is about
+    # where the blend acts rather than about float noise:
+    delta = np.abs(blended - unblended)
+    moved = delta.max() * 1e-3
+    rows = delta.max(axis=(1, 2)) > moved
+    cols = delta.max(axis=(0, 2)) > moved
+    npt.assert_equal(np.any(rows), True)
+    # Every row that moved is within a few widths of the raphe, so the far
+    # field is untouched...
+    npt.assert_array_less(np.abs(y[rows]).max(), 4 * width)
+    # ...while columns moved right across the grid, including far from x=0,
+    # which a blend across the vertical meridian would have left alone:
+    npt.assert_array_less(4 * width, np.abs(x[cols]).max())
+
+
+def test_AxonMapSpatial_meridian_blend_reapplies_threshold():
+    # Blending pulls brightness across the raphe, which could otherwise lift a
+    # point that `thresh_percept` had zeroed back off zero.
+    implant = ArgusII(stim={'C4': 1})
+    model = AxonMapSpatial(xrange=(-6, 6), yrange=(-6, 6), step=0.25, rho=200,
+                           lam=400, n_axons=250, n_ax_segments=200,
+                           ignore_pickle=True, meridian_blend=1,
+                           thresh_percept=0.1).build()
+    data = model.predict_percept(implant).data
+    npt.assert_equal(np.any(data > 0), True)
+    # Nothing survives strictly between zero and the threshold:
+    npt.assert_equal(np.any((np.abs(data) > 0) & (np.abs(data) < 0.1)), False)
+
+
+def test_AxonMapSpatial_meridian_blend_over_time():
+    # Every frame is blended, and each one on its own.
+    implant = ArgusII(stim=Stimulus({'C4': [0, 1, 2], 'C8': [2, 1, 0]}))
+    model = AxonMapSpatial(xrange=(-6, 6), yrange=(-6, 6), step=0.5, rho=200,
+                           lam=400, n_axons=250, n_ax_segments=200,
+                           ignore_pickle=True, meridian_blend=1).build()
+    percept = model.predict_percept(implant)
+    npt.assert_equal(percept.data.shape[-1], 3)
+    for t in range(3):
+        frame = ArgusII(encoder=None, stim=Stimulus(
+            {'C4': [0, 1, 2][t], 'C8': [2, 1, 0][t]}))
+        npt.assert_allclose(percept.data[..., t],
+                            model.predict_percept(frame).data[..., 0],
+                            atol=1e-6)

--- a/pulse2percept/models/tests/test_beyeler2019.py
+++ b/pulse2percept/models/tests/test_beyeler2019.py
@@ -933,8 +933,6 @@ def _straddling_pair(coord):
 
 @pytest.mark.parametrize('ModelClass', [AxonMapSpatial, AxonMapModel])
 def test_AxonMapSpatial_meridian_blend(ModelClass):
-    # The axon map is cut along the horizontal raphe, so this blends across
-    # y=0 -- and only there, and only along y.
     def make(**params):
         # Offset by half a step so the nearest rows straddle the raphe.
         return ModelClass(xrange=(-6, 6), yrange=(-6.125, 5.875), step=0.25,
@@ -945,8 +943,6 @@ def test_AxonMapSpatial_meridian_blend(ModelClass):
     plain = make(meridian_blend=0)
     unblended = plain.predict_percept(implant).data
 
-    # The model blends out of the box, so this exercises the default rather
-    # than passing a width of its own:
     width = 1
     blended_model = make()
     npt.assert_equal(blended_model.meridian_blend, width)
@@ -955,9 +951,7 @@ def test_AxonMapSpatial_meridian_blend(ModelClass):
     npt.assert_equal(blended.dtype, unblended.dtype)
 
     y, x = plain.grid.y[:, 0], plain.grid.x[0, :]
-    # The raphe is where the two halves of the axon map meet, and the step
-    # across it is what the blend is for. Percept rows are ordered by the
-    # grid's y, so the seam is the pair of rows straddling y=0:
+    # The raphe is where the two halves of the axon map meet:
     seam = _straddling_pair(y)
 
     def jump(data):
@@ -966,11 +960,7 @@ def test_AxonMapSpatial_meridian_blend(ModelClass):
     npt.assert_array_less(0, jump(unblended))
     npt.assert_array_less(jump(blended), jump(unblended))
 
-    # It is the *horizontal* meridian this model blends across, so the change
-    # is a band in y and not one in x. Which rows and columns moved:
-    # Count a row or column as having moved if it moved by at least a
-    # thousandth of the largest change anywhere, so the bound below is about
-    # where the blend acts rather than about float noise:
+    # Blend across horizontal meridian:
     delta = np.abs(blended - unblended)
     moved = delta.max() * 1e-3
     rows = delta.max(axis=(1, 2)) > moved
@@ -979,8 +969,7 @@ def test_AxonMapSpatial_meridian_blend(ModelClass):
     # Every row that moved is within a few widths of the raphe, so the far
     # field is untouched...
     npt.assert_array_less(np.abs(y[rows]).max(), 4 * width)
-    # ...while columns moved right across the grid, including far from x=0,
-    # which a blend across the vertical meridian would have left alone:
+    # ...while columns moved right across the grid:
     npt.assert_array_less(4 * width, np.abs(x[cols]).max())
 
 

--- a/pulse2percept/models/tests/test_beyeler2019.py
+++ b/pulse2percept/models/tests/test_beyeler2019.py
@@ -647,18 +647,23 @@ def test_AxonMapModel_predict_percept():
     img_stim = np.zeros(60)
     img_stim[47] = 1
     percept = model.predict_percept(ArgusII(stim=img_stim))
-    # Single bright pixel, rest of arc is less bright:
-    npt.assert_equal(np.sum(percept.data > 0.8), 1)
+    # Single bright pixel, rest of arc is less bright. The default
+    # `meridian_blend` smooths the percept near the raphe, which brings the
+    # peak down to just under 0.8 and spreads a little brightness into the dim
+    # tail, so the thresholds and counts below differ from the unblended
+    # model's:
+    npt.assert_equal(np.sum(percept.data > 0.75), 1)
     npt.assert_equal(np.sum(percept.data > 0.6), 2)
     npt.assert_equal(np.sum(percept.data > 0.1), 7)
-    npt.assert_equal(np.sum(percept.data > 0.0001), 32)
+    npt.assert_equal(np.sum(percept.data > 0.0001), 53)
     # Overall only a few bright pixels:
-    npt.assert_almost_equal(np.sum(percept.data), 3.4062, decimal=3)
+    npt.assert_almost_equal(np.sum(percept.data), 3.5846, decimal=3)
     # Brightest pixel is in lower right:
     npt.assert_almost_equal(percept.data[33, 46, 0], np.max(percept.data))
-    # Top half is empty:
-    npt.assert_almost_equal(np.sum(percept.data[:27, :, 0]), 0)
-    # Same for lower band:
+    # Top half is all but empty: this electrode drives the inferior field, and
+    # the only thing above the raphe is what the blend carries across it.
+    npt.assert_array_less(np.sum(percept.data[:27, :, 0]), 1e-3)
+    # The lower band is untouched by the blend, and stays empty:
     npt.assert_almost_equal(np.sum(percept.data[39:, :, 0]), 0)
 
     # Full Argus II with small lambda: 60 bright spots
@@ -668,8 +673,8 @@ def test_AxonMapModel_predict_percept():
     percept = model.predict_percept(ArgusII(stim=np.ones(60)))
     # Most spots are pretty bright, but there are 2 dimmer ones (due to their
     # location on the retina):
-    npt.assert_equal(np.sum(percept.data > 0.5), 28)
-    npt.assert_equal(np.sum(percept.data > 0.275), 56)
+    npt.assert_equal(np.sum(percept.data > 0.5), 25)
+    npt.assert_equal(np.sum(percept.data > 0.275), 55)
 
     # Model gives same outcome as Spatial:
     spatial = AxonMapSpatial(step=1, rho=100, lam=40,
@@ -921,23 +926,35 @@ def test_AxonMapModel_build_rejects_pre_step_cache(tmp_path):
     npt.assert_equal(payload[0], _AXON_CACHE_VERSION)
 
 
+def _straddling_pair(coord):
+    """Indices of the samples nearest the meridian, one on each side of it
+
+    Not ``argsort(abs(coord))[:2]``: on a grid that samples the meridian
+    itself, that picks up the zero sample plus whichever neighbor the sort
+    happens to place first, and the two candidates are tied. A sample at
+    exactly 0 is not a neutral point to measure across either -- it belongs to
+    one side or the other, and Polimeni2006Map jitters it onto one hemisphere.
+    """
+    below = np.flatnonzero(coord < 0)
+    above = np.flatnonzero(coord > 0)
+    return below[np.argmax(coord[below])], above[np.argmin(coord[above])]
+
+
 @pytest.mark.parametrize('ModelClass', [AxonMapSpatial, AxonMapModel])
 def test_AxonMapSpatial_meridian_blend(ModelClass):
     # The axon map is cut along the horizontal raphe, so this blends across
     # y=0 -- and only there, and only along y.
     def make(**params):
-        return ModelClass(xrange=(-6, 6), yrange=(-6, 6), step=0.25,
+        # `yrange` is offset by half a step, so that no row sits exactly on
+        # the raphe and the two rows nearest it are adjacent as well as on
+        # opposite sides:
+        return ModelClass(xrange=(-6, 6), yrange=(-6.125, 5.875), step=0.25,
                           rho=200, lam=400, n_axons=250, n_ax_segments=200,
                           ignore_pickle=True, **params).build()
 
     implant = ArgusII(stim={'C4': 1, 'C8': 1})
-    plain = make()
+    plain = make(meridian_blend=0)
     unblended = plain.predict_percept(implant).data
-
-    # The default is 0, and 0 has to be the model exactly as it was:
-    npt.assert_equal(plain.meridian_blend, 0)
-    npt.assert_array_equal(make(meridian_blend=0).predict_percept(implant).data,
-                           unblended)
 
     width = 1
     blended = make(meridian_blend=width).predict_percept(implant).data
@@ -948,11 +965,12 @@ def test_AxonMapSpatial_meridian_blend(ModelClass):
     # The raphe is where the two halves of the axon map meet, and the step
     # across it is what the blend is for. Percept rows are ordered by the
     # grid's y, so the seam is the pair of rows straddling y=0:
-    seam = np.argsort(np.abs(y))[:2]
+    seam = _straddling_pair(y)
 
     def jump(data):
         return np.abs(data[seam[0], :, 0] - data[seam[1], :, 0]).max()
 
+    npt.assert_array_less(0, jump(unblended))
     npt.assert_array_less(jump(blended), jump(unblended))
 
     # It is the *horizontal* meridian this model blends across, so the change

--- a/pulse2percept/models/tests/test_granley2021.py
+++ b/pulse2percept/models/tests/test_granley2021.py
@@ -701,3 +701,34 @@ def test_BiphasicAxonMap_dimension_before_waveform():
         BiphasicAxonMapSpatial(step=2).build().predict_percept(
             ArgusII(stim={'A1': MonophasicPulse(-1, 0.45, stim_dur=100)}))
     npt.assert_equal('BiphasicPulseTrain' in str(excinfo.value), True)
+
+
+@pytest.mark.parametrize('ModelClass', [BiphasicAxonMapSpatial,
+                                        BiphasicAxonMapModel])
+def test_BiphasicAxonMapSpatial_meridian_blend(ModelClass):
+    # This model replaces `predict_percept` instead of customizing
+    # `_predict_spatial`, so it has to call the postprocessing hook itself --
+    # otherwise `meridian_blend`, inherited from `AxonMapSpatial`, would be
+    # accepted and then quietly ignored.
+    def make(**params):
+        return ModelClass(xrange=(-6, 6), yrange=(-6, 6), step=0.25, rho=200,
+                          lam=400, n_axons=250, n_ax_segments=200,
+                          ignore_pickle=True, **params).build()
+
+    implant = ArgusII(stim={'C4': BiphasicPulseTrain(20, 20, 0.45),
+                            'C8': BiphasicPulseTrain(20, 20, 0.45)})
+    plain = make()
+    unblended = plain.predict_percept(implant).data
+    npt.assert_array_equal(make(meridian_blend=0).predict_percept(implant).data,
+                           unblended)
+
+    width = 1
+    blended = make(meridian_blend=width).predict_percept(implant).data
+    npt.assert_equal(blended.shape, unblended.shape)
+    npt.assert_equal(blended.dtype, unblended.dtype)
+    npt.assert_equal(np.array_equal(blended, unblended), False)
+    # It is the horizontal meridian here, so the change is a band around y=0:
+    y = plain.grid.y[:, 0]
+    delta = np.abs(blended - unblended)
+    rows = delta.max(axis=(1, 2)) > delta.max() * 1e-3
+    npt.assert_array_less(np.abs(y[rows]).max(), 4 * width)

--- a/pulse2percept/models/tests/test_granley2021.py
+++ b/pulse2percept/models/tests/test_granley2021.py
@@ -720,8 +720,12 @@ def test_BiphasicAxonMapSpatial_meridian_blend(ModelClass):
     plain = make(meridian_blend=0)
     unblended = plain.predict_percept(implant).data
 
+    # Exercises the width inherited from `AxonMapSpatial` rather than one of
+    # its own -- the point of the test is that the hook runs at all here:
     width = 1
-    blended = make(meridian_blend=width).predict_percept(implant).data
+    blended_model = make()
+    npt.assert_equal(blended_model.meridian_blend, width)
+    blended = blended_model.predict_percept(implant).data
     npt.assert_equal(blended.shape, unblended.shape)
     npt.assert_equal(blended.dtype, unblended.dtype)
     npt.assert_equal(np.array_equal(blended, unblended), False)

--- a/pulse2percept/models/tests/test_granley2021.py
+++ b/pulse2percept/models/tests/test_granley2021.py
@@ -717,10 +717,8 @@ def test_BiphasicAxonMapSpatial_meridian_blend(ModelClass):
 
     implant = ArgusII(stim={'C4': BiphasicPulseTrain(20, 20, 0.45),
                             'C8': BiphasicPulseTrain(20, 20, 0.45)})
-    plain = make()
+    plain = make(meridian_blend=0)
     unblended = plain.predict_percept(implant).data
-    npt.assert_array_equal(make(meridian_blend=0).predict_percept(implant).data,
-                           unblended)
 
     width = 1
     blended = make(meridian_blend=width).predict_percept(implant).data

--- a/pulse2percept/topography/tests/test_neuropythy.py
+++ b/pulse2percept/topography/tests/test_neuropythy.py
@@ -333,8 +333,12 @@ def test_ndim_mixup(neuropythy_available):
 
 @pytest.mark.slow
 def test_neuropythy_scoreboard(neuropythy_available):
+    # `meridian_blend=0` throughout: the sums below pin the neuropythy
+    # map, which the default postprocessing does not change. The blend
+    # itself is covered by `test_CortexSpatial_meridian_blend`.
     nmap = NeuropythyMap('fsaverage')
-    model = ScoreboardModel(rho=800, step=.25, vfmap=nmap).build()
+    model = ScoreboardModel(rho=800, step=.25, vfmap=nmap,
+                            meridian_blend=0).build()
     implant = Neuralink.from_neuropythy(nmap, xrange=(-3, 3), yrange=(-3, 3))
     implant.stim = {e : 1 for e in implant.electrode_names}
     percept = model.predict_percept(implant)
@@ -342,7 +346,8 @@ def test_neuropythy_scoreboard(neuropythy_available):
     npt.assert_almost_equal(np.max(percept.data), 27.3698, decimal=3)
 
     nmap = NeuropythyMap('fsaverage', regions=['v2'])
-    model = ScoreboardModel(rho=800, step=.25, vfmap=nmap).build()
+    model = ScoreboardModel(rho=800, step=.25, vfmap=nmap,
+                            meridian_blend=0).build()
     implant = Neuralink.from_neuropythy(nmap, xrange=(-3, 3), yrange=(-3, 3), region='v2')
     implant.stim = {e : 1 for e in implant.electrode_names}
     percept = model.predict_percept(implant)
@@ -351,7 +356,8 @@ def test_neuropythy_scoreboard(neuropythy_available):
 
     # mega implant
     nmap = NeuropythyMap('fsaverage', regions=['v1', 'v2', 'v3'])
-    model = ScoreboardModel(rho=800, step=.25, vfmap=nmap).build()
+    model = ScoreboardModel(rho=800, step=.25, vfmap=nmap,
+                            meridian_blend=0).build()
     i1 = Neuralink.from_neuropythy(nmap, xrange=(-3, 3), yrange=(-3, 3), region='v1')
     i2 = Neuralink.from_neuropythy(nmap, xrange=(-3, 3), yrange=(-3, 3), region='v2')
     i3 = Neuralink.from_neuropythy(nmap, xrange=(-3, 3), yrange=(-3, 3), region='v3')


### PR DESCRIPTION
Closes #677.

Adds `meridian_blend` to spatial models with artificial anatomical seams. `AxonMapSpatial` blends across the horizontal raphe by default, while cortical `ScoreboardSpatial` blends across the vertical meridian. Set `meridian_blend=0` to recover the previous behavior.

Blending is applied in visual-field space after the tissue-level model prediction, without changing the underlying axon or cortical maps.

This also adds a small `_postprocess_spatial` hook to `SpatialModel` for the shared implementation, including the custom `BiphasicAxonMapSpatial` prediction path.