### PR TITLE
[ENH] Improve multi-electrode stimulus plotting

### DIFF
--- a/doc/topics/stimuli.rst
+++ b/doc/topics/stimuli.rst
@@ -146,13 +146,6 @@ Every Stimulus exposes the same basic pieces:
 ``stim.time``
     The time axis, or ``None`` for a stimulus without a time component.
 
-For a time-varying stimulus, the easiest way to see what is being delivered is
-often:
-
-.. code-block:: python
-
-    stim.plot()
-
 Stimuli can also be indexed by electrode name and time:
 
 .. code-block:: python
@@ -167,6 +160,33 @@ you want ordinary NumPy indexing by row and column.
 The time axis does not need to be uniformly sampled. Pulse classes store the
 important transition points rather than a dense sample at every simulation
 step, which keeps long pulse trains compact.
+
+Looking at a stimulus
+---------------------
+
+:py:meth:`~pulse2percept.stimuli.Stimulus.plot` draws either an overview of
+the whole stimulus or the waveforms of the electrodes you name:
+
+.. code-block:: python
+
+    stim.plot()                          # compact overview
+    stim.plot(time=(0, 50 * ms))         # the same overview, zoomed in time
+    stim.plot(electrodes=['A1', 'A2'])   # inspect individual waveforms
+
+The overview is an electrode-by-time heatmap: one row per electrode, color for
+current, zero in the middle of a diverging colormap so that cathodic and
+anodic phases are told apart. An encoded Argus II stimulus drives 60
+electrodes, and 60 stacked waveforms show nothing useful; the heatmap shows
+which electrodes fire, how strongly, and in what order. Because it plots
+against the real time axis rather than against column number, the
+sub-millisecond phases of a pulse stay sub-millisecond next to the long gaps
+between pulses.
+
+Naming electrodes means "show me these signals in detail", so it draws
+waveforms instead, one subplot per electrode. So does a single-electrode
+stimulus such as a pulse or a pulse train.
+
+Pass ``kind='traces'`` or ``kind='heatmap'`` to overrule that choice.
 
 Images and videos are different
 -------------------------------

--- a/doc/users/release_notes.rst
+++ b/doc/users/release_notes.rst
@@ -76,6 +76,11 @@ API changes:
   previously had its gray levels silently treated as microamps. The same check
   guards the ``safe_mode`` and ``max_current`` safety checks.
 
+* :py:meth:`~pulse2percept.stimuli.Stimulus.plot` draws a whole
+  multi-electrode stimulus as an electrode-by-time heatmap rather than as one
+  subplot per electrode. Name ``electrodes`` for waveforms, or pass
+  ``kind='traces'`` / ``kind='heatmap'`` to choose outright.
+
 * Minimum dependency versions were raised for NumPy 2 compatibility. NumPy 1.x
   users should remain on v0.9.1.
 

--- a/examples/stimuli/plot_pulses.py
+++ b/examples/stimuli/plot_pulses.py
@@ -108,11 +108,15 @@ stim = Stimulus({
     'A1': MonophasicPulse(-20, 1, stim_dur=75),
     'C7': AsymmetricBiphasicPulse(-20, 2, 1, 10, delay_dur=25, stim_dur=100)
 })
-stim.plot()
+stim.plot(electrodes=['A1', 'C7'])
 
 ##############################################################################
 # Note how the different stimuli will be padded as necessary to bring all of
 # them to a common stimulus duration.
+#
+# Naming the electrodes asks for their waveforms. Leaving ``electrodes`` out
+# asks for an overview of the whole stimulus instead, which is what the next
+# section is about.
 #
 # Alternatively, you can also pass the stimuli as a list, in which case you
 # might want to specify the electrode names in a list as well:
@@ -121,4 +125,34 @@ stim = Stimulus([MonophasicPulse(-20, 1, stim_dur=100),
                  AsymmetricBiphasicPulse(-20, 2, 1, 10, delay_dur=25,
                                          stim_dur=100)],
                 electrodes=['A1', 'C7'])
