### PR TITLE
[TST] Refactor neuropythy tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,9 +52,6 @@ jobs:
           sudo apt-get install -y libomp-dev zlib1g-dev libjpeg-turbo8-dev
 
       # ---- Bootstrap build toolchain + NumPy headers ----
-      # NumPy 2.x is the only supported major, on every Python in the matrix,
-      # so there is nothing to choose per version and nothing to constrain:
-      # the resolver cannot pick a NumPy the package does not declare.
       - name: Upgrade pip and bootstrap build tools
         run: |
           python -m pip install --upgrade pip
@@ -84,17 +81,19 @@ jobs:
           pip freeze | sed -n '1,120p'
 
       # ---- Tests ----
-      - name: Run default test suite for push
-        if: github.event_name == 'push' && !github.event.pull_request
+      # Run from an empty directory so that `--pyargs` tests the installed
+      # package rather than the source tree next to it.
+      - name: Run test suite
         run: |
           mkdir -p test_dir && cd test_dir
           pytest --pyargs pulse2percept --cov=pulse2percept --cov-branch --cov-report=xml --doctest-modules -x
 
-      - name: Run slow tests for pull requests
-        if: github.event_name == 'pull_request'
+      # Run expensive integration tests once per PR and append their coverage:
+      - name: Run slow tests
+        if: github.event_name == 'pull_request' && matrix.os == 'ubuntu-latest' && matrix.python-version == '3.12'
         run: |
-          mkdir -p test_dir && cd test_dir
-          pytest --pyargs pulse2percept --cov=pulse2percept --runslow --cov-branch --cov-report=xml --doctest-modules -x
+          cd test_dir
+          pytest --pyargs pulse2percept --cov=pulse2percept --cov-append --cov-branch --cov-report=xml --runslow -m slow -x
 
       # ---- Coverage upload ----
       - name: Upload coverage report to codecov.io

--- a/pulse2percept/topography/tests/test_neuropythy.py
+++ b/pulse2percept/topography/tests/test_neuropythy.py
@@ -1,11 +1,7 @@
-"""Tests for :py:class:`~pulse2percept.topography.NeuropythyMap`
+"""Tests for :class:`~pulse2percept.topography.NeuropythyMap`.
 
