### PR TITLE
[ENH] Refactor Stimulus around structured, lazy-load stimulation

### DIFF
--- a/doc/topics/encoders.rst
+++ b/doc/topics/encoders.rst
@@ -7,7 +7,7 @@ Stimulus Encoders
 .. versionadded:: 0.10.0
 
 A visual prosthesis does not stimulate with pixels. It stimulates with
-electrical pulses. An :py:class:`~pulse2percept.stimuli.Encoder` defines how
+electrical pulses. An :py:class:`~pulse2percept.stimuli.StimulusEncoder` defines how
 the gray levels of an image or video are turned into those pulses:
 
 ::
@@ -102,6 +102,40 @@ If the pulse rate is lower than the frame rate, some frames may never coincide
 with a pulse and therefore contribute no stimulation; the encoder warns when
 that happens.
 
+What the encoded stimulus is
+----------------------------
+
+:py:meth:`~pulse2percept.stimuli.StimulusEncoder.encode` returns the **delivered
+electrical stimulus**: the biphasic pulse trains the device would actually
+emit, on the device's own timing. Its waveform is generated only when
+something asks for samples, so encoding a video onto a large implant is cheap
+until a model needs the pulses.
+
+The stimulus also remembers what was *asked* of each electrode, which is what
+lets each kind of model read the half it can express:
+
+* A purely spatial model (:py:class:`~pulse2percept.models.ScoreboardModel`,
+  :py:class:`~pulse2percept.models.AxonMapModel`) has no clock, so it reads the
+  frame-level modulation: one amplitude per electrode per frame of the source.
+  It never sees the pulse timing, and never generates the waveform.
+* A temporal or combined model integrates the delivered pulses, because that
+  is what such a model is for.
+
+This does not depend on how the stimulus got to the implant. Encoding by hand
+and assigning the result is the same thing as letting the implant encode:
+
+.. code-block:: python
+
+    implant.stim = encoder.encode(source)      # these two
+
+    implant.encoder = encoder                  # ... behave identically
+    implant.stim = source
+
+.. versionchanged:: 0.10.0
+    A spatial model reads the frame-level modulation of any encoded stimulus.
+    Previously only stimuli encoded during assignment to an implant were read
+    that way, and a hand-encoded one came out as a sequence of raster slots.
+
 Hardware constraints, when you need them
 ----------------------------------------
 
@@ -144,7 +178,7 @@ full units convention.
 
 .. seealso::
 
-    * :py:class:`pulse2percept.stimuli.Encoder` for the common encoder options
+    * :py:class:`pulse2percept.stimuli.StimulusEncoder` for the common encoder options
     * :py:class:`pulse2percept.stimuli.AmplitudeEncoder`
     * :py:class:`pulse2percept.stimuli.FrequencyEncoder`
     * :ref:`Electrical Stimuli <topics-stimuli>`

--- a/doc/topics/encoders.rst
+++ b/doc/topics/encoders.rst
@@ -22,7 +22,8 @@ The usual workflow
 ------------------
 
 For example, an :py:class:`~pulse2percept.stimuli.AmplitudeEncoder` maps image
-brightness onto pulse amplitude while keeping pulse frequency fixed:
+brightness onto pulse amplitude while keeping pulse frequency fixed. Give the
+implant an encoder, and assigning an image or a video encodes it:
 
 .. code-block:: python
 
@@ -30,35 +31,40 @@ brightness onto pulse amplitude while keeping pulse frequency fixed:
     from pulse2percept.units import uA, Hz
 
     implant = p2p.implants.ArgusII()
-    encoder = p2p.stimuli.AmplitudeEncoder(
-        implant, amp_range=(0, 50 * uA), freq=20 * Hz
+    implant.encoder = p2p.stimuli.AmplitudeEncoder(
+        amp_range=(0, 50 * uA),
+        freq=20 * Hz,
     )
 
     source = p2p.stimuli.BostonTrain()
-    implant.stim = encoder.encode(source)
+    implant.stim = source
 
     model = p2p.models.ScoreboardModel().build()
     percept = model.predict_percept(implant)
 
-Here a gray level of 0 maps to 0 uA, a gray level of 255 maps to 50 uA, and every
-electrode is driven at 20 Hz. The returned stimulus contains the actual
-biphasic pulse trains, ready to assign to ``implant.stim``.
+Here a gray level of 0 maps to 0 uA, a gray level of 1 maps to 50 uA, and every
+electrode is driven at 20 Hz. ``implant.stim`` is the actual biphasic pulse
+trains that result.
 
-Passing the implant matters
----------------------------
+Encoding explicitly
+-------------------
 
-When an implant is supplied to the encoder, the image or video is sampled at
-the implant's electrode locations before pulse trains are constructed. This is
-usually what you want:
+You can also encode a source yourself and assign the result:
 
 .. code-block:: python
 
-    encoder = p2p.stimuli.AmplitudeEncoder(implant)
-    stim = encoder.encode(source)
+    encoder = p2p.stimuli.AmplitudeEncoder(
+        amp_range=(0, 50 * uA),
+        freq=20 * Hz,
+    )
+    stim = encoder.encode(source, implant=implant)
+    implant.stim = stim
 
-The resulting stimulus has one row per electrode, with electrode names that
-match the implant. If ``implant=None``, every source pixel is treated as its
-own electrode instead. That can be useful for custom workflows, but can also
+Passing ``implant`` samples the image or video at the implant's electrode
+locations before pulse trains are constructed. This is usually what you want:
+the resulting stimulus has one row per electrode, with electrode names that
+match the implant. Leave it out and every source pixel is treated as its own
+electrode instead, which can be useful for custom workflows but can also
 produce unnecessarily large stimuli.
 
 Amplitude or frequency?
@@ -81,13 +87,16 @@ same way from the user's point of view:
 
 .. code-block:: python
 
-    encoder = p2p.stimuli.FrequencyEncoder(
-        implant, amp=50 * uA, freq_range=(0, 100 * Hz)
+    implant.encoder = p2p.stimuli.FrequencyEncoder(
+        amp=50 * uA,
+        freq_range=(0, 60 * Hz),
     )
-    implant.stim = encoder.encode(source)
+    implant.stim = source
 
-A gray level of 0 then maps to 0 Hz and a gray level of 255 to 100 Hz, with pulse
-amplitude fixed at 50 uA.
+A gray level of 0 then maps to 0 Hz and a gray level of 1 to 60 Hz, with pulse
+amplitude fixed at 50 uA. How high the range can go depends on the implant's
+raster: a sweep through its groups has to fit inside the shortest pulse period
+requested. See :ref:`topics-rasters`.
 
 Frames and pulses have separate clocks
 --------------------------------------
@@ -126,9 +135,9 @@ and assigning the result is the same thing as letting the implant encode:
 
 .. code-block:: python
 
-    implant.stim = encoder.encode(source)      # these two
+    implant.stim = encoder.encode(source, implant=implant)   # these two
 
-    implant.encoder = encoder                  # ... behave identically
+    implant.encoder = encoder                                # ... are the same
     implant.stim = source
 
 .. versionchanged:: 0.10.0
@@ -148,9 +157,10 @@ stimulator. Optional parameters let you add hardware constraints later:
 ``n_levels``
     Quantizes input gray levels before they are mapped onto stimulation.
 
-``raster``
-    Describes which groups of electrodes may stimulate at the same time. If
-    omitted, the implant's own raster is used when it has one.
+The raster -- which groups of electrodes may stimulate at the same time -- is
+a property of the device rather than of the encoder, so it is set on the
+implant (``implant.raster``) and picked up from there. See
+:ref:`topics-rasters`.
 
 These constraints never make an electrode pulse faster than requested. Timing
 is rounded conservatively so that an unrealizable pulse period becomes a
@@ -166,7 +176,6 @@ Encoder parameters accept both the usual bare numbers and unitful quantities:
     import pulse2percept.units as u
 
     encoder = p2p.stimuli.AmplitudeEncoder(
-        implant,
         amp_range=(0 * u.uA, 0.05 * u.mA),
         freq=20 * u.Hz,
         phase_dur=460 * u.us,

--- a/doc/topics/implants.rst
+++ b/doc/topics/implants.rst
@@ -429,7 +429,6 @@ For a custom array, you usually do not need a new implant class. An
     earray = ElectrodeGrid(
         shape=(10, 10),
         spacing=500,
-        r=100,
     )
     implant = ProsthesisSystem(earray=earray)
 

--- a/doc/topics/implants.rst
+++ b/doc/topics/implants.rst
@@ -63,10 +63,10 @@ For an epiretinal implant such as Argus II, a typical simulation looks like:
 
     implant = p2p.implants.ArgusII()
 
-    encoder = p2p.stimuli.AmplitudeEncoder(
-        implant, amp_range=(0, 50), freq=20
+    implant.encoder = p2p.stimuli.AmplitudeEncoder(
+        amp_range=(0, 50), freq=20
     )
-    implant.stim = encoder.encode(p2p.stimuli.BostonTrain())
+    implant.stim = p2p.stimuli.BostonTrain()
 
     model = p2p.models.AxonMapModel().build()
     percept = model.predict_percept(implant)
@@ -450,9 +450,7 @@ split an array into groups that take turns:
 
 .. code-block:: python
 
-    implant.raster = p2p.implants.CheckerboardRaster(
-        implant, n_groups=5
-    )
+    implant.raster = p2p.implants.CheckerboardRaster(n_groups=5)
 
 The encoder uses that schedule when constructing the electrical stimulus. See
 :ref:`topics-rasters` for the details.

--- a/doc/topics/rasters.rst
+++ b/doc/topics/rasters.rst
@@ -21,7 +21,7 @@ A raster is a **scheduling constraint**, not a stimulus by itself:
                        Raster
 
 The raster says **which electrodes may pulse together**. The
-:py:class:`~pulse2percept.stimuli.Encoder` decides when the pulses occur and
+:py:class:`~pulse2percept.stimuli.StimulusEncoder` decides when the pulses occur and
 what their amplitudes or frequencies are.
 
 The usual workflow

--- a/doc/topics/rasters.rst
+++ b/doc/topics/rasters.rst
@@ -36,12 +36,16 @@ by an encoder:
     from pulse2percept.units import uA, Hz
 
     implant = p2p.implants.ArgusII()
-    implant.raster = p2p.implants.CheckerboardRaster(implant, n_groups=5)
+    implant.raster = p2p.implants.CheckerboardRaster(n_groups=5)
 
     encoder = p2p.stimuli.AmplitudeEncoder(
-        implant, amp_range=(0, 50 * uA), freq=20 * Hz
+        amp_range=(0, 50 * uA),
+        freq=20 * Hz,
     )
-    implant.stim = encoder.encode(p2p.stimuli.BostonTrain())
+    implant.stim = encoder.encode(
+        p2p.stimuli.BostonTrain(),
+        implant=implant,
+    )
 
 Here the 60 electrodes are split into five groups. Electrodes within one group
 may pulse together, while different groups receive different time slots.
@@ -50,7 +54,7 @@ You can inspect the grouping directly:
 
 .. code-block:: python
 
-    implant.raster.plot(implant)
+    implant.raster.plot()
     implant.raster.members(implant.electrode_names, 0)
 
 Built-in strategies
@@ -87,7 +91,7 @@ A checkerboard raster is usually more spatially distributed:
 
 .. code-block:: python
 
-    implant.raster = p2p.implants.CheckerboardRaster(implant, n_groups=5)
+    implant.raster = p2p.implants.CheckerboardRaster(n_groups=5)
 
 It derives the grouping from the electrode locations, so it works with square,
 rectangular, rotated, and hexagonal grids. The array must actually lie on a

--- a/doc/topics/stimuli.rst
+++ b/doc/topics/stimuli.rst
@@ -161,6 +161,43 @@ The time axis does not need to be uniformly sampled. Pulse classes store the
 important transition points rather than a dense sample at every simulation
 step, which keeps long pulse trains compact.
 
+Immutable, and sampled when asked
+---------------------------------
+
+.. versionchanged:: 0.10.0
+
+A Stimulus is an immutable scientific value. Its ``data``, ``time`` and
+``electrodes`` arrays are read-only, so a stimulus you hand to an implant or a
+model is the one you get back.
+
+For an arbitrary stimulus, that sampled waveform *is* the stimulus. Pulses,
+pulse trains and encoded images and videos are different: they retain the
+parameters or the schedule that define them, and only generate their waveform
+when samples are asked for.
+
+.. code-block:: python
+
+    pt = p2p.stimuli.BiphasicPulseTrain(20 * Hz, 50 * uA, 0.45 * ms)
+
+    pt.freq, pt.amp, pt.phase_dur   # free -- the parameters are the stimulus
+    pt.data                         # generates the waveform, then caches it
+
+So pulse parameters are first-class and read-only, and reading them never
+costs a waveform. ``stim.data`` remains the public sampled waveform, and
+reading it may be what generates it.
+
+Operations return a **new** stimulus rather than modifying one. Where the
+result is still describable in the same terms, it keeps that form:
+
+.. code-block:: python
+
+    pt * 2          # still a BiphasicPulseTrain, at twice the amplitude
+    pt + 5          # a plain Stimulus: a DC offset is not a pulse train
+
+An operation that cannot be represented truthfully -- a DC offset, a shift in
+time, appending a second train -- falls back to an ordinary waveform-backed
+Stimulus rather than reporting parameters that no longer describe it.
+
 Looking at a stimulus
 ---------------------
 
@@ -202,7 +239,7 @@ For example:
     source = p2p.stimuli.BostonTrain()
 
 That object is a visual source. It should be passed through an
-:py:class:`~pulse2percept.stimuli.Encoder` before it is used as electrical
+:py:class:`~pulse2percept.stimuli.StimulusEncoder` before it is used as electrical
 stimulation:
 
 .. code-block:: python

--- a/doc/topics/stimuli.rst
+++ b/doc/topics/stimuli.rst
@@ -161,12 +161,12 @@ The time axis does not need to be uniformly sampled. Pulse classes store the
 important transition points rather than a dense sample at every simulation
 step, which keeps long pulse trains compact.
 
-Immutable, and sampled when asked
+Read-only, and sampled when asked
 ---------------------------------
 
 .. versionchanged:: 0.10.0
 
-A Stimulus is an immutable scientific value. Its ``data``, ``time`` and
+A Stimulus owns its scientific state. Its ``data``, ``time`` and
 ``electrodes`` arrays are read-only, so a stimulus you hand to an implant or a
 model is the one you get back.
 
@@ -186,8 +186,8 @@ So pulse parameters are first-class and read-only, and reading them never
 costs a waveform. ``stim.data`` remains the public sampled waveform, and
 reading it may be what generates it.
 
-Operations return a **new** stimulus rather than modifying one. Where the
-result is still describable in the same terms, it keeps that form:
+Most operations return a **new** stimulus rather than modifying one. Where
+the result is still describable in the same terms, it keeps that form:
 
 .. code-block:: python
 
@@ -197,6 +197,10 @@ result is still describable in the same terms, it keeps that form:
 An operation that cannot be represented truthfully -- a DC offset, a shift in
 time, appending a second train -- falls back to an ordinary waveform-backed
 Stimulus rather than reporting parameters that no longer describe it.
+
+:py:meth:`~pulse2percept.stimuli.Stimulus.compress` and
+:py:meth:`~pulse2percept.stimuli.Stimulus.remove` are the exceptions. Both
+predate this and still replace the stimulus' own state in place.
 
 Looking at a stimulus
 ---------------------
@@ -244,13 +248,12 @@ stimulation:
 
 .. code-block:: python
 
-    encoder = p2p.stimuli.AmplitudeEncoder(
-        implant,
+    implant.encoder = p2p.stimuli.AmplitudeEncoder(
         amp_range=(0, 50 * uA),
         freq=20 * Hz,
     )
 
-    implant.stim = encoder.encode(source)
+    implant.stim = source
 
 This distinction matters. A gray level of 0.5 is not 0.5 uA; the encoder is
 what defines how image intensity maps onto stimulation. See

--- a/doc/topics/stimuli.rst
+++ b/doc/topics/stimuli.rst
@@ -123,7 +123,7 @@ or dictionaries:
 
 .. code-block:: python
 
-    stim = p2p.stimuli.Stimulus({
+    static = p2p.stimuli.Stimulus({
         'A1': 10 * uA,
         'A2': 20 * uA,
         'A3': 30 * uA,
@@ -149,6 +149,8 @@ Every Stimulus exposes the same basic pieces:
 Stimuli can also be indexed by electrode name and time:
 
 .. code-block:: python
+
+    stim = implant.stim
 
     stim['A5']
     stim['A5', 10 * ms]
@@ -212,7 +214,7 @@ the whole stimulus or the waveforms of the electrodes you name:
 
     stim.plot()                          # compact overview
     stim.plot(time=(0, 50 * ms))         # the same overview, zoomed in time
-    stim.plot(electrodes=['A1', 'A2'])   # inspect individual waveforms
+    stim.plot(electrodes=['A5', 'B5'])   # inspect individual waveforms
 
 The overview is an electrode-by-time heatmap: one row per electrode, color for
 current, zero in the middle of a diverging colormap so that cathodic and

--- a/doc/users/release_notes.rst
+++ b/doc/users/release_notes.rst
@@ -11,7 +11,7 @@ Highlights:
 
 * New :py:class:`~pulse2percept.stimuli.StimulusEncoder` classes translate
   images and videos into electrical stimulation using amplitude or frequency
-  modulation (see :ref:`Stimulus Encoders <topics-encoders>`. 
+  modulation (see :ref:`Stimulus Encoders <topics-encoders>`).
   New :py:class:`~pulse2percept.implants.Raster` classes describe how
   stimulators multiplex electrodes that cannot be driven simultaneously
   (see :ref:`Raster Strategies <topics-rasters>`).

--- a/doc/users/release_notes.rst
+++ b/doc/users/release_notes.rst
@@ -9,146 +9,94 @@ v0.10.0 Encoders (unreleased)
 
 Highlights:
 
-*  New :py:class:`~pulse2percept.stimuli.StimulusEncoder` classes translate
-   images and videos into electrical stimulation using amplitude or frequency
-   modulation.
+* New :py:class:`~pulse2percept.stimuli.StimulusEncoder` classes translate
+  images and videos into electrical stimulation using amplitude or frequency
+  modulation (see :ref:`Stimulus Encoders <topics-encoders>`. 
+  New :py:class:`~pulse2percept.implants.Raster` classes describe how
+  stimulators multiplex electrodes that cannot be driven simultaneously
+  (see :ref:`Raster Strategies <topics-rasters>`).
 
-*  New :py:class:`~pulse2percept.implants.Raster` classes describe how
-   stimulators multiplex electrodes that cannot be driven simultaneously.
-   :py:class:`~pulse2percept.implants.CheckerboardRaster` implements the
-   checkerboard pattern of [Kasowski2025]_ in a generalized form.
+* Stimuli now retain their scientific representation instead of eagerly
+  reducing everything to waveform samples. Pulse parameters and stimulus arrays
+  are read-only; pulses, pulse trains, multi-electrode collections, and encoder
+  output generate and cache their waveform only when needed. This substantially
+  reduces the time and memory required to construct large stimuli.
 
-*  New :py:mod:`~pulse2percept.units` module support using physical quantities
-   (``50 * uA``, ``450 * us``, ``15 * mm``, ``2 * dva``), which are
-   dimension-checked and converted to the unit the code expects. Bare numbers
-   keep working and keep their documented meaning everywhere.
-   See :ref:`Physical Units <topics-units>`.
+* New :py:mod:`~pulse2percept.units` support adds dimension-checked physical
+  quantities (``50 * uA``, ``450 * us``, ``15 * mm``, ``2 * dva``) throughout
+  the public API. Bare numbers retain their documented meaning.
+  See :ref:`Physical Units <topics-units>`.
 
-*  :py:class:`~pulse2percept.stimuli.Stimulus` is now an immutable value with
-   a lazily generated waveform. Pulses, pulse trains, collections of them, and
-   encoder output retain the parameters or schedule that define them and sample
-   it only when asked, so encoding an image or video onto a large implant no
-   longer allocates a waveform up front.
+* Temporal modeling and playback have been substantially improved:
+  temporal models can summarize percepts over an interval rather than sampling
+  a single instant, and :py:meth:`~pulse2percept.percepts.Percept.play` and
+  :py:meth:`~pulse2percept.stimuli.VideoStimulus.play` are much faster and
+  produce smaller notebooks and documentation pages.
 
-* :py:meth:`~pulse2percept.percepts.Percept.play` and
-  :py:meth:`~pulse2percept.stimuli.VideoStimulus.play` are roughly 100x faster
-  and produce much smaller notebooks and documentation pages.
+* New :py:meth:`~pulse2percept.percepts.Percept.load` reads percepts back from
+  image and video files.
 
-* New :py:meth:`~pulse2percept.percepts.Percept.load` reads a percept back
-  from an image, GIF, or movie file.
+* Python 3.14 is supported. Python 3.11 and NumPy 2 are now required.
 
-* Python 3.14 is now supported. Python 3.11 and NumPy 2 are now required.
 
 API changes:
 
-* :py:class:`~pulse2percept.models.FadingTemporal` is now driven by
-  :math:`\max(-A, 0)` rather than :math:`-A`: anodic current no longer reduces
-  brightness, it is ignored. A stimulus that is purely cathodic is unaffected.
-  In addition, ``FadingTemporal`` now enforces ``tau >= dt``.
+* Stimulus handling was overhauled. ``Stimulus.data``, ``time`` and
+  ``electrodes`` are read-only, pulse and pulse-train parameters such as
+  ``amp``, ``freq`` and ``phase_dur`` are first-class attributes, and exact
+  transformations such as scaling preserve structured pulse representations
+  when possible. New :py:meth:`~pulse2percept.stimuli.Stimulus.shift` and
+  :py:meth:`~pulse2percept.stimuli.Stimulus.pad` provide explicit time-axis
+  transformations. ``compress`` and ``remove`` remain in-place operations.
 
-* The grid-spacing parameter ``xystep`` was renamed to ``step`` across spatial
-  models and implant-grid factory methods. The axon-map parameter ``axlambda``
-  was similarly renamed to ``lam``.
+* Encoded stimuli now carry both the delivered electrical stimulation and the
+  frame-level modulation it realizes. Purely spatial models read the latter,
+  while temporal models use the delivered pulses. This behavior no longer
+  depends on whether encoding happened explicitly or during assignment to an
+  implant.
 
-* Temporal models gained a ``reduce`` parameter. When ``predict_percept`` picks
-  the output times itself (``t_percept=None``), ``reduce='peak'`` makes each
-  point report the highest brightness reached over the interval leading up to
-  it rather than the brightness at the instant it ends.
+* :py:class:`~pulse2percept.implants.ProsthesisSystem` now supports encoders,
+  raster strategies, and maximum-current limits. Raster strategies are attached
+  to the implant and bound to its electrode array.
 
-* :py:attr:`~pulse2percept.stimuli.Stimulus.data`,
-  :py:attr:`~pulse2percept.stimuli.Stimulus.time` and
-  :py:attr:`~pulse2percept.stimuli.Stimulus.electrodes` are read-only; write to
-  a copy, or build a new stimulus.
+* Temporal models gained a ``reduce`` parameter for choosing how automatically
+  selected output times summarize the preceding interval. In addition,
+  :py:class:`~pulse2percept.models.FadingTemporal` now ignores anodic current
+  rather than treating it as negative brightness, and enforces ``tau >= dt``.
 
-* Pulse and pulse-train parameters (``amp``, ``freq``, ``phase_dur``, ...) are
-  first-class read-only attributes and can be read without generating a
-  waveform. Scaling a parameter-backed stimulus keeps that form (``pt * 2`` is
-  a pulse train at twice the amplitude); an operation the parameters cannot
-  describe exactly returns a plain ``Stimulus``.
+* Spatial-model APIs were cleaned up: ``xystep`` was renamed to ``step`` and
+  ``axlambda`` to ``lam``. Axon-map and cortical scoreboard models also gained
+  configurable smoothing across their relevant visual-field meridians.
 
-* :py:class:`~pulse2percept.models.BiphasicAxonMapModel` and
-  :py:class:`~pulse2percept.models.cortex.DynaphosModel` read pulse parameters
-  off the pulse trains a stimulus is made of rather than out of its metadata.
-  Dynaphos still falls back to the metadata for stimuli merged by
-  :py:class:`~pulse2percept.implants.EnsembleImplant`, which does not preserve
-  the trains.
+* ``predict_percept`` and implant safety checks now enforce physical stimulus
+  dimensions instead of silently interpreting image gray levels as electrical
+  current.
 
-* A spatial model reads the frame-level modulation of any encoded stimulus,
-  not only one encoded while being assigned to an implant. Wrap in
-  ``Stimulus(stim)`` to be handed the delivered pulses instead.
+* Stimulus and percept visualization gained several usability improvements,
+  including multi-electrode stimulus heatmaps and ``vmin``/``vmax`` controls
+  for percept playback and saving.
 
-* :py:class:`~pulse2percept.implants.ProsthesisSystem` now exposes ``encoder``,
-  ``raster`` and ``max_current``. A raster is bound to the implant it is
-  assigned to (:py:meth:`~pulse2percept.implants.Raster.bind`).
-
-* New :py:meth:`~pulse2percept.stimuli.Stimulus.shift` and
-  :py:meth:`~pulse2percept.stimuli.Stimulus.pad` translate a stimulus in time
-  and add zero-valued endpoints at ``t=0`` and ``t=duration`` as needed.
-
-* :py:meth:`~pulse2percept.percepts.Percept.play` and
-  :py:meth:`~pulse2percept.percepts.Percept.save` gained ``vmin`` and
-  ``vmax``. ``play`` also gained a ``fmt`` argument (defaulting to JPEG in
-  :py:meth:`~pulse2percept.stimuli.VideoStimulus.play` and PNG in
-  :py:meth:`~pulse2percept.percepts.Percept.play`).
-
-* :py:class:`~pulse2percept.models.AxonMapSpatial` now smooths across the
-  horizontal meridian by default (``meridian_blend=1`` dva), and
-  :py:class:`~pulse2percept.models.cortex.ScoreboardSpatial` smooths across
-  the vertical meridian (``meridian_blend=0.1`` dva). Set
-  ``meridian_blend=0`` to recover the previous behavior.
-
-* ``predict_percept`` now raises ``DimensionMismatchError`` when the stimulus
-  is not the physical quantity the model reads. Assigning an
-  :py:class:`~pulse2percept.stimuli.ImageStimulus` or
-  :py:class:`~pulse2percept.stimuli.VideoStimulus` straight to ``implant.stim``
-  previously had its gray levels silently treated as microamps. The same check
-  guards the ``safe_mode`` and ``max_current`` safety checks.
-
-* :py:meth:`~pulse2percept.stimuli.Stimulus.plot` draws a whole
-  multi-electrode stimulus as an electrode-by-time heatmap rather than as one
-  subplot per electrode. Name ``electrodes`` for waveforms, or pass
-  ``kind='traces'`` / ``kind='heatmap'`` to choose outright.
-
-* Minimum dependency versions were raised for NumPy 2 compatibility. NumPy 1.x
-  users should remain on v0.9.1.
 
 Bug fixes:
 
-* Stimulus time axes now use float64 precision, fixing false
-  :py:attr:`~pulse2percept.stimuli.Stimulus.is_charge_balanced` failures for
-  longer pulse trains and improving frequency-modulation accuracy.
+* Stimulus timing, metadata propagation, and pulse-train handling are more
+  robust. Time axes now use float64 precision, metadata survives model
+  prediction and transformations, and Dynaphos uses the actual frequency and
+  phase duration of directly assigned biphasic pulse trains.
 
-* Stimulus metadata now survives ``predict_percept`` and other transformations.
+* Fixed several image/video issues, including accidental input mutation,
+  argument forwarding to scikit-image, image centering, single-frame playback,
+  and handling of nonuniform time axes.
 
-* :py:class:`~pulse2percept.models.cortex.DynaphosModel` now uses the frequency
-  and phase duration of a pulse train assigned straight to ``implant.stim``,
-  instead of falling back to the model's defaults.
+* Fixed several visual-field-map issues, including equality and hashing,
+  array-shaped inverse cortical mappings, exact mesh-vertex mappings, and
+  incorrect cortical-coordinate units in the documentation.
 
-* Various fixes for :py:class:`~pulse2percept.stimuli.ImageStimulus`:
-  keyword arguments are passed on to scikit-image; inputs are no longer
-  modified in place; :py:meth:`~pulse2percept.stimuli.ImageStimulus.center`
-  honors its ``loc`` argument instead of always centering on the middle of
-  the image.
-
-* :py:meth:`~pulse2percept.percepts.Percept.play`,
-  :py:meth:`~pulse2percept.stimuli.VideoStimulus.play`, and
-  :py:meth:`~pulse2percept.percepts.Percept.save` now handle single-frame
-  inputs correctly and give a useful error for nonuniform time axes.
-
-* :py:class:`~pulse2percept.implants.EnsembleImplant` now merges nearly
-  identical time points using the same tolerance as
+* :py:class:`~pulse2percept.implants.EnsembleImplant` now handles nearly
+  coincident stimulus time points consistently with
   :py:class:`~pulse2percept.stimuli.Stimulus`.
 
-* Visual-field-map equality now handles array-valued attributes correctly,
-  maps are hashable again, and maps of different classes no longer compare
-  equal.
-
-* :py:meth:`~pulse2percept.topography.NeuropythyMap.cortex_to_dva` (and the
-  ``v1_to_dva``, ``v2_to_dva``, ``v3_to_dva`` methods that call it) now returns
-  coordinates with the same shape as its input. Cortical points that land
-  exactly on a mesh vertex now map to that vertex instead of dividing by zero
-  and returning NaN. The docstrings said the cortical coordinates were in mm;
-  they are in um, as the code always assumed.
+* Various smaller correctness, compatibility, and documentation fixes.
 
 v0.9.1 (2026-08-06)
 -------------------

--- a/doc/users/release_notes.rst
+++ b/doc/users/release_notes.rst
@@ -24,6 +24,12 @@ Highlights:
    keep working and keep their documented meaning everywhere.
    See :ref:`Physical Units <topics-units>`.
 
+*  :py:class:`~pulse2percept.stimuli.Stimulus` is now an immutable value with
+   a lazily generated waveform. Pulses, pulse trains, collections of them, and
+   encoder output retain the parameters or schedule that define them and sample
+   it only when asked, so encoding an image or video onto a large implant no
+   longer allocates a waveform up front.
+
 * :py:meth:`~pulse2percept.percepts.Percept.play` and
   :py:meth:`~pulse2percept.stimuli.VideoStimulus.play` are roughly 100x faster
   and produce much smaller notebooks and documentation pages.
@@ -48,6 +54,28 @@ API changes:
   the output times itself (``t_percept=None``), ``reduce='peak'`` makes each
   point report the highest brightness reached over the interval leading up to
   it rather than the brightness at the instant it ends.
+
+* :py:attr:`~pulse2percept.stimuli.Stimulus.data`,
+  :py:attr:`~pulse2percept.stimuli.Stimulus.time` and
+  :py:attr:`~pulse2percept.stimuli.Stimulus.electrodes` are read-only; write to
+  a copy, or build a new stimulus.
+
+* Pulse and pulse-train parameters (``amp``, ``freq``, ``phase_dur``, ...) are
+  first-class read-only attributes and can be read without generating a
+  waveform. Scaling a parameter-backed stimulus keeps that form (``pt * 2`` is
+  a pulse train at twice the amplitude); an operation the parameters cannot
+  describe exactly returns a plain ``Stimulus``.
+
+* :py:class:`~pulse2percept.models.BiphasicAxonMapModel` and
+  :py:class:`~pulse2percept.models.cortex.DynaphosModel` read pulse parameters
+  off the pulse trains a stimulus is made of rather than out of its metadata.
+  Dynaphos still falls back to the metadata for stimuli merged by
+  :py:class:`~pulse2percept.implants.EnsembleImplant`, which does not preserve
+  the trains.
+
+* A spatial model reads the frame-level modulation of any encoded stimulus,
+  not only one encoded while being assigned to an implant. Wrap in
+  ``Stimulus(stim)`` to be handed the delivered pulses instead.
 
 * :py:class:`~pulse2percept.implants.ProsthesisSystem` now exposes ``encoder``,
   ``raster`` and ``max_current``. A raster is bound to the implant it is
@@ -91,6 +119,10 @@ Bug fixes:
   longer pulse trains and improving frequency-modulation accuracy.
 
 * Stimulus metadata now survives ``predict_percept`` and other transformations.
+
+* :py:class:`~pulse2percept.models.cortex.DynaphosModel` now uses the frequency
+  and phase duration of a pulse train assigned straight to ``implant.stim``,
+  instead of falling back to the model's defaults.
 
 * Various fixes for :py:class:`~pulse2percept.stimuli.ImageStimulus`:
   keyword arguments are passed on to scikit-image; inputs are no longer

--- a/pulse2percept/implants/base.py
+++ b/pulse2percept/implants/base.py
@@ -94,7 +94,7 @@ class ProsthesisSystem(PrettyPrint):
 
     """
     # Frozen class: User cannot add more class attributes
-    __slots__ = ('_earray', '_stim', '_spatial_stim', '_eye', 'safe_mode',
+    __slots__ = ('_earray', '_stim', '_eye', 'safe_mode',
                  'preprocess', '_encoder', '_raster', '_max_current')
 
     #: The physical quantity this system delivers, mirroring
@@ -426,18 +426,11 @@ class ProsthesisSystem(PrettyPrint):
         self.earray.deactivate(electrodes)
         # Switching an electrode off rewrites the stimulus, so it is replaced
         # rather than modified in place: it may be an object the caller still
-        # holds, and one defined by its pulse parameters cannot lose an
-        # electrode and remain one (see `Stimulus._derived`).
+        # holds, and one defined by more than its samples cannot lose an
+        # electrode and remain one unless it says how (see
+        # `Stimulus._without_electrodes`).
         if self.stim is not None:
-            stim = self.stim._derived()
-            stim.remove(electrodes)
-            self._stim = stim
-        # An electrode switched off delivers nothing, whichever of the two
-        # descriptions of the stimulus is being read:
-        if getattr(self, '_spatial_stim', None) is not None:
-            spatial = self._spatial_stim._derived()
-            spatial.remove(electrodes)
-            self._spatial_stim = spatial
+            self._stim = self.stim._without_electrodes(electrodes)
 
     @property
     def earray(self):
@@ -518,17 +511,6 @@ class ProsthesisSystem(PrettyPrint):
     @stim.setter
     def stim(self, data):
         """Stimulus setter (called upon ``self.stim = data``)"""
-        # `_spatial_stim` is the other description of an encoded stimulus: the
-        # modulation the encoder asked for, one amplitude per electrode per
-        # frame of the source, with no waveform, pulse clock or raster in it.
-        # `stim` stays the pulse train the device delivers; this is what a
-        # reader with no clock of its own can make sense of, and it is read by
-        # `pulse2percept.models.SpatialModel.predict_percept`. Cleared on every
-        # path through this setter and rebuilt below only where this implant's
-        # own encoder produced it, so that it can never be left describing the
-        # picture before last:
-        self._spatial_stim = None
-        spatial = None
         # if stim is empty or None
         if data is None:
             self._stim = None
@@ -557,13 +539,13 @@ class ProsthesisSystem(PrettyPrint):
             # where it becomes stimulation. Preprocessing goes first and may
             # have done the job already (a `preprocess` that encodes is exactly
             # as valid as an `encoder`), in which case there is nothing
-            # dimensionless left to encode. Both halves of the encoding are
-            # kept: what the device delivers, and the modulation it was asked
-            # for (see `_spatial_stim` above).
+            # dimensionless left to encode. What comes back knows both what
+            # the device delivers and what it was asked for, so there is one
+            # stimulus here and not two (see `Stimulus._spatial_view`).
             if (self.encoder is not None and
                     stim.unit.dimension.is_dimensionless and
                     stim.unit.dimension != self.stimulus_unit.dimension):
-                spatial, stim = self.encoder._encode_both(stim, implant=self)
+                stim = self.encoder.encode(stim, implant=self)
 
             # If the stim is larger than the number of electrodes, most commonly
             # we're dealing with an image or video stim. In this case, we might
@@ -585,23 +567,18 @@ class ProsthesisSystem(PrettyPrint):
                                      f'implant.')
             # Remove deactivated electrodes from the stimulus. Removal
             # rewrites the stimulus, so it happens on a copy: the caller's
-            # object is theirs, and a stimulus defined by its pulse parameters
-            # (rather than by its samples) cannot lose an electrode and remain
-            # one -- `_derived` hands back a plain stimulus for those.
+            # object is theirs, and a stimulus defined by more than its
+            # samples keeps that description only if it says how to drop an
+            # electrode (see `Stimulus._without_electrodes`).
             off = [name for (name, e) in self.electrodes.items()
                    if not e.activated and name in stim.electrodes]
             if off:
-                stim = stim._derived()
-                stim.remove(off)
-                if spatial is not None:
-                    spatial = spatial._derived()
-                    spatial.remove(off)
+                stim = stim._without_electrodes(off)
             # Perform safety checks, etc. These are all questions about what
             # gets delivered, so they are asked of the pulse train:
             self.check_stim(stim)
             # Store stimulus:
             self._stim = deepcopy(stim)
-            self._spatial_stim = None if spatial is None else deepcopy(spatial)
 
     @property
     def eye(self):

--- a/pulse2percept/implants/base.py
+++ b/pulse2percept/implants/base.py
@@ -424,12 +424,20 @@ class ProsthesisSystem(PrettyPrint):
 
     def deactivate(self, electrodes):
         self.earray.deactivate(electrodes)
+        # Switching an electrode off rewrites the stimulus, so it is replaced
+        # rather than modified in place: it may be an object the caller still
+        # holds, and one defined by its pulse parameters cannot lose an
+        # electrode and remain one (see `Stimulus._derived`).
         if self.stim is not None:
-            self.stim.remove(electrodes)
+            stim = self.stim._derived()
+            stim.remove(electrodes)
+            self._stim = stim
         # An electrode switched off delivers nothing, whichever of the two
         # descriptions of the stimulus is being read:
         if getattr(self, '_spatial_stim', None) is not None:
-            self._spatial_stim.remove(electrodes)
+            spatial = self._spatial_stim._derived()
+            spatial.remove(electrodes)
+            self._spatial_stim = spatial
 
     @property
     def earray(self):
@@ -575,12 +583,19 @@ class ProsthesisSystem(PrettyPrint):
                 if not self.earray[electrode]:
                     raise ValueError(f'Electrode "{electrode}" not found in '
                                      f'implant.')
-            # Remove deactivated electrodes from the stimulus:
+            # Remove deactivated electrodes from the stimulus. Removal
+            # rewrites the stimulus, so it happens on a copy: the caller's
+            # object is theirs, and a stimulus defined by its pulse parameters
+            # (rather than by its samples) cannot lose an electrode and remain
+            # one -- `_derived` hands back a plain stimulus for those.
             off = [name for (name, e) in self.electrodes.items()
                    if not e.activated and name in stim.electrodes]
-            stim.remove(off)
-            if spatial is not None:
-                spatial.remove(off)
+            if off:
+                stim = stim._derived()
+                stim.remove(off)
+                if spatial is not None:
+                    spatial = spatial._derived()
+                    spatial.remove(off)
             # Perform safety checks, etc. These are all questions about what
             # gets delivered, so they are asked of the pulse train:
             self.check_stim(stim)

--- a/pulse2percept/implants/ensemble.py
+++ b/pulse2percept/implants/ensemble.py
@@ -3,7 +3,8 @@ import numpy as np
 from .base import ProsthesisSystem
 from .electrodes import Electrode
 from .electrode_arrays import ElectrodeArray
-from ..stimuli.base import _describe_unit, unique_time_points
+from ..stimuli._merge import unique_time_points
+from ..stimuli.base import _describe_unit
 from ..units import DimensionMismatchError, as_value, dva, um
 from ..utils import rename_parameter
 

--- a/pulse2percept/implants/tests/test_base.py
+++ b/pulse2percept/implants/tests/test_base.py
@@ -551,22 +551,24 @@ def test_ProsthesisSystem_encoder():
     npt.assert_equal(len(np.unique(np.abs(implant.stim.data) > 0, axis=0)), 6)
 
 
-def test_ProsthesisSystem_spatial_stim():
-    """An encoded stimulus keeps the modulation it was asked for, not just the
-    pulse train it was realized as
+def test_ProsthesisSystem_encoded_stim_is_one_object():
+    """An encoded stimulus knows both what it delivers and what it was asked
+    for, so the implant stores one of it
     """
     img = ImageStimulus(np.linspace(0, 1, 16).reshape((4, 4)))
     implant = ArgusII(stim=img)
+    npt.assert_equal(hasattr(implant, '_spatial_stim'), False)
     # `stim` is still the delivered pulse train -- that invariant is what makes
     # the safety checks and the temporal models meaningful:
     npt.assert_equal(implant.stim.time.size > 1, True)
-    # ... and beside it sits what the encoder actually asked each electrode
-    # for: one column, no waveform, no raster.
-    npt.assert_equal(implant._spatial_stim.shape, (60, 1))
-    npt.assert_equal(implant._spatial_stim.time, None)
-    npt.assert_equal(implant._spatial_stim.unit, uA)
+    # ... and the same object says what the encoder asked each electrode for:
+    # one column, no waveform, no raster.
+    spatial = implant.stim._spatial_view()
+    npt.assert_equal(spatial.shape, (60, 1))
+    npt.assert_equal(spatial.time, None)
+    npt.assert_equal(spatial.unit, uA)
     npt.assert_almost_equal(np.abs(implant.stim.data).max(axis=1),
-                            implant._spatial_stim.data.ravel(), decimal=4)
+                            spatial.data.ravel(), decimal=4)
 
     # A video keeps one column per video frame:
     vid = VideoStimulus(np.random.default_rng(0).random((6, 10, 4)),
@@ -575,26 +577,33 @@ def test_ProsthesisSystem_spatial_stim():
         # 6 Hz against 20 fps; irrelevant here, but it is not the modulation
         # that goes short of frames, only the train delivering it:
         implant.stim = vid
-    npt.assert_equal(implant._spatial_stim.shape, (60, 4))
-    npt.assert_almost_equal(implant._spatial_stim.time, np.arange(4) * 50.0)
+    npt.assert_equal(implant.stim._spatial_view().shape, (60, 4))
+    npt.assert_almost_equal(implant.stim._spatial_view().time,
+                            np.arange(4) * 50.0)
 
-    # Anything that did not come out of this implant's encoder has only the
-    # one description of itself, and assigning it clears the stale one:
-    for source in ({'A1': 20}, np.ones(60), None,
-                   AmplitudeEncoder(amp_range=(0, 50)).encode(img)):
+    # An encoded stimulus carries that description wherever it came from, so
+    # encoding by hand and assigning the result is the same thing as letting
+    # the implant do it:
+    by_hand = ArgusII(encoder=None,
+                      stim=AmplitudeEncoder(amp_range=(0, 50)).encode(
+                          img, implant=ArgusII()))
+    npt.assert_almost_equal(by_hand.stim._spatial_view().data,
+                            ArgusII(stim=img).stim._spatial_view().data)
+    # A stimulus assigned as current has only the one description of itself:
+    for source in ({'A1': 20}, np.ones(60)):
         implant.stim = source
-        npt.assert_equal(implant._spatial_stim, None)
-    # ... including an implant that never had an encoder:
-    npt.assert_equal(ArgusII(stim={'A1': 20})._spatial_stim, None)
-    npt.assert_equal(ProsthesisSystem(ArgusII().earray)._spatial_stim, None)
+        npt.assert_equal(implant.stim._spatial_view() is implant.stim, True)
+        npt.assert_equal(implant.stim._has_spatial_view, False)
 
     # Switching an electrode off reaches both descriptions, or a model reading
-    # one of them would go on stimulating through a dead electrode:
+    # one of them would go on stimulating through a dead electrode -- and it
+    # does not cost the schedule:
     implant = ArgusII(stim=img)
     implant.deactivate(['A1', 'B2'])
+    npt.assert_equal(implant.stim._has_spatial_view, True)
     npt.assert_equal(implant.stim.shape[0], 58)
-    npt.assert_equal(implant._spatial_stim.shape[0], 58)
-    npt.assert_equal('A1' in implant._spatial_stim.electrodes, False)
+    npt.assert_equal(implant.stim._spatial_view().shape[0], 58)
+    npt.assert_equal('A1' in implant.stim._spatial_view().electrodes, False)
 
 
 def test_ProsthesisSystem_preprocess_crosses_the_boundary():

--- a/pulse2percept/implants/tests/test_base.py
+++ b/pulse2percept/implants/tests/test_base.py
@@ -16,7 +16,8 @@ from pulse2percept.implants import (PointSource, ElectrodeArray, ElectrodeGrid,
 from pulse2percept.stimuli import (Stimulus, ImageStimulus, VideoStimulus,
                                    BostonTrain, LogoBVL)
 from pulse2percept.stimuli import (AmplitudeEncoder, BiphasicPulse,
-                                   FrequencyEncoder, MonophasicPulse)
+                                   BiphasicPulseTrain, FrequencyEncoder,
+                                   MonophasicPulse)
 from pulse2percept.implants import (ArgusII, DiskElectrode)
 from pulse2percept.models import ScoreboardModel
 
@@ -689,3 +690,33 @@ def test_ProsthesisSystem_deactivated_electrodes_do_not_mutate_the_source():
     implant = ArgusII(stim=stim)
     npt.assert_equal(sorted(str(e) for e in implant.stim.electrodes),
                      ['A1', 'B2'])
+
+
+def test_ProsthesisSystem_deactivated_electrode_does_not_render_the_others():
+    # An implant drops a deactivated electrode from a dict of pulse trains by
+    # forgetting the entry that drives it, so the trains on the electrodes
+    # that are still on never get sampled.
+    def unrendered(stim):
+        return sum(c._Stimulus__stim['data'] is None
+                   for c, _ in stim._components)
+
+    trains = {name: BiphasicPulseTrain(20 + i, 10, 0.45, stim_dur=200)
+              for i, name in enumerate(['A1', 'A2', 'A3'])}
+    implant = ArgusII()
+    implant.deactivate('A2')
+    implant.stim = trains
+    npt.assert_equal([str(e) for e in implant.stim.electrodes], ['A1', 'A3'])
+    npt.assert_equal(implant.stim._components is None, False)
+    npt.assert_equal(unrendered(implant.stim), 2)
+
+    # ...and deactivating one after the fact is the same story:
+    implant = ArgusII(stim={name: BiphasicPulseTrain(20 + i, 10, 0.45,
+                                                     stim_dur=200)
+                            for i, name in enumerate(['A1', 'A2', 'A3'])})
+    npt.assert_equal(unrendered(implant.stim), 3)
+    implant.deactivate('A2')
+    npt.assert_equal([str(e) for e in implant.stim.electrodes], ['A1', 'A3'])
+    npt.assert_equal(unrendered(implant.stim), 2)
+    # The waveform is still the one the trains describe:
+    npt.assert_equal(implant.stim.data.shape[0], 2)
+    npt.assert_almost_equal(implant.stim.time[-1], 200)

--- a/pulse2percept/implants/tests/test_base.py
+++ b/pulse2percept/implants/tests/test_base.py
@@ -644,3 +644,48 @@ def test_ProsthesisSystem_historical_stimuli_unchanged():
     implant.max_current = 0.2 * mA
     implant.stim = {name: 2 for name in ArgusII().electrode_names}
     npt.assert_equal(implant.stim.unit, uA)
+
+
+def test_ProsthesisSystem_deactivated_electrodes_do_not_mutate_the_source():
+    # Filtering out deactivated electrodes rewrites the stimulus, so it
+    # happens on a copy. A stimulus defined by its pulse parameters cannot
+    # lose an electrode and remain one, so what the implant stores for it is
+    # an ordinary Stimulus -- assigning a perfectly good pulse must not fail
+    # merely because the electrode it names happens to be switched off.
+    pulse = BiphasicPulse(20, 0.45, electrode='A1')
+    implant = ArgusII()
+    implant.deactivate('A1')
+    implant.stim = pulse
+    npt.assert_equal(type(implant.stim), Stimulus)
+    npt.assert_equal(implant.stim.shape[0], 0)
+    # The caller still holds their pulse, unchanged:
+    npt.assert_equal(type(pulse), BiphasicPulse)
+    npt.assert_equal(pulse.shape[0], 1)
+    npt.assert_almost_equal(pulse.amp, 20)
+
+    # Same for an electrode switched off after the fact:
+    implant = ArgusII(stim=BiphasicPulse(20, 0.45, electrode='A1'))
+    npt.assert_equal(type(implant.stim), BiphasicPulse)
+    implant.deactivate('A1')
+    npt.assert_equal(type(implant.stim), Stimulus)
+    npt.assert_equal(implant.stim.shape[0], 0)
+
+    # An ordinary stimulus is not mutated by either path, which it used to be:
+    for deactivate_first in (True, False):
+        stim = Stimulus({'A1': 10, 'B2': 20})
+        implant = ArgusII()
+        if deactivate_first:
+            implant.deactivate('A1')
+            implant.stim = stim
+        else:
+            implant.stim = stim
+            implant.deactivate('A1')
+        npt.assert_equal(sorted(str(e) for e in stim.electrodes),
+                         ['A1', 'B2'])
+        npt.assert_equal([str(e) for e in implant.stim.electrodes], ['B2'])
+
+    # Nothing deactivated means nothing is copied or removed:
+    stim = Stimulus({'A1': 10, 'B2': 20})
+    implant = ArgusII(stim=stim)
+    npt.assert_equal(sorted(str(e) for e in implant.stim.electrodes),
+                     ['A1', 'B2'])

--- a/pulse2percept/models/base.py
+++ b/pulse2percept/models/base.py
@@ -257,19 +257,12 @@ def _require_stim_dimension(model, stim):
 def _spatial_input(implant):
     """The stimulus a model with no temporal component reads off an implant
 
-    A pulse train is a description of *when* current flows, and a raster is a
-    description of which electrodes are allowed to flow at the same time. Both
-    are facts about time, and a model with no temporal component has no
-    machinery to express either: handed the delivered train, it reports the
-    stimulus one instant at a time, so an encoded image comes out as a
-    sequence of raster slots rather than as the image.
-
-    So a stimulus that knows what it was *asked* for, as well as what it
-    delivers, is read for the first: one amplitude per electrode per frame of
-    the source, which is exactly as much of it as such a model can say
-    anything about. Everything else -- a stimulus assigned as current, an
-    implant with no encoder -- has only the one description of itself and is
-    its own answer.
+    A pulse train says *when* current flows and a raster says which electrodes
+    may flow at once. Both are facts about time that such a model has no
+    machinery to express -- handed the delivered train, it would report an
+    encoded image as a sequence of raster slots. So an encoded stimulus is
+    read for the modulation it realizes instead: one amplitude per electrode
+    per frame of the source. Anything else is its own answer.
     """
     return implant.stim._spatial_view()
 
@@ -310,13 +303,11 @@ def _rescaled_implant(implant, amp):
 def _delivered(implant):
     """The same implant, made to hand a spatial model the pulse train
 
-    The other side of :py:func:`_spatial_input`. A spatial model that feeds a
-    temporal one is the case where the pulses are exactly what has to get
-    through, since integrating them is what the temporal model is for. A
-    shallow copy is enough to say so, with the stimulus wrapped in an ordinary
-    :py:class:`~pulse2percept.stimuli.Stimulus`: an ordinary stimulus is its
-    own spatial view, so the wrapper is what asks for the delivered pulses.
-    The wrapper stays unmaterialized until something reads them.
+    The other side of :py:func:`_spatial_input`: when a temporal stage follows,
+    integrating the pulses is the point, so they are what has to get through.
+    An ordinary :py:class:`~pulse2percept.stimuli.Stimulus` is its own spatial
+    view, so wrapping in one is how the delivered pulses are asked for -- and
+    the wrapper stays unmaterialized until something reads them.
     """
     if implant.stim is None or not implant.stim._has_spatial_view:
         return implant

--- a/pulse2percept/models/base.py
+++ b/pulse2percept/models/base.py
@@ -264,19 +264,23 @@ def _spatial_input(implant):
     stimulus one instant at a time, so an encoded image comes out as a
     sequence of raster slots rather than as the image.
 
-    So where the implant's encoder left the modulation behind the delivered
-    train (``_spatial_stim``), that is what a spatial model reads: one
-    amplitude per electrode per frame of the source, which is exactly as much
-    of the stimulus as such a model can say anything about. Everything else --
-    a stimulus assigned as current, an implant with no encoder -- has only the
-    one description of itself, and it is used unchanged.
+    So a stimulus that knows what it was *asked* for, as well as what it
+    delivers, is read for the first: one amplitude per electrode per frame of
+    the source, which is exactly as much of it as such a model can say
+    anything about. Everything else -- a stimulus assigned as current, an
+    implant with no encoder -- has only the one description of itself and is
+    its own answer.
     """
-    spatial = getattr(implant, '_spatial_stim', None)
-    return implant.stim if spatial is None else spatial
+    return implant.stim._spatial_view()
 
 
 def _rescale(stim, scale):
     """A copy of ``stim`` with every amplitude multiplied by ``scale``
+
+    Rebuilt from the data rather than scaled through the operator, because a
+    stimulus with no time component picks one up on the way through: that is
+    what lets a temporal model be handed one at all, and
+    :py:meth:`TemporalModel.find_threshold` has always relied on it.
 
     The metadata is carried across: it is what tells ``predict_percept`` which
     video the stimulus was encoded from, and hence when to report a percept.
@@ -291,20 +295,15 @@ def _rescale(stim, scale):
 def _rescaled_implant(implant, amp):
     """A copy of ``implant`` whose stimulus peaks at ``amp``
 
-    What ``find_threshold`` varies from trial to trial. *Both* descriptions of
-    the stimulus are scaled, because which one a model reads depends on
-    whether it has a temporal component (see :py:func:`_spatial_input`), and a
-    search run on one description would not be a search for the threshold of
-    what the caller's own ``predict_percept`` reports.
+    What ``find_threshold`` varies from trial to trial. Scaling the stimulus
+    scales every description of it at once: an encoded one is still the
+    schedule it was, delivering less current, and what a spatial model reads
+    off it moves with what a temporal one does. A search run on only one of
+    them would not be a search for the threshold of what the caller's own
+    ``predict_percept`` reports.
     """
     trial = deepcopy(implant)
-    scale = amp / implant.stim.data.max()
-    modulation = getattr(implant, '_spatial_stim', None)
-    trial.stim = _rescale(implant.stim, scale)
-    if modulation is not None:
-        # After the assignment above, which clears it -- an ordinary stimulus
-        # assigned to an implant has no modulation behind it:
-        trial._spatial_stim = _rescale(modulation, scale)
+    trial.stim = implant.stim * (amp / implant.stim.data.max())
     return trial
 
 
@@ -314,14 +313,15 @@ def _delivered(implant):
     The other side of :py:func:`_spatial_input`. A spatial model that feeds a
     temporal one is the case where the pulses are exactly what has to get
     through, since integrating them is what the temporal model is for. A
-    shallow copy is enough to say so: nothing but the stimulus attribute
-    differs, and neither the electrode array nor the stimulus itself is
-    duplicated.
+    shallow copy is enough to say so, with the stimulus wrapped in an ordinary
+    :py:class:`~pulse2percept.stimuli.Stimulus`: an ordinary stimulus is its
+    own spatial view, so the wrapper is what asks for the delivered pulses.
+    The wrapper stays unmaterialized until something reads them.
     """
-    if getattr(implant, '_spatial_stim', None) is None:
+    if implant.stim is None or not implant.stim._has_spatial_view:
         return implant
     stand_in = copy(implant)
-    stand_in._spatial_stim = None
+    stand_in._stim = Stimulus(implant.stim)
     return stand_in
 
 

--- a/pulse2percept/models/cortex/dynaphos.py
+++ b/pulse2percept/models/cortex/dynaphos.py
@@ -15,21 +15,51 @@ from ...topography import Polimeni2006Map
 def _pulse_train_clocks(stim):
     """``{electrode: (freq, phase_dur)}`` where the stimulus is pulse trains
 
-    Read off the trains the stimulus is made of rather than off a copy of
-    their numbers in its metadata. ``None`` when it is not made of them, in
-    which case this model simulates on its own default clock, as it always
-    has.
+    Read off the trains the stimulus is made of. ``None`` when it is not made
+    of them, in which case this model simulates on its own default clock, as
+    it always has.
 
     Has to be asked *before* the stimulus is compressed: compression installs
     a new waveform, and that is exactly what says the trains no longer
     describe it.
     """
     sources = stim._structured_sources()
-    if sources is None:
+    if sources is not None:
+        if any(type(src) is not BiphasicPulseTrain for _, src in sources):
+            return None
+        return {str(e): (src.freq, src.phase_dur) for e, src in sources}
+    return _legacy_clocks(stim)
+
+
+def _legacy_clocks(stim):
+    """The same clocks, from a container that kept only a copy of them
+
+    Compatibility for the one thing that still builds a stimulus this way:
+    :py:meth:`~pulse2percept.implants.EnsembleImplant.merge_stimuli`
+    interpolates its members into a single raw array and records what each
+    electrode was driven by alongside it. That record is all that is left of
+    the pulse trains, and without it this model would silently drop each
+    member's clock for its own default.
+
+    Not the preferred representation, and deliberately strict: only entries
+    that say they came from a
+    :py:class:`~pulse2percept.stimuli.BiphasicPulseTrain` count, so that user
+    metadata which happens to have a ``freq`` key cannot change what this
+    model simulates. Anything short of a clock for every electrode falls back
+    to the model's own.
+    """
+    try:
+        entries = stim.metadata['electrodes']
+        clocks = {}
+        for electrode in stim.electrodes:
+            entry = entries[str(electrode)]
+            if entry['type'] is not BiphasicPulseTrain:
+                return None
+            params = entry['metadata']
+            clocks[str(electrode)] = (params['freq'], params['phase_dur'])
+        return clocks
+    except (KeyError, TypeError):
         return None
-    if any(type(src) is not BiphasicPulseTrain for _, src in sources):
-        return None
-    return {str(e): (src.freq, src.phase_dur) for e, src in sources}
 
 
 #: Amperes in a microamp (1e-6). The activation cascade below is the published

--- a/pulse2percept/models/cortex/dynaphos.py
+++ b/pulse2percept/models/cortex/dynaphos.py
@@ -12,6 +12,7 @@ from ...utils import cart2pol, deprecated_alias
 from ...utils.constants import MS_PER_S, UM_PER_MM, ZORDER
 from ...topography import Polimeni2006Map
 
+
 def _pulse_train_clocks(stim):
     """``{electrode: (freq, phase_dur)}`` where the stimulus is pulse trains
 

--- a/pulse2percept/models/cortex/dynaphos.py
+++ b/pulse2percept/models/cortex/dynaphos.py
@@ -6,10 +6,31 @@ from copy import deepcopy, copy
 from ..base import BaseModel, NotBuiltError, _require_stim_dimension
 from ...percepts import Percept
 from ...implants import ProsthesisSystem
+from ...stimuli import BiphasicPulseTrain
 from ...units import A, Quantity, as_value, dva, Hz, mm, ms, uA
 from ...utils import cart2pol, deprecated_alias
 from ...utils.constants import MS_PER_S, UM_PER_MM, ZORDER
 from ...topography import Polimeni2006Map
+
+def _pulse_train_clocks(stim):
+    """``{electrode: (freq, phase_dur)}`` where the stimulus is pulse trains
+
+    Read off the trains the stimulus is made of rather than off a copy of
+    their numbers in its metadata. ``None`` when it is not made of them, in
+    which case this model simulates on its own default clock, as it always
+    has.
+
+    Has to be asked *before* the stimulus is compressed: compression installs
+    a new waveform, and that is exactly what says the trains no longer
+    describe it.
+    """
+    sources = stim._structured_sources()
+    if sources is None:
+        return None
+    if any(type(src) is not BiphasicPulseTrain for _, src in sources):
+        return None
+    return {str(e): (src.freq, src.phase_dur) for e, src in sources}
+
 
 #: Amperes in a microamp (1e-6). The activation cascade below is the published
 #: one, which is written in SI units, while a p2p stimulus is in microamps.
@@ -230,7 +251,7 @@ class DynaphosModel(BaseModel):
         self.is_built = True
         return self
                     
-    def _predict_percept(self, earray, stim, t_percept):
+    def _predict_percept(self, earray, stim, t_percept, clocks=None):
         """Predicts the brightness at spatial locations over time"""
         x_el, y_el, _ = self._electrode_coords(earray, stim)
         # whether to allow current to spread between hemispheres
@@ -259,24 +280,17 @@ class DynaphosModel(BaseModel):
         n_time = len(t_percept)
         idx_percept = np.uint32(np.round(t_percept / self.dt))
 
-        # default values
+        # The model's own clock, unless the stimulus brought one per
+        # electrode. `clocks` is keyed by name because compression drops the
+        # electrodes that are driven at zero, and these have to line up with
+        # the ones that survived:
         freq = self.freq
         p_dur = self.p_dur
-        
-        # get from biphasic pulse train data if possible
-        try:
-            elec_params = []
-            for e in stim.electrodes:
-                amp = stim.metadata['electrodes'][str(e)]['metadata']['amp']
-                freq = stim.metadata['electrodes'][str(e)]['metadata']['freq']
-                pdur = stim.metadata['electrodes'][str(e)]['metadata']['phase_dur']
-                elec_params.append([freq, amp, pdur])
-            elec_params = np.array(elec_params)
-            freq = elec_params[:,0]
-            p_dur = elec_params[:,2]
-        except KeyError:
-            pass
-        
+        if clocks is not None:
+            per_electrode = np.array([clocks[str(e)] for e in stim.electrodes])
+            freq = per_electrode[:, 0]
+            p_dur = per_electrode[:, 1]
+
         # holds instantaneous current for each phosphene
         amp = np.zeros(len(x_el))
         # holds current activation for each phosphene
@@ -411,6 +425,10 @@ class DynaphosModel(BaseModel):
                              f"have a time component.")
         # Make sure we don't change the user's Stimulus object:
         stim = deepcopy(implant.stim)
+        # The pulse clock is a question about what the stimulus is made of,
+        # and compressing it answers "samples, and nothing else". So ask
+        # first; the waveform below is what the time evolution runs on:
+        clocks = _pulse_train_clocks(stim)
         # Make sure to operate on the compressed stim:
         if not stim.is_compressed:
             stim.compress()
@@ -440,7 +458,8 @@ class DynaphosModel(BaseModel):
             # Stimulus was compressed to zero:
             resp = np.zeros((self.grid.x.size, n_time), dtype=np.float32)
         else:
-            resp = self._predict_percept(implant.earray, stim, t_percept)
+            resp = self._predict_percept(implant.earray, stim, t_percept,
+                                         clocks)
         return Percept(resp.reshape(list(self.grid.x.shape) + [t_percept.size]),
                        space=self.grid, time=t_percept,
                        time_unit=self.time_unit,

--- a/pulse2percept/models/cortex/tests/test_dynaphos.py
+++ b/pulse2percept/models/cortex/tests/test_dynaphos.py
@@ -6,11 +6,14 @@ import warnings
 import matplotlib.pyplot as plt
 
 from pulse2percept.models.cortex import DynaphosModel
-from pulse2percept.implants import ProsthesisSystem, ElectrodeArray, DiskElectrode
+from pulse2percept.models.cortex.dynaphos import _pulse_train_clocks
+from pulse2percept.implants import (DiskElectrode, ElectrodeArray,
+                                    EnsembleImplant, ProsthesisSystem)
 from pulse2percept.implants.cortex import Cortivis, Orion
 from pulse2percept.topography import Polimeni2006Map
 from pulse2percept.percepts import Percept
-from pulse2percept.stimuli import BiphasicPulseTrain, Stimulus
+from pulse2percept.stimuli import (AsymmetricBiphasicPulseTrain,
+                                   BiphasicPulseTrain, Stimulus)
 from pulse2percept.units import (DimensionMismatchError, Quantity, mA,
                                  ms, s, uA, um)
 from pulse2percept.utils.testing import assert_warns_msg
@@ -290,3 +293,80 @@ def test_dynaphos_reads_the_clock_before_compression():
     npt.assert_allclose(both.data,
                         model.predict_percept(
                             implant, t_percept=np.arange(0, 200, 20)).data)
+
+
+def _ensemble_of_two_clocks():
+    """Two implants driven at different frequencies, merged into one
+
+    `merge_stimuli` interpolates its members into a single raw array, so the
+    trains themselves do not survive -- only the record of them that this
+    model's legacy fallback reads.
+    """
+    fast = Orion(stim={e: BiphasicPulseTrain(50, 300, 0.45, stim_dur=100)
+                       for e in Orion().electrode_names})
+    slow = Orion(x=-35000,
+                 stim={e: BiphasicPulseTrain(20, 300, 0.85, stim_dur=100)
+                       for e in Orion().electrode_names})
+    return EnsembleImplant([fast, slow])
+
+
+def test_dynaphos_recovers_ensemble_clocks():
+    # An ensemble keeps no pulse trains, so without the compatibility path
+    # every member would silently be simulated at the model's own default
+    # clock instead of the one it was built with.
+    ensemble = _ensemble_of_two_clocks()
+    npt.assert_equal(ensemble.stim._structured_sources(), None)
+    clocks = _pulse_train_clocks(ensemble.stim)
+    npt.assert_equal(len(clocks), len(ensemble.stim.electrodes))
+    npt.assert_equal(sorted(set(clocks.values())), [(20, 0.85), (50, 0.45)])
+    # ...and the members keep their own, rather than sharing one:
+    npt.assert_equal(clocks['0-96'], (50, 0.45))
+    npt.assert_equal(clocks['1-96'], (20, 0.85))
+
+
+def test_dynaphos_ensemble_prediction_uses_those_clocks():
+    model = DynaphosModel(xrange=(-3, 3), yrange=(-3, 3), step=1).build()
+    ensemble = _ensemble_of_two_clocks()
+    with_clocks = model.predict_percept(ensemble).data
+    npt.assert_equal(np.any(with_clocks), True)
+    # Take the record away and the model is back on its own default clock.
+    # That the answer moves is what says the recovered clocks reached the
+    # simulation rather than merely being collected:
+    ensemble.stim.metadata['electrodes'].clear()
+    npt.assert_equal(_pulse_train_clocks(ensemble.stim), None)
+    npt.assert_equal(np.allclose(with_clocks,
+                                 model.predict_percept(ensemble).data), False)
+
+
+@pytest.mark.parametrize('build_stim', [
+    # No record of a pulse train at all:
+    lambda: Stimulus([[0, 100, 100, 0]], time=[0, 1, 99, 100]),
+    # A record that says the source was something else:
+    lambda: Stimulus([[0, 100, 100, 0]], time=[0, 1, 99, 100],
+                     metadata={'electrodes': {'0': {'type': Stimulus,
+                                                    'metadata': {}}},
+                               'user': None}),
+    # User metadata that merely happens to have the right keys:
+    lambda: Stimulus([[0, 100, 100, 0]], time=[0, 1, 99, 100],
+                     metadata={'electrodes': {'0': {'type': dict,
+                                                    'metadata': {
+                                                        'freq': 1,
+                                                        'phase_dur': 9}}},
+                               'user': None}),
+])
+def test_dynaphos_legacy_clocks_are_strict(build_stim):
+    # The fallback exists for containers that really did hold pulse trains.
+    # Anything else leaves the model on its own clock:
+    npt.assert_equal(_pulse_train_clocks(build_stim()), None)
+
+
+def test_dynaphos_legacy_clocks_are_not_read_when_structure_says_otherwise():
+    # A DC offset leaves no train behind, and drops the parameters with it --
+    # the fallback must not resurrect them from a leftover record:
+    stim = Stimulus({'0': BiphasicPulseTrain(20, 100, 0.45, stim_dur=100)})
+    npt.assert_equal(_pulse_train_clocks(stim + 5), None)
+    # A stimulus made of something other than biphasic trains stays on the
+    # defaults too, rather than falling through to whatever was recorded:
+    asym = Stimulus({'0': AsymmetricBiphasicPulseTrain(20, 100, 50, 0.45, 0.9,
+                                                       stim_dur=100)})
+    npt.assert_equal(_pulse_train_clocks(asym), None)

--- a/pulse2percept/models/cortex/tests/test_dynaphos.py
+++ b/pulse2percept/models/cortex/tests/test_dynaphos.py
@@ -12,8 +12,10 @@ from pulse2percept.implants import (DiskElectrode, ElectrodeArray,
 from pulse2percept.implants.cortex import Cortivis, Orion
 from pulse2percept.topography import Polimeni2006Map
 from pulse2percept.percepts import Percept
-from pulse2percept.stimuli import (AsymmetricBiphasicPulseTrain,
-                                   BiphasicPulseTrain, Stimulus)
+from pulse2percept.stimuli import (AmplitudeEncoder,
+                                   AsymmetricBiphasicPulseTrain,
+                                   BiphasicPulseTrain, ImageStimulus,
+                                   Stimulus)
 from pulse2percept.units import (DimensionMismatchError, Quantity, mA,
                                  ms, s, uA, um)
 from pulse2percept.utils.testing import assert_warns_msg
@@ -370,3 +372,18 @@ def test_dynaphos_legacy_clocks_are_not_read_when_structure_says_otherwise():
     asym = Stimulus({'0': AsymmetricBiphasicPulseTrain(20, 100, 50, 0.45, 0.9,
                                                        stim_dur=100)})
     npt.assert_equal(_pulse_train_clocks(asym), None)
+
+
+def test_dynaphos_uses_its_defaults_for_an_encoded_stimulus():
+    # An encoder's schedule can change frequency from frame to frame, so there
+    # is no per-electrode clock to take from it. The model stays on its own,
+    # and does not fall through to whatever the metadata happens to hold:
+    implant = Cortivis(x=1000)
+    encoded = AmplitudeEncoder().encode(
+        ImageStimulus(np.linspace(0, 1, 64).reshape(8, 8)), implant=implant)
+    npt.assert_equal(_pulse_train_clocks(encoded), None)
+    # A single-electrode schedule is a structured source, and is refused on
+    # the same grounds rather than read as a pulse train:
+    solo = AmplitudeEncoder().encode(ImageStimulus(np.array([[0.7]])))
+    npt.assert_equal(len(solo._structured_sources()), 1)
+    npt.assert_equal(_pulse_train_clocks(solo), None)

--- a/pulse2percept/models/cortex/tests/test_dynaphos.py
+++ b/pulse2percept/models/cortex/tests/test_dynaphos.py
@@ -10,7 +10,7 @@ from pulse2percept.implants import ProsthesisSystem, ElectrodeArray, DiskElectro
 from pulse2percept.implants.cortex import Cortivis, Orion
 from pulse2percept.topography import Polimeni2006Map
 from pulse2percept.percepts import Percept
-from pulse2percept.stimuli import BiphasicPulseTrain
+from pulse2percept.stimuli import BiphasicPulseTrain, Stimulus
 from pulse2percept.units import (DimensionMismatchError, Quantity, mA,
                                  ms, s, uA, um)
 from pulse2percept.utils.testing import assert_warns_msg
@@ -65,20 +65,26 @@ def test_temporal_predict():
         implant.stim = np.ones((96, 100))
         model.predict_percept(implant, t_percept=[0.2, 0.2])
 
-    # Brightness scales with amplitude:
+    # Brightness scales with amplitude. The train is built on the model's own
+    # clock, so that the duty cycle driving the activation is the one that
+    # produced the waveform. It used not to be: a train assigned on its own
+    # (rather than as {electrode: train}) carried no per-electrode metadata,
+    # so this model silently simulated it at `self.freq`/`self.p_dur` however
+    # it was actually built. It now reads the train itself.
     model.dt = 20
     sdur = 1000.0  # stimulus duration (ms)
-    pdur = 0.45  # (ms)
+    pdur = model.p_dur  # (ms)
     t_percept = np.arange(0, sdur, 20)
     implant = ProsthesisSystem(ElectrodeArray(DiskElectrode(0, 0, 0, 260)))
     bright_amp = []
     for amp in np.linspace(20, 70, 5):
-        implant.stim = BiphasicPulseTrain(20, amp, pdur, interphase_dur=pdur,
-                                          stim_dur=sdur)
+        implant.stim = BiphasicPulseTrain(model.freq, amp, pdur,
+                                          interphase_dur=pdur, stim_dur=sdur)
         percept = model.predict_percept(implant, t_percept=t_percept)
         bright_amp.append(percept.data.max())
-    bright_amp_ref = np.array([0.0, 0.0, 0.0, 0.66, 0.841])
+    bright_amp_ref = np.array([0.0, 0.0, 0.4636, 0.7247, 0.8891])
     npt.assert_almost_equal(bright_amp, bright_amp_ref, decimal=3)
+    npt.assert_equal(np.all(np.diff(bright_amp) >= 0), True)
 
     # Test that default models give expected values
     implant = Orion(x=15000, stim={'55': BiphasicPulseTrain(freq=300, amp=100, phase_dur=0.17)})
@@ -217,3 +223,70 @@ def test_DynaphosModel_deprecated_xystep():
         model = DynaphosModel(step=1)
         model.step = 2
         npt.assert_almost_equal(model.step, 2)
+
+
+def test_dynaphos_reads_the_pulse_train_not_its_metadata():
+    # The same train has to predict the same percept however it is assigned,
+    # and whatever its metadata says. Both used to be false: a bare train
+    # carried no per-electrode metadata and was simulated on the model's
+    # default clock instead of its own.
+    model = DynaphosModel(step=0.5, xrange=(-2, 2), yrange=(-2, 2)).build()
+    model.dt = 20
+    t_percept = np.arange(0, 200, 20)
+
+    def predict(stim):
+        implant = ProsthesisSystem(ElectrodeArray(DiskElectrode(0, 0, 0, 260)))
+        implant.stim = stim
+        return model.predict_percept(implant, t_percept=t_percept).data
+
+    def train():
+        return BiphasicPulseTrain(300, 100, 0.17, interphase_dur=0.17,
+                                  stim_dur=200)
+    bare = predict(train())
+    npt.assert_array_equal(bare, predict({0: train()}))
+    npt.assert_equal(np.any(bare), True)
+
+    # Corrupting the compatibility metadata changes nothing:
+    corrupt = train()
+    corrupt.metadata.update(freq=1, amp=0, phase_dur=99)
+    npt.assert_array_equal(bare, predict(corrupt))
+    wiped = train()
+    wiped.metadata.clear()
+    npt.assert_array_equal(bare, predict(wiped))
+
+
+def test_dynaphos_uses_its_defaults_for_an_arbitrary_waveform():
+    # No pulse train behind the samples, so there is no clock to read and the
+    # model simulates on its own -- which is what it has always done:
+    model = DynaphosModel(step=0.5, xrange=(-2, 2), yrange=(-2, 2)).build()
+    model.dt = 20
+    implant = ProsthesisSystem(ElectrodeArray(DiskElectrode(0, 0, 0, 260)))
+    implant.stim = Stimulus([[0, 100, 100, 0]], time=[0, 1, 199, 200])
+    percept = model.predict_percept(implant, t_percept=np.arange(0, 200, 20))
+    npt.assert_equal(np.any(percept.data), True)
+    # A train whose own clock happens to be the model's gives the same answer
+    # as the defaults do, which is what says the defaults were used:
+    model.freq, model.p_dur = 111, 0.29
+    other = model.predict_percept(implant,
+                                  t_percept=np.arange(0, 200, 20)).data
+    npt.assert_equal(np.allclose(percept.data, other), False)
+
+
+def test_dynaphos_reads_the_clock_before_compression():
+    # `compress` installs a new waveform, which is what says the trains behind
+    # it no longer describe it. The parameters have to be taken first -- and
+    # compression drops the electrodes driven at zero, so what is left has to
+    # still line up with the right train.
+    model = DynaphosModel(step=0.5, xrange=(-2, 2), yrange=(-2, 2)).build()
+    model.dt = 20
+    implant = ProsthesisSystem(ElectrodeArray([
+        DiskElectrode(0, 0, 0, 260), DiskElectrode(1000, 0, 0, 260)]))
+    implant.stim = {0: BiphasicPulseTrain(300, 0, 0.17, stim_dur=200),
+                    1: BiphasicPulseTrain(300, 100, 0.17, stim_dur=200)}
+    both = model.predict_percept(implant, t_percept=np.arange(0, 200, 20))
+    # Only the second electrode survives compression, and it is the second
+    # train's clock that has to reach the simulation:
+    implant.stim = {1: BiphasicPulseTrain(300, 100, 0.17, stim_dur=200)}
+    npt.assert_allclose(both.data,
+                        model.predict_percept(
+                            implant, t_percept=np.arange(0, 200, 20)).data)

--- a/pulse2percept/models/granley2021.py
+++ b/pulse2percept/models/granley2021.py
@@ -14,14 +14,14 @@ from .base import NotBuiltError, BaseModel, _require_stim_dimension
 from ._granley2021 import fast_biphasic_axon_map
 
 # `find_threshold` bisects on a scaled copy of the stimulus *data*. This model
-# reads amplitude from the stimulus metadata instead, where it means a
-# multiple of threshold rather than a current, so scaling the data leaves the
-# prediction untouched and the search cannot converge:
+# reads amplitude off the pulse train instead, where it means a multiple of
+# threshold rather than a current, so scaling the data leaves the prediction
+# untouched and the search cannot converge:
 _FIND_THRESHOLD_MSG = (
     "{cls} does not support find_threshold. It takes amplitude as a multiple "
-    "of threshold and reads it from the stimulus metadata, not from the "
-    "stimulus data, so scaling the data leaves the percept unchanged. Vary "
-    "`amp` when building the BiphasicPulseTrain instead."
+    "of threshold and reads it from the pulse train the stimulus is made of, "
+    "not from the stimulus data, so scaling the data leaves the percept "
+    "unchanged. Vary `amp` when building the BiphasicPulseTrain instead."
 )
 
 
@@ -202,6 +202,48 @@ class DefaultStreakModel(BaseModel):
         min_f_streak = self.min_lambda**2 / self.lam ** 2
         F_streak = self.a9 - self.a7 * pdur ** self.a8
         return np.maximum(F_streak, min_f_streak)
+
+
+def _pulse_train_params(stim):
+    """``(electrode, freq, amp, phase_dur)`` for every electrode driven
+
+    Read off the pulse trains the stimulus is made of rather than off a copy
+    of their numbers in its metadata: a stimulus whose samples were rewritten
+    has no train behind it any more, and this is what tells the two apart. No
+    waveform is generated to answer the question.
+
+    Electrodes driven at zero amplitude are left out, so an empty list means
+    the percept is zero.
+
+    Raises
+    ------
+    TypeError
+        If any electrode is driven by something other than a
+        :py:class:`~pulse2percept.stimuli.BiphasicPulseTrain` with
+        ``delay_dur=0``.
+    """
+    sources = stim._structured_sources()
+    if sources is None:
+        # No pulse train is retained anywhere. A stimulus of nothing but
+        # zeros is not one either, but it has always been answered with a
+        # zero percept rather than an error -- and it is the only case that
+        # costs a waveform this model otherwise never asks for:
+        if not np.any(stim.data):
+            return []
+        raise TypeError("All stimuli must be BiphasicPulseTrains with no "
+                        "delay dur")
+    params = []
+    for electrode, source in sources:
+        # The exact class, not a subclass: this model's parameters are the
+        # ones `BiphasicPulseTrain` is made of, and nothing else has been
+        # shown to mean the same thing to it.
+        if type(source) is not BiphasicPulseTrain or source.delay_dur != 0:
+            raise TypeError(f"All stimuli must be BiphasicPulseTrains with "
+                            f"no delay dur (Failing electrode: {electrode})")
+        if source.amp == 0:
+            continue
+        params.append((electrode, source.freq, source.amp, source.phase_dur))
+    return params
 
 
 class BiphasicAxonMapSpatial(AxonMapSpatial):
@@ -449,21 +491,10 @@ class BiphasicAxonMapSpatial(AxonMapSpatial):
         if not isinstance(stim, Stimulus):
             raise TypeError(
                 "Stim must be of type Stimulus but it is " + str(type(stim)))
-        elec_params = []
-        active = []
-        try:
-            for e in stim.electrodes:
-                amp = stim.metadata['electrodes'][str(e)]['metadata']['amp']
-                if amp == 0:
-                    continue
-                freq = stim.metadata['electrodes'][str(e)]['metadata']['freq']
-                pdur = stim.metadata['electrodes'][str(e)]['metadata']['phase_dur']
-                elec_params.append([freq, amp, pdur])
-                active.append(e)
-        except KeyError:
-            raise TypeError(f"All stimuli must be BiphasicPulseTrains with no " +
-                            f"delay dur")
-        elec_params = np.array(elec_params, dtype=np.float32)
+        params = _pulse_train_params(stim)
+        active = [electrode for electrode, _, _, _ in params]
+        elec_params = np.array([p[1:] for p in params],
+                               dtype=np.float32).reshape((-1, 3))
         # Only the electrodes that are actually driven, in the order they were
         # collected above:
         xyz = earray.coordinates(self.space_unit, electrodes=active)
@@ -548,35 +579,21 @@ class BiphasicAxonMapSpatial(AxonMapSpatial):
         # current at all, and saying so is more use than asking it for pulse
         # metadata it was never going to have.
         _require_stim_dimension(self, implant.stim)
-        # Make sure stimulus is a BiphasicPulseTrain:
-        if not isinstance(implant.stim, BiphasicPulseTrain):
-            # Could still be a stimulus where each electrode has a biphasic pulse train
-            # or a 0 stimulus
-            try:
-                for i, (ele, params) in enumerate(implant.stim.metadata
-                                                ['electrodes'].items()):
-                    if (params['type'] != BiphasicPulseTrain or
-                            params['metadata']['delay_dur'] != 0) and \
-                            np.any(implant.stim[i]):
-                        raise TypeError(
-                            f"All stimuli must be BiphasicPulseTrains with no " +
-                            f"delay dur (Failing electrode: {ele})")
-            except KeyError:
-                raise TypeError(f"All stimuli must be BiphasicPulseTrains with no " +
-                                f"delay dur")
+        # Which pulse trains this stimulus is made of, and whether it is made
+        # of pulse trains at all. Asked here so that an unreadable stimulus is
+        # refused before any of the work below:
+        params = _pulse_train_params(implant.stim)
         t_percept = as_value(t_percept, self.time_unit, 't_percept')
         stim = implant.stim
         # `np.array([t]).size` rather than `len(t)`, so that the documented
         # scalar spelling `t_percept=20` counts as one time point instead
         # of raising -- the same idiom `SpatialModel.predict_percept` uses:
         n_time = 1 if t_percept is None else np.array([t_percept]).size
-        if not np.any(stim.data):
-            # Stimulus is 0
+        if not params:
+            # Nothing is driven above zero amplitude:
             resp = np.zeros(list(self.grid.x.shape) + [n_time],
                             dtype=np.float32)
         else:
-            # Make sure stimulus is in proper format
-            stim = Stimulus(stim)
             resp = np.zeros(list(self.grid.x.shape) + [n_time])
             # Response goes in first frame
             resp[:, :, 0] = self._predict_spatial(
@@ -621,12 +638,16 @@ class BiphasicAxonMapModel(Model):
         Stimuli should pass amplitude as a factor of threshold, NOT as raw
         amplitude in microamps.
 
-        This model interacts with `Stimulus` objects by reading the intended
-        amplitude, frequency, and pulse duration from their metadata, not
-        from the raw stimulus data. The arithmetic operators keep that
-        metadata in sync, so scaling a pulse train (``pt * 2``) or the
-        stimulus assembled from one (``implant.stim * 2``) does change the
-        percept, while editing the data array in place does not.
+        This model reads amplitude, frequency and pulse duration off the
+        :py:class:`~pulse2percept.stimuli.BiphasicPulseTrain` objects the
+        stimulus is made of, not off its samples. Scaling a pulse train
+        (``pt * 2``) or the stimulus assembled from one
+        (``implant.stim * 2``) gives a train at the new amplitude and does
+        change the percept, while editing the data array in place does not.
+        A stimulus that is only samples -- a raw waveform, an appended
+        sequence of two trains, anything whose amplitudes were rewritten --
+        is refused rather than predicted from numbers that no longer
+        describe it.
 
     Parameters
     ----------
@@ -761,10 +782,11 @@ class BiphasicAxonMapModel(Model):
             Stimuli should pass amplitude as a factor of threshold,
             NOT as raw amplitude in microamps.
 
-            The model interacts with `Stimulus` objects by reading the
-            intended amplitude, frequency, and pulse duration from their
-            metadata, not from the raw stimulus data. Editing the data
-            array in place will not change the predicted percept.
+            The model reads the intended amplitude, frequency and pulse
+            duration off the
+            :py:class:`~pulse2percept.stimuli.BiphasicPulseTrain` objects the
+            stimulus is made of, not off its samples. Editing the data array
+            in place will not change the predicted percept.
 
         Parameters
         ----------

--- a/pulse2percept/models/tests/test_base.py
+++ b/pulse2percept/models/tests/test_base.py
@@ -1935,3 +1935,25 @@ def test_postprocess_spatial_hook():
     npt.assert_equal(len(seen), 1)
     npt.assert_equal(seen[0], (plain.grid.x.size, expected.data.shape[-1]))
     npt.assert_allclose(got.data, 2 * expected.data)
+
+
+def test_models_accept_read_only_stimulus_data():
+    # Every Cython kernel receives `Stimulus.data` as it is stored, and a
+    # stimulus stores it read-only. A memoryview that is not declared `const`
+    # rejects such an array outright ("buffer source array is read-only"),
+    # which is a failure no numerical test would catch on its own.
+    from pulse2percept.models import Nanduri2012Spatial, Nanduri2012Temporal
+    implant = ArgusII(stim={'A1': BiphasicPulseTrain(20, 50, 0.45,
+                                                     stim_dur=20)})
+    npt.assert_equal(implant.stim.data.flags.writeable, False)
+    spatial = Nanduri2012Spatial(xrange=(-1, 1), yrange=(-1, 1),
+                                 step=1).build()
+    resp = spatial.predict_percept(implant)
+    npt.assert_equal(np.all(np.isfinite(resp.data)), True)
+    temporal = Nanduri2012Temporal().build()
+    npt.assert_equal(temporal.predict_percept(implant.stim) is not None, True)
+    # And the same for the axon map / scoreboard kernels:
+    for cls in (ScoreboardSpatial, AxonMapSpatial):
+        model = cls(xrange=(-1, 1), yrange=(-1, 1), step=1).build()
+        npt.assert_equal(np.all(np.isfinite(
+            model.predict_percept(implant).data)), True)

--- a/pulse2percept/models/tests/test_base.py
+++ b/pulse2percept/models/tests/test_base.py
@@ -1,3 +1,4 @@
+from contextlib import contextmanager
 import copy
 import multiprocessing
 import warnings
@@ -17,7 +18,7 @@ from pulse2percept.models import (AxonMapModel, AxonMapSpatial, BaseModel,
                                   FadingTemporal, Model, NotBuiltError,
                                   ScoreboardModel, ScoreboardSpatial,
                                   SpatialModel, TemporalModel)
-from pulse2percept.models.base import _blend_meridian
+from pulse2percept.models.base import _blend_meridian, _rescaled_implant
 from pulse2percept.models.cortex import (ScoreboardSpatial as
                                          CortexScoreboardSpatial)
 from pulse2percept.units import (DimensionMismatchError, Quantity,
@@ -1660,7 +1661,7 @@ def test_spatial_model_reads_modulation_not_pulses():
     npt.assert_equal(percept.data.shape[-1], 1)
     # ... and every electrode the image lights is lit in it, rather than the
     # one raster group that happened to be firing at the sampled instant:
-    lit = implant._spatial_stim.data.ravel() > 0
+    lit = implant.stim._spatial_view().data.ravel() > 0
     npt.assert_equal(lit.sum() > 10, True)
     groups = implant.raster.groups(implant.electrode_names)
     # No instant of the delivered train ever holds more than one group, so
@@ -1671,7 +1672,7 @@ def test_spatial_model_reads_modulation_not_pulses():
     # Which is what the percept says too: it is the same picture the
     # modulation asked for, run through the model.
     direct = spatial.predict_percept(
-        ArgusII(encoder=None, stim=implant._spatial_stim))
+        ArgusII(encoder=None, stim=implant.stim._spatial_view()))
     npt.assert_almost_equal(percept.data, direct.data)
 
     # A video reports one percept frame per *video* frame:
@@ -1697,7 +1698,7 @@ def test_spatial_model_reads_modulation_not_pulses():
     both.predict_percept(implant)
     npt.assert_array_less(seen[-1], 0)
     # ... and the implant it was handed is untouched by that:
-    npt.assert_equal(implant._spatial_stim is None, False)
+    npt.assert_equal(implant.stim._has_spatial_view, True)
     # Spatial-only, the same model class reads the modulation instead:
     seen.clear()
     Recording(xrange=(-12, 12), yrange=(-8, 8),
@@ -1708,7 +1709,7 @@ def test_spatial_model_reads_modulation_not_pulses():
     # modulation behind it, so there is nothing to prefer.
     plain = ArgusII(stim={'A1': BiphasicPulseTrain(20, 50, 0.45,
                                                    stim_dur=100)})
-    npt.assert_equal(plain._spatial_stim, None)
+    npt.assert_equal(plain.stim._has_spatial_view, False)
     npt.assert_equal(
         spatial.predict_percept(plain).data.shape[-1],
         plain.stim.time.size)
@@ -1725,9 +1726,10 @@ def test_find_threshold_scales_both_representations():
     npt.assert_equal(0 < amp_th < 500, True)
     # The answer is a threshold of what `predict_percept` reports, which is
     # only true if both descriptions were scaled together:
+    modulation = implant.stim._spatial_view()
     scaled = ArgusII(encoder=None, stim=Stimulus(
-        implant._spatial_stim.data * amp_th / implant.stim.data.max(),
-        electrodes=implant._spatial_stim.electrodes))
+        modulation.data * amp_th / implant.stim.data.max(),
+        electrodes=modulation.electrodes))
     npt.assert_allclose(model.predict_percept(scaled).data.max(), 50,
                         rtol=0.05)
 
@@ -1957,3 +1959,94 @@ def test_models_accept_read_only_stimulus_data():
         model = cls(xrange=(-1, 1), yrange=(-1, 1), step=1).build()
         npt.assert_equal(np.all(np.isfinite(
             model.predict_percept(implant).data)), True)
+
+
+@contextmanager
+def _no_schedule_expansion():
+    """Make expanding an encoder schedule into a waveform an error
+
+    The only way to state "this path never needs the pulses" as a test: if
+    anything reaches for them, it fails loudly.
+    """
+    from pulse2percept.stimuli.encoders import _EncodedStimulus
+    original = _EncodedStimulus._render
+
+    def refuse(self):
+        raise AssertionError('expanded an encoder schedule')
+    _EncodedStimulus._render = refuse
+    try:
+        yield
+    finally:
+        _EncodedStimulus._render = original
+
+
+@pytest.mark.parametrize('source', ['image', 'video'])
+def test_spatial_model_predicts_without_expanding_the_schedule(source):
+    # A spatial model reads one amplitude per electrode per frame. Nothing
+    # about that needs the pulse train the schedule would expand into.
+    spatial = ScoreboardSpatial(xrange=(-12, 12), yrange=(-8, 8),
+                                step=1).build()
+    picture = (LogoBVL() if source == 'image' else
+               VideoStimulus(np.random.default_rng(0).random((6, 10, 4)),
+                             metadata={'fps': 20}))
+    with warnings.catch_warnings():
+        warnings.simplefilter('ignore')
+        implant = ArgusII(stim=picture)
+    with _no_schedule_expansion():
+        percept = spatial.predict_percept(implant)
+    npt.assert_equal(np.any(percept.data), True)
+    npt.assert_equal(percept.data.shape[-1], 1 if source == 'image' else 4)
+
+
+def test_combined_model_still_integrates_the_delivered_pulses():
+    # The opposite case: a temporal stage integrates pulses, so the spatial
+    # stage under it has to be handed them. That reading is unchanged, and the
+    # implant it was asked of keeps its own schedule.
+    implant = ArgusII(stim=LogoBVL())
+    seen = []
+
+    class Recording(ScoreboardSpatial):
+        def _predict_spatial(self, earray, stim):
+            # A pulse train has cathodic phases in it; modulation amplitudes
+            # never do. The sign says which one arrived:
+            seen.append(float(stim.data.min()))
+            return super()._predict_spatial(earray, stim)
+
+    both = Model(spatial=Recording(xrange=(-12, 12), yrange=(-8, 8), step=1),
+                 temporal=FadingTemporal(tau=100)).build()
+    both.predict_percept(implant)
+    npt.assert_array_less(seen[-1], 0)
+    # The stand-in did not take the schedule away from the implant:
+    npt.assert_equal(implant.stim._has_spatial_view, True)
+
+
+def test_find_threshold_scales_an_encoded_stimulus_structurally():
+    # Every trial scales the one schedule, so the modulation a spatial model
+    # reads and the waveform a temporal one would read move together -- and
+    # the search never has to expand either.
+    implant = ArgusII(stim=LogoBVL())
+    model = ScoreboardModel(xrange=(-12, 12), yrange=(-8, 8), step=1).build()
+    # The search reads the delivered peak once, to know what it is scaling
+    # to. From there on nothing needs the pulses:
+    peak = implant.stim.data.max()
+    with _no_schedule_expansion():
+        trial = _rescaled_implant(implant, 2 * peak)
+        npt.assert_equal(type(trial.stim), type(implant.stim))
+        npt.assert_allclose(trial.stim._spatial_view().data,
+                            2 * implant.stim._spatial_view().data, rtol=1e-6)
+        npt.assert_equal(np.any(model.predict_percept(trial).data), True)
+
+
+def test_deactivating_an_encoded_electrode_keeps_the_schedule():
+    implant = ArgusII(stim=LogoBVL())
+    before = implant.stim._spatial_view()
+    with _no_schedule_expansion():
+        implant.deactivate(['A1', 'B2'])
+        after = implant.stim._spatial_view()
+    npt.assert_equal(implant.stim._has_spatial_view, True)
+    npt.assert_equal(len(implant.stim.electrodes), 58)
+    keep = [i for i, e in enumerate(before.electrodes)
+            if str(e) not in ('A1', 'B2')]
+    npt.assert_array_equal(after.data, before.data[keep])
+    # The waveform is still there to be had, and matches too:
+    npt.assert_equal(implant.stim.data.shape[0], 58)

--- a/pulse2percept/models/tests/test_end_to_end.py
+++ b/pulse2percept/models/tests/test_end_to_end.py
@@ -24,7 +24,8 @@ from pulse2percept.implants import (ArgusII, CustomRaster, DiskElectrode,
                                     ElectrodeArray, ProsthesisSystem)
 from pulse2percept.models import FadingTemporal, Model, ScoreboardSpatial
 from pulse2percept.stimuli import (AmplitudeEncoder, BostonTrain,
-                                   FrequencyEncoder, ImageStimulus)
+                                   FrequencyEncoder, ImageStimulus,
+                                   Stimulus)
 from pulse2percept.utils.constants import DT
 
 # Electrode names in the order `ElectrodeArray` keeps them, and their positions
@@ -96,6 +97,13 @@ def test_endtoend_amplitude_modulation():
     npt.assert_almost_equal(net, 0, decimal=4)
 
     # --- what the model made of it --------------------------------------
+    # A spatial model reads what the encoder *asked* each electrode for, since
+    # a raster slot is a fact about time it has no way to express (see
+    # `models.base._spatial_input`). Wrapping the schedule in an ordinary
+    # `Stimulus` is what asks for the delivered pulses instead, which is what
+    # makes the raster visible below:
+    npt.assert_equal(implant.stim._spatial_view().shape, (4, 1))
+    implant.stim = Stimulus(stim)
     model = ScoreboardSpatial(xrange=(-4, 4), yrange=(-4, 4), step=0.2,
                               rho=200).build()
     percept = model.predict_percept(implant)
@@ -234,7 +242,9 @@ def test_endtoend_raster_order(order):
 
     # And the percept says the same: the electrodes light up one at a time, in
     # the order the raster puts them in, and each is as bright as its own gray
-    # level regardless of when its turn comes.
+    # level regardless of when its turn comes. Asked of the delivered pulses,
+    # because that is where a raster lives (see `_spatial_input`):
+    implant.stim = Stimulus(stim)
     model = ScoreboardSpatial(xrange=(-4, 4), yrange=(-4, 4), step=0.2,
                               rho=200).build()
     percept = model.predict_percept(implant)

--- a/pulse2percept/models/tests/test_granley2021.py
+++ b/pulse2percept/models/tests/test_granley2021.py
@@ -1,3 +1,4 @@
+from contextlib import contextmanager
 import copy
 import warnings
 
@@ -7,7 +8,8 @@ import numpy.testing as npt
 
 from pulse2percept.implants import ArgusI, ArgusII
 from pulse2percept.percepts import Percept
-from pulse2percept.stimuli import (BiphasicPulseTrain, ImageStimulus,
+from pulse2percept.stimuli import (AsymmetricBiphasicPulseTrain,
+                                   BiphasicPulseTrain, ImageStimulus,
                                    MonophasicPulse, Stimulus)
 from pulse2percept.models import BiphasicAxonMapModel, BiphasicAxonMapSpatial, \
     AxonMapSpatial
@@ -439,10 +441,10 @@ def test_DefaultStreakModel_deprecated_axlambda():
 @pytest.mark.parametrize('model_cls', [BiphasicAxonMapModel,
                                        BiphasicAxonMapSpatial])
 def test_find_threshold_not_supported(model_cls):
-    # This model takes amplitude as a multiple of threshold and reads it from
-    # the stimulus metadata, so the inherited `find_threshold` - which bisects
-    # on a scaled copy of the stimulus data - cannot converge. It has to say
-    # so rather than fail somewhere deeper with a confusing message.
+    # This model takes amplitude as a multiple of threshold and reads it off
+    # the pulse train, so the inherited `find_threshold` - which bisects on a
+    # scaled copy of the stimulus data - cannot converge. It has to say so
+    # rather than fail somewhere deeper with a confusing message.
     model = model_cls(xrange=(-3, 3), yrange=(-2, 2), step=1,
                       n_ax_segments=30).build()
     implant = ArgusII(stim={'A1': BiphasicPulseTrain(20, 1, 0.45,
@@ -450,7 +452,7 @@ def test_find_threshold_not_supported(model_cls):
     with pytest.raises(NotImplementedError) as excinfo:
         model.find_threshold(implant, 0.5)
     npt.assert_equal(model_cls.__name__ in str(excinfo.value), True)
-    npt.assert_equal('metadata' in str(excinfo.value), True)
+    npt.assert_equal('pulse train' in str(excinfo.value), True)
     # predict_percept is unaffected:
     npt.assert_equal(model.predict_percept(implant) is not None, True)
 
@@ -734,3 +736,111 @@ def test_BiphasicAxonMapSpatial_meridian_blend(ModelClass):
     delta = np.abs(blended - unblended)
     rows = delta.max(axis=(1, 2)) > delta.max() * 1e-3
     npt.assert_array_less(np.abs(y[rows]).max(), 4 * width)
+
+
+@contextmanager
+def _no_pulse_train_rendering():
+    """Make generating a pulse train's waveform an error
+
+    The only way to state "this model never asks for samples" as a test: if
+    anything on the prediction path reaches for one, it fails loudly.
+    """
+    original = BiphasicPulseTrain._render
+
+    def refuse(self):
+        raise AssertionError('generated a pulse train waveform')
+    BiphasicPulseTrain._render = refuse
+    try:
+        yield
+    finally:
+        BiphasicPulseTrain._render = original
+
+
+@pytest.mark.parametrize('model_cls', [BiphasicAxonMapModel,
+                                       BiphasicAxonMapSpatial])
+@pytest.mark.parametrize('build_stim', [
+    lambda: BiphasicPulseTrain(20, 1, 0.45, stim_dur=100, electrode='C5'),
+    lambda: {'C5': BiphasicPulseTrain(20, 1, 0.45, stim_dur=100),
+             'A2': BiphasicPulseTrain(30, 2, 0.45, stim_dur=100)},
+    lambda: Stimulus({'C5': BiphasicPulseTrain(20, 1, 0.45, stim_dur=100)}) * 2,
+])
+def test_BiphasicAxonMap_predicts_without_a_waveform(model_cls, build_stim):
+    # This model is a function of frequency, amplitude and phase duration, and
+    # it now takes them from the pulse trains themselves. None of them needs
+    # the train sampled, so predicting must not sample one.
+    model = model_cls(xrange=(-3, 3), yrange=(-2, 2), step=1,
+                      n_ax_segments=30).build()
+    implant = ArgusII(stim=build_stim())
+    with _no_pulse_train_rendering():
+        percept = model.predict_percept(implant)
+    npt.assert_equal(np.any(percept.data), True)
+
+
+@pytest.mark.parametrize('model_cls', [BiphasicAxonMapModel,
+                                       BiphasicAxonMapSpatial])
+@pytest.mark.parametrize('corrupt', [
+    lambda m: m.clear(),
+    lambda m: m['electrodes'].clear(),
+    lambda m: m['electrodes']['C5']['metadata'].update(amp=999, freq=1),
+    lambda m: m['electrodes']['C5'].update(type=object),
+])
+def test_BiphasicAxonMap_ignores_pulse_metadata(model_cls, corrupt):
+    # The metadata is a copy of what the trains say, kept for compatibility.
+    # Corrupting it must not move the percept, and must not change whether the
+    # stimulus is accepted:
+    model = model_cls(xrange=(-3, 3), yrange=(-2, 2), step=1,
+                      n_ax_segments=30).build()
+    implant = ArgusII(stim={'C5': BiphasicPulseTrain(20, 1, 0.45,
+                                                     stim_dur=100)})
+    expected = model.predict_percept(implant).data
+    corrupt(implant.stim.metadata)
+    npt.assert_array_equal(model.predict_percept(implant).data, expected)
+
+
+@pytest.mark.parametrize('model_cls', [BiphasicAxonMapModel,
+                                       BiphasicAxonMapSpatial])
+@pytest.mark.parametrize('build_stim', [
+    lambda: {'C5': MonophasicPulse(-1, 0.45, stim_dur=100)},
+    lambda: {'C5': AsymmetricBiphasicPulseTrain(20, 1, 2, 0.45, 0.9,
+                                                stim_dur=100)},
+    lambda: {'C5': BiphasicPulseTrain(20, 1, 0.45, delay_dur=1,
+                                      stim_dur=100)},
+    lambda: (BiphasicPulseTrain(20, 1, 0.45, stim_dur=100, electrode='C5')
+             .append(BiphasicPulseTrain(50, 1, 0.45, stim_dur=100,
+                                        electrode='C5'))),
+    lambda: {'C5': Stimulus([[0, 1, 1, 0]], time=[0, 1, 99, 100])},
+])
+def test_BiphasicAxonMap_rejects_what_it_cannot_read(model_cls, build_stim):
+    # A sequence of two trains has no single frequency, an asymmetric train is
+    # not this model's protocol, a delayed one is outside what it was fit on,
+    # and a raw waveform has no parameters at all. Each is refused rather than
+    # predicted from whatever numbers happen to be lying around:
+    model = model_cls(xrange=(-3, 3), yrange=(-2, 2), step=1,
+                      n_ax_segments=30).build()
+    implant = ArgusII(stim=build_stim())
+    with pytest.raises(TypeError):
+        model.predict_percept(implant)
+
+
+@pytest.mark.parametrize('model_cls', [BiphasicAxonMapModel,
+                                       BiphasicAxonMapSpatial])
+def test_BiphasicAxonMap_zero_amplitude_is_inactive(model_cls):
+    # A train at zero amplitude drives nothing, which is a zero percept rather
+    # than an error -- and is read off `amp`, not off the waveform:
+    model = model_cls(xrange=(-3, 3), yrange=(-2, 2), step=1,
+                      n_ax_segments=30).build()
+    implant = ArgusII(stim={'C5': BiphasicPulseTrain(20, 0, 0.45,
+                                                     stim_dur=100),
+                            'A2': BiphasicPulseTrain(20, 0, 0.45,
+                                                     stim_dur=100)})
+    with _no_pulse_train_rendering():
+        percept = model.predict_percept(implant)
+    npt.assert_almost_equal(percept.data, 0)
+    # One driven electrode among zeros still predicts from that one alone:
+    implant.stim = {'C5': BiphasicPulseTrain(20, 0, 0.45, stim_dur=100),
+                    'A2': BiphasicPulseTrain(20, 1, 0.45, stim_dur=100)}
+    with _no_pulse_train_rendering():
+        mixed = model.predict_percept(implant).data
+    only = model.predict_percept(ArgusII(
+        stim={'A2': BiphasicPulseTrain(20, 1, 0.45, stim_dur=100)})).data
+    npt.assert_array_almost_equal(mixed, only)

--- a/pulse2percept/models/tests/test_granley2021.py
+++ b/pulse2percept/models/tests/test_granley2021.py
@@ -8,7 +8,8 @@ import numpy.testing as npt
 
 from pulse2percept.implants import ArgusI, ArgusII
 from pulse2percept.percepts import Percept
-from pulse2percept.stimuli import (AsymmetricBiphasicPulseTrain,
+from pulse2percept.stimuli import (AmplitudeEncoder,
+                                   AsymmetricBiphasicPulseTrain,
                                    BiphasicPulseTrain, ImageStimulus,
                                    MonophasicPulse, Stimulus)
 from pulse2percept.models import BiphasicAxonMapModel, BiphasicAxonMapSpatial, \
@@ -844,3 +845,21 @@ def test_BiphasicAxonMap_zero_amplitude_is_inactive(model_cls):
     only = model.predict_percept(ArgusII(
         stim={'A2': BiphasicPulseTrain(20, 1, 0.45, stim_dur=100)})).data
     npt.assert_array_almost_equal(mixed, only)
+
+
+@pytest.mark.parametrize('model_cls', [BiphasicAxonMapModel,
+                                       BiphasicAxonMapSpatial])
+def test_BiphasicAxonMap_rejects_an_encoded_stimulus(model_cls):
+    # An encoder's output is a schedule, not a pulse train: its amplitude and
+    # frequency may differ from frame to frame, so there is no one `freq` for
+    # this model to read. It stays refused, and refusing it does not expand
+    # the schedule into a waveform either.
+    model = model_cls(xrange=(-3, 3), yrange=(-2, 2), step=1,
+                      n_ax_segments=30).build()
+    implant = ArgusII()
+    encoded = AmplitudeEncoder().encode(
+        ImageStimulus(np.linspace(0, 1, 64).reshape(8, 8)), implant=implant)
+    npt.assert_equal(encoded._structured_sources(), None)
+    implant.stim = encoded
+    with pytest.raises(TypeError):
+        model.predict_percept(implant)

--- a/pulse2percept/stimuli/_base.pyx
+++ b/pulse2percept/stimuli/_base.pyx
@@ -10,7 +10,7 @@ cnp.import_array()
 ctypedef Py_ssize_t index_t
 
 
-cpdef bool[::1] fast_compress_space(float32[:, ::1] data):
+cpdef bool[::1] fast_compress_space(const float32[:, ::1] data):
     """Compress a stimulus in space"""
     # In space, we only keep electrodes with nonzero activation values.
     # Note that `c_isclose(x, 0)` is an exact test, not a tolerant one: its
@@ -33,7 +33,7 @@ cpdef bool[::1] fast_compress_space(float32[:, ::1] data):
 
     return np.asarray(idx_space)
 
-cpdef bool[::1] fast_compress_time(float32[:, ::1] data):
+cpdef bool[::1] fast_compress_time(const float32[:, ::1] data):
     """Compress a stimulus in time"""
     # In time, we can't just remove empty columns. We need to walk
     # through each column and save all the "state transitions" along

--- a/pulse2percept/stimuli/_merge.py
+++ b/pulse2percept/stimuli/_merge.py
@@ -1,0 +1,141 @@
+"""Merging the time axes of several stimuli
+
+Kept apart from :py:mod:`~pulse2percept.stimuli.base` because
+:py:class:`~pulse2percept.implants.EnsembleImplant` merges its children on the
+same notion of "the same instant".
+"""
+import numpy as np
+
+from ..utils.constants import DT
+
+
+def _same_time_point(t, merge_tolerance):
+    """How close two time points have to be to count as the same point
+
+    Two stimuli that sample the very same instant hand us time points that
+    differ by a few ulps: pulse trains build their time axis by accumulating a
+    window duration, so the drift between two frequencies grows with t. Those
+    are too far apart to merge on an exact comparison, yet far closer than the
+    DT that the rest of the code expects to separate two distinct time points,
+    so the tolerance scales with the magnitude of ``t``. The cap keeps it below
+    DT no matter how large ``t`` gets, so that points which really are a time
+    step apart are never merged.
+
+    Parameters
+    ----------
+    t : np.ndarray
+        The time points whose magnitude sets the tolerance.
+    merge_tolerance : float
+        Lower bound on the tolerance, used where the accumulated drift is
+        smaller than it (i.e., for small ``t``).
+
+    Returns
+    -------
+    tol : np.ndarray
+        Element-wise tolerance, same shape as ``t``.
+    """
+    return np.minimum(0.5 * DT,
+                      np.maximum(merge_tolerance,
+                                 8 * np.spacing(np.abs(t))))
+
+
+def unique_time_points(time, merge_tolerance=1e-6):
+    """Sorted union of several time axes, merging points that coincide
+
+    Two stimuli that sample the same instant rarely agree on it to the last
+    bit, because each accumulated its own way there. An exact ``np.unique``
+    would keep both copies, leaving the merged axis with a pair of points far
+    closer together than the DT that separates two genuinely distinct ones.
+
+    Parameters
+    ----------
+    time : list of 1-D arrays
+        The time axes to merge.
+    merge_tolerance : float, optional
+        Two time points closer together than this (or than the accumulated
+        drift at their magnitude, whichever is coarser) are the same point.
+
+    Returns
+    -------
+    t_sorted : 1-D array
+        The sorted, concatenated time points.
+    starts_group : 1-D bool array
+        Which entries of ``t_sorted`` start a new group, i.e. which of them
+        survive the merge.
+    order : 1-D int array
+        The permutation that sorted the concatenated axes.
+
+    """
+    t_all = np.concatenate(time).astype(np.float64)
+    order = np.argsort(t_all, kind='stable')
+    t_sorted = t_all[order]
+    tol = _same_time_point(t_sorted[:-1], merge_tolerance)
+    starts_group = np.concatenate(([True], np.diff(t_sorted) > tol))
+    return t_sorted, starts_group, order
+
+
+def merge_time_axes(data, time, merge_tolerance=1e-6):
+    """Merge the time axes of a collection of sources into a single one
+
+    Sources passed together may sample different instants, or run for
+    different durations. Interpolating them onto one axis is expensive, so
+    identical axes are detected and returned untouched.
+
+    Parameters
+    ----------
+    data : list of np.ndarray
+        The data associated with each time axis.
+    time : list of np.ndarray
+        The time axes to merge.
+    merge_tolerance : float, optional
+        Two time points closer together than this (or than float32 can
+        resolve at their own magnitude, whichever is coarser) are the same
+        point.
+
+    Returns
+    -------
+    data : list of np.ndarray
+        The data, linearly interpolated onto the merged axis.
+    time : list of one np.ndarray
+        The merged axis.
+
+    """
+    t0 = time[0]
+    t0_tol = None
+    identical = True
+    for t in time:
+        # np.array_equal is a lot cheaper than the element-wise comparison
+        # (which builds several full-size temporaries) and, whenever it
+        # succeeds, implies it. Use it as a fast path for the common case
+        # where all stimuli share the very same time axis:
+        if len(t) != len(t0):
+            identical = False
+            break
+        if np.array_equal(t, t0):
+            continue
+        if t0_tol is None:
+            t0_tol = _same_time_point(t0, merge_tolerance)
+        # The axes may still be the same axis up to float32 noise. This used
+        # to be an `np.allclose`, whose relative tolerance is 0.01 ms at
+        # t = 1000 ms - ten time steps, which silently threw away time points
+        # that differ by much more than float32 noise:
+        if not np.all(np.abs(np.subtract(t, t0, dtype=np.float64)) <= t0_tol):
+            identical = False
+            break
+    if identical:
+        return data, [t0]
+    lengths = [len(t) for t in time]
+    t_sorted, starts_group, order = unique_time_points(time, merge_tolerance)
+    new_time = t_sorted[starts_group]
+    # Snap every time axis onto the merged one, so that interpolating below
+    # reproduces each stimulus exactly at its own sample points rather than an
+    # ulp before or after them:
+    snapped = np.empty_like(t_sorted)
+    snapped[order] = new_time[np.cumsum(starts_group) - 1]
+    new_data = []
+    for t, d in zip(np.split(snapped, np.cumsum(lengths)[:-1]), data):
+        # `d` is a 2-D data matrix and might have more than one row:
+        new_rows = [np.interp(new_time, t, row) for row in d]
+        new_rows = np.array(new_rows).reshape((-1, len(new_time)))
+        new_data.append(new_rows)
+    return new_data, [new_time]

--- a/pulse2percept/stimuli/_plot.py
+++ b/pulse2percept/stimuli/_plot.py
@@ -1,0 +1,173 @@
+"""Drawing a :py:class:`~pulse2percept.stimuli.Stimulus`
+
+Imported by :py:meth:`~pulse2percept.stimuli.Stimulus.plot` rather than at the
+top of :py:mod:`~pulse2percept.stimuli.base`, so that the stimulus itself does
+not depend on Matplotlib.
+"""
+import numpy as np
+from matplotlib.axes import Axes
+import matplotlib.pyplot as plt
+
+from ..units import uA
+from ..utils.constants import DT
+
+
+def _cell_edges(t):
+    """Turn sample times into the cell edges a heatmap colors between"""
+    t = np.asarray(t, dtype=float)
+    if t.size == 1:
+        # No neighbor to split an interval with; one sample is one time step:
+        return np.array([t[0] - DT / 2, t[0] + DT / 2])
+    return np.concatenate(([t[0]], 0.5 * (t[:-1] + t[1:]), [t[-1]]))
+
+
+def _times(stim, time):
+    """Resolve a requested time range into an index and its x values"""
+    # The user can ask for a range, slice, or list of time points, which are
+    # either interpolated or loaded directly.
+    if time is None:
+        # Ask for a slice instead of `stim.time` to avoid interpolation:
+        time = slice(None)
+    # A range, a list of time points, or the endpoints and step of a slice
+    # may all be given as quantities:
+    time = stim._as_time(time)
+    if isinstance(time, tuple):
+        t_idx = (stim.time > time[0]) & (stim.time < time[1])
+        # Include the end points (might have to be interpolated):
+        t_vals = [time[0]] + list(stim.time[t_idx]) + [time[1]]
+        t_idx = t_vals
+    elif isinstance(time, (list, np.ndarray)):
+        t_idx = time
+        t_vals = time
+    elif isinstance(time, slice):
+        t_vals = stim._slice_times(time)
+        if t_vals is None:
+            # Every stored sample, taken by position:
+            t_idx = time
+            t_vals = stim.time[time]
+        else:
+            t_idx = t_vals
+    elif time == Ellipsis:
+        t_idx = time
+        t_vals = stim.time[t_idx]
+    else:
+        raise TypeError(f'"time" must be a tuple, slice, list, or NumPy '
+                        f'array, not {type(time)}.')
+    return t_idx, t_vals
+
+
+def _value_label(stim):
+    """What the stimulus values are, as an axis or colorbar label"""
+    if stim.unit.dimension.is_dimensionless:
+        return 'Value'
+    if stim.unit == uA:
+        # Spelled the way Matplotlib renders it:
+        return r'Amplitude ($\mu$A)'
+    return f'Amplitude ({stim.unit})'
+
+
+def _traces(stim, electrodes, t_idx, t_vals, fmt, ax):
+    """Draw one waveform per electrode, each in its own Axes"""
+    owns_figure = ax is None
+    axes = ax
+    if axes is None:
+        if len(electrodes) == 1:
+            axes = plt.gca()
+        else:
+            axes = plt.subplots(nrows=len(electrodes),
+                                figsize=(8, 1.2 * len(electrodes)),
+                                layout='constrained')[1]
+    if not isinstance(axes, (list, np.ndarray)):
+        axes = [axes]
+    for i, ax in enumerate(axes):
+        if not isinstance(ax, Axes):
+            raise TypeError(f"'ax' must be a list of subplots, but "
+                            f"ax[{i}] is {type(ax)}.")
+    if len(axes) != len(electrodes):
+        raise ValueError(f"Number of subplots ({len(axes)}) must be equal "
+                         f"to the number of electrodes "
+                         f"({len(electrodes)}).")
+    for ax, electrode in zip(axes, electrodes):
+        # Slice or interpolate stimulus:
+        slc = stim[electrode, t_idx]
+        ax.plot(t_vals, np.squeeze(slc), fmt, linewidth=2)
+        # Turn off the ugly box spines:
+        ax.spines['top'].set_visible(False)
+        ax.spines['right'].set_visible(False)
+        ax.spines['bottom'].set_visible(False)
+        ax.set_xticks([])
+        ax.set_yticks([slc.min(), 0, slc.max()])
+        x_pad = 0.02 * (t_vals[-1] - t_vals[0])
+        ax.set_xlim(t_vals[0] - x_pad, t_vals[-1] + x_pad)
+        y_pad = np.maximum(1, 0.02 * (slc.max() - slc.min()))
+        ax.set_ylim(slc.min() - y_pad, slc.max() + y_pad)
+        ax.set_ylabel(electrode)
+    # Only the bottom subplot carries the shared time axis:
+    axes[-1].set_xticks(np.linspace(t_vals[0], t_vals[-1], num=5))
+    axes[-1].set_xlabel(f'Time ({stim.time_unit})')
+    if owns_figure:
+        axes[-1].figure.supylabel(_value_label(stim))
+    if len(axes) == 1:
+        return axes[0]
+    return axes
+
+
+def _heatmap(stim, electrodes, t_idx, t_vals, ax):
+    """Draw the stimulus as a single electrode-by-time image"""
+    if isinstance(ax, (list, np.ndarray)):
+        raise TypeError(f"A heatmap is drawn in a single Axes, but 'ax' "
+                        f"is a sequence of {len(ax)}.")
+    electrodes = list(electrodes)
+    owns_figure = ax is None
+    if ax is None:
+        # Give every electrode a readable row of its own:
+        height = float(np.clip(0.18 * len(electrodes), 2.5, 12))
+        ax = plt.subplots(figsize=(8, height), layout='constrained')[1]
+    elif not isinstance(ax, Axes):
+        raise TypeError(f"'ax' must be a Matplotlib Axes, not {type(ax)}.")
+    data = np.atleast_2d(stim[electrodes, t_idx])
+    t_vals = np.asarray(t_vals, dtype=float)
+    vmax = np.max(np.abs(data))
+    if not np.isfinite(vmax) or vmax == 0:
+        vmax = 1.0
+    if data.min() < 0:
+        cmap, vmin = 'RdBu_r', -vmax
+    else:
+        cmap, vmin = 'viridis', 0.0
+    mesh = ax.pcolormesh(_cell_edges(t_vals), np.arange(len(data) + 1),
+                         data, cmap=cmap, vmin=vmin, vmax=vmax)
+    ax.set_yticks(np.arange(len(data)) + 0.5,
+                  labels=[str(e) for e in electrodes])
+    # Read top to bottom, in the order the electrodes were asked for:
+    ax.invert_yaxis()
+    ax.set_xlabel(f'Time ({stim.time_unit})')
+    ax.set_ylabel('Electrode')
+    if owns_figure:
+        ax.figure.colorbar(mesh, ax=ax, label=_value_label(stim))
+    return ax
+
+
+def plot_stimulus(stim, electrodes=None, time=None, fmt='k-', ax=None,
+                  kind=None):
+    """Implements :py:meth:`~pulse2percept.stimuli.Stimulus.plot`"""
+    if stim.time is None:
+        # Cannot plot stimulus with single time point:
+        raise NotImplementedError
+    if kind is None:
+        if isinstance(ax, (list, np.ndarray)):
+            kind = 'traces'
+        elif electrodes is None and len(stim.electrodes) > 1:
+            kind = 'heatmap'
+        else:
+            kind = 'traces'
+    elif kind not in ('traces', 'heatmap'):
+        raise ValueError(f"Unknown kind '{kind}'. Choose from 'traces' or "
+                         f"'heatmap'.")
+    if electrodes is None:
+        electrodes = stim.electrodes
+    elif isinstance(electrodes, (int, str)):
+        electrodes = [electrodes]
+    t_idx, t_vals = _times(stim, time)
+    if kind == 'heatmap':
+        return _heatmap(stim, electrodes, t_idx, t_vals, ax)
+    return _traces(stim, electrodes, t_idx, t_vals, fmt, ax)

--- a/pulse2percept/stimuli/base.py
+++ b/pulse2percept/stimuli/base.py
@@ -825,9 +825,12 @@ class Stimulus(PrettyPrint):
         described by its samples and by nothing else, so it cannot claim an
         amplitude or a duration it does not deliver.
         """
-        return Stimulus(self.data, electrodes=self.electrodes,
-                        time=self.time,
-                        metadata=deepcopy(self.metadata))._inherit_units(self)
+        stim = Stimulus(self.data, electrodes=self.electrodes, time=self.time)
+        # Assigned rather than passed to the constructor: a class that keeps
+        # its waveform parameters in ``metadata`` (a pulse train's frequency,
+        # say) has a dict of a shape the constructor would file under 'user'.
+        stim.metadata = deepcopy(self.metadata)
+        return stim._inherit_units(self)
 
     def _derived(self):
         """The object a waveform-rewriting operation builds its result on
@@ -895,6 +898,20 @@ class Stimulus(PrettyPrint):
         metadata : dict
         """
         return metadata
+
+    def _rescale_result(self, stim, factor):
+        """Keep the metadata of a transformed copy in step with its data
+
+        ``stim`` is what an operation on ``self`` produced. Usually it is a
+        copy of ``self`` and knows how to read its own metadata. For a
+        parameter-backed stimulus it is a plain
+        :py:class:`~pulse2percept.stimuli.Stimulus` instead (see
+        :py:meth:`_derived`), which does not -- so the class that wrote those
+        parameters rewrites them from here, while it is still known.
+        """
+        stim._rescale_metadata(factor)
+        if self._is_parametric:
+            stim.metadata = type(self)._rescale_params(stim.metadata, factor)
 
     def _rescale_metadata(self, factor):
         """Keep the metadata in sync with data that was scaled by ``factor``
@@ -1021,7 +1038,7 @@ class Stimulus(PrettyPrint):
         # any parameters describing the first one no longer describe the
         # result -- a pulse train appended to another is not one pulse train
         # at one amplitude and frequency, whatever its type still says:
-        stim._rescale_metadata(None)
+        self._rescale_result(stim, None)
         return stim
 
     def remove(self, electrodes):
@@ -1553,7 +1570,7 @@ class Stimulus(PrettyPrint):
         # Parameters that describe the waveform (a pulse train's amplitude,
         # say) have to follow the data, or a model reading them back predicts
         # from a stimulus that is no longer the one it was handed:
-        stim._rescale_metadata(_scale_factor(a, op, b, field))
+        self._rescale_result(stim, _scale_factor(a, op, b, field))
         return stim
 
     def _as_amplitude(self, scalar):

--- a/pulse2percept/stimuli/base.py
+++ b/pulse2percept/stimuli/base.py
@@ -429,10 +429,7 @@ class Stimulus(PrettyPrint):
 
     def __init__(self, source, electrodes=None, time=None, metadata=None,
                  compress=False):
-        if isinstance(metadata, dict) and 'electrodes' in metadata.keys():
-            self.metadata = metadata
-        else:
-            self.metadata = {'electrodes': {}, 'user': metadata}
+        self.metadata = self._wrap_metadata(metadata)
         # Flag will be flipped in the compress method:
         self._is_compressed = False
         # Settle what the numbers below mean before reading any of them, then
@@ -443,6 +440,70 @@ class Stimulus(PrettyPrint):
         time = as_value(time, self._time_unit, 'time')
         # Extract the data and coordinates (electrodes, time) from the source:
         self._factory(source, electrodes, time, compress)
+
+    @staticmethod
+    def _wrap_metadata(metadata):
+        """File the caller's metadata under 'user', unless it is already ours
+
+        A dict that already has an 'electrodes' key is a metadata container
+        this class built (when one stimulus is rebuilt from another), and is
+        taken as it is.
+        """
+        if isinstance(metadata, dict) and 'electrodes' in metadata.keys():
+            return metadata
+        return {'electrodes': {}, 'user': metadata}
+
+    def _defer(self, electrodes, unit=None, time_unit=None, metadata=None):
+        """Set this stimulus up to generate its waveform later
+
+        The constructor of a subclass whose canonical state is a set of
+        stimulation parameters rather than a set of samples calls this in
+        place of ``Stimulus.__init__``. It records everything such a stimulus
+        knows without sampling anything -- which electrodes it drives, what
+        its numbers mean, and its metadata -- and leaves the waveform to
+        :py:meth:`_render`, which runs the first time one is asked for.
+
+        Parameters
+        ----------
+        electrodes : array-like or ElectrodeNames
+            The electrodes this stimulus drives, in the order ``_render``
+            will return rows for.
+        unit, time_unit : :py:class:`~pulse2percept.units.Unit`, optional
+            What the rendered numbers will mean. Default to the class's own.
+        metadata : dict, optional
+        """
+        self.metadata = self._wrap_metadata(metadata)
+        self._is_compressed = False
+        self._unit = self._default_unit if unit is None else unit
+        self._time_unit = (self._default_time_unit if time_unit is None
+                           else time_unit)
+        if not isinstance(electrodes, ElectrodeNames):
+            electrodes = np.array([electrodes]).ravel()
+        # `data=None` is what says the waveform has not been generated yet.
+        # No state that has been through `_check_stim` can look like this:
+        # the check reads `data.shape` before anything else.
+        self.__stim = {'data': None, 'time': None,
+                       'electrodes': self._own_names(electrodes)}
+
+    def _render(self):
+        """Generate the waveform this stimulus describes
+
+        The seam a parameter-backed stimulus is built on. An ordinary
+        ``Stimulus`` *is* its waveform and builds it in the constructor, so it
+        never gets here. A subclass that called :py:meth:`_defer` instead
+        overrides this and returns the state to install::
+
+            {'data': ..., 'electrodes': ..., 'time': ...}
+
+        It runs at most once per stimulus, and what it returns goes through
+        the ``_stim`` setter like any other state -- so the waveform it built
+        is owned, immutable and validated on exactly the same terms as one
+        that was passed in.
+        """
+        raise NotImplementedError(
+            f"{type(self).__name__} has no stimulus data, and does not know "
+            f"how to generate any. A subclass that defers its waveform must "
+            f"override '_render'.")
 
     def _resolve_units(self, source):
         """Determine the units this stimulus stores its data and time in
@@ -1617,7 +1678,24 @@ class Stimulus(PrettyPrint):
 
     @property
     def _stim(self):
-        """A dictionary containing all the stimulus data"""
+        """A dictionary containing all the stimulus data
+
+        Reading this is what materializes the waveform of a stimulus that
+        deferred building one (see :py:meth:`_defer` and :py:meth:`_render`).
+        Everything that needs samples goes through here, so that is the one
+        place the waveform can come into existence; ``electrodes`` is the
+        exception, and reads the container directly.
+        """
+        if self.__stim['data'] is None:
+            promised = self.__stim['electrodes']
+            # The setter installs the rendered state, so `_render` runs once:
+            self._stim = self._render()
+            if not _names_equal(promised, self.__stim['electrodes']):
+                raise ValueError(
+                    f"{type(self).__name__}._render() returned rows for "
+                    f"different electrodes than the stimulus said it drives. "
+                    f"Naming them is what lets 'electrodes' be read without "
+                    f"generating a waveform, so the two cannot disagree.")
         return self.__stim
 
     @_stim.setter
@@ -1770,7 +1848,10 @@ class Stimulus(PrettyPrint):
         A list of electrode names, corresponding to the rows in the data
         container.
         """
-        return self._stim['electrodes']
+        # Reads the container directly rather than through `_stim`: which
+        # electrodes a stimulus drives is known before its waveform is, and
+        # asking for them must not be what generates one.
+        return self.__stim['electrodes']
 
     @property
     def time(self):

--- a/pulse2percept/stimuli/base.py
+++ b/pulse2percept/stimuli/base.py
@@ -1271,6 +1271,33 @@ class Stimulus(PrettyPrint):
                        'electrodes': self._own_names(self.electrodes[keep_el])}
         return True
 
+    def _structured_sources(self):
+        """The stimulus describing each electrode, where one is still retained
+
+        Returns ``[(electrode_name, source), ...]`` in row order, or ``None``
+        when this stimulus is only its samples -- because it always was, or
+        because an operation rewrote them and whatever described them before
+        no longer does.
+
+        This is what a model reads to find out that an electrode is driven by
+        a pulse train at 20 Hz, instead of taking a copy of that number from
+        the metadata and hoping it kept up. Read-only, and deliberately
+        shallow: an entry driving more than one electrode has no
+        one-source-per-electrode reading, and gets ``None`` rather than a
+        recursive one.
+        """
+        if self._components is not None:
+            if any(n_rows != 1 or not isinstance(src, Stimulus)
+                   for src, n_rows in self._components):
+                return None
+            return [(name, src) for name, (src, _)
+                    in zip(self.electrodes, self._components)]
+        if self._is_parametric and len(self.electrodes) == 1:
+            # The stimulus is the source: a pulse train assigned straight to
+            # an implant arrives here as itself.
+            return [(self.electrodes[0], self)]
+        return None
+
     def shift(self, dt):
         """Shift the stimulus in time.
 

--- a/pulse2percept/stimuli/base.py
+++ b/pulse2percept/stimuli/base.py
@@ -8,10 +8,9 @@ from ..utils import PrettyPrint, is_strictly_increasing
 from ..utils.array import _interp_rows, _slice_times
 from ..utils.constants import DT, MIN_AMP
 from ._base import fast_compress_space, fast_compress_time
+from ._merge import merge_time_axes
 from .names import ElectrodeNames
 
-from matplotlib.axes import Axes
-import matplotlib.pyplot as plt
 from copy import copy, deepcopy
 import operator as ops
 from math import isclose
@@ -20,13 +19,7 @@ import numpy as np
 
 
 def _as_scalar_column(source):
-    """Convert a flat sequence of scalars into an (N, 1) data container
-
-    Returns None if ``source`` is not a non-empty list or tuple of scalars, in
-    which case the caller has to fall back to the generic per-element path.
-    An empty sequence is excluded on purpose: it must keep producing a 1-D
-    (empty) data container.
-    """
+    """Convert a flat sequence of scalars into an (N, 1) data container"""
     if not isinstance(source, (list, tuple)) or not source:
         return None
     if not np.isscalar(source[0]) or isinstance(source[0], str):
@@ -34,25 +27,16 @@ def _as_scalar_column(source):
     try:
         flat = np.asarray(source)
     except (TypeError, ValueError):
-        # Ragged (e.g. [1, [2, 3]]): let the generic path run, so that it
-        # raises the error it has always raised:
         return None
-    # Let the dtype NumPy infers decide. Forcing float32 here would quietly
-    # accept sequences the generic path rejects: `[1, None]` would become
-    # `[1.0, nan]` rather than a TypeError. Strings, None and complex values
-    # all infer to a non-numeric dtype and so fall through:
+    # Strings, None and complex values all infer to a non-numeric dtype and so
+    # fall through:
     if flat.ndim != 1 or flat.dtype.kind not in 'biuf':
         return None
     return flat.astype(np.float32).reshape((-1, 1))
 
 
 def _names_equal(a, b):
-    """Whether two containers hold the same electrode names
-
-    Two ``ElectrodeNames`` over the same grid hold the same names iff they
-    select the same indices, which compares a few million integers rather than
-    generating (and then comparing) a few million strings.
-    """
+    """Whether two containers hold the same electrode names"""
     if isinstance(a, ElectrodeNames) and isinstance(b, ElectrodeNames):
         if a.grid_shape == b.grid_shape:
             return np.array_equal(a.indices, b.indices)
@@ -60,182 +44,21 @@ def _names_equal(a, b):
 
 
 def _index_of_name(electrodes, name):
-    """Return the position of electrode ``name`` in ``electrodes``
-
-    ``ElectrodeNames`` can do this arithmetically, in constant time.
-    Everything else falls back to a linear scan, which is what looking up a
-    name in a plain array of names has always cost.
-    """
+    """Return the position of electrode ``name`` in ``electrodes``"""
     if isinstance(electrodes, ElectrodeNames):
         return electrodes.index(name)
     return list(electrodes).index(name)
 
 
-def _same_time_point(t, merge_tolerance):
-    """How close two time points have to be to count as the same point
-
-    Two stimuli that sample the very same instant hand us time points that
-    differ by a few ulps: pulse trains build their time axis by accumulating a
-    window duration, so the drift between two frequencies grows with t. Those
-    are too far apart to merge on an exact comparison, yet far closer than the
-    DT that the rest of the code expects to separate two distinct time points,
-    so the tolerance scales with the magnitude of ``t``. The cap keeps it below
-    DT no matter how large ``t`` gets, so that points which really are a time
-    step apart are never merged.
-
-    Parameters
-    ----------
-    t : np.ndarray
-        The time points whose magnitude sets the tolerance.
-    merge_tolerance : float
-        Lower bound on the tolerance, used where the accumulated drift is
-        smaller than it (i.e., for small ``t``).
-
-    Returns
-    -------
-    tol : np.ndarray
-        Element-wise tolerance, same shape as ``t``.
-    """
-    return np.minimum(0.5 * DT,
-                      np.maximum(merge_tolerance,
-                                 8 * np.spacing(np.abs(t))))
-
-
-def unique_time_points(time, merge_tolerance=1e-6):
-    """Sorted union of several time axes, merging points that coincide
-
-    Two stimuli that sample the same instant rarely agree on it to the last
-    bit, because each accumulated its own way there. An exact ``np.unique``
-    would keep both copies, leaving the merged axis with a pair of points far
-    closer together than the DT that separates two genuinely distinct ones.
-
-    Parameters
-    ----------
-    time : list of 1-D arrays
-        The time axes to merge.
-    merge_tolerance : float, optional
-        Two time points closer together than this (or than the accumulated
-        drift at their magnitude, whichever is coarser) are the same point.
-
-    Returns
-    -------
-    t_sorted : 1-D array
-        The sorted, concatenated time points.
-    starts_group : 1-D bool array
-        Which entries of ``t_sorted`` start a new group, i.e. which of them
-        survive the merge.
-    order : 1-D int array
-        The permutation that sorted the concatenated axes.
-
-    """
-    t_all = np.concatenate(time).astype(np.float64)
-    order = np.argsort(t_all, kind='stable')
-    t_sorted = t_all[order]
-    tol = _same_time_point(t_sorted[:-1], merge_tolerance)
-    starts_group = np.concatenate(([True], np.diff(t_sorted) > tol))
-    return t_sorted, starts_group, order
-
-
-def merge_time_axes(data, time, merge_tolerance=1e-6):
-    """
-    Merge time axes
-
-    When a collection of source types is passed, it is possible that they
-    have different time axes (e.g., different time steps, or a different
-    stimulus duration). In this case, we need to merge all time axes into a
-    single, coherent one. This is expensive, because of interpolation.
-
-    Parameters
-    ----------
-    data: list
-        List of numpy.ndarray's containing data points associated with time axes.
-    time: list
-        List of numpy.ndarray's containing time points to merge
-    merge_tolerance: float
-        Absolute tolerance used when collecting unique time points from the
-        time axes. Two time points that are closer together than this (or
-        closer than float32 can resolve at their own magnitude, whichever is
-        coarser) are treated as the same point.
-    Returns
-        Tuple of: list of new data points (linearly interpolated from merged time axis), list of new merged time axis.
-    -------
-
-    """
-    # We can skip the costly interpolation if all `time` vectors are
-    # identical:
-    t0 = time[0]
-    t0_tol = None
-    identical = True
-    for t in time:
-        # np.array_equal is a lot cheaper than the element-wise comparison
-        # (which builds several full-size temporaries) and, whenever it
-        # succeeds, implies it. Use it as a fast path for the common case
-        # where all stimuli share the very same time axis:
-        if len(t) != len(t0):
-            identical = False
-            break
-        if np.array_equal(t, t0):
-            continue
-        if t0_tol is None:
-            t0_tol = _same_time_point(t0, merge_tolerance)
-        # The axes may still be the same axis up to float32 noise. This used
-        # to be an `np.allclose`, whose relative tolerance is 0.01 ms at
-        # t = 1000 ms - ten time steps, which silently threw away time points
-        # that differ by much more than float32 noise:
-        if not np.all(np.abs(np.subtract(t, t0, dtype=np.float64)) <= t0_tol):
-            identical = False
-            break
-    if identical:
-        return data, [t0]
-    # Otherwise, we need to interpolate. Keep only the unique time points
-    # across stimuli. We need a higher tolerance to ensure interpolation is
-    # correct.
-    lengths = [len(t) for t in time]
-    t_sorted, starts_group, order = unique_time_points(time, merge_tolerance)
-    new_time = t_sorted[starts_group]
-    # Snap every time axis onto the merged one, so that interpolating below
-    # reproduces each stimulus exactly at its own sample points rather than an
-    # ulp before or after them:
-    snapped = np.empty_like(t_sorted)
-    snapped[order] = new_time[np.cumsum(starts_group) - 1]
-    # Now we need to interpolate the data values at each of these
-    # new time points.
-    new_data = []
-    for t, d in zip(np.split(snapped, np.cumsum(lengths)[:-1]), data):
-        # t is a 1D vector, d is a 2D data matrix and might have more than
-        # one row:
-        new_rows = [np.interp(new_time, t, row) for row in d]
-        new_rows = np.array(new_rows).reshape((-1, len(new_time)))
-        new_data.append(new_rows)
-    return new_data, [new_time]
-
-
 def _describe_unit(unit):
-    """Name a unit the way an error message wants to read
-
-    A dimensionless unit has no symbol to show, so saying "dimensionless ()"
-    is worse than saying nothing at all.
-    """
+    """Name a unit the way an error message wants to read"""
     if unit.dimension.is_dimensionless:
         return 'dimensionless units'
     return f'{unit.dimension.name} ({unit})'
 
 
-def _cell_edges(t):
-    """Turn sample times into the cell edges a heatmap colors between"""
-    t = np.asarray(t, dtype=float)
-    if t.size == 1:
-        # No neighbor to split an interval with; one sample is one time step:
-        return np.array([t[0] - DT / 2, t[0] + DT / 2])
-    return np.concatenate(([t[0]], 0.5 * (t[:-1] + t[1:]), [t[-1]]))
-
-
 def _stimulus_sources(source):
-    """The Stimulus objects a source is built from, if any
-
-    A source is either one stimulus, a collection of them, or something with
-    no unit of its own (a scalar, an array, a filename).
-    """
+    """The Stimulus objects a source is built from, if any"""
     if isinstance(source, Stimulus):
         return [source]
     if isinstance(source, dict):
@@ -246,60 +69,27 @@ def _stimulus_sources(source):
 
 
 def _has_waveform(stim):
-    """Whether a stimulus has already generated the samples it describes
-
-    Reads the private container, because every public attribute that could
-    answer the question would generate them first.
-    """
+    """Whether a stimulus has already generated the samples it describes"""
     return stim._Stimulus__stim['data'] is not None
 
 
 def _snapshot(source):
-    """One entry of a collection, as it was when the collection was built
-
-    A collection that has not been merged yet keeps its entries instead of
-    their samples, so it has to keep them frozen: a stimulus built from a
-    pulse train describes that train as it was, not as its author went on to
-    change it. Deep-copying a stimulus is cheap -- its arrays are immutable
-    and shared -- and the raw entries are one electrode's worth of numbers.
-    """
+    """One entry of a collection, as it was when the collection was built"""
     if np.isscalar(source):
         return source
     return deepcopy(source)
 
 
 def _component_shape(source):
-    """What one entry of a collection contributes, without sampling it
-
-    Returns the electrode names the entry brings along (``None`` if it does
-    not name its own), how many rows it contributes, and whether it has a time
-    component. This is what lets a collection settle its electrodes, and
-    reject the mistakes that are about electrodes, before any waveform exists.
-    """
+    """What one entry of a collection contributes, without sampling it"""
     if isinstance(source, Stimulus):
-        # An unrendered stimulus is one of ours, and every parameter-backed
-        # class in the library is a pulse -- which has a time axis. Asking one
-        # that has already been rendered costs nothing.
         has_time = not _has_waveform(source) or source.time is not None
         return source.electrodes, len(source.electrodes), has_time
-    # Anything else is a single electrode; only a scalar has no time axis
-    # (`_parse_source` gives a nested sequence one point per element):
     return None, 1, not (np.isscalar(source) and not isinstance(source, str))
 
 
 def _strip_units(source, unit):
-    """Convert a source's quantities into plain numbers expressed in ``unit``
-
-    Runs before the source-dispatch machinery in ``Stimulus._factory``, which
-    reads dicts, lists, tuples and arrays element by element. A
-    :py:class:`~pulse2percept.units.Quantity` deliberately has no sequence
-    protocol, so it cannot be read that way -- and normalizing here means the
-    dispatch, the interpolation and the compression below all keep seeing
-    ordinary numbers, exactly as they always have.
-
-    Anything without a unit is returned untouched, including the container it
-    came in.
-    """
+    """Convert a source's quantities into plain numbers expressed in unit"""
     if isinstance(source, (Quantity, Unit)):
         return as_value(source, unit, 'source')
     if isinstance(source, dict):
@@ -312,29 +102,14 @@ def _strip_units(source, unit):
 
 
 def _scale_factor(op, scalar, reverse=False, field='data'):
-    """The factor by which an arithmetic operator scales the stimulus data
-
-    Returns 1 for an operator that leaves every amplitude where it is (a shift
-    in time, or adding zero), the factor for one that scales them all by the
-    same number, and None for one that does neither: a DC offset moves the
-    waveform rather than resizing it, and no factor describes that.
-
-    ``reverse`` says the stimulus is the operand on the right (``5 - stim``).
-    Deliberately answerable from the operator alone, so that a class which can
-    express a scaled version of itself is asked before anything is sampled;
-    see :py:meth:`~pulse2percept.stimuli.Stimulus._operate`.
-    """
+    """The factor by which an arithmetic operator scales the stimulus data"""
     if field == 'time':
-        # Shifting in time moves the whole stimulus, but every amplitude in it
-        # stays what it was:
+        # Shifting in time moves the whole stim but amps remain:
         return 1.0
     if op is ops.mul:
-        # Multiplication is commutative, so the operand order is moot:
         factor = scalar
     elif op is ops.truediv:
         # `Stimulus` has no `__rtruediv__`, so this is always data/scalar.
-        # Dividing the data by zero fills it with inf rather than raising, so
-        # the factor must not raise either -- it comes out non-finite below:
         with np.errstate(divide='ignore', invalid='ignore'):
             factor = np.divide(1.0, scalar)
     elif scalar == 0:
@@ -342,8 +117,6 @@ def _scale_factor(op, scalar, reverse=False, field='data'):
         factor = -1.0 if reverse else 1.0
     else:
         return None
-    # `stim * np.inf`, `stim * np.nan` and `stim / 0` leave a waveform of
-    # infinities and NaNs, which is not a scaled version of anything:
     return factor if np.isfinite(factor) else None
 
 
@@ -355,12 +128,8 @@ class Stimulus(PrettyPrint):
     A stimulus can be created from a variety of source types (e.g., scalars,
     lists, NumPy arrays, and dictionaries).
 
-    A stimulus owns its scientific state: ``data``, ``time``, ``electrodes``
-    and the pulse parameters are read-only, so callers cannot mutate them in
-    place. For an arbitrary stimulus the sampled waveform *is* the stimulus;
-    pulse-based and encoded stimuli instead retain the parameters or the
-    schedule that define them, and generate their waveform only when samples
-    such as ``data`` are asked for.
+    Pulse parameters (``data``, ``time``, ``electrodes``) are read-only.
+    Arbitrary stimuli are kept as sampled waveforms only.
 
     .. seealso ::
 
@@ -369,8 +138,7 @@ class Stimulus(PrettyPrint):
     .. versionadded:: 0.6
 
     .. versionchanged:: 0.10.0
-        ``data``, ``time`` and ``electrodes`` are read-only, and pulse-based
-        and encoded stimuli generate their waveform lazily.
+        Pulse parameters are read-only, and waveform are generated lazily.
 
     Parameters
     ----------
@@ -437,15 +205,8 @@ class Stimulus(PrettyPrint):
        its value will be automatically interpolated from neighboring values.
     *  If a requested time point lies outside the range of stored data,
        the value of its closest end point will be returned.
-    *  Pulse parameters such as ``amp``, ``freq`` and ``phase_dur`` are
-       first-class and read-only, and reading them never generates a waveform.
-    *  Most transformations return a new stimulus. One whose result the
-       parameters still describe keeps its structured form (``pulse_train * 2``
-       is a pulse train at twice the amplitude); one they cannot -- a DC
-       offset, a shift in time, an appended second train -- falls back to a
-       plain, waveform-backed ``Stimulus``.
-    *  :py:meth:`compress` and :py:meth:`remove` are the exceptions: they
-       replace the stimulus' own state rather than returning a new object.
+    *  All transformations return a new stimulus, except for
+       :py:meth:`compress` and :py:meth:`remove`.
 
     Examples
     --------
@@ -478,27 +239,14 @@ class Stimulus(PrettyPrint):
     __slots__ = ('metadata', '_is_compressed', '__stim', '_unit',
                  '_time_unit', '_components')
 
-    #: The unit ``data`` is stored in. Electrical stimuli are microamps, which
-    #: is what every model, pulse and safety check in the library assumes; a
-    #: subclass whose data is not a current (an image's gray levels, say)
-    #: overrides this. A stimulus built from another stimulus inherits its
-    #: unit instead, so a copy of an image stimulus does not become a current.
+    # data is stored in microamps and millisecond
     _default_unit = uA
-
-    #: The unit ``time`` is stored in.
     _default_time_unit = ms
 
-    #: Whether :py:meth:`_spatial_view` describes something other than this
-    #: stimulus. False for a stimulus that is its own spatial description,
-    #: which is every stimulus that was handed to the library as current.
+    #: False for a stimulus that is its own spatial description
     _has_spatial_view = False
 
-    #: Whether this class' canonical state is a set of stimulation parameters
-    #: rather than the waveform itself. Such a stimulus cannot survive a
-    #: change to its samples, because its parameters would go on describing a
-    #: waveform it no longer has: operations that return a new stimulus hand
-    #: back a plain one (see :py:meth:`_derived`), and the in-place ones that
-    #: would drop electrodes refuse.
+    #: whether the canonical state is a set of stim params
     _is_parametric = False
 
     def __init__(self, source, electrodes=None, time=None, metadata=None,
@@ -509,9 +257,6 @@ class Stimulus(PrettyPrint):
         # Set by `_factory` when this is a collection whose entries have not
         # been merged into a waveform yet (see `_render`):
         self._components = None
-        # Settle what the numbers below mean before reading any of them, then
-        # convert every quantity into that unit. From here on the source is
-        # ordinary numbers, which is all `_factory` has ever had to handle:
         self._unit, self._time_unit = self._resolve_units(source)
         source = _strip_units(source, self._unit)
         time = as_value(time, self._time_unit, 'time')
@@ -520,35 +265,13 @@ class Stimulus(PrettyPrint):
 
     @staticmethod
     def _wrap_metadata(metadata):
-        """File the caller's metadata under 'user', unless it is already ours
-
-        A dict that already has an 'electrodes' key is a metadata container
-        this class built (when one stimulus is rebuilt from another), and is
-        taken as it is.
-        """
+        """File the caller's metadata under user, unless it is already ours"""
         if isinstance(metadata, dict) and 'electrodes' in metadata.keys():
             return metadata
         return {'electrodes': {}, 'user': metadata}
 
     def _defer(self, electrodes, unit=None, time_unit=None, metadata=None):
-        """Set this stimulus up to generate its waveform later
-
-        The constructor of a subclass whose canonical state is a set of
-        stimulation parameters rather than a set of samples calls this in
-        place of ``Stimulus.__init__``. It records everything such a stimulus
-        knows without sampling anything -- which electrodes it drives, what
-        its numbers mean, and its metadata -- and leaves the waveform to
-        :py:meth:`_render`, which runs the first time one is asked for.
-
-        Parameters
-        ----------
-        electrodes : array-like or ElectrodeNames
-            The electrodes this stimulus drives, in the order ``_render``
-            will return rows for.
-        unit, time_unit : :py:class:`~pulse2percept.units.Unit`, optional
-            What the rendered numbers will mean. Default to the class's own.
-        metadata : dict, optional
-        """
+        """Set this stimulus up to generate its waveform later"""
         self.metadata = self._wrap_metadata(metadata)
         self._is_compressed = False
         self._components = None
@@ -557,26 +280,21 @@ class Stimulus(PrettyPrint):
                            else time_unit)
         if not isinstance(electrodes, ElectrodeNames):
             electrodes = np.array([electrodes]).ravel()
-        # `data=None` is what says the waveform has not been generated yet.
-        # No state that has been through `_check_stim` can look like this:
-        # the check reads `data.shape` before anything else.
+        # `data=None` is what says the waveform has not been generated yet
         self.__stim = {'data': None, 'time': None,
                        'electrodes': self._own_names(electrodes)}
 
     def _render(self):
         """Generate the waveform this stimulus describes
 
-        The seam a parameter-backed stimulus is built on. An ordinary
-        ``Stimulus`` *is* its waveform and builds it in the constructor, so it
-        never gets here. A subclass that called :py:meth:`_defer` instead
-        overrides this and returns the state to install::
+        A subclass that called :py:meth:`_defer` overrides this and returns
+        the state to install::
 
             {'data': ..., 'electrodes': ..., 'time': ...}
 
-        It runs at most once per stimulus, and what it returns goes through
-        the ``_stim`` setter like any other state -- so the waveform it built
-        is owned, immutable and validated on exactly the same terms as one
-        that was passed in.
+        It runs at most once, and what it returns goes through the ``_stim``
+        setter like any other state, so the waveform it built is owned,
+        immutable and validated on the same terms as one that was passed in.
         """
         if self._components is None:
             raise NotImplementedError(
@@ -592,13 +310,7 @@ class Stimulus(PrettyPrint):
         return {'data': _data, 'electrodes': self.electrodes, 'time': _time}
 
     def _resolve_units(self, source):
-        """Determine the units this stimulus stores its data and time in
-
-        A stimulus built from other stimuli speaks their unit; anything else
-        speaks this class's default. Sources that disagree are an error rather
-        than a silent choice of one of them: an image stimulus and a pulse
-        train in the same collection have no common interpretation.
-        """
+        """Determine the units this stimulus stores its data and time in"""
         unit, time_unit = self._default_unit, self._default_time_unit
         sources = _stimulus_sources(source)
         if not sources:
@@ -618,13 +330,7 @@ class Stimulus(PrettyPrint):
         return unit, time_unit
 
     def _inherit_units(self, other):
-        """Adopt the units of another stimulus
-
-        For the handful of places that rebuild a stimulus out of raw arrays
-        (resampling it onto an implant's electrodes, evaluating it at
-        particular time points) and would otherwise fall back to the class
-        default. Returns ``self`` so it can be chained onto a constructor.
-        """
+        """Adopt the units of another stimulus"""
         self._unit = other.unit
         self._time_unit = other.time_unit
         return self
@@ -641,12 +347,7 @@ class Stimulus(PrettyPrint):
         """Whether to keep this source's entries instead of merging them now
 
         Worth doing when an entry is a stimulus that is defined by its
-        stimulation parameters, or that has not generated a waveform yet:
-        merging is what would force one into existence. A collection of raw
-        numbers has nothing to save and stays on the eager path.
-
-        An explicit ``time`` axis or ``compress=True`` both ask a question
-        about the merged waveform, so neither defers.
+        stimulation parameters, or that has not generated a waveform yet
         """
         if time is not None or compress:
             return False
@@ -691,14 +392,9 @@ class Stimulus(PrettyPrint):
 
         ``nested`` selects between the two readings. Only a collection can
         contain a nested source, so only a collection passes ``nested=True``.
-
-        Returns ``electrodes=None`` when the source does not name its own
-        electrodes; it is then up to the caller to number them. Likewise,
-        ``time=None`` means the source has no time component (e.g. a scalar).
         """
         if isinstance(source, Stimulus):
-            # e.g. a Stimulus being renamed, or a dict of Stimulus objects.
-            # Brings along its own electrode names and time axis:
+            # e.g. a Stimulus being renamed, or a dict of Stimulus objects
             return source.data, source.time, source.electrodes
         if np.isscalar(source) and not isinstance(source, str):
             # Scalar: 1 electrode, no time component - either way round
@@ -733,18 +429,14 @@ class Stimulus(PrettyPrint):
 
     def _factory(self, source, electrodes, time, compress):
         """Build the Stimulus object from the specified source type"""
-        # Whether we numbered the electrodes ourselves (0..N-1), in which case
-        # they cannot possibly contain duplicates:
+        # Whether we numbered the electrodes ourselves (0..N-1):
         _auto_electrodes = False
         if (_flat := _as_scalar_column(source)) is not None:
-            # A flat sequence of scalars is one electrode per element, with no
-            # time component. The collection path below would build a separate
-            # 1x1 array (and time axis) for every single electrode:
+            # one electrode per element, no time component
             _data, _time, _electrodes = _flat, None, None
             _n_rows = _data.shape[0]
         elif isinstance(source, (dict, list, tuple)):
-            # A collection: every entry is itself a source, contributing one
-            # electrode (or, for a Stimulus, however many it already has):
+            # A collection: every entry is itself a source
             if isinstance(source, dict):
                 iterator = source.items()
             else:
@@ -757,14 +449,11 @@ class Stimulus(PrettyPrint):
             _no_time = []
             for ele, src in iterator:
                 if self._components is None:
-                    # Extract times and data from source:
                     d, t, e = self._parse_source(src, nested=True)
                     _time.append(t)
                     _data.append(d)
                 else:
-                    # Nothing is sampled yet. An entry already knows how many
-                    # electrodes it drives and what they are called, and a
-                    # snapshot of it is what `_render` will read later:
+                    # Nothing is sampled yet:
                     src = _snapshot(src)
                     e, n_rows, has_time = _component_shape(src)
                     self._components.append((src, n_rows))
@@ -779,8 +468,7 @@ class Stimulus(PrettyPrint):
                 try:
                     # Compatibility channel: what described this electrode,
                     # for a reader that ends up with only the samples (see
-                    # `_rescale_params`). `_structured_sources` is where the
-                    # sources themselves are read.
+                    # `_rescale_params`)
                     self.metadata['electrodes'][str(ele)] = {
                         'metadata': src.metadata,
                         'type': type(src)
@@ -791,16 +479,11 @@ class Stimulus(PrettyPrint):
                 _data, _time = self._merge_sources(_data, _time)
                 _n_rows = _data.shape[0]
             else:
-                # Asked here as well as in `_merge_sources`, because a
-                # collection that mixes the two conventions is wrong when it
-                # is written, not when it is first read:
+                # Asked here as well as in `_merge_sources`:
                 self._require_one_time_convention(_no_time)
                 _n_rows = sum(n for _, n in self._components)
         else:
-            # A single source: a scalar, a NumPy array, or a Stimulus. The
-            # latter might be handed to us by ProsthesisSystem if the user
-            # built the stimulus themselves, and is also how a stimulus gets
-            # new electrode names or a new time axis:
+            # A single source: a scalar, a NumPy array, or a Stimulus
             if self._defers_waveform(source, electrodes, time, compress):
                 # Renaming or re-wrapping a stimulus that has not generated
                 # its waveform must not be what generates it:
@@ -821,27 +504,16 @@ class Stimulus(PrettyPrint):
         if _electrodes is None:
             # The source did not name its electrodes, so they are 0..N-1 --
             # unique by construction. Only build that array if something will
-            # read it: user-supplied `electrodes` replaces it immediately
-            # below, and the sole other reader is the metadata rename further
-            # down, which needs per-electrode metadata to do anything at all.
-            # An image or video stimulus has neither, so skipping this keeps a
-            # million-element arange off the path that builds one.
+            # read it
             _auto_electrodes = True
             if electrodes is None or self.metadata.get('electrodes'):
                 _electrodes = np.arange(_n_rows)
 
         # User can overwrite the names of the electrodes:
         if electrodes is not None:
-            # May still be None, when the block above declined to build it.
-            # The rename below already guards against that.
             _renamed_from = _electrodes
             if isinstance(electrodes, ElectrodeNames):
-                # Names generated from a grid pattern. Flattening one is a
-                # view, not a copy, and it already knows whether it can
-                # contain duplicates - so neither the copy below nor the
-                # `np.unique` further down is needed. This is the path taken
-                # by every image and video stimulus, where `electrodes` has
-                # one entry per pixel:
+                # Names generated from a grid pattern:
                 _electrodes = electrodes.ravel()
                 _auto_electrodes = _electrodes.check_unique()
             else:
@@ -850,9 +522,7 @@ class Stimulus(PrettyPrint):
         else:
             _renamed_from = None
             if isinstance(_electrodes, ElectrodeNames):
-                # The source brought its own generated names along (e.g.
-                # `Stimulus(image_stim)`). Keep them lazy rather than
-                # flattening them into actual strings below:
+                # The source brought its own generated names along:
                 _electrodes = _electrodes.ravel()
                 _auto_electrodes = _electrodes.check_unique()
             elif not isinstance(_electrodes, np.ndarray):
@@ -866,14 +536,9 @@ class Stimulus(PrettyPrint):
                              f"not match the number of electrodes in the data "
                              f"({_n_rows}).")
         # Electrodes we numbered ourselves are 0..N-1 and therefore unique by
-        # construction, so the sort that np.unique performs can be skipped
-        # (it dominates the cost of building an image or video stimulus):
+        # construction, so the sort that np.unique performs can be skipped:
         if not _auto_electrodes:
             if isinstance(_electrodes, ElectrodeNames):
-                # Only a repeated index can make grid names collide, and
-                # `check_unique` has just established that one does. The
-                # renaming below writes into the container, so it needs the
-                # actual names:
                 _electrodes = np.asarray(_electrodes)
             unq, nunq = np.unique(_electrodes, return_index=True)
             if len(unq) != _n_rows:
@@ -893,12 +558,7 @@ class Stimulus(PrettyPrint):
 
         # Per-electrode metadata is addressed by electrode name (that is how
         # BiphasicAxonMapModel finds its stimulus parameters), so renaming the
-        # electrodes has to rename those keys too. Only stimuli that carry
-        # such metadata need any of this, and they are the small ones: an
-        # image or video stimulus has one electrode per pixel and no
-        # per-electrode metadata at all. Testing that first keeps the
-        # pair-by-pair walk below off the path that renames a million
-        # electrodes:
+        # electrodes has to rename those keys too:
         elec_meta = self.metadata.get('electrodes')
         if (elec_meta and _renamed_from is not None and
                 len(_renamed_from) == len(_electrodes)):
@@ -926,113 +586,47 @@ class Stimulus(PrettyPrint):
             _time = time
 
         if self._components is not None:
-            # The electrodes are settled, the waveform is not. `_defer` is not
-            # used here because everything else it sets up has already been
-            # set up by `__init__`:
             self.__stim = {'data': None, 'time': None,
                            'electrodes': self._own_names(_electrodes)}
             return
-        # Store the data in the private container. Setting all elements at once
-        # enforces consistency; e.g., between shape of electrodes and time.
-        # The setter is what settles dtype, layout and ownership, so nothing
-        # here converts anything: doing it twice would copy twice.
         self._stim = {
             'data': _data,
             'electrodes': _electrodes,
             'time': _time,
         }
-        # Compress the data upon request:
         if compress:
             self.compress()
 
     def _shallow_copy(self):
-        """Copy the object without duplicating the data container
-
-        Methods that return a new stimulus (``append``, the arithmetic
-        operators) replace ``_stim`` wholesale, so there is no point in
-        deep-copying the (potentially large) data arrays first. Everything
-        else is preserved as it would be by ``deepcopy``: the subclass, its
-        additional attributes, and an independent copy of ``metadata``.
-
-        Note that the returned object shares its ``_stim`` dict with ``self``
-        until the caller assigns a new one, which the ``_stim`` setter always
-        does (it never mutates the dict in place).
-        """
+        """Copy the object without duplicating the data container"""
         stim = copy(self)
         stim.metadata = deepcopy(self.metadata)
         return stim
 
     def _waveform_copy(self):
-        """This stimulus' waveform, as an ordinary ``Stimulus``
-
-        The escape hatch for an operation that rewrites the waveform of a
-        stimulus which is defined by something else. What comes back is
-        described by its samples and by nothing else, so it cannot claim an
-        amplitude or a duration it does not deliver.
-        """
+        """This stimulus' waveform, as an ordinary ``Stimulus``"""
         stim = Stimulus(self.data, electrodes=self.electrodes, time=self.time)
-        # Assigned rather than passed to the constructor: a class that keeps
-        # its waveform parameters in ``metadata`` (a pulse train's frequency,
-        # say) has a dict of a shape the constructor would file under 'user'.
         stim.metadata = deepcopy(self.metadata)
         return stim._inherit_units(self)
 
     def _spatial_view(self):
-        """This stimulus as a reader with no clock of its own can read it
-
-        A pulse train says *when* current flows, and a raster says which
-        electrodes may flow at once. Both are facts about time, and a model
-        with no temporal component has no machinery to express either. A
-        stimulus that was handed to the library as current has only the one
-        description of itself and is its own answer, which is what this
-        returns. A class that knows what it was *asked* for, as well as what
-        it delivers, overrides this and says so (see ``_has_spatial_view``).
-        """
+        """This stimulus as a reader with no clock of its own can read it"""
         return self
 
     def _without_electrodes(self, electrodes):
-        """A copy of this stimulus that no longer drives ``electrodes``
-
-        What an implant does with an electrode it has switched off. Taking the
-        waveform and dropping its rows is what any stimulus described by its
-        samples can do; a class that also describes what it was asked for
-        overrides this, so that switching an electrode off does not cost that
-        description.
-        """
+        """A copy of this stimulus that no longer drives ``electrodes``"""
         stim = self._derived()
         stim.remove(electrodes)
         return stim
 
     def _derived(self):
-        """The object a waveform-rewriting operation builds its result on
-
-        An ordinary stimulus *is* its waveform, so a transformation of that
-        waveform is still one of these and keeps the subclass: an
-        :py:class:`~pulse2percept.stimuli.ImageStimulus` scaled by two is
-        still an image. A stimulus whose canonical state is a set of
-        stimulation parameters is a different matter -- those parameters
-        describe the waveform it was built with, and rewriting the samples
-        leaves them describing nothing. Such a class declares itself with
-        ``_is_parametric`` and gets a plain stimulus instead.
-        """
+        """The object a waveform-rewriting operation builds its result on"""
         if self._is_parametric:
             return self._waveform_copy()
         return self._shallow_copy()
 
     def __deepcopy__(self, memo):
-        """A copy that shares the data container with the original
-
-        There is nothing to gain from duplicating arrays that nobody can write
-        into, and something to lose: NumPy deep-copies a read-only array into
-        a *writable* one, which would hand back a stimulus whose data can be
-        rewritten after all. What genuinely has to be independent is
-        ``metadata``, the one part of a stimulus that stays mutable.
-
-        The new object goes into ``memo`` before its metadata is copied.
-        Metadata is arbitrary user data and may refer back to the stimulus it
-        describes; registering first is what makes such a cycle copy as one
-        object graph rather than recurse.
-        """
+        """A copy that shares the data container with the original"""
         stim = copy(self)
         memo[id(self)] = stim
         stim.metadata = deepcopy(self.metadata, memo)
@@ -1049,58 +643,18 @@ class Stimulus(PrettyPrint):
         its children into. There the copy is the only surviving description of
         the pulse trains, and
         :py:class:`~pulse2percept.models.cortex.DynaphosModel` still reads it.
-
-        Returns the metadata a stimulus of this class would carry after its
-        data was multiplied by ``factor``, or -- for ``factor=None`` -- after
-        an operation those parameters can no longer describe at all. A plain
-        ``Stimulus`` has no such parameters, so there is nothing to keep in
-        sync.
-
-        Parameters
-        ----------
-        metadata : dict
-            The metadata of a stimulus of this class. Never modified in place.
-        factor : float or None
-            The factor the data was scaled by, or None if the operation was
-            not a scaling (see ``_scale_factor``).
-
-        Returns
-        -------
-        metadata : dict
         """
         return metadata
 
     def _rescale_result(self, stim, factor):
-        """Keep the metadata of a transformed copy in step with its data
-
-        ``stim`` is what an operation on ``self`` produced. Usually it is a
-        copy of ``self`` and knows how to read its own metadata. For a
-        parameter-backed stimulus it is a plain
-        :py:class:`~pulse2percept.stimuli.Stimulus` instead (see
-        :py:meth:`_derived`), which does not -- so the class that wrote those
-        parameters rewrites them from here, while it is still known.
-        """
+        """Keep the metadata of a transformed copy in step with its data"""
         stim._rescale_metadata(factor)
         if self._is_parametric:
             stim.metadata = type(self)._rescale_params(stim.metadata, factor)
 
     def _rescale_metadata(self, factor):
-        """Keep the metadata in sync with data that was scaled by ``factor``
-
-        Called on the *copy* returned by ``append`` and by the arithmetic
-        operators, once its data container has been replaced. That copy owns
-        its metadata outright (``_shallow_copy`` deep-copies it), so this is
-        free to rewrite it in place.
-
-        A stimulus assembled from a collection carries the metadata of each
-        source under ``metadata['electrodes']``, filed by electrode name and
-        tagged with the class it came from. Dispatch to that class, which is
-        the one that knows what its own parameters mean -- otherwise
-        ``implant.stim * 2`` would scale the data and go on advertising the
-        amplitude the pulse trains were built with.
-        """
+        """Keep the metadata in sync with data that was scaled by ``factor``"""
         if factor == 1:
-            # Nothing about the waveform changed
             return
         elec_meta = self.metadata.get('electrodes')
         if not elec_meta:
@@ -1114,14 +668,10 @@ class Stimulus(PrettyPrint):
                 entry['metadata'] = src._rescale_params(meta, factor)
 
     def compress(self):
-        """Compress the source data
-
-        Modifies the stimulus in place; returns nothing.
-        """
+        """Compress the source data in place"""
         data = self.data
         electrodes = self.electrodes
         time = self.time
-        # Remove rows (electrodes) with all zeros:
         keep_el = fast_compress_space(data)
         data = data[keep_el]
         electrodes = electrodes[keep_el]
@@ -1163,9 +713,7 @@ class Stimulus(PrettyPrint):
             raise TypeError(f"Other object must be a Stimulus, not "
                             f"{type(other)}.")
         # The result is a copy of `self` with `other`'s data concatenated onto
-        # its own, so it would carry `self`'s unit over numbers that never
-        # meant that. Two stimuli can only be laid end to end if they measure
-        # the same thing:
+        # its own:
         if self.unit != other.unit:
             raise DimensionMismatchError(
                 f"Cannot append a stimulus measured in "
@@ -1193,28 +741,16 @@ class Stimulus(PrettyPrint):
                        f"{DT:.1e} ms.")
             raise ValueError(err_str)
         if self._is_parametric or other._is_parametric:
-            # A stimulus described by something other than its samples keeps
-            # that description: a 20 Hz train followed by a 50 Hz train is two
-            # trains, and neither of their frequencies is the sequence's.
             return _SequenceStimulus(_sequence_parts(self) +
                                      _sequence_parts(other))
         return self._append_waveform(other)
 
     def _end_column(self):
-        """The last column of the waveform
-
-        All that matters about this stimulus when another is laid after it.
-        Split out so that a sequence can answer from its last part instead of
-        concatenating everything before it (see :py:class:`_SequenceStimulus`).
-        """
+        """The last column of the waveform"""
         return self.data[:, -1]
 
     def _append_waveform(self, other):
-        """Lay ``other``'s samples after this stimulus' own
-
-        The concatenation itself; :py:meth:`append` owns the validation, and
-        has already run it.
-        """
+        """Lay ``other``'s samples after this stimulus' own"""
         stim = self._derived()
         if isclose(other.time[0], 0, abs_tol=DT):
             # The shared endpoint is written once:
@@ -1223,15 +759,9 @@ class Stimulus(PrettyPrint):
         else:
             time = np.hstack((self.time, other.time + self.time[-1]))
             data = np.hstack((self.data, other.data))
-        # Append the data points. If there's something wrong with the
-        # concatenated list of time points, the stim setter will catch it:
         stim._stim = {'data': data,
                       'electrodes': self.electrodes,
                       'time': time}
-        # Concatenating two waveforms in time is not a rescaling of either, so
-        # any parameters describing the first one no longer describe the
-        # result -- a pulse train appended to another is not one pulse train
-        # at one amplitude and frequency, whatever its type still says:
         self._rescale_result(stim, None)
         return stim
 
@@ -1248,13 +778,8 @@ class Stimulus(PrettyPrint):
             The item(s) to remove from the stimulus. Can either be an electrode
             index, electrode name, or a list thereof.
         """
-        # Nothing to remove. Note that ``electrodes`` must not be tested for
-        # falsiness here, because 0 is a perfectly valid electrode index:
         if electrodes is None or np.size(electrodes) == 0:
-            return
-        # Unlike the operators, an in-place method has no second object to
-        # hand back, so there is nowhere to put a stimulus that has lost the
-        # electrode its parameters describe:
+            return  # nothing to remove
         if self._is_parametric:
             raise NotImplementedError(
                 f"Cannot remove electrodes from a {type(self).__name__}, "
@@ -1284,12 +809,7 @@ class Stimulus(PrettyPrint):
         }
 
     def _keep_mask(self, electrodes):
-        """Which rows survive removing ``electrodes``
-
-        Indices and names both, on the terms :py:meth:`remove` has always
-        used. Shared with :py:meth:`_without_electrodes`, so that an implant
-        switching an electrode off selects exactly what removing it would.
-        """
+        """Which rows survive removing ``electrodes``"""
         # Start with a list of True and set the removed electrodes to False:
         keep_el = np.ones(len(self.electrodes), dtype=bool)
         if np.isscalar(electrodes) and electrodes == 'all':
@@ -1310,17 +830,7 @@ class Stimulus(PrettyPrint):
         return keep_el
 
     def _drop_components(self, keep_el):
-        """Forget whole entries of a collection that has not been merged yet
-
-        Such a collection loses an electrode by forgetting the entry that
-        contributes it, which is how an implant takes a deactivated electrode
-        out of a stimulus without generating the waveform of the others.
-
-        Returns False -- leaving the caller to do it the ordinary way -- when
-        this is not that kind of collection, or when the electrodes to remove
-        cut through an entry that contributes several: there is no way to take
-        one row out of an entry that has not been sampled.
-        """
+        """Forget whole entries of an unmerged collection"""
         if self._components is None or _has_waveform(self):
             return False
         kept, start = [], 0
@@ -1331,7 +841,6 @@ class Stimulus(PrettyPrint):
                 kept.append(component)
             elif rows.any():
                 return False
-        # Never written into: `copy` hands out objects that share both:
         self._components = kept
         self.__stim = {**self.__stim,
                        'electrodes': self._own_names(self.electrodes[keep_el])}
@@ -1345,12 +854,11 @@ class Stimulus(PrettyPrint):
         because an operation rewrote them and whatever described them before
         no longer does.
 
-        This is what a model reads to find out that an electrode is driven by
-        a pulse train at 20 Hz, instead of taking a copy of that number from
-        the metadata and hoping it kept up. Read-only, and deliberately
-        shallow: an entry driving more than one electrode has no
-        one-source-per-electrode reading, and gets ``None`` rather than a
-        recursive one.
+        What a model reads to find that an electrode is driven by a pulse
+        train at 20 Hz, rather than taking a copy of that number out of the
+        metadata and hoping it kept up. Deliberately shallow: an entry driving
+        several electrodes has no one-source-per-electrode reading, and gets
+        ``None`` rather than a recursive one.
         """
         if self._components is not None:
             if any(n_rows != 1 or not isinstance(src, Stimulus)
@@ -1359,8 +867,7 @@ class Stimulus(PrettyPrint):
             return [(name, src) for name, (src, _)
                     in zip(self.electrodes, self._components)]
         if self._is_parametric and len(self.electrodes) == 1:
-            # The stimulus is the source: a pulse train assigned straight to
-            # an implant arrives here as itself.
+            # The stimulus is the source:
             return [(self.electrodes[0], self)]
         return None
 
@@ -1495,156 +1002,9 @@ class Stimulus(PrettyPrint):
             ``kind='heatmap'``.
 
         """
-        if self.time is None:
-            # Cannot plot stimulus with single time point:
-            raise NotImplementedError
-        if kind is None:
-            if isinstance(ax, (list, np.ndarray)):
-                kind = 'traces'
-            elif electrodes is None and len(self.electrodes) > 1:
-                kind = 'heatmap'
-            else:
-                kind = 'traces'
-        elif kind not in ('traces', 'heatmap'):
-            raise ValueError(f"Unknown kind '{kind}'. Choose from 'traces' or "
-                             f"'heatmap'.")
-        if electrodes is None:
-            # Plot all electrodes:
-            electrodes = self.electrodes
-        elif isinstance(electrodes, (int, str)):
-            # Convert to list so we can iterate over it:
-            electrodes = [electrodes]
-        t_idx, t_vals = self._plot_times(time)
-        if kind == 'heatmap':
-            return self._plot_heatmap(electrodes, t_idx, t_vals, ax)
-        return self._plot_traces(electrodes, t_idx, t_vals, fmt, ax)
-
-    def _plot_times(self, time):
-        """Resolve a requested time range into an index and its x values"""
-        # The user can ask for a range, slice, or list of time points, which
-        # are either interpolated or loaded directly.
-        if time is None:
-            # Ask for a slice instead of `self.time` to avoid interpolation:
-            time = slice(None)
-        # A range, a list of time points, or the endpoints and step of a slice
-        # may all be given as quantities:
-        time = self._as_time(time)
-        if isinstance(time, tuple):
-            # Return a range of time points:
-            t_idx = (self.time > time[0]) & (self.time < time[1])
-            # Include the end points (might have to be interpolated):
-            t_vals = [time[0]] + list(self.time[t_idx]) + [time[1]]
-            t_idx = t_vals
-        elif isinstance(time, (list, np.ndarray)):
-            # Return list of exact time points:
-            t_idx = time
-            t_vals = time
-        elif isinstance(time, slice):
-            t_vals = self._slice_times(time)
-            if t_vals is None:
-                # Every stored sample, taken by position:
-                t_idx = time
-                t_vals = self.time[time]
-            else:
-                t_idx = t_vals
-        elif time == Ellipsis:
-            t_idx = time
-            t_vals = self.time[t_idx]
-        else:
-            raise TypeError(f'"time" must be a tuple, slice, list, or NumPy '
-                            f'array, not {type(time)}.')
-        return t_idx, t_vals
-
-    def _value_label(self):
-        """What the stimulus values are, as an axis or colorbar label"""
-        if self.unit.dimension.is_dimensionless:
-            return 'Value'
-        if self.unit == uA:
-            # Spelled the way Matplotlib renders it:
-            return r'Amplitude ($\mu$A)'
-        return f'Amplitude ({self.unit})'
-
-    def _plot_traces(self, electrodes, t_idx, t_vals, fmt, ax):
-        """Draw one waveform per electrode, each in its own Axes"""
-        owns_figure = ax is None
-        axes = ax
-        if axes is None:
-            if len(electrodes) == 1:
-                axes = plt.gca()
-            else:
-                _, axes = plt.subplots(nrows=len(electrodes),
-                                       figsize=(8, 1.2 * len(electrodes)),
-                                       layout='constrained')
-        if not isinstance(axes, (list, np.ndarray)):
-            # Convert to list so we can iterate over it:
-            axes = [axes]
-        for i, ax in enumerate(axes):
-            if not isinstance(ax, Axes):
-                raise TypeError(f"'ax' must be a list of subplots, but "
-                                f"ax[{i}] is {type(ax)}.")
-        if len(axes) != len(electrodes):
-            raise ValueError(f"Number of subplots ({len(axes)}) must be equal "
-                             f"to the number of electrodes "
-                             f"({len(electrodes)}).")
-        # Plot each electrode in its own subplot:
-        for ax, electrode in zip(axes, electrodes):
-            # Slice or interpolate stimulus:
-            slc = self.__getitem__((electrode, t_idx))
-            ax.plot(t_vals, np.squeeze(slc), fmt, linewidth=2)
-            # Turn off the ugly box spines:
-            ax.spines['top'].set_visible(False)
-            ax.spines['right'].set_visible(False)
-            ax.spines['bottom'].set_visible(False)
-            # Annotate the subplot:
-            ax.set_xticks([])
-            ax.set_yticks([slc.min(), 0, slc.max()])
-            x_pad = 0.02 * (t_vals[-1] - t_vals[0])
-            ax.set_xlim(t_vals[0] - x_pad, t_vals[-1] + x_pad)
-            y_pad = np.maximum(1, 0.02 * (slc.max() - slc.min()))
-            ax.set_ylim(slc.min() - y_pad, slc.max() + y_pad)
-            ax.set_ylabel(electrode)
-        # Only the bottom subplot carries the shared time axis:
-        axes[-1].set_xticks(np.linspace(t_vals[0], t_vals[-1], num=5))
-        axes[-1].set_xlabel(f'Time ({self.time_unit})')
-        if owns_figure:
-            axes[-1].figure.supylabel(self._value_label())
-        if len(axes) == 1:
-            return axes[0]
-        return axes
-
-    def _plot_heatmap(self, electrodes, t_idx, t_vals, ax):
-        """Draw the stimulus as a single electrode-by-time image"""
-        if isinstance(ax, (list, np.ndarray)):
-            raise TypeError(f"A heatmap is drawn in a single Axes, but 'ax' "
-                            f"is a sequence of {len(ax)}.")
-        electrodes = list(electrodes)
-        owns_figure = ax is None
-        if ax is None:
-            # Give every electrode a readable row of its own:
-            height = float(np.clip(0.18 * len(electrodes), 2.5, 12))
-            _, ax = plt.subplots(figsize=(8, height), layout='constrained')
-        elif not isinstance(ax, Axes):
-            raise TypeError(f"'ax' must be a Matplotlib Axes, not {type(ax)}.")
-        data = np.atleast_2d(self.__getitem__((electrodes, t_idx)))
-        t_vals = np.asarray(t_vals, dtype=float)
-        vmax = np.max(np.abs(data))
-        if not np.isfinite(vmax) or vmax == 0:
-            vmax = 1.0
-        if data.min() < 0:
-            cmap, vmin = 'RdBu_r', -vmax
-        else:
-            cmap, vmin = 'viridis', 0.0
-        mesh = ax.pcolormesh(_cell_edges(t_vals), np.arange(len(data) + 1),
-                             data, cmap=cmap, vmin=vmin, vmax=vmax)
-        ax.set_yticks(np.arange(len(data)) + 0.5,
-                      labels=[str(e) for e in electrodes])
-        # Read top to bottom, in the order the electrodes were asked for:
-        ax.invert_yaxis()
-        ax.set_xlabel(f'Time ({self.time_unit})')
-        ax.set_ylabel('Electrode')
-        if owns_figure:
-            ax.figure.colorbar(mesh, ax=ax, label=self._value_label())
-        return ax
+        # Imported here so that a stimulus does not depend on Matplotlib:
+        from ._plot import plot_stimulus
+        return plot_stimulus(self, electrodes, time, fmt, ax, kind)
 
     def __getitem__(self, item):
         """Returns an item from the data array, interpolated if necessary
@@ -1657,7 +1017,6 @@ class Stimulus(PrettyPrint):
         *  ``stim[:, 1]``: always interpreted as t=1.0, not index=1
         *  ``stim[:, 1.234]``: interpolated time
         *  ``stim[:, stim.time < 0.4]``, ``stim[:, 0.3:1.9:0.001]``
-
         """
         # STEP 1: AVOID CONFUSING TIME POINTS WITH COLUMN INDICES
         # NumPy handles most indexing and slicing. However, we need to prevent
@@ -1671,7 +1030,6 @@ class Stimulus(PrettyPrint):
                 if sliced is not None:
                     time = sliced
             elif time is not Ellipsis:
-                # A requested time point (or a list of them) may be unitful
                 time = self._as_time(time)
                 # Convert to float so time is not mistaken for column index
                 if np.array(time).dtype != bool:
@@ -1685,7 +1043,6 @@ class Stimulus(PrettyPrint):
             parsed_electrodes = []
             for e in np.array([electrodes]).ravel():
                 if isinstance(e, str):
-                    # Use string as index into the list of electrode names:
                     parsed_electrodes.append(_index_of_name(self.electrodes, e))
                 else:
                     # Most likely an integer index:
@@ -1696,7 +1053,6 @@ class Stimulus(PrettyPrint):
             else:
                 # Otherwise return an array:
                 electrodes = np.array(parsed_electrodes)
-        # Make sure electrode index is valid:
         try:
             self._stim['data'][electrodes]
         except IndexError:
@@ -1780,9 +1136,6 @@ class Stimulus(PrettyPrint):
             return False
         if self.shape != other.shape:
             return False
-        # np.allclose builds several full-size temporaries. np.array_equal is
-        # much cheaper and, whenever it succeeds, implies it - so use it as a
-        # fast path for the common case of comparing identical stimuli:
         if not (np.array_equal(self.data, other.data) or
                 np.allclose(self.data, other.data)):
             return False
@@ -1823,8 +1176,7 @@ class Stimulus(PrettyPrint):
                             f"{type(b)}")
         # Return a copy of the current object with the new data. The operator
         # produces a new array for `field`; the other fields must be copied
-        # explicitly, so that the returned stimulus shares no buffer with the
-        # original (`_shallow_copy` does not duplicate the data container):
+        # explicitly:
         stim = self._derived()
         time = stim.time
         if field == 'time':
@@ -1835,86 +1187,45 @@ class Stimulus(PrettyPrint):
                       'electrodes': stim.electrodes.copy(),
                       'time': time}
         # Parameters that describe the waveform (a pulse train's amplitude,
-        # say) have to follow the data, or a model reading them back predicts
-        # from a stimulus that is no longer the one it was handed:
+        # say) have to follow the data:
         reverse = bool(a_supported)
         self._rescale_result(stim, _scale_factor(op, a if reverse else b,
                                                  reverse, field))
         return stim
 
     def _scaled(self, factor):
-        """This stimulus with every amplitude scaled by ``factor``
-
-        The seam for a class that can express a scaled version of itself
-        without rewriting any samples: a pulse train at twice the amplitude is
-        a pulse train, and a collection of them is that collection with every
-        entry scaled. Returning ``None`` -- which is what a stimulus that
-        *is* its waveform does -- runs the ordinary waveform operation
-        instead.
-
-        Only ever called with a finite factor, and only for operations that
-        scale every amplitude by the same number.
-        """
+        """This stimulus with every amplitude scaled by ``factor``"""
         return self._scale_components(factor)
 
     def _scale_components(self, factor):
-        """A collection that has not been merged scales its entries instead
-
-        Only when every entry is a stimulus in its own right: scaling a raw
-        entry would mean sampling it, which is the work staying unmerged
-        exists to avoid.
-        """
+        """An unmerged collection scales its entries instead"""
         if self._components is None or _has_waveform(self):
             return None
         if not all(isinstance(src, Stimulus) for src, _ in self._components):
             return None
         stim = self._shallow_copy()
-        # A new list rather than a write: `_shallow_copy` hands out the same
-        # one. The entries scale themselves, structurally where they can:
         stim._components = [(src * factor, n) for src, n in self._components]
-        # `metadata['electrodes']` describes those entries, and is what the
-        # models still read their pulse parameters off:
         stim._rescale_metadata(factor)
         return stim
 
     def _operate(self, op, scalar, reverse=False):
-        """Apply an arithmetic operator to the stimulus
-
-        Asks :py:meth:`_scaled` first, so that a class which can express the
-        result in its own terms never has to sample itself to produce it.
-        ``reverse`` says the stimulus is the operand on the right.
-        """
+        """Apply an arithmetic operator to the stimulus"""
         if np.isscalar(scalar) and not isinstance(scalar, str):
             factor = _scale_factor(op, scalar, reverse)
             if factor is not None:
                 scaled = self._scaled(factor)
                 if scaled is not None:
                     return scaled
-        # Nothing structured describes this, so the waveform is the answer.
-        # An unsupported operand also lands here, and is rejected there:
         data = self.data
         a, b = (scalar, data) if reverse else (data, scalar)
         return self._apply_operator(a, op, b)
 
     def _as_amplitude(self, scalar):
-        """Normalize an operand that is added to or subtracted from the data
-
-        Adding to the data means adding an amplitude, so a quantity has to be
-        one: ``stim + 0.5 * mA`` is 500 uA more current everywhere, and
-        ``stim + 5 * ms`` is nothing at all. A bare number is taken to be in
-        the stimulus' own unit, as it always was.
-        """
+        """Normalize an operand that is added to or subtracted from the data"""
         return as_value(scalar, self.unit)
 
     def _as_factor(self, scalar):
-        """Normalize an operand that scales the data
-
-        Deliberately narrower than
-        :py:meth:`~pulse2percept.stimuli.Stimulus._as_amplitude`: a scale
-        factor is a plain number. Letting ``stim * ms`` through would turn a
-        stimulus into a charge, and a stimulus is a stimulus rather than a
-        general physical array.
-        """
+        """Normalize an operand that scales the data"""
         return as_value(scalar, dimensionless)
 
     def _as_time(self, scalar):
@@ -1922,11 +1233,7 @@ class Stimulus(PrettyPrint):
         return as_value(scalar, self.time_unit)
 
     def _slice_times(self, time):
-        """The time points a slice of the time axis asks for
-
-        See :py:func:`~pulse2percept.utils.array._slice_times`, which
-        :py:class:`~pulse2percept.percepts.Percept` indexing shares.
-        """
+        """The time points a slice of the time axis asks for"""
         return _slice_times(time, self.time, self.time_unit)
 
     def __add__(self, scalar):
@@ -1963,22 +1270,15 @@ class Stimulus(PrettyPrint):
         return self.__mul__(-1)
 
     def __rshift__(self, scalar):
-        """Shift every time point in the stimulus some ms into the future
-
-        Shorthand for :py:meth:`~pulse2percept.stimuli.Stimulus.shift`.
-        """
+        """Shift all times some ms into the future (shorthand for shift)"""
         return self.shift(scalar)
 
     def __lshift__(self, scalar):
-        """Shift every time point in the stimulus some ms into the past
-
-        Shorthand for ``shift(-scalar)``; see
-        :py:meth:`~pulse2percept.stimuli.Stimulus.shift`.
-        """
+        """Shift all times some ms into the past (shorthand for -shift)"""
         return self.shift(-self._as_time(scalar))
 
     def _check_stim(self, stim):
-        # Check stimulus data for consistency:
+        """Check stimulus data for consistency"""
         for field in ['data', 'electrodes', 'time']:
             if field not in stim:
                 raise AttributeError(f"Stimulus dict must contain a field "
@@ -1999,10 +1299,7 @@ class Stimulus(PrettyPrint):
                                  f"number of columns in the data array "
                                  f"({data_shape[1]}).")
             if not is_strictly_increasing(stim['time'], tol=0.95*DT):
-                # Report the offending points rather than the whole axis: a
-                # long pulse train has hundreds of thousands of time points,
-                # and printing all of them buries the handful that are wrong
-                # under megabytes of output.
+                # Report the offending points rather than the whole axis:
                 t = np.asarray(stim['time'])
                 bad = np.flatnonzero(np.diff(t) < 0.95 * DT)
                 shown = ', '.join(f"t[{i}]={t[i]:g} -> t[{i + 1}]={t[i + 1]:g}"
@@ -2018,25 +1315,7 @@ class Stimulus(PrettyPrint):
 
     @staticmethod
     def _own(arr, dtype):
-        """An immutable, C-contiguous array of ``dtype`` that nothing aliases
-
-        Ownership is what makes immutability mean anything. Marking whatever
-        buffer arrived read-only would take the caller's own array away from
-        them, and storing it as it came would let ``arr[0] = 99`` rewrite a
-        stimulus long after it was built. So the stimulus takes a copy, and
-        that copy is the only writable reference there ever was to it.
-
-        Copy unconditionally rather than only where a conversion is needed:
-        "returned a different object" is not the same claim as "shares no
-        memory with the input", and it is the second one this has to make.
-        Asking for a view of a subclass, for one, hands back a new ndarray
-        over the very same buffer.
-
-        C-contiguity is not incidental: every Cython kernel in the library
-        takes the data as ``float32[:, ::1]``, and not everything that builds
-        a stimulus produces that (selecting columns, as ``compress`` does,
-        hands back an F-ordered array for a multi-electrode stimulus).
-        """
+        """An immutable, C-contiguous array of dtype"""
         if arr is None:
             return None
         owned = np.array(arr, dtype=dtype, order='C', copy=True)
@@ -2045,13 +1324,7 @@ class Stimulus(PrettyPrint):
 
     @staticmethod
     def _own_names(electrodes):
-        """The electrode names, in a container nobody can write into
-
-        :py:class:`~pulse2percept.stimuli.ElectrodeNames` generates its names
-        from a grid rather than storing them, and has no way to set one, so it
-        is already what this method promises -- and materializing it into an
-        array would cost a million strings for an image stimulus.
-        """
+        """The electrode names, in a container nobody can write into"""
         if isinstance(electrodes, ElectrodeNames):
             return electrodes
         owned = np.array(electrodes)
@@ -2064,15 +1337,11 @@ class Stimulus(PrettyPrint):
 
         Reading this is what materializes the waveform of a stimulus that
         deferred building one (see :py:meth:`_defer` and :py:meth:`_render`).
-        Everything that needs samples goes through here, so that is the one
-        place the waveform can come into existence; ``electrodes`` is the
-        exception, and reads the container directly.
         """
         if self.__stim['data'] is None:
             promised = self.__stim['electrodes']
             # The setter installs the rendered state, so `_render` runs once.
-            # It also clears the components, and this is the one waveform they
-            # do describe, so they are put back afterwards:
+            # It also clears the components:
             components = self._components
             self._stim = self._render()
             self._components = components
@@ -2087,26 +1356,10 @@ class Stimulus(PrettyPrint):
     @_stim.setter
     def _stim(self, stim):
         self._check_stim(stim)
-        # A waveform that arrives from outside is not the one the components
-        # describe -- an operation that rewrote the samples would otherwise
-        # leave a stimulus whose structured source says something else. Only
-        # the render path in the getter above, which builds the waveform *from*
-        # the components, puts them back.
         self._components = None
-        # All checks passed. Take ownership of every array before storing it,
-        # so that the scientific state of a stimulus cannot change once it
-        # has one. `copy` hands out objects that share this dict, so replace
-        # it rather than writing through:
         self.__stim = {**stim,
                        'data': self._own(stim['data'], np.float32),
-                       # Time is float64 while data is float32. The asymmetry
-                       # is deliberate: a time axis has one entry per column
-                       # where the data has one per electrode per column, so
-                       # widening it costs almost nothing, and float32 cannot
-                       # carry a time axis at all. Its resolution reaches
-                       # DT=1e-3 ms at t = 8.4 s, past which the DT-wide edges
-                       # of a pulse collapse to zero width -- a 30 s pulse
-                       # train lost 952 of its edges that way.
+                       # Time is deliberately float64 while data is float32:
                        'time': self._own(stim['time'], np.float64),
                        'electrodes': self._own_names(stim['electrodes'])}
 
@@ -2116,11 +1369,6 @@ class Stimulus(PrettyPrint):
 
         A read-only 2-D NumPy array that contains the sampled waveform, where
         the rows denote electrodes and the columns denote points in time.
-
-        For a pulse-based or encoded stimulus the waveform is what the
-        parameters or the schedule describe rather than what the stimulus
-        stores, so reading this may be what generates it. It is cached
-        afterwards, and the parameters can be read without it.
         """
         return self._stim['data']
 
@@ -2133,14 +1381,6 @@ class Stimulus(PrettyPrint):
     def unit(self):
         """The unit ``data`` is expressed in
 
-        Microamps for an electrical stimulus, dimensionless for the gray
-        levels of an :py:class:`~pulse2percept.stimuli.ImageStimulus` or
-        :py:class:`~pulse2percept.stimuli.VideoStimulus`.
-
-        Read-only. The canonical storage unit is fixed so that models, safety
-        checks and Cython kernels can rely on it; ask for another unit with
-        :py:meth:`~pulse2percept.stimuli.Stimulus.values`.
-
         .. versionadded:: 0.10.0
 
         """
@@ -2148,7 +1388,7 @@ class Stimulus(PrettyPrint):
 
     @property
     def time_unit(self):
-        """The unit ``time`` is expressed in (milliseconds)
+        """The unit ``time`` is expressed in
 
         .. versionadded:: 0.10.0
 
@@ -2200,8 +1440,7 @@ class Stimulus(PrettyPrint):
         -------
         values : np.ndarray
             An ordinary NumPy array, never a
-            :py:class:`~pulse2percept.units.Quantity`. This is the boundary a
-            numerical implementation should take its data across.
+            :py:class:`~pulse2percept.units.Quantity`.
 
         Examples
         --------
@@ -2246,33 +1485,21 @@ class Stimulus(PrettyPrint):
         A list of electrode names, corresponding to the rows in the data
         container.
         """
-        # Reads the container directly rather than through `_stim`: which
-        # electrodes a stimulus drives is known before its waveform is, and
-        # asking for them must not be what generates one.
         return self.__stim['electrodes']
 
     @property
     def time(self):
-        """Time steps
-        A list of time steps, corresponding to the columns in the data
-        container.
-        """
+        """A list of time steps (i.e., the columns in the data container)"""
         return self._stim['time']
 
     @property
     def is_compressed(self):
-        """Flag indicating whether the stimulus has been compressed
-
-        Read-only: the flag is maintained by ``compress``. Assigning to it
-        raises an ``AttributeError``.
-        """
+        """Flag indicating whether the stimulus has been compressed"""
         return self._is_compressed
 
     @property
     def dt(self):
-        """Sampling time step (ms)
-
-        Defines the duration of the signal edge transitions.
+        """Sampling time step (duration of signal edge transitions)
 
         .. versionadded:: 0.7
 
@@ -2288,18 +1515,9 @@ class Stimulus(PrettyPrint):
         For the whole stimulus to be charge-balanced, every electrode must be
         charge-balanced as well.
 
-        Returns None if the stimulus is not a current at all: the gray levels
-        of an :py:class:`~pulse2percept.stimuli.ImageStimulus` integrate to a
-        number like any others, but that number is not a charge and asking
-        whether it is zero answers nothing. Note that this is "not applicable",
-        not "unbalanced" -- it is
-        :py:attr:`~pulse2percept.implants.ProsthesisSystem.safe_mode` that
-        turns the question into an error, since a safety system genuinely
-        cannot do its job on a stimulus that is not electrical.
-
         .. versionchanged:: 0.10.0
             Returns None for a stimulus that is not measured in units of
-            current (was: integrated the values anyway).
+            current.
 
         """
         if self.unit.dimension != uA.dimension:
@@ -2322,8 +1540,6 @@ def _has_time_axis(stim):
 def _sequence_parts(stim):
     """The parts a stimulus contributes to a sequence, already flattened"""
     if isinstance(stim, _SequenceStimulus):
-        # Already snapshots, and appending to a sequence extends it rather
-        # than nesting one inside another:
         return list(stim.parts)
     return [_snapshot(stim)]
 
@@ -2336,9 +1552,7 @@ class _SequenceStimulus(Stimulus):
     20 Hz train followed by a 50 Hz train goes on being two trains; only the
     concatenation waits for :py:meth:`_render`.
 
-    Private on purpose: this is a temporal sequence and nothing else. It is
-    not an expression tree, and it does not answer questions about pulse
-    parameters -- a sequence has no single frequency to report.
+    Private on purpose.
     """
     #: Described by its parts rather than by its samples:
     _is_parametric = True
@@ -2351,11 +1565,6 @@ class _SequenceStimulus(Stimulus):
         self._defer(first.electrodes, unit=first.unit,
                     time_unit=first.time_unit)
         self.metadata = deepcopy(first.metadata)
-        # A sequence has no one frequency or amplitude, so the parameters that
-        # described its first part are dropped here exactly as
-        # `_append_waveform` drops them: a model asking for them rejects the
-        # stimulus rather than predicting from the first part's numbers. The
-        # parts keep their own, and `parts` is where to read them.
         first._rescale_result(self, None)
 
     @property

--- a/pulse2percept/stimuli/base.py
+++ b/pulse2percept/stimuli/base.py
@@ -50,6 +50,25 @@ def _index_of_name(electrodes, name):
     return list(electrodes).index(name)
 
 
+class _Owned(np.ndarray):
+    """An array the library allocated for one stimulus"""
+    __slots__ = ()
+
+
+def _owned(arr):
+    """Promise that arr is the library's alone"""
+    return arr.view(_Owned)
+
+
+def _freeze(arr):
+    """Make ``arr``, and every array it is a view of, read-only"""
+    level = arr
+    while isinstance(level, np.ndarray):
+        level.flags.writeable = False
+        level = level.base
+    return arr
+
+
 def _describe_unit(unit):
     """Name a unit the way an error message wants to read"""
     if unit.dimension.is_dimensionless:
@@ -243,7 +262,7 @@ class Stimulus(PrettyPrint):
     _default_unit = uA
     _default_time_unit = ms
 
-    #: False for a stimulus that is its own spatial description
+    #: Whether this stimulus provides a separate spatial-only view
     _has_spatial_view = False
 
     #: whether the canonical state is a set of stim params
@@ -847,18 +866,10 @@ class Stimulus(PrettyPrint):
         return True
 
     def _structured_sources(self):
-        """The stimulus describing each electrode, where one is still retained
+        """Return ``(electrode, source)`` pairs for retained structured sources.
 
-        Returns ``[(electrode_name, source), ...]`` in row order, or ``None``
-        when this stimulus is only its samples -- because it always was, or
-        because an operation rewrote them and whatever described them before
-        no longer does.
-
-        What a model reads to find that an electrode is driven by a pulse
-        train at 20 Hz, rather than taking a copy of that number out of the
-        metadata and hoping it kept up. Deliberately shallow: an entry driving
-        several electrodes has no one-source-per-electrode reading, and gets
-        ``None`` rather than a recursive one.
+        Returns ``None`` if the stimulus is waveform-only or cannot be mapped
+        one source per electrode.
         """
         if self._components is not None:
             if any(n_rows != 1 or not isinstance(src, Stimulus)
@@ -1318,6 +1329,8 @@ class Stimulus(PrettyPrint):
         """An immutable, C-contiguous array of dtype"""
         if arr is None:
             return None
+        if isinstance(arr, _Owned) and arr.dtype == dtype:
+            return _freeze(np.ascontiguousarray(arr))
         owned = np.array(arr, dtype=dtype, order='C', copy=True)
         owned.flags.writeable = False
         return owned

--- a/pulse2percept/stimuli/base.py
+++ b/pulse2percept/stimuli/base.py
@@ -468,6 +468,11 @@ class Stimulus(PrettyPrint):
     #: The unit ``time`` is stored in.
     _default_time_unit = ms
 
+    #: Whether :py:meth:`_spatial_view` describes something other than this
+    #: stimulus. False for a stimulus that is its own spatial description,
+    #: which is every stimulus that was handed to the library as current.
+    _has_spatial_view = False
+
     #: Whether this class' canonical state is a set of stimulation parameters
     #: rather than the waveform itself. Such a stimulus cannot survive a
     #: change to its samples, because its parameters would go on describing a
@@ -948,6 +953,32 @@ class Stimulus(PrettyPrint):
         stim.metadata = deepcopy(self.metadata)
         return stim._inherit_units(self)
 
+    def _spatial_view(self):
+        """This stimulus as a reader with no clock of its own can read it
+
+        A pulse train says *when* current flows, and a raster says which
+        electrodes may flow at once. Both are facts about time, and a model
+        with no temporal component has no machinery to express either. A
+        stimulus that was handed to the library as current has only the one
+        description of itself and is its own answer, which is what this
+        returns. A class that knows what it was *asked* for, as well as what
+        it delivers, overrides this and says so (see ``_has_spatial_view``).
+        """
+        return self
+
+    def _without_electrodes(self, electrodes):
+        """A copy of this stimulus that no longer drives ``electrodes``
+
+        What an implant does with an electrode it has switched off. Taking the
+        waveform and dropping its rows is what any stimulus described by its
+        samples can do; a class that also describes what it was asked for
+        overrides this, so that switching an electrode off does not cost that
+        description.
+        """
+        stim = self._derived()
+        stim.remove(electrodes)
+        return stim
+
     def _derived(self):
         """The object a waveform-rewriting operation builds its result on
 
@@ -1221,8 +1252,27 @@ class Stimulus(PrettyPrint):
                 'time': self.time
             }
             return
+        keep_el = self._keep_mask(electrodes)
+        if self._drop_components(keep_el):
+            return
+        self._stim = {
+            'data': self.data[keep_el],
+            'electrodes': self.electrodes[keep_el],
+            'time': self.time,
+        }
+
+    def _keep_mask(self, electrodes):
+        """Which rows survive removing ``electrodes``
+
+        Indices and names both, on the terms :py:meth:`remove` has always
+        used. Shared with :py:meth:`_without_electrodes`, so that an implant
+        switching an electrode off selects exactly what removing it would.
+        """
         # Start with a list of True and set the removed electrodes to False:
         keep_el = np.ones(len(self.electrodes), dtype=bool)
+        if np.isscalar(electrodes) and electrodes == 'all':
+            keep_el[:] = False
+            return keep_el
         for electrode in np.array([electrodes]).ravel():
             try:
                 # Check if `electrode` is an index into the electrodes array:
@@ -1235,13 +1285,7 @@ class Stimulus(PrettyPrint):
                     keep_el[_index_of_name(self.electrodes, electrode)] = False
                 except ValueError:
                     raise ValueError(f'Electrode "{electrode}" not found.')
-        if self._drop_components(keep_el):
-            return
-        self._stim = {
-            'data': self.data[keep_el],
-            'electrodes': self.electrodes[keep_el],
-            'time': self.time,
-        }
+        return keep_el
 
     def _drop_components(self, keep_el):
         """Forget whole entries of a collection that has not been merged yet

--- a/pulse2percept/stimuli/base.py
+++ b/pulse2percept/stimuli/base.py
@@ -848,7 +848,7 @@ class Stimulus(PrettyPrint):
 
     def _drop_components(self, keep_el):
         """Forget whole entries of an unmerged collection"""
-        if self._components is None:
+        if self._components is None or not keep_el.any():
             return False
         kept, start = [], 0
         for component in self._components:

--- a/pulse2percept/stimuli/base.py
+++ b/pulse2percept/stimuli/base.py
@@ -245,6 +245,48 @@ def _stimulus_sources(source):
     return []
 
 
+def _has_waveform(stim):
+    """Whether a stimulus has already generated the samples it describes
+
+    Reads the private container, because every public attribute that could
+    answer the question would generate them first.
+    """
+    return stim._Stimulus__stim['data'] is not None
+
+
+def _snapshot(source):
+    """One entry of a collection, as it was when the collection was built
+
+    A collection that has not been merged yet keeps its entries instead of
+    their samples, so it has to keep them frozen: a stimulus built from a
+    pulse train describes that train as it was, not as its author went on to
+    change it. Deep-copying a stimulus is cheap -- its arrays are immutable
+    and shared -- and the raw entries are one electrode's worth of numbers.
+    """
+    if np.isscalar(source):
+        return source
+    return deepcopy(source)
+
+
+def _component_shape(source):
+    """What one entry of a collection contributes, without sampling it
+
+    Returns the electrode names the entry brings along (``None`` if it does
+    not name its own), how many rows it contributes, and whether it has a time
+    component. This is what lets a collection settle its electrodes, and
+    reject the mistakes that are about electrodes, before any waveform exists.
+    """
+    if isinstance(source, Stimulus):
+        # An unrendered stimulus is one of ours, and every parameter-backed
+        # class in the library is a pulse -- which has a time axis. Asking one
+        # that has already been rendered costs nothing.
+        has_time = not _has_waveform(source) or source.time is not None
+        return source.electrodes, len(source.electrodes), has_time
+    # Anything else is a single electrode; only a scalar has no time axis
+    # (`_parse_source` gives a nested sequence one point per element):
+    return None, 1, not (np.isscalar(source) and not isinstance(source, str))
+
+
 def _strip_units(source, unit):
     """Convert a source's quantities into plain numbers expressed in ``unit``
 
@@ -415,7 +457,8 @@ class Stimulus(PrettyPrint):
 
     """
     # Frozen class: Only the following class attributes are allowed
-    __slots__ = ('metadata', '_is_compressed', '__stim', '_unit', '_time_unit')
+    __slots__ = ('metadata', '_is_compressed', '__stim', '_unit',
+                 '_time_unit', '_components')
 
     #: The unit ``data`` is stored in. Electrical stimuli are microamps, which
     #: is what every model, pulse and safety check in the library assumes; a
@@ -440,6 +483,9 @@ class Stimulus(PrettyPrint):
         self.metadata = self._wrap_metadata(metadata)
         # Flag will be flipped in the compress method:
         self._is_compressed = False
+        # Set by `_factory` when this is a collection whose entries have not
+        # been merged into a waveform yet (see `_render`):
+        self._components = None
         # Settle what the numbers below mean before reading any of them, then
         # convert every quantity into that unit. From here on the source is
         # ordinary numbers, which is all `_factory` has ever had to handle:
@@ -482,6 +528,7 @@ class Stimulus(PrettyPrint):
         """
         self.metadata = self._wrap_metadata(metadata)
         self._is_compressed = False
+        self._components = None
         self._unit = self._default_unit if unit is None else unit
         self._time_unit = (self._default_time_unit if time_unit is None
                            else time_unit)
@@ -508,10 +555,18 @@ class Stimulus(PrettyPrint):
         is owned, immutable and validated on exactly the same terms as one
         that was passed in.
         """
-        raise NotImplementedError(
-            f"{type(self).__name__} has no stimulus data, and does not know "
-            f"how to generate any. A subclass that defers its waveform must "
-            f"override '_render'.")
+        if self._components is None:
+            raise NotImplementedError(
+                f"{type(self).__name__} has no stimulus data, and does not "
+                f"know how to generate any. A subclass that defers its "
+                f"waveform must override '_render'.")
+        _data, _time = [], []
+        for src, _ in self._components:
+            d, t, _e = self._parse_source(src, nested=True)
+            _data.append(d)
+            _time.append(t)
+        _data, _time = self._merge_sources(_data, _time)
+        return {'data': _data, 'electrodes': self.electrodes, 'time': _time}
 
     def _resolve_units(self, source):
         """Determine the units this stimulus stores its data and time in
@@ -557,6 +612,43 @@ class Stimulus(PrettyPrint):
                 'time': self.time, 'shape': self.shape, 'dt': self.dt,
                 'is_charge_balanced': self.is_charge_balanced,
                 'metadata': self.metadata}
+
+    @staticmethod
+    def _defers_waveform(source, electrodes, time, compress):
+        """Whether to keep this source's entries instead of merging them now
+
+        Worth doing when an entry is a stimulus that is defined by its
+        stimulation parameters, or that has not generated a waveform yet:
+        merging is what would force one into existence. A collection of raw
+        numbers has nothing to save and stays on the eager path.
+
+        An explicit ``time`` axis or ``compress=True`` both ask a question
+        about the merged waveform, so neither defers.
+        """
+        if time is not None or compress:
+            return False
+        return any(s._is_parametric or not _has_waveform(s)
+                   for s in _stimulus_sources(source))
+
+    @staticmethod
+    def _require_one_time_convention(no_time):
+        """Every entry of a collection has a time axis, or none of them does"""
+        if len(np.unique(no_time)) > 1:
+            raise ValueError("If one stimulus has time=None, all others "
+                             "must have time=None as well.")
+
+    @classmethod
+    def _merge_sources(cls, _data, _time):
+        """Stack the entries of a collection onto one common time axis"""
+        cls._require_one_time_convention([t is None for t in _time])
+        # When none of the stimuli have time=None, we need to merge the
+        # time axes (this is expensive because of interpolation):
+        if len(_time) > 1 and _time[0] is not None:
+            _data, _time = merge_time_axes(_data, _time)
+        # Now make `_data` a 2-D NumPy array, with `_electrodes` as rows
+        # and `_time` as columns (except sometimes `_time` is None).
+        return (np.vstack(_data) if _data else np.array([]),
+                _time[0] if _time else None)
 
     def _parse_source(self, source, nested=False):
         """Extract data, time and electrode names from a single source
@@ -626,6 +718,7 @@ class Stimulus(PrettyPrint):
             # time component. The collection path below would build a separate
             # 1x1 array (and time axis) for every single electrode:
             _data, _time, _electrodes = _flat, None, None
+            _n_rows = _data.shape[0]
         elif isinstance(source, (dict, list, tuple)):
             # A collection: every entry is itself a source, contributing one
             # electrode (or, for a Stimulus, however many it already has):
@@ -633,14 +726,26 @@ class Stimulus(PrettyPrint):
                 iterator = source.items()
             else:
                 iterator = enumerate(source)
+            if self._defers_waveform(source, electrodes, time, compress):
+                self._components = []
             _time = []
             _electrodes = []
             _data = []
+            _no_time = []
             for ele, src in iterator:
-                # Extract times and data from source:
-                d, t, e = self._parse_source(src, nested=True)
-                _time.append(t)
-                _data.append(d)
+                if self._components is None:
+                    # Extract times and data from source:
+                    d, t, e = self._parse_source(src, nested=True)
+                    _time.append(t)
+                    _data.append(d)
+                else:
+                    # Nothing is sampled yet. An entry already knows how many
+                    # electrodes it drives and what they are called, and a
+                    # snapshot of it is what `_render` will read later:
+                    src = _snapshot(src)
+                    e, n_rows, has_time = _component_shape(src)
+                    self._components.append((src, n_rows))
+                    _no_time.append(not has_time)
                 if isinstance(source, dict):
                     # Special case, electrode names are specified in a dict:
                     _electrodes.append(ele)
@@ -655,24 +760,30 @@ class Stimulus(PrettyPrint):
                     }
                 except AttributeError:
                     pass
-            # Make sure all stimuli have time=None or none of them do:
-            if len(np.unique([t is None for t in _time])) > 1:
-                raise ValueError("If one stimulus has time=None, all others "
-                                 "must have time=None as well.")
-            # When none of the stimuli have time=None, we need to merge the
-            # time axes (this is expensive because of interpolation):
-            if len(_time) > 1 and _time[0] is not None:
-                _data, _time = merge_time_axes(_data, _time)
-            # Now make `_data` a 2-D NumPy array, with `_electrodes` as rows
-            # and `_time` as columns (except sometimes `_time` is None).
-            _data = np.vstack(_data) if _data else np.array([])
-            _time = _time[0] if _time else None
+            if self._components is None:
+                _data, _time = self._merge_sources(_data, _time)
+                _n_rows = _data.shape[0]
+            else:
+                # Asked here as well as in `_merge_sources`, because a
+                # collection that mixes the two conventions is wrong when it
+                # is written, not when it is first read:
+                self._require_one_time_convention(_no_time)
+                _n_rows = sum(n for _, n in self._components)
         else:
             # A single source: a scalar, a NumPy array, or a Stimulus. The
             # latter might be handed to us by ProsthesisSystem if the user
             # built the stimulus themselves, and is also how a stimulus gets
             # new electrode names or a new time axis:
-            _data, _time, _electrodes = self._parse_source(source)
+            if self._defers_waveform(source, electrodes, time, compress):
+                # Renaming or re-wrapping a stimulus that has not generated
+                # its waveform must not be what generates it:
+                snapshot = _snapshot(source)
+                _electrodes, _n_rows, _ = _component_shape(snapshot)
+                self._components = [(snapshot, _n_rows)]
+                _data, _time = None, None
+            else:
+                _data, _time, _electrodes = self._parse_source(source)
+                _n_rows = _data.shape[0]
             if isinstance(source, Stimulus):
                 if 'electrodes' not in source.metadata.keys():
                     self.metadata['electrodes'][str(_electrodes[0])] = {
@@ -690,7 +801,7 @@ class Stimulus(PrettyPrint):
             # million-element arange off the path that builds one.
             _auto_electrodes = True
             if electrodes is None or self.metadata.get('electrodes'):
-                _electrodes = np.arange(_data.shape[0])
+                _electrodes = np.arange(_n_rows)
 
         # User can overwrite the names of the electrodes:
         if electrodes is not None:
@@ -723,10 +834,10 @@ class Stimulus(PrettyPrint):
                     _electrodes = np.concatenate(_electrodes)
                 except ValueError:
                     _electrodes = np.array(_electrodes)
-        if len(_electrodes) != _data.shape[0]:
+        if len(_electrodes) != _n_rows:
             raise ValueError(f"Number of electrodes provided ({len(_electrodes)}) does "
                              f"not match the number of electrodes in the data "
-                             f"({_data.shape[0]}).")
+                             f"({_n_rows}).")
         # Electrodes we numbered ourselves are 0..N-1 and therefore unique by
         # construction, so the sort that np.unique performs can be skipped
         # (it dominates the cost of building an image or video stimulus):
@@ -738,7 +849,7 @@ class Stimulus(PrettyPrint):
                 # actual names:
                 _electrodes = np.asarray(_electrodes)
             unq, nunq = np.unique(_electrodes, return_index=True)
-            if len(unq) != _data.shape[0]:
+            if len(unq) != _n_rows:
                 # We found duplicate names: replace them by integer index
                 idx = np.delete(np.arange(len(_electrodes)), nunq)
                 msg = (f"Duplicate electrode names detected "
@@ -787,6 +898,13 @@ class Stimulus(PrettyPrint):
                                  f"({_data.shape[1]}).")
             _time = time
 
+        if self._components is not None:
+            # The electrodes are settled, the waveform is not. `_defer` is not
+            # used here because everything else it sets up has already been
+            # set up by `__init__`:
+            self.__stim = {'data': None, 'time': None,
+                           'electrodes': self._own_names(_electrodes)}
+            return
         # Store the data in the private container. Setting all elements at once
         # enforces consistency; e.g., between shape of electrodes and time.
         # The setter is what settles dtype, layout and ownership, so nothing
@@ -1069,6 +1187,9 @@ class Stimulus(PrettyPrint):
                 f"pulse. Take the waveform first: "
                 f"Stimulus(stim).remove(...).")
         if np.isscalar(electrodes) and electrodes == 'all':
+            gone = np.zeros(len(self.electrodes), dtype=bool)
+            if self._drop_components(gone):
+                return
             self._stim = {
                 'data': self.data[[]],
                 # Keep `electrodes` an array (of the same dtype) so that it can
@@ -1091,11 +1212,41 @@ class Stimulus(PrettyPrint):
                     keep_el[_index_of_name(self.electrodes, electrode)] = False
                 except ValueError:
                     raise ValueError(f'Electrode "{electrode}" not found.')
+        if self._drop_components(keep_el):
+            return
         self._stim = {
             'data': self.data[keep_el],
             'electrodes': self.electrodes[keep_el],
             'time': self.time,
         }
+
+    def _drop_components(self, keep_el):
+        """Forget whole entries of a collection that has not been merged yet
+
+        Such a collection loses an electrode by forgetting the entry that
+        contributes it, which is how an implant takes a deactivated electrode
+        out of a stimulus without generating the waveform of the others.
+
+        Returns False -- leaving the caller to do it the ordinary way -- when
+        this is not that kind of collection, or when the electrodes to remove
+        cut through an entry that contributes several: there is no way to take
+        one row out of an entry that has not been sampled.
+        """
+        if self._components is None or _has_waveform(self):
+            return False
+        kept, start = [], 0
+        for component in self._components:
+            rows = keep_el[start:start + component[1]]
+            start += component[1]
+            if rows.all():
+                kept.append(component)
+            elif rows.any():
+                return False
+        # Never written into: `copy` hands out objects that share both:
+        self._components = kept
+        self.__stim = {**self.__stim,
+                       'electrodes': self._own_names(self.electrodes[keep_el])}
+        return True
 
     def shift(self, dt):
         """Shift the stimulus in time.

--- a/pulse2percept/stimuli/base.py
+++ b/pulse2percept/stimuli/base.py
@@ -719,18 +719,13 @@ class Stimulus(PrettyPrint):
             _time = time
 
         # Store the data in the private container. Setting all elements at once
-        # enforces consistency; e.g., between shape of electrodes and time:
+        # enforces consistency; e.g., between shape of electrodes and time.
+        # The setter is what settles dtype, layout and ownership, so nothing
+        # here converts anything: doing it twice would copy twice.
         self._stim = {
-            'data': np.ascontiguousarray(_data, dtype=np.float32),
+            'data': _data,
             'electrodes': _electrodes,
-            # Time is float64 while data is float32. The asymmetry is
-            # deliberate: a time axis has one entry per column where the data
-            # has one per electrode per column, so widening it costs almost
-            # nothing, and float32 cannot carry a time axis at all. Its
-            # resolution reaches DT=1e-3 ms at t = 8.4 s, past which the
-            # DT-wide edges of a pulse collapse to zero width -- a 30 s pulse
-            # train lost 952 of its edges that way.
-            'time': _time if _time is None else _time.astype(np.float64),
+            'time': _time,
         }
         # Compress the data upon request:
         if compress:
@@ -751,6 +746,20 @@ class Stimulus(PrettyPrint):
         """
         stim = copy(self)
         stim.metadata = deepcopy(self.metadata)
+        return stim
+
+    def __deepcopy__(self, memo):
+        """A copy that shares the data container with the original
+
+        There is nothing to gain from duplicating arrays that nobody can write
+        into, and something to lose: NumPy deep-copies a read-only array into
+        a *writable* one, which would hand back a stimulus whose data can be
+        rewritten after all. What genuinely has to be independent is
+        ``metadata``, the one part of a stimulus that stays mutable, and
+        ``_shallow_copy`` is exactly that copy.
+        """
+        stim = self._shallow_copy()
+        memo[id(self)] = stim
         return stim
 
     @classmethod
@@ -1559,6 +1568,48 @@ class Stimulus(PrettyPrint):
                 raise ValueError("Number of columns in the data array must be "
                                  "1 if time=None.")
 
+    @staticmethod
+    def _own(arr, dtype):
+        """An immutable, C-contiguous array of ``dtype`` that nothing aliases
+
+        Ownership is what makes immutability mean anything. Marking whatever
+        buffer arrived read-only would take the caller's own array away from
+        them, and storing it as it came would let ``arr[0] = 99`` rewrite a
+        stimulus long after it was built. So the stimulus takes a copy, and
+        that copy is the only writable reference there ever was to it.
+
+        ``ascontiguousarray`` already returns a private array whenever it has
+        to convert one, so only the case where it hands its argument straight
+        back needs a copy of its own.
+
+        C-contiguity is not incidental: every Cython kernel in the library
+        takes the data as ``float32[:, ::1]``, and not everything that builds
+        a stimulus produces that (selecting columns, as ``compress`` does,
+        hands back an F-ordered array for a multi-electrode stimulus).
+        """
+        if arr is None:
+            return None
+        owned = np.ascontiguousarray(arr, dtype=dtype)
+        if owned is arr:
+            owned = owned.copy()
+        owned.flags.writeable = False
+        return owned
+
+    @staticmethod
+    def _own_names(electrodes):
+        """The electrode names, in a container nobody can write into
+
+        :py:class:`~pulse2percept.stimuli.ElectrodeNames` generates its names
+        from a grid rather than storing them, and has no way to set one, so it
+        is already what this method promises -- and materializing it into an
+        array would cost a million strings for an image stimulus.
+        """
+        if isinstance(electrodes, ElectrodeNames):
+            return electrodes
+        owned = np.array(electrodes)
+        owned.flags.writeable = False
+        return owned
+
     @property
     def _stim(self):
         """A dictionary containing all the stimulus data"""
@@ -1567,22 +1618,22 @@ class Stimulus(PrettyPrint):
     @_stim.setter
     def _stim(self, stim):
         self._check_stim(stim)
-        # Every Cython kernel in the library takes the data as
-        # ``float32[:, ::1]``, so the container has to hold it C-contiguous.
-        # Not everything that builds a stimulus produces that: selecting
-        # columns, as ``compress`` does, hands back an F-ordered array for a
-        # multi-electrode stimulus. Left alone it would surface much later, as
-        # a "ndarray is not C-contiguous" from whichever kernel happened to
-        # receive it -- including ``fast_compress_space`` on a second
-        # ``compress``. Fixing it here rather than at each call site keeps the
-        # invariant in one place.
-        data = np.ascontiguousarray(stim['data'])
-        if data is not stim['data']:
-            # `copy` hands out objects that share this dict, so replace it
-            # rather than writing through:
-            stim = {**stim, 'data': data}
-        # All checks passed, store the data:
-        self.__stim = stim
+        # All checks passed. Take ownership of every array before storing it,
+        # so that the scientific state of a stimulus cannot change once it
+        # has one. `copy` hands out objects that share this dict, so replace
+        # it rather than writing through:
+        self.__stim = {**stim,
+                       'data': self._own(stim['data'], np.float32),
+                       # Time is float64 while data is float32. The asymmetry
+                       # is deliberate: a time axis has one entry per column
+                       # where the data has one per electrode per column, so
+                       # widening it costs almost nothing, and float32 cannot
+                       # carry a time axis at all. Its resolution reaches
+                       # DT=1e-3 ms at t = 8.4 s, past which the DT-wide edges
+                       # of a pulse collapse to zero width -- a 30 s pulse
+                       # train lost 952 of its edges that way.
+                       'time': self._own(stim['time'], np.float64),
+                       'electrodes': self._own_names(stim['electrodes'])}
 
     @property
     def data(self):

--- a/pulse2percept/stimuli/base.py
+++ b/pulse2percept/stimuli/base.py
@@ -755,11 +755,16 @@ class Stimulus(PrettyPrint):
         into, and something to lose: NumPy deep-copies a read-only array into
         a *writable* one, which would hand back a stimulus whose data can be
         rewritten after all. What genuinely has to be independent is
-        ``metadata``, the one part of a stimulus that stays mutable, and
-        ``_shallow_copy`` is exactly that copy.
+        ``metadata``, the one part of a stimulus that stays mutable.
+
+        The new object goes into ``memo`` before its metadata is copied.
+        Metadata is arbitrary user data and may refer back to the stimulus it
+        describes; registering first is what makes such a cycle copy as one
+        object graph rather than recurse.
         """
-        stim = self._shallow_copy()
+        stim = copy(self)
         memo[id(self)] = stim
+        stim.metadata = deepcopy(self.metadata, memo)
         return stim
 
     @classmethod
@@ -1578,9 +1583,11 @@ class Stimulus(PrettyPrint):
         stimulus long after it was built. So the stimulus takes a copy, and
         that copy is the only writable reference there ever was to it.
 
-        ``ascontiguousarray`` already returns a private array whenever it has
-        to convert one, so only the case where it hands its argument straight
-        back needs a copy of its own.
+        Copy unconditionally rather than only where a conversion is needed:
+        "returned a different object" is not the same claim as "shares no
+        memory with the input", and it is the second one this has to make.
+        Asking for a view of a subclass, for one, hands back a new ndarray
+        over the very same buffer.
 
         C-contiguity is not incidental: every Cython kernel in the library
         takes the data as ``float32[:, ::1]``, and not everything that builds
@@ -1589,9 +1596,7 @@ class Stimulus(PrettyPrint):
         """
         if arr is None:
             return None
-        owned = np.ascontiguousarray(arr, dtype=dtype)
-        if owned is arr:
-            owned = owned.copy()
+        owned = np.array(arr, dtype=dtype, order='C', copy=True)
         owned.flags.writeable = False
         return owned
 

--- a/pulse2percept/stimuli/base.py
+++ b/pulse2percept/stimuli/base.py
@@ -311,7 +311,7 @@ def _strip_units(source, unit):
     return source
 
 
-def _scale_factor(a, op, b, field):
+def _scale_factor(op, scalar, reverse=False, field='data'):
     """The factor by which an arithmetic operator scales the stimulus data
 
     Returns 1 for an operator that leaves every amplitude where it is (a shift
@@ -319,17 +319,15 @@ def _scale_factor(a, op, b, field):
     same number, and None for one that does neither: a DC offset moves the
     waveform rather than resizing it, and no factor describes that.
 
-    Stimulus types that record the parameters of their waveform in their
-    metadata read this to keep those parameters in sync with the data. See
-    :py:meth:`~pulse2percept.stimuli.Stimulus._rescale_metadata`.
+    ``reverse`` says the stimulus is the operand on the right (``5 - stim``).
+    Deliberately answerable from the operator alone, so that a class which can
+    express a scaled version of itself is asked before anything is sampled;
+    see :py:meth:`~pulse2percept.stimuli.Stimulus._operate`.
     """
     if field == 'time':
         # Shifting in time moves the whole stimulus, but every amplitude in it
         # stays what it was:
         return 1.0
-    # `_apply_operator` has established that exactly one of the operands is a
-    # scalar; the other one is the data:
-    scalar = b if np.ndim(a) else a
     if op is ops.mul:
         # Multiplication is commutative, so the operand order is moot:
         factor = scalar
@@ -341,7 +339,7 @@ def _scale_factor(a, op, b, field):
             factor = np.divide(1.0, scalar)
     elif scalar == 0:
         # `stim + 0` and `stim - 0` change nothing; `0 - stim` flips the sign:
-        factor = -1.0 if np.ndim(b) else 1.0
+        factor = -1.0 if reverse else 1.0
     else:
         return None
     # `stim * np.inf`, `stim * np.nan` and `stim / 0` leave a waveform of
@@ -1125,23 +1123,48 @@ class Stimulus(PrettyPrint):
                 f"Cannot append a stimulus whose time is measured in "
                 f"{_describe_unit(other.time_unit)} to one whose time is "
                 f"measured in {_describe_unit(self.time_unit)}.")
-        if self.time is None or other.time is None:
+        if not _has_time_axis(self) or not _has_time_axis(other):
             raise ValueError("Cannot append another stimulus if time=None.")
         if not _names_equal(self.electrodes, other.electrodes):
             raise ValueError("Both stimuli must have the same electrodes.")
         if other.time[0] < 0:
             raise NotImplementedError("Appending a stimulus with a negative "
                                       "time axis is currently not supported.")
-        stim = self._derived()
         # Last time point of `self` can be merged with first point of `other`
         # but only if they have the same amplitude(s):
+        if isclose(other.time[0], 0, abs_tol=DT) and \
+                not np.allclose(other.data[:, 0], self._end_column()):
+            err_str = (f"Data mismatch: Cannot append other stimulus "
+                       f"because other[t=0] != this[t={self.time[-1]}ms]. You may need "
+                       f"to shift the other stimulus in time by at least "
+                       f"{DT:.1e} ms.")
+            raise ValueError(err_str)
+        if self._is_parametric or other._is_parametric:
+            # A stimulus described by something other than its samples keeps
+            # that description: a 20 Hz train followed by a 50 Hz train is two
+            # trains, and neither of their frequencies is the sequence's.
+            return _SequenceStimulus(_sequence_parts(self) +
+                                     _sequence_parts(other))
+        return self._append_waveform(other)
+
+    def _end_column(self):
+        """The last column of the waveform
+
+        All that matters about this stimulus when another is laid after it.
+        Split out so that a sequence can answer from its last part instead of
+        concatenating everything before it (see :py:class:`_SequenceStimulus`).
+        """
+        return self.data[:, -1]
+
+    def _append_waveform(self, other):
+        """Lay ``other``'s samples after this stimulus' own
+
+        The concatenation itself; :py:meth:`append` owns the validation, and
+        has already run it.
+        """
+        stim = self._derived()
         if isclose(other.time[0], 0, abs_tol=DT):
-            if not np.allclose(other.data[:, 0], self.data[:, -1]):
-                err_str = (f"Data mismatch: Cannot append other stimulus "
-                           f"because other[t=0] != this[t={self.time[-1]}ms]. You may need "
-                           f"to shift the other stimulus in time by at least "
-                           f"{DT:.1e} ms.")
-                raise ValueError(err_str)
+            # The shared endpoint is written once:
             time = np.hstack((self.time, other.time[1:] + self.time[-1]))
             data = np.hstack((self.data, other.data[:, 1:]))
         else:
@@ -1721,8 +1744,64 @@ class Stimulus(PrettyPrint):
         # Parameters that describe the waveform (a pulse train's amplitude,
         # say) have to follow the data, or a model reading them back predicts
         # from a stimulus that is no longer the one it was handed:
-        self._rescale_result(stim, _scale_factor(a, op, b, field))
+        reverse = bool(a_supported)
+        self._rescale_result(stim, _scale_factor(op, a if reverse else b,
+                                                 reverse, field))
         return stim
+
+    def _scaled(self, factor):
+        """This stimulus with every amplitude scaled by ``factor``
+
+        The seam for a class that can express a scaled version of itself
+        without rewriting any samples: a pulse train at twice the amplitude is
+        a pulse train, and a collection of them is that collection with every
+        entry scaled. Returning ``None`` -- which is what a stimulus that
+        *is* its waveform does -- runs the ordinary waveform operation
+        instead.
+
+        Only ever called with a finite factor, and only for operations that
+        scale every amplitude by the same number.
+        """
+        return self._scale_components(factor)
+
+    def _scale_components(self, factor):
+        """A collection that has not been merged scales its entries instead
+
+        Only when every entry is a stimulus in its own right: scaling a raw
+        entry would mean sampling it, which is the work staying unmerged
+        exists to avoid.
+        """
+        if self._components is None or _has_waveform(self):
+            return None
+        if not all(isinstance(src, Stimulus) for src, _ in self._components):
+            return None
+        stim = self._shallow_copy()
+        # A new list rather than a write: `_shallow_copy` hands out the same
+        # one. The entries scale themselves, structurally where they can:
+        stim._components = [(src * factor, n) for src, n in self._components]
+        # `metadata['electrodes']` describes those entries, and is what the
+        # models still read their pulse parameters off:
+        stim._rescale_metadata(factor)
+        return stim
+
+    def _operate(self, op, scalar, reverse=False):
+        """Apply an arithmetic operator to the stimulus
+
+        Asks :py:meth:`_scaled` first, so that a class which can express the
+        result in its own terms never has to sample itself to produce it.
+        ``reverse`` says the stimulus is the operand on the right.
+        """
+        if np.isscalar(scalar) and not isinstance(scalar, str):
+            factor = _scale_factor(op, scalar, reverse)
+            if factor is not None:
+                scaled = self._scaled(factor)
+                if scaled is not None:
+                    return scaled
+        # Nothing structured describes this, so the waveform is the answer.
+        # An unsupported operand also lands here, and is rejected there:
+        data = self.data
+        a, b = (scalar, data) if reverse else (data, scalar)
+        return self._apply_operator(a, op, b)
 
     def _as_amplitude(self, scalar):
         """Normalize an operand that is added to or subtracted from the data
@@ -1759,8 +1838,7 @@ class Stimulus(PrettyPrint):
 
     def __add__(self, scalar):
         """Add a scalar to every data point in the stimulus"""
-        return self._apply_operator(self.data, ops.add,
-                                    self._as_amplitude(scalar))
+        return self._operate(ops.add, self._as_amplitude(scalar))
 
     def __radd__(self, scalar):
         """Add a scalar to every data point in the stimulus"""
@@ -1768,18 +1846,16 @@ class Stimulus(PrettyPrint):
 
     def __sub__(self, scalar):
         """Subtract a scalar from every data point in the stimulus"""
-        return self._apply_operator(self.data, ops.sub,
-                                    self._as_amplitude(scalar))
+        return self._operate(ops.sub, self._as_amplitude(scalar))
 
     def __rsub__(self, scalar):
         """Subtract every data point in the stimulus from a scalar"""
-        return self._apply_operator(self._as_amplitude(scalar), ops.sub,
-                                    self.data)
+        return self._operate(ops.sub, self._as_amplitude(scalar),
+                             reverse=True)
 
     def __mul__(self, scalar):
         """Multiply every data point in the stimulus with a scalar"""
-        return self._apply_operator(self.data, ops.mul,
-                                    self._as_factor(scalar))
+        return self._operate(ops.mul, self._as_factor(scalar))
 
     def __rmul__(self, scalar):
         """Multiply every data point in the stimulus with a scalar"""
@@ -1787,8 +1863,7 @@ class Stimulus(PrettyPrint):
 
     def __truediv__(self, scalar):
         """Divide every data point in the stimulus by a scalar"""
-        return self._apply_operator(self.data, ops.truediv,
-                                    self._as_factor(scalar))
+        return self._operate(ops.truediv, self._as_factor(scalar))
 
     def __neg__(self):
         """Flip the sign of every data point in the stimulus"""
@@ -1902,8 +1977,12 @@ class Stimulus(PrettyPrint):
         """
         if self.__stim['data'] is None:
             promised = self.__stim['electrodes']
-            # The setter installs the rendered state, so `_render` runs once:
+            # The setter installs the rendered state, so `_render` runs once.
+            # It also clears the components, and this is the one waveform they
+            # do describe, so they are put back afterwards:
+            components = self._components
             self._stim = self._render()
+            self._components = components
             if not _names_equal(promised, self.__stim['electrodes']):
                 raise ValueError(
                     f"{type(self).__name__}._render() returned rows for "
@@ -1915,6 +1994,12 @@ class Stimulus(PrettyPrint):
     @_stim.setter
     def _stim(self, stim):
         self._check_stim(stim)
+        # A waveform that arrives from outside is not the one the components
+        # describe -- an operation that rewrote the samples would otherwise
+        # leave a stimulus whose structured source says something else. Only
+        # the render path in the getter above, which builds the waveform *from*
+        # the components, puts them back.
+        self._components = None
         # All checks passed. Take ownership of every array before storing it,
         # so that the scientific state of a stimulus cannot change once it
         # has one. `copy` hands out objects that share this dict, so replace
@@ -2128,3 +2213,79 @@ class Stimulus(PrettyPrint):
     def duration(self):
         """Stimulus duration (ms)"""
         return self.time[-1]
+
+
+def _has_time_axis(stim):
+    """Whether a stimulus has a time component, without sampling it"""
+    return _component_shape(stim)[2]
+
+
+def _sequence_parts(stim):
+    """The parts a stimulus contributes to a sequence, already flattened"""
+    if isinstance(stim, _SequenceStimulus):
+        # Already snapshots, and appending to a sequence extends it rather
+        # than nesting one inside another:
+        return list(stim.parts)
+    return [_snapshot(stim)]
+
+
+class _SequenceStimulus(Stimulus):
+    """Two or more stimuli delivered one after another
+
+    What :py:meth:`Stimulus.append` returns when either side is described by
+    something other than its samples. The parts are kept as they are, so a
+    20 Hz train followed by a 50 Hz train goes on being two trains; only the
+    concatenation waits for :py:meth:`_render`.
+
+    Private on purpose: this is a temporal sequence and nothing else. It is
+    not an expression tree, and it does not answer questions about pulse
+    parameters -- a sequence has no single frequency to report.
+    """
+    #: Described by its parts rather than by its samples:
+    _is_parametric = True
+
+    __slots__ = ('_parts',)
+
+    def __init__(self, parts):
+        self._parts = tuple(parts)
+        first = self._parts[0]
+        self._defer(first.electrodes, unit=first.unit,
+                    time_unit=first.time_unit)
+        self.metadata = deepcopy(first.metadata)
+        # A sequence has no one frequency or amplitude, so the parameters that
+        # described its first part are dropped here exactly as
+        # `_append_waveform` drops them: a model asking for them rejects the
+        # stimulus rather than predicting from the first part's numbers. The
+        # parts keep their own, and `parts` is where to read them.
+        first._rescale_result(self, None)
+
+    @property
+    def parts(self):
+        """The stimuli this one delivers, in order"""
+        return self._parts
+
+    @property
+    def duration(self):
+        """Duration of the stimulus (ms)"""
+        return self.time[-1]
+
+    def _end_column(self):
+        # Concatenation leaves the last part's last column where it was:
+        return self._parts[-1].data[:, -1]
+
+    def _render(self):
+        """Lay the parts end to end, on the terms `append` always used"""
+        stim = Stimulus(self._parts[0])
+        for part in self._parts[1:]:
+            stim = stim._append_waveform(part)
+        return {'data': stim.data, 'electrodes': self.electrodes,
+                'time': stim.time}
+
+    def _scaled(self, factor):
+        """Scaling a sequence scales each of its parts"""
+        return _SequenceStimulus([part * factor for part in self._parts])
+
+    def _pprint_params(self):
+        """Return a dict of class arguments to pretty-print"""
+        return {'parts': [type(p).__name__ for p in self._parts],
+                'electrodes': self.electrodes, 'metadata': self.metadata}

--- a/pulse2percept/stimuli/base.py
+++ b/pulse2percept/stimuli/base.py
@@ -355,10 +355,12 @@ class Stimulus(PrettyPrint):
     A stimulus can be created from a variety of source types (e.g., scalars,
     lists, NumPy arrays, and dictionaries).
 
-    A stimulus is immutable. For an arbitrary stimulus, the sampled waveform
-    *is* the stimulus. Pulse-based and encoded stimuli instead retain the
-    parameters or the schedule that define them, and generate their waveform
-    only when samples such as ``data`` are asked for.
+    A stimulus owns its scientific state: ``data``, ``time``, ``electrodes``
+    and the pulse parameters are read-only, so callers cannot mutate them in
+    place. For an arbitrary stimulus the sampled waveform *is* the stimulus;
+    pulse-based and encoded stimuli instead retain the parameters or the
+    schedule that define them, and generate their waveform only when samples
+    such as ``data`` are asked for.
 
     .. seealso ::
 
@@ -437,11 +439,13 @@ class Stimulus(PrettyPrint):
        the value of its closest end point will be returned.
     *  Pulse parameters such as ``amp``, ``freq`` and ``phase_dur`` are
        first-class and read-only, and reading them never generates a waveform.
-    *  Transformations return a new stimulus. One whose result the parameters
-       still describe keeps its structured form (``pulse_train * 2`` is a pulse
-       train at twice the amplitude); one they cannot -- a DC offset, a shift
-       in time, an appended second train -- falls back to a plain, waveform-
-       backed ``Stimulus``.
+    *  Most transformations return a new stimulus. One whose result the
+       parameters still describe keeps its structured form (``pulse_train * 2``
+       is a pulse train at twice the amplitude); one they cannot -- a DC
+       offset, a shift in time, an appended second train -- falls back to a
+       plain, waveform-backed ``Stimulus``.
+    *  :py:meth:`compress` and :py:meth:`remove` are the exceptions: they
+       replace the stimulus' own state rather than returning a new object.
 
     Examples
     --------
@@ -1112,9 +1116,7 @@ class Stimulus(PrettyPrint):
     def compress(self):
         """Compress the source data
 
-        Returns
-        -------
-        compressed : :py:class:`~pulse2percept.stimuli.Stimulus`
+        Modifies the stimulus in place; returns nothing.
         """
         data = self.data
         electrodes = self.electrodes

--- a/pulse2percept/stimuli/base.py
+++ b/pulse2percept/stimuli/base.py
@@ -355,11 +355,20 @@ class Stimulus(PrettyPrint):
     A stimulus can be created from a variety of source types (e.g., scalars,
     lists, NumPy arrays, and dictionaries).
 
+    A stimulus is immutable. For an arbitrary stimulus, the sampled waveform
+    *is* the stimulus. Pulse-based and encoded stimuli instead retain the
+    parameters or the schedule that define them, and generate their waveform
+    only when samples such as ``data`` are asked for.
+
     .. seealso ::
 
         *  `Basic Concepts > Electrical Stimuli <topics-stimuli>`
 
     .. versionadded:: 0.6
+
+    .. versionchanged:: 0.10.0
+        ``data``, ``time`` and ``electrodes`` are read-only, and pulse-based
+        and encoded stimuli generate their waveform lazily.
 
     Parameters
     ----------
@@ -426,6 +435,13 @@ class Stimulus(PrettyPrint):
        its value will be automatically interpolated from neighboring values.
     *  If a requested time point lies outside the range of stored data,
        the value of its closest end point will be returned.
+    *  Pulse parameters such as ``amp``, ``freq`` and ``phase_dur`` are
+       first-class and read-only, and reading them never generates a waveform.
+    *  Transformations return a new stimulus. One whose result the parameters
+       still describe keeps its structured form (``pulse_train * 2`` is a pulse
+       train at twice the amplitude); one they cannot -- a DC offset, a shift
+       in time, an appended second train -- falls back to a plain, waveform-
+       backed ``Stimulus``.
 
     Examples
     --------
@@ -757,6 +773,10 @@ class Stimulus(PrettyPrint):
                     # the source (unless they're None):
                     _electrodes.append(e if e is not None else ele)
                 try:
+                    # Compatibility channel: what described this electrode,
+                    # for a reader that ends up with only the samples (see
+                    # `_rescale_params`). `_structured_sources` is where the
+                    # sources themselves are read.
                     self.metadata['electrodes'][str(ele)] = {
                         'metadata': src.metadata,
                         'type': type(src)
@@ -1018,19 +1038,19 @@ class Stimulus(PrettyPrint):
     def _rescale_params(cls, metadata, factor):
         """Rewrite waveform parameters for a waveform scaled by ``factor``
 
-        Some stimulus types describe their waveform with parameters that a
-        model reads back instead of measuring the data itself: a
-        :py:class:`~pulse2percept.stimuli.BiphasicPulseTrain` records
-        amplitude, frequency and phase duration, and
-        :py:class:`~pulse2percept.models.BiphasicAxonMapModel` predicts from
-        those rather than from ``data``. Such a type overrides this method, so
-        that an operation on the data carries its parameters along.
+        Compatibility only. A pulse-based stimulus owns its parameters and
+        the models read them off it (see :py:meth:`_structured_sources`); this
+        files a copy under ``metadata`` for waveform-only containers, which is
+        what :py:class:`~pulse2percept.implants.EnsembleImplant` interpolates
+        its children into. There the copy is the only surviving description of
+        the pulse trains, and
+        :py:class:`~pulse2percept.models.cortex.DynaphosModel` still reads it.
 
         Returns the metadata a stimulus of this class would carry after its
         data was multiplied by ``factor``, or -- for ``factor=None`` -- after
-        an operation that leaves it no longer describable by those parameters
-        at all. A plain ``Stimulus`` has no such parameters, so there is
-        nothing to keep in sync.
+        an operation those parameters can no longer describe at all. A plain
+        ``Stimulus`` has no such parameters, so there is nothing to keep in
+        sync.
 
         Parameters
         ----------
@@ -2091,8 +2111,14 @@ class Stimulus(PrettyPrint):
     @property
     def data(self):
         """Stimulus data container
-        A 2-D NumPy array that contains the stimulus data, where the rows
-        denote electrodes and the columns denote points in time.
+
+        A read-only 2-D NumPy array that contains the sampled waveform, where
+        the rows denote electrodes and the columns denote points in time.
+
+        For a pulse-based or encoded stimulus the waveform is what the
+        parameters or the schedule describe rather than what the stimulus
+        stores, so reading this may be what generates it. It is cached
+        afterwards, and the parameters can be read without it.
         """
         return self._stim['data']
 

--- a/pulse2percept/stimuli/base.py
+++ b/pulse2percept/stimuli/base.py
@@ -141,8 +141,9 @@ class Stimulus(PrettyPrint):
     A stimulus can be created from a variety of source types (e.g., scalars,
     lists, NumPy arrays, and dictionaries).
 
-    Pulse parameters (``data``, ``time``, ``electrodes``) are read-only.
-    Arbitrary stimuli are kept as sampled waveforms only.
+    The stimulus arrays (``data``, ``time``, ``electrodes``) and the pulse
+    parameters of a stimulus that has any are read-only. Arbitrary stimuli are
+    kept as sampled waveforms only.
 
     .. seealso ::
 
@@ -151,7 +152,8 @@ class Stimulus(PrettyPrint):
     .. versionadded:: 0.6
 
     .. versionchanged:: 0.10.0
-        Pulse parameters are read-only, and waveform are generated lazily.
+        Stimulus arrays and pulse parameters are read-only, and waveforms
+        are generated lazily.
 
     Parameters
     ----------
@@ -294,6 +296,11 @@ class Stimulus(PrettyPrint):
         if not isinstance(electrodes, ElectrodeNames):
             electrodes = np.array([electrodes]).ravel()
         # `data=None` is what says the waveform has not been generated yet
+        self.__stim = {'data': None, 'time': None,
+                       'electrodes': self._own_names(electrodes)}
+
+    def _forget_waveform(self, electrodes):
+        """Drop a cached waveform the components no longer describe"""
         self.__stim = {'data': None, 'time': None,
                        'electrodes': self._own_names(electrodes)}
 
@@ -753,9 +760,6 @@ class Stimulus(PrettyPrint):
                        f"to shift the other stimulus in time by at least "
                        f"{DT:.1e} ms.")
             raise ValueError(err_str)
-        if self._is_parametric or other._is_parametric:
-            return _SequenceStimulus(_sequence_parts(self) +
-                                     _sequence_parts(other))
         return self._append_waveform(other)
 
     def _end_column(self):
@@ -844,7 +848,7 @@ class Stimulus(PrettyPrint):
 
     def _drop_components(self, keep_el):
         """Forget whole entries of an unmerged collection"""
-        if self._components is None or _has_waveform(self):
+        if self._components is None:
             return False
         kept, start = [], 0
         for component in self._components:
@@ -855,8 +859,7 @@ class Stimulus(PrettyPrint):
             elif rows.any():
                 return False
         self._components = kept
-        self.__stim = {**self.__stim,
-                       'electrodes': self._own_names(self.electrodes[keep_el])}
+        self._forget_waveform(self.electrodes[keep_el])
         return True
 
     def _structured_sources(self):
@@ -1204,12 +1207,13 @@ class Stimulus(PrettyPrint):
 
     def _scale_components(self, factor):
         """An unmerged collection scales its entries instead"""
-        if self._components is None or _has_waveform(self):
+        if self._components is None:
             return None
         if not all(isinstance(src, Stimulus) for src, _ in self._components):
             return None
         stim = self._shallow_copy()
         stim._components = [(src * factor, n) for src, n in self._components]
+        stim._forget_waveform(self.electrodes)
         stim._rescale_metadata(factor)
         return stim
 
@@ -1543,65 +1547,3 @@ class Stimulus(PrettyPrint):
 def _has_time_axis(stim):
     """Whether a stimulus has a time component, without sampling it"""
     return _component_shape(stim)[2]
-
-
-def _sequence_parts(stim):
-    """The parts a stimulus contributes to a sequence, already flattened"""
-    if isinstance(stim, _SequenceStimulus):
-        return list(stim.parts)
-    return [_snapshot(stim)]
-
-
-class _SequenceStimulus(Stimulus):
-    """Two or more stimuli delivered one after another
-
-    What :py:meth:`Stimulus.append` returns when either side is described by
-    something other than its samples. The parts are kept as they are, so a
-    20 Hz train followed by a 50 Hz train goes on being two trains; only the
-    concatenation waits for :py:meth:`_render`.
-
-    Private on purpose.
-    """
-    #: Described by its parts rather than by its samples:
-    _is_parametric = True
-
-    __slots__ = ('_parts',)
-
-    def __init__(self, parts):
-        self._parts = tuple(parts)
-        first = self._parts[0]
-        self._defer(first.electrodes, unit=first.unit,
-                    time_unit=first.time_unit)
-        self.metadata = deepcopy(first.metadata)
-        first._rescale_result(self, None)
-
-    @property
-    def parts(self):
-        """The stimuli this one delivers, in order"""
-        return self._parts
-
-    @property
-    def duration(self):
-        """Duration of the stimulus (ms)"""
-        return self.time[-1]
-
-    def _end_column(self):
-        # Concatenation leaves the last part's last column where it was:
-        return self._parts[-1].data[:, -1]
-
-    def _render(self):
-        """Lay the parts end to end, on the terms `append` always used"""
-        stim = Stimulus(self._parts[0])
-        for part in self._parts[1:]:
-            stim = stim._append_waveform(part)
-        return {'data': stim.data, 'electrodes': self.electrodes,
-                'time': stim.time}
-
-    def _scaled(self, factor):
-        """Scaling a sequence scales each of its parts"""
-        return _SequenceStimulus([part * factor for part in self._parts])
-
-    def _pprint_params(self):
-        """Return a dict of class arguments to pretty-print"""
-        return {'parts': [type(p).__name__ for p in self._parts],
-                'electrodes': self.electrodes, 'metadata': self.metadata}

--- a/pulse2percept/stimuli/base.py
+++ b/pulse2percept/stimuli/base.py
@@ -50,23 +50,17 @@ def _index_of_name(electrodes, name):
     return list(electrodes).index(name)
 
 
-class _Owned(np.ndarray):
-    """An array the library allocated for one stimulus"""
+class _AdoptableArray(np.ndarray):
+    """Internal marker for an array that may be installed without copying
+
+    Views keep the subclass, so the mark survives the reshaping on the way in.
+    """
     __slots__ = ()
 
 
-def _owned(arr):
-    """Promise that arr is the library's alone"""
-    return arr.view(_Owned)
-
-
-def _freeze(arr):
-    """Make ``arr``, and every array it is a view of, read-only"""
-    level = arr
-    while isinstance(level, np.ndarray):
-        level.flags.writeable = False
-        level = level.base
-    return arr
+def _adoptable(arr):
+    """Mark arr as safe for a stimulus to install without copying"""
+    return arr.view(_AdoptableArray)
 
 
 def _describe_unit(unit):
@@ -1329,9 +1323,10 @@ class Stimulus(PrettyPrint):
         """An immutable, C-contiguous array of dtype"""
         if arr is None:
             return None
-        if isinstance(arr, _Owned) and arr.dtype == dtype:
-            return _freeze(np.ascontiguousarray(arr))
-        owned = np.array(arr, dtype=dtype, order='C', copy=True)
+        if isinstance(arr, _AdoptableArray) and arr.dtype == dtype:
+            owned = np.ascontiguousarray(arr, dtype=dtype)
+        else:
+            owned = np.array(arr, dtype=dtype, order='C', copy=True)
         owned.flags.writeable = False
         return owned
 

--- a/pulse2percept/stimuli/base.py
+++ b/pulse2percept/stimuli/base.py
@@ -427,6 +427,14 @@ class Stimulus(PrettyPrint):
     #: The unit ``time`` is stored in.
     _default_time_unit = ms
 
+    #: Whether this class' canonical state is a set of stimulation parameters
+    #: rather than the waveform itself. Such a stimulus cannot survive a
+    #: change to its samples, because its parameters would go on describing a
+    #: waveform it no longer has: operations that return a new stimulus hand
+    #: back a plain one (see :py:meth:`_derived`), and the in-place ones that
+    #: would drop electrodes refuse.
+    _is_parametric = False
+
     def __init__(self, source, electrodes=None, time=None, metadata=None,
                  compress=False):
         self.metadata = self._wrap_metadata(metadata)
@@ -809,6 +817,34 @@ class Stimulus(PrettyPrint):
         stim.metadata = deepcopy(self.metadata)
         return stim
 
+    def _waveform_copy(self):
+        """This stimulus' waveform, as an ordinary ``Stimulus``
+
+        The escape hatch for an operation that rewrites the waveform of a
+        stimulus which is defined by something else. What comes back is
+        described by its samples and by nothing else, so it cannot claim an
+        amplitude or a duration it does not deliver.
+        """
+        return Stimulus(self.data, electrodes=self.electrodes,
+                        time=self.time,
+                        metadata=deepcopy(self.metadata))._inherit_units(self)
+
+    def _derived(self):
+        """The object a waveform-rewriting operation builds its result on
+
+        An ordinary stimulus *is* its waveform, so a transformation of that
+        waveform is still one of these and keeps the subclass: an
+        :py:class:`~pulse2percept.stimuli.ImageStimulus` scaled by two is
+        still an image. A stimulus whose canonical state is a set of
+        stimulation parameters is a different matter -- those parameters
+        describe the waveform it was built with, and rewriting the samples
+        leaves them describing nothing. Such a class declares itself with
+        ``_is_parametric`` and gets a plain stimulus instead.
+        """
+        if self._is_parametric:
+            return self._waveform_copy()
+        return self._shallow_copy()
+
     def __deepcopy__(self, memo):
         """A copy that shares the data container with the original
 
@@ -961,7 +997,7 @@ class Stimulus(PrettyPrint):
         if other.time[0] < 0:
             raise NotImplementedError("Appending a stimulus with a negative "
                                       "time axis is currently not supported.")
-        stim = self._shallow_copy()
+        stim = self._derived()
         # Last time point of `self` can be merged with first point of `other`
         # but only if they have the same amplitude(s):
         if isclose(other.time[0], 0, abs_tol=DT):
@@ -1005,6 +1041,16 @@ class Stimulus(PrettyPrint):
         # falsiness here, because 0 is a perfectly valid electrode index:
         if electrodes is None or np.size(electrodes) == 0:
             return
+        # Unlike the operators, an in-place method has no second object to
+        # hand back, so there is nowhere to put a stimulus that has lost the
+        # electrode its parameters describe:
+        if self._is_parametric:
+            raise NotImplementedError(
+                f"Cannot remove electrodes from a {type(self).__name__}, "
+                f"which is defined by the pulse it delivers rather than by "
+                f"its samples -- what was left would go on advertising that "
+                f"pulse. Take the waveform first: "
+                f"Stimulus(stim).remove(...).")
         if np.isscalar(electrodes) and electrodes == 'all':
             self._stim = {
                 'data': self.data[[]],
@@ -1114,7 +1160,7 @@ class Stimulus(PrettyPrint):
             # hstack allocates; the no-op path must copy explicitly
             data = data.copy()
             time = time.copy()
-        stim = self._shallow_copy()
+        stim = self._derived()
         stim._stim = {'data': data,
                       'electrodes': self.electrodes.copy(),
                       'time': time}
@@ -1495,7 +1541,7 @@ class Stimulus(PrettyPrint):
         # produces a new array for `field`; the other fields must be copied
         # explicitly, so that the returned stimulus shares no buffer with the
         # original (`_shallow_copy` does not duplicate the data container):
-        stim = self._shallow_copy()
+        stim = self._derived()
         time = stim.time
         if field == 'time':
             time = op(a, b)

--- a/pulse2percept/stimuli/encoders.py
+++ b/pulse2percept/stimuli/encoders.py
@@ -5,7 +5,7 @@ from abc import ABCMeta, abstractmethod
 import numpy as np
 from copy import deepcopy
 
-from .base import Stimulus
+from .base import Stimulus, _owned
 from .images import ImageStimulus
 from .pulses import BiphasicPulse
 from .videos import VideoStimulus
@@ -240,7 +240,9 @@ class _EncodedStimulus(Stimulus):
             at = np.searchsorted(onset, self._ticks, side='right') - 1
             np.clip(at, 0, onset.size - 1, out=at)
             data[rows] = self._amp[rows][:, frame[at]] * wave
-        return {'data': data, 'electrodes': self.electrodes,
+        # Allocated here for this stimulus and returned straight to it, so
+        # `Stimulus` need not copy it away from anyone:
+        return {'data': _owned(data), 'electrodes': self.electrodes,
                 'time': self.time}
 
     def _pprint_params(self):

--- a/pulse2percept/stimuli/encoders.py
+++ b/pulse2percept/stimuli/encoders.py
@@ -5,7 +5,7 @@ from abc import ABCMeta, abstractmethod
 import numpy as np
 from copy import deepcopy
 
-from .base import Stimulus, _owned
+from .base import Stimulus, _adoptable
 from .images import ImageStimulus
 from .pulses import BiphasicPulse
 from .videos import VideoStimulus
@@ -242,7 +242,7 @@ class _EncodedStimulus(Stimulus):
             data[rows] = self._amp[rows][:, frame[at]] * wave
         # Allocated here for this stimulus and returned straight to it, so
         # `Stimulus` need not copy it away from anyone:
-        return {'data': _owned(data), 'electrodes': self.electrodes,
+        return {'data': _adoptable(data), 'electrodes': self.electrodes,
                 'time': self.time}
 
     def _pprint_params(self):

--- a/pulse2percept/stimuli/encoders.py
+++ b/pulse2percept/stimuli/encoders.py
@@ -256,6 +256,7 @@ class _EncodedStimulus(Stimulus):
                 'duration': self._total,
                 'metadata': self.metadata}
 
+
 class StimulusEncoder(PrettyPrint, metaclass=ABCMeta):
     """Abstract base class for all stimulus encoders
 

--- a/pulse2percept/stimuli/encoders.py
+++ b/pulse2percept/stimuli/encoders.py
@@ -3,6 +3,7 @@
    :py:class:`~pulse2percept.stimuli.FrequencyEncoder`"""
 from abc import ABCMeta, abstractmethod
 import numpy as np
+from copy import deepcopy
 
 from .base import Stimulus
 from .images import ImageStimulus
@@ -81,11 +82,17 @@ class _EncodedStimulus(Stimulus):
     #: the waveform could keep true, so one hands back a plain stimulus.
     _is_parametric = True
 
+    #: What the encoder asked the device for is not what the device delivers,
+    #: and this class is the one that knows both (see `_spatial_view`):
+    _has_spatial_view = True
+
     __slots__ = ('_amp', '_ticks', '_sched', '_onsets', '_frames',
-                 '_pulse_ticks', '_pulse_vals', '_total')
+                 '_pulse_ticks', '_pulse_vals', '_total', '_firing',
+                 '_frame_time', '_frame_dur', '_time')
 
     def __init__(self, electrodes, amp, ticks, sched, onsets, frames,
-                 pulse_ticks, pulse_vals, total, encoder_metadata):
+                 pulse_ticks, pulse_vals, total, firing, frame_time,
+                 frame_dur, cycle):
         # `dtype=a.dtype` throughout: these are the scheduler's own numbers,
         # and converting any of them would change the waveform below.
         self._amp = self._own(amp, amp.dtype)
@@ -96,8 +103,101 @@ class _EncodedStimulus(Stimulus):
         self._pulse_ticks = self._own(pulse_ticks, pulse_ticks.dtype)
         self._pulse_vals = self._own(pulse_vals, pulse_vals.dtype)
         self._total = float(total)
+        # Which electrode-frames were asked for a pulse rate at all. Kept as a
+        # mask rather than the frequencies themselves: what survives into the
+        # spatial view is on/off, and a rate is a fact about time that a
+        # reader with no clock cannot express anyway.
+        self._firing = self._own(firing, bool)
+        self._frame_time = self._own(frame_time, frame_time.dtype)
+        self._frame_dur = float(frame_dur)
+        # Built on demand by `time`, which is cheap enough to be worth not
+        # expanding a waveform for:
+        self._time = None
         self._defer(electrodes)
-        self.metadata['encoder'] = encoder_metadata
+        # The frame clock, which is what decides when a percept is worth
+        # reporting (see `pulse2percept.models.base._frame_clock`), and the
+        # raster sweep the schedule was actually realized on. Derived from the
+        # frozen state above, which stays the authority:
+        self.metadata['encoder'] = {'frame_time': self._frame_time,
+                                    'frame_dur': self._frame_dur,
+                                    'cycle': cycle}
+
+    def _spatial_view(self):
+        """What the encoder asked each electrode for, frame by frame
+
+        One column per frame of the source and one row per electrode, holding
+        the current that electrode is modulated to over that frame. It is what
+        the encoder *asks the device for*, before the device's own timing --
+        the pulse shape, the pulse clock, the raster -- settles when any of it
+        is actually delivered.
+
+        An electrode whose train never fires delivers no current at all, so a
+        zero frequency reads as zero amplitude here however high an amplitude
+        it was handed. Past that, rate does not survive into this
+        representation: what a rate means is a fact about time, and a reader
+        with no clock of its own has no way to express it. So frequency
+        modulation collapses to on/off here, which is the least misleading
+        thing it can do.
+        """
+        data = np.where(self._firing, self._amp, np.float32(0)).astype(
+            np.float32)
+        # A source with a single frame has no time axis of its own, and gets
+        # none here either: what it asks for is one steady thing, and saying so
+        # is what lets a spatial model report a single picture rather than a
+        # sequence of one. Flattened, because that is how `Stimulus` is told
+        # a stimulus has no time component -- an (n, 1) container with
+        # `time=None` is given a time axis of [0] instead.
+        if self._frame_time.size > 1:
+            stim = Stimulus(data, electrodes=self.electrodes,
+                            time=self._frame_time)
+        else:
+            stim = Stimulus(data.ravel(), electrodes=self.electrodes)
+        # The frame clock and nothing else: there is no schedule here to
+        # record, which is the whole point of this representation.
+        stim.metadata['encoder'] = {'frame_time': self._frame_time,
+                                    'frame_dur': self._frame_dur}
+        return stim
+
+    def _rebuilt(self, electrodes, amp, sched, firing):
+        """This schedule, driving different electrodes or amplitudes
+
+        The one place the electrode-indexed halves of the schedule are
+        replaced. Everything about *when* a pulse happens is untouched, and
+        the per-schedule arrays are shared: an entry no row refers to any more
+        is simply one `_render` skips.
+        """
+        rebuilt = _EncodedStimulus(
+            electrodes, amp, self._ticks, sched, self._onsets, self._frames,
+            self._pulse_ticks, self._pulse_vals, self._total, firing,
+            self._frame_time, self._frame_dur,
+            self.metadata['encoder']['cycle'])
+        # What the user put in the metadata is theirs; the encoder keys are
+        # rebuilt from the frozen state by the constructor:
+        rebuilt.metadata['user'] = deepcopy(self.metadata.get('user'))
+        return rebuilt
+
+    def _scaled(self, factor):
+        """This schedule, delivering amplitudes scaled by ``factor``
+
+        Scaling changes what each electrode delivers, not when: the onsets,
+        the raster, the frame clock, the pulse shape and which electrodes fire
+        at all are still the ones this schedule resolved. So both descriptions
+        of it -- the waveform and the modulation behind it -- scale together.
+        """
+        return self._rebuilt(self.electrodes, self._amp * factor, self._sched,
+                             self._firing)
+
+    def _without_electrodes(self, electrodes):
+        """This schedule, no longer driving ``electrodes``
+
+        Only the electrode-indexed arrays are filtered. The schedules
+        themselves are left as they are, including any that no electrode
+        refers to any more -- `_render` skips those, and compacting them would
+        buy nothing but tidiness.
+        """
+        keep = self._keep_mask(electrodes)
+        return self._rebuilt(self.electrodes[keep], self._amp[keep],
+                             self._sched[keep], self._firing[keep])
 
     @property
     def duration(self):
@@ -107,6 +207,20 @@ class _EncodedStimulus(Stimulus):
         generate a waveform to find out.
         """
         return self._total
+
+    @property
+    def time(self):
+        """Time points of the stimulus (ms)
+
+        The schedule already says where every pulse edge falls, so asking for
+        the axis does not expand it into a waveform. Cached, so that the axis
+        a caller sees before the samples exist is the one it sees after.
+        """
+        if self._time is None:
+            time = self._ticks * DT
+            time[-1] = self._total
+            self._time = self._own(time, np.float64)
+        return self._time
 
     def _render(self):
         """Expand the schedule into the pulse trains it describes
@@ -126,9 +240,8 @@ class _EncodedStimulus(Stimulus):
             at = np.searchsorted(onset, self._ticks, side='right') - 1
             np.clip(at, 0, onset.size - 1, out=at)
             data[rows] = self._amp[rows][:, frame[at]] * wave
-        time = self._ticks * DT
-        time[-1] = self._total
-        return {'data': data, 'electrodes': self.electrodes, 'time': time}
+        return {'data': data, 'electrodes': self.electrodes,
+                'time': self.time}
 
     def _pprint_params(self):
         """Return a dict of class attributes to pretty-print
@@ -832,12 +945,8 @@ class StimulusEncoder(PrettyPrint, metaclass=ABCMeta):
         # asks for samples:
         return _EncodedStimulus(
             electrodes, amp, ticks, sched, onsets, frames, pulse_ticks,
-            pulse_vals, total,
-            # The frame clock, which is what decides when a percept is worth
-            # reporting (see `pulse2percept.models.base._frame_clock`), and
-            # the raster sweep the schedule was actually realized on:
-            {'frame_time': frame_time, 'frame_dur': frame_dur,
-             'cycle': None if cycle is None else cycle * DT})
+            pulse_vals, total, freq > 0, frame_time, frame_dur,
+            None if cycle is None else cycle * DT)
 
     def _modulation(self, source, implant=None):
         """What the source asks each electrode for, frame by frame
@@ -850,8 +959,8 @@ class StimulusEncoder(PrettyPrint, metaclass=ABCMeta):
         :py:meth:`_assemble`, and they are what makes the result a *train*
         rather than a description of one.
 
-        Returns the arguments both halves of the split take, in the order
-        :py:meth:`_assemble` and :py:meth:`_as_spatial` accept them.
+        Returns the arguments :py:meth:`_assemble` takes, in the order it
+        takes them.
         """
         gray, electrodes, frame_time, frame_dur = self._as_frames(source,
                                                                   implant)
@@ -867,54 +976,6 @@ class StimulusEncoder(PrettyPrint, metaclass=ABCMeta):
             gray = np.round(gray * steps) / steps
         amp, freq = self._modulate(gray)
         return amp, freq, electrodes, frame_time, frame_dur
-
-    def _as_spatial(self, amp, freq, electrodes, frame_time, frame_dur):
-        """The modulation parameters as a Stimulus, with no waveform in them
-
-        One column per frame of the source and one row per electrode, holding
-        the current that electrode is modulated to over that frame. It is what
-        the encoder *asks the device for*, before the device's own timing --
-        the pulse shape, the pulse clock, the raster -- settles when any of it
-        is actually delivered.
-
-        An electrode whose train never fires delivers no current at all, so a
-        zero frequency reads as zero amplitude here however high an amplitude
-        it was handed. Past that, rate does not survive into this
-        representation: what a rate means is a fact about time, and a reader
-        with no clock of its own has no way to express it. So frequency
-        modulation collapses to on/off here, which is the least misleading
-        thing it can do.
-        """
-        shape = (len(electrodes), frame_time.size)
-        amp = np.broadcast_to(np.asarray(amp, dtype=np.float32), shape)
-        freq = np.broadcast_to(np.asarray(freq, dtype=np.float64), shape)
-        data = np.where(freq > 0, amp, np.float32(0)).astype(np.float32)
-        # A source with a single frame has no time axis of its own, and gets
-        # none here either: what it asks for is one steady thing, and saying so
-        # is what lets a spatial model report a single picture rather than a
-        # sequence of one. Flattened, because that is how `Stimulus` is told
-        # a stimulus has no time component -- an (n, 1) container with
-        # `time=None` is given a time axis of [0] instead.
-        if frame_time.size > 1:
-            stim = Stimulus(data, electrodes=electrodes, time=frame_time)
-        else:
-            stim = Stimulus(data.ravel(), electrodes=electrodes)
-        # The frame clock and nothing else: there is no schedule here to
-        # record, which is the whole point of this representation.
-        stim.metadata['encoder'] = {'frame_time': frame_time,
-                                    'frame_dur': frame_dur}
-        return stim
-
-    def _encode_both(self, source, implant=None):
-        """Both descriptions of one source, sharing the modulation step
-
-        What an implant needs when a picture is assigned to it: the modulation
-        the source asks for and the pulse train realizing it. Sampling the
-        source at the electrodes is the expensive half of encoding, so the two
-        are built from one pass over it rather than two.
-        """
-        mod = self._modulation(source, implant)
-        return self._as_spatial(*mod), self._assemble(*mod, implant=implant)
 
     def encode(self, source, implant=None):
         """Encode an image or a video as a train of electrical pulses

--- a/pulse2percept/stimuli/encoders.py
+++ b/pulse2percept/stimuli/encoders.py
@@ -61,6 +61,88 @@ def _fps(metadata):
     return user.get('fps') if isinstance(user, dict) else None
 
 
+class _EncodedStimulus(Stimulus):
+    """A resolved encoder schedule, before it is a waveform
+
+    What :py:meth:`StimulusEncoder._assemble` produces once it has settled
+    *when* every electrode pulses and *how hard*: the pulse template, the
+    onsets of every distinct schedule, which frame each onset belongs to, and
+    the global time axis they all live on. Turning that into an
+    ``n_electrodes x n_time`` matrix is the expensive half, and the only half
+    that waits.
+
+    Deliberately not a scheduler abstraction. The schedule is resolved once,
+    eagerly, by the encoder -- including every validation and warning -- and
+    this class only carries the result of that work to whoever asks for the
+    samples.
+    """
+    #: Described by its schedule rather than by its samples. A frame-varying
+    #: amplitude and a raster realization are not something an operation on
+    #: the waveform could keep true, so one hands back a plain stimulus.
+    _is_parametric = True
+
+    __slots__ = ('_amp', '_ticks', '_sched', '_onsets', '_frames',
+                 '_pulse_ticks', '_pulse_vals', '_total')
+
+    def __init__(self, electrodes, amp, ticks, sched, onsets, frames,
+                 pulse_ticks, pulse_vals, total, encoder_metadata):
+        # `dtype=a.dtype` throughout: these are the scheduler's own numbers,
+        # and converting any of them would change the waveform below.
+        self._amp = self._own(amp, amp.dtype)
+        self._ticks = self._own(ticks, ticks.dtype)
+        self._sched = self._own(sched, sched.dtype)
+        self._onsets = tuple(self._own(o, o.dtype) for o in onsets)
+        self._frames = tuple(self._own(f, f.dtype) for f in frames)
+        self._pulse_ticks = self._own(pulse_ticks, pulse_ticks.dtype)
+        self._pulse_vals = self._own(pulse_vals, pulse_vals.dtype)
+        self._total = float(total)
+        self._defer(electrodes)
+        self.metadata['encoder'] = encoder_metadata
+
+    @property
+    def duration(self):
+        """Duration of the stimulus (ms)
+
+        Settled by the source the schedule was built from, so this does not
+        generate a waveform to find out.
+        """
+        return self._total
+
+    def _render(self):
+        """Expand the schedule into the pulse trains it describes
+
+        One unit-amplitude waveform per distinct schedule, scaled by the
+        amplitude of whichever frame each pulse belongs to.
+        """
+        data = np.zeros((len(self.electrodes), self._ticks.size),
+                        dtype=np.float32)
+        for s, (onset, frame) in enumerate(zip(self._onsets, self._frames)):
+            rows = np.flatnonzero(self._sched == s)
+            if rows.size == 0 or onset.size == 0:
+                continue
+            wave = StimulusEncoder._sample(onset, self._pulse_ticks,
+                                           self._pulse_vals, self._ticks)
+            # Which pulse each time point belongs to:
+            at = np.searchsorted(onset, self._ticks, side='right') - 1
+            np.clip(at, 0, onset.size - 1, out=at)
+            data[rows] = self._amp[rows][:, frame[at]] * wave
+        time = self._ticks * DT
+        time[-1] = self._total
+        return {'data': data, 'electrodes': self.electrodes, 'time': time}
+
+    def _pprint_params(self):
+        """Return a dict of class attributes to pretty-print
+
+        The schedule rather than the waveform it describes, so that printing
+        one does not generate it.
+        """
+        return {'electrodes': self.electrodes,
+                'n_frames': self._amp.shape[1],
+                'n_time': self._ticks.size,
+                'n_schedules': len(self._onsets),
+                'duration': self._total,
+                'metadata': self.metadata}
+
 class StimulusEncoder(PrettyPrint, metaclass=ABCMeta):
     """Abstract base class for all stimulus encoders
 
@@ -745,29 +827,17 @@ class StimulusEncoder(PrettyPrint, metaclass=ABCMeta):
                 f"to encode at electrode resolution instead.",
                 category=UserWarning)
 
-        # One unit-amplitude waveform per schedule, scaled by the amplitude of
-        # whichever frame each pulse belongs to:
-        data = np.zeros((n_el, n_time), dtype=np.float32)
-        for s, (onset, frame) in enumerate(zip(onsets, frames)):
-            rows = np.flatnonzero(sched == s)
-            if rows.size == 0 or onset.size == 0:
-                continue
-            wave = self._sample(onset, pulse_ticks, pulse_vals, ticks)
-            # Which pulse each time point belongs to:
-            at = np.searchsorted(onset, ticks, side='right') - 1
-            np.clip(at, 0, onset.size - 1, out=at)
-            data[rows] = amp[rows][:, frame[at]] * wave
-        time = ticks * DT
-        time[-1] = total
-        stim = Stimulus(data, electrodes=electrodes, time=time)
-        # The frame clock, which is what decides when a percept is worth
-        # reporting (see `pulse2percept.models.base._frame_clock`), and the
-        # raster sweep the schedule was actually realized on:
-        stim.metadata['encoder'] = {'frame_time': frame_time,
-                                    'frame_dur': frame_dur,
-                                    'cycle': None if cycle is None else
-                                    cycle * DT}
-        return stim
+        # The schedule is settled. Expanding it into an n_el x n_time matrix
+        # is the expensive half, and the half nothing needs until somebody
+        # asks for samples:
+        return _EncodedStimulus(
+            electrodes, amp, ticks, sched, onsets, frames, pulse_ticks,
+            pulse_vals, total,
+            # The frame clock, which is what decides when a percept is worth
+            # reporting (see `pulse2percept.models.base._frame_clock`), and
+            # the raster sweep the schedule was actually realized on:
+            {'frame_time': frame_time, 'frame_dur': frame_dur,
+             'cycle': None if cycle is None else cycle * DT})
 
     def _modulation(self, source, implant=None):
         """What the source asks each electrode for, frame by frame

--- a/pulse2percept/stimuli/encoders.py
+++ b/pulse2percept/stimuli/encoders.py
@@ -63,27 +63,12 @@ def _fps(metadata):
 
 
 class _EncodedStimulus(Stimulus):
-    """A resolved encoder schedule, before it is a waveform
-
-    What :py:meth:`StimulusEncoder._assemble` produces once it has settled
-    *when* every electrode pulses and *how hard*: the pulse template, the
-    onsets of every distinct schedule, which frame each onset belongs to, and
-    the global time axis they all live on. Turning that into an
-    ``n_electrodes x n_time`` matrix is the expensive half, and the only half
-    that waits.
-
-    Deliberately not a scheduler abstraction. The schedule is resolved once,
-    eagerly, by the encoder -- including every validation and warning -- and
-    this class only carries the result of that work to whoever asks for the
-    samples.
-    """
-    #: Described by its schedule rather than by its samples. A frame-varying
-    #: amplitude and a raster realization are not something an operation on
-    #: the waveform could keep true, so one hands back a plain stimulus.
+    """A resolved encoder schedule, expanded into a waveform on demand"""
+    #: whether the stimulus is described by its schedule rather than by its
+    #: samples
     _is_parametric = True
 
-    #: What the encoder asked the device for is not what the device delivers,
-    #: and this class is the one that knows both (see `_spatial_view`):
+    #: whether the stimulus has a special spatial view
     _has_spatial_view = True
 
     __slots__ = ('_amp', '_ticks', '_sched', '_onsets', '_frames',
@@ -93,8 +78,6 @@ class _EncodedStimulus(Stimulus):
     def __init__(self, electrodes, amp, ticks, sched, onsets, frames,
                  pulse_ticks, pulse_vals, total, firing, frame_time,
                  frame_dur, cycle):
-        # `dtype=a.dtype` throughout: these are the scheduler's own numbers,
-        # and converting any of them would change the waveform below.
         self._amp = self._own(amp, amp.dtype)
         self._ticks = self._own(ticks, ticks.dtype)
         self._sched = self._own(sched, sched.dtype)
@@ -103,10 +86,7 @@ class _EncodedStimulus(Stimulus):
         self._pulse_ticks = self._own(pulse_ticks, pulse_ticks.dtype)
         self._pulse_vals = self._own(pulse_vals, pulse_vals.dtype)
         self._total = float(total)
-        # Which electrode-frames were asked for a pulse rate at all. Kept as a
-        # mask rather than the frequencies themselves: what survives into the
-        # spatial view is on/off, and a rate is a fact about time that a
-        # reader with no clock cannot express anyway.
+        # Which electrode-frames were asked for a pulse rate at all:
         self._firing = self._own(firing, bool)
         self._frame_time = self._own(frame_time, frame_time.dtype)
         self._frame_dur = float(frame_dur)
@@ -114,108 +94,53 @@ class _EncodedStimulus(Stimulus):
         # expanding a waveform for:
         self._time = None
         self._defer(electrodes)
-        # The frame clock, which is what decides when a percept is worth
-        # reporting (see `pulse2percept.models.base._frame_clock`), and the
-        # raster sweep the schedule was actually realized on. Derived from the
-        # frozen state above, which stays the authority:
         self.metadata['encoder'] = {'frame_time': self._frame_time,
                                     'frame_dur': self._frame_dur,
                                     'cycle': cycle}
 
     def _spatial_view(self):
-        """What the encoder asked each electrode for, frame by frame
-
-        One column per frame of the source and one row per electrode, holding
-        the current that electrode is modulated to over that frame. It is what
-        the encoder *asks the device for*, before the device's own timing --
-        the pulse shape, the pulse clock, the raster -- settles when any of it
-        is actually delivered.
-
-        An electrode whose train never fires delivers no current at all, so a
-        zero frequency reads as zero amplitude here however high an amplitude
-        it was handed. Past that, rate does not survive into this
-        representation: what a rate means is a fact about time, and a reader
-        with no clock of its own has no way to express it. So frequency
-        modulation collapses to on/off here, which is the least misleading
-        thing it can do.
-        """
+        """One column per frame of the source and one row per electrode"""
         data = np.where(self._firing, self._amp, np.float32(0)).astype(
             np.float32)
-        # A source with a single frame has no time axis of its own, and gets
-        # none here either: what it asks for is one steady thing, and saying so
-        # is what lets a spatial model report a single picture rather than a
-        # sequence of one. Flattened, because that is how `Stimulus` is told
-        # a stimulus has no time component -- an (n, 1) container with
-        # `time=None` is given a time axis of [0] instead.
+        # A source with a single frame has no time axis of its own
         if self._frame_time.size > 1:
             stim = Stimulus(data, electrodes=self.electrodes,
                             time=self._frame_time)
         else:
             stim = Stimulus(data.ravel(), electrodes=self.electrodes)
-        # The frame clock and nothing else: there is no schedule here to
-        # record, which is the whole point of this representation.
         stim.metadata['encoder'] = {'frame_time': self._frame_time,
                                     'frame_dur': self._frame_dur}
         return stim
 
     def _rebuilt(self, electrodes, amp, sched, firing):
-        """This schedule, driving different electrodes or amplitudes
-
-        The one place the electrode-indexed halves of the schedule are
-        replaced. Everything about *when* a pulse happens is untouched, and
-        the per-schedule arrays are shared: an entry no row refers to any more
-        is simply one `_render` skips.
-        """
+        """This schedule, driving different electrodes or amplitudes"""
         rebuilt = _EncodedStimulus(
             electrodes, amp, self._ticks, sched, self._onsets, self._frames,
             self._pulse_ticks, self._pulse_vals, self._total, firing,
             self._frame_time, self._frame_dur,
             self.metadata['encoder']['cycle'])
-        # What the user put in the metadata is theirs; the encoder keys are
-        # rebuilt from the frozen state by the constructor:
         rebuilt.metadata['user'] = deepcopy(self.metadata.get('user'))
         return rebuilt
 
     def _scaled(self, factor):
-        """This schedule, delivering amplitudes scaled by ``factor``
-
-        Scaling changes what each electrode delivers, not when: the onsets,
-        the raster, the frame clock, the pulse shape and which electrodes fire
-        at all are still the ones this schedule resolved. So both descriptions
-        of it -- the waveform and the modulation behind it -- scale together.
-        """
+        """This schedule, delivering amplitudes scaled by ``factor``"""
         return self._rebuilt(self.electrodes, self._amp * factor, self._sched,
                              self._firing)
 
     def _without_electrodes(self, electrodes):
-        """This schedule, no longer driving ``electrodes``
-
-        Only the electrode-indexed arrays are filtered. The schedules
-        themselves are left as they are, including any that no electrode
-        refers to any more -- `_render` skips those, and compacting them would
-        buy nothing but tidiness.
-        """
+        """This schedule, no longer driving ``electrodes``"""
         keep = self._keep_mask(electrodes)
         return self._rebuilt(self.electrodes[keep], self._amp[keep],
                              self._sched[keep], self._firing[keep])
 
     @property
     def duration(self):
-        """Duration of the stimulus (ms)
-
-        Settled by the source the schedule was built from, so this does not
-        generate a waveform to find out.
-        """
+        """Duration of the stimulus (ms)"""
         return self._total
 
     @property
     def time(self):
-        """Time points of the stimulus (ms)
-
-        The schedule already says where every pulse edge falls, so asking for
-        the axis does not expand it into a waveform. Cached, so that the axis
-        a caller sees before the samples exist is the one it sees after.
-        """
+        """Time points of the stimulus (ms)"""
         if self._time is None:
             time = self._ticks * DT
             time[-1] = self._total
@@ -223,11 +148,7 @@ class _EncodedStimulus(Stimulus):
         return self._time
 
     def _render(self):
-        """Expand the schedule into the pulse trains it describes
-
-        One unit-amplitude waveform per distinct schedule, scaled by the
-        amplitude of whichever frame each pulse belongs to.
-        """
+        """Expand the schedule into the pulse trains it describes"""
         data = np.zeros((len(self.electrodes), self._ticks.size),
                         dtype=np.float32)
         for s, (onset, frame) in enumerate(zip(self._onsets, self._frames)):
@@ -246,11 +167,7 @@ class _EncodedStimulus(Stimulus):
                 'time': self.time}
 
     def _pprint_params(self):
-        """Return a dict of class attributes to pretty-print
-
-        The schedule rather than the waveform it describes, so that printing
-        one does not generate it.
-        """
+        """Return a dict of class attributes to pretty-print"""
         return {'electrodes': self.electrodes,
                 'n_frames': self._amp.shape[1],
                 'n_time': self._ticks.size,

--- a/pulse2percept/stimuli/images.py
+++ b/pulse2percept/stimuli/images.py
@@ -17,7 +17,7 @@ from skimage.filters import (threshold_mean, threshold_minimum, threshold_otsu,
                              median)
 from skimage.feature import canny
 
-from .base import Stimulus
+from .base import Stimulus, _owned
 from .names import ElectrodeNames
 from ..units import dimensionless
 from ..utils import center_image, shift_image, scale_image, trim_image
@@ -74,9 +74,7 @@ class ImageStimulus(Stimulus):
     """
     __slots__ = ('img_shape',)
 
-    #: Pixel intensities are gray levels in [0, 1], not currents. An encoder
-    #: is what turns them into stimulation; see
-    #: :py:class:`~pulse2percept.stimuli.AmplitudeEncoder`.
+    #: Pixel intensities are gray levels in [0, 1], not currents
     _default_unit = dimensionless
 
     def __init__(self, source, resize=None, as_gray=False,
@@ -85,6 +83,8 @@ class ImageStimulus(Stimulus):
             metadata = {}
         elif not isinstance(metadata, dict):
             metadata = {'user': metadata}
+        # The buffer the caller still holds, if any:
+        borrowed = None
         if isinstance(source, str):
             # Filename provided:
             img = imread(source)
@@ -92,11 +92,13 @@ class ImageStimulus(Stimulus):
             metadata['source_shape'] = img.shape
         elif isinstance(source, ImageStimulus):
             img = source.data.reshape(source.img_shape)
+            borrowed = source.data
             metadata.update(source.metadata)
             if electrodes is None:
                 electrodes = source.electrodes
         elif isinstance(source, np.ndarray):
             img = source
+            borrowed = source
         else:
             raise TypeError(f"Source must be a filename or another "
                             f"ImageStimulus, not {type(source)}.")
@@ -126,11 +128,12 @@ class ImageStimulus(Stimulus):
             # Name every pixel after its place in the image: 'A1' is the
             # top-left pixel, 'C12' sits in the third row and twelfth column,
             # and a color image suffixes the channel ('A1_R'). The names are
-            # generated on demand rather than stored, which is what keeps a
-            # megapixel image from paying for a million strings:
+            # generated on demand rather than stored:
             electrodes = ElectrodeNames(self.img_shape)
-        # Convert to float array in [0, 1] and call the Stimulus constructor:
-        super().__init__(img_as_float32(img).ravel(),
+        data = img_as_float32(img)
+        if borrowed is not None and np.may_share_memory(data, borrowed):
+            data = data.copy()
+        super().__init__(_owned(data.ravel()),
                                             time=None, electrodes=electrodes,
                                             metadata=metadata,
                                             compress=compress)
@@ -142,15 +145,7 @@ class ImageStimulus(Stimulus):
         return params
 
     def _names_for(self, img, electrodes):
-        """Electrode names for an image derived from this one
-
-        A pixel keeps its name across an operation that leaves the pixel grid
-        alone, which is what makes 'A1' refer to the same thing before and
-        after. An operation that resamples the grid (a resize, a rotation that
-        grows the canvas) has no such correspondence to preserve, so the result
-        is named afresh rather than inheriting names that no longer describe
-        it.
-        """
+        """Electrode names for an image derived from this one"""
         if electrodes is not None:
             return electrodes
         return self.electrodes if np.shape(img) == self.img_shape else None
@@ -246,11 +241,7 @@ class ImageStimulus(Stimulus):
         """
         img = self.data.reshape(self.img_shape)
         if img.ndim == 3 and img.shape[2] == 4:
-            # Blend the background with black. Doing it in one pass rather
-            # than through ``rgba2rgb`` avoids materializing the intermediate
-            # three-channel image, which for a full-resolution photograph is
-            # the bulk of the work. The arithmetic is the same, so the result
-            # is identical:
+            # Blend the background with black in one pass:
             img = np.clip(img[..., :3] * img[..., 3:4], 0.0, 1.0)
         if img.ndim == 3:
             img = rgb2gray(img)

--- a/pulse2percept/stimuli/images.py
+++ b/pulse2percept/stimuli/images.py
@@ -17,7 +17,7 @@ from skimage.filters import (threshold_mean, threshold_minimum, threshold_otsu,
                              median)
 from skimage.feature import canny
 
-from .base import Stimulus, _owned
+from .base import Stimulus, _adoptable
 from .names import ElectrodeNames
 from ..units import dimensionless
 from ..utils import center_image, shift_image, scale_image, trim_image
@@ -133,7 +133,7 @@ class ImageStimulus(Stimulus):
         data = img_as_float32(img)
         if borrowed is not None and np.may_share_memory(data, borrowed):
             data = data.copy()
-        super().__init__(_owned(data.ravel()),
+        super().__init__(_adoptable(data.ravel()),
                                             time=None, electrodes=electrodes,
                                             metadata=metadata,
                                             compress=compress)

--- a/pulse2percept/stimuli/images.py
+++ b/pulse2percept/stimuli/images.py
@@ -21,6 +21,7 @@ from .base import Stimulus
 from .names import ElectrodeNames
 from ..units import dimensionless
 from ..utils import center_image, shift_image, scale_image, trim_image
+from ..utils.images import _as_writable
 
 
 class ImageStimulus(Stimulus):
@@ -189,7 +190,10 @@ class ImageStimulus(Stimulus):
         stim : `ImageStimulus`
             A copy of the stimulus object with the new image
         """
-        img = func(self.data.reshape(self.img_shape), *args, **kwargs)
+        # `func` gets a frame of its own: several of the scikit-image
+        # transforms this exists to reach cannot take a read-only one.
+        img = func(_as_writable(self.data.reshape(self.img_shape)),
+                   *args, **kwargs)
         return ImageStimulus(img, electrodes=self._names_for(img, electrodes),
                              metadata=self.metadata)
 
@@ -504,8 +508,8 @@ class ImageStimulus(Stimulus):
         # Rotating in place is the common case, and keeps the pixel names
         # meaningful; ``resize=True`` is available through kwargs:
         kwargs.setdefault('resize', False)
-        img = img_rotate(self.data.reshape(self.img_shape), angle, mode=mode,
-                         **kwargs)
+        img = img_rotate(_as_writable(self.data.reshape(self.img_shape)),
+                         angle, mode=mode, **kwargs)
         return ImageStimulus(img, electrodes=self._names_for(img, electrodes),
                              metadata=self.metadata)
 

--- a/pulse2percept/stimuli/psychophysics.py
+++ b/pulse2percept/stimuli/psychophysics.py
@@ -195,7 +195,9 @@ class BarStimulus(VideoStimulus):
                                   spatial_freq=spatial_freq,
                                   temporal_freq=temporal_freq)
 
-        bar = grating.data.reshape(grating.vid_shape)
+        # A copy, because the loop below rewrites the grating frame by frame
+        # and a stimulus does not hand out a buffer anyone can write into:
+        bar = grating.data.reshape(grating.vid_shape).copy()
         for i in range(bar.shape[-1]):
             frame = bar[..., i]
             # There are 3 regions:

--- a/pulse2percept/stimuli/pulse_trains.py
+++ b/pulse2percept/stimuli/pulse_trains.py
@@ -456,12 +456,13 @@ class BiphasicPulseTrain(Stimulus):
     def _rescale_params(cls, metadata, factor):
         """Keep the pulse parameters in sync with the data
 
-        :py:class:`~pulse2percept.models.BiphasicAxonMapModel` and
-        :py:class:`~pulse2percept.models.cortex.DynaphosModel` read amplitude,
-        frequency and phase duration off the metadata rather than off the data.
-        An operation that rewrites the data but leaves the metadata behind
-        makes the two disagree: ``pt * 2`` delivers twice the current, and the
-        model would go on predicting the very same percept.
+        Compatibility only: the models read these numbers off the train
+        itself now (see
+        :py:meth:`~pulse2percept.stimuli.Stimulus._structured_sources`). The
+        copy under ``metadata`` is kept for anything that still reads it, and
+        has to stay in step for the same reason it always did: ``pt * 2``
+        delivers twice the current, and a reader left with the old ``amp``
+        would make of it the very same percept.
 
         Scaling is the one operation that leaves a biphasic pulse train a
         biphasic pulse train, so it scales ``amp`` (a negative factor only

--- a/pulse2percept/stimuli/pulse_trains.py
+++ b/pulse2percept/stimuli/pulse_trains.py
@@ -372,8 +372,9 @@ class BiphasicPulseTrain(Stimulus):
                                  stim_dur=stim_dur)
         self._defer(_electrode_names(electrode))
 
-        # Store metadata for BiphasicAxonMapModel. `amp` is stored as a
-        # magnitude, because that is all of it that reaches the data:
+        # Compatibility copy of the parameters this train owns outright
+        # (see `Stimulus._rescale_params`). `amp` is a magnitude, because that
+        # is all of it that reaches the data:
         # `BiphasicPulse` takes `np.abs(amp)` and reads the polarity off
         # `cathodic_first`. Storing the sign the caller happened to type would
         # have two identical waveforms predict two different percepts, since
@@ -454,25 +455,15 @@ class BiphasicPulseTrain(Stimulus):
 
     @classmethod
     def _rescale_params(cls, metadata, factor):
-        """Keep the pulse parameters in sync with the data
-
-        Compatibility only: the models read these numbers off the train
-        itself now (see
-        :py:meth:`~pulse2percept.stimuli.Stimulus._structured_sources`). The
-        copy under ``metadata`` is kept for anything that still reads it, and
-        has to stay in step for the same reason it always did: ``pt * 2``
-        delivers twice the current, and a reader left with the old ``amp``
-        would make of it the very same percept.
+        """Keep the compatibility copy of the pulse parameters in step
 
         Scaling is the one operation that leaves a biphasic pulse train a
         biphasic pulse train, so it scales ``amp`` (a negative factor only
         swaps the two phases, which does not change the magnitude). Anything
-        else -- a DC offset, an appended second train, a non-finite factor --
-        leaves something that is no longer one biphasic pulse train at one
-        amplitude and frequency, so the pulse parameters are dropped: a model
-        asking for them then rejects the stimulus rather than predicting from
-        numbers that no longer describe it. What the user put in ``metadata``
-        is theirs, and survives either way.
+        else leaves something no single amplitude and frequency describe, so
+        the parameters are dropped and a reader rejects the stimulus rather
+        than predicting from numbers that no longer fit it. What the user put
+        in ``metadata`` is theirs, and survives either way.
         """
         if 'amp' not in metadata:
             # Parameters an earlier operation has already dropped

--- a/pulse2percept/stimuli/pulse_trains.py
+++ b/pulse2percept/stimuli/pulse_trains.py
@@ -2,12 +2,14 @@
    :py:class:`~pulse2percept.stimuli.BiphasicPulseTrain`, 
    :py:class:`~pulse2percept.stimuli.AsymmetricBiphasicPulseTrain`"""
 import numpy as np
+from copy import deepcopy
 from math import isclose
 
 # DT: Sampling time step (ms); defines the duration of the signal edge
 # transitions:
 from .base import Stimulus
-from .pulses import BiphasicPulse, AsymmetricBiphasicPulse, MonophasicPulse
+from .pulses import (AsymmetricBiphasicPulse, BiphasicPulse,
+                     MonophasicPulse, _electrode_names)
 from ..units import Hz, as_value, ms, uA
 from ..utils.constants import DT, MS_PER_S
 
@@ -111,7 +113,11 @@ class PulseTrain(Stimulus):
        one gives a dimensionless train.
 
     """
-    __slots__ = ('freq', 'pulse_type')
+    #: Defined by the pulse it repeats rather than by its samples
+    #: (see `Stimulus._is_parametric`):
+    _is_parametric = True
+
+    __slots__ = ('_freq', '_pulse', '_n_pulses', '_stim_dur')
 
     def __init__(self, freq, pulse, n_pulses=None, stim_dur=1000.0,
                  electrode=None, metadata=None):
@@ -122,11 +128,19 @@ class PulseTrain(Stimulus):
         if not isinstance(pulse, Stimulus):
             raise TypeError(f"'pulse' must be a Stimulus object, not "
                             f"{type(pulse)}.")
-        if pulse.shape[0] == 0:
+        n_rows = len(pulse.electrodes)
+        if n_rows == 0:
             raise ValueError(f"'pulse' has invalid shape "
                              f"({pulse.shape[0]}, {pulse.shape[1]}).")
-        if pulse.time is None:
+        # Every parameter-backed stimulus in the library is a pulse, and a
+        # pulse always has a time axis. So this only has to ask a raw
+        # stimulus, whose waveform is already there to be asked:
+        if not pulse._is_parametric and pulse.time is None:
             raise ValueError("'pulse' does not have a time component.")
+        # `duration` rather than `time[-1]`: a parametric pulse knows how long
+        # it is from its parameters, so none of the arithmetic below has to
+        # generate a waveform to find out.
+        pulse_dur = pulse.duration
 
         # How many pulses fit into stim dur. `freq` counts cycles per second
         # and `stim_dur` counts milliseconds, so this is the one place the two
@@ -146,20 +160,85 @@ class PulseTrain(Stimulus):
             # short would leave the train with a net current -- a 30 Hz train
             # in a 33.37 ms window used to end on half a cathodic phase, and
             # so was not charge-balanced.
-            n_pulses = int(np.floor((stim_dur - pulse.time[-1]) /
+            n_pulses = int(np.floor((stim_dur - pulse_dur) /
                                     (MS_PER_S / freq) + 1e-9)) + 1
-        # 0 Hz is allowed, and so is a pulse too long to fit even once:
+        # 0 Hz is allowed, and so is a pulse too long to fit even once. A
+        # silent train is a single row of zeros, whatever the pulse looked
+        # like, which is what this class has always produced:
+        if n_pulses <= 0:
+            n_rows = 1
+        else:
+            # Window duration (ms) is the inverse of pulse train frequency.
+            # Asked here rather than in `_render`, so that a pulse too long to
+            # fit is refused where the caller can see why:
+            window_dur = MS_PER_S / freq
+            if pulse_dur > window_dur:
+                raise ValueError(f"Pulse (dur={pulse_dur:.2f} ms) does not fit into "
+                                 f"pulse train window (dur={window_dur:.2f} "
+                                 f"ms)")
+        if electrode is None:
+            names = np.arange(n_rows)
+        else:
+            names = np.array([electrode]).ravel()
+            if len(names) != n_rows:
+                raise ValueError(f"Number of electrodes provided "
+                                 f"({len(names)}) does not match the number "
+                                 f"of electrodes in the pulse ({n_rows}).")
+        self._freq = freq
+        # A snapshot, not the caller's object: tiling used to copy the pulse's
+        # values into the train there and then, so a pulse the caller goes on
+        # to replace must not change a train already built from it. Immutable
+        # waveform state makes this share arrays rather than duplicate them.
+        self._pulse = deepcopy(pulse)
+        self._n_pulses = n_pulses
+        self._stim_dur = stim_dur
+        # This class tiles whatever pulse it is handed, and the tiled numbers
+        # mean whatever that pulse's did -- including the zeros of a silent
+        # train. Without this the result would fall back to the default
+        # (current) reading of them:
+        self._defer(names, unit=pulse.unit, time_unit=pulse.time_unit)
+        self.metadata = {'user': metadata}
+
+    @property
+    def freq(self):
+        """Pulse train frequency (Hz)"""
+        return self._freq
+
+    @property
+    def pulse(self):
+        """The single pulse this train repeats"""
+        return self._pulse
+
+    @property
+    def n_pulses(self):
+        """Number of pulses delivered
+
+        Resolved at construction: ``n_pulses=None`` means as many whole
+        pulses as fit into ``stim_dur``.
+        """
+        return self._n_pulses
+
+    @property
+    def stim_dur(self):
+        """Total stimulus duration (ms)"""
+        return self._stim_dur
+
+    @property
+    def pulse_type(self):
+        """Name of the class the repeated pulse came from"""
+        return self._pulse.__class__.__name__
+
+    def _render(self):
+        """Tile the pulse into the train the parameters above describe"""
+        pulse, freq = self._pulse, self._freq
+        n_pulses, stim_dur = self._n_pulses, self._stim_dur
         if n_pulses <= 0:
             time = np.array([0, stim_dur], dtype=np.float64)
             data = np.array([[0, 0]], dtype=np.float32)
         else:
             # Window duration (ms) is the inverse of pulse train frequency:
             window_dur = MS_PER_S / freq
-            if pulse.time[-1] > window_dur:
-                raise ValueError(f"Pulse (dur={pulse.time[-1]:.2f} ms) does not fit into "
-                                 f"pulse train window (dur={window_dur:.2f} "
-                                 f"ms)")
-            shift = np.maximum(0, window_dur - pulse.time[-1])
+            shift = np.maximum(0, window_dur - pulse.duration)
             data, time = _tile_pulse(pulse, shift, n_pulses)
         if time[-1] > stim_dur + DT:
             # If stimulus is longer than the requested `stim_dur`, trim it.
@@ -177,25 +256,19 @@ class PulseTrain(Stimulus):
             time = np.append(time[t_idx], stim_dur)
         elif time[-1] < stim_dur - DT:
             # If stimulus is shorter than the requested `stim_dur`, add a zero:
-            data = np.hstack((data, np.zeros((pulse.data.shape[0], 1))))
+            data = np.hstack((data, np.zeros((data.shape[0], 1))))
             time = np.append(time, stim_dur)
-        super().__init__(data, time=time, electrodes=electrode, metadata=None,
-                         compress=False)
-        # This class tiles whatever pulse it is handed, and the tiled numbers
-        # mean whatever that pulse's did -- including the zeros of a silent
-        # train. Without this the result would fall back to the default
-        # (current) reading of them:
-        self._inherit_units(pulse)
-        self.freq = freq
-        self.pulse_type = pulse.__class__.__name__
-        self.metadata = {'user': metadata}
+        return {'data': data, 'electrodes': self.electrodes, 'time': time}
 
     def _pprint_params(self):
-        """Return a dict of class arguments to pretty-print"""
-        params = super()._pprint_params()
-        params.update({'freq': self.freq,
-                       'pulse_type': self.pulse_type})
-        return params
+        """Return a dict of class arguments to pretty-print
+
+        The parameters that define the train rather than the waveform they
+        describe, so that printing one does not generate it.
+        """
+        return {'freq': self.freq, 'pulse_type': self.pulse_type,
+                'n_pulses': self.n_pulses, 'stim_dur': self.stim_dur,
+                'electrodes': self.electrodes, 'metadata': self.metadata}
 
 
 class BiphasicPulseTrain(Stimulus):
@@ -248,7 +321,11 @@ class BiphasicPulseTrain(Stimulus):
        converted to those units. See :py:mod:`pulse2percept.units`.
 
     """
-    __slots__ = ('freq', 'cathodic_first')
+    #: Defined by the pulse it repeats rather than by its samples
+    #: (see `Stimulus._is_parametric`):
+    _is_parametric = True
+
+    __slots__ = ('_train',)
 
     def __init__(self, freq, amp, phase_dur, interphase_dur=0, delay_dur=0,
                  n_pulses=None, stim_dur=1000.0, cathodic_first=True,
@@ -267,12 +344,12 @@ class BiphasicPulseTrain(Stimulus):
                               interphase_dur=interphase_dur,
                               cathodic_first=cathodic_first,
                               electrode=electrode)
-        # Concatenate the pulses:
-        pt = PulseTrain(freq, pulse, n_pulses=n_pulses, stim_dur=stim_dur)
-        super().__init__(pt.data, time=pt.time, electrodes=electrode,
-                         compress=False)
-        self.freq = freq
-        self.cathodic_first = cathodic_first
+        # Concatenate the pulses. Built here rather than in `_render`, so that
+        # every argument is still checked at construction; neither object
+        # generates a waveform until one is asked for.
+        self._train = PulseTrain(freq, pulse, n_pulses=n_pulses,
+                                 stim_dur=stim_dur)
+        self._defer(_electrode_names(electrode))
 
         # Store metadata for BiphasicAxonMapModel. `amp` is stored as a
         # magnitude, because that is all of it that reaches the data:
@@ -285,6 +362,51 @@ class BiphasicPulseTrain(Stimulus):
                          'phase_dur': phase_dur,
                          'delay_dur': delay_dur,
                          'user': metadata}
+
+    @property
+    def freq(self):
+        """Pulse train frequency (Hz)"""
+        return self._train.freq
+
+    @property
+    def n_pulses(self):
+        """Number of pulses delivered"""
+        return self._train.n_pulses
+
+    @property
+    def stim_dur(self):
+        """Total stimulus duration (ms)"""
+        return self._train.stim_dur
+
+    @property
+    def amp(self):
+        """Magnitude (uA) of both phases of each pulse"""
+        return self._train.pulse.amp
+
+    @property
+    def phase_dur(self):
+        """Duration (ms) of the cathodic/anodic phase"""
+        return self._train.pulse.phase_dur
+
+    @property
+    def interphase_dur(self):
+        """Duration (ms) of the gap between the two phases"""
+        return self._train.pulse.interphase_dur
+
+    @property
+    def delay_dur(self):
+        """Delay (ms) before the first phase of each pulse"""
+        return self._train.pulse.delay_dur
+
+    @property
+    def cathodic_first(self):
+        """Whether the cathodic phase is delivered first"""
+        return self._train.pulse.cathodic_first
+
+    def _render(self):
+        """The tiled train the parameters above describe"""
+        return {'data': self._train.data, 'electrodes': self.electrodes,
+                'time': self._train.time}
 
     @classmethod
     def _rescale_params(cls, metadata, factor):
@@ -314,22 +436,18 @@ class BiphasicPulseTrain(Stimulus):
             return {'user': metadata.get('user')}
         return dict(metadata, amp=abs(metadata['amp'] * factor))
 
-    def _rescale_metadata(self, factor):
-        """Keep this train's own parameters, and its polarity, in sync"""
-        if factor == 1:
-            return
-        self.metadata = self._rescale_params(self.metadata, factor)
-        if factor is not None and factor < 0:
-            # The two phases swapped places. `BiphasicPulse` reads the polarity
-            # off this flag, so that is where the sign belongs:
-            self.cathodic_first = not self.cathodic_first
-
     def _pprint_params(self):
-        """Return a dict of class arguments to pretty-print"""
-        params = super()._pprint_params()
-        params.update({'cathodic_first': self.cathodic_first,
-                       'freq': self.freq})
-        return params
+        """Return a dict of class arguments to pretty-print
+
+        The parameters that define the train rather than the waveform they
+        describe, so that printing one does not generate it.
+        """
+        return {'freq': self.freq, 'amp': self.amp,
+                'phase_dur': self.phase_dur,
+                'interphase_dur': self.interphase_dur,
+                'delay_dur': self.delay_dur, 'stim_dur': self.stim_dur,
+                'cathodic_first': self.cathodic_first,
+                'electrodes': self.electrodes, 'metadata': self.metadata}
 
 
 class AsymmetricBiphasicPulseTrain(Stimulus):
@@ -379,7 +497,11 @@ class AsymmetricBiphasicPulseTrain(Stimulus):
        converted to those units. See :py:mod:`pulse2percept.units`.
 
     """
-    __slots__ = ('freq', 'cathodic_first')
+    #: Defined by the pulse it repeats rather than by its samples
+    #: (see `Stimulus._is_parametric`):
+    _is_parametric = True
+
+    __slots__ = ('_train',)
 
     def __init__(self, freq, amp1, amp2, phase_dur1, phase_dur2,
                  interphase_dur=0, delay_dur=0, n_pulses=None, stim_dur=1000.0,
@@ -399,20 +521,80 @@ class AsymmetricBiphasicPulseTrain(Stimulus):
                                         interphase_dur=interphase_dur,
                                         cathodic_first=cathodic_first,
                                         electrode=electrode)
-        # Concatenate the pulses:
-        pt = PulseTrain(freq, pulse, n_pulses=n_pulses, stim_dur=stim_dur)
-        super().__init__(pt.data, time=pt.time, electrodes=electrode,
-                         compress=False)
-        self.freq = freq
-        self.cathodic_first = cathodic_first
+        # Concatenate the pulses (see `BiphasicPulseTrain.__init__`):
+        self._train = PulseTrain(freq, pulse, n_pulses=n_pulses,
+                                 stim_dur=stim_dur)
+        self._defer(_electrode_names(electrode))
         self.metadata = {'user': metadata}
 
+    @property
+    def freq(self):
+        """Pulse train frequency (Hz)"""
+        return self._train.freq
+
+    @property
+    def n_pulses(self):
+        """Number of pulses delivered"""
+        return self._train.n_pulses
+
+    @property
+    def stim_dur(self):
+        """Total stimulus duration (ms)"""
+        return self._train.stim_dur
+
+    @property
+    def amp1(self):
+        """Magnitude (uA) of the first phase of each pulse"""
+        return self._train.pulse.amp1
+
+    @property
+    def amp2(self):
+        """Magnitude (uA) of the second phase of each pulse"""
+        return self._train.pulse.amp2
+
+    @property
+    def phase_dur1(self):
+        """Duration (ms) of the first pulse phase"""
+        return self._train.pulse.phase_dur1
+
+    @property
+    def phase_dur2(self):
+        """Duration (ms) of the second pulse phase"""
+        return self._train.pulse.phase_dur2
+
+    @property
+    def interphase_dur(self):
+        """Duration (ms) of the gap between the two phases"""
+        return self._train.pulse.interphase_dur
+
+    @property
+    def delay_dur(self):
+        """Delay (ms) before the first phase of each pulse"""
+        return self._train.pulse.delay_dur
+
+    @property
+    def cathodic_first(self):
+        """Whether the cathodic phase is delivered first"""
+        return self._train.pulse.cathodic_first
+
+    def _render(self):
+        """The tiled train the parameters above describe"""
+        return {'data': self._train.data, 'electrodes': self.electrodes,
+                'time': self._train.time}
+
     def _pprint_params(self):
-        """Return a dict of class arguments to pretty-print"""
-        params = super()._pprint_params()
-        params.update({'cathodic_first': self.cathodic_first,
-                       'freq': self.freq})
-        return params
+        """Return a dict of class arguments to pretty-print
+
+        The parameters that define the train rather than the waveform they
+        describe, so that printing one does not generate it.
+        """
+        return {'freq': self.freq, 'amp1': self.amp1, 'amp2': self.amp2,
+                'phase_dur1': self.phase_dur1,
+                'phase_dur2': self.phase_dur2,
+                'interphase_dur': self.interphase_dur,
+                'delay_dur': self.delay_dur, 'stim_dur': self.stim_dur,
+                'cathodic_first': self.cathodic_first,
+                'electrodes': self.electrodes, 'metadata': self.metadata}
 
 
 class BiphasicTripletTrain(Stimulus):
@@ -468,7 +650,11 @@ class BiphasicTripletTrain(Stimulus):
        converted to those units. See :py:mod:`pulse2percept.units`.
 
     """
-    __slots__ = ('freq', 'cathodic_first')
+    #: Defined by the pulse it repeats rather than by its samples
+    #: (see `Stimulus._is_parametric`):
+    _is_parametric = True
+
+    __slots__ = ('_train', '_pulse', '_interpulse_dur')
 
     def __init__(self, freq, amp, phase_dur, interphase_dur=0, interpulse_dur=0,
                  delay_dur=0, n_pulses=None, stim_dur=1000.0, cathodic_first=True,
@@ -486,6 +672,12 @@ class BiphasicTripletTrain(Stimulus):
                               delay_dur=delay_dur,
                               cathodic_first=cathodic_first,
                               electrode=electrode)
+        # The pulse the triplet is made of, kept for the parameters below.
+        # The triplet itself is assembled once, here, rather than at render
+        # time: it is three copies of a handful of time points, and building
+        # it is what checks that they fit together at all.
+        self._pulse = pulse
+        self._interpulse_dur = interpulse_dur
         if interpulse_dur != 0:
             # Create an interpulse 'delay' pulse. It has to sit on the same
             # electrode as `pulse`, or the two cannot be appended:
@@ -493,18 +685,72 @@ class BiphasicTripletTrain(Stimulus):
             pulse = pulse.append(delay_pulse)
         # Create the pulse triplet:
         triplet = pulse.append(pulse).append(pulse)
-        # Create the triplet train:
-        pt = PulseTrain(freq, triplet, n_pulses=n_pulses, stim_dur=stim_dur)
-        # Set up the Stimulus object through the constructor:
-        super().__init__(pt.data, time=pt.time, electrodes=electrode,
-                         compress=False)
-        self.freq = freq
-        self.cathodic_first = cathodic_first
+        # Create the triplet train (see `BiphasicPulseTrain.__init__`):
+        self._train = PulseTrain(freq, triplet, n_pulses=n_pulses,
+                                 stim_dur=stim_dur)
+        self._defer(_electrode_names(electrode))
         self.metadata = {'user': metadata}
 
+    @property
+    def freq(self):
+        """Pulse train frequency (Hz)"""
+        return self._train.freq
+
+    @property
+    def n_pulses(self):
+        """Number of pulses delivered"""
+        return self._train.n_pulses
+
+    @property
+    def stim_dur(self):
+        """Total stimulus duration (ms)"""
+        return self._train.stim_dur
+
+    @property
+    def amp(self):
+        """Magnitude (uA) of both phases of each pulse"""
+        return self._pulse.amp
+
+    @property
+    def phase_dur(self):
+        """Duration (ms) of the cathodic/anodic phase"""
+        return self._pulse.phase_dur
+
+    @property
+    def interphase_dur(self):
+        """Duration (ms) of the gap between the two phases"""
+        return self._pulse.interphase_dur
+
+    @property
+    def interpulse_dur(self):
+        """Delay (ms) after each pulse of the triplet"""
+        return self._interpulse_dur
+
+    @property
+    def delay_dur(self):
+        """Delay (ms) before the first phase of each pulse"""
+        return self._pulse.delay_dur
+
+    @property
+    def cathodic_first(self):
+        """Whether the cathodic phase is delivered first"""
+        return self._pulse.cathodic_first
+
+    def _render(self):
+        """The tiled train the parameters above describe"""
+        return {'data': self._train.data, 'electrodes': self.electrodes,
+                'time': self._train.time}
+
     def _pprint_params(self):
-        """Return a dict of class arguments to pretty-print"""
-        params = super()._pprint_params()
-        params.update({'cathodic_first': self.cathodic_first,
-                       'freq': self.freq})
-        return params
+        """Return a dict of class arguments to pretty-print
+
+        The parameters that define the train rather than the waveform they
+        describe, so that printing one does not generate it.
+        """
+        return {'freq': self.freq, 'amp': self.amp,
+                'phase_dur': self.phase_dur,
+                'interphase_dur': self.interphase_dur,
+                'interpulse_dur': self.interpulse_dur,
+                'delay_dur': self.delay_dur, 'stim_dur': self.stim_dur,
+                'cathodic_first': self.cathodic_first,
+                'electrodes': self.electrodes, 'metadata': self.metadata}

--- a/pulse2percept/stimuli/pulse_trains.py
+++ b/pulse2percept/stimuli/pulse_trains.py
@@ -7,7 +7,7 @@ from math import isclose
 
 # DT: Sampling time step (ms); defines the duration of the signal edge
 # transitions:
-from .base import Stimulus
+from .base import Stimulus, _scale_factor
 from .pulses import (AsymmetricBiphasicPulse, BiphasicPulse,
                      MonophasicPulse, _electrode_names)
 from ..units import Hz, as_value, ms, uA
@@ -407,6 +407,44 @@ class BiphasicPulseTrain(Stimulus):
         """The tiled train the parameters above describe"""
         return {'data': self._train.data, 'electrodes': self.electrodes,
                 'time': self._train.time}
+
+    def _scaled(self, factor):
+        """This train with every amplitude multiplied by ``factor``
+
+        Built from the parameters rather than from the samples: ``amp`` is
+        canonical state now, so twice this train is the train at twice its
+        amplitude -- not the float32 waveform cache doubled and its rounding
+        promoted to truth. The two agree to within a float32 ulp.
+        """
+        return BiphasicPulseTrain(
+            self.freq, self.amp * abs(factor), self.phase_dur,
+            interphase_dur=self.interphase_dur, delay_dur=self.delay_dur,
+            n_pulses=self.n_pulses, stim_dur=self.stim_dur,
+            # A negative factor swaps the two phases, which is exactly what
+            # this flag says:
+            cathodic_first=(self.cathodic_first if factor >= 0
+                            else not self.cathodic_first),
+            electrode=self.electrodes[0],
+            # The compatibility metadata is rebuilt by the constructor, from
+            # the new amplitude. Only what the user put there is theirs to
+            # carry across:
+            metadata=deepcopy(self.metadata.get('user')))
+
+    def _apply_operator(self, a, op, b, field='data'):
+        """Scaling a biphasic pulse train leaves a biphasic pulse train
+
+        Multiplying every amplitude by a finite factor is exactly what a
+        different ``amp`` does, and a negative factor is exactly what swapping
+        the two phases does, so the result is still described by the
+        parameters this class is made of. Anything else -- a DC offset, a
+        shift in time, a factor that is not finite -- is not, and falls
+        through to the ordinary waveform operation, which hands back a plain
+        stimulus (see :py:meth:`~pulse2percept.stimuli.Stimulus._derived`).
+        """
+        factor = _scale_factor(a, op, b, field)
+        if field != 'data' or factor is None:
+            return super()._apply_operator(a, op, b, field=field)
+        return self._scaled(factor)
 
     @classmethod
     def _rescale_params(cls, metadata, factor):

--- a/pulse2percept/stimuli/pulse_trains.py
+++ b/pulse2percept/stimuli/pulse_trains.py
@@ -698,27 +698,16 @@ class BiphasicTripletTrain(Stimulus):
         interpulse_dur = as_value(interpulse_dur, ms, 'interpulse_dur')
         delay_dur = as_value(delay_dur, ms, 'delay_dur')
         stim_dur = as_value(stim_dur, ms, 'stim_dur')
-        # Create the pulse:
         pulse = BiphasicPulse(amp, phase_dur, interphase_dur=interphase_dur,
                               delay_dur=delay_dur,
                               cathodic_first=cathodic_first,
                               electrode=electrode)
-        # The pulse the triplet is made of, kept for the parameters below.
-        # The triplet itself is assembled once, here, rather than at render
-        # time: it is three copies of a handful of time points, and building
-        # it is what checks that they fit together at all.
         self._pulse = pulse
         self._interpulse_dur = interpulse_dur
         if interpulse_dur != 0:
-            # Create an interpulse 'delay' pulse. It has to sit on the same
-            # electrode as `pulse`, or the two cannot be appended:
             delay_pulse = MonophasicPulse(0, interpulse_dur, electrode=electrode)
             pulse = pulse.append(delay_pulse)
-        # Create the pulse triplet. Three copies of one pulse is not three
-        # protocols, so this keeps the waveform rather than the sequence
-        # `append` would otherwise hand back:
-        triplet = Stimulus(pulse.append(pulse).append(pulse))
-        # Create the triplet train (see `BiphasicPulseTrain.__init__`):
+        triplet = pulse.append(pulse).append(pulse)
         self._train = PulseTrain(freq, triplet, n_pulses=n_pulses,
                                  stim_dur=stim_dur)
         self._defer(_electrode_names(electrode))

--- a/pulse2percept/stimuli/pulse_trains.py
+++ b/pulse2percept/stimuli/pulse_trains.py
@@ -7,7 +7,7 @@ from math import isclose
 
 # DT: Sampling time step (ms); defines the duration of the signal edge
 # transitions:
-from .base import Stimulus, _scale_factor
+from .base import Stimulus
 from .pulses import (AsymmetricBiphasicPulse, BiphasicPulse,
                      MonophasicPulse, _electrode_names)
 from ..units import Hz, as_value, ms, uA
@@ -117,7 +117,8 @@ class PulseTrain(Stimulus):
     #: (see `Stimulus._is_parametric`):
     _is_parametric = True
 
-    __slots__ = ('_freq', '_pulse', '_n_pulses', '_stim_dur')
+    __slots__ = ('_freq', '_pulse', '_n_pulses', '_n_pulses_asked',
+                 '_stim_dur')
 
     def __init__(self, freq, pulse, n_pulses=None, stim_dur=1000.0,
                  electrode=None, metadata=None):
@@ -146,6 +147,12 @@ class PulseTrain(Stimulus):
         # and `stim_dur` counts milliseconds, so this is the one place the two
         # clocks have to be reconciled:
         n_max_pulses = freq * stim_dur / MS_PER_S
+        # Kept as it was asked for, alongside the count it resolves to below.
+        # The two are not interchangeable: this guard measures a request
+        # against `n_max_pulses`, while the default counts whole pulses from
+        # t=0 and can legitimately come out one higher. Rebuilding a train
+        # (see `_scaled`) has to pass the request back, not the result.
+        self._n_pulses_asked = n_pulses
         # The requested number of pulses cannot be greater than max pulses:
         if n_pulses is not None:
             n_pulses = int(n_pulses)
@@ -259,6 +266,20 @@ class PulseTrain(Stimulus):
             data = np.hstack((data, np.zeros((data.shape[0], 1))))
             time = np.append(time, stim_dur)
         return {'data': data, 'electrodes': self.electrodes, 'time': time}
+
+    def _scaled(self, factor):
+        """This train, tiling a pulse whose amplitudes were scaled
+
+        Tiling copies the pulse without doing arithmetic on it, so scaling
+        every sample of the train is the same thing as scaling the pulse it
+        repeats -- and the train's own parameters (frequency, pulse count,
+        window) are untouched by either.
+        """
+        return PulseTrain(self.freq, self.pulse * factor,
+                          n_pulses=self._n_pulses_asked,
+                          stim_dur=self.stim_dur,
+                          electrode=self.electrodes,
+                          metadata=deepcopy(self.metadata.get('user')))
 
     def _pprint_params(self):
         """Return a dict of class arguments to pretty-print
@@ -419,7 +440,8 @@ class BiphasicPulseTrain(Stimulus):
         return BiphasicPulseTrain(
             self.freq, self.amp * abs(factor), self.phase_dur,
             interphase_dur=self.interphase_dur, delay_dur=self.delay_dur,
-            n_pulses=self.n_pulses, stim_dur=self.stim_dur,
+            n_pulses=self._train._n_pulses_asked,
+            stim_dur=self.stim_dur,
             # A negative factor swaps the two phases, which is exactly what
             # this flag says:
             cathodic_first=(self.cathodic_first if factor >= 0
@@ -429,22 +451,6 @@ class BiphasicPulseTrain(Stimulus):
             # the new amplitude. Only what the user put there is theirs to
             # carry across:
             metadata=deepcopy(self.metadata.get('user')))
-
-    def _apply_operator(self, a, op, b, field='data'):
-        """Scaling a biphasic pulse train leaves a biphasic pulse train
-
-        Multiplying every amplitude by a finite factor is exactly what a
-        different ``amp`` does, and a negative factor is exactly what swapping
-        the two phases does, so the result is still described by the
-        parameters this class is made of. Anything else -- a DC offset, a
-        shift in time, a factor that is not finite -- is not, and falls
-        through to the ordinary waveform operation, which hands back a plain
-        stimulus (see :py:meth:`~pulse2percept.stimuli.Stimulus._derived`).
-        """
-        factor = _scale_factor(a, op, b, field)
-        if field != 'data' or factor is None:
-            return super()._apply_operator(a, op, b, field=field)
-        return self._scaled(factor)
 
     @classmethod
     def _rescale_params(cls, metadata, factor):
@@ -620,6 +626,22 @@ class AsymmetricBiphasicPulseTrain(Stimulus):
         return {'data': self._train.data, 'electrodes': self.electrodes,
                 'time': self._train.time}
 
+    def _scaled(self, factor):
+        """This train with both phase magnitudes multiplied by ``factor``
+
+        See :py:meth:`BiphasicPulseTrain._scaled`.
+        """
+        return AsymmetricBiphasicPulseTrain(
+            self.freq, self.amp1 * abs(factor), self.amp2 * abs(factor),
+            self.phase_dur1, self.phase_dur2,
+            interphase_dur=self.interphase_dur, delay_dur=self.delay_dur,
+            n_pulses=self._train._n_pulses_asked,
+            stim_dur=self.stim_dur,
+            cathodic_first=(self.cathodic_first if factor >= 0
+                            else not self.cathodic_first),
+            electrode=self.electrodes[0],
+            metadata=deepcopy(self.metadata.get('user')))
+
     def _pprint_params(self):
         """Return a dict of class arguments to pretty-print
 
@@ -721,8 +743,10 @@ class BiphasicTripletTrain(Stimulus):
             # electrode as `pulse`, or the two cannot be appended:
             delay_pulse = MonophasicPulse(0, interpulse_dur, electrode=electrode)
             pulse = pulse.append(delay_pulse)
-        # Create the pulse triplet:
-        triplet = pulse.append(pulse).append(pulse)
+        # Create the pulse triplet. Three copies of one pulse is not three
+        # protocols, so this keeps the waveform rather than the sequence
+        # `append` would otherwise hand back:
+        triplet = Stimulus(pulse.append(pulse).append(pulse))
         # Create the triplet train (see `BiphasicPulseTrain.__init__`):
         self._train = PulseTrain(freq, triplet, n_pulses=n_pulses,
                                  stim_dur=stim_dur)
@@ -778,6 +802,23 @@ class BiphasicTripletTrain(Stimulus):
         """The tiled train the parameters above describe"""
         return {'data': self._train.data, 'electrodes': self.electrodes,
                 'time': self._train.time}
+
+    def _scaled(self, factor):
+        """This train with every phase magnitude multiplied by ``factor``
+
+        See :py:meth:`BiphasicPulseTrain._scaled`. The triplet structure --
+        three pulses per window, ``interpulse_dur`` apart -- is untouched.
+        """
+        return BiphasicTripletTrain(
+            self.freq, self.amp * abs(factor), self.phase_dur,
+            interphase_dur=self.interphase_dur,
+            interpulse_dur=self.interpulse_dur, delay_dur=self.delay_dur,
+            n_pulses=self._train._n_pulses_asked,
+            stim_dur=self.stim_dur,
+            cathodic_first=(self.cathodic_first if factor >= 0
+                            else not self.cathodic_first),
+            electrode=self.electrodes[0],
+            metadata=deepcopy(self.metadata.get('user')))
 
     def _pprint_params(self):
         """Return a dict of class arguments to pretty-print

--- a/pulse2percept/stimuli/pulse_trains.py
+++ b/pulse2percept/stimuli/pulse_trains.py
@@ -214,15 +214,16 @@ class PulseTrain(Stimulus):
     @property
     def pulse(self):
         """The single pulse this train repeats"""
-        return self._pulse
+        return deepcopy(self._pulse)
+
+    def __deepcopy__(self, memo):
+        train = super().__deepcopy__(memo)
+        train._pulse = deepcopy(self._pulse, memo)
+        return train
 
     @property
     def n_pulses(self):
-        """Number of pulses delivered
-
-        Resolved at construction: ``n_pulses=None`` means as many whole
-        pulses as fit into ``stim_dur``.
-        """
+        """Number of pulses delivered"""
         return self._n_pulses
 
     @property
@@ -234,6 +235,11 @@ class PulseTrain(Stimulus):
     def pulse_type(self):
         """Name of the class the repeated pulse came from"""
         return self._pulse.__class__.__name__
+
+    @property
+    def duration(self):
+        """Stimulus duration (ms)"""
+        return self._stim_dur
 
     def _render(self):
         """Tile the pulse into the train the parameters above describe"""
@@ -268,25 +274,15 @@ class PulseTrain(Stimulus):
         return {'data': data, 'electrodes': self.electrodes, 'time': time}
 
     def _scaled(self, factor):
-        """This train, tiling a pulse whose amplitudes were scaled
-
-        Tiling copies the pulse without doing arithmetic on it, so scaling
-        every sample of the train is the same thing as scaling the pulse it
-        repeats -- and the train's own parameters (frequency, pulse count,
-        window) are untouched by either.
-        """
-        return PulseTrain(self.freq, self.pulse * factor,
+        """This train, tiling a pulse whose amplitudes were scaled"""
+        return PulseTrain(self.freq, self._pulse * factor,
                           n_pulses=self._n_pulses_asked,
                           stim_dur=self.stim_dur,
                           electrode=self.electrodes,
                           metadata=deepcopy(self.metadata.get('user')))
 
     def _pprint_params(self):
-        """Return a dict of class arguments to pretty-print
-
-        The parameters that define the train rather than the waveform they
-        describe, so that printing one does not generate it.
-        """
+        """Return a dict of class arguments to pretty-print"""
         return {'freq': self.freq, 'pulse_type': self.pulse_type,
                 'n_pulses': self.n_pulses, 'stim_dur': self.stim_dur,
                 'electrodes': self.electrodes, 'metadata': self.metadata}
@@ -401,29 +397,34 @@ class BiphasicPulseTrain(Stimulus):
         return self._train.stim_dur
 
     @property
+    def duration(self):
+        """Stimulus duration (ms)"""
+        return self._train.stim_dur
+
+    @property
     def amp(self):
         """Magnitude (uA) of both phases of each pulse"""
-        return self._train.pulse.amp
+        return self._train._pulse.amp
 
     @property
     def phase_dur(self):
         """Duration (ms) of the cathodic/anodic phase"""
-        return self._train.pulse.phase_dur
+        return self._train._pulse.phase_dur
 
     @property
     def interphase_dur(self):
         """Duration (ms) of the gap between the two phases"""
-        return self._train.pulse.interphase_dur
+        return self._train._pulse.interphase_dur
 
     @property
     def delay_dur(self):
         """Delay (ms) before the first phase of each pulse"""
-        return self._train.pulse.delay_dur
+        return self._train._pulse.delay_dur
 
     @property
     def cathodic_first(self):
         """Whether the cathodic phase is delivered first"""
-        return self._train.pulse.cathodic_first
+        return self._train._pulse.cathodic_first
 
     def _render(self):
         """The tiled train the parameters above describe"""
@@ -431,13 +432,7 @@ class BiphasicPulseTrain(Stimulus):
                 'time': self._train.time}
 
     def _scaled(self, factor):
-        """This train with every amplitude multiplied by ``factor``
-
-        Built from the parameters rather than from the samples: ``amp`` is
-        canonical state now, so twice this train is the train at twice its
-        amplitude -- not the float32 waveform cache doubled and its rounding
-        promoted to truth. The two agree to within a float32 ulp.
-        """
+        """This train with every amplitude multiplied by ``factor``"""
         return BiphasicPulseTrain(
             self.freq, self.amp * abs(factor), self.phase_dur,
             interphase_dur=self.interphase_dur, delay_dur=self.delay_dur,
@@ -455,29 +450,15 @@ class BiphasicPulseTrain(Stimulus):
 
     @classmethod
     def _rescale_params(cls, metadata, factor):
-        """Keep the compatibility copy of the pulse parameters in step
-
-        Scaling is the one operation that leaves a biphasic pulse train a
-        biphasic pulse train, so it scales ``amp`` (a negative factor only
-        swaps the two phases, which does not change the magnitude). Anything
-        else leaves something no single amplitude and frequency describe, so
-        the parameters are dropped and a reader rejects the stimulus rather
-        than predicting from numbers that no longer fit it. What the user put
-        in ``metadata`` is theirs, and survives either way.
-        """
+        """Return a scaled copy of the meta parameters"""
         if 'amp' not in metadata:
-            # Parameters an earlier operation has already dropped
             return metadata
         if factor is None:
             return {'user': metadata.get('user')}
         return dict(metadata, amp=abs(metadata['amp'] * factor))
 
     def _pprint_params(self):
-        """Return a dict of class arguments to pretty-print
-
-        The parameters that define the train rather than the waveform they
-        describe, so that printing one does not generate it.
-        """
+        """Return a dict of class arguments to pretty-print"""
         return {'freq': self.freq, 'amp': self.amp,
                 'phase_dur': self.phase_dur,
                 'interphase_dur': self.interphase_dur,
@@ -579,39 +560,44 @@ class AsymmetricBiphasicPulseTrain(Stimulus):
         return self._train.stim_dur
 
     @property
+    def duration(self):
+        """Stimulus duration (ms)"""
+        return self._train.stim_dur
+
+    @property
     def amp1(self):
         """Magnitude (uA) of the first phase of each pulse"""
-        return self._train.pulse.amp1
+        return self._train._pulse.amp1
 
     @property
     def amp2(self):
         """Magnitude (uA) of the second phase of each pulse"""
-        return self._train.pulse.amp2
+        return self._train._pulse.amp2
 
     @property
     def phase_dur1(self):
         """Duration (ms) of the first pulse phase"""
-        return self._train.pulse.phase_dur1
+        return self._train._pulse.phase_dur1
 
     @property
     def phase_dur2(self):
         """Duration (ms) of the second pulse phase"""
-        return self._train.pulse.phase_dur2
+        return self._train._pulse.phase_dur2
 
     @property
     def interphase_dur(self):
         """Duration (ms) of the gap between the two phases"""
-        return self._train.pulse.interphase_dur
+        return self._train._pulse.interphase_dur
 
     @property
     def delay_dur(self):
         """Delay (ms) before the first phase of each pulse"""
-        return self._train.pulse.delay_dur
+        return self._train._pulse.delay_dur
 
     @property
     def cathodic_first(self):
         """Whether the cathodic phase is delivered first"""
-        return self._train.pulse.cathodic_first
+        return self._train._pulse.cathodic_first
 
     def _render(self):
         """The tiled train the parameters above describe"""
@@ -619,10 +605,7 @@ class AsymmetricBiphasicPulseTrain(Stimulus):
                 'time': self._train.time}
 
     def _scaled(self, factor):
-        """This train with both phase magnitudes multiplied by ``factor``
-
-        See :py:meth:`BiphasicPulseTrain._scaled`.
-        """
+        """This train with both phase magnitudes multiplied by ``factor``"""
         return AsymmetricBiphasicPulseTrain(
             self.freq, self.amp1 * abs(factor), self.amp2 * abs(factor),
             self.phase_dur1, self.phase_dur2,
@@ -635,11 +618,7 @@ class AsymmetricBiphasicPulseTrain(Stimulus):
             metadata=deepcopy(self.metadata.get('user')))
 
     def _pprint_params(self):
-        """Return a dict of class arguments to pretty-print
-
-        The parameters that define the train rather than the waveform they
-        describe, so that printing one does not generate it.
-        """
+        """Return a dict of class arguments to pretty-print"""
         return {'freq': self.freq, 'amp1': self.amp1, 'amp2': self.amp2,
                 'phase_dur1': self.phase_dur1,
                 'phase_dur2': self.phase_dur2,
@@ -761,6 +740,11 @@ class BiphasicTripletTrain(Stimulus):
         return self._train.stim_dur
 
     @property
+    def duration(self):
+        """Stimulus duration (ms)"""
+        return self._train.stim_dur
+
+    @property
     def amp(self):
         """Magnitude (uA) of both phases of each pulse"""
         return self._pulse.amp
@@ -796,11 +780,7 @@ class BiphasicTripletTrain(Stimulus):
                 'time': self._train.time}
 
     def _scaled(self, factor):
-        """This train with every phase magnitude multiplied by ``factor``
-
-        See :py:meth:`BiphasicPulseTrain._scaled`. The triplet structure --
-        three pulses per window, ``interpulse_dur`` apart -- is untouched.
-        """
+        """This train with every phase magnitude multiplied by ``factor``"""
         return BiphasicTripletTrain(
             self.freq, self.amp * abs(factor), self.phase_dur,
             interphase_dur=self.interphase_dur,
@@ -813,11 +793,7 @@ class BiphasicTripletTrain(Stimulus):
             metadata=deepcopy(self.metadata.get('user')))
 
     def _pprint_params(self):
-        """Return a dict of class arguments to pretty-print
-
-        The parameters that define the train rather than the waveform they
-        describe, so that printing one does not generate it.
-        """
+        """Return a dict of class arguments to pretty-print"""
         return {'freq': self.freq, 'amp': self.amp,
                 'phase_dur': self.phase_dur,
                 'interphase_dur': self.interphase_dur,

--- a/pulse2percept/stimuli/pulses.py
+++ b/pulse2percept/stimuli/pulses.py
@@ -96,6 +96,10 @@ class MonophasicPulse(Stimulus):
     >>> pulse = MonophasicPulse(-20, 1, delay_dur=2, stim_dur=10)
 
     """
+    #: Defined by the parameters above rather than by its samples
+    #: (see `Stimulus._is_parametric`):
+    _is_parametric = True
+
     __slots__ = ('_amp', '_phase_dur', '_delay_dur', '_stim_dur')
 
     def __init__(self, amp, phase_dur, delay_dur=0, stim_dur=None,
@@ -246,6 +250,10 @@ class BiphasicPulse(Stimulus):
     >>> pulse = BiphasicPulse(-20, 1, delay_dur=2, stim_dur=10)
 
     """
+    #: Defined by the parameters above rather than by its samples
+    #: (see `Stimulus._is_parametric`):
+    _is_parametric = True
+
     __slots__ = ('_amp', '_phase_dur', '_interphase_dur', '_delay_dur',
                  '_stim_dur', '_cathodic_first')
 
@@ -423,6 +431,10 @@ class AsymmetricBiphasicPulse(Stimulus):
     ...                                 delay_dur=2, stim_dur=15)
 
     """
+    #: Defined by the parameters above rather than by its samples
+    #: (see `Stimulus._is_parametric`):
+    _is_parametric = True
+
     __slots__ = ('_amp1', '_amp2', '_phase_dur1', '_phase_dur2',
                  '_interphase_dur', '_delay_dur', '_stim_dur',
                  '_cathodic_first')

--- a/pulse2percept/stimuli/pulses.py
+++ b/pulse2percept/stimuli/pulses.py
@@ -180,6 +180,17 @@ class MonophasicPulse(Stimulus):
         data, time = _pad_to_stim_dur(time, data, self._stim_dur)
         return {'data': data, 'electrodes': self.electrodes, 'time': time}
 
+    def _scaled(self, factor):
+        """This pulse with its amplitude multiplied by ``factor``
+
+        ``amp`` carries the polarity here, so a negative factor needs nothing
+        else said about it.
+        """
+        return MonophasicPulse(self.amp * factor, self.phase_dur,
+                               delay_dur=self.delay_dur,
+                               stim_dur=self.stim_dur,
+                               electrode=self.electrodes[0])
+
     def _pprint_params(self):
         """Return a dict of class arguments to pretty-print
 
@@ -353,6 +364,22 @@ class BiphasicPulse(Stimulus):
         data += [-amp, -amp, 0]
         data, time = _pad_to_stim_dur(time, data, self._stim_dur)
         return {'data': data, 'electrodes': self.electrodes, 'time': time}
+
+    def _scaled(self, factor):
+        """This pulse with both phase magnitudes multiplied by ``factor``
+
+        Only the magnitude is stored, so a negative factor is expressed by
+        swapping the two phases -- which is exactly what ``cathodic_first``
+        says.
+        """
+        return BiphasicPulse(self.amp * abs(factor), self.phase_dur,
+                             interphase_dur=self.interphase_dur,
+                             delay_dur=self.delay_dur,
+                             stim_dur=self.stim_dur,
+                             cathodic_first=(self.cathodic_first
+                                             if factor >= 0
+                                             else not self.cathodic_first),
+                             electrode=self.electrodes[0])
 
     def _pprint_params(self):
         """Return a dict of class arguments to pretty-print
@@ -555,6 +582,21 @@ class AsymmetricBiphasicPulse(Stimulus):
         data += [amp2, amp2, 0]
         data, time = _pad_to_stim_dur(time, data, self._stim_dur)
         return {'data': data, 'electrodes': self.electrodes, 'time': time}
+
+    def _scaled(self, factor):
+        """This pulse with both phase magnitudes multiplied by ``factor``
+
+        See :py:meth:`BiphasicPulse._scaled`; the two phases keep their order,
+        and only which of them is cathodic changes.
+        """
+        return AsymmetricBiphasicPulse(
+            self.amp1 * abs(factor), self.amp2 * abs(factor),
+            self.phase_dur1, self.phase_dur2,
+            interphase_dur=self.interphase_dur, delay_dur=self.delay_dur,
+            stim_dur=self.stim_dur,
+            cathodic_first=(self.cathodic_first if factor >= 0
+                            else not self.cathodic_first),
+            electrode=self.electrodes[0])
 
     def _pprint_params(self):
         """Return a dict of class arguments to pretty-print

--- a/pulse2percept/stimuli/pulses.py
+++ b/pulse2percept/stimuli/pulses.py
@@ -1,4 +1,4 @@
-""":py:class:`~pulse2percept.stimuli.MonophasicPulse`, 
+""":py:class:`~pulse2percept.stimuli.MonophasicPulse`,
    :py:class:`~pulse2percept.stimuli.BiphasicPulse`,
    :py:class:`~pulse2percept.stimuli.AsymmetricBiphasicPulse`"""
 import numpy as np
@@ -10,6 +10,43 @@ from ..units import as_value, ms, uA
 from ..utils.constants import DT
 
 
+def _electrode_names(electrode):
+    """The name a single-electrode pulse is filed under
+
+    ``Stimulus`` numbers electrodes 0..N-1 where the source did not name them,
+    so an unnamed pulse is electrode 0. A pulse drives exactly one electrode,
+    which is checked here rather than left to the waveform: the constructor
+    is where a caller finds out that they named two.
+    """
+    if electrode is None:
+        return [0]
+    names = np.array([electrode]).ravel()
+    if len(names) != 1:
+        raise ValueError(f"A pulse is delivered to a single electrode, but "
+                         f"{len(names)} names were given ({electrode}).")
+    return names
+
+
+def _pad_to_stim_dur(time, data, stim_dur):
+    """Close a pulse waveform off at ``stim_dur``
+
+    Either by adding a final zero, or -- where the pulse already ends within a
+    time step of it -- by moving its last point onto it, so that the stimulus
+    is exactly ``stim_dur`` long either way.
+    """
+    if stim_dur - time[-1] > DT:
+        # If the stimulus extends beyond the second pulse, add another data
+        # point:
+        time += [stim_dur]
+        data += [0]
+    else:
+        # But, if the end point is close enough to `stim_dur`, update the
+        # last time point so that the stimulus is exactly `stim_dur` long:
+        time[-1] = stim_dur
+    return (np.array(data, dtype=np.float32).reshape((1, -1)),
+            np.array(time, dtype=np.float64))
+
+
 class MonophasicPulse(Stimulus):
     """Monophasic pulse
 
@@ -17,6 +54,10 @@ class MonophasicPulse(Stimulus):
     cathodic/negative or anodic/positive).
 
     .. versionadded:: 0.6
+
+    .. versionchanged:: 0.10.0
+        The pulse retains the parameters that define it, and generates its
+        sampled waveform only when one is asked for.
 
     Parameters
     ----------
@@ -43,6 +84,8 @@ class MonophasicPulse(Stimulus):
     *  Arguments may be given as plain numbers in the units documented above,
        or as unitful quantities (e.g. ``0.05 * mA``, ``450 * us``), which are
        converted to those units. See :py:mod:`pulse2percept.units`.
+    *  The parameters above are read-only. A pulse with different parameters
+       is a different pulse; build another one.
 
     Examples
     --------
@@ -53,7 +96,7 @@ class MonophasicPulse(Stimulus):
     >>> pulse = MonophasicPulse(-20, 1, delay_dur=2, stim_dur=10)
 
     """
-    __slots__ = ('cathodic',)
+    __slots__ = ('_amp', '_phase_dur', '_delay_dur', '_stim_dur')
 
     def __init__(self, amp, phase_dur, delay_dur=0, stim_dur=None,
                  electrode=None):
@@ -75,6 +118,50 @@ class MonophasicPulse(Stimulus):
             if stim_dur < min_dur:
                 raise ValueError(f"'stim_dur' must be at least {min_dur:.3f} ms, not "
                                  f"{stim_dur:.3f} ms.")
+        self._amp = amp
+        self._phase_dur = phase_dur
+        self._delay_dur = delay_dur
+        self._stim_dur = stim_dur
+        self._defer(_electrode_names(electrode))
+
+    @property
+    def amp(self):
+        """Current amplitude (uA); negative is cathodic"""
+        return self._amp
+
+    @property
+    def phase_dur(self):
+        """Duration (ms) of the cathodic or anodic phase"""
+        return self._phase_dur
+
+    @property
+    def delay_dur(self):
+        """Delay (ms) before the pulse is delivered"""
+        return self._delay_dur
+
+    @property
+    def stim_dur(self):
+        """Total stimulus duration (ms)"""
+        return self._stim_dur
+
+    @property
+    def duration(self):
+        """Stimulus duration (ms)
+
+        The waveform is built to end exactly at ``stim_dur``, so this is
+        known without generating one.
+        """
+        return self._stim_dur
+
+    @property
+    def cathodic(self):
+        """Whether the pulse delivers a negative current"""
+        return self._amp <= 0
+
+    def _render(self):
+        """Build the waveform from the parameters above"""
+        amp, phase_dur = self._amp, self._phase_dur
+        delay_dur = self._delay_dur
         # We only need to store the time points at which the stimulus changes.
         time = [0]
         data = [0]
@@ -86,25 +173,19 @@ class MonophasicPulse(Stimulus):
         time += [delay_dur + DT, delay_dur + phase_dur - DT,
                  delay_dur + phase_dur]
         data += [amp, amp, 0]
-        if stim_dur - time[-1] > DT:
-            # If the stimulus extends beyond the second pulse, add another data
-            # point:
-            time += [stim_dur]
-            data += [0]
-        else:
-            # But, if the end point is close enough to `stim_dur`, update the
-            # last time point so that the stimulus is exactly `stim_dur` long:
-            time[-1] = stim_dur
-        data = np.array(data, dtype=np.float32).reshape((1, -1))
-        time = np.array(time, dtype=np.float64)
-        super().__init__(data, electrodes=electrode, time=time, compress=False)
-        self.cathodic = amp <= 0
+        data, time = _pad_to_stim_dur(time, data, self._stim_dur)
+        return {'data': data, 'electrodes': self.electrodes, 'time': time}
 
     def _pprint_params(self):
-        """Return a dict of class arguments to pretty-print"""
-        params = super()._pprint_params()
-        params.update({'cathodic': self.cathodic})
-        return params
+        """Return a dict of class arguments to pretty-print
+
+        The defining parameters rather than the waveform, so that printing a
+        pulse does not generate one.
+        """
+        return {'amp': self.amp, 'phase_dur': self.phase_dur,
+                'delay_dur': self.delay_dur, 'stim_dur': self.stim_dur,
+                'cathodic': self.cathodic, 'electrodes': self.electrodes,
+                'metadata': self.metadata}
 
 
 class BiphasicPulse(Stimulus):
@@ -115,6 +196,10 @@ class BiphasicPulse(Stimulus):
     Both cathodic and anodic phases have the same duration ("symmetric").
 
     .. versionadded:: 0.6
+
+    .. versionchanged:: 0.10.0
+        The pulse retains the parameters that define it, and generates its
+        sampled waveform only when one is asked for.
 
     Parameters
     ----------
@@ -146,6 +231,11 @@ class BiphasicPulse(Stimulus):
     *  Arguments may be given as plain numbers in the units documented above,
        or as unitful quantities (e.g. ``0.05 * mA``, ``450 * us``), which are
        converted to those units. See :py:mod:`pulse2percept.units`.
+    *  The parameters above are read-only. A pulse with different parameters
+       is a different pulse; build another one.
+    *  ``amp`` reads back as a magnitude, because that is all of it that
+       reaches the waveform: the constructor takes ``np.abs(amp)`` and gets
+       the polarity from ``cathodic_first``.
 
     Examples
     --------
@@ -156,7 +246,8 @@ class BiphasicPulse(Stimulus):
     >>> pulse = BiphasicPulse(-20, 1, delay_dur=2, stim_dur=10)
 
     """
-    __slots__ = ('cathodic_first',)
+    __slots__ = ('_amp', '_phase_dur', '_interphase_dur', '_delay_dur',
+                 '_stim_dur', '_cathodic_first')
 
     def __init__(self, amp, phase_dur, interphase_dur=0, delay_dur=0,
                  stim_dur=None, cathodic_first=True, electrode=None):
@@ -180,7 +271,60 @@ class BiphasicPulse(Stimulus):
             if stim_dur < min_dur:
                 raise ValueError(f"'stim_dur' must be at least {min_dur:.3f} ms, not "
                                  f"{stim_dur:.3f} ms.")
-        amp = -np.abs(amp) if cathodic_first else np.abs(amp)
+        # Only the magnitude is stored; `cathodic_first` is where the sign of
+        # each phase comes from (see `_render`):
+        self._amp = abs(amp)
+        self._phase_dur = phase_dur
+        self._interphase_dur = interphase_dur
+        self._delay_dur = delay_dur
+        self._stim_dur = stim_dur
+        self._cathodic_first = cathodic_first
+        self._defer(_electrode_names(electrode))
+
+    @property
+    def amp(self):
+        """Magnitude (uA) of both pulse phases"""
+        return self._amp
+
+    @property
+    def phase_dur(self):
+        """Duration (ms) of the cathodic/anodic phase"""
+        return self._phase_dur
+
+    @property
+    def interphase_dur(self):
+        """Duration (ms) of the gap between the two phases"""
+        return self._interphase_dur
+
+    @property
+    def delay_dur(self):
+        """Delay (ms) before the first phase is delivered"""
+        return self._delay_dur
+
+    @property
+    def stim_dur(self):
+        """Total stimulus duration (ms)"""
+        return self._stim_dur
+
+    @property
+    def duration(self):
+        """Stimulus duration (ms)
+
+        The waveform is built to end exactly at ``stim_dur``, so this is
+        known without generating one.
+        """
+        return self._stim_dur
+
+    @property
+    def cathodic_first(self):
+        """Whether the cathodic phase is delivered first"""
+        return self._cathodic_first
+
+    def _render(self):
+        """Build the waveform from the parameters above"""
+        amp = -self._amp if self._cathodic_first else self._amp
+        phase_dur, interphase_dur = self._phase_dur, self._interphase_dur
+        delay_dur = self._delay_dur
         # We only need to store the time points at which the stimulus changes.
         time = [0]
         data = [0]
@@ -199,25 +343,20 @@ class BiphasicPulse(Stimulus):
                  delay_dur + 2 * phase_dur + interphase_dur - DT,
                  delay_dur + 2 * phase_dur + interphase_dur]
         data += [-amp, -amp, 0]
-        if stim_dur - time[-1] > DT:
-            # If the stimulus extends beyond the second pulse, add another data
-            # point:
-            time += [stim_dur]
-            data += [0]
-        else:
-            # But, if the end point is close enough to `stim_dur`, update the
-            # last time point so that the stimulus is exactly `stim_dur` long:
-            time[-1] = stim_dur
-        data = np.array(data, dtype=np.float32).reshape((1, -1))
-        time = np.array(time, dtype=np.float64)
-        super().__init__(data, electrodes=electrode, time=time, compress=False)
-        self.cathodic_first = cathodic_first
+        data, time = _pad_to_stim_dur(time, data, self._stim_dur)
+        return {'data': data, 'electrodes': self.electrodes, 'time': time}
 
     def _pprint_params(self):
-        """Return a dict of class arguments to pretty-print"""
-        params = super()._pprint_params()
-        params.update({'cathodic_first': self.cathodic_first})
-        return params
+        """Return a dict of class arguments to pretty-print
+
+        The defining parameters rather than the waveform, so that printing a
+        pulse does not generate one.
+        """
+        return {'amp': self.amp, 'phase_dur': self.phase_dur,
+                'interphase_dur': self.interphase_dur,
+                'delay_dur': self.delay_dur, 'stim_dur': self.stim_dur,
+                'cathodic_first': self.cathodic_first,
+                'electrodes': self.electrodes, 'metadata': self.metadata}
 
 
 class AsymmetricBiphasicPulse(Stimulus):
@@ -229,6 +368,10 @@ class AsymmetricBiphasicPulse(Stimulus):
     ("asymmetric").
 
     .. versionadded:: 0.6
+
+    .. versionchanged:: 0.10.0
+        The pulse retains the parameters that define it, and generates its
+        sampled waveform only when one is asked for.
 
     Parameters
     ----------
@@ -263,6 +406,11 @@ class AsymmetricBiphasicPulse(Stimulus):
     *  Arguments may be given as plain numbers in the units documented above,
        or as unitful quantities (e.g. ``0.05 * mA``, ``450 * us``), which are
        converted to those units. See :py:mod:`pulse2percept.units`.
+    *  The parameters above are read-only. A pulse with different parameters
+       is a different pulse; build another one.
+    *  ``amp1`` and ``amp2`` read back as magnitudes, because that is all of
+       them that reaches the waveform: the constructor takes ``np.abs`` of
+       each and gets the polarity from ``cathodic_first``.
 
     Examples
     --------
@@ -275,7 +423,9 @@ class AsymmetricBiphasicPulse(Stimulus):
     ...                                 delay_dur=2, stim_dur=15)
 
     """
-    __slots__ = ('cathodic_first',)
+    __slots__ = ('_amp1', '_amp2', '_phase_dur1', '_phase_dur2',
+                 '_interphase_dur', '_delay_dur', '_stim_dur',
+                 '_cathodic_first')
 
     def __init__(self, amp1, amp2, phase_dur1, phase_dur2, interphase_dur=0,
                  delay_dur=0, stim_dur=None, cathodic_first=True,
@@ -304,12 +454,75 @@ class AsymmetricBiphasicPulse(Stimulus):
             if stim_dur < min_dur:
                 raise ValueError(f"'stim_dur' must be at least {min_dur:.3f} ms, not "
                                  f"{stim_dur:.3f} ms.")
-        if cathodic_first:
-            amp1 = -np.abs(amp1)
-            amp2 = np.abs(amp2)
+        # Only the magnitudes are stored; `cathodic_first` is where the sign
+        # of each phase comes from (see `_render`):
+        self._amp1 = abs(amp1)
+        self._amp2 = abs(amp2)
+        self._phase_dur1 = phase_dur1
+        self._phase_dur2 = phase_dur2
+        self._interphase_dur = interphase_dur
+        self._delay_dur = delay_dur
+        self._stim_dur = stim_dur
+        self._cathodic_first = cathodic_first
+        self._defer(_electrode_names(electrode))
+
+    @property
+    def amp1(self):
+        """Magnitude (uA) of the first pulse phase"""
+        return self._amp1
+
+    @property
+    def amp2(self):
+        """Magnitude (uA) of the second pulse phase"""
+        return self._amp2
+
+    @property
+    def phase_dur1(self):
+        """Duration (ms) of the first pulse phase"""
+        return self._phase_dur1
+
+    @property
+    def phase_dur2(self):
+        """Duration (ms) of the second pulse phase"""
+        return self._phase_dur2
+
+    @property
+    def interphase_dur(self):
+        """Duration (ms) of the gap between the two phases"""
+        return self._interphase_dur
+
+    @property
+    def delay_dur(self):
+        """Delay (ms) before the first phase is delivered"""
+        return self._delay_dur
+
+    @property
+    def stim_dur(self):
+        """Total stimulus duration (ms)"""
+        return self._stim_dur
+
+    @property
+    def duration(self):
+        """Stimulus duration (ms)
+
+        The waveform is built to end exactly at ``stim_dur``, so this is
+        known without generating one.
+        """
+        return self._stim_dur
+
+    @property
+    def cathodic_first(self):
+        """Whether the cathodic phase is delivered first"""
+        return self._cathodic_first
+
+    def _render(self):
+        """Build the waveform from the parameters above"""
+        if self._cathodic_first:
+            amp1, amp2 = -self._amp1, self._amp2
         else:
-            amp1 = np.abs(amp1)
-            amp2 = -np.abs(amp2)
+            amp1, amp2 = self._amp1, -self._amp2
+        phase_dur1, phase_dur2 = self._phase_dur1, self._phase_dur2
+        interphase_dur, delay_dur = self._interphase_dur, self._delay_dur
         # We only need to store the time points at which the stimulus changes.
         time = [0]
         data = [0]
@@ -328,22 +541,19 @@ class AsymmetricBiphasicPulse(Stimulus):
                  delay_dur + phase_dur1 + interphase_dur + phase_dur2 - DT,
                  delay_dur + phase_dur1 + interphase_dur + phase_dur2]
         data += [amp2, amp2, 0]
-        if stim_dur - time[-1] > DT:
-            # If the stimulus extends beyond the second pulse, add another data
-            # point:
-            time += [stim_dur]
-            data += [0]
-        else:
-            # But, if the end point is close enough to `stim_dur`, update the
-            # last time point so that the stimulus is exactly `stim_dur` long:
-            time[-1] = stim_dur
-        data = np.array(data, dtype=np.float32).reshape((1, -1))
-        time = np.array(time, dtype=np.float64)
-        super().__init__(data, electrodes=electrode, time=time, compress=False)
-        self.cathodic_first = cathodic_first
+        data, time = _pad_to_stim_dur(time, data, self._stim_dur)
+        return {'data': data, 'electrodes': self.electrodes, 'time': time}
 
     def _pprint_params(self):
-        """Return a dict of class arguments to pretty-print"""
-        params = super()._pprint_params()
-        params.update({'cathodic_first': self.cathodic_first})
-        return params
+        """Return a dict of class arguments to pretty-print
+
+        The defining parameters rather than the waveform, so that printing a
+        pulse does not generate one.
+        """
+        return {'amp1': self.amp1, 'amp2': self.amp2,
+                'phase_dur1': self.phase_dur1,
+                'phase_dur2': self.phase_dur2,
+                'interphase_dur': self.interphase_dur,
+                'delay_dur': self.delay_dur, 'stim_dur': self.stim_dur,
+                'cathodic_first': self.cathodic_first,
+                'electrodes': self.electrodes, 'metadata': self.metadata}

--- a/pulse2percept/stimuli/tests/test_base.py
+++ b/pulse2percept/stimuli/tests/test_base.py
@@ -6,7 +6,7 @@ import numpy as np
 import numpy.testing as npt
 import pytest
 
-from copy import deepcopy
+from copy import copy, deepcopy
 from collections import OrderedDict as ODict
 from matplotlib.axes import Subplot
 import matplotlib.pyplot as plt
@@ -1643,3 +1643,119 @@ def test_Stimulus_immutable_operations():
     # The operations themselves are unaffected:
     npt.assert_equal(compressed.shape, (1, 3))
     npt.assert_equal(list(removed.electrodes), ['B2'])
+
+
+class CountingLazy(Stimulus):
+    """A stimulus that counts how often it generates its waveform
+
+    Stands in for the parameter-backed stimuli that follow: it is defined by
+    ``n_time``, not by samples, and only ``_render`` ever builds any.
+    """
+    __slots__ = ('n_time', 'n_renders')
+
+    def __init__(self, n_time=4, electrodes=('A1', 'B2'), metadata=None):
+        self.n_time = n_time
+        self.n_renders = 0
+        self._defer(electrodes, metadata=metadata)
+
+    def _render(self):
+        self.n_renders += 1
+        n_el = len(self.electrodes)
+        data = np.arange(n_el * self.n_time,
+                         dtype=np.float32).reshape((n_el, self.n_time))
+        return {'data': data, 'electrodes': self.electrodes,
+                'time': np.arange(self.n_time, dtype=np.float64)}
+
+
+def test_Stimulus_lazy_construction_does_not_render():
+    stim = CountingLazy(metadata={'x': 1})
+    npt.assert_equal(stim.n_renders, 0)
+    # Everything a stimulus knows without sampling anything:
+    npt.assert_equal(list(stim.electrodes), ['A1', 'B2'])
+    npt.assert_equal(len(stim.electrodes), 2)
+    npt.assert_equal(stim.unit, uA)
+    npt.assert_equal(stim.time_unit, ms)
+    npt.assert_equal(stim.metadata['user'], {'x': 1})
+    npt.assert_equal(stim.is_compressed, False)
+    npt.assert_equal(stim.dt, DT)
+    npt.assert_equal(stim.n_renders, 0)
+
+
+def test_Stimulus_lazy_renders_once():
+    stim = CountingLazy()
+    npt.assert_almost_equal(stim.data, [[0, 1, 2, 3], [4, 5, 6, 7]])
+    npt.assert_equal(stim.n_renders, 1)
+    # The cache serves every later read, of either array:
+    for _ in range(3):
+        npt.assert_equal(stim.data.shape, (2, 4))
+        npt.assert_almost_equal(stim.time, [0, 1, 2, 3])
+        npt.assert_almost_equal(stim[0, 1.5], 1.5)
+        npt.assert_equal(stim.duration, 3)
+    npt.assert_equal(stim.n_renders, 1)
+    # Asking for `time` first renders just the same:
+    other = CountingLazy()
+    npt.assert_almost_equal(other.time, [0, 1, 2, 3])
+    npt.assert_equal(other.n_renders, 1)
+    npt.assert_almost_equal(other.data, stim.data)
+    npt.assert_equal(other.n_renders, 1)
+
+
+def test_Stimulus_lazy_state_is_immutable():
+    # A rendered waveform is installed through the same setter as any other,
+    # so it is owned, immutable and C-contiguous on the same terms:
+    stim = CountingLazy()
+    npt.assert_equal(stim.data.flags.writeable, False)
+    npt.assert_equal(stim.time.flags.writeable, False)
+    npt.assert_equal(stim.data.flags['C_CONTIGUOUS'], True)
+    npt.assert_equal(stim.data.dtype, np.float32)
+    npt.assert_equal(stim.time.dtype, np.float64)
+    with pytest.raises(ValueError):
+        stim.electrodes[0] = 'X'
+    # And it is validated on the same terms, too:
+    class BadShape(CountingLazy):
+        __slots__ = ()
+
+        def _render(self):
+            return {'data': np.ones((5, 2), dtype=np.float32),
+                    'electrodes': self.electrodes,
+                    'time': np.arange(2, dtype=np.float64)}
+    with pytest.raises(ValueError):
+        BadShape().data
+
+
+def test_Stimulus_lazy_electrodes_must_match_render():
+    # Naming the electrodes up front is what lets them be read without
+    # generating a waveform, so a render that disagrees with them would make
+    # the answer depend on when it was asked for:
+    class Renamer(CountingLazy):
+        __slots__ = ()
+
+        def _render(self):
+            state = super()._render()
+            return dict(state, electrodes=np.array(['C3', 'D4']))
+    stim = Renamer()
+    npt.assert_equal(list(stim.electrodes), ['A1', 'B2'])
+    with pytest.raises(ValueError):
+        stim.data
+
+
+def test_Stimulus_lazy_copy_does_not_render():
+    stim = CountingLazy()
+    for copied in (copy(stim), deepcopy(stim)):
+        npt.assert_equal(copied.n_renders, 0)
+        npt.assert_equal(stim.n_renders, 0)
+        npt.assert_equal(list(copied.electrodes), ['A1', 'B2'])
+        npt.assert_equal(copied.n_renders, 0)
+    # A copy taken after materialization shares the cached waveform, which is
+    # immutable and so has nothing to gain from being duplicated:
+    npt.assert_equal(stim.data.shape, (2, 4))
+    shared = deepcopy(stim)
+    npt.assert_equal(np.shares_memory(shared.data, stim.data), True)
+    npt.assert_equal(stim.n_renders, 1)
+
+
+def test_Stimulus_render_is_not_implemented_by_default():
+    # A plain `Stimulus` is its waveform and never renders, so the base
+    # implementation exists only to name what a subclass forgot:
+    with pytest.raises(NotImplementedError):
+        Stimulus._render(Stimulus(3))

--- a/pulse2percept/stimuli/tests/test_base.py
+++ b/pulse2percept/stimuli/tests/test_base.py
@@ -1950,10 +1950,13 @@ def test_Stimulus_collection_removes_whole_entries_without_rendering():
     # Only the entry that survived is ever generated:
     npt.assert_equal(stim.data.shape, (1, 7))
     npt.assert_equal(_n_renders(stim), 1)
+    # Dropping every entry is the exception: an emptied stimulus keeps the
+    # time axis it ran on, which only the merged waveform knows.
     empty = Stimulus({'A1': CountingLazy(4, ['A1'])})
     empty.remove('all')
-    npt.assert_equal(_lazy(empty), True)
+    npt.assert_equal(_lazy(empty), False)
     npt.assert_equal(len(empty.electrodes), 0)
+    npt.assert_equal(empty.data.shape, (0, 4))
     # A copy taken before the removal keeps the entry it was built with:
     stim = Stimulus({'A1': CountingLazy(4, ['A1']),
                      'B2': CountingLazy(4, ['B2'])})
@@ -1989,13 +1992,33 @@ def test_Stimulus_rewriting_a_waveform_forgets_the_components():
     npt.assert_equal(compressed._components, None)
 
 
+@pytest.mark.parametrize('render', [False, True])
+def test_Stimulus_collection_emptied_keeps_its_time_axis(render, monkeypatch):
+    # `remove('all')` leaves zero rows on the axis the stimulus ran on, so an
+    # emptied collection still has a duration
+    def build():
+        return Stimulus({'A1': BiphasicPulseTrain(20, 10, 0.45, stim_dur=100),
+                         'B2': BiphasicPulseTrain(23, 20, 0.45,
+                                                  stim_dur=100)})
+    lazy = build()
+    if render:
+        lazy.data
+    monkeypatch.setattr(Stimulus, '_defers_waveform',
+                        staticmethod(lambda *a, **kw: False))
+    eager = build()
+    for stim in (lazy, eager):
+        stim.remove('all')
+    npt.assert_equal(lazy.data.shape, eager.data.shape)
+    npt.assert_equal(lazy.data.shape[0], 0)
+    npt.assert_array_equal(lazy.time, eager.time)
+    npt.assert_almost_equal(lazy.duration, eager.duration)
+
+
 @pytest.mark.parametrize('operate', [
     lambda s: s * 2, lambda s: -s, lambda s: s._without_electrodes('A1')])
 def test_Stimulus_collection_exact_operations_ignore_a_cached_waveform(
         operate):
-    # Reading `.data` caches a waveform, it does not rewrite one, so the
-    # components stay canonical and an exact operation still works on them.
-    # Whether anybody looked first must not change the outcome.
+    # Reading `.data` caches a waveform, it does not rewrite one
     def build():
         return Stimulus({'A1': BiphasicPulseTrain(20, 10, 0.45, stim_dur=100),
                          'B2': BiphasicPulseTrain(23, 20, 0.45,
@@ -2014,8 +2037,6 @@ def test_Stimulus_collection_exact_operations_ignore_a_cached_waveform(
 
 @pytest.mark.parametrize('factor', [2, 0.5, -1, 0])
 def test_Stimulus_collection_scaling_stays_deferred(factor):
-    # Scaling a collection of pulse trains scales the trains, and the
-    # expensive part -- merging their time axes -- still has not happened.
     def build():
         return {'A1': BiphasicPulseTrain(20, 10, 0.45, stim_dur=100),
                 'B2': BiphasicPulseTrain(23, 20, 0.45, stim_dur=100)}

--- a/pulse2percept/stimuli/tests/test_base.py
+++ b/pulse2percept/stimuli/tests/test_base.py
@@ -1588,6 +1588,41 @@ def test_Stimulus_owns_its_arrays():
     npt.assert_equal(np.shares_memory(stim.data, copied.data), False)
     npt.assert_equal(np.shares_memory(stim.time, copied.time), False)
 
+    # A contiguous view of a larger buffer needs no dtype or layout
+    # conversion, and an ndarray subclass is handed back as a *different*
+    # ndarray over the very same memory. Neither is a private array, so
+    # neither may be stored as it came:
+    class Tagged(np.ndarray):
+        """A minimal ndarray subclass; only its type matters here"""
+
+    big = np.arange(12, dtype=np.float32).reshape((4, 3))
+    for source in (big[:2], big[:2].view(Tagged)):
+        stim = Stimulus(source, time=[0, 1, 2])
+        npt.assert_equal(np.shares_memory(big, stim.data), False)
+        npt.assert_equal(big.flags.writeable, True)
+        # ...and what comes out is an ordinary array, whatever went in:
+        npt.assert_equal(type(stim.data), np.ndarray)
+
+
+def test_Stimulus_deepcopy():
+    # Duplicating arrays nobody can write into buys nothing, and NumPy would
+    # deep-copy a read-only array into a writable one -- so the copy shares
+    # the data container and only `metadata` is made independent:
+    stim = BiphasicPulseTrain(20, 20, 0.45, stim_dur=100)
+    copied = deepcopy(stim)
+    npt.assert_equal(copied is stim, False)
+    npt.assert_equal(np.shares_memory(copied.data, stim.data), True)
+    npt.assert_equal(copied.metadata is stim.metadata, False)
+    copied.metadata['user'] = 'changed'
+    npt.assert_equal(stim.metadata['user'], None)
+    npt.assert_equal(copied.freq, stim.freq)
+    npt.assert_equal(type(copied), type(stim))
+    # Metadata is arbitrary user data and may point back at the stimulus it
+    # describes. The copy has to resolve that as one object graph:
+    stim.metadata['self'] = stim
+    copied = deepcopy(stim)
+    npt.assert_equal(copied.metadata['self'] is copied, True)
+
 
 def test_Stimulus_immutable_operations():
     # Everything that returns or rebuilds a stimulus still works, and hands

--- a/pulse2percept/stimuli/tests/test_base.py
+++ b/pulse2percept/stimuli/tests/test_base.py
@@ -1780,9 +1780,9 @@ def _lazy(stim):
     return stim._Stimulus__stim['data'] is None
 
 
-# The collections Phase 5 has to keep unmerged, each as (name, source). The
-# expensive one is the last: differing frequencies means every entry lands on
-# its own time axis, and merging them interpolates all of them onto the union.
+# Collections that stay unmerged, each as (name, source). The expensive one
+# is the last: differing frequencies means every entry lands on its own time
+# axis, and merging them interpolates all of them onto the union.
 COLLECTIONS = [
     ('same protocol', lambda: {'A1': CountingLazy(4, ['A1']),
                                'B2': CountingLazy(4, ['B2'])}),
@@ -1840,8 +1840,8 @@ def test_Stimulus_collection_matches_the_eager_merge(name, build,
 @pytest.mark.parametrize('freqs', [(20, 20), (20, 23), (20, 23, 41)])
 def test_Stimulus_pulse_train_collection_merges_as_it_always_did(freqs,
                                                                  monkeypatch):
-    # The case Phase 5 exists for: differing frequencies put every train on a
-    # time axis of its own, so the merge is the expensive part.
+    # Differing frequencies put every train on a time axis of its own, so
+    # the merge is the expensive part.
     def build():
         return {f'E{i}': BiphasicPulseTrain(f, 10 + i, 0.45, stim_dur=200)
                 for i, f in enumerate(freqs)}
@@ -1982,24 +1982,40 @@ def test_Stimulus_rewriting_a_waveform_forgets_the_components():
     npt.assert_equal(stim.data.shape, (2, 4))
     # Rendering is the one install that keeps them -- it built that waveform:
     npt.assert_equal(stim._components is None, False)
-    for rewrite in (lambda s: s + 5, lambda s: s * 2, lambda s: s >> 1,
-                    lambda s: -s):
+    for rewrite in (lambda s: s + 5, lambda s: s >> 1):
         npt.assert_equal(rewrite(stim)._components, None)
     compressed = stim._shallow_copy()
     compressed.compress()
     npt.assert_equal(compressed._components, None)
-    # Removing an electrode from a collection that has already been rendered
-    # goes through the waveform, so it drops them too:
-    removed = stim._shallow_copy()
-    removed.remove('A1')
-    npt.assert_equal(removed._components, None)
+
+
+@pytest.mark.parametrize('operate', [
+    lambda s: s * 2, lambda s: -s, lambda s: s._without_electrodes('A1')])
+def test_Stimulus_collection_exact_operations_ignore_a_cached_waveform(
+        operate):
+    # Reading `.data` caches a waveform, it does not rewrite one, so the
+    # components stay canonical and an exact operation still works on them.
+    # Whether anybody looked first must not change the outcome.
+    def build():
+        return Stimulus({'A1': BiphasicPulseTrain(20, 10, 0.45, stim_dur=100),
+                         'B2': BiphasicPulseTrain(23, 20, 0.45,
+                                                  stim_dur=100)})
+    fresh, cached = build(), build()
+    cached.data  # inspect the waveform, and nothing more
+    a, b = operate(fresh), operate(cached)
+
+    def described(stim):
+        return [(name, type(src), src.freq, src.amp)
+                for name, src in stim._structured_sources()]
+    npt.assert_equal(described(a), described(b))
+    npt.assert_array_equal(a.electrodes, b.electrodes)
+    npt.assert_allclose(a.data, b.data, rtol=1e-6, atol=1e-6)
 
 
 @pytest.mark.parametrize('factor', [2, 0.5, -1, 0])
 def test_Stimulus_collection_scaling_stays_deferred(factor):
-    # The Phase 6 target case: scaling a collection of pulse trains scales the
-    # trains, and the expensive part -- merging their time axes -- still has
-    # not happened.
+    # Scaling a collection of pulse trains scales the trains, and the
+    # expensive part -- merging their time axes -- still has not happened.
     def build():
         return {'A1': BiphasicPulseTrain(20, 10, 0.45, stim_dur=100),
                 'B2': BiphasicPulseTrain(23, 20, 0.45, stim_dur=100)}

--- a/pulse2percept/stimuli/tests/test_base.py
+++ b/pulse2percept/stimuli/tests/test_base.py
@@ -850,9 +850,14 @@ def test_Stimulus_shift():
     npt.assert_equal(shifted.time_unit, stim.time_unit)
     npt.assert_equal(shifted.metadata, stim.metadata)
     npt.assert_almost_equal(stim.time, [0, 1, 2])
-    # Including the type of a subclass:
+    # A pulse is defined by its parameters, so shifting one hands back a
+    # plain stimulus rather than a pulse whose `stim_dur` contradicts the
+    # time axis it now has (see test_pulses.py):
     pulse = BiphasicPulse(-20, 1)
-    npt.assert_equal(isinstance(pulse.shift(5), BiphasicPulse), True)
+    shifted = pulse.shift(5)
+    npt.assert_equal(type(shifted), Stimulus)
+    npt.assert_almost_equal(shifted.time, pulse.time + 5)
+    npt.assert_almost_equal(shifted.data, pulse.data)
 
 
 def test_Stimulus_pad():
@@ -867,7 +872,7 @@ def test_Stimulus_pad():
     npt.assert_almost_equal(padded.data[:, -1], 0)
     npt.assert_almost_equal(padded.time[1:-1], pulse.time + 3000)
     npt.assert_almost_equal(padded.data[:, 1:-1], pulse.data)
-    npt.assert_equal(isinstance(padded, BiphasicPulse), True)
+    npt.assert_equal(type(padded), Stimulus)
 
     # A stimulus that already starts at t=0 only gets trailing padding:
     stim = Stimulus([[1, 0]], time=[0, 2])

--- a/pulse2percept/stimuli/tests/test_base.py
+++ b/pulse2percept/stimuli/tests/test_base.py
@@ -1720,6 +1720,7 @@ def test_Stimulus_lazy_state_is_immutable():
     with pytest.raises(ValueError):
         stim.electrodes[0] = 'X'
     # And it is validated on the same terms, too:
+
     class BadShape(CountingLazy):
         __slots__ = ()
 
@@ -1791,7 +1792,7 @@ COLLECTIONS = [
                                       'B2': Stimulus([[1, 2, 3, 4]])}),
     ('list', lambda: [CountingLazy(4, ['A1']), CountingLazy(5, ['B2'])]),
     ('multi-electrode entry', lambda: [CountingLazy(4, ['x', 'y']),
-                                      CountingLazy(6, ['B2'])]),
+                                       CountingLazy(6, ['B2'])]),
 ]
 
 

--- a/pulse2percept/stimuli/tests/test_base.py
+++ b/pulse2percept/stimuli/tests/test_base.py
@@ -1021,25 +1021,24 @@ def test_Stimulus_shallow_copy():
     # `append` and the arithmetic operators return a copy that shares nothing
     # mutable with the original, even though the data container is no longer
     # deep-copied first.
-    stim = BiphasicPulseTrain(20, 20, 0.45, stim_dur=100)
-    # Negating the train flips its polarity, which `BiphasicPulseTrain` records
-    # on `cathodic_first`; every other derivation leaves the flag alone:
-    for derive, flips in ((lambda s: s * 2, False), (lambda s: s + 1, False),
-                          (lambda s: -s, True), (lambda s: s >> 1.0, False),
-                          (lambda s: s.append(s >> 1.0), False)):
+    # A stimulus that is defined by its samples keeps its class; one defined
+    # by pulse parameters does not (see `Stimulus._derived` and
+    # test_pulse_trains.py):
+    stim = Stimulus([[0, 1, 0]], time=[0, 1, 2], metadata={'x': 1})
+    for derive in (lambda s: s * 2, lambda s: s + 1, lambda s: -s,
+                   lambda s: s >> 1.0, lambda s: s.append(s >> 1.0)):
         copied = derive(stim)
         # Same class and extra attributes:
         npt.assert_equal(type(copied), type(stim))
-        npt.assert_equal(copied.freq, stim.freq)
-        npt.assert_equal(copied.cathodic_first, stim.cathodic_first != flips)
+        npt.assert_equal(copied.unit, stim.unit)
         npt.assert_equal(copied.is_compressed, stim.is_compressed)
         # Metadata is independent. Its contents need not be identical: both
-        # `append` and the operators keep the pulse parameters in sync with the
-        # data, dropping them where they no longer describe it (see
+        # `append` and the operators keep any waveform parameters in sync with
+        # the data, dropping them where they no longer describe it (see
         # test_pulse_trains.py):
         npt.assert_equal(copied.metadata is stim.metadata, False)
-        copied.metadata['user'] = 'changed'
-        npt.assert_equal(stim.metadata['user'], None)
+        copied.metadata['mine'] = 'changed'
+        npt.assert_equal('mine' in stim.metadata, False)
         # The data container is independent, too:
         npt.assert_equal(copied._stim is stim._stim, False)
         npt.assert_equal(np.shares_memory(copied.data, stim.data), False)
@@ -1614,6 +1613,10 @@ def test_Stimulus_deepcopy():
     # deep-copy a read-only array into a writable one -- so the copy shares
     # the data container and only `metadata` is made independent:
     stim = BiphasicPulseTrain(20, 20, 0.45, stim_dur=100)
+    # Materialize first: a train that has not generated its waveform yet has
+    # no container to share, and the copy generates its own (see
+    # test_pulse_trains.py):
+    stim.data
     copied = deepcopy(stim)
     npt.assert_equal(copied is stim, False)
     npt.assert_equal(np.shares_memory(copied.data, stim.data), True)

--- a/pulse2percept/stimuli/tests/test_base.py
+++ b/pulse2percept/stimuli/tests/test_base.py
@@ -1767,3 +1767,205 @@ def test_Stimulus_render_is_not_implemented_by_default():
     # implementation exists only to name what a subclass forgot:
     with pytest.raises(NotImplementedError):
         Stimulus._render(Stimulus(3))
+
+
+def _n_renders(stim):
+    """How often the `CountingLazy` entries of a collection have rendered"""
+    return sum(getattr(c, 'n_renders', 0) for c, _ in stim._components)
+
+
+def _lazy(stim):
+    return stim._Stimulus__stim['data'] is None
+
+
+# The collections Phase 5 has to keep unmerged, each as (name, source). The
+# expensive one is the last: differing frequencies means every entry lands on
+# its own time axis, and merging them interpolates all of them onto the union.
+COLLECTIONS = [
+    ('same protocol', lambda: {'A1': CountingLazy(4, ['A1']),
+                               'B2': CountingLazy(4, ['B2'])}),
+    ('differing lengths', lambda: {'A1': CountingLazy(4, ['A1']),
+                                   'B2': CountingLazy(7, ['B2']),
+                                   'C3': CountingLazy(11, ['C3'])}),
+    ('mixed representation', lambda: {'A1': CountingLazy(4, ['A1']),
+                                      'B2': Stimulus([[1, 2, 3, 4]])}),
+    ('list', lambda: [CountingLazy(4, ['A1']), CountingLazy(5, ['B2'])]),
+    ('multi-electrode entry', lambda: [CountingLazy(4, ['x', 'y']),
+                                      CountingLazy(6, ['B2'])]),
+]
+
+
+@pytest.mark.parametrize('name, build', COLLECTIONS,
+                         ids=[c[0] for c in COLLECTIONS])
+def test_Stimulus_collection_defers_the_merge(name, build):
+    stim = Stimulus(build())
+    npt.assert_equal(_lazy(stim), True)
+    # Everything a collection knows before its entries have been sampled:
+    npt.assert_equal(_n_renders(stim), 0)
+    npt.assert_equal(len(stim.electrodes) > 1, True)
+    npt.assert_equal(stim.unit, uA)
+    npt.assert_equal(stim.time_unit, ms)
+    npt.assert_equal(sorted(stim.metadata['electrodes']) != [], True)
+    npt.assert_equal(stim.is_compressed, False)
+    copies = [copy(stim), deepcopy(stim)]
+    npt.assert_equal(_n_renders(stim), 0)
+    for copied in copies:
+        npt.assert_equal(_lazy(copied), True)
+    # ...and the first read of the waveform is what builds one, once:
+    n_lazy = sum(isinstance(c, CountingLazy) for c, _ in stim._components)
+    data = stim.data
+    npt.assert_equal(_n_renders(stim), n_lazy)
+    for _ in range(3):
+        npt.assert_equal(np.shares_memory(stim.data, data), True)
+        npt.assert_equal(stim.time.dtype, np.float64)
+    npt.assert_equal(_n_renders(stim), n_lazy)
+
+
+@pytest.mark.parametrize('name, build', COLLECTIONS,
+                         ids=[c[0] for c in COLLECTIONS])
+def test_Stimulus_collection_matches_the_eager_merge(name, build,
+                                                     monkeypatch):
+    lazy = Stimulus(build())
+    monkeypatch.setattr(Stimulus, '_defers_waveform',
+                        staticmethod(lambda *a, **kw: False))
+    eager = Stimulus(build())
+    npt.assert_equal(_lazy(eager), False)
+    npt.assert_array_equal(lazy.data, eager.data)
+    npt.assert_array_equal(lazy.time, eager.time)
+    npt.assert_array_equal(lazy.electrodes, eager.electrodes)
+
+
+@pytest.mark.parametrize('freqs', [(20, 20), (20, 23), (20, 23, 41)])
+def test_Stimulus_pulse_train_collection_merges_as_it_always_did(freqs,
+                                                                 monkeypatch):
+    # The case Phase 5 exists for: differing frequencies put every train on a
+    # time axis of its own, so the merge is the expensive part.
+    def build():
+        return {f'E{i}': BiphasicPulseTrain(f, 10 + i, 0.45, stim_dur=200)
+                for i, f in enumerate(freqs)}
+    lazy = Stimulus(build())
+    npt.assert_equal(_lazy(lazy), True)
+    monkeypatch.setattr(Stimulus, '_defers_waveform',
+                        staticmethod(lambda *a, **kw: False))
+    eager = Stimulus(build())
+    npt.assert_array_equal(lazy.data, eager.data)
+    npt.assert_array_equal(lazy.time, eager.time)
+
+
+@pytest.mark.parametrize('vary', ['freq', 'amp', 'phase_dur'])
+def test_Stimulus_heterogeneous_pulse_parameters_merge_unchanged(vary,
+                                                                 monkeypatch):
+    kwargs = {'freq': 20, 'amp': 10, 'phase_dur': 0.45, 'stim_dur': 200}
+    other = dict(kwargs, **{vary: {'freq': 23, 'amp': 25,
+                                   'phase_dur': 0.9}[vary]})
+
+    def build():
+        return {'A1': BiphasicPulseTrain(**kwargs),
+                'B2': BiphasicPulseTrain(**other)}
+    lazy = Stimulus(build())
+    monkeypatch.setattr(Stimulus, '_defers_waveform',
+                        staticmethod(lambda *a, **kw: False))
+    npt.assert_array_equal(lazy.data, Stimulus(build()).data)
+
+
+def test_Stimulus_collection_with_a_silent_child(monkeypatch):
+    # A 0 Hz train is a flat row, and it still has to end where the others do:
+    def build():
+        return {'A1': BiphasicPulseTrain(0, 10, 0.45, stim_dur=200),
+                'B2': BiphasicPulseTrain(20, 10, 0.45, stim_dur=200)}
+    lazy = Stimulus(build())
+    npt.assert_equal(_lazy(lazy), True)
+    npt.assert_almost_equal(lazy.time[-1], 200)
+    npt.assert_almost_equal(np.abs(lazy.data[0]).max(), 0)
+    monkeypatch.setattr(Stimulus, '_defers_waveform',
+                        staticmethod(lambda *a, **kw: False))
+    npt.assert_array_equal(lazy.data, Stimulus(build()).data)
+
+
+def test_Stimulus_collection_of_raw_sources_stays_eager():
+    # Nothing to save: these entries are already the numbers they describe.
+    for source in ({'A1': [1, 2, 3], 'B2': [4, 5, 6]}, [[1, 2], [3, 4]],
+                   {'A1': 1, 'B2': 2}):
+        npt.assert_equal(Stimulus(source)._components, None)
+    # An explicit time axis and `compress` both ask about the merged waveform:
+    stim = Stimulus({'A1': CountingLazy(3, ['A1'])}, time=[0, 1, 2])
+    npt.assert_equal(stim._components, None)
+    npt.assert_equal(Stimulus({'A1': CountingLazy(3, ['A1'])},
+                              compress=True)._components, None)
+
+
+def test_Stimulus_collection_snapshots_its_entries():
+    raw = [1.0, 2.0, 3.0, 4.0]
+    child = CountingLazy(4, ['A1'])
+    stim = Stimulus({'A1': child, 'B2': raw})
+    raw[0] = 99.0
+    npt.assert_equal(stim._components[0][0] is child, False)
+    npt.assert_almost_equal(stim.data[1], [1, 2, 3, 4])
+    # Rendering the caller's object is not what rendered the collection:
+    npt.assert_equal(child.n_renders, 0)
+
+
+def test_Stimulus_collection_validates_what_it_can_without_rendering():
+    child = CountingLazy(4, ['A1'])
+    with pytest.raises(ValueError):
+        # A scalar has no time component, the other entry does:
+        Stimulus({'A1': child, 'B2': 5})
+    with pytest.raises(ValueError):
+        Stimulus({'A1': child}, electrodes=['A1', 'B2'])
+    with pytest.raises(ValueError):
+        Stimulus({'A1': child, 'B2': CountingLazy(4, ['B2'])},
+                 electrodes=['only-one'])
+    assert_warns_msg(UserWarning,
+                     lambda: Stimulus([CountingLazy(4, ['A1']),
+                                       CountingLazy(4, ['A1'])]),
+                     'Duplicate electrode names detected')
+    npt.assert_equal(child.n_renders, 0)
+
+
+def test_Stimulus_collection_renames_without_rendering():
+    child = CountingLazy(4, ['A1'])
+    renamed = Stimulus({'A1': child, 'B2': CountingLazy(4, ['B2'])},
+                       electrodes=['X', 'Y'])
+    npt.assert_equal(_lazy(renamed), True)
+    npt.assert_equal(list(renamed.electrodes), ['X', 'Y'])
+    npt.assert_equal(sorted(renamed.metadata['electrodes']), ['X', 'Y'])
+    npt.assert_equal(child.n_renders, 0)
+    # Re-wrapping a single deferred stimulus is a rename too:
+    solo = Stimulus(CountingLazy(4, ['A1']), electrodes=['Z'])
+    npt.assert_equal(_lazy(solo), True)
+    npt.assert_equal(list(solo.electrodes), ['Z'])
+    npt.assert_equal(solo.data.shape, (1, 4))
+
+
+def test_Stimulus_collection_removes_whole_entries_without_rendering():
+    stim = Stimulus({'A1': CountingLazy(4, ['A1']),
+                     'B2': CountingLazy(7, ['B2']),
+                     'C3': CountingLazy(11, ['C3'])})
+    stim.remove(['A1', 'C3'])
+    npt.assert_equal(_lazy(stim), True)
+    npt.assert_equal(list(stim.electrodes), ['B2'])
+    npt.assert_equal(_n_renders(stim), 0)
+    # Only the entry that survived is ever generated:
+    npt.assert_equal(stim.data.shape, (1, 7))
+    npt.assert_equal(_n_renders(stim), 1)
+    empty = Stimulus({'A1': CountingLazy(4, ['A1'])})
+    empty.remove('all')
+    npt.assert_equal(_lazy(empty), True)
+    npt.assert_equal(len(empty.electrodes), 0)
+    # A copy taken before the removal keeps the entry it was built with:
+    stim = Stimulus({'A1': CountingLazy(4, ['A1']),
+                     'B2': CountingLazy(4, ['B2'])})
+    other = stim._derived()
+    other.remove('A1')
+    npt.assert_equal(list(stim.electrodes), ['A1', 'B2'])
+    npt.assert_equal(list(other.electrodes), ['B2'])
+
+
+def test_Stimulus_collection_removing_part_of_an_entry_materializes():
+    # 'x' and 'y' come from one entry, so dropping 'x' means generating it.
+    stim = Stimulus([CountingLazy(4, ['x', 'y']),
+                     CountingLazy(4, ['B2'])])
+    stim.remove('x')
+    npt.assert_equal(_lazy(stim), False)
+    npt.assert_equal(list(stim.electrodes), ['y', 'B2'])
+    npt.assert_equal(stim.data.shape, (2, 4))

--- a/pulse2percept/stimuli/tests/test_base.py
+++ b/pulse2percept/stimuli/tests/test_base.py
@@ -928,15 +928,13 @@ def test_Stimulus_pad():
     npt.assert_equal(padded.metadata, multi.metadata)
 
     # A pad that has nothing to add still returns an independent copy, rather
-    # than a stimulus writing through to the buffers of the original:
+    # than a stimulus sharing the buffers of the original:
     noop = Stimulus([[0, 1, 0]], time=[0, 2, 4])
     padded = noop.pad(noop.duration)
     npt.assert_almost_equal(padded.time, noop.time)
     npt.assert_almost_equal(padded.data, noop.data)
-    padded.data[:] = 0
-    padded.time[:] = 0
-    npt.assert_almost_equal(noop.data, [[0, 1, 0]])
-    npt.assert_almost_equal(noop.time, [0, 2, 4])
+    npt.assert_equal(np.shares_memory(padded.data, noop.data), False)
+    npt.assert_equal(np.shares_memory(padded.time, noop.time), False)
 
     # Padding a compressed stimulus does not make it uncompressed:
     compressed = Stimulus([[0, 1, 2, 0]], time=[0, 1, 2, 3], compress=True)
@@ -1039,9 +1037,7 @@ def test_Stimulus_shallow_copy():
         npt.assert_equal(stim.metadata['user'], None)
         # The data container is independent, too:
         npt.assert_equal(copied._stim is stim._stim, False)
-        before = stim.data.copy()
-        copied.data[:] = 0
-        npt.assert_array_equal(stim.data, before)
+        npt.assert_equal(np.shares_memory(copied.data, stim.data), False)
 
     # Subclass-specific attributes survive as well:
     img = ImageStimulus(np.ones((4, 5), dtype=np.float32))
@@ -1551,3 +1547,64 @@ def test_Stimulus_is_charge_balanced_needs_a_current():
     # picture:
     for stim in (img, vid):
         npt.assert_equal('is_charge_balanced' in str(stim), True)
+
+
+@pytest.mark.parametrize('build', [
+    lambda: Stimulus(np.arange(6, dtype=np.float32).reshape((2, 3))),
+    lambda: Stimulus({'A1': [0, 1, 0], 'B2': [0, 2, 0]}),
+    lambda: BiphasicPulseTrain(20, 50, 0.45, stim_dur=100),
+    lambda: ImageStimulus(np.linspace(0, 1, 16).reshape((4, 4))),
+    lambda: VideoStimulus(np.ones((2, 2, 3)) * 0.5, time=[0, 20, 40]),
+])
+def test_Stimulus_is_immutable(build):
+    stim = build()
+    with pytest.raises(ValueError):
+        stim.data[0, 0] = 1
+    if stim.time is not None:
+        with pytest.raises(ValueError):
+            stim.time[0] = 1
+    # `ImageStimulus` names its pixels with an `ElectrodeNames`, which
+    # generates them from a grid instead of storing them and so has no way to
+    # set one at all:
+    with pytest.raises((ValueError, TypeError)):
+        stim.electrodes[0] = 'X'
+    # Metadata stays writable: it is the user's, and describes the stimulus
+    # rather than being it.
+    stim.metadata['user'] = 'mine'
+    npt.assert_equal(stim.metadata['user'], 'mine')
+
+
+def test_Stimulus_owns_its_arrays():
+    # Building a stimulus must neither take the caller's array away from them
+    # nor leave them a handle on the stimulus:
+    arr = np.ones((2, 3), dtype=np.float32)
+    stim = Stimulus(arr, time=[0, 1, 2])
+    npt.assert_equal(arr.flags.writeable, True)
+    npt.assert_equal(np.shares_memory(arr, stim.data), False)
+    arr[0, 0] = 99
+    npt.assert_almost_equal(stim.data, np.ones((2, 3)))
+    # Nor may one stimulus write through to another's buffers:
+    copied = Stimulus(stim)
+    npt.assert_equal(np.shares_memory(stim.data, copied.data), False)
+    npt.assert_equal(np.shares_memory(stim.time, copied.time), False)
+
+
+def test_Stimulus_immutable_operations():
+    # Everything that returns or rebuilds a stimulus still works, and hands
+    # back one that is immutable in its turn:
+    stim = Stimulus({'A1': [0, 1, 1, 0], 'B2': [0, 0, 0, 0]},
+                    time=[0, 1, 2, 3])
+    derived = [stim * 2, -stim, stim + 1, stim >> 1.0, stim / 2,
+               stim.append(stim >> 1.0), stim.pad(9)]
+    compressed = Stimulus(stim)
+    compressed.compress()
+    removed = Stimulus(stim)
+    removed.remove('A1')
+    derived += [compressed, removed]
+    for out in derived:
+        npt.assert_equal(out.data.flags.writeable, False)
+        npt.assert_equal(out.time.flags.writeable, False)
+        npt.assert_equal(out.data.flags['C_CONTIGUOUS'], True)
+    # The operations themselves are unaffected:
+    npt.assert_equal(compressed.shape, (1, 3))
+    npt.assert_equal(list(removed.electrodes), ['B2'])

--- a/pulse2percept/stimuli/tests/test_base.py
+++ b/pulse2percept/stimuli/tests/test_base.py
@@ -16,7 +16,8 @@ from pulse2percept.stimuli import (BiphasicPulse, BiphasicPulseTrain,
                                    MonophasicPulse)
 from pulse2percept.stimuli import ImageStimulus
 from pulse2percept.stimuli import VideoStimulus
-from pulse2percept.stimuli.base import _interp_rows, merge_time_axes
+from pulse2percept.stimuli._merge import merge_time_axes
+from pulse2percept.stimuli.base import _interp_rows
 from pulse2percept.units import (DimensionMismatchError, Quantity,
                                  dimensionless, mA, ms, uA, us)
 # `s` is a loop variable elsewhere in this module, so import the unit

--- a/pulse2percept/stimuli/tests/test_base.py
+++ b/pulse2percept/stimuli/tests/test_base.py
@@ -1969,3 +1969,77 @@ def test_Stimulus_collection_removing_part_of_an_entry_materializes():
     npt.assert_equal(_lazy(stim), False)
     npt.assert_equal(list(stim.electrodes), ['y', 'B2'])
     npt.assert_equal(stim.data.shape, (2, 4))
+
+
+def test_Stimulus_rewriting_a_waveform_forgets_the_components():
+    # The components describe one waveform: the one they render to. An
+    # operation that installs a different one has to drop them, or a stimulus
+    # would go on carrying a structured source that says something else.
+    stim = Stimulus({'A1': CountingLazy(4, ['A1']),
+                     'B2': CountingLazy(4, ['B2'])})
+    npt.assert_equal(stim.data.shape, (2, 4))
+    # Rendering is the one install that keeps them -- it built that waveform:
+    npt.assert_equal(stim._components is None, False)
+    for rewrite in (lambda s: s + 5, lambda s: s * 2, lambda s: s >> 1,
+                    lambda s: -s):
+        npt.assert_equal(rewrite(stim)._components, None)
+    compressed = stim._shallow_copy()
+    compressed.compress()
+    npt.assert_equal(compressed._components, None)
+    # Removing an electrode from a collection that has already been rendered
+    # goes through the waveform, so it drops them too:
+    removed = stim._shallow_copy()
+    removed.remove('A1')
+    npt.assert_equal(removed._components, None)
+
+
+@pytest.mark.parametrize('factor', [2, 0.5, -1, 0])
+def test_Stimulus_collection_scaling_stays_deferred(factor):
+    # The Phase 6 target case: scaling a collection of pulse trains scales the
+    # trains, and the expensive part -- merging their time axes -- still has
+    # not happened.
+    def build():
+        return {'A1': BiphasicPulseTrain(20, 10, 0.45, stim_dur=100),
+                'B2': BiphasicPulseTrain(23, 20, 0.45, stim_dur=100)}
+    stim = Stimulus(build())
+    scaled = stim * factor
+    npt.assert_equal(_lazy(scaled), True)
+    npt.assert_equal(_lazy(stim), True)
+    # The entries are still pulse trains, at the scaled amplitude:
+    npt.assert_equal([type(c) for c, _ in scaled._components],
+                     [BiphasicPulseTrain, BiphasicPulseTrain])
+    npt.assert_almost_equal([c.amp for c, _ in scaled._components],
+                            [10 * abs(factor), 20 * abs(factor)])
+    # ...and so is what the models read off the metadata:
+    npt.assert_almost_equal(
+        [v['metadata']['amp'] for v in scaled.metadata['electrodes'].values()],
+        [10 * abs(factor), 20 * abs(factor)])
+    npt.assert_allclose(scaled.data, factor * Stimulus(build()).data,
+                        rtol=1e-6, atol=1e-6)
+    # The original is untouched, in both descriptions:
+    npt.assert_almost_equal([c.amp for c, _ in stim._components], [10, 20])
+    npt.assert_almost_equal(
+        [v['metadata']['amp'] for v in stim.metadata['electrodes'].values()],
+        [10, 20])
+
+
+def test_Stimulus_collection_scaling_needs_every_entry_to_be_a_stimulus():
+    # A raw entry would have to be sampled to be scaled, which is the work
+    # staying unmerged exists to avoid -- so the collection gives way instead:
+    stim = Stimulus({'A1': CountingLazy(4, ['A1']), 'B2': [1, 2, 3, 4]})
+    scaled = stim * 2
+    npt.assert_equal(scaled._components, None)
+    npt.assert_almost_equal(scaled.data[1], [2, 4, 6, 8])
+
+
+def test_Stimulus_collection_offset_materializes():
+    # A DC offset is not something an entry's parameters express, so the
+    # collection materializes and hands back a plain waveform with no
+    # structured source left behind it:
+    stim = Stimulus({'A1': BiphasicPulseTrain(20, 10, 0.45, stim_dur=100),
+                     'B2': BiphasicPulseTrain(23, 20, 0.45, stim_dur=100)})
+    out = stim + 5
+    npt.assert_equal(type(out), Stimulus)
+    npt.assert_equal(out._components, None)
+    npt.assert_almost_equal(out.data, stim.data + 5)
+    npt.assert_equal(_lazy(stim), False)

--- a/pulse2percept/stimuli/tests/test_characterization.py
+++ b/pulse2percept/stimuli/tests/test_characterization.py
@@ -1,0 +1,193 @@
+"""Waveform characterization for pulses, pulse trains and encoders
+
+These tests pin down numbers that no other test asserts directly -- the exact
+tick each signal edge sits on, the dtypes the data and time axes are stored
+in, and the shape of the container -- so that a change in how a stimulus is
+*represented* cannot quietly change what it *delivers*.
+"""
+import numpy as np
+import numpy.testing as npt
+import pytest
+from scipy.integrate import trapezoid
+
+from pulse2percept.implants import ArgusII
+from pulse2percept.stimuli import (AmplitudeEncoder,
+                                   AsymmetricBiphasicPulse,
+                                   AsymmetricBiphasicPulseTrain,
+                                   BiphasicPulse, BiphasicPulseTrain,
+                                   BiphasicTripletTrain, ImageStimulus,
+                                   MonophasicPulse, PulseTrain, Stimulus,
+                                   VideoStimulus)
+
+
+def _fake_pulse():
+    """A three-point pulse, the minimum `PulseTrain` will tile"""
+    return Stimulus([[0, -1, 0]], time=[0, 0.1, 0.2])
+
+
+def _digest(stim):
+    """A compact fingerprint of a waveform
+
+    Records where the signal changes rather than every sample, so that a long
+    train is described by a handful of numbers instead of a frozen array. The
+    two integrals catch a changed amplitude, and ``net_area`` doubles as the
+    charge-balance result.
+    """
+    data, time = stim.data, stim.time
+    edges = time[1:][np.any(np.diff(data, axis=1) != 0, axis=0)]
+    return {'shape': data.shape,
+            't_end': float(time[-1]),
+            'n_edges': int(edges.size),
+            'first_edges': [round(float(e), 6) for e in edges[:5]],
+            'last_edges': [round(float(e), 6) for e in edges[-2:]],
+            'abs_area': round(float(trapezoid(np.abs(data), time).sum()), 6),
+            'net_area': round(float(trapezoid(data, time).sum()), 9),
+            'peak': (round(float(data.min()), 6),
+                     round(float(data.max()), 6))}
+
+
+# One entry per (build, expected digest). Between them these cover a zero
+# frequency, a nonzero interphase gap, a delay, an explicit pulse count, a
+# 20-second train and a multi-electrode collection:
+WAVEFORMS = [
+    (lambda: MonophasicPulse(-20, 1, delay_dur=2, stim_dur=10),
+     {'shape': (1, 6), 't_end': 10.0, 'n_edges': 2,
+      'first_edges': [2.001, 3.0], 'last_edges': [2.001, 3.0],
+      'abs_area': 19.98, 'net_area': -19.979999542, 'peak': (-20.0, 0.0)}),
+    (lambda: MonophasicPulse(13, 0.45),
+     {'shape': (1, 4), 't_end': 0.45, 'n_edges': 2,
+      'first_edges': [0.001, 0.45], 'last_edges': [0.001, 0.45],
+      'abs_area': 5.836999, 'net_area': 5.836999416, 'peak': (0.0, 13.0)}),
+    (lambda: BiphasicPulse(-20, 1, delay_dur=2, stim_dur=10),
+     {'shape': (1, 9), 't_end': 10.0, 'n_edges': 4,
+      'first_edges': [2.001, 3.0, 3.001, 4.0], 'last_edges': [3.001, 4.0],
+      'abs_area': 39.959999, 'net_area': 0.0, 'peak': (-20.0, 20.0)}),
+    (lambda: BiphasicPulse(20, 0.45, interphase_dur=0.5,
+                           cathodic_first=False),
+     {'shape': (1, 8), 't_end': 1.4, 'n_edges': 4,
+      'first_edges': [0.001, 0.45, 0.951, 1.4], 'last_edges': [0.951, 1.4],
+      'abs_area': 17.960001, 'net_area': 2.29e-07, 'peak': (-20.0, 20.0)}),
+    (lambda: AsymmetricBiphasicPulse(-40, 10, 1, 4, interphase_dur=1,
+                                     delay_dur=2, stim_dur=15),
+     {'shape': (1, 10), 't_end': 15.0, 'n_edges': 4,
+      'first_edges': [2.001, 3.0, 4.001, 8.0], 'last_edges': [4.001, 8.0],
+      'abs_area': 79.949997, 'net_area': 0.030002594, 'peak': (-40.0, 10.0)}),
+    (lambda: AsymmetricBiphasicPulse(40, 10, 0.45, 0.9,
+                                     cathodic_first=False),
+     {'shape': (1, 7), 't_end': 1.35, 'n_edges': 4,
+      'first_edges': [0.001, 0.45, 0.451, 1.35], 'last_edges': [0.451, 1.35],
+      'abs_area': 26.949999, 'net_area': 8.970002174, 'peak': (-10.0, 40.0)}),
+    (lambda: PulseTrain(10, _fake_pulse(), n_pulses=3, electrode='A4'),
+     {'shape': (1, 10), 't_end': 1000.0, 'n_edges': 6,
+      'first_edges': [0.1, 0.2, 100.1, 100.2, 200.1],
+      'last_edges': [200.1, 200.2], 'abs_area': 0.3,
+      'net_area': -0.300000012, 'peak': (-1.0, 0.0)}),
+    (lambda: PulseTrain(3, _fake_pulse(), stim_dur=11),
+     {'shape': (1, 4), 't_end': 11.0, 'n_edges': 2,
+      'first_edges': [0.1, 0.2], 'last_edges': [0.1, 0.2], 'abs_area': 0.1,
+      'net_area': -0.100000001, 'peak': (-1.0, 0.0)}),
+    (lambda: BiphasicPulseTrain(20, 50, 0.45, stim_dur=1000),
+     {'shape': (1, 141), 't_end': 1000.0, 'n_edges': 80,
+      'first_edges': [0.001, 0.45, 0.451, 0.9, 50.001],
+      'last_edges': [950.451, 950.9], 'abs_area': 898.000061,
+      'net_area': 3.82e-07, 'peak': (-50.0, 50.0)}),
+    (lambda: BiphasicPulseTrain(0, 50, 0.45, stim_dur=100),
+     {'shape': (1, 2), 't_end': 100.0, 'n_edges': 0, 'first_edges': [],
+      'last_edges': [], 'abs_area': 0.0, 'net_area': 0.0,
+      'peak': (0.0, 0.0)}),
+    (lambda: BiphasicPulseTrain(23.456, -3, 2, interphase_dur=np.pi,
+                                delay_dur=np.e, stim_dur=657.456,
+                                cathodic_first=False),
+     {'shape': (1, 145), 't_end': 657.456, 'n_edges': 64,
+      'first_edges': [2.719282, 4.718282, 7.860874, 9.859874, 45.352297],
+      'last_edges': [647.3561, 649.3551], 'abs_area': 191.903992,
+      'net_area': 0.0, 'peak': (-3.0, 3.0)}),
+    (lambda: BiphasicPulseTrain(500, 30, 0.05, n_pulses=4, stim_dur=19),
+     {'shape': (1, 29), 't_end': 19.0, 'n_edges': 16,
+      'first_edges': [0.001, 0.05, 0.051, 0.1, 2.001],
+      'last_edges': [6.051, 6.1], 'abs_area': 11.760001,
+      'net_area': -1.05e-07, 'peak': (-30.0, 30.0)}),
+    (lambda: BiphasicPulseTrain(50, 50, 0.46, stim_dur=20000),
+     {'shape': (1, 7001), 't_end': 20000.0, 'n_edges': 4000,
+      'first_edges': [0.001, 0.46, 0.461, 0.92, 20.001],
+      'last_edges': [19980.461, 19980.92], 'abs_area': 45900.007812,
+      'net_area': 1.3351e-05, 'peak': (-50.0, 50.0)}),
+    (lambda: AsymmetricBiphasicPulseTrain(20, -1, 4, 1, 2, interphase_dur=1,
+                                          delay_dur=6, stim_dur=500),
+     {'shape': (1, 91), 't_end': 500.0, 'n_edges': 40,
+      'first_edges': [6.001, 7.0, 8.001, 10.0, 56.001],
+      'last_edges': [458.001, 460.0], 'abs_area': 89.949997,
+      'net_area': 69.969993591, 'peak': (-1.0, 4.0)}),
+    (lambda: BiphasicTripletTrain(20, -3, 1, interphase_dur=1,
+                                  interpulse_dur=1, delay_dur=4,
+                                  stim_dur=500),
+     {'shape': (1, 341), 't_end': 500.0, 'n_edges': 120,
+      'first_edges': [4.001, 5.0, 6.001, 7.0, 12.001],
+      'last_edges': [472.001, 473.0], 'abs_area': 179.819992,
+      'net_area': 0.0, 'peak': (-3.0, 3.0)}),
+    (lambda: Stimulus({'A1': BiphasicPulseTrain(20, 50, 0.45, stim_dur=200),
+                       'B2': BiphasicPulseTrain(30, -20, 0.45,
+                                                stim_dur=200)}),
+     {'shape': (2, 57), 't_end': 200.0, 'n_edges': 32,
+      'first_edges': [0.001, 0.45, 0.451, 0.9, 33.334333],
+      'last_edges': [167.117667, 167.566667], 'abs_area': 287.359985,
+      'net_area': -4.58e-07, 'peak': (-50.0, 50.0)}),
+]
+
+
+@pytest.mark.parametrize('build, expected', WAVEFORMS)
+def test_waveform_characterization(build, expected):
+    npt.assert_equal(_digest(build()), expected)
+
+
+@pytest.mark.parametrize('build, expected', WAVEFORMS)
+def test_waveform_container_invariants(build, expected):
+    # Every model in the library reads the data as a C-contiguous float32
+    # matrix, and the time axis has to be float64: float32 cannot resolve two
+    # points a DT step apart past t = 8.4 s, which is well inside a 20 s train.
+    stim = build()
+    npt.assert_equal(stim.data.dtype, np.float32)
+    npt.assert_equal(stim.time.dtype, np.float64)
+    npt.assert_equal(stim.data.flags['C_CONTIGUOUS'], True)
+
+
+def test_pulse_train_electrode_names():
+    # A train names the electrode it was built for, and a collection of them
+    # keeps the names it was keyed by:
+    npt.assert_equal(BiphasicPulseTrain(20, 50, 0.45, electrode='C3'
+                                        ).electrodes, ['C3'])
+    npt.assert_equal(PulseTrain(10, _fake_pulse(), n_pulses=2,
+                                electrode='A4').electrodes, ['A4'])
+    stim = Stimulus({'A1': BiphasicPulseTrain(20, 50, 0.45, stim_dur=200),
+                     'B2': BiphasicPulseTrain(30, -20, 0.45, stim_dur=200)})
+    npt.assert_equal(list(stim.electrodes), ['A1', 'B2'])
+
+
+def _encoded():
+    """The encoder cases the refactor has to reproduce exactly"""
+    implant = ArgusII()
+    rng = np.random.RandomState(0)
+    img = ImageStimulus(rng.rand(60, 60).astype(np.float32))
+    vid = VideoStimulus(rng.rand(60, 60, 4).astype(np.float32),
+                        time=np.arange(4) * 50.0)
+    return [('amp-image', AmplitudeEncoder(freq=20).encode(img,
+                                                           implant=implant)),
+            ('amp-video', AmplitudeEncoder(freq=20).encode(vid,
+                                                           implant=implant))]
+
+
+@pytest.mark.parametrize('name, expected', [
+    ('amp-image', {'shape': (60, 421), 't_end': 500.0, 'n_frames': 1,
+                   'frame_dur': 500.0}),
+    ('amp-video', {'shape': (60, 169), 't_end': 200.0, 'n_frames': 4,
+                   'frame_dur': 50.0}),
+])
+def test_encoder_characterization(name, expected):
+    stim = dict(_encoded())[name]
+    meta = stim.metadata['encoder']
+    npt.assert_equal({'shape': stim.data.shape,
+                      't_end': float(stim.time[-1]),
+                      'n_frames': int(meta['frame_time'].size),
+                      'frame_dur': float(meta['frame_dur'])}, expected)
+    npt.assert_equal(stim.data.dtype, np.float32)
+    npt.assert_equal(stim.time.dtype, np.float64)

--- a/pulse2percept/stimuli/tests/test_encoders.py
+++ b/pulse2percept/stimuli/tests/test_encoders.py
@@ -1,4 +1,5 @@
 import warnings
+from copy import copy, deepcopy
 
 import numpy as np
 import numpy.testing as npt
@@ -14,6 +15,7 @@ from pulse2percept.stimuli import (AmplitudeEncoder, BiphasicPulse,
                                    VideoStimulus)
 from pulse2percept.stimuli import encoders
 from pulse2percept.utils.constants import DT
+from pulse2percept.utils.testing import assert_warns_msg
 from pulse2percept.units import (DimensionMismatchError, Hz, Quantity,
                                  dimensionless, kHz, mA, ms, uA, us)
 from pulse2percept.units import s as sec
@@ -1185,3 +1187,140 @@ def test_encoder_pulse_template_unit_agnostic():
     for out in outs:
         npt.assert_equal(out.unit, uA)
         npt.assert_almost_equal(np.abs(out.data).max(), 50)
+
+
+def _rendered(stim):
+    """Whether the encoded stimulus has expanded its schedule into samples"""
+    return stim._Stimulus__stim['data'] is not None
+
+
+# One case per thing the schedule can do: a still frame, several frames, a
+# per-electrode frequency, a device raster, a stimulator clock, a supplied
+# pulse, and a source that asks for nothing at all.
+ENCODED = [
+    ('amplitude', lambda: AmplitudeEncoder().encode(
+        ImageStimulus(np.linspace(0, 1, 64).reshape(8, 8)))),
+    ('amplitude-video', lambda: AmplitudeEncoder().encode(
+        VideoStimulus(np.linspace(0, 1, 192).reshape(8, 8, 3),
+                      time=np.arange(3) * 40.0))),
+    ('frequency', lambda: FrequencyEncoder(freq_range=(0, 60)).encode(
+        ImageStimulus(np.linspace(0, 1, 64).reshape(8, 8)))),
+    ('rastered', lambda: AmplitudeEncoder().encode(
+        ImageStimulus(np.linspace(0, 1, 64).reshape(8, 8)),
+        implant=ArgusII())),
+    ('clocked', lambda: AmplitudeEncoder(clock=1.0).encode(
+        ImageStimulus(np.linspace(0, 1, 64).reshape(8, 8)))),
+    ('custom-pulse', lambda: AmplitudeEncoder(
+        pulse=BiphasicPulse(1, 0.2, interphase_dur=0.1)).encode(
+            ImageStimulus(np.linspace(0, 1, 64).reshape(8, 8)))),
+    ('all-zero', lambda: FrequencyEncoder(freq_range=(0, 60)).encode(
+        ImageStimulus(np.zeros((6, 6))))),
+]
+
+
+@pytest.mark.parametrize('name, build', ENCODED, ids=[c[0] for c in ENCODED])
+def test_encoded_stimulus_defers_only_the_waveform(name, build):
+    stim = build()
+    npt.assert_equal(_rendered(stim), False)
+    # Everything the schedule already settled, without expanding it:
+    npt.assert_equal(len(stim.electrodes) > 0, True)
+    npt.assert_equal(stim.unit, uA)
+    npt.assert_equal(stim.time_unit, ms)
+    npt.assert_equal(sorted(stim.metadata['encoder']),
+                     ['cycle', 'frame_dur', 'frame_time'])
+    npt.assert_equal(stim.duration > 0, True)
+    repr(stim)
+    copies = [copy(stim), deepcopy(stim)]
+    npt.assert_equal(_rendered(stim), False)
+    for copied in copies:
+        npt.assert_equal(_rendered(copied), False)
+    # ...and the first read of the waveform is what expands it, once:
+    data = stim.data
+    npt.assert_equal(_rendered(stim), True)
+    for _ in range(3):
+        npt.assert_equal(np.shares_memory(stim.data, data), True)
+    npt.assert_equal(stim.data.dtype, np.float32)
+    npt.assert_equal(stim.time.dtype, np.float64)
+    npt.assert_almost_equal(stim.time[-1], stim.duration)
+
+
+@pytest.mark.parametrize('name, build', ENCODED, ids=[c[0] for c in ENCODED])
+def test_encoded_stimulus_holds_no_waveform_sized_array(name, build):
+    # The point of the phase: what is retained may scale with electrodes x
+    # frames, with the pulse onsets, or with the global time axis -- but not
+    # with electrodes x time, which is the array that gets large.
+    stim = build()
+    n_el, n_time = len(stim.electrodes), stim._ticks.size
+    retained = [stim._amp, stim._ticks, stim._sched, stim._pulse_ticks,
+                stim._pulse_vals, *stim._onsets, *stim._frames]
+    for array in retained:
+        npt.assert_equal(array.shape == (n_el, n_time), False)
+        # Frozen, like every other piece of a stimulus' scientific state:
+        npt.assert_equal(array.flags.writeable, False)
+    npt.assert_equal(stim._amp.shape[0], n_el)
+    # The matrix appears only when asked for:
+    npt.assert_equal(stim.data.shape, (n_el, n_time))
+
+
+def test_encoded_stimulus_is_independent_of_the_encoder():
+    # The schedule is resolved once, at `encode`. Whatever the encoder or its
+    # pulse template does afterwards describes some other encoding:
+    encoder = AmplitudeEncoder(amp_range=(0, 50), freq=20)
+    img = ImageStimulus(np.linspace(0, 1, 64).reshape(8, 8))
+    stim = encoder.encode(img)
+    encoder.amp_range = (0, 500)
+    encoder.freq = 200
+    encoder.phase_dur = 4.0
+    npt.assert_array_equal(stim.data, encoder.__class__(
+        amp_range=(0, 50), freq=20).encode(img).data)
+
+
+@pytest.mark.parametrize('modify', [lambda s: s * 2, lambda s: s + 5,
+                                    lambda s: -s, lambda s: s >> 5])
+def test_encoded_stimulus_transformations_degrade(modify):
+    # A schedule describes when each electrode pulses and how hard on each
+    # frame. Rewriting the samples leaves it describing nothing, so what comes
+    # back is an ordinary stimulus:
+    stim = AmplitudeEncoder().encode(
+        ImageStimulus(np.linspace(0, 1, 64).reshape(8, 8)))
+    out = modify(stim)
+    npt.assert_equal(type(out), Stimulus)
+    npt.assert_equal(out._is_parametric, False)
+
+
+def test_encoded_stimulus_validates_while_it_schedules():
+    # Scheduling stays eager, so what is wrong with an encoding is still said
+    # when the encoding is asked for -- not when its waveform is:
+    img = ImageStimulus(np.linspace(0, 1, 64).reshape(8, 8))
+    with pytest.raises(ValueError):
+        # A pulse longer than the source it has to fit into:
+        AmplitudeEncoder(phase_dur=400).encode(img)
+    with pytest.raises(ValueError):
+        # A raster that cannot get through in one pulse period:
+        FrequencyEncoder(freq_range=(0, 300)).encode(img, implant=ArgusII())
+    with pytest.raises(ValueError):
+        # A pulse whose time points DT cannot resolve:
+        AmplitudeEncoder(pulse=Stimulus([[0, 1, 0]],
+                                        time=[0, 1e-5, 2e-5])).encode(img)
+    # ...and so is the warning about frames that never reach an electrode:
+    assert_warns_msg(UserWarning,
+                     lambda: AmplitudeEncoder(freq=1).encode(
+                         VideoStimulus(np.ones((4, 4, 8)),
+                                       time=np.arange(8) * 40.0)),
+                     'deliver no pulse at all')
+
+
+def test_encoded_stimulus_survives_assignment_unrendered():
+    # An implant stores a copy of what it is given; that copy has no more
+    # reason to hold a waveform than the original did.
+    implant = ArgusII()
+    implant.stim = AmplitudeEncoder().encode(
+        ImageStimulus(np.linspace(0, 1, 64).reshape(8, 8)), implant=implant)
+    npt.assert_equal(_rendered(implant.stim), False)
+    npt.assert_equal(len(implant.stim.electrodes), 60)
+    # Assigning the picture itself goes through the implant's own encoder, and
+    # arrives just as unexpanded:
+    encoded = ArgusII(encoder=AmplitudeEncoder())
+    encoded.stim = ImageStimulus(np.linspace(0, 1, 64).reshape(8, 8))
+    npt.assert_equal(_rendered(encoded.stim), False)
+    npt.assert_equal(encoded.stim.data.shape[0], 60)

--- a/pulse2percept/stimuli/tests/test_encoders.py
+++ b/pulse2percept/stimuli/tests/test_encoders.py
@@ -885,16 +885,16 @@ def test_StimulusEncoder_implant_reshape():
         npt.assert_equal(list(enc.electrodes), list(implant.electrode_names))
 
 
-def test_StimulusEncoder_encode_both():
+def test_StimulusEncoder_spatial_view():
     """The modulation half of encoding, with none of the device's timing in it
     """
     img = ImageStimulus(np.linspace(0, 1, 16).reshape((4, 4)))
     implant = pixel_implant((4, 4), SequentialRaster(4, interleave=True))
     enc = AmplitudeEncoder(amp_range=(0, 50), freq=100, frame_dur=100)
-    spatial, delivered = enc._encode_both(img, implant=implant)
-    # The delivered half is exactly what `encode` gives on its own:
-    npt.assert_array_equal(delivered.data, enc.encode(img,
-                                                      implant=implant).data)
+    delivered = enc.encode(img, implant=implant)
+    spatial = delivered._spatial_view()
+    # Asking for it does not expand the schedule into a waveform:
+    npt.assert_equal(_rendered(delivered), False)
 
     # One row per electrode, one column per frame of the source -- and an
     # image is one frame, so there is no time axis at all:
@@ -929,26 +929,27 @@ def test_StimulusEncoder_encode_both():
     # `encode`):
     vid = VideoStimulus(np.random.default_rng(0).random((4, 4, 5)),
                         metadata={'fps': 20})
-    spatial = enc._encode_both(vid, implant=implant)[0]
+    spatial = enc.encode(vid, implant=implant)._spatial_view()
     npt.assert_equal(spatial.shape, (16, 5))
     npt.assert_almost_equal(spatial.time, np.arange(5) * 100.0)
 
     # Encoding for no implant at all works the same way, at pixel resolution:
-    bare = enc._encode_both(img)[0]
+    bare = enc.encode(img)._spatial_view()
     npt.assert_equal(bare.shape, (16, 1))
     npt.assert_almost_equal(bare.data.ravel(), np.linspace(0, 1, 16) * 50,
                             decimal=4)
     # ... and a source that is not a picture is refused here too:
     with pytest.raises(DimensionMismatchError):
-        enc._encode_both(Stimulus([0.5]))
+        enc.encode(Stimulus([0.5]))
 
 
-def test_FrequencyEncoder_encode_both():
+def test_FrequencyEncoder_spatial_view():
     """A spatial reading of rate coding says what it can and no more"""
     grays = np.array([[0.0, 0.5], [0.75, 1.0]])
     img = ImageStimulus(grays)
     enc = FrequencyEncoder(freq_range=(0, 200), amp=30, frame_dur=100)
-    spatial, delivered = enc._encode_both(img)
+    delivered = enc.encode(img)
+    spatial = delivered._spatial_view()
     # Every electrode that pulses at all pulses at the same amplitude, which
     # is all a reader with no clock can be told, so rate collapses to on/off.
     # An electrode at 0 Hz never pulses, so it delivers no current -- that
@@ -1275,17 +1276,58 @@ def test_encoded_stimulus_is_independent_of_the_encoder():
         amp_range=(0, 50), freq=20).encode(img).data)
 
 
-@pytest.mark.parametrize('modify', [lambda s: s * 2, lambda s: s + 5,
-                                    lambda s: -s, lambda s: s >> 5])
+@pytest.mark.parametrize('modify', [lambda s: s + 5, lambda s: s >> 5,
+                                    lambda s: s * np.inf,
+                                    lambda s: s.pad(s.duration + 10)])
 def test_encoded_stimulus_transformations_degrade(modify):
     # A schedule describes when each electrode pulses and how hard on each
-    # frame. Rewriting the samples leaves it describing nothing, so what comes
-    # back is an ordinary stimulus:
+    # frame. A DC offset or a shift in time leaves it describing nothing, so
+    # what comes back is an ordinary stimulus:
     stim = AmplitudeEncoder().encode(
         ImageStimulus(np.linspace(0, 1, 64).reshape(8, 8)))
-    out = modify(stim)
+    with np.errstate(divide='ignore', invalid='ignore'):
+        out = modify(stim)
     npt.assert_equal(type(out), Stimulus)
     npt.assert_equal(out._is_parametric, False)
+
+
+@pytest.mark.parametrize('factor', [2, 0.5, -1, 1, 0])
+def test_encoded_stimulus_scaling_scales_both_descriptions(factor):
+    # Scaling changes how hard each electrode is driven, not when. So the
+    # schedule survives -- and the waveform and the modulation behind it move
+    # together, which is what `find_threshold` varies from trial to trial.
+    stim = AmplitudeEncoder().encode(
+        ImageStimulus(np.linspace(0, 1, 64).reshape(8, 8)))
+    view = stim._spatial_view()
+    scaled = stim * factor
+    npt.assert_equal(type(scaled), type(stim))
+    npt.assert_equal(_rendered(scaled), False)
+    npt.assert_allclose(scaled._spatial_view().data, factor * view.data,
+                        rtol=1e-6, atol=1e-6)
+    npt.assert_allclose(scaled.data, factor * stim.data, rtol=1e-6, atol=1e-6)
+    npt.assert_array_equal(scaled.time, stim.time)
+    # The frame clock is a fact about the source, and scaling is not:
+    npt.assert_equal(scaled.metadata['encoder'], stim.metadata['encoder'])
+    npt.assert_allclose(view.data, stim._spatial_view().data)
+
+
+def test_encoded_stimulus_drops_electrodes_structurally():
+    # An implant switching an electrode off must not cost the modulation view,
+    # which is the only thing a spatial model can read.
+    stim = AmplitudeEncoder().encode(
+        ImageStimulus(np.linspace(0, 1, 64).reshape(8, 8)))
+    fewer = stim._without_electrodes([0, 3])
+    npt.assert_equal(type(fewer), type(stim))
+    npt.assert_equal(_rendered(fewer), False)
+    npt.assert_equal(len(fewer.electrodes), 62)
+    kept_rows = [i for i in range(len(stim.electrodes)) if i not in (0, 3)]
+    npt.assert_array_equal(np.asarray(fewer.electrodes),
+                           np.asarray(stim.electrodes)[kept_rows])
+    # The same rows are gone from both descriptions of it:
+    npt.assert_array_equal(fewer._spatial_view().data,
+                           stim._spatial_view().data[kept_rows])
+    npt.assert_array_equal(fewer.data, stim.data[kept_rows])
+    npt.assert_array_equal(fewer.time, stim.time)
 
 
 def test_encoded_stimulus_validates_while_it_schedules():

--- a/pulse2percept/stimuli/tests/test_images.py
+++ b/pulse2percept/stimuli/tests/test_images.py
@@ -546,3 +546,28 @@ def test_ImageStimulus_invert_preserves_alpha():
     npt.assert_array_equal(inverted[..., 3], rgba[..., 3])
     # The original is untouched:
     npt.assert_array_equal(stim.data, before)
+
+
+@pytest.mark.parametrize('dtype', [np.float32, np.float64, np.uint8])
+def test_ImageStimulus_owns_its_data(dtype):
+    # `img_as_float32` hands back an already-float32 image unchanged, so that
+    # is the dtype where an image could end up sharing the caller's buffer:
+    arr = (np.linspace(0, 1, 24).reshape((4, 6)) if dtype != np.uint8
+           else np.arange(24, dtype=np.uint8).reshape((4, 6)))
+    arr = np.ascontiguousarray(arr, dtype=dtype)
+    stim = ImageStimulus(arr)
+    before = stim.data.copy()
+    arr[...] = 0
+    npt.assert_array_equal(stim.data, before)
+    npt.assert_equal(np.shares_memory(arr, stim.data), False)
+    npt.assert_equal(stim.data.flags.writeable, False)
+    # Freezing what the stimulus took must not reach back into what the
+    # caller kept:
+    npt.assert_equal(arr.flags.writeable, True)
+
+
+def test_ImageStimulus_does_not_alias_another_stimulus():
+    first = ImageStimulus(np.linspace(0, 1, 24, dtype=np.float32)
+                          .reshape((4, 6)))
+    second = ImageStimulus(first)
+    npt.assert_equal(np.shares_memory(first.data, second.data), False)

--- a/pulse2percept/stimuli/tests/test_pulse_trains.py
+++ b/pulse2percept/stimuli/tests/test_pulse_trains.py
@@ -358,12 +358,8 @@ def test_BiphasicPulseTrain_metadata_polarity():
                                     lambda pt: pt * np.nan,
                                     lambda pt: pt / 0])
 def test_BiphasicPulseTrain_metadata_invalidated(modify):
-    # A DC offset is neither biphasic nor charge-balanced; a non-finite factor
-    # leaves a waveform of infinities; an appended second train is no longer
-    # one train at one amplitude and frequency. Keeping the pulse parameters
-    # would have BiphasicAxonMapModel predict from numbers that no longer
-    # describe the stimulus, so they are dropped instead - the model rejects a
-    # stimulus whose parameters it cannot find:
+    # A DC offset is neither biphasic nor charge-balanced, and a non-finite
+    # factor leaves a waveform of infinities
     pt = BiphasicPulseTrain(20, 10, 0.45, stim_dur=100, metadata='userdata')
     with np.errstate(divide='ignore', invalid='ignore'):
         modified = modify(pt)
@@ -394,18 +390,9 @@ def test_BiphasicPulseTrain_metadata_shift():
 @pytest.mark.parametrize('modify, expected', [
     (lambda s: s * 2, 20), (lambda s: 2 * s, 20), (lambda s: s / 2, 5),
     (lambda s: -s, 10), (lambda s: s >> 5, 10), (lambda s: s + 0, 10),
-    # A negative factor that also resizes: the composed path dispatches to
-    # `_rescale_params`, not to the pulse train's own `_rescale_metadata`, so
-    # there is no `cathodic_first` to carry the sign and `amp` has to come
-    # back as a magnitude. The direct-BPT polarity tests all use factor -1,
-    # where the magnitude cannot tell the two apart:
     (lambda s: s * -2, 20), (lambda s: -2 * s, 20), (lambda s: s / -0.5, 20)])
 def test_Stimulus_rescales_electrode_metadata(modify, expected):
-    # A pulse train handed to an implant becomes one row of a plain Stimulus,
-    # and its parameters move to `metadata['electrodes']` - which is where
-    # BiphasicAxonMapModel reads them from. Scaling the composed stimulus has
-    # to reach them there too, or `implant.stim * 2` delivers twice the current
-    # and predicts the very same percept:
+    # A pulse train handed to an implant becomes one row of a plain Stimulus
     stim = Stimulus({'A1': BiphasicPulseTrain(20, 10, 0.45, stim_dur=100),
                      'B2': BiphasicPulseTrain(20, 4, 0.45, stim_dur=100)})
     modified = modify(stim)
@@ -419,8 +406,7 @@ def test_Stimulus_rescales_electrode_metadata(modify, expected):
     npt.assert_equal(modified.metadata['electrodes']['A1']['type'],
                      BiphasicPulseTrain)
     npt.assert_equal(stim.metadata['electrodes']['A1']['metadata']['amp'], 10)
-    # Scaling leaves the entry describable, so only `amp` moves - the entry is
-    # rescaled, not invalidated:
+    # Scaling leaves the entry describable
     for key, value in (('freq', 20), ('phase_dur', 0.45), ('delay_dur', 0)):
         npt.assert_equal(
             modified.metadata['electrodes']['A1']['metadata'][key], value)
@@ -430,9 +416,6 @@ def test_Stimulus_rescales_electrode_metadata(modify, expected):
                                     lambda s: s * np.inf,
                                     lambda s: s.append(s >> 1)])
 def test_Stimulus_invalidates_electrode_metadata(modify):
-    # ...and an operation that leaves the electrodes carrying something other
-    # than a biphasic pulse train has to drop their parameters, exactly as it
-    # would on the pulse train itself:
     stim = Stimulus({'A1': BiphasicPulseTrain(20, 10, 0.45, stim_dur=100)})
     with np.errstate(divide='ignore', invalid='ignore'):
         modified = modify(stim)
@@ -442,10 +425,7 @@ def test_Stimulus_invalidates_electrode_metadata(modify):
 
 
 def test_Stimulus_rescale_metadata_leaves_the_source_alone():
-    # A composed stimulus files the very dict its source carries, not a copy
-    # of it, so `composed.metadata[...]['metadata'] is pt.metadata`. Rescaling
-    # the composition must still not reach back into the pulse train the
-    # caller is holding.
+    # A composed stimulus files the very dict its source carries
     pt = BiphasicPulseTrain(20, 10, 0.45, stim_dur=100)
     composed = Stimulus({'A1': pt})
     scaled = composed * 2
@@ -467,10 +447,7 @@ def test_Stimulus_rescale_metadata_leaves_the_source_alone():
 
 @pytest.mark.parametrize('factor', [2, -2, None])
 def test_BiphasicPulseTrain_metadata_rescale_params_does_not_mutate(factor):
-    # `_rescale_params` returns the rewritten metadata and never modifies
-    # the dict it was given. No caller depends on that today -- every one of
-    # them hands it a dict `_shallow_copy` already deep-copied -- so only the
-    # contract holds a subclass author to it:
+    # `_rescale_params` returns the rewritten metadata
     meta = {'freq': 20, 'amp': 10, 'phase_dur': 0.45, 'delay_dur': 0,
             'user': None}
     before = dict(meta)
@@ -479,10 +456,7 @@ def test_BiphasicPulseTrain_metadata_rescale_params_does_not_mutate(factor):
 
 
 def test_Stimulus_rescale_metadata_mixed_sources():
-    # An implant's stimulus need not be all pulse trains. Each electrode's
-    # parameters go to the class that recorded them, so a train is
-    # transformed and an ordinary stimulus - which describes no waveform
-    # parameters at all - comes through exactly as it was:
+    # An implant's stimulus need not be all pulse trains
     plain = {'electrodes': {}, 'user': {'note': 'mine'}}
     stim = Stimulus({'A1': BiphasicPulseTrain(20, 10, 0.45, stim_dur=100),
                      'B2': Stimulus([[1, 2, 3]], time=[0, 1, 2],
@@ -514,10 +488,6 @@ def test_Stimulus_rescale_metadata_mixed_sources():
     {'type': BiphasicPulseTrain},                        # no metadata recorded
     'not-an-entry-at-all'])
 def test_Stimulus_rescale_metadata_tolerates_odd_entries(entry):
-    # `_rescale_metadata` calls a hook off the type it finds recorded in the
-    # entry, so an entry it cannot recognize has to come through unchanged: a
-    # user who hand-edited `metadata` gets their entry back, not an
-    # AttributeError from inside an arithmetic operator.
     stim = Stimulus({'A1': BiphasicPulseTrain(20, 10, 0.45, stim_dur=100)})
     stim.metadata['electrodes']['A1'] = entry
     for modified in (stim * 2, stim * -2, stim + 5, stim.append(stim >> 1)):
@@ -541,9 +511,7 @@ def test_Stimulus_rescale_metadata_leaves_plain_metadata_alone():
                           (225, 0.075, 0.075), (2000, 0.1, 0)])
 def test_PulseTrain_tiling(freq, phase_dur, interphase_dur):
     # The pulse train is assembled by tiling rather than by repeatedly calling
-    # `append`. The two must agree bit-for-bit: temporal models resolve
-    # stimulus edges on a fixed simulation grid, so even a sub-nanosecond
-    # difference in the time axis can change model output.
+    # `append`
     pulse = BiphasicPulse(20, phase_dur, interphase_dur=interphase_dur)
     n_pulses = 7
     window_dur = 1000.0 / freq
@@ -588,10 +556,6 @@ def test_PulseTrain_tiling_errors():
     (BiphasicTripletTrain, (20, 30, 0.45), {'interpulse_dur': 0.5}),
 ])
 def test_PulseTrain_electrode_name(cls, args, kwargs):
-    # The `electrode` argument is documented on every pulse train, so it must
-    # actually reach the Stimulus constructor. It also decides the key under
-    # which per-electrode metadata is filed, which is how BiphasicAxonMapModel
-    # looks up freq/amp/phase_dur.
     stim = cls(*args, stim_dur=100, electrode='A1', **kwargs)
     npt.assert_equal(stim.electrodes, ['A1'])
     # Without a name, electrodes are still numbered from 0:
@@ -777,7 +741,7 @@ def test_pulse_train_renders_once_and_only_when_asked(cls, build, params):
 def test_PulseTrain_snapshots_its_pulse():
     # Tiling used to copy the pulse values into the train there and then, so a
     # train must not change when the caller replaces the pulse it was built
-    # from. Immutable waveform state makes the snapshot share arrays.
+    # from
     pulse = BiphasicPulse(50, 0.45)
     train = PulseTrain(20, pulse, stim_dur=100)
     npt.assert_equal(train.pulse is pulse, False)
@@ -786,10 +750,7 @@ def test_PulseTrain_snapshots_its_pulse():
 
 
 def test_PulseTrain_pulse_is_not_a_way_into_the_train():
-    # `remove` and `compress` rewrite a stimulus in place, so handing out the
-    # retained pulse itself would let a caller rewrite what the train renders
-    # from -- and leave it driving electrodes its own name list does not
-    # mention. A plain Stimulus is the pulse that has those methods.
+    # `remove` and `compress` rewrite a stimulus in place
     pulse = Stimulus([[0, -50, 50, 0]], electrodes=['A1'],
                      time=[0, 0.1, 0.2, 0.3])
     train = PulseTrain(20, pulse, stim_dur=100)
@@ -804,9 +765,6 @@ def test_PulseTrain_pulse_is_not_a_way_into_the_train():
 
 @pytest.mark.parametrize('factor', [2, 0.5, -1, -2, 1, 0, 1e-3])
 def test_BiphasicPulseTrain_scaling_rebuilds_its_model_metadata(factor):
-    # Scaling every amplitude by a finite factor is exactly what a different
-    # `amp` does, so twice this train is the train at twice its amplitude,
-    # built from the parameters rather than degraded to a waveform.
     pt = BiphasicPulseTrain(20, 10, 0.45, interphase_dur=0.2, delay_dur=1,
                             stim_dur=100, metadata='userdata')
     routes = [pt * factor, factor * pt]
@@ -852,10 +810,6 @@ def test_BiphasicPulseTrain_scaling_matches_a_train_built_that_way():
                                     lambda pt: pt * np.nan,
                                     lambda pt: pt / 0])
 def test_BiphasicPulseTrain_inexact_operations_degrade(modify):
-    # A DC offset, a shift in time, a non-finite factor and an appended second
-    # train are none of them expressible in this class's parameters, so they
-    # hand back a plain stimulus rather than a train advertising numbers it no
-    # longer delivers:
     pt = BiphasicPulseTrain(20, 10, 0.45, stim_dur=100)
     with np.errstate(divide='ignore', invalid='ignore'):
         modified = modify(pt)
@@ -866,10 +820,6 @@ def test_BiphasicPulseTrain_inexact_operations_degrade(modify):
 @pytest.mark.parametrize('cls, build, params', TRAINS)
 @pytest.mark.parametrize('factor', [2, 0.5, -1, -2, 1, 0, 1e-3])
 def test_train_scaling_stays_a_train(cls, build, params, factor):
-    # Every train class is defined by the pulse it repeats and the clock it
-    # repeats it on. Scaling touches only the amplitude of that pulse, so the
-    # result is still one of these -- and is built from the parameters rather
-    # than from the tiled samples.
     train = build()
     reference = factor * np.asarray(train.data)
     for scaled in (train * factor, factor * train):
@@ -896,8 +846,7 @@ def test_train_scaling_stays_a_train(cls, build, params, factor):
 
 
 def test_PulseTrain_scaling_keeps_the_pulse_it_repeats():
-    # A generic train scales the pulse it tiles rather than the tiled samples,
-    # so a train of biphasic pulses stays a train of biphasic pulses:
+    # A generic train scales the pulse it tiles rather than the tiled samples
     train = PulseTrain(20, BiphasicPulse(50, 0.45), stim_dur=200)
     scaled = train * 2
     npt.assert_equal(scaled.pulse_type, 'BiphasicPulse')
@@ -906,10 +855,6 @@ def test_PulseTrain_scaling_keeps_the_pulse_it_repeats():
 
 
 def test_train_scaling_survives_a_partial_last_window():
-    # A 23 Hz train fits three whole pulses into 100 ms, which is more than
-    # the `n_pulses` guard's own estimate of 2.3 -- so rebuilding the train
-    # has to pass back the count that was *asked* for (None), not the one it
-    # resolved to.
     train = BiphasicPulseTrain(23, 20, 0.45, stim_dur=100)
     npt.assert_equal(train.n_pulses, 3)
     npt.assert_equal((train * 2).n_pulses, 3)

--- a/pulse2percept/stimuli/tests/test_pulse_trains.py
+++ b/pulse2percept/stimuli/tests/test_pulse_trains.py
@@ -355,8 +355,7 @@ def test_BiphasicPulseTrain_metadata_polarity():
                                     lambda pt: (pt + 5) * 2,
                                     lambda pt: pt * np.inf,
                                     lambda pt: pt * np.nan,
-                                    lambda pt: pt / 0,
-                                    lambda pt: pt.append(pt >> 1)])
+                                    lambda pt: pt / 0])
 def test_BiphasicPulseTrain_metadata_invalidated(modify):
     # A DC offset is neither biphasic nor charge-balanced; a non-finite factor
     # leaves a waveform of infinities; an appended second train is no longer
@@ -787,7 +786,7 @@ def test_PulseTrain_snapshots_its_pulse():
 
 
 @pytest.mark.parametrize('factor', [2, 0.5, -1, -2, 1, 0, 1e-3])
-def test_BiphasicPulseTrain_scaling_stays_a_pulse_train(factor):
+def test_BiphasicPulseTrain_scaling_rebuilds_its_model_metadata(factor):
     # Scaling every amplitude by a finite factor is exactly what a different
     # `amp` does, so the result is built from the parameters rather than
     # degraded to a waveform. `amp` is canonical state now, so twice this
@@ -835,8 +834,7 @@ def test_BiphasicPulseTrain_scaling_matches_a_train_built_that_way():
                                     lambda pt: pt << 1,
                                     lambda pt: pt * np.inf,
                                     lambda pt: pt * np.nan,
-                                    lambda pt: pt / 0,
-                                    lambda pt: pt.append(pt >> 1)])
+                                    lambda pt: pt / 0])
 def test_BiphasicPulseTrain_inexact_operations_degrade(modify):
     # A DC offset, a shift in time, a non-finite factor and an appended second
     # train are none of them expressible in this class's parameters, so they
@@ -849,13 +847,127 @@ def test_BiphasicPulseTrain_inexact_operations_degrade(modify):
     npt.assert_equal(modified._is_parametric, False)
 
 
-@pytest.mark.parametrize('cls, build, params',
-                         [t for t in TRAINS if t[0] is not BiphasicPulseTrain])
-def test_other_trains_still_degrade_under_scaling(cls, build, params):
-    # Structured scaling is `BiphasicPulseTrain` only for now, because that is
-    # the class the models read their parameters off. The others fall back
-    # safely until exact transformations arrive for all of them.
+@pytest.mark.parametrize('cls, build, params', TRAINS)
+@pytest.mark.parametrize('factor', [2, 0.5, -1, -2, 1, 0, 1e-3])
+def test_train_scaling_stays_a_train(cls, build, params, factor):
+    # Every train class is defined by the pulse it repeats and the clock it
+    # repeats it on. Scaling touches only the amplitude of that pulse, so the
+    # result is still one of these -- and is built from the parameters rather
+    # than from the tiled samples.
     train = build()
-    npt.assert_equal(type(train * 2), Stimulus)
+    reference = factor * np.asarray(train.data)
+    for scaled in (train * factor, factor * train):
+        npt.assert_equal(type(scaled), cls)
+        npt.assert_equal(_rendered(scaled), False)
+        npt.assert_allclose(scaled.data, reference, rtol=1e-6, atol=1e-6)
+        # The train's own clock is untouched by its amplitude:
+        for name in ('freq', 'n_pulses', 'stim_dur', 'phase_dur',
+                     'phase_dur1', 'phase_dur2', 'interphase_dur',
+                     'interpulse_dur', 'delay_dur'):
+            if name in params:
+                npt.assert_almost_equal(getattr(scaled, name), params[name])
+        for name in ('amp', 'amp1', 'amp2'):
+            if name in params:
+                npt.assert_almost_equal(getattr(scaled, name),
+                                        params[name] * abs(factor))
+        if 'cathodic_first' in params:
+            npt.assert_equal(scaled.cathodic_first,
+                             params['cathodic_first'] if factor >= 0
+                             else not params['cathodic_first'])
+    # The original is untouched:
+    for name, expected in params.items():
+        npt.assert_equal(getattr(train, name), expected)
+
+
+def test_PulseTrain_scaling_keeps_the_pulse_it_repeats():
+    # A generic train scales the pulse it tiles rather than the tiled samples,
+    # so a train of biphasic pulses stays a train of biphasic pulses:
+    train = PulseTrain(20, BiphasicPulse(50, 0.45), stim_dur=200)
+    scaled = train * 2
+    npt.assert_equal(scaled.pulse_type, 'BiphasicPulse')
+    npt.assert_almost_equal(scaled.pulse.amp, 100)
+    npt.assert_almost_equal(train.pulse.amp, 50)
+
+
+def test_train_scaling_survives_a_partial_last_window():
+    # A 23 Hz train fits three whole pulses into 100 ms, which is more than
+    # the `n_pulses` guard's own estimate of 2.3 -- so rebuilding the train
+    # has to pass back the count that was *asked* for (None), not the one it
+    # resolved to.
+    train = BiphasicPulseTrain(23, 20, 0.45, stim_dur=100)
+    npt.assert_equal(train.n_pulses, 3)
+    npt.assert_equal((train * 2).n_pulses, 3)
     npt.assert_allclose((train * 2).data, 2 * train.data, rtol=1e-6,
                         atol=1e-6)
+    # An explicitly requested count still comes back unchanged:
+    asked = BiphasicPulseTrain(23, 20, 0.45, n_pulses=2, stim_dur=100)
+    npt.assert_equal((asked * 2).n_pulses, 2)
+
+
+def test_append_keeps_two_distinct_protocols():
+    # The case the sequence exists for: a 20 Hz train followed by a 50 Hz one
+    # is two protocols, and neither frequency describes the whole thing.
+    pt20 = BiphasicPulseTrain(20, 10, 0.45, stim_dur=100, metadata='mine')
+    pt50 = BiphasicPulseTrain(50, 20, 0.45, stim_dur=100)
+    seq = pt20.append(pt50)
+    npt.assert_equal([p.freq for p in seq.parts], [20, 50])
+    npt.assert_equal([p.amp for p in seq.parts], [10, 20])
+    npt.assert_equal([type(p) for p in seq.parts],
+                     [BiphasicPulseTrain, BiphasicPulseTrain])
+    # No single `freq` is claimed, and the parameters a model reads are gone
+    # rather than stale -- what the user put in metadata is still theirs:
+    npt.assert_equal(hasattr(seq, 'freq'), False)
+    npt.assert_equal(seq.metadata, {'user': 'mine'})
+    # Appending again extends the sequence rather than nesting one in another:
+    npt.assert_equal(len(seq.append(pt20).parts), 3)
+    npt.assert_equal([p.freq for p in seq.append(pt20).parts], [20, 50, 20])
+
+
+def test_append_renders_what_the_waveform_append_did():
+    pt20 = BiphasicPulseTrain(20, 10, 0.45, stim_dur=100)
+    pt50 = BiphasicPulseTrain(50, 20, 0.45, stim_dur=100)
+    plain20 = Stimulus(pt20.data, electrodes=pt20.electrodes, time=pt20.time)
+    plain50 = Stimulus(pt50.data, electrodes=pt50.electrodes, time=pt50.time)
+    expected = plain20.append(plain50)
+    seq = pt20.append(pt50)
+    npt.assert_array_equal(seq.data, expected.data)
+    npt.assert_array_equal(seq.time, expected.time)
+    npt.assert_almost_equal(seq.duration, 200)
+
+
+def test_append_scaling_scales_every_part():
+    pt20 = BiphasicPulseTrain(20, 10, 0.45, stim_dur=100)
+    pt50 = BiphasicPulseTrain(50, 20, 0.45, stim_dur=100)
+    seq = pt20.append(pt50)
+    scaled = seq * 2
+    npt.assert_equal(type(scaled), type(seq))
+    npt.assert_equal([p.amp for p in scaled.parts], [20, 40])
+    npt.assert_allclose(scaled.data, 2 * seq.data, rtol=1e-6, atol=1e-6)
+    npt.assert_equal([p.amp for p in seq.parts], [10, 20])
+
+
+@pytest.mark.parametrize('modify', [lambda s: s + 5, lambda s: s >> 5,
+                                    lambda s: s.pad(s.duration + 10)])
+def test_append_inexact_operations_degrade(modify):
+    # A DC offset or a shift in time is not something the parts describe, so
+    # the sequence gives way to a plain waveform:
+    seq = (BiphasicPulseTrain(20, 10, 0.45, stim_dur=100)
+           .append(BiphasicPulseTrain(50, 20, 0.45, stim_dur=100)))
+    out = modify(seq)
+    npt.assert_equal(type(out), Stimulus)
+    npt.assert_equal(out._is_parametric, False)
+
+
+def test_append_still_rejects_what_it_always_did():
+    pt = BiphasicPulseTrain(20, 10, 0.45, stim_dur=100)
+    with pytest.raises(TypeError):
+        pt.append(5)
+    with pytest.raises(ValueError):
+        # Different electrodes:
+        pt.append(BiphasicPulseTrain(20, 10, 0.45, stim_dur=100,
+                                     electrode='A1'))
+    with pytest.raises(ValueError):
+        # `other` starts at t=0 with an amplitude this one does not end on:
+        pt.append(Stimulus([[5, 5]], electrodes=pt.electrodes, time=[0, 10]))
+    with pytest.raises(DimensionMismatchError):
+        pt.append(VideoStimulus(np.ones((1, 1, 3))))

--- a/pulse2percept/stimuli/tests/test_pulse_trains.py
+++ b/pulse2percept/stimuli/tests/test_pulse_trains.py
@@ -339,9 +339,13 @@ def test_BiphasicPulseTrain_metadata_polarity():
     for flipped in (-pt, pt * -1, 0 - pt, pt / -1):
         npt.assert_almost_equal(flipped.data, -pt.data)
         npt.assert_equal(flipped.metadata['amp'], 10)
-        npt.assert_equal(flipped.cathodic_first, not pt.cathodic_first)
+        # A flipped train is not a BiphasicPulseTrain: its parameters would
+        # have to describe a waveform it no longer has (see
+        # `Stimulus._derived`), so the swapped phases live in the data rather
+        # than on a `cathodic_first` flag.
+        npt.assert_equal(type(flipped), Stimulus)
     # Flipping twice comes back to where it started:
-    npt.assert_equal((-(-pt)).cathodic_first, pt.cathodic_first)
+    npt.assert_almost_equal((-(-pt)).data, pt.data)
     # A flipped train is the train that was built the other way round:
     direct = BiphasicPulseTrain(20, 10, 0.45, stim_dur=100,
                                 cathodic_first=False)
@@ -379,7 +383,9 @@ def test_BiphasicPulseTrain_metadata_shift():
     pt = BiphasicPulseTrain(20, 10, 0.45, stim_dur=100)
     for shifted in (pt >> 5, pt << 5, pt + 0, pt - 0):
         npt.assert_equal(shifted.metadata, pt.metadata)
-        npt.assert_equal(shifted.cathodic_first, pt.cathodic_first)
+        # ...on a plain Stimulus, though: a shifted train no longer ends where
+        # its `stim_dur` says (see `Stimulus._derived`).
+        npt.assert_equal(type(shifted), Stimulus)
     npt.assert_almost_equal((pt >> 5).time, pt.time + 5)
 
 

--- a/pulse2percept/stimuli/tests/test_pulse_trains.py
+++ b/pulse2percept/stimuli/tests/test_pulse_trains.py
@@ -339,13 +339,10 @@ def test_BiphasicPulseTrain_metadata_polarity():
     for flipped in (-pt, pt * -1, 0 - pt, pt / -1):
         npt.assert_almost_equal(flipped.data, -pt.data)
         npt.assert_equal(flipped.metadata['amp'], 10)
-        # A flipped train is not a BiphasicPulseTrain: its parameters would
-        # have to describe a waveform it no longer has (see
-        # `Stimulus._derived`), so the swapped phases live in the data rather
-        # than on a `cathodic_first` flag.
-        npt.assert_equal(type(flipped), Stimulus)
+        npt.assert_equal(type(flipped), BiphasicPulseTrain)
+        npt.assert_equal(flipped.cathodic_first, not pt.cathodic_first)
     # Flipping twice comes back to where it started:
-    npt.assert_almost_equal((-(-pt)).data, pt.data)
+    npt.assert_equal((-(-pt)).cathodic_first, pt.cathodic_first)
     # A flipped train is the train that was built the other way round:
     direct = BiphasicPulseTrain(20, 10, 0.45, stim_dur=100,
                                 cathodic_first=False)
@@ -381,11 +378,16 @@ def test_BiphasicPulseTrain_metadata_shift():
     # A shift moves the whole train, but every pulse in it keeps its
     # amplitude, frequency and duration:
     pt = BiphasicPulseTrain(20, 10, 0.45, stim_dur=100)
-    for shifted in (pt >> 5, pt << 5, pt + 0, pt - 0):
+    for shifted in (pt >> 5, pt << 5):
         npt.assert_equal(shifted.metadata, pt.metadata)
         # ...on a plain Stimulus, though: a shifted train no longer ends where
         # its `stim_dur` says (see `Stimulus._derived`).
         npt.assert_equal(type(shifted), Stimulus)
+    # Adding zero changes nothing at all, so what comes back is still a train:
+    for same in (pt + 0, pt - 0):
+        npt.assert_equal(same.metadata, pt.metadata)
+        npt.assert_equal(type(same), BiphasicPulseTrain)
+        npt.assert_equal(same.cathodic_first, pt.cathodic_first)
     npt.assert_almost_equal((pt >> 5).time, pt.time + 5)
 
 
@@ -700,3 +702,160 @@ def test_PulseTrain_unit_provenance():
                   AsymmetricBiphasicPulseTrain(20, -40, 10, 1, 4,
                                                stim_dur=200)):
         npt.assert_equal(train.unit, uA)
+
+
+def _rendered(stim):
+    """Whether the stimulus has generated its waveform yet
+
+    Reads the private container, because every public attribute that could
+    answer the question would generate one first.
+    """
+    return stim._Stimulus__stim['data'] is not None
+
+
+TRAINS = [
+    (PulseTrain,
+     lambda: PulseTrain(20, BiphasicPulse(50, 0.45), stim_dur=30000),
+     {'freq': 20, 'n_pulses': 600, 'stim_dur': 30000,
+      'pulse_type': 'BiphasicPulse'}),
+    (BiphasicPulseTrain,
+     lambda: BiphasicPulseTrain(20, 50, 0.45, interphase_dur=0.2,
+                                delay_dur=1, stim_dur=30000,
+                                cathodic_first=False),
+     {'freq': 20, 'amp': 50, 'phase_dur': 0.45, 'interphase_dur': 0.2,
+      'delay_dur': 1, 'cathodic_first': False, 'n_pulses': 600,
+      'stim_dur': 30000}),
+    (AsymmetricBiphasicPulseTrain,
+     lambda: AsymmetricBiphasicPulseTrain(20, 50, 20, 0.45, 0.9,
+                                          stim_dur=30000),
+     {'freq': 20, 'amp1': 50, 'amp2': 20, 'phase_dur1': 0.45,
+      'phase_dur2': 0.9, 'interphase_dur': 0, 'delay_dur': 0,
+      'cathodic_first': True, 'n_pulses': 600, 'stim_dur': 30000}),
+    (BiphasicTripletTrain,
+     lambda: BiphasicTripletTrain(20, 50, 0.45, interpulse_dur=1,
+                                  stim_dur=30000),
+     {'freq': 20, 'amp': 50, 'phase_dur': 0.45, 'interphase_dur': 0,
+      'interpulse_dur': 1, 'delay_dur': 0, 'cathodic_first': True,
+      'n_pulses': 600, 'stim_dur': 30000}),
+]
+
+
+@pytest.mark.parametrize('cls, build, params', TRAINS)
+def test_pulse_train_parameters_are_canonical(cls, build, params):
+    train = build()
+    for name, expected in params.items():
+        npt.assert_equal(getattr(train, name), expected)
+
+
+@pytest.mark.parametrize('cls, build, params', TRAINS)
+def test_pulse_train_parameters_are_read_only(cls, build, params):
+    train = build()
+    for name in params:
+        with pytest.raises(AttributeError):
+            setattr(train, name, 1)
+
+
+@pytest.mark.parametrize('cls, build, params', TRAINS)
+def test_pulse_train_renders_once_and_only_when_asked(cls, build, params):
+    # A 30-second train delivers 600 pulses; not one of them is sampled until
+    # something asks for a waveform.
+    train = build()
+    npt.assert_equal(_rendered(train), False)
+    for name in params:
+        getattr(train, name)
+    npt.assert_equal(len(train.electrodes), 1)
+    repr(train)
+    npt.assert_equal(_rendered(train), False)
+    first = train.data
+    npt.assert_equal(_rendered(train), True)
+    for _ in range(3):
+        npt.assert_equal(np.shares_memory(train.data, first), True)
+    npt.assert_equal(train.data.flags.writeable, False)
+    npt.assert_equal(train.data.dtype, np.float32)
+    npt.assert_equal(train.time.dtype, np.float64)
+
+
+def test_PulseTrain_snapshots_its_pulse():
+    # Tiling used to copy the pulse values into the train there and then, so a
+    # train must not change when the caller replaces the pulse it was built
+    # from. Immutable waveform state makes the snapshot share arrays.
+    pulse = BiphasicPulse(50, 0.45)
+    train = PulseTrain(20, pulse, stim_dur=100)
+    npt.assert_equal(train.pulse is pulse, False)
+    npt.assert_equal(train.pulse.amp, pulse.amp)
+    npt.assert_equal(train.pulse_type, 'BiphasicPulse')
+
+
+@pytest.mark.parametrize('factor', [2, 0.5, -1, -2, 1, 0, 1e-3])
+def test_BiphasicPulseTrain_scaling_stays_a_pulse_train(factor):
+    # Scaling every amplitude by a finite factor is exactly what a different
+    # `amp` does, so the result is built from the parameters rather than
+    # degraded to a waveform. `amp` is canonical state now, so twice this
+    # train is the train at twice its amplitude:
+    pt = BiphasicPulseTrain(20, 10, 0.45, interphase_dur=0.2, delay_dur=1,
+                            stim_dur=100, metadata='userdata')
+    routes = [pt * factor, factor * pt]
+    if factor:
+        routes.append(pt / (1 / factor))
+    for scaled in routes:
+        npt.assert_equal(type(scaled), BiphasicPulseTrain)
+        npt.assert_almost_equal(scaled.amp, pt.amp * abs(factor))
+        npt.assert_equal(scaled.cathodic_first,
+                         pt.cathodic_first if factor >= 0
+                         else not pt.cathodic_first)
+        # Everything else is untouched:
+        for name in ('freq', 'phase_dur', 'interphase_dur', 'delay_dur',
+                     'n_pulses', 'stim_dur'):
+            npt.assert_almost_equal(getattr(scaled, name), getattr(pt, name))
+        # What the user put in the metadata is theirs; the compatibility keys
+        # are rebuilt by the constructor, from the new amplitude:
+        npt.assert_equal(scaled.metadata['user'], 'userdata')
+        npt.assert_almost_equal(scaled.metadata['amp'], pt.amp * abs(factor))
+        # ...and the waveform is the scaled one, to within float32 rounding:
+        npt.assert_allclose(scaled.data, factor * pt.data, rtol=1e-6,
+                            atol=1e-6)
+    # The original is untouched:
+    npt.assert_equal(pt.amp, 10)
+    npt.assert_equal(pt.cathodic_first, True)
+
+
+def test_BiphasicPulseTrain_scaling_matches_a_train_built_that_way():
+    pt = BiphasicPulseTrain(20, 10, 0.45, stim_dur=100)
+    direct = BiphasicPulseTrain(20, 20, 0.45, stim_dur=100)
+    npt.assert_array_equal((pt * 2).data, direct.data)
+    npt.assert_array_equal((pt * 2).time, direct.time)
+    npt.assert_equal((pt * 2).metadata, direct.metadata)
+    flipped = BiphasicPulseTrain(20, 10, 0.45, stim_dur=100,
+                                 cathodic_first=False)
+    npt.assert_array_equal((-pt).data, flipped.data)
+
+
+@pytest.mark.parametrize('modify', [lambda pt: pt + 5, lambda pt: pt - 5,
+                                    lambda pt: 5 - pt, lambda pt: pt >> 5,
+                                    lambda pt: pt << 1,
+                                    lambda pt: pt * np.inf,
+                                    lambda pt: pt * np.nan,
+                                    lambda pt: pt / 0,
+                                    lambda pt: pt.append(pt >> 1)])
+def test_BiphasicPulseTrain_inexact_operations_degrade(modify):
+    # A DC offset, a shift in time, a non-finite factor and an appended second
+    # train are none of them expressible in this class's parameters, so they
+    # hand back a plain stimulus rather than a train advertising numbers it no
+    # longer delivers:
+    pt = BiphasicPulseTrain(20, 10, 0.45, stim_dur=100)
+    with np.errstate(divide='ignore', invalid='ignore'):
+        modified = modify(pt)
+    npt.assert_equal(type(modified), Stimulus)
+    npt.assert_equal(modified._is_parametric, False)
+
+
+@pytest.mark.parametrize('cls, build, params',
+                         [t for t in TRAINS if t[0] is not BiphasicPulseTrain])
+def test_other_trains_still_degrade_under_scaling(cls, build, params):
+    # Structured scaling is `BiphasicPulseTrain` only for now, because that is
+    # the class the models read their parameters off. The others fall back
+    # safely until exact transformations arrive for all of them.
+    train = build()
+    npt.assert_equal(type(train * 2), Stimulus)
+    npt.assert_allclose((train * 2).data, 2 * train.data, rtol=1e-6,
+                        atol=1e-6)

--- a/pulse2percept/stimuli/tests/test_pulse_trains.py
+++ b/pulse2percept/stimuli/tests/test_pulse_trains.py
@@ -1,4 +1,5 @@
 import warnings
+from copy import deepcopy
 
 import numpy as np
 import pytest
@@ -444,9 +445,7 @@ def test_Stimulus_rescale_metadata_leaves_the_source_alone():
     # A composed stimulus files the very dict its source carries, not a copy
     # of it, so `composed.metadata[...]['metadata'] is pt.metadata`. Rescaling
     # the composition must still not reach back into the pulse train the
-    # caller is holding. What keeps it out is the deep copy `_shallow_copy`
-    # takes before `_rescale_metadata` rewrites anything; drop that and an
-    # operator corrupts an object it was never handed:
+    # caller is holding.
     pt = BiphasicPulseTrain(20, 10, 0.45, stim_dur=100)
     composed = Stimulus({'A1': pt})
     scaled = composed * 2
@@ -468,12 +467,10 @@ def test_Stimulus_rescale_metadata_leaves_the_source_alone():
 
 @pytest.mark.parametrize('factor', [2, -2, None])
 def test_BiphasicPulseTrain_metadata_rescale_params_does_not_mutate(factor):
-    # `_rescale_params` is documented to return the rewritten metadata and
-    # never to modify the dict it was given. Today every caller hands it a
-    # dict that `_shallow_copy` already deep-copied, so breaking this would
-    # not corrupt anything - which is exactly why it needs its own test. A
-    # subclass author writing the next `_rescale_params` reads the contract,
-    # not the call sites:
+    # `_rescale_params` returns the rewritten metadata and never modifies
+    # the dict it was given. No caller depends on that today -- every one of
+    # them hands it a dict `_shallow_copy` already deep-copied -- so only the
+    # contract holds a subclass author to it:
     meta = {'freq': 20, 'amp': 10, 'phase_dur': 0.45, 'delay_dur': 0,
             'user': None}
     before = dict(meta)
@@ -517,12 +514,10 @@ def test_Stimulus_rescale_metadata_mixed_sources():
     {'type': BiphasicPulseTrain},                        # no metadata recorded
     'not-an-entry-at-all'])
 def test_Stimulus_rescale_metadata_tolerates_odd_entries(entry):
-    # p2p writes these entries itself, so none of this arises in practice.
-    # But `_rescale_metadata` walks whatever is in the dict and calls a hook
-    # off the type it finds recorded there, so an entry it cannot recognize
-    # has to come through unchanged rather than be assumed to implement the
-    # hook - a user who has hand-edited `metadata` gets their entry back, not
-    # an AttributeError from inside an arithmetic operator:
+    # `_rescale_metadata` calls a hook off the type it finds recorded in the
+    # entry, so an entry it cannot recognize has to come through unchanged: a
+    # user who hand-edited `metadata` gets their entry back, not an
+    # AttributeError from inside an arithmetic operator.
     stim = Stimulus({'A1': BiphasicPulseTrain(20, 10, 0.45, stim_dur=100)})
     stim.metadata['electrodes']['A1'] = entry
     for modified in (stim * 2, stim * -2, stim + 5, stim.append(stim >> 1)):
@@ -744,6 +739,11 @@ def test_pulse_train_parameters_are_canonical(cls, build, params):
     train = build()
     for name, expected in params.items():
         npt.assert_equal(getattr(train, name), expected)
+    # `duration` is one of them: `stim_dur` already says where the train ends,
+    # so asking must not tile 600 pulses to find out.
+    npt.assert_almost_equal(train.duration, params['stim_dur'])
+    npt.assert_equal(_rendered(train), False)
+    npt.assert_almost_equal(train.time[-1], train.duration, decimal=3)
 
 
 @pytest.mark.parametrize('cls, build, params', TRAINS)
@@ -785,12 +785,28 @@ def test_PulseTrain_snapshots_its_pulse():
     npt.assert_equal(train.pulse_type, 'BiphasicPulse')
 
 
+def test_PulseTrain_pulse_is_not_a_way_into_the_train():
+    # `remove` and `compress` rewrite a stimulus in place, so handing out the
+    # retained pulse itself would let a caller rewrite what the train renders
+    # from -- and leave it driving electrodes its own name list does not
+    # mention. A plain Stimulus is the pulse that has those methods.
+    pulse = Stimulus([[0, -50, 50, 0]], electrodes=['A1'],
+                     time=[0, 0.1, 0.2, 0.3])
+    train = PulseTrain(20, pulse, stim_dur=100)
+    train.pulse.remove('all')
+    npt.assert_equal(len(train.pulse.electrodes), 1)
+    npt.assert_equal(train.data.shape[0], 1)
+    # A copy renders from a pulse of its own, too:
+    copied = deepcopy(train)
+    copied._pulse.compress()
+    npt.assert_equal(train._pulse.is_compressed, False)
+
+
 @pytest.mark.parametrize('factor', [2, 0.5, -1, -2, 1, 0, 1e-3])
 def test_BiphasicPulseTrain_scaling_rebuilds_its_model_metadata(factor):
     # Scaling every amplitude by a finite factor is exactly what a different
-    # `amp` does, so the result is built from the parameters rather than
-    # degraded to a waveform. `amp` is canonical state now, so twice this
-    # train is the train at twice its amplitude:
+    # `amp` does, so twice this train is the train at twice its amplitude,
+    # built from the parameters rather than degraded to a waveform.
     pt = BiphasicPulseTrain(20, 10, 0.45, interphase_dur=0.2, delay_dur=1,
                             stim_dur=100, metadata='userdata')
     routes = [pt * factor, factor * pt]
@@ -904,58 +920,21 @@ def test_train_scaling_survives_a_partial_last_window():
     npt.assert_equal((asked * 2).n_pulses, 2)
 
 
-def test_append_keeps_two_distinct_protocols():
-    # The case the sequence exists for: a 20 Hz train followed by a 50 Hz one
-    # is two protocols, and neither frequency describes the whole thing.
+def test_append_gives_a_plain_waveform():
+    # No single frequency describes a 20 Hz train followed by a 50 Hz one, so
+    # the result stops claiming to be a train at all.
     pt20 = BiphasicPulseTrain(20, 10, 0.45, stim_dur=100, metadata='mine')
     pt50 = BiphasicPulseTrain(50, 20, 0.45, stim_dur=100)
-    seq = pt20.append(pt50)
-    npt.assert_equal([p.freq for p in seq.parts], [20, 50])
-    npt.assert_equal([p.amp for p in seq.parts], [10, 20])
-    npt.assert_equal([type(p) for p in seq.parts],
-                     [BiphasicPulseTrain, BiphasicPulseTrain])
-    # No single `freq` is claimed, and the parameters a model reads are gone
-    # rather than stale -- what the user put in metadata is still theirs:
-    npt.assert_equal(hasattr(seq, 'freq'), False)
-    npt.assert_equal(seq.metadata, {'user': 'mine'})
-    # Appending again extends the sequence rather than nesting one in another:
-    npt.assert_equal(len(seq.append(pt20).parts), 3)
-    npt.assert_equal([p.freq for p in seq.append(pt20).parts], [20, 50, 20])
-
-
-def test_append_renders_what_the_waveform_append_did():
-    pt20 = BiphasicPulseTrain(20, 10, 0.45, stim_dur=100)
-    pt50 = BiphasicPulseTrain(50, 20, 0.45, stim_dur=100)
+    out = pt20.append(pt50)
+    npt.assert_equal(type(out), Stimulus)
+    npt.assert_equal(hasattr(out, 'freq'), False)
+    # ...and it is the concatenation the waveforms alone would have produced:
     plain20 = Stimulus(pt20.data, electrodes=pt20.electrodes, time=pt20.time)
     plain50 = Stimulus(pt50.data, electrodes=pt50.electrodes, time=pt50.time)
     expected = plain20.append(plain50)
-    seq = pt20.append(pt50)
-    npt.assert_array_equal(seq.data, expected.data)
-    npt.assert_array_equal(seq.time, expected.time)
-    npt.assert_almost_equal(seq.duration, 200)
-
-
-def test_append_scaling_scales_every_part():
-    pt20 = BiphasicPulseTrain(20, 10, 0.45, stim_dur=100)
-    pt50 = BiphasicPulseTrain(50, 20, 0.45, stim_dur=100)
-    seq = pt20.append(pt50)
-    scaled = seq * 2
-    npt.assert_equal(type(scaled), type(seq))
-    npt.assert_equal([p.amp for p in scaled.parts], [20, 40])
-    npt.assert_allclose(scaled.data, 2 * seq.data, rtol=1e-6, atol=1e-6)
-    npt.assert_equal([p.amp for p in seq.parts], [10, 20])
-
-
-@pytest.mark.parametrize('modify', [lambda s: s + 5, lambda s: s >> 5,
-                                    lambda s: s.pad(s.duration + 10)])
-def test_append_inexact_operations_degrade(modify):
-    # A DC offset or a shift in time is not something the parts describe, so
-    # the sequence gives way to a plain waveform:
-    seq = (BiphasicPulseTrain(20, 10, 0.45, stim_dur=100)
-           .append(BiphasicPulseTrain(50, 20, 0.45, stim_dur=100)))
-    out = modify(seq)
-    npt.assert_equal(type(out), Stimulus)
-    npt.assert_equal(out._is_parametric, False)
+    npt.assert_array_equal(out.data, expected.data)
+    npt.assert_array_equal(out.time, expected.time)
+    npt.assert_almost_equal(out.duration, 200)
 
 
 def test_append_still_rejects_what_it_always_did():

--- a/pulse2percept/stimuli/tests/test_pulses.py
+++ b/pulse2percept/stimuli/tests/test_pulses.py
@@ -1,3 +1,5 @@
+from contextlib import contextmanager
+
 import numpy as np
 import numpy.testing as npt
 import pytest
@@ -338,3 +340,136 @@ def test_pulse_units():
         AsymmetricBiphasicPulse(-40 * ms, 10, 1, 4)
     with pytest.raises(DimensionMismatchError):
         AsymmetricBiphasicPulse(-40, 10, 1, 4, interphase_dur=1 * uA)
+
+
+@contextmanager
+def counting_renders(cls):
+    """Count how often ``cls`` generates a waveform inside the block"""
+    original = cls._render
+    counts = []
+
+    def counted(self):
+        counts.append(type(self).__name__)
+        return original(self)
+    cls._render = counted
+    try:
+        yield counts
+    finally:
+        cls._render = original
+
+
+def _rendered(stim):
+    """Whether the stimulus has generated its waveform yet
+
+    Reads the private container, because every public attribute that could
+    answer the question would generate one first.
+    """
+    return stim._Stimulus__stim['data'] is not None
+
+
+# One entry per (class, build, the parameters that define it):
+PULSES = [
+    (MonophasicPulse,
+     lambda: MonophasicPulse(-20, 1, delay_dur=2, stim_dur=10),
+     {'amp': -20, 'phase_dur': 1, 'delay_dur': 2, 'stim_dur': 10,
+      'cathodic': True}),
+    (MonophasicPulse,
+     lambda: MonophasicPulse(13, 0.45),
+     {'amp': 13, 'phase_dur': 0.45, 'delay_dur': 0, 'stim_dur': 0.45,
+      'cathodic': False}),
+    (BiphasicPulse,
+     lambda: BiphasicPulse(-20, 1, interphase_dur=0.5, delay_dur=2,
+                           stim_dur=10),
+     {'amp': 20, 'phase_dur': 1, 'interphase_dur': 0.5, 'delay_dur': 2,
+      'stim_dur': 10, 'cathodic_first': True}),
+    (BiphasicPulse,
+     lambda: BiphasicPulse(20, 0.45, cathodic_first=False),
+     {'amp': 20, 'phase_dur': 0.45, 'interphase_dur': 0, 'delay_dur': 0,
+      'stim_dur': 0.9, 'cathodic_first': False}),
+    (AsymmetricBiphasicPulse,
+     lambda: AsymmetricBiphasicPulse(-40, 10, 1, 4, interphase_dur=1,
+                                     delay_dur=2, stim_dur=15),
+     {'amp1': 40, 'amp2': 10, 'phase_dur1': 1, 'phase_dur2': 4,
+      'interphase_dur': 1, 'delay_dur': 2, 'stim_dur': 15,
+      'cathodic_first': True}),
+    (AsymmetricBiphasicPulse,
+     lambda: AsymmetricBiphasicPulse(40, 10, 0.45, 0.9, cathodic_first=False),
+     {'amp1': 40, 'amp2': 10, 'phase_dur1': 0.45, 'phase_dur2': 0.9,
+      'interphase_dur': 0, 'delay_dur': 0, 'stim_dur': 1.35,
+      'cathodic_first': False}),
+]
+
+
+@pytest.mark.parametrize('cls, build, params', PULSES)
+def test_pulse_parameters_are_canonical(cls, build, params):
+    # A pulse reads back the parameters it was built from. The two amplitude
+    # conventions differ on purpose: a monophasic pulse gets its polarity from
+    # the sign of `amp`, a biphasic one from `cathodic_first`, so the latter
+    # keeps only the magnitude (which is all of it that reaches the waveform).
+    pulse = build()
+    for name, expected in params.items():
+        npt.assert_almost_equal(getattr(pulse, name), expected)
+    # The asymmetric parameters stay distinct from one another:
+    if cls is AsymmetricBiphasicPulse:
+        npt.assert_equal(pulse.amp1 != pulse.amp2, True)
+        npt.assert_equal(pulse.phase_dur1 != pulse.phase_dur2, True)
+
+
+@pytest.mark.parametrize('cls, build, params', PULSES)
+def test_pulse_parameters_are_read_only(cls, build, params):
+    # Assigning one would leave a cached waveform contradicting the pulse it
+    # is supposed to describe. Build another pulse instead:
+    pulse = build()
+    for name in params:
+        with pytest.raises(AttributeError):
+            setattr(pulse, name, 1)
+
+
+@pytest.mark.parametrize('cls, build, params', PULSES)
+def test_pulse_renders_once_and_only_when_asked(cls, build, params):
+    with counting_renders(cls) as counts:
+        pulse = build()
+        npt.assert_equal(_rendered(pulse), False)
+        npt.assert_equal(counts, [])
+        # Everything a pulse knows from its parameters alone:
+        for name in params:
+            getattr(pulse, name)
+        npt.assert_equal(list(pulse.electrodes), [0])
+        npt.assert_almost_equal(pulse.duration, params['stim_dur'])
+        repr(pulse)
+        npt.assert_equal(counts, [])
+        npt.assert_equal(_rendered(pulse), False)
+        # ...and the waveform, which is generated exactly once:
+        npt.assert_equal(pulse.data.shape[0], 1)
+        npt.assert_equal(len(counts), 1)
+        npt.assert_equal(_rendered(pulse), True)
+        for _ in range(3):
+            pulse.data, pulse.time, pulse.shape, pulse[0, 0.001]
+        npt.assert_equal(len(counts), 1)
+        # `duration` is the same number the waveform ends on:
+        npt.assert_almost_equal(pulse.duration, pulse.time[-1])
+
+
+@pytest.mark.parametrize('cls, build, params', PULSES)
+def test_pulse_rendered_state_is_immutable(cls, build, params):
+    pulse = build()
+    npt.assert_equal(pulse.data.flags.writeable, False)
+    npt.assert_equal(pulse.time.flags.writeable, False)
+    npt.assert_equal(pulse.data.dtype, np.float32)
+    npt.assert_equal(pulse.time.dtype, np.float64)
+    npt.assert_equal(pulse.data.flags['C_CONTIGUOUS'], True)
+
+
+def test_pulse_electrode_names():
+    # An unnamed pulse is electrode 0, as `Stimulus` has always numbered it:
+    npt.assert_equal(list(MonophasicPulse(-20, 1).electrodes), [0])
+    npt.assert_equal(list(BiphasicPulse(-20, 1, electrode='C3').electrodes),
+                     ['C3'])
+    # A pulse drives one electrode, and says so at construction rather than
+    # leaving the mismatch to surface out of the waveform:
+    for build in (lambda e: MonophasicPulse(-20, 1, electrode=e),
+                  lambda e: BiphasicPulse(-20, 1, electrode=e),
+                  lambda e: AsymmetricBiphasicPulse(-40, 10, 1, 4,
+                                                    electrode=e)):
+        with pytest.raises(ValueError):
+            build(['A1', 'B2'])

--- a/pulse2percept/stimuli/tests/test_pulses.py
+++ b/pulse2percept/stimuli/tests/test_pulses.py
@@ -545,23 +545,19 @@ def test_pulse_scaling_stays_a_pulse(cls, build, params, factor):
 
 
 @pytest.mark.parametrize('cls, build, params', PULSES)
-def test_pulse_append_keeps_both_pulses(cls, build, params):
-    # A pulse laid after another is two pulses, so the result keeps both
-    # rather than becoming an anonymous waveform -- but it is no longer one
-    # pulse, and does not answer as one.
+def test_pulse_append_gives_a_plain_waveform(cls, build, params):
+    # Two pulses laid end to end are not one pulse, so the result stops
+    # answering as one rather than reporting parameters that describe half
+    # of it.
     pulse = build()
-    seq = pulse.append(pulse >> DT)
-    npt.assert_equal(type(seq).__name__, '_SequenceStimulus')
-    npt.assert_equal(len(seq.parts), 2)
-    npt.assert_equal(type(seq.parts[0]), cls)
+    out = pulse.append(pulse >> DT)
+    npt.assert_equal(type(out), Stimulus)
     for name in params:
-        npt.assert_equal(hasattr(seq, name), False)
-        npt.assert_almost_equal(getattr(seq.parts[0], name), params[name])
-    npt.assert_almost_equal(seq.duration, 2 * pulse.duration + DT)
-    # ...and it is the same waveform the plain concatenation produced:
+        npt.assert_equal(hasattr(out, name), False)
+    npt.assert_almost_equal(out.duration, 2 * pulse.duration + DT)
     plain = Stimulus(pulse.data, electrodes=pulse.electrodes, time=pulse.time)
-    npt.assert_array_equal(seq.data, plain.append(pulse >> DT).data)
-    npt.assert_array_equal(seq.time, plain.append(pulse >> DT).time)
+    npt.assert_array_equal(out.data, plain.append(pulse >> DT).data)
+    npt.assert_array_equal(out.time, plain.append(pulse >> DT).time)
 
 
 @pytest.mark.parametrize('cls, build, params', PULSES)

--- a/pulse2percept/stimuli/tests/test_pulses.py
+++ b/pulse2percept/stimuli/tests/test_pulses.py
@@ -477,27 +477,25 @@ def test_pulse_electrode_names():
 
 @pytest.mark.parametrize('cls, build, params', PULSES)
 @pytest.mark.parametrize('label, transform', [
-    ('scale', lambda p: p * 2),
-    ('rscale', lambda p: 2 * p),
-    ('divide', lambda p: p / 2),
-    ('negate', lambda p: -p),
     ('offset', lambda p: p + 1),
     ('subtract', lambda p: p - 1),
     ('rsubtract', lambda p: 1 - p),
     ('shift', lambda p: p >> 5),
     ('shift_method', lambda p: p.shift(5)),
     ('pad', lambda p: p.pad(p.duration + 10)),
-    ('append', lambda p: p.append(p >> DT)),
+    ('infinite', lambda p: p * np.inf),
+    ('divide_by_zero', lambda p: p / 0),
 ])
 def test_pulse_transformations_are_not_pulses(cls, build, params, label,
                                               transform):
     # A pulse's parameters describe the waveform it was built with. An
-    # operation that rewrites those samples would leave them describing
-    # nothing, so what comes back is an ordinary Stimulus. (Operations that
-    # *can* be expressed in the parameters may become structured later; until
-    # then, correctness beats structure.)
+    # operation that rewrites those samples in a way no parameter of this
+    # class expresses -- a DC offset, a shift in time, a second pulse laid
+    # after it -- would leave them describing nothing, so what comes back is
+    # an ordinary Stimulus. Scaling is the exception; see below.
     pulse = build()
-    out = transform(pulse)
+    with np.errstate(divide='ignore', invalid='ignore'):
+        out = transform(pulse)
     npt.assert_equal(type(out), Stimulus)
     npt.assert_equal(out._is_parametric, False)
     # ...and it no longer answers questions only a pulse can answer:
@@ -507,6 +505,63 @@ def test_pulse_transformations_are_not_pulses(cls, build, params, label,
     for name, expected in params.items():
         npt.assert_almost_equal(getattr(pulse, name), expected)
     npt.assert_almost_equal(pulse.duration, pulse.time[-1])
+
+
+@pytest.mark.parametrize('cls, build, params', PULSES)
+@pytest.mark.parametrize('factor', [2, 0.5, -1, -2, 1, 0, 1e-3])
+def test_pulse_scaling_stays_a_pulse(cls, build, params, factor):
+    # Multiplying every amplitude by a finite factor is exactly what a
+    # different `amp` does, so the result is still described by the
+    # parameters this class is made of -- and is built from them rather than
+    # from the samples.
+    pulse = build()
+    reference = factor * np.asarray(pulse.data)
+    for scaled in (pulse * factor, factor * pulse):
+        npt.assert_equal(type(scaled), cls)
+        # Scaling is expressible without sampling anything:
+        npt.assert_equal(_rendered(scaled), False)
+        npt.assert_allclose(scaled.data, reference, rtol=1e-6, atol=1e-6)
+        # Timing is a property of the pulse, not of its amplitude:
+        for name in ('phase_dur', 'phase_dur1', 'phase_dur2',
+                     'interphase_dur', 'delay_dur', 'stim_dur'):
+            if name in params:
+                npt.assert_almost_equal(getattr(scaled, name), params[name])
+        for name in ('amp', 'amp1', 'amp2'):
+            if name in params:
+                # Only `MonophasicPulse` stores a signed amplitude:
+                signed = 'cathodic' in params
+                npt.assert_almost_equal(
+                    getattr(scaled, name),
+                    params[name] * (factor if signed else abs(factor)))
+        # A negative factor swaps which phase is cathodic. `MonophasicPulse`
+        # carries the polarity in `amp` instead, which the check above covers:
+        if 'cathodic_first' in params:
+            npt.assert_equal(scaled.cathodic_first,
+                             params['cathodic_first'] if factor >= 0
+                             else not params['cathodic_first'])
+    # The original is untouched:
+    for name, expected in params.items():
+        npt.assert_almost_equal(getattr(pulse, name), expected)
+
+
+@pytest.mark.parametrize('cls, build, params', PULSES)
+def test_pulse_append_keeps_both_pulses(cls, build, params):
+    # A pulse laid after another is two pulses, so the result keeps both
+    # rather than becoming an anonymous waveform -- but it is no longer one
+    # pulse, and does not answer as one.
+    pulse = build()
+    seq = pulse.append(pulse >> DT)
+    npt.assert_equal(type(seq).__name__, '_SequenceStimulus')
+    npt.assert_equal(len(seq.parts), 2)
+    npt.assert_equal(type(seq.parts[0]), cls)
+    for name in params:
+        npt.assert_equal(hasattr(seq, name), False)
+        npt.assert_almost_equal(getattr(seq.parts[0], name), params[name])
+    npt.assert_almost_equal(seq.duration, 2 * pulse.duration + DT)
+    # ...and it is the same waveform the plain concatenation produced:
+    plain = Stimulus(pulse.data, electrodes=pulse.electrodes, time=pulse.time)
+    npt.assert_array_equal(seq.data, plain.append(pulse >> DT).data)
+    npt.assert_array_equal(seq.time, plain.append(pulse >> DT).time)
 
 
 @pytest.mark.parametrize('cls, build, params', PULSES)

--- a/pulse2percept/stimuli/tests/test_pulses.py
+++ b/pulse2percept/stimuli/tests/test_pulses.py
@@ -473,3 +473,91 @@ def test_pulse_electrode_names():
                                                     electrode=e)):
         with pytest.raises(ValueError):
             build(['A1', 'B2'])
+
+
+@pytest.mark.parametrize('cls, build, params', PULSES)
+@pytest.mark.parametrize('label, transform', [
+    ('scale', lambda p: p * 2),
+    ('rscale', lambda p: 2 * p),
+    ('divide', lambda p: p / 2),
+    ('negate', lambda p: -p),
+    ('offset', lambda p: p + 1),
+    ('subtract', lambda p: p - 1),
+    ('rsubtract', lambda p: 1 - p),
+    ('shift', lambda p: p >> 5),
+    ('shift_method', lambda p: p.shift(5)),
+    ('pad', lambda p: p.pad(p.duration + 10)),
+    ('append', lambda p: p.append(p >> DT)),
+])
+def test_pulse_transformations_are_not_pulses(cls, build, params, label,
+                                              transform):
+    # A pulse's parameters describe the waveform it was built with. An
+    # operation that rewrites those samples would leave them describing
+    # nothing, so what comes back is an ordinary Stimulus. (Operations that
+    # *can* be expressed in the parameters may become structured later; until
+    # then, correctness beats structure.)
+    pulse = build()
+    out = transform(pulse)
+    npt.assert_equal(type(out), Stimulus)
+    npt.assert_equal(out._is_parametric, False)
+    # ...and it no longer answers questions only a pulse can answer:
+    for name in params:
+        npt.assert_equal(hasattr(out, name), False)
+    # The original is untouched:
+    for name, expected in params.items():
+        npt.assert_almost_equal(getattr(pulse, name), expected)
+    npt.assert_almost_equal(pulse.duration, pulse.time[-1])
+
+
+@pytest.mark.parametrize('cls, build, params', PULSES)
+def test_pulse_transformations_are_numerically_right(cls, build, params):
+    pulse = build()
+    npt.assert_almost_equal((pulse * 2).data, pulse.data * 2)
+    npt.assert_almost_equal((-pulse).data, -pulse.data)
+    npt.assert_almost_equal((pulse + 1).data, pulse.data + 1)
+    npt.assert_almost_equal((pulse / 2).data, pulse.data / 2)
+    shifted = pulse >> 5
+    npt.assert_almost_equal(shifted.time, pulse.time + 5)
+    npt.assert_almost_equal(shifted.data, pulse.data)
+    # Units survive the fall back to a plain stimulus:
+    npt.assert_equal((pulse * 2).unit, pulse.unit)
+    npt.assert_equal((pulse * 2).time_unit, pulse.time_unit)
+
+
+@pytest.mark.parametrize('cls, build, params', PULSES)
+def test_pulse_compress_keeps_its_parameters_true(cls, build, params):
+    # Compression only drops samples the waveform does not need, so a pulse
+    # survives it: every model's predict_percept compresses a copy of the
+    # stimulus it was handed, and a pulse assigned straight to an implant is
+    # what arrives there.
+    pulse = build()
+    peak = np.abs(pulse.data).max()
+    pulse.compress()
+    npt.assert_equal(pulse.is_compressed, True)
+    # Compression drops samples, but not the ones the parameters speak about:
+    # the pulse still ends where `stim_dur` says and still peaks where its
+    # amplitude says.
+    npt.assert_almost_equal(pulse.duration, pulse.time[-1])
+    npt.assert_almost_equal(np.abs(pulse.data).max(), peak)
+    for name, expected in params.items():
+        npt.assert_almost_equal(getattr(pulse, name), expected)
+
+
+@pytest.mark.parametrize('cls, build, params', PULSES)
+def test_pulse_remove_refuses_to_outdate_its_parameters(cls, build, params):
+    # Removing the electrode would leave a pulse advertising a pulse it no
+    # longer delivers, and an in-place method has no second object to hand
+    # back instead:
+    pulse = build()
+    with pytest.raises(NotImplementedError):
+        pulse.remove(pulse.electrodes[0])
+    with pytest.raises(NotImplementedError):
+        pulse.remove('all')
+    # Removing nothing is still a no-op, which ProsthesisSystem relies on:
+    for nothing in (None, [], (), np.array([])):
+        pulse.remove(nothing)
+    npt.assert_equal(pulse.shape[0], 1)
+    # And the documented way through is to take the waveform first:
+    plain = Stimulus(pulse)
+    plain.remove(plain.electrodes[0])
+    npt.assert_equal(plain.shape[0], 0)

--- a/pulse2percept/stimuli/tests/test_videos.py
+++ b/pulse2percept/stimuli/tests/test_videos.py
@@ -566,3 +566,28 @@ def test_VideoStimulus_data_is_contiguous(tmp_path):
     for kwargs in ({}, {'as_gray': True}, {'resize': (16, 24)}):
         stim = VideoStimulus(fname, **kwargs)
         npt.assert_equal(stim.data.flags['C_CONTIGUOUS'], True)
+
+
+@pytest.mark.parametrize('dtype', [np.float32, np.float64, np.uint8])
+def test_VideoStimulus_owns_its_data(dtype):
+    # See `test_ImageStimulus_owns_its_data`: float32 is the dtype that
+    # `img_as_float32` passes through untouched.
+    arr = (np.linspace(0, 1, 60).reshape((4, 5, 3)) if dtype != np.uint8
+           else np.arange(60, dtype=np.uint8).reshape((4, 5, 3)))
+    arr = np.ascontiguousarray(arr, dtype=dtype)
+    stim = VideoStimulus(arr)
+    before = stim.data.copy()
+    arr[...] = 0
+    npt.assert_array_equal(stim.data, before)
+    npt.assert_equal(np.shares_memory(arr, stim.data), False)
+    npt.assert_equal(stim.data.flags.writeable, False)
+    # Freezing what the stimulus took must not reach back into what the
+    # caller kept:
+    npt.assert_equal(arr.flags.writeable, True)
+
+
+def test_VideoStimulus_does_not_alias_another_stimulus():
+    first = VideoStimulus(np.linspace(0, 1, 60, dtype=np.float32)
+                          .reshape((4, 5, 3)))
+    second = VideoStimulus(first)
+    npt.assert_equal(np.shares_memory(first.data, second.data), False)

--- a/pulse2percept/stimuli/videos.py
+++ b/pulse2percept/stimuli/videos.py
@@ -260,8 +260,8 @@ class VideoStimulus(Stimulus):
         """
         # `func` gets a frame of its own: several of the scikit-image
         # transforms this exists to reach cannot take a read-only one.
-        vid = np.array([func(_as_writable(
-                                 frame.reshape(self.vid_shape[:-1])),
+        shape = self.vid_shape[:-1]
+        vid = np.array([func(_as_writable(frame.reshape(shape)),
                              *args, **kwargs)
                         for frame in self])
         # Move first axis (frames) to last:

--- a/pulse2percept/stimuli/videos.py
+++ b/pulse2percept/stimuli/videos.py
@@ -18,6 +18,7 @@ from ..units import dimensionless
 from .names import ElectrodeNames
 from ..utils import (center_image, shift_image, scale_image, trim_image,
                      frame_interval, HTMLAnimation)
+from ..utils.images import _as_writable
 from ..utils.constants import MS_PER_S
 
 
@@ -257,8 +258,11 @@ class VideoStimulus(Stimulus):
         stim : `VideoStimulus`
             A copy of the stimulus object with the new video
         """
-        vid = np.array([func(frame.reshape(self.vid_shape[:-1]), *args,
-                             **kwargs)
+        # `func` gets a frame of its own: several of the scikit-image
+        # transforms this exists to reach cannot take a read-only one.
+        vid = np.array([func(_as_writable(
+                                 frame.reshape(self.vid_shape[:-1])),
+                             *args, **kwargs)
                         for frame in self])
         # Move first axis (frames) to last:
         vid = np.moveaxis(vid, 0, -1)
@@ -540,7 +544,8 @@ class VideoStimulus(Stimulus):
         if len(self.vid_shape) == 3:
             # A grayscale video can be fed to `rotate` in one go, with its
             # frames standing in for the color channels it expects:
-            data = vid_rotate(data, angle, mode=mode, **kwargs)
+            data = vid_rotate(_as_writable(data), angle, mode=mode,
+                              **kwargs)
             return VideoStimulus(data,
                                  electrodes=self._names_for(data, electrodes),
                                  metadata=self.metadata, time=self.time)

--- a/pulse2percept/stimuli/videos.py
+++ b/pulse2percept/stimuli/videos.py
@@ -13,7 +13,7 @@ from skimage.feature import canny
 from skimage import img_as_float32
 from imageio import get_reader as video_reader
 
-from .base import Stimulus
+from .base import Stimulus, _owned
 from ..units import dimensionless
 from .names import ElectrodeNames
 from ..utils import (center_image, shift_image, scale_image, trim_image,
@@ -95,6 +95,8 @@ class VideoStimulus(Stimulus):
             metadata = {}
         elif not isinstance(metadata, dict):
             metadata = {'user': metadata}
+        # The buffer the caller still holds, if any (see below):
+        borrowed = None
         if isinstance(source, str):
             # Filename provided, read the video:
             reader = video_reader(source, format=format)
@@ -119,6 +121,7 @@ class VideoStimulus(Stimulus):
             time = np.arange(vid.shape[-1]) * MS_PER_S / meta['fps']
         elif isinstance(source, VideoStimulus):
             vid = source.data.reshape(source.vid_shape)
+            borrowed = source.data
             metadata.update(source.metadata)
             if electrodes is None:
                 electrodes = source.electrodes
@@ -126,6 +129,7 @@ class VideoStimulus(Stimulus):
                 time = source.time
         elif isinstance(source, np.ndarray):
             vid = source
+            borrowed = source
             if time is None and 'fps' in metadata:
                 # Infer the time points from the video frame rate:
                 time = np.arange(vid.shape[-1]) * MS_PER_S / metadata['fps']
@@ -158,7 +162,9 @@ class VideoStimulus(Stimulus):
             # ('A1', 'C12', 'A1_R' for a color video). The last axis holds the
             # frames, which are the time component and not electrodes:
             electrodes = ElectrodeNames(self.vid_shape[:-1])
-        super().__init__(vid.reshape((-1, vid.shape[-1])),
+        if borrowed is not None and np.may_share_memory(vid, borrowed):
+            vid = vid.copy()
+        super().__init__(_owned(vid.reshape((-1, vid.shape[-1]))),
                                             time=time, electrodes=electrodes,
                                             metadata=metadata,
                                             compress=compress)

--- a/pulse2percept/stimuli/videos.py
+++ b/pulse2percept/stimuli/videos.py
@@ -13,7 +13,7 @@ from skimage.feature import canny
 from skimage import img_as_float32
 from imageio import get_reader as video_reader
 
-from .base import Stimulus, _owned
+from .base import Stimulus, _adoptable
 from ..units import dimensionless
 from .names import ElectrodeNames
 from ..utils import (center_image, shift_image, scale_image, trim_image,
@@ -164,7 +164,7 @@ class VideoStimulus(Stimulus):
             electrodes = ElectrodeNames(self.vid_shape[:-1])
         if borrowed is not None and np.may_share_memory(vid, borrowed):
             vid = vid.copy()
-        super().__init__(_owned(vid.reshape((-1, vid.shape[-1]))),
+        super().__init__(_adoptable(vid.reshape((-1, vid.shape[-1]))),
                                             time=time, electrodes=electrodes,
                                             metadata=metadata,
                                             compress=compress)

--- a/pulse2percept/utils/_fast_array.pyx
+++ b/pulse2percept/utils/_fast_array.pyx
@@ -7,7 +7,9 @@ cnp.import_array()
 ctypedef cnp.float64_t float64
 ctypedef Py_ssize_t index_t
 
-cpdef bint fast_is_strictly_increasing(float64[::1] a, float64[::1] b, float64 tol) noexcept nogil:
+cpdef bint fast_is_strictly_increasing(const float64[::1] a,
+                                      const float64[::1] b,
+                                      float64 tol) noexcept nogil:
     """Check if b[i] - a[i] is strictly greater than tol for all i
 
     Takes float64 because it is used on stimulus time axes, which are stored

--- a/pulse2percept/utils/images.py
+++ b/pulse2percept/utils/images.py
@@ -10,6 +10,22 @@ from skimage.measure import moments
 from skimage.transform import warp, SimilarityTransform
 
 
+def _as_writable(img):
+    """A buffer scikit-image's warping kernels will accept
+
+    ``skimage.transform.warp`` and ``rotate`` pass the image straight into a
+    Cython kernel that declares a *writable* memoryview, so they reject a
+    read-only array outright even though neither of them writes into it. The
+    data of a :py:class:`~pulse2percept.stimuli.Stimulus` is read-only, so
+    every call into those two has to go through here.
+
+    Keep this at the scikit-image boundary. Handing out writable stimulus
+    data anywhere else would give up the guarantee that a stimulus cannot
+    change once it has been built.
+    """
+    return img if img.flags.writeable else np.array(img)
+
+
 def shift_image(img, shift_cols, shift_rows):
     """Shift the image foreground
 
@@ -41,7 +57,7 @@ def shift_image(img, shift_cols, shift_rows):
         raise ValueError(f"Only 2D and 3D images are allowed, not "
                          f"{img.ndim}D.")
     tf = SimilarityTransform(translation=[shift_cols, shift_rows])
-    img_warped = warp(img, tf.inverse)
+    img_warped = warp(_as_writable(img), tf.inverse)
     # Warp automatically converts to double, so we need to convert the image
     # back to its original format:
     if img.dtype == bool:
@@ -135,7 +151,7 @@ def scale_image(img, scaling_factor):
     tf_shift_inv = SimilarityTransform(translation=center_mass)
     # Combine all three transforms:
     tf = tf_shift + tf_scale + tf_shift_inv
-    img_warped = warp(img, tf.inverse)
+    img_warped = warp(_as_writable(img), tf.inverse)
     # Warp automatically converts to double, so we need to convert the image
     # back to its original format:
     if img.dtype == bool:


### PR DESCRIPTION
This refactors `Stimulus` so pulse-based and encoded stimuli are "parameter-first" (i.e., they retain the parameters or schedule that define them) and generate the waveforms only when needed (lazy loading).

Key changes:
- [x] make stimulus arrays and pulse parameters read-only
- [x] lazily generate/cache waveforms for pulses, pulse trains, multi-electrode collections, and encoder output
- [x] preserve structured form through exact operations such as amplitude scaling
- [x] let Granley and Dynaphos read pulse parameters directly instead of relying on duplicated metadata
- [x] remove the duplicate `_spatial_stim` representation; encoded stimuli now provide both their delivered waveform and frame-level spatial modulation from one source of truth
- [x] preserve existing waveform numerics and timing

The main payoff is avoiding large waveform allocations unless samples are actually needed. For example, frequency-encoding a 32x32 image drops from ~6.5 s / 379 MB to ~0.23 s / 1.25 MB before `.data` is accessed.

Closes #550.