-stim.plot()
+stim.plot(kind='traces')
+
+##############################################################################
+# Inspecting a whole implant
+# --------------------------
+#
+# Stacked waveforms stop being readable at more than a handful of electrodes,
+# so :py:meth:`~pulse2percept.stimuli.Stimulus.plot` draws a whole
+# multi-electrode stimulus as an electrode-by-time heatmap. Here are all 60
+# electrodes of an :py:class:`~pulse2percept.implants.ArgusII`, driven by an
+# amplitude-encoded eye chart:
+
+from pulse2percept.implants import ArgusII
+from pulse2percept.stimuli import AmplitudeEncoder, SnellenChart
+
+implant = ArgusII()
+encoder = AmplitudeEncoder(amp_range=(0, 50), freq=20)
+implant.stim = encoder.encode(SnellenChart().invert(), implant=implant)
+
+implant.stim.plot(time=(0, 100))
+
+##############################################################################
+# Color is current, centered on zero, so the cathodic and anodic phase of each
+# pulse are told apart. The time axis is the real one: the sub-millisecond
+# phases of a pulse are not stretched to the width of the 50 ms gaps between
+# them.
+#
+# Zoom in time with ``time=``, and drill down into individual waveforms by
+# naming electrodes:
+
+implant.stim.plot(electrodes=['A1', 'C7', 'F10'])

--- a/pulse2percept/stimuli/base.py
+++ b/pulse2percept/stimuli/base.py
@@ -1081,8 +1081,7 @@ class Stimulus(PrettyPrint):
                for a whole implant's worth of electrodes.
 
             If None, a whole stimulus of more than one electrode is drawn as a
-            heatmap and everything else as traces: naming electrodes means
-            "show me these signals in detail".
+            heatmap and everything else as traces.
 
         Returns
         -------
@@ -1095,8 +1094,12 @@ class Stimulus(PrettyPrint):
             # Cannot plot stimulus with single time point:
             raise NotImplementedError
         if kind is None:
-            overview = electrodes is None and len(self.electrodes) > 1
-            kind = 'heatmap' if overview else 'traces'
+            if isinstance(ax, (list, np.ndarray)):
+                kind = 'traces'
+            elif electrodes is None and len(self.electrodes) > 1:
+                kind = 'heatmap'
+            else:
+                kind = 'traces'
         elif kind not in ('traces', 'heatmap'):
             raise ValueError(f"Unknown kind '{kind}'. Choose from 'traces' or "
                              f"'heatmap'.")
@@ -1116,8 +1119,7 @@ class Stimulus(PrettyPrint):
         # The user can ask for a range, slice, or list of time points, which
         # are either interpolated or loaded directly.
         if time is None:
-            # Ask for a slice instead of `self.time` to avoid interpolation,
-            # which can be time-consuming for an uncompressed stimulus:
+            # Ask for a slice instead of `self.time` to avoid interpolation:
             time = slice(None)
         # A range, a list of time points, or the endpoints and step of a slice
         # may all be given as quantities:
@@ -1133,10 +1135,6 @@ class Stimulus(PrettyPrint):
             t_idx = time
             t_vals = time
         elif isinstance(time, slice):
-            # A stepped slice is a time range, and `__getitem__` will
-            # interpolate onto it. Resolve it to those time points here as
-            # well, or the curve would be drawn against the time points that
-            # happen to sit at those column *indices* instead:
             t_vals = self._slice_times(time)
             if t_vals is None:
                 # Every stored sample, taken by position:
@@ -1163,6 +1161,7 @@ class Stimulus(PrettyPrint):
 
     def _plot_traces(self, electrodes, t_idx, t_vals, fmt, ax):
         """Draw one waveform per electrode, each in its own Axes"""
+        owns_figure = ax is None
         axes = ax
         if axes is None:
             if len(electrodes) == 1:
@@ -1202,9 +1201,8 @@ class Stimulus(PrettyPrint):
         # Only the bottom subplot carries the shared time axis:
         axes[-1].set_xticks(np.linspace(t_vals[0], t_vals[-1], num=5))
         axes[-1].set_xlabel(f'Time ({self.time_unit})')
-        # Every Axes spends its y label on an electrode name, so the unit has
-        # to go where the whole stack can share it:
-        axes[-1].figure.supylabel(self._value_label())
+        if owns_figure:
+            axes[-1].figure.supylabel(self._value_label())
         if len(axes) == 1:
             return axes[0]
         return axes
@@ -1215,6 +1213,7 @@ class Stimulus(PrettyPrint):
             raise TypeError(f"A heatmap is drawn in a single Axes, but 'ax' "
                             f"is a sequence of {len(ax)}.")
         electrodes = list(electrodes)
+        owns_figure = ax is None
         if ax is None:
             # Give every electrode a readable row of its own:
             height = float(np.clip(0.18 * len(electrodes), 2.5, 12))
@@ -1238,7 +1237,8 @@ class Stimulus(PrettyPrint):
         ax.invert_yaxis()
         ax.set_xlabel(f'Time ({self.time_unit})')
         ax.set_ylabel('Electrode')