-Almost everything this map owns -- the bookkeeping around a lookup, the
-hemisphere split, the nearest-neighbor interpolation, the download cache --
-works the same whatever subject is loaded, and is tested here against the toy
-cortex below. The handful of tests marked ``slow`` are the ones that check p2p
-against real Neuropythy and the Benson & Winawer (2018) data; they need
-``--runslow``, and they share a single ``fsaverage`` map.
+Most behavior is tested against a deterministic toy cortex. Slow tests use one
+shared ``fsaverage`` map to exercise the real Neuropythy pipeline.
 """
 import numpy as np
 import numpy.testing as npt
@@ -21,22 +17,12 @@ from pulse2percept.topography import CorticalMap, NeuropythyMap
 from pulse2percept.units import DimensionMismatchError, dva, mm, um
 
 
-#: Where each surface of the toy cortex sits along z, in millimeters.
 TOY_SURFACE_MM = {'white': -1.0, 'midgray': 0.0, 'pial': 1.0}
-
-#: How far out the toy visual field mesh reaches, in dva. A point beyond it
-#: has no face to be addressed to, the way a point outside V1 has none.
 TOY_MAX_ECC = 5.0
 
 
 def toy_cortex_mm(x, y, surface):
-    """Where the toy cortex puts the visual field point ``(x, y)``
-
-    The three surfaces are scaled copies of each other, so the direction from
-    one to the next depends on where the point is -- which is what
-    :py:meth:`~pulse2percept.implants.cortex.Neuralink.from_neuropythy` turns
-    into a thread orientation.
-    """
+    """Map toy visual-field coordinates onto a cortical surface."""
     scale = 1 + TOY_SURFACE_MM[surface] / 4
     return np.stack([scale * np.asarray(x, dtype=float),
                      -scale * np.asarray(y, dtype=float),
@@ -44,14 +30,7 @@ def toy_cortex_mm(x, y, surface):
 
 
 class ToyMesh:
-    """Stands in for one hemisphere's visual field mesh of one region
-
-    Addressing a point on a real mesh gives the face containing it and the
-    point's barycentric coordinates within that face; a point the mesh does
-    not contain addresses to NaN. The toy keeps the visual field coordinates
-    themselves as the barycentric ones, so the surface below can unaddress
-    them without a triangulation, and records what it was asked for.
-    """
+    """Minimal visual-field mesh used by the toy map."""
 
     def __init__(self, coordinates):
         # `cortex_to_dva` looks a vertex's dva coordinates up here:
@@ -67,7 +46,7 @@ class ToyMesh:
 
 
 class ToySurface:
-    """Stands in for one FreeSurfer surface of one hemisphere (in mm)"""
+    """Minimal FreeSurfer-like surface."""
 
     def __init__(self, name):
         self.name = name
@@ -78,7 +57,7 @@ class ToySurface:
 
 
 class ToyHemisphere:
-    """Stands in for one hemisphere, recording which surfaces were asked for"""
+    """Hemisphere that records requested surfaces."""
 
     def __init__(self):
         self.surfaces_asked = []
@@ -89,33 +68,18 @@ class ToyHemisphere:
 
 
 class ToySubject:
-    """Stands in for a FreeSurfer subject: two hemispheres of surfaces"""
+    """Minimal two-hemisphere subject."""
 
     def __init__(self):
         self.hemis = {'lh': ToyHemisphere(), 'rh': ToyHemisphere()}
 
 
-class ToyNeuropythyMap(NeuropythyMap):
-    """A NeuropythyMap with a toy cortex in place of a FreeSurfer subject
-
-    Going backward, the cortical mesh is a row of ``n`` vertices 1 mm apart --
-    exactly ``cort_nn_thresh`` -- with vertex ``i`` sitting at ``(i, 0, 0)`` mm
-    and looking at ``(i, -i)`` dva.
-
-    Going forward, addressing a point is neuropythy's job even here, so the toy
-    only supplies the mesh and the surfaces it addresses onto: a visual field
-    point lands where :py:func:`toy_cortex_mm` puts it, and a point beyond
-    ``TOY_MAX_ECC`` comes back NaN.
-
-    The two directions are separate stand-ins rather than inverses of each
-    other. Nothing in ``NeuropythyMap`` composes them, and keeping them apart
-    keeps both sets of numbers hand-checkable.
-    """
+cclass ToyNeuropythyMap(NeuropythyMap):
+    """NeuropythyMap backed by deterministic toy meshes and surfaces."""
 
     def __init__(self, n=6, regions=('v1', 'v2', 'v3'), cache_dir=None,
                  **params):
-        # NeuropythyMap.__init__ needs neuropythy and a subject, so go
-        # straight to the parameter defaults it would have set:
+        # Skip NeuropythyMap.__init__, which requires a real subject.
         CorticalMap.__init__(self, regions=list(regions), **params)
         self.cache_dir = cache_dir
         self.cortex_tree = cKDTree(np.stack([np.arange(n, dtype=float),
@@ -133,15 +97,7 @@ class ToyNeuropythyMap(NeuropythyMap):
 
 @pytest.fixture(scope='module')
 def neuropythy():
-    """The neuropythy package, or skip
-
-    Addressing a point is neuropythy's job even when the mesh is a toy, so the
-    forward direction needs the package imported -- but no subject, and no
-    Benson & Winawer download.
-
-    Only an absent neuropythy skips. An ImportError from *inside* neuropythy
-    is a broken install, and must fail rather than quietly go green.
-    """
+    """Import neuropythy, skipping only when the package is absent."""
     try:
         import neuropythy as ny
     except ModuleNotFoundError as err:
@@ -153,14 +109,7 @@ def neuropythy():
 
 @pytest.fixture(scope='module')
 def fsaverage(neuropythy):
-    """One real 'fsaverage' map, shared by every test that needs real data
-
-    Building it predicts retinotopy and meshes three regions, and may download
-    the Benson & Winawer (2018) dataset first, which is why every test using it
-    is marked slow. A missing neuropythy skips those tests; anything else that
-    goes wrong is a failure, not a skip.
-    """
-    return NeuropythyMap('fsaverage', regions=['v1', 'v2', 'v3'])
+    """Shared real fsaverage map for slow integration tests."""
 
 
 # -----------------------------------------------------------------------------
@@ -210,9 +159,7 @@ def test_cortex_to_dva_shape_and_nans():
 def test_cortex_to_dva_interpolation():
     """Nearby vertices are averaged; distant ones do not count at all."""
     nmap = ToyNeuropythyMap()
-    # A point sitting exactly on a vertex is at zero distance from it, which
-    # must not divide by zero (Issue #774). It maps to that vertex, not to a
-    # blend with its neighbors and not to NaN:
+    # Exact vertex hits must not divide by zero (Issue #774).
     verts = nmap.cortex_tree.data * 1000  # mm -> um
     with np.errstate(divide='raise', invalid='raise'):
         xdva, ydva = nmap.cortex_to_dva(verts[:, 0], verts[:, 1], verts[:, 2])
@@ -224,8 +171,7 @@ def test_cortex_to_dva_interpolation():
     npt.assert_almost_equal(xdva, [2.5])
     npt.assert_almost_equal(ydva, [-2.5])
 
-    # `cort_nn_thresh` is how far a vertex reaches, not a rounding: a point
-    # exactly that far away still maps, one micron further does not:
+    # The threshold is inclusive.
     npt.assert_almost_equal(nmap.cort_nn_thresh, 1000)
     xdva, ydva = nmap.cortex_to_dva(np.array([-1000.]), np.zeros(1),
                                     np.zeros(1))
@@ -260,7 +206,7 @@ def test_dva_to_cortex_regions(neuropythy):
         with pytest.raises(ValueError):
             dva_to(1, 1)
 
-    # Each of the three dispatches to its own region's mesh:
+    # Each region dispatches to its own mesh.
     nmap = ToyNeuropythyMap()
     for region, dva_to in [('v1', nmap.dva_to_v1), ('v2', nmap.dva_to_v2),
                            ('v3', nmap.dva_to_v3)]:
@@ -268,7 +214,6 @@ def test_dva_to_cortex_regions(neuropythy):
         npt.assert_equal([len(m.addressed)
                           for m in nmap.region_meshes[region]], [1, 0])
 
-    # The hemisphere is not something `dva_to_cortex` can guess:
     with pytest.raises(ValueError):
         nmap.dva_to_cortex(np.ones(1), np.ones(1), region='v1')
     with pytest.raises(ValueError):
@@ -283,12 +228,12 @@ def test_dva_to_cortex_hemispheres_and_shapes(neuropythy):
     lh, rh = nmap.region_meshes['v1']
     npt.assert_almost_equal(rh.addressed[-1][0], [-1])
     npt.assert_almost_equal(lh.addressed[-1][0], [0, 2])
-    # ... and the answers come back in the caller's order, in microns:
+    # Preserve input order and convert mm -> um:
     npt.assert_almost_equal(xc, [-1000, 0, 2000])
     npt.assert_almost_equal(yc, [-1000, -1000, 1000])
     npt.assert_almost_equal(zc, [0, 0, 0])
 
-    # The output has the shape of the input, down to a scalar:
+    # Preserve input shape:
     for shape in [(), (1,), (6,), (2, 3)]:
         zeros = np.zeros(shape)
         npt.assert_equal([c.shape for c in nmap.dva_to_v1(zeros, zeros)],
@@ -396,13 +341,7 @@ def fake_config():
 
 
 class DownloadOnAccess:
-    """A stand-in for ``ny.data['benson_winawer_2018'].subjects``
-
-    Looking a subject up here is what downloads it, and is the only reason p2p
-    reaches for the dataset at all. The real dataset is keyed by the subject
-    ids exactly as Benson & Winawer spell them, so a key it does not know is a
-    KeyError rather than a silent success.
-    """
+    """Fake Benson-Winawer subject collection that records downloads."""
     subject_ids = ('fsaverage', 'S1201', 'S1202', 'S1203', 'S1204', 'S1205',
                    'S1206', 'S1207', 'S1208')
 
@@ -500,14 +439,7 @@ def test_parse_subject_reraises_unknown_subject(neuropythy, tmp_path,
 # -----------------------------------------------------------------------------
 
 def test_Neuralink_from_neuropythy(neuropythy):
-    """One thread per visual field location, sitting on the pial surface
-
-    ``from_neuropythy`` is tested on its own -- grids, thread names, regions,
-    insertion angles -- against a stub map in
-    ``implants/cortex/tests/test_neuralink.py``. What is left to check here is
-    that what a real ``NeuropythyMap`` lookup returns, hemisphere split and
-    NaNs and all, is what that factory expects.
-    """
+    """One thread per valid visual-field location."""
     nmap = ToyNeuropythyMap()
     locs = np.array([[0, 0], [3, 3], [-2, -2], [TOY_MAX_ECC, TOY_MAX_ECC]])
     nlink = Neuralink.from_neuropythy(nmap, locs=locs)
@@ -528,18 +460,12 @@ def test_Neuralink_from_neuropythy(neuropythy):
 # The real thing: Neuropythy and the Benson & Winawer (2018) data
 # -----------------------------------------------------------------------------
 
-#: Visual field points (dva) looked up on the real 'fsaverage' subject. The
-#: two on the vertical meridian have no cortex of their own; for V2 and V3 the
-#: horizontal meridian is a boundary too.
+# Regression points and expected fsaverage cortical coordinates.
 FSAVERAGE_POINTS = {
     'v1': ([1, 1, 0, 0, -1, -1], [1, -1, 1, -1, 1, -1]),
     'v2': ([1, 1, 0, 0, -1, -1], [1, -1, 1, -1, 0, -1]),
     'v3': ([1, 1, 0, 0, -1, -1], [1, -1, 1, -1, 0, -1]),
 }
-
-#: Where `FSAVERAGE_POINTS` land on the cortex (um), by region and by
-#: `jitter_boundary`. These numbers are a regression baseline: they say the
-#: mapping has not moved, not that it is anatomically right.
 FSAVERAGE_CORTEX = {
     ('v1', False): ([-10035.355, -13315.073, np.nan, np.nan, 12075.739,
                      13630.971],
@@ -579,7 +505,7 @@ FSAVERAGE_CORTEX = {
 
 @pytest.mark.slow
 def test_fsaverage_meshes(fsaverage):
-    """The subject arrives with a predicted retinotopy and a mesh per region."""
+    """Build real V1-V3 meshes."""
     npt.assert_equal(fsaverage.predicted_retinotopy is not None, True)
     npt.assert_equal(list(fsaverage.region_meshes.keys()), ['v1', 'v2', 'v3'])
     for meshes in fsaverage.region_meshes.values():
@@ -596,7 +522,7 @@ def test_fsaverage_meshes(fsaverage):
 @pytest.mark.parametrize('region', ['v1', 'v2', 'v3'])
 def test_fsaverage_dva_to_cortex(region, jitter_boundary, fsaverage,
                                  monkeypatch):
-    """Known visual field points still land where they used to on fsaverage."""
+    """Check real fsaverage forward mapping."""
     monkeypatch.setattr(fsaverage, 'jitter_boundary', jitter_boundary)
     x, y = FSAVERAGE_POINTS[region]
     expected = FSAVERAGE_CORTEX[(region, jitter_boundary)]
@@ -610,7 +536,7 @@ def test_fsaverage_dva_to_cortex(region, jitter_boundary, fsaverage,
 @pytest.mark.slow
 @pytest.mark.parametrize('region', ['v1', 'v2', 'v3'])
 def test_fsaverage_cortex_to_dva(region, fsaverage):
-    """The inverse lands back on the visual field point it started from."""
+    """Check real fsaverage inverse mapping."""
     to_dva = fsaverage.to_dva()[region]
     # The forward regression, run backwards:
     xc, yc, zc = (np.array(c) for c in FSAVERAGE_CORTEX[(region, False)])
@@ -621,8 +547,7 @@ def test_fsaverage_cortex_to_dva(region, fsaverage):
     npt.assert_allclose(ydva, np.array(FSAVERAGE_POINTS[region][1])[keep],
                         rtol=.05, atol=0.1)
 
-    # ... and a whole diagonal of the lower left quadrant, which is far enough
-    # from every boundary that the round trip has to close:
+    # ... and a whole diagonal of the lower left quadrant:
     x = y = np.arange(-10, -1, .1)
     xdva, ydva = to_dva(*fsaverage.from_dva()[region](x, y))
     npt.assert_allclose(xdva, x, rtol=.05, atol=0.1)
@@ -631,7 +556,7 @@ def test_fsaverage_cortex_to_dva(region, fsaverage):
 
 @pytest.mark.slow
 def test_fsaverage_scoreboard(fsaverage):
-    """A real map still drives a real implant through a real model."""
+    """Run one end-to-end real-map model integration."""
     model = ScoreboardModel(rho=800, step=.25, vfmap=fsaverage).build()
     implants = [Neuralink.from_neuropythy(fsaverage, xrange=(-3, 3),
                                           yrange=(-3, 3), region=region)

--- a/pulse2percept/topography/tests/test_neuropythy.py
+++ b/pulse2percept/topography/tests/test_neuropythy.py
@@ -74,7 +74,7 @@ class ToySubject:
         self.hemis = {'lh': ToyHemisphere(), 'rh': ToyHemisphere()}
 
 
-cclass ToyNeuropythyMap(NeuropythyMap):
+class ToyNeuropythyMap(NeuropythyMap):
     """NeuropythyMap backed by deterministic toy meshes and surfaces."""
 
     def __init__(self, n=6, regions=('v1', 'v2', 'v3'), cache_dir=None,
@@ -110,6 +110,7 @@ def neuropythy():
 @pytest.fixture(scope='module')
 def fsaverage(neuropythy):
     """Shared real fsaverage map for slow integration tests."""
+    return NeuropythyMap('fsaverage', regions=['v1', 'v2', 'v3'])
 
 
 # -----------------------------------------------------------------------------

--- a/pulse2percept/topography/tests/test_neuropythy.py
+++ b/pulse2percept/topography/tests/test_neuropythy.py
@@ -138,9 +138,17 @@ def neuropythy():
     Addressing a point is neuropythy's job even when the mesh is a toy, so the
     forward direction needs the package imported -- but no subject, and no
     Benson & Winawer download.
+
+    Only an absent neuropythy skips. An ImportError from *inside* neuropythy
+    is a broken install, and must fail rather than quietly go green.
     """
-    return pytest.importorskip('neuropythy',
-                               reason="requires `pip install neuropythy`")
+    try:
+        import neuropythy as ny
+    except ModuleNotFoundError as err:
+        if err.name == 'neuropythy':
+            pytest.skip("requires `pip install neuropythy`")
+        raise
+    return ny
 
 
 @pytest.fixture(scope='module')
@@ -359,6 +367,15 @@ def test_NeuropythyMap_units(neuropythy):
     with pytest.raises(DimensionMismatchError):
         vfmap.v1_to_dva(xc * dva, yc, zc)
 