-        ax.figure.colorbar(mesh, ax=ax, label=self._value_label())
+        if owns_figure:
+            ax.figure.colorbar(mesh, ax=ax, label=self._value_label())
         return ax
 
     def __getitem__(self, item):
@@ -1265,12 +1265,8 @@ class Stimulus(PrettyPrint):
                 sliced = self._slice_times(time)
                 if sliced is not None:
                     time = sliced
-                # Otherwise the slice stays what it is, and NumPy takes the
-                # columns it names below.
             elif time is not Ellipsis:
-                # A requested time point (or a list of them) may be unitful;
-                # after this it is an ordinary number, which is what the
-                # indexing and interpolation below have always worked on:
+                # A requested time point (or a list of them) may be unitful
                 time = self._as_time(time)
                 # Convert to float so time is not mistaken for column index
                 if np.array(time).dtype != bool:
@@ -1281,8 +1277,6 @@ class Stimulus(PrettyPrint):
 
         # STEP 2: ELECTRODES COULD BE SPECIFIED AS INT OR STR
         if isinstance(electrodes, (list, np.ndarray)) or np.isscalar(electrodes):
-            # Electrodes cannot be interpolated, so convert from slice,
-            # ellipsis or indices into a list:
             parsed_electrodes = []
             for e in np.array([electrodes]).ravel():
                 if isinstance(e, str):
@@ -1312,15 +1306,12 @@ class Stimulus(PrettyPrint):
         try:
             return self._stim['data'][item]
         except IndexError as e:
-            # IndexErrors must still be thrown except when `item` is a tuple,
-            # in which case we might want to interpolate time:
             if not isinstance(item, tuple):
                 raise IndexError(e)
 
         # STEP 3: INTERPOLATE TIME
         # From here on out, we know that ``item`` is a tuple, otherwise we
         # would have raised an IndexError above.
-        # First of all, if time=None, we won't interp:
         if self.time is None:
             raise ValueError("Cannot interpolate time if time=None.")
         time = np.array([time]).flatten()

--- a/pulse2percept/stimuli/base.py
+++ b/pulse2percept/stimuli/base.py
@@ -221,6 +221,15 @@ def _describe_unit(unit):
     return f'{unit.dimension.name} ({unit})'
 
 
+def _cell_edges(t):
+    """Turn sample times into the cell edges a heatmap colors between"""
+    t = np.asarray(t, dtype=float)
+    if t.size == 1:
+        # No neighbor to split an interval with; one sample is one time step:
+        return np.array([t[0] - DT / 2, t[0] + DT / 2])
+    return np.concatenate(([t[0]], 0.5 * (t[:-1] + t[1:]), [t[-1]]))
+
+
 def _stimulus_sources(source):
     """The Stimulus objects a source is built from, if any
 
@@ -1036,10 +1045,15 @@ class Stimulus(PrettyPrint):
                       'time': time}
         return stim
 
-    def plot(self, electrodes=None, time=None, fmt='k-', ax=None):
+    def plot(self, electrodes=None, time=None, fmt='k-', ax=None, kind=None):
         """Plot the stimulus
 
         .. versionadded:: 0.7
+
+        .. versionchanged:: 0.10.0
+            Added ``kind``: a whole multi-electrode stimulus is now drawn as
+            an electrode-by-time heatmap rather than as one subplot per
+            electrode.
 
         Parameters
         ----------
@@ -1052,25 +1066,53 @@ class Stimulus(PrettyPrint):
             points to interpolate.
             If None, all time points are plotted.
         fmt : str, optional, default: 'k-'
-            A Matplotlib format string; e.g., 'ro' for red circles.
+            A Matplotlib format string; e.g., 'ro' for red circles to use
+            when ``kind='traces'``.
         ax : matplotlib.axes.Axes or list thereof; optional, default: None
-            A Matplotlib Axes object or a list thereof (one per electrode to
-            plot). If None, a new Axes object will be created.
+            A Matplotlib Axes object. ``kind='traces'`` also accepts a list
+            thereof (one per electrode to plot); ``kind='heatmap'`` draws into
+            a single Axes. If None, a new Axes object will be created.
+        kind : {'traces', 'heatmap'}, optional, default: None
+            What to draw:
+
+            *  'traces': the waveform of each electrode, one Axes per
+               electrode. Good for a handful of electrodes.
+            *  'heatmap': an electrode-by-time image in a single Axes. Good
+               for a whole implant's worth of electrodes.
+
+            If None, a whole stimulus of more than one electrode is drawn as a
+            heatmap and everything else as traces: naming electrodes means
+            "show me these signals in detail".
 
         Returns
         -------
-        axes : matplotlib.axes.Axes or np.ndarray of them
-            Returns one matplotlib.axes.Axes per electrode
+        ax : matplotlib.axes.Axes or np.ndarray of them
+            One Axes per electrode for ``kind='traces'``, a single Axes for
+            ``kind='heatmap'``.
+
         """
         if self.time is None:
             # Cannot plot stimulus with single time point:
             raise NotImplementedError
+        if kind is None:
+            overview = electrodes is None and len(self.electrodes) > 1
+            kind = 'heatmap' if overview else 'traces'
+        elif kind not in ('traces', 'heatmap'):
+            raise ValueError(f"Unknown kind '{kind}'. Choose from 'traces' or "
+                             f"'heatmap'.")
         if electrodes is None:
             # Plot all electrodes:
             electrodes = self.electrodes
         elif isinstance(electrodes, (int, str)):
             # Convert to list so we can iterate over it:
             electrodes = [electrodes]
+        t_idx, t_vals = self._plot_times(time)
+        if kind == 'heatmap':
+            return self._plot_heatmap(electrodes, t_idx, t_vals, ax)
+        return self._plot_traces(electrodes, t_idx, t_vals, fmt, ax)
+
+    def _plot_times(self, time):
+        """Resolve a requested time range into an index and its x values"""
         # The user can ask for a range, slice, or list of time points, which
         # are either interpolated or loaded directly.
         if time is None:
@@ -1108,23 +1150,38 @@ class Stimulus(PrettyPrint):
         else:
             raise TypeError(f'"time" must be a tuple, slice, list, or NumPy '
                             f'array, not {type(time)}.')
+        return t_idx, t_vals
+
+    def _value_label(self):
+        """What the stimulus values are, as an axis or colorbar label"""
+        if self.unit.dimension.is_dimensionless:
+            return 'Value'
+        if self.unit == uA:
+            # Spelled the way Matplotlib renders it:
+            return r'Amplitude ($\mu$A)'
+        return f'Amplitude ({self.unit})'
+
+    def _plot_traces(self, electrodes, t_idx, t_vals, fmt, ax):
+        """Draw one waveform per electrode, each in its own Axes"""
         axes = ax
         if axes is None:
             if len(electrodes) == 1:
                 axes = plt.gca()
             else:
                 _, axes = plt.subplots(nrows=len(electrodes),
-                                       figsize=(8, 1.2 * len(electrodes)))
+                                       figsize=(8, 1.2 * len(electrodes)),
+                                       layout='constrained')
         if not isinstance(axes, (list, np.ndarray)):
-            # Convert to list so w can iterate over it:
+            # Convert to list so we can iterate over it:
             axes = [axes]
         for i, ax in enumerate(axes):
             if not isinstance(ax, Axes):
-                raise TypeError(f"'axes' must be a list of subplots, but "
-                                f"axes[{i}] is {type(ax)}.")
+                raise TypeError(f"'ax' must be a list of subplots, but "
+                                f"ax[{i}] is {type(ax)}.")
         if len(axes) != len(electrodes):
-            raise ValueError(f"Number of subplots ({len(axes)}) must be equal to the "
-                             f"number of electrodes ({len(electrodes)}).")
+            raise ValueError(f"Number of subplots ({len(axes)}) must be equal "
+                             f"to the number of electrodes "
+                             f"({len(electrodes)}).")
         # Plot each electrode in its own subplot:
         for ax, electrode in zip(axes, electrodes):
             # Slice or interpolate stimulus:
@@ -1142,26 +1199,47 @@ class Stimulus(PrettyPrint):
             y_pad = np.maximum(1, 0.02 * (slc.max() - slc.min()))
             ax.set_ylim(slc.min() - y_pad, slc.max() + y_pad)
             ax.set_ylabel(electrode)
-        # Show x-ticks only on last subplot:
+        # Only the bottom subplot carries the shared time axis:
         axes[-1].set_xticks(np.linspace(t_vals[0], t_vals[-1], num=5))
-        # Labels are common to all subplots. What the y axis shows depends on
-        # what the stimulus is made of: an image or video stimulus holds gray
-        # levels, and calling those an amplitude in microamps is simply wrong.
-        if self.unit.dimension.is_dimensionless:
-            ylabel = 'Value'
-        elif self.unit == uA:
-            # Spelled the way Matplotlib renders it:
-            ylabel = r'Amplitude ($\mu$A)'
-        else:
-            ylabel = f'Amplitude ({self.unit})'
-        axes[-1].figure.subplots_adjust(bottom=0.2)
-        axes[-1].figure.text(0.5, 0, f'Time ({self.time_unit})', va='top',
-                             ha='center')
-        axes[-1].figure.text(0, 0.5, ylabel, va='center', ha='center',
-                             rotation='vertical')
+        axes[-1].set_xlabel(f'Time ({self.time_unit})')
+        # Every Axes spends its y label on an electrode name, so the unit has
+        # to go where the whole stack can share it:
+        axes[-1].figure.supylabel(self._value_label())
         if len(axes) == 1:
             return axes[0]
         return axes
+
+    def _plot_heatmap(self, electrodes, t_idx, t_vals, ax):
+        """Draw the stimulus as a single electrode-by-time image"""
+        if isinstance(ax, (list, np.ndarray)):
+            raise TypeError(f"A heatmap is drawn in a single Axes, but 'ax' "
+                            f"is a sequence of {len(ax)}.")
+        electrodes = list(electrodes)
+        if ax is None:
+            # Give every electrode a readable row of its own:
+            height = float(np.clip(0.18 * len(electrodes), 2.5, 12))
+            _, ax = plt.subplots(figsize=(8, height), layout='constrained')
+        elif not isinstance(ax, Axes):
+            raise TypeError(f"'ax' must be a Matplotlib Axes, not {type(ax)}.")
+        data = np.atleast_2d(self.__getitem__((electrodes, t_idx)))
+        t_vals = np.asarray(t_vals, dtype=float)
+        vmax = np.max(np.abs(data))
+        if not np.isfinite(vmax) or vmax == 0:
+            vmax = 1.0
+        if data.min() < 0:
+            cmap, vmin = 'RdBu_r', -vmax
+        else:
+            cmap, vmin = 'viridis', 0.0
+        mesh = ax.pcolormesh(_cell_edges(t_vals), np.arange(len(data) + 1),
+                             data, cmap=cmap, vmin=vmin, vmax=vmax)
+        ax.set_yticks(np.arange(len(data)) + 0.5,
+                      labels=[str(e) for e in electrodes])
+        # Read top to bottom, in the order the electrodes were asked for:
+        ax.invert_yaxis()
+        ax.set_xlabel(f'Time ({self.time_unit})')
+        ax.set_ylabel('Electrode')
+        ax.figure.colorbar(mesh, ax=ax, label=self._value_label())
+        return ax
 
     def __getitem__(self, item):
         """Returns an item from the data array, interpolated if necessary