+    # `cort_nn_thresh` is a distance between mesh vertices, so it is stored in
+    # microns however it was handed over:
+    npt.assert_equal(ToyNeuropythyMap(cort_nn_thresh=1 * mm).cort_nn_thresh,
+                     1000)
+    npt.assert_equal(ToyNeuropythyMap(cort_nn_thresh=500 * um).cort_nn_thresh,
+                     500)
+    with pytest.raises(DimensionMismatchError):
+        ToyNeuropythyMap(cort_nn_thresh=1 * dva)
+
 
 def test_ndim_mixup():
     """A 3D cortical map cannot drive a model that only knows 2D grids."""
@@ -382,13 +399,19 @@ class DownloadOnAccess:
     """A stand-in for ``ny.data['benson_winawer_2018'].subjects``
 
     Looking a subject up here is what downloads it, and is the only reason p2p
-    reaches for the dataset at all.
+    reaches for the dataset at all. The real dataset is keyed by the subject
+    ids exactly as Benson & Winawer spell them, so a key it does not know is a
+    KeyError rather than a silent success.
     """
+    subject_ids = ('fsaverage', 'S1201', 'S1202', 'S1203', 'S1204', 'S1205',
+                   'S1206', 'S1207', 'S1208')
 
     def __init__(self, downloaded):
         self.downloaded = downloaded
 
     def __getitem__(self, name):
+        if name not in self.subject_ids:
+            raise KeyError(name)
         self.downloaded.append(name)
         return name
 
@@ -432,8 +455,7 @@ def test_parse_subject_configures_cache(neuropythy, tmp_path, monkeypatch):
     npt.assert_equal(len(config['freesurfer_subject_paths']), 1)
 
 
-@pytest.mark.parametrize('subject', ['S1201', 's1201'])
-def test_parse_subject_downloads_benson_winawer(subject, neuropythy, tmp_path,
+def test_parse_subject_downloads_benson_winawer(neuropythy, tmp_path,
                                                 monkeypatch):
     """Neuropythy only downloads the dataset for 'fsaverage' on its own
 
@@ -455,9 +477,9 @@ def test_parse_subject_downloads_benson_winawer(subject, neuropythy, tmp_path,
     monkeypatch.setattr(neuropythy, 'data', {'benson_winawer_2018': dataset})
 
     nmap = ToyNeuropythyMap(cache_dir=str(tmp_path))
-    npt.assert_equal(nmap.parse_subject(subject), f'loaded {subject}')
-    npt.assert_equal(downloaded, [subject])
-    npt.assert_equal(attempts, [subject, subject])
+    npt.assert_equal(nmap.parse_subject('S1201'), 'loaded S1201')
+    npt.assert_equal(downloaded, ['S1201'])
+    npt.assert_equal(attempts, ['S1201', 'S1201'])
 
 
 def test_parse_subject_reraises_unknown_subject(neuropythy, tmp_path,

--- a/pulse2percept/topography/tests/test_neuropythy.py
+++ b/pulse2percept/topography/tests/test_neuropythy.py
@@ -1,94 +1,163 @@
+"""Tests for :py:class:`~pulse2percept.topography.NeuropythyMap`
+
+Almost everything this map owns -- the bookkeeping around a lookup, the
+hemisphere split, the nearest-neighbor interpolation, the download cache --
+works the same whatever subject is loaded, and is tested here against the toy
+cortex below. The handful of tests marked ``slow`` are the ones that check p2p
+against real Neuropythy and the Benson & Winawer (2018) data; they need
+``--runslow``, and they share a single ``fsaverage`` map.
+"""
 import numpy as np
 import numpy.testing as npt
 import pytest
 from scipy.spatial import cKDTree
 from types import SimpleNamespace
-from pulse2percept.models.cortex import ScoreboardModel
-from pulse2percept.models import ScoreboardModel as BeyelerScoreboard
-from pulse2percept.implants.cortex import Neuralink
+
 from pulse2percept.implants import EnsembleImplant
+from pulse2percept.implants.cortex import Neuralink
+from pulse2percept.models import ScoreboardModel as BeyelerScoreboard
+from pulse2percept.models.cortex import ScoreboardModel
 from pulse2percept.topography import CorticalMap, NeuropythyMap
-from pulse2percept.units import (DimensionMismatchError, dva, mm, um)
-import time
-import os
+from pulse2percept.units import DimensionMismatchError, dva, mm, um
 
-def load_fsaverage_or_skip():
-    """Load the Neuropythy 'fsaverage' subject, or skip the calling test.
 
-    Loading a subject may download the Benson & Winawer (2018) dataset, which
-    can fail for any number of reasons outside our control (neuropythy not
-    installed, no network, moved download endpoints, no disk space, ...). All
-    of them should skip the test rather than error it out.
+#: Where each surface of the toy cortex sits along z, in millimeters.
+TOY_SURFACE_MM = {'white': -1.0, 'midgray': 0.0, 'pial': 1.0}
+
+#: How far out the toy visual field mesh reaches, in dva. A point beyond it
+#: has no face to be addressed to, the way a point outside V1 has none.
+TOY_MAX_ECC = 5.0
+
+
+def toy_cortex_mm(x, y, surface):
+    """Where the toy cortex puts the visual field point ``(x, y)``
+
+    The three surfaces are scaled copies of each other, so the direction from
+    one to the next depends on where the point is -- which is what
+    :py:meth:`~pulse2percept.implants.cortex.Neuralink.from_neuropythy` turns
+    into a thread orientation.
     """
-    try:
-        return NeuropythyMap('fsaverage')
-    except Exception as err:
-        pytest.skip(f"Could not load the Neuropythy 'fsaverage' subject "
-                    f"({type(err).__name__}: {err}). Download the Benson & "
-                    f"Winawer 2018 dataset to run this test.")
+    scale = 1 + TOY_SURFACE_MM[surface] / 4
+    return np.stack([scale * np.asarray(x, dtype=float),
+                     -scale * np.asarray(y, dtype=float),
+                     np.full(np.shape(x), TOY_SURFACE_MM[surface])])
 
 
-@pytest.fixture(scope='session')
-def neuropythy_available():
-    """Skip the test unless the 'fsaverage' subject can be loaded.
+class ToyMesh:
+    """Stands in for one hemisphere's visual field mesh of one region
 
-    This is a fixture rather than a ``skipif`` condition on purpose:
-    conditions are evaluated at collection time, so a ``skipif`` would hit the
-    network on every test run, including runs where these tests are all
-    skipped anyway.
+    Addressing a point on a real mesh gives the face containing it and the
+    point's barycentric coordinates within that face; a point the mesh does
+    not contain addresses to NaN. The toy keeps the visual field coordinates
+    themselves as the barycentric ones, so the surface below can unaddress
+    them without a triangulation, and records what it was asked for.
     """
-    return load_fsaverage_or_skip()
+
+    def __init__(self, coordinates):
+        # `cortex_to_dva` looks a vertex's dva coordinates up here:
+        self.coordinates = np.asarray(coordinates, dtype=float)
+        self.addressed = []
+
+    def address(self, coords):
+        x, y = (np.atleast_1d(np.asarray(c, dtype=float)) for c in coords)
+        self.addressed.append((x.copy(), y.copy()))
+        bc = np.stack([x, y])
+        bc[:, np.hypot(x, y) > TOY_MAX_ECC] = np.nan
+        return {'faces': np.zeros((3, x.size), dtype=int), 'coordinates': bc}
 
 
-def test_load_fsaverage_or_skip_swallows_any_error():
-    """Any failure to load the subject must skip, not error out.
+class ToySurface:
+    """Stands in for one FreeSurfer surface of one hemisphere (in mm)"""
 
-    This runs without neuropythy installed and without touching the network,
-    so it guards the fixture that gates every other test in this module.
-    """
-    import pulse2percept.topography.tests.test_neuropythy as mod
+    def __init__(self, name):
+        self.name = name
 
-    for err in (ImportError('no neuropythy'), ValueError('no such subject'),
-                OSError('network is down'), RuntimeError('something else')):
-        def boom(*args, _err=err, **kwargs):
-            raise _err
+    def unaddress(self, addr):
+        x, y = np.asarray(addr['coordinates'], dtype=float)
+        return toy_cortex_mm(x, y, self.name)
 
-        orig = mod.NeuropythyMap
-        mod.NeuropythyMap = boom
-        try:
-            with pytest.raises(pytest.skip.Exception) as excinfo:
-                load_fsaverage_or_skip()
-            # The skip reason names the underlying error, so a future
-            # breakage is diagnosable straight from the CI log:
-            npt.assert_equal(type(err).__name__ in str(excinfo.value), True)
-        finally:
-            mod.NeuropythyMap = orig
+
+class ToyHemisphere:
+    """Stands in for one hemisphere, recording which surfaces were asked for"""
+
+    def __init__(self):
+        self.surfaces_asked = []
+
+    def surface(self, name):
+        self.surfaces_asked.append(name)
+        return ToySurface(name)
+
+
+class ToySubject:
+    """Stands in for a FreeSurfer subject: two hemispheres of surfaces"""
+
+    def __init__(self):
+        self.hemis = {'lh': ToyHemisphere(), 'rh': ToyHemisphere()}
 
 
 class ToyNeuropythyMap(NeuropythyMap):
-    """A NeuropythyMap whose cortical mesh is a row of ``n`` vertices.
+    """A NeuropythyMap with a toy cortex in place of a FreeSurfer subject
 
-    ``cortex_to_dva`` only reads the k-d tree and the mesh lookup tables, so
-    filling those in with a toy mesh exercises all of its bookkeeping (output
-    shape, NaN handling, exact hits) with hand-checkable numbers and without a
-    subject download. Vertex ``i`` sits at ``(i, 0, 0)`` mm on the cortex and
-    maps to ``(i, -i)`` dva; vertices are 1 mm apart, which is exactly
-    ``cort_nn_thresh``.
+    Going backward, the cortical mesh is a row of ``n`` vertices 1 mm apart --
+    exactly ``cort_nn_thresh`` -- with vertex ``i`` sitting at ``(i, 0, 0)`` mm
+    and looking at ``(i, -i)`` dva.
+
+    Going forward, addressing a point is neuropythy's job even here, so the toy
+    only supplies the mesh and the surfaces it addresses onto: a visual field
+    point lands where :py:func:`toy_cortex_mm` puts it, and a point beyond
+    ``TOY_MAX_ECC`` comes back NaN.
+
+    The two directions are separate stand-ins rather than inverses of each
+    other. Nothing in ``NeuropythyMap`` composes them, and keeping them apart
+    keeps both sets of numbers hand-checkable.
     """
 
-    def __init__(self, n=6):
+    def __init__(self, n=6, regions=('v1', 'v2', 'v3'), cache_dir=None,
+                 **params):
         # NeuropythyMap.__init__ needs neuropythy and a subject, so go
         # straight to the parameter defaults it would have set:
-        CorticalMap.__init__(self)
+        CorticalMap.__init__(self, regions=list(regions), **params)
+        self.cache_dir = cache_dir
         self.cortex_tree = cKDTree(np.stack([np.arange(n, dtype=float),
-                                             np.zeros(n), np.zeros(n)], axis=-1))
+                                             np.zeros(n), np.zeros(n)],
+                                            axis=-1))
         self.addr_idxs = {'addr': np.arange(n),
-                          'region': np.array(['v1'] * n),
+                          'region': np.array([self.regions[0]] * n),
                           'hemi': np.zeros(n, dtype=int)}