--- a/pulse2percept/stimuli/tests/test_base.py
+++ b/pulse2percept/stimuli/tests/test_base.py
@@ -308,7 +308,7 @@ def test_Stimulus_plot():
         stim = Stimulus(np.random.rand(n_electrodes, 20),
                         electrodes=[f'E{i}' for i in range(n_electrodes)])
         fig, axes = plt.subplots(ncols=n_electrodes)
-        stim.plot(ax=axes)
+        stim.plot(ax=axes, kind='traces')
         npt.assert_equal(isinstance(axes, (list, np.ndarray)), True)
         for ax, electrode in zip(axes, stim.electrodes):
             npt.assert_equal(isinstance(ax, Subplot), True)
@@ -328,17 +328,149 @@ def test_Stimulus_plot():
         stim.plot(ax='as')
     with pytest.raises(TypeError):
         stim.plot(time='0 0.1')
+    with pytest.raises(ValueError):
+        stim.plot(kind='waterfall')
     with pytest.raises(NotImplementedError):
         Stimulus(np.ones(10)).plot()
     with pytest.raises(ValueError):
         stim = Stimulus(np.ones((3, 10)))
         _, axes = plt.subplots(nrows=4)
-        stim.plot(ax=axes)
+        stim.plot(ax=axes, kind='traces')
     with pytest.raises(TypeError):
         stim = Stimulus(np.ones((3, 10)))
         _, axes = plt.subplots(nrows=3)
         axes[1] = 0
-        stim.plot(ax=axes)
+        stim.plot(ax=axes, kind='traces')
+    with pytest.raises(TypeError):
+        # A heatmap has nowhere to put a second Axes:
+        _, axes = plt.subplots(nrows=3)
+        Stimulus(np.ones((3, 10))).plot(ax=axes, kind='heatmap')
+    plt.close('all')
+
+
+def test_Stimulus_plot_kind_default():
+    """A named electrode asks for detail, a whole implant for an overview"""
+    single = Stimulus([[0, -10, 10, 0]], time=[0, 1, 2, 3])
+    npt.assert_equal(len(single.plot().lines), 1)
+    plt.close('all')
+    multi = Stimulus(np.random.rand(4, 8),
+                     electrodes=[f'E{i}' for i in range(4)])
+    ax = multi.plot()
+    npt.assert_equal(isinstance(ax, Subplot), True)
+    npt.assert_equal(len(ax.lines), 0)
+    npt.assert_equal(len(ax.collections), 1)
+    plt.close('all')
+    # Naming electrodes means traces, however many are named:
+    axes = multi.plot(electrodes=['E0', 'E1', 'E2'])
+    npt.assert_equal(len(axes), 3)
+    npt.assert_equal([ax.get_ylabel() for ax in axes], ['E0', 'E1', 'E2'])
+    plt.close('all')
+    # `kind` overrides both defaults:
+    npt.assert_equal(len(multi.plot(kind='traces')), 4)
+    plt.close('all')
+    ax = multi.plot(electrodes=['E2', 'E0'], kind='heatmap')
+    npt.assert_equal([t.get_text() for t in ax.get_yticklabels()],
+                     ['E2', 'E0'])
+    plt.close('all')
+
+
+def test_Stimulus_plot_electrode_order():
+    """Electrodes are shown in the order they were asked for, not stored in"""
+    stim = Stimulus(np.arange(12, dtype=float).reshape((3, 4)),
+                    electrodes=['A1', 'A2', 'A3'], time=[0, 1, 2, 3])
+    axes = stim.plot(electrodes=['A3', 'A1'])
+    npt.assert_equal([ax.get_ylabel() for ax in axes], ['A3', 'A1'])
+    npt.assert_almost_equal(axes[0].lines[0].get_data()[1], stim['A3'])
+    plt.close('all')
+    # Electrodes may also be named by index:
+    axes = stim.plot(electrodes=[2, 0])
+    npt.assert_almost_equal(axes[0].lines[0].get_data()[1], stim['A3'])
+    npt.assert_almost_equal(axes[1].lines[0].get_data()[1], stim['A1'])
+    plt.close('all')
+    ax = stim.plot(electrodes=[2, 0], kind='heatmap')
+    npt.assert_almost_equal(np.asarray(ax.collections[0].get_array()),
+                            stim.data[[2, 0], :])
+    plt.close('all')
+
+
+def test_Stimulus_plot_heatmap_time_is_not_uniform():
+    """A compressed pulse train is not sampled at a constant rate
+
+    Drawing it with equal-width columns would stretch the DT-wide edges of a
+    pulse until they look as long as the gaps between pulses.
+    """
+    stim = Stimulus({'A1': BiphasicPulseTrain(20, 50, 0.45, stim_dur=100),
+                     'A2': BiphasicPulseTrain(20, 25, 0.45, stim_dur=100)})
+    dt = np.diff(stim.time)
+    npt.assert_equal(dt.max() > 100 * dt.min(), True)
+    x = stim.plot().collections[0].get_coordinates()[0, :, 0]
+    # One cell per stored sample, spanning exactly the stimulus duration:
+    npt.assert_equal(len(x), len(stim.time) + 1)
+    npt.assert_almost_equal([x[0], x[-1]], [stim.time[0], stim.time[-1]])
+    # Cells are as wide as the intervals they stand for, so a pulse edge stays
+    # a pulse edge and the gaps stay long:
+    npt.assert_almost_equal(x[1:-1], (stim.time[:-1] + stim.time[1:]) / 2)
+    widths = np.diff(x)
+    npt.assert_equal(widths.min() < DT, True)
+    npt.assert_equal(widths.max() > 10, True)
+    plt.close('all')
+    # A time selection is drawn on the same footing:
+    x = stim.plot(time=(1 * ms, 3 * ms)).collections[0]
+    x = x.get_coordinates()[0, :, 0]
+    npt.assert_almost_equal([x[0], x[-1]], [1, 3])
+    plt.close('all')
+
+
+def test_Stimulus_plot_heatmap_color_scale():
+    # A signed stimulus is normalized symmetrically around zero, so that the
+    # middle of the colormap is "no current":
+    signed = Stimulus([[0, -30, 10, 0], [0, 5, -2, 0]], time=[0, 1, 2, 3])
+    mesh = signed.plot().collections[0]
+    npt.assert_almost_equal([mesh.norm.vmin, mesh.norm.vmax], [-30, 30])
+    plt.close('all')
+    # Nonnegative data has no sign to show and is not drawn as if it did:
+    unsigned = Stimulus([[0, 1, 2, 3], [0, 2, 4, 6]], time=[0, 1, 2, 3])
+    unsigned_mesh = unsigned.plot().collections[0]
+    npt.assert_almost_equal([unsigned_mesh.norm.vmin, unsigned_mesh.norm.vmax],
+                            [0, 6])
+    npt.assert_equal(unsigned_mesh.cmap.name == mesh.cmap.name, False)
+    plt.close('all')
+    # An all-zero stimulus has no magnitude to scale by, and must not blow up:
+    mesh = Stimulus(np.zeros((3, 4)), time=[0, 1, 2, 3]).plot().collections[0]
+    npt.assert_equal(mesh.norm.vmin < mesh.norm.vmax, True)
+    plt.close('all')
+
+
+def test_Stimulus_plot_heatmap_electrode_selection():
+    stim = Stimulus(np.arange(12, dtype=float).reshape((3, 4)),
+                    electrodes=['A1', 'A2', 'A3'], time=[0, 1, 2, 3])
+    ax = stim.plot(electrodes='A2', kind='heatmap')
+    npt.assert_equal([t.get_text() for t in ax.get_yticklabels()], ['A2'])
+    npt.assert_almost_equal(np.asarray(ax.collections[0].get_array()).ravel(),
+                            stim['A2'])
+    plt.close('all')
+    ax = stim.plot(electrodes=['A1', 'A3'], kind='heatmap')
+    npt.assert_almost_equal(np.asarray(ax.collections[0].get_array()),
+                            stim.data[[0, 2], :])
+    plt.close('all')
+
+
+def test_Stimulus_plot_leaves_the_callers_figure_alone():
+    """`plot` draws where it is told; it does not re-lay-out someone's figure
+
+    Positions are only compared between Axes `plot` was not given, so this
+    does not pin down what a plot looks like -- only that the rest of the
+    figure survives it.
+    """
+    stim = Stimulus(np.random.rand(3, 8), electrodes=['E0', 'E1', 'E2'])
+    for kwargs in ({'kind': 'heatmap'}, {'electrodes': ['E0']}):
+        fig, (mine, theirs) = plt.subplots(ncols=2)
+        before = theirs.get_position().bounds
+        stim.plot(ax=mine, **kwargs)
+        npt.assert_almost_equal(theirs.get_position().bounds, before)
+        # A figure-wide layout engine would move every Axes at draw time:
+        npt.assert_equal(fig.get_layout_engine(), None)
+        plt.close(fig)
 
 
 def _unique_timepoints(stim, data):