-        mesh = SimpleNamespace(coordinates=np.stack([np.arange(n, dtype=float),
-                                                     -np.arange(n, dtype=float)]))
-        self.region_meshes = {'v1': (mesh, mesh)}
+        coords = np.stack([np.arange(n, dtype=float),
+                           -np.arange(n, dtype=float)])
+        self.region_meshes = {r: (ToyMesh(coords), ToyMesh(coords))
+                              for r in self.regions}
+        self.subject = ToySubject()
 
+
+@pytest.fixture(scope='module')
+def neuropythy():
+    """The neuropythy package, or skip
+
+    Addressing a point is neuropythy's job even when the mesh is a toy, so the
+    forward direction needs the package imported -- but no subject, and no
+    Benson & Winawer download.
+    """
+    return pytest.importorskip('neuropythy',
+                               reason="requires `pip install neuropythy`")
+
+
+@pytest.fixture(scope='module')
+def fsaverage(neuropythy):
+    """One real 'fsaverage' map, shared by every test that needs real data
+
+    Building it predicts retinotopy and meshes three regions, and may download
+    the Benson & Winawer (2018) dataset first, which is why every test using it
+    is marked slow. A missing neuropythy skips those tests; anything else that
+    goes wrong is a failure, not a skip.
+    """
+    return NeuropythyMap('fsaverage', regions=['v1', 'v2', 'v3'])
+
+
+# -----------------------------------------------------------------------------
+# cortex -> dva
+# -----------------------------------------------------------------------------
 
 def test_cortex_to_dva_shape_and_nans():
     """Every input point must get its own output slot (Issue #774)."""
@@ -130,14 +199,15 @@ def test_cortex_to_dva_shape_and_nans():
         nmap.cortex_to_dva(np.zeros(3), np.zeros(2), np.zeros(3))
 
 
-def test_cortex_to_dva_exact_vertex():
-    """A point sitting exactly on a mesh vertex must not divide by zero."""
+def test_cortex_to_dva_interpolation():
+    """Nearby vertices are averaged; distant ones do not count at all."""
     nmap = ToyNeuropythyMap()
+    # A point sitting exactly on a vertex is at zero distance from it, which
+    # must not divide by zero (Issue #774). It maps to that vertex, not to a
+    # blend with its neighbors and not to NaN:
     verts = nmap.cortex_tree.data * 1000  # mm -> um
     with np.errstate(divide='raise', invalid='raise'):
         xdva, ydva = nmap.cortex_to_dva(verts[:, 0], verts[:, 1], verts[:, 2])
-    # Each vertex maps to its own dva coordinate, not to a blend with its
-    # neighbors and not to NaN:
     npt.assert_almost_equal(xdva, np.arange(len(verts)))
     npt.assert_almost_equal(ydva, -np.arange(len(verts)))
 
@@ -146,359 +216,131 @@ def test_cortex_to_dva_exact_vertex():
     npt.assert_almost_equal(xdva, [2.5])
     npt.assert_almost_equal(ydva, [-2.5])
 
-    # Beyond cort_nn_thresh of every vertex, there is nothing to average:
-    xdva, ydva = nmap.cortex_to_dva(np.array([-2000.]), np.zeros(1), np.zeros(1))
+    # `cort_nn_thresh` is how far a vertex reaches, not a rounding: a point
+    # exactly that far away still maps, one micron further does not:
+    npt.assert_almost_equal(nmap.cort_nn_thresh, 1000)
+    xdva, ydva = nmap.cortex_to_dva(np.array([-1000.]), np.zeros(1),
+                                    np.zeros(1))
+    npt.assert_almost_equal(xdva, [0])
+    npt.assert_almost_equal(ydva, [0])
+    xdva, ydva = nmap.cortex_to_dva(np.array([-1001.]), np.zeros(1),
+                                    np.zeros(1))
     npt.assert_almost_equal(xdva, [np.nan])
     npt.assert_almost_equal(ydva, [np.nan])
 
 
-# use pytest.mark.slow because all neuropythy tests
-# take a long time to run. This way, they will be skipped
-# unless the user passes --runslow to pytest (which must be)
-# done either from the root p2p directory or from this tests
-# folder.
-@pytest.mark.slow
-def test_subject_parsing(neuropythy_available):
-    import neuropythy as ny
-    # random subject shouldn't download 
-    start = time.time()
-    with pytest.raises(ValueError):
-        nmap = NeuropythyMap('invalid_subject')
-    npt.assert_equal(time.time() - start < 10, True)
+def test_cortex_to_dva_region_dispatch():
+    """v1/v2/v3 all read the same cortical mesh; only the name differs."""
+    nmap = ToyNeuropythyMap()
+    coords = (np.array([500.]), np.zeros(1), np.zeros(1))
+    expected = nmap.cortex_to_dva(*coords)
+    for to_dva in (nmap.v1_to_dva, nmap.v2_to_dva, nmap.v3_to_dva):
+        npt.assert_almost_equal(to_dva(*coords), expected)
+    npt.assert_equal(sorted(nmap.to_dva().keys()), ['v1', 'v2', 'v3'])
 
-    # test non fsaverage subject first, to see if it downloads
-    # (since this is non default behaviour for neuropythy)
-    # this test will also pass if the subject has been previously downloaded
-    nmap = NeuropythyMap('S1201')
-    # smoke test
+
+# -----------------------------------------------------------------------------
+# dva -> cortex
+# -----------------------------------------------------------------------------
+
+def test_dva_to_cortex_regions(neuropythy):
+    """A region the map was not built with has nothing to look a point up in."""
+    nmap = ToyNeuropythyMap(regions=['v1'])
+    npt.assert_equal(sorted(nmap.from_dva().keys()), ['v1'])
     nmap.dva_to_v1(1, 1)
-
-    # should have been cached to cache_dir
-    npt.assert_equal(os.path.exists(os.path.join(nmap.cache_dir, 'benson_winawer_2018', 'freesurfer_subjects')), True)
-    npt.assert_equal(os.path.join(nmap.cache_dir, 'benson_winawer_2018', 'freesurfer_subjects') in ny.config['freesurfer_subject_paths'], True)
-    npt.assert_equal(ny.config['benson_winawer_2018_path'], os.path.join(nmap.cache_dir, 'benson_winawer_2018'))
-
-    # now any other subject should be loaded quickly (<40 sec)
-    start = time.time()
-    nmap = NeuropythyMap('fsaverage')
-    npt.assert_equal(time.time() - start < 40, True)
-
-    npt.assert_equal(nmap.predicted_retinotopy is not None, True)
-    npt.assert_equal('v1' in nmap.region_meshes.keys(), True)
-
-
-# these take long so dont do every combo
-@pytest.mark.slow()
-@pytest.mark.parametrize('regions', [['v1'], ['v1', 'v3'], ['v1', 'v2', 'v3']])
-@pytest.mark.parametrize('jitter_boundary', [True, False])
-def test_dva_to_cortex(regions, jitter_boundary, neuropythy_available):
-    nmap = NeuropythyMap('fsaverage', regions=regions, jitter_boundary=jitter_boundary)
-    npt.assert_equal(nmap.predicted_retinotopy is not None, True)
-    npt.assert_equal(nmap.region_meshes is not None, True)
-    if 'v1' in regions:
-        npt.assert_equal(nmap.region_meshes['v1'] is not None, True)
-    if 'v2' in regions:
-        npt.assert_equal(nmap.region_meshes['v2'] is not None, True)
-    if 'v3' in regions:
-        npt.assert_equal(nmap.region_meshes['v3'] is not None, True)
-
-    
-    npt.assert_equal(list(nmap.region_meshes.keys()), regions)
-    if 'v2' not in regions:
+    for dva_to in (nmap.dva_to_v2, nmap.dva_to_v3):
         with pytest.raises(ValueError):
-            nmap.dva_to_v2(0, 0)
+            dva_to(1, 1)
 
-    if 'v3' not in regions:
-        with pytest.raises(ValueError):
-            nmap.dva_to_v3(0, 0)
-    
-    if 'v1' in regions:
-        # smoke test
-        nmap.dva_to_v1(0, 0)
-        for surface in ['white', 'pial']:
-            nmap.dva_to_v1(0, 0, surface=surface)
-        
-        x, y, z = nmap.dva_to_v1([1, 1, 0, 0, -1, -1], [1, -1, 1, -1, 1, -1])
-        npt.assert_equal(x.shape, (6,))
-        npt.assert_equal(y.shape, (6,))
-        npt.assert_equal(z.shape, (6,))
-        if jitter_boundary:
-            npt.assert_almost_equal(x, np.array([-10035.355, -13315.073, -11266.07, -16252.549, 12075.739, 13630.971]), decimal=3)
-            npt.assert_almost_equal(y, np.array([ -96637.12, -102852.29,  -96669.43, -102938.95,  -95358.4,  -101546.41]), decimal=2)
-            npt.assert_almost_equal(z, np.array([-10769.129, -3861.491, -12831.113, -1908.735, -7168.826, 924.938]), decimal=3)
-        else:
-            npt.assert_almost_equal(x, np.array([-10035.355, -13315.073, np.nan, np.nan, 12075.739, 13630.971]), decimal=3)
-            npt.assert_almost_equal(y, np.array([ -96637.12, -102852.29,  np.nan, np.nan,  -95358.4,  -101546.41]), decimal=2)
-            npt.assert_almost_equal(z, np.array([-10769.129, -3861.491, np.nan, np.nan, -7168.826, 924.938]), decimal=3)
+    # Each of the three dispatches to its own region's mesh:
+    nmap = ToyNeuropythyMap()
+    for region, dva_to in [('v1', nmap.dva_to_v1), ('v2', nmap.dva_to_v2),
+                           ('v3', nmap.dva_to_v3)]:
+        dva_to(1, 1)
+        npt.assert_equal([len(m.addressed)
+                          for m in nmap.region_meshes[region]], [1, 0])
 
-    if 'v2' in regions:
-        # smoke test
-        nmap.dva_to_v2(0, 0)
-        for surface in ['white', 'pial']:
-            nmap.dva_to_v2(0, 0, surface=surface)
-        
-        x, y, z = nmap.dva_to_v2([1, 1, 0, 0, -1, -1], [1, -1, 1, -1, 0, -1])
-        npt.assert_equal(x.shape, (6,))
-        npt.assert_equal(y.shape, (6,))
-        npt.assert_equal(z.shape, (6,))
-        if jitter_boundary:
-            npt.assert_almost_equal(x, np.array([-11731.504, -20458.03, np.nan ,-18807.701, 26066.922,  22283.799] ), decimal=3)
-            npt.assert_almost_equal(y, np.array([ -93461.92,  -100803.35, np.nan, -101528.13,   -96025.48,   -99334.945]), decimal=2)
-            npt.assert_almost_equal(z, np.array([-11246.644,   1673.845, np.nan,   -313.502,   4501.598,   7011.859]), decimal=3)
-        else:
-            npt.assert_almost_equal(x, np.array([-11731.504, -20458.03, np.nan ,np.nan, np.nan,  22283.799] ), decimal=3)
-            npt.assert_almost_equal(y, np.array([ -93461.92,  -100803.35, np.nan, np.nan,   np.nan,   -99334.945]), decimal=2)
-            npt.assert_almost_equal(z, np.array([-11246.644,   1673.845, np.nan,   np.nan,   np.nan,   7011.859]), decimal=3)
-
-    
-    if 'v3' in regions:
-        # smoke test
-        nmap.dva_to_v3(0, 0)
-        for surface in ['white', 'pial']:
-            nmap.dva_to_v3(0, 0, surface=surface)
-        
-        x, y, z = nmap.dva_to_v3([1, 1, 0, 0, -1, -1], [1, -1, 1, -1, 0, -1])
-        npt.assert_equal(x.shape, (6,))
-        npt.assert_equal(y.shape, (6,))
-        npt.assert_equal(z.shape, (6,))
-        if jitter_boundary:
-            npt.assert_almost_equal(x, np.array([-23812.113, -23514.828, -29542.21,  -25206.152,  27090.357,  28547.275]), decimal=3)
-            npt.assert_almost_equal(y, np.array([-84409.51, -93015.07, -83442.17, -89647.35, -94726.14, -93238.63]), decimal=2)
-            npt.assert_almost_equal(z, np.array([-15261.302,   4050.124, -16078.909,   3062.166,   4468.217,   8467.487]), decimal=3)
-        else:
-            npt.assert_almost_equal(x, np.array([-23812.113, -23514.828, np.nan,  np.nan,  np.nan,  28547.275]), decimal=3)
-            npt.assert_almost_equal(y, np.array([-84409.51, -93015.07, np.nan, np.nan, np.nan, -93238.63]), decimal=2)
-            npt.assert_almost_equal(z, np.array([-15261.302,   4050.124, np.nan,   np.nan,   np.nan,   8467.487]), decimal=3)
-
-
-@pytest.mark.slow
-def test_Neuralink_from_neuropythy(neuropythy_available):
-    nmap = NeuropythyMap('fsaverage', regions=['v1'], jitter_boundary=False)
-    nlink = Neuralink.from_neuropythy(nmap, locs=np.array([[0, 0], [3, 3], [-2, -2]]))
-    # 0, 0 should be nan so it wont make one
-    npt.assert_almost_equal(len(nlink.implants), 2)
-    npt.assert_almost_equal(nlink.implants['A'].x, nmap.dva_to_v1(3, 3, surface='pial')[0])
-    npt.assert_almost_equal(nlink.implants['A'].y, nmap.dva_to_v1(3, 3, surface='pial')[1])
-    npt.assert_almost_equal(nlink.implants['A'].z, nmap.dva_to_v1(3, 3, surface='pial')[2])
-    npt.assert_almost_equal(nlink.implants['B'].x, nmap.dva_to_v1(-2, -2, surface='pial')[0])
-    npt.assert_almost_equal(nlink.implants['B'].y, nmap.dva_to_v1(-2, -2, surface='pial')[1])
-    npt.assert_almost_equal(nlink.implants['B'].z, nmap.dva_to_v1(-2, -2, surface='pial')[2])
-
-    orient1 = np.array(nmap.dva_to_v1(3, 3, surface='midgray')) - np.array(nmap.dva_to_v1(3, 3, surface='pial'))
-    orient2 = np.array(nmap.dva_to_v1(-2, -2, surface='midgray')) - np.array(nmap.dva_to_v1(-2, -2, surface='pial'))
-    orient1 = orient1 / np.linalg.norm(orient1)
-    orient2 = orient2 / np.linalg.norm(orient2)
-    npt.assert_almost_equal(nlink.implants['A'].direction, orient1, decimal=4)
-    npt.assert_almost_equal(nlink.implants['B'].direction, orient2, decimal=4)
-
-    nmap.jitter_boundary=True
-    nlink = Neuralink.from_neuropythy(nmap, xrange=[-5, 5], yrange=(-3, 3), step=1)
-    npt.assert_equal(len(nlink.implants), 77)
-    # thank god for chatgpt
-    npt.assert_equal(list(nlink.implants.keys()), ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J',
-                                                   'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T',
-                                                   'U', 'V', 'W', 'X', 'Y', 'Z', 'AA', 'AB', 'AC', 'AD',
-                                                   'AE', 'AF', 'AG', 'AH', 'AI', 'AJ', 'AK', 'AL', 'AM',
-                                                   'AN', 'AO', 'AP', 'AQ', 'AR', 'AS', 'AT', 'AU', 'AV',
-                                                   'AW', 'AX', 'AY', 'AZ', 'BA', 'BB', 'BC', 'BD', 'BE',
-                                                   'BF', 'BG', 'BH', 'BI', 'BJ', 'BK', 'BL', 'BM', 'BN',
-                                                   'BO', 'BP', 'BQ', 'BR', 'BS', 'BT', 'BU', 'BV', 'BW',
-                                                   'BX', 'BY'])
-    idx = 0
-    for vy in range(3, -4, -1):
-        for vx in range(-5, 6, 1):
-            # print(idx, vx, vy)
-            implant = nlink.implants[list(nlink.implants.keys())[idx]]
-            cx, cy, cz = nmap.dva_to_v1(vx, vy, surface='pial')
-            npt.assert_almost_equal(implant.x, cx)
-            npt.assert_almost_equal(implant.y, cy)
-            npt.assert_almost_equal(implant.z, cz)
-
-            orient = np.array(nmap.dva_to_v1(vx, vy, surface='midgray')) - np.array(nmap.dva_to_v1(vx, vy, surface='pial'))
-            orient = orient / np.linalg.norm(orient)
-            npt.assert_almost_equal(implant.direction, orient, decimal=3)
-
-            idx += 1
-            
-
-@pytest.mark.slow
-def test_ndim_mixup(neuropythy_available):
-    nmap = NeuropythyMap('fsaverage')
-    model = BeyelerScoreboard(vfmap=nmap)
-    npt.assert_equal(2 in model.ndim, True)
-    npt.assert_equal(3 in model.ndim, False)
+    # The hemisphere is not something `dva_to_cortex` can guess:
     with pytest.raises(ValueError):