@@ -1319,12 +1451,20 @@ def test_Stimulus_plot_units():
     npt.assert_equal(isinstance(stim.plot(time=[1, 2] * ms), Subplot), True)
     with pytest.raises(DimensionMismatchError):
         stim.plot(time=(1 * uA, 3 * uA))
-    # The y axis says what the stimulus is actually made of:
-    npt.assert_equal(stim.plot().figure.texts[-1].get_text(),
-                     r'Amplitude ($\mu$A)')
-    npt.assert_equal(stim.plot().figure.texts[-2].get_text(), 'Time (ms)')
+    # The axes say what the stimulus is actually made of:
+    ax = stim.plot()
+    npt.assert_equal(ax.get_xlabel(), 'Time (ms)')
+    npt.assert_equal(ax.figure.get_supylabel(), r'Amplitude ($\mu$A)')
     dimless = Stimulus(VideoStimulus(np.ones((1, 1, 3)), time=[0, 1, 2]))
-    npt.assert_equal(dimless.plot().figure.texts[-1].get_text(), 'Value')
+    npt.assert_equal(dimless.plot().figure.get_supylabel(), 'Value')
+    plt.close('all')
+    # A heatmap says it on the colorbar instead:
+    two = Stimulus(np.ones((2, 3)), time=[0, 1, 2])
+    npt.assert_equal(two.plot().collections[0].colorbar.ax.get_ylabel(),
+                     r'Amplitude ($\mu$A)')
+    dimless = Stimulus(VideoStimulus(np.ones((1, 2, 3)), time=[0, 1, 2]))
+    npt.assert_equal(dimless.plot().collections[0].colorbar.ax.get_ylabel(),
+                     'Value')
     plt.close('all')
 
 