-        model.build()
+        nmap.dva_to_cortex(np.ones(1), np.ones(1), region='v1')
+    with pytest.raises(ValueError):
+        nmap.dva_to_cortex(np.ones(1), np.ones(1), region='v1', hemi='both')
 
 
-@pytest.mark.slow
-def test_neuropythy_scoreboard(neuropythy_available):
-    nmap = NeuropythyMap('fsaverage')
-    model = ScoreboardModel(rho=800, step=.25, vfmap=nmap).build()
-    implant = Neuralink.from_neuropythy(nmap, xrange=(-3, 3), yrange=(-3, 3))
-    implant.stim = {e : 1 for e in implant.electrode_names}
-    percept = model.predict_percept(implant)
-    npt.assert_almost_equal(np.sum(percept.data), 5600.183, decimal=3)
-    npt.assert_almost_equal(np.max(percept.data), 27.3698, decimal=3)
+def test_dva_to_cortex_hemispheres_and_shapes(neuropythy):
+    """Points are split at x=0, looked up, and put back where they came from."""
+    nmap = ToyNeuropythyMap()
+    x, y = np.array([-1., 0., 2.]), np.array([1., 1., -1.])
+    xc, yc, zc = nmap.dva_to_v1(x, y)
+    lh, rh = nmap.region_meshes['v1']
+    npt.assert_almost_equal(rh.addressed[-1][0], [-1])
+    npt.assert_almost_equal(lh.addressed[-1][0], [0, 2])
+    # ... and the answers come back in the caller's order, in microns:
+    npt.assert_almost_equal(xc, [-1000, 0, 2000])
+    npt.assert_almost_equal(yc, [-1000, -1000, 1000])
+    npt.assert_almost_equal(zc, [0, 0, 0])
 
-    nmap = NeuropythyMap('fsaverage', regions=['v2'])
-    model = ScoreboardModel(rho=800, step=.25, vfmap=nmap).build()
-    implant = Neuralink.from_neuropythy(nmap, xrange=(-3, 3), yrange=(-3, 3), region='v2')
-    implant.stim = {e : 1 for e in implant.electrode_names}
-    percept = model.predict_percept(implant)
-    npt.assert_almost_equal(np.sum(percept.data), 5344.173, decimal=2)
-    npt.assert_almost_equal(np.max(percept.data), 27.845, decimal=2)
+    # The output has the shape of the input, down to a scalar:
+    for shape in [(), (1,), (6,), (2, 3)]:
+        zeros = np.zeros(shape)
+        npt.assert_equal([c.shape for c in nmap.dva_to_v1(zeros, zeros)],
+                         [shape] * 3)
+    # ... including an empty one, which never reaches the mesh at all:
+    addressed = len(lh.addressed)
+    npt.assert_equal([c.shape
+                      for c in nmap.dva_to_v1(np.array([]), np.array([]))],
+                     [(0,)] * 3)
+    npt.assert_equal(len(lh.addressed), addressed)
 
-    # mega implant
-    nmap = NeuropythyMap('fsaverage', regions=['v1', 'v2', 'v3'])
-    model = ScoreboardModel(rho=800, step=.25, vfmap=nmap).build()
-    i1 = Neuralink.from_neuropythy(nmap, xrange=(-3, 3), yrange=(-3, 3), region='v1')
-    i2 = Neuralink.from_neuropythy(nmap, xrange=(-3, 3), yrange=(-3, 3), region='v2')
-    i3 = Neuralink.from_neuropythy(nmap, xrange=(-3, 3), yrange=(-3, 3), region='v3')
-    implant = EnsembleImplant([i1, i2, i3])
-    implant.stim = {e : 1 for e in implant.electrode_names}
-    percept = model.predict_percept(implant)
-    npt.assert_almost_equal(np.sum(percept.data), 20245.445, decimal=1)
-    npt.assert_almost_equal(np.max(percept.data), 86.4913, decimal=1)
+    for dva_to in (nmap.dva_to_v1, nmap.dva_to_v2, nmap.dva_to_v3):
+        with pytest.raises(ValueError):
+            dva_to(np.zeros(3), np.zeros(2))
 
-
-@pytest.mark.slow()
-@pytest.mark.parametrize('regions', [['v1'], ['v1', 'v3'], ['v1', 'v2', 'v3']])
-def test_cortex_to_dva(regions, neuropythy_available):
-    nmap = NeuropythyMap('fsaverage', regions=regions, jitter_boundary=True)
-    npt.assert_equal(nmap.predicted_retinotopy is not None, True)
-    npt.assert_equal(nmap.region_meshes is not None, True)
-    if 'v1' in regions:
-        npt.assert_equal(nmap.region_meshes['v1'] is not None, True)
-    if 'v2' in regions:
-        npt.assert_equal(nmap.region_meshes['v2'] is not None, True)
-    if 'v3' in regions:
-        npt.assert_equal(nmap.region_meshes['v3'] is not None, True)
-
-    
-    npt.assert_equal(list(nmap.region_meshes.keys()), regions)
-    
-    if 'v1' in regions:
-        # should work with all shapes, and keep them
-        npt.assert_equal(np.isnan(nmap.v1_to_dva(0, 0, 0)[0]), True)
-        npt.assert_equal(nmap.v1_to_dva([100, 200, 300], [100, 200, 300],
-                                        [100, 200, 300])[0].shape, (3,))
-        npt.assert_equal(nmap.v1_to_dva(np.eye(3), np.eye(3), np.eye(3))[0].shape,
-                         (3, 3))
-
-        x = np.array([-10035.355, -13315.073,  12075.739, 13630.971])
-        y = np.array([ -96637.12, -102852.29,   -95358.4,  -101546.41])
-        z = np.array([-10769.129, -3861.491, -7168.826, 924.938])
+    # A point the mesh cannot address keeps its slot and comes back NaN:
+    xc, yc, zc = nmap.dva_to_v1([1., TOY_MAX_ECC + 1], [0., 0.])
+    npt.assert_almost_equal(xc, [1000, np.nan])
+    npt.assert_almost_equal(yc, [0, np.nan])
+    npt.assert_almost_equal(zc, [0, np.nan])
 
 
-        xdva, ydva = nmap.v1_to_dva(x, y, z)
-        npt.assert_equal(x.shape, (4,))
-        npt.assert_equal(y.shape, (4,))
-        npt.assert_almost_equal(xdva, np.array([1, 1, -1, -1]), decimal=1)
-        npt.assert_almost_equal(ydva, np.array([1, -1,  1, -1]), decimal=1)
-
-        # A NaN point keeps its own slot rather than dropping out and
-        # shifting the points after it up (Issue #774):
-        xnan, ynan, znan = x.copy(), y.copy(), z.copy()
-        xnan[1], ynan[1], znan[1] = np.nan, np.nan, np.nan
-        xdva, ydva = nmap.v1_to_dva(xnan, ynan, znan)
-        npt.assert_equal(xdva.shape, (4,))
-        npt.assert_almost_equal(xdva, np.array([1, np.nan, -1, -1]), decimal=1)
-        npt.assert_almost_equal(ydva, np.array([1, np.nan, 1, -1]), decimal=1)
-        # ... and the same points laid out as a 2D grid come back as one:
-        xdva, ydva = nmap.v1_to_dva(*[np.stack([c, c]) for c in (x, y, z)])
-        npt.assert_equal(xdva.shape, (2, 4))
-        npt.assert_almost_equal(xdva, np.stack([[1, 1, -1, -1]] * 2), decimal=1)
-        npt.assert_almost_equal(ydva, np.stack([[1, -1, 1, -1]] * 2), decimal=1)
-
-        # Points that land exactly on a mesh vertex have zero distance to it,
-        # which used to divide by zero (Issue #774). They map to that vertex:
-        verts = nmap.cortex_tree.data * 1000  # mm -> um
-        xdva, ydva = nmap.v1_to_dva(verts[:, 0], verts[:, 1], verts[:, 2])
-        npt.assert_equal(np.any(np.isnan(xdva)), False)
-        npt.assert_equal(np.any(np.isnan(ydva)), False)
-
-        x = np.arange(-10, -1, .1)
-        y = np.arange(-10, -1, .1)
-        x1, y2 = nmap.v1_to_dva(*nmap.dva_to_v1(x, y))
-        npt.assert_allclose(x, x1, rtol=.05, atol=0.1)
-        npt.assert_allclose(y, y2, rtol=.05, atol=0.1)
+@pytest.mark.parametrize('surface', ['white', 'midgray', 'pial'])
+def test_dva_to_cortex_surface(surface, neuropythy):
+    """`surface` picks which surface of the subject the point lands on."""
+    nmap = ToyNeuropythyMap()
+    npt.assert_almost_equal(nmap.dva_to_v1(2., 2., surface=surface),
+                            toy_cortex_mm(2., 2., surface) * 1000, decimal=3)
+    npt.assert_equal(nmap.subject.hemis['lh'].surfaces_asked, [surface])
+    npt.assert_equal(nmap.subject.hemis['rh'].surfaces_asked, [])
+    # The address itself is what a caller asking for no surface wants:
+    addr = nmap.dva_to_cortex(np.ones(1), np.ones(1), hemi='lh', surface=None)
+    npt.assert_equal(sorted(addr.keys()), ['coordinates', 'faces'])
 
 
-        # test cort_nn_thresh
-        idx = np.argmax(nmap.subject.hemis['rh'].surface('midgray').coordinates[0])
-        x = np.array([nmap.subject.hemis['rh'].surface('midgray').coordinates[0][idx]])
-        y = np.array([nmap.subject.hemis['rh'].surface('midgray').coordinates[1][idx]])
-        z = np.array([nmap.subject.hemis['rh'].surface('midgray').coordinates[2][idx]])
-        xdva, ydva = nmap.v1_to_dva(x, y, z)
-        npt.assert_equal(xdva != np.array([np.nan]), True)
-        npt.assert_equal(ydva != np.array([np.nan]), True)
-        x1 = x + 999
-        xdva, ydva = nmap.v1_to_dva(x1, y, z)
-        npt.assert_equal(xdva != np.array([np.nan]), True)
-        npt.assert_equal(ydva != np.array([np.nan]), True)
-        x1 = x +1001
-        xdva, ydva = nmap.v1_to_dva(x1, y, z)
-        npt.assert_equal(xdva, np.array([np.nan]))
-        npt.assert_equal(ydva, np.array([np.nan]))
+@pytest.mark.parametrize('region', ['v1', 'v2', 'v3'])
+def test_dva_to_cortex_jitter_boundary(region, neuropythy):
+    """Jittering moves points off the meridians, which have no cortex of their own
+
+    V1 spans the horizontal meridian, so only the vertical one is a
+    discontinuity there; V2 and V3 are bounded by both.
+    """
+    x, y = [0., 1.], [0., 1.]
+    nmap = ToyNeuropythyMap(jitter_boundary=False)
+    nmap.from_dva()[region](x, y)
+    addressed_x, addressed_y = nmap.region_meshes[region][0].addressed[-1]
+    npt.assert_almost_equal(addressed_x, [0, 1])
+    npt.assert_almost_equal(addressed_y, [0, 1])
+
+    nmap = ToyNeuropythyMap(jitter_boundary=True)
+    nmap.from_dva()[region](x, y)
+    addressed_x, addressed_y = nmap.region_meshes[region][0].addressed[-1]
+    npt.assert_almost_equal(addressed_x, [nmap.jitter_thresh, 1], decimal=6)
+    expected_y = [0, 1] if region == 'v1' else [nmap.jitter_thresh, 1]
+    npt.assert_almost_equal(addressed_y, expected_y, decimal=6)
 
 
-
-
-    if 'v2' in regions:
-        npt.assert_equal(np.isnan(nmap.v2_to_dva(0, 0, 0)[0]), True)
-        npt.assert_equal(nmap.v2_to_dva([100, 200, 300], [100, 200, 300],
-                                        [100, 200, 300])[0].shape, (3,))
-        npt.assert_equal(nmap.v2_to_dva(np.eye(3), np.eye(3), np.eye(3))[0].shape,
-                         (3, 3))
-
-
-        x = np.array([-11731.504, -20458.03,  22283.799] )
-        y = np.array([ -93461.92,  -100803.35, -99334.945])
-        z = np.array([-11246.644,   1673.845,    7011.859])
-        
-        xdva, ydva = nmap.v2_to_dva(x, y, z)
-        npt.assert_equal(xdva.shape, (3,))
-        npt.assert_equal(ydva.shape, (3,))
-        npt.assert_allclose(xdva, np.array([1, 1, -1]), rtol=.05, atol=0.1)
-        npt.assert_allclose(ydva, np.array([1, -1, -1]), rtol=.05, atol=0.1)
-
-        x = np.arange(-10, -1, .1)
-        y = np.arange(-10, -1, .1)
-        x1, y2 = nmap.v2_to_dva(*nmap.dva_to_v2(x, y))
-        npt.assert_allclose(x, x1, rtol=.05, atol=0.1)
-        npt.assert_allclose(y, y2, rtol=.05, atol=0.1)
-
-    
-    if 'v3' in regions:
-        npt.assert_equal(np.isnan(nmap.v3_to_dva(0, 0, 0)[0]), True)
-        npt.assert_equal(nmap.v3_to_dva([100, 200, 300], [100, 200, 300],
-                                        [100, 200, 300])[0].shape, (3,))
-        npt.assert_equal(nmap.v3_to_dva(np.eye(3), np.eye(3), np.eye(3))[0].shape,
-                         (3, 3))
-
-
-        x = np.array([-23812.113, -23514.828,  28547.275])
-        y = np.array([-84409.51, -93015.07,  -93238.63])
-        z = np.array([-15261.302,   4050.124,    8467.487])
-
-        xdva, ydva = nmap.v3_to_dva(x, y, z)
-        
-        npt.assert_equal(xdva.shape, (3,))
-        npt.assert_equal(ydva.shape, (3,))
-        npt.assert_allclose(xdva, np.array([1, 1, -1]), rtol=.05, atol=0.1)
-        npt.assert_allclose(ydva, np.array([1, -1, -1]), rtol=.05, atol=0.1)
-
-        x = np.arange(-10, -1, .1)
-        y = np.arange(-10, -1, .1)
-        x1, y2 = nmap.v3_to_dva(*nmap.dva_to_v3(x, y))
-        npt.assert_allclose(x, x1, rtol=.05, atol=0.1)
-        npt.assert_allclose(y, y2, rtol=.05, atol=0.1)
-
-
-def test_NeuropythyMap_units():
+def test_NeuropythyMap_units(neuropythy):
     """The FreeSurfer map converts between the same two sides as any other"""
-    vfmap = load_fsaverage_or_skip()
+    vfmap = ToyNeuropythyMap()
     npt.assert_equal(vfmap.visual_unit, dva)
     npt.assert_equal(vfmap.tissue_unit, um)
     x, y = np.array([1.0, 3.0]), np.array([1.0, -2.0])
@@ -508,7 +350,7 @@ def test_NeuropythyMap_units():
     npt.assert_allclose(vfmap.dva_to_v1(x * dva, y * dva, surface='pial'),
                         vfmap.dva_to_v1(x, y, surface='pial'), rtol=1e-12)
     # Back again, with the three coordinates spelled differently:
-    xc, yc, zc = bare
+    xc, yc, zc = np.array([1000.0, 2500.0]), np.zeros(2), np.zeros(2)
     npt.assert_allclose(
         vfmap.v1_to_dva((xc / 1000) * mm, yc * um, (zc / 1000) * mm),
         vfmap.v1_to_dva(xc, yc, zc), rtol=1e-6)
@@ -516,3 +358,264 @@ def test_NeuropythyMap_units():
         vfmap.dva_to_v1(x * um, y)
     with pytest.raises(DimensionMismatchError):
         vfmap.v1_to_dva(xc * dva, yc, zc)
+
+
+def test_ndim_mixup():
+    """A 3D cortical map cannot drive a model that only knows 2D grids."""
+    model = BeyelerScoreboard(vfmap=ToyNeuropythyMap())
+    npt.assert_equal(2 in model.ndim, True)
+    npt.assert_equal(3 in model.ndim, False)
+    with pytest.raises(ValueError):
+        model.build()
+
+
+# -----------------------------------------------------------------------------
+# parse_subject
+# -----------------------------------------------------------------------------
+
+def fake_config():
+    """A stand-in for ``ny.config``, as unconfigured as a fresh install"""
+    return {'benson_winawer_2018_path': None, 'freesurfer_subject_paths': []}
+
+
+class DownloadOnAccess:
+    """A stand-in for ``ny.data['benson_winawer_2018'].subjects``
+
+    Looking a subject up here is what downloads it, and is the only reason p2p
+    reaches for the dataset at all.
+    """
+
+    def __init__(self, downloaded):
+        self.downloaded = downloaded
+
+    def __getitem__(self, name):
+        self.downloaded.append(name)
+        return name
+
+
+def test_parse_subject_passes_through_loaded_subject(neuropythy, tmp_path,
+                                                     monkeypatch):
+    """A subject the caller loaded themselves is used as it is."""
+    class LoadedSubject:
+        pass
+
+    def no_lookup(subject):
+        raise AssertionError("should not have gone looking for a subject")
+
+    monkeypatch.setattr(neuropythy.mri.core, 'Subject', LoadedSubject)
+    monkeypatch.setattr(neuropythy, 'config', fake_config())
+    monkeypatch.setattr(neuropythy, 'freesurfer_subject', no_lookup)
+    nmap = ToyNeuropythyMap(cache_dir=str(tmp_path))
+    subject = LoadedSubject()
+    npt.assert_equal(nmap.parse_subject(subject) is subject, True)
+
+
+def test_parse_subject_configures_cache(neuropythy, tmp_path, monkeypatch):
+    """The cache is created and pointed at before any subject is looked up."""
+    config = fake_config()
+    monkeypatch.setattr(neuropythy, 'config', config)
+    monkeypatch.setattr(neuropythy, 'freesurfer_subject',
+                        lambda subject: f'loaded {subject}')
+    cache_dir = tmp_path / 'cache'
+    nmap = ToyNeuropythyMap(cache_dir=str(cache_dir))
+    npt.assert_equal(nmap.parse_subject('fsaverage'), 'loaded fsaverage')
+
+    dataset = cache_dir / 'benson_winawer_2018'
+    npt.assert_equal(dataset.is_dir(), True)
+    npt.assert_equal(config['benson_winawer_2018_path'], str(dataset))
+    npt.assert_equal(config['freesurfer_subject_paths'],
+                     [str(dataset / 'freesurfer_subjects')])
+    # A second subject must not point neuropythy anywhere else, nor add the
+    # same search path twice:
+    nmap.parse_subject('S1201')
+    npt.assert_equal(config['benson_winawer_2018_path'], str(dataset))
+    npt.assert_equal(len(config['freesurfer_subject_paths']), 1)
+
+
+@pytest.mark.parametrize('subject', ['S1201', 's1201'])
+def test_parse_subject_downloads_benson_winawer(subject, neuropythy, tmp_path,
+                                                monkeypatch):
+    """Neuropythy only downloads the dataset for 'fsaverage' on its own
+
+    Every other Benson & Winawer subject comes back as a ValueError until the
+    dataset is on disk, so p2p asks for it and tries again.
+    """
+    downloaded = []
+    attempts = []
+
+    def freesurfer_subject(name):
+        attempts.append(name)
+        if not downloaded:
+            raise ValueError(f"no such subject: {name}")
+        return f'loaded {name}'
+
+    dataset = SimpleNamespace(subjects=DownloadOnAccess(downloaded))
+    monkeypatch.setattr(neuropythy, 'config', fake_config())
+    monkeypatch.setattr(neuropythy, 'freesurfer_subject', freesurfer_subject)
+    monkeypatch.setattr(neuropythy, 'data', {'benson_winawer_2018': dataset})
+
+    nmap = ToyNeuropythyMap(cache_dir=str(tmp_path))
+    npt.assert_equal(nmap.parse_subject(subject), f'loaded {subject}')
+    npt.assert_equal(downloaded, [subject])
+    npt.assert_equal(attempts, [subject, subject])
+
+
+def test_parse_subject_reraises_unknown_subject(neuropythy, tmp_path,
+                                                monkeypatch):
+    """A subject that is not ours to download stays neuropythy's error."""
+    def freesurfer_subject(name):
+        raise ValueError(f"no such subject: {name}")
+
+    monkeypatch.setattr(neuropythy, 'config', fake_config())
+    monkeypatch.setattr(neuropythy, 'freesurfer_subject', freesurfer_subject)
+    nmap = ToyNeuropythyMap(cache_dir=str(tmp_path))
+    with pytest.raises(ValueError):
+        nmap.parse_subject('invalid_subject')
+
+
+# -----------------------------------------------------------------------------
+# Neuralink.from_neuropythy
+# -----------------------------------------------------------------------------
+
+def test_Neuralink_from_neuropythy(neuropythy):
+    """One thread per visual field location, sitting on the pial surface
+
+    ``from_neuropythy`` is tested on its own -- grids, thread names, regions,
+    insertion angles -- against a stub map in
+    ``implants/cortex/tests/test_neuralink.py``. What is left to check here is
+    that what a real ``NeuropythyMap`` lookup returns, hemisphere split and
+    NaNs and all, is what that factory expects.
+    """
+    nmap = ToyNeuropythyMap()
+    locs = np.array([[0, 0], [3, 3], [-2, -2], [TOY_MAX_ECC, TOY_MAX_ECC]])
+    nlink = Neuralink.from_neuropythy(nmap, locs=locs)
+    # The last location is off the mesh, so there is nowhere to put a thread:
+    npt.assert_equal(list(nlink.implants.keys()), ['A', 'B', 'C'])
+    for name, (x, y) in zip(['A', 'B', 'C'], locs[:3]):
+        implant = nlink.implants[name]
+        pial = np.array(nmap.dva_to_v1(x, y, surface='pial'))
+        npt.assert_almost_equal([implant.x, implant.y, implant.z], pial,
+                                decimal=3)
+        # A thread points from where it enters the cortex to where it ends up:
+        orient = np.array(nmap.dva_to_v1(x, y, surface='midgray')) - pial
+        npt.assert_almost_equal(implant.direction,
+                                orient / np.linalg.norm(orient), decimal=4)
+
+
+# -----------------------------------------------------------------------------
+# The real thing: Neuropythy and the Benson & Winawer (2018) data
+# -----------------------------------------------------------------------------
+
+#: Visual field points (dva) looked up on the real 'fsaverage' subject. The
+#: two on the vertical meridian have no cortex of their own; for V2 and V3 the
+#: horizontal meridian is a boundary too.
+FSAVERAGE_POINTS = {
+    'v1': ([1, 1, 0, 0, -1, -1], [1, -1, 1, -1, 1, -1]),
+    'v2': ([1, 1, 0, 0, -1, -1], [1, -1, 1, -1, 0, -1]),
+    'v3': ([1, 1, 0, 0, -1, -1], [1, -1, 1, -1, 0, -1]),
+}
+
+#: Where `FSAVERAGE_POINTS` land on the cortex (um), by region and by
+#: `jitter_boundary`. These numbers are a regression baseline: they say the
+#: mapping has not moved, not that it is anatomically right.
+FSAVERAGE_CORTEX = {
+    ('v1', False): ([-10035.355, -13315.073, np.nan, np.nan, 12075.739,
+                     13630.971],
+                    [-96637.12, -102852.29, np.nan, np.nan, -95358.4,
+                     -101546.41],
+                    [-10769.129, -3861.491, np.nan, np.nan, -7168.826,
+                     924.938]),
+    ('v1', True): ([-10035.355, -13315.073, -11266.07, -16252.549, 12075.739,
+                    13630.971],
+                   [-96637.12, -102852.29, -96669.43, -102938.95, -95358.4,
+                    -101546.41],
+                   [-10769.129, -3861.491, -12831.113, -1908.735, -7168.826,
+                    924.938]),
+    ('v2', False): ([-11731.504, -20458.03, np.nan, np.nan, np.nan,
+                     22283.799],
+                    [-93461.92, -100803.35, np.nan, np.nan, np.nan,
+                     -99334.945],
+                    [-11246.644, 1673.845, np.nan, np.nan, np.nan, 7011.859]),
+    ('v2', True): ([-11731.504, -20458.03, np.nan, -18807.701, 26066.922,
+                    22283.799],
+                   [-93461.92, -100803.35, np.nan, -101528.13, -96025.48,
+                    -99334.945],
+                   [-11246.644, 1673.845, np.nan, -313.502, 4501.598,
+                    7011.859]),
+    ('v3', False): ([-23812.113, -23514.828, np.nan, np.nan, np.nan,
+                     28547.275],
+                    [-84409.51, -93015.07, np.nan, np.nan, np.nan, -93238.63],
+                    [-15261.302, 4050.124, np.nan, np.nan, np.nan, 8467.487]),
+    ('v3', True): ([-23812.113, -23514.828, -29542.21, -25206.152, 27090.357,
+                    28547.275],
+                   [-84409.51, -93015.07, -83442.17, -89647.35, -94726.14,
+                    -93238.63],
+                   [-15261.302, 4050.124, -16078.909, 3062.166, 4468.217,
+                    8467.487]),
+}
+
+
+@pytest.mark.slow
+def test_fsaverage_meshes(fsaverage):
+    """The subject arrives with a predicted retinotopy and a mesh per region."""
+    npt.assert_equal(fsaverage.predicted_retinotopy is not None, True)
+    npt.assert_equal(list(fsaverage.region_meshes.keys()), ['v1', 'v2', 'v3'])
+    for meshes in fsaverage.region_meshes.values():
+        # One mesh per hemisphere, each with vertices in it:
+        npt.assert_equal(len(meshes), 2)
+        for mesh in meshes:
+            npt.assert_equal(mesh.coordinates.shape[0], 2)
+            npt.assert_equal(mesh.coordinates.shape[1] > 0, True)
+    npt.assert_equal(fsaverage.cortex_tree.n > 0, True)
+
+
+@pytest.mark.slow
+@pytest.mark.parametrize('jitter_boundary', [False, True])
+@pytest.mark.parametrize('region', ['v1', 'v2', 'v3'])
+def test_fsaverage_dva_to_cortex(region, jitter_boundary, fsaverage,
+                                 monkeypatch):
+    """Known visual field points still land where they used to on fsaverage."""
+    monkeypatch.setattr(fsaverage, 'jitter_boundary', jitter_boundary)
+    x, y = FSAVERAGE_POINTS[region]
+    expected = FSAVERAGE_CORTEX[(region, jitter_boundary)]
+    coords = fsaverage.from_dva()[region](x, y)
+    npt.assert_equal([c.shape for c in coords], [(6,)] * 3)
+    npt.assert_almost_equal(coords[0], expected[0], decimal=3)
+    npt.assert_almost_equal(coords[1], expected[1], decimal=2)
+    npt.assert_almost_equal(coords[2], expected[2], decimal=3)
+
+
+@pytest.mark.slow
+@pytest.mark.parametrize('region', ['v1', 'v2', 'v3'])
+def test_fsaverage_cortex_to_dva(region, fsaverage):
+    """The inverse lands back on the visual field point it started from."""
+    to_dva = fsaverage.to_dva()[region]
+    # The forward regression, run backwards:
+    xc, yc, zc = (np.array(c) for c in FSAVERAGE_CORTEX[(region, False)])
+    keep = ~np.isnan(xc)
+    xdva, ydva = to_dva(xc[keep], yc[keep], zc[keep])
+    npt.assert_allclose(xdva, np.array(FSAVERAGE_POINTS[region][0])[keep],
+                        rtol=.05, atol=0.1)
+    npt.assert_allclose(ydva, np.array(FSAVERAGE_POINTS[region][1])[keep],
+                        rtol=.05, atol=0.1)
+
+    # ... and a whole diagonal of the lower left quadrant, which is far enough
+    # from every boundary that the round trip has to close:
+    x = y = np.arange(-10, -1, .1)
+    xdva, ydva = to_dva(*fsaverage.from_dva()[region](x, y))
+    npt.assert_allclose(xdva, x, rtol=.05, atol=0.1)
+    npt.assert_allclose(ydva, y, rtol=.05, atol=0.1)
+
+
+@pytest.mark.slow
+def test_fsaverage_scoreboard(fsaverage):
+    """A real map still drives a real implant through a real model."""
+    model = ScoreboardModel(rho=800, step=.25, vfmap=fsaverage).build()
+    implants = [Neuralink.from_neuropythy(fsaverage, xrange=(-3, 3),
+                                          yrange=(-3, 3), region=region)
+                for region in ['v1', 'v2', 'v3']]
+    implant = EnsembleImplant(implants)
+    implant.stim = {e: 1 for e in implant.electrode_names}
+    percept = model.predict_percept(implant)
+    npt.assert_almost_equal(np.sum(percept.data), 20245.445, decimal=1)
+    npt.assert_almost_equal(np.max(percept.data), 86.4913, decimal=1)


### PR DESCRIPTION
The Neuropythy tests repeatedly download the data and use full-size maps where smaller deterministic tests would be more useful. This PR refactors that, keeping the real pipeline but not needlessly repeating it. The rest runs on faster tests now