--- a/pulse2percept/stimuli/tests/test_base.py
+++ b/pulse2percept/stimuli/tests/test_base.py
@@ -308,7 +308,7 @@ def test_Stimulus_plot():
         stim = Stimulus(np.random.rand(n_electrodes, 20),
                         electrodes=[f'E{i}' for i in range(n_electrodes)])
         fig, axes = plt.subplots(ncols=n_electrodes)
-        stim.plot(ax=axes, kind='traces')
+        stim.plot(ax=axes)
         npt.assert_equal(isinstance(axes, (list, np.ndarray)), True)
         for ax, electrode in zip(axes, stim.electrodes):
             npt.assert_equal(isinstance(ax, Subplot), True)
@@ -335,12 +335,12 @@ def test_Stimulus_plot():
     with pytest.raises(ValueError):
         stim = Stimulus(np.ones((3, 10)))
         _, axes = plt.subplots(nrows=4)
-        stim.plot(ax=axes, kind='traces')
+        stim.plot(ax=axes)
     with pytest.raises(TypeError):
         stim = Stimulus(np.ones((3, 10)))
         _, axes = plt.subplots(nrows=3)
         axes[1] = 0
-        stim.plot(ax=axes, kind='traces')
+        stim.plot(ax=axes)
     with pytest.raises(TypeError):
         # A heatmap has nowhere to put a second Axes:
         _, axes = plt.subplots(nrows=3)
@@ -365,12 +365,22 @@ def test_Stimulus_plot_kind_default():
     npt.assert_equal(len(axes), 3)
     npt.assert_equal([ax.get_ylabel() for ax in axes], ['E0', 'E1', 'E2'])
     plt.close('all')
-    # `kind` overrides both defaults:
+    # Handing over an Axes per electrode says the same thing:
+    _, axes = plt.subplots(nrows=4)
+    multi.plot(ax=axes)
+    npt.assert_equal([len(ax.lines) for ax in axes], [1, 1, 1, 1])
+    plt.close('all')
+    # `kind` overrides all of that:
     npt.assert_equal(len(multi.plot(kind='traces')), 4)
     plt.close('all')
     ax = multi.plot(electrodes=['E2', 'E0'], kind='heatmap')
     npt.assert_equal([t.get_text() for t in ax.get_yticklabels()],
                      ['E2', 'E0'])
+    plt.close('all')
+    with pytest.raises(TypeError):
+        # ... including into a request a heatmap cannot honor:
+        _, axes = plt.subplots(nrows=4)
+        multi.plot(ax=axes, kind='heatmap')
     plt.close('all')
 
 
@@ -456,7 +466,7 @@ def test_Stimulus_plot_heatmap_electrode_selection():
 
 
 def test_Stimulus_plot_leaves_the_callers_figure_alone():
-    """`plot` draws where it is told; it does not re-lay-out someone's figure
+    """A supplied Axes is the whole canvas `plot` gets
 
     Positions are only compared between Axes `plot` was not given, so this
     does not pin down what a plot looks like -- only that the rest of the
@@ -470,7 +480,18 @@ def test_Stimulus_plot_leaves_the_callers_figure_alone():
         npt.assert_almost_equal(theirs.get_position().bounds, before)
         # A figure-wide layout engine would move every Axes at draw time:
         npt.assert_equal(fig.get_layout_engine(), None)
+        # Nothing figure-level was added either: no shared label, and no
+        # colorbar Axes squeezing in next to the caller's own:
+        npt.assert_equal(fig.get_supylabel(), '')
+        npt.assert_equal(fig.texts, [])
+        npt.assert_equal(fig.axes, [mine, theirs])
         plt.close(fig)
+    # Owning the figure is what earns `plot` the decoration:
+    ax = stim.plot()
+    npt.assert_equal(ax.collections[0].colorbar is not None, True)
+    npt.assert_equal(stim.plot(kind='traces')[0].figure.get_supylabel(),
+                     r'Amplitude ($\mu$A)')
+    plt.close('all')
 
 
 def _unique_timepoints(stim, data):


### PR DESCRIPTION
Improves `Stimulus.plot()` for implant-scale stimuli.

Multi-electrode stimuli now default to a compact electrode-by-time heatmap, while single or explicitly selected electrodes are shown as waveform traces. The heatmap respects nonuniform stimulus timing, making compressed pulse trains and rastered stimulation readable without generating dozens of subplots.

Also cleans up plot layout handling from #203, preserves the existing trace view via `kind='traces'`, and adds tests/docs for the new overview-and-drill-down workflow.

Closes #203.