### PR TITLE
[ENH] Add efficient VideoStimulus time slicing

### DIFF
--- a/doc/users/release_notes.rst
+++ b/doc/users/release_notes.rst
@@ -76,7 +76,6 @@ API changes:
   including multi-electrode stimulus heatmaps and ``vmin``/``vmax`` controls
   for percept playback and saving.
 
-
 Bug fixes:
 
 * Stimulus timing, metadata propagation, and pulse-train handling are more

--- a/pulse2percept/implants/tests/test_base.py
+++ b/pulse2percept/implants/tests/test_base.py
@@ -321,7 +321,13 @@ def test_ProsthesisSystem_rgb_video_stim():
 
 
 def test_implant_geometry_units():
-    """Every implant places itself the same way, however its xyz is spelled"""
+    """Every implant places itself the same way, however its x/y/z is spelled
+
+    Some device constructors inspect or adjust the geometry themselves before
+    handing it to an ElectrodeGrid (Orion checks `z`, PRIMA writes a
+    per-electrode `z` list onto the electrodes afterwards), so it is not enough
+    to normalize inside the grid.
+    """
     cases = [
         (implants.ArgusI, {'x': 1 * mm, 'y': -0.5 * mm, 'z': 100 * um},
          {'x': 1000, 'y': -500, 'z': 100}),

--- a/pulse2percept/implants/tests/test_base.py
+++ b/pulse2percept/implants/tests/test_base.py
@@ -308,14 +308,20 @@ def test_ProsthesisSystem_reshape_stim_frames_independent():
     npt.assert_equal(np.all(sampled.data[:, 2] == 0), True)
 
 
-def test_implant_geometry_units():
-    """Every implant places itself the same way, however its x/y/z is spelled
+def test_ProsthesisSystem_rgb_video_stim():
+    """An RGB video can be assigned to an implant directly (Issue #802)"""
+    n_frames = 4
+    vid = VideoStimulus(np.random.default_rng(0).random((6, 10, 3, n_frames)),
+                        metadata={'fps': 20})
+    implant = ArgusII(encoder=AmplitudeEncoder(amp_range=(0, 20)))
+    implant.stim = vid
+    npt.assert_equal(len(implant.stim.electrodes), implant.n_electrodes)
+    npt.assert_equal(implant.stim._spatial_view().shape,
+                     (implant.n_electrodes, n_frames))
 
-    Some device constructors inspect or adjust the geometry themselves before
-    handing it to an ElectrodeGrid (Orion checks `z`, PRIMA writes a
-    per-electrode `z` list onto the electrodes afterwards), so it is not enough
-    to normalize inside the grid.
-    """
+
+def test_implant_geometry_units():
+    """Every implant places itself the same way, however its xyz is spelled"""
     cases = [
         (implants.ArgusI, {'x': 1 * mm, 'y': -0.5 * mm, 'z': 100 * um},
          {'x': 1000, 'y': -500, 'z': 100}),

--- a/pulse2percept/stimuli/tests/test_videos.py
+++ b/pulse2percept/stimuli/tests/test_videos.py
@@ -1,5 +1,6 @@
 from pulse2percept.stimuli import (AmplitudeEncoder, VideoStimulus,
                                    BostonTrain, GirlPool)
+from pulse2percept.stimuli.videos import _frame_index
 from pulse2percept.units import (DimensionMismatchError, Hz, kHz, ms, s,
                                  uA)
 from skimage.color import rgb2gray
@@ -104,7 +105,9 @@ def test_VideoStimulus_resize(tmp_path):
 
 def test_VideoStimulus_resize_kwargs():
     """Keyword arguments reach scikit-image (Issue #501)"""
-    # A white square on black
+    # A white square on black. Nearest-neighbor interpolation keeps the video
+    # binary; the default (bilinear, with anti-aliasing on the way down) does
+    # not, which is what makes the two distinguishable:
     ndarray = np.zeros((8, 8, 3), dtype=np.float32)
     ndarray[2:6, 2:6] = 1
     stim = VideoStimulus(ndarray)
@@ -202,6 +205,18 @@ def test_VideoStimulus_clip_rejects_in_memory_source(clip_source, source):
         src = src.data.reshape(src.vid_shape)
     with pytest.raises(ValueError):
         VideoStimulus(src, stop_time=500)
+
+
+def test_frame_index_on_frame_boundaries():
+    """A frame's own start time names that frame, not the one after it
+
+    29.97 fps makes ``i * 1000 / fps * fps / 1000`` land just off ``i``, which
+    is what the tolerance in ``_frame_index`` is for. Every other clipping test
+    here runs at 10 fps, where the arithmetic happens to be exact.
+    """
+    fps = 29.97
+    for i in (1, 10, 100, 1000):
+        npt.assert_equal(_frame_index(i * 1000 / fps, fps), i)
 
 
 def test_VideoStimulus_clip_does_not_decode_the_whole_file(monkeypatch):

--- a/pulse2percept/stimuli/tests/test_videos.py
+++ b/pulse2percept/stimuli/tests/test_videos.py
@@ -1,6 +1,7 @@
 from pulse2percept.stimuli import (AmplitudeEncoder, VideoStimulus,
                                    BostonTrain, GirlPool)
-from pulse2percept.units import DimensionMismatchError, Hz, kHz, ms, uA
+from pulse2percept.units import (DimensionMismatchError, Hz, kHz, ms, s,
+                                 uA)
 from skimage.color import rgb2gray
 from skimage.io import imsave
 from skimage.transform import resize as vid_resize
@@ -103,9 +104,7 @@ def test_VideoStimulus_resize(tmp_path):
 
 def test_VideoStimulus_resize_kwargs():
     """Keyword arguments reach scikit-image (Issue #501)"""
-    # A white square on black. Nearest-neighbor interpolation keeps the video
-    # binary; the default (bilinear, with anti-aliasing on the way down) does
-    # not, which is what makes the two distinguishable:
+    # A white square on black
     ndarray = np.zeros((8, 8, 3), dtype=np.float32)
     ndarray[2:6, 2:6] = 1
     stim = VideoStimulus(ndarray)
@@ -115,6 +114,133 @@ def test_VideoStimulus_resize_kwargs():
     # An unknown keyword argument is scikit-image's to reject, not ours:
     with pytest.raises(TypeError):
         stim.resize((4, 4), not_a_skimage_kwarg=0)
+
+
+@pytest.fixture
+def clip_source(tmp_path):
+    """A 20-frame RGB movie at 10 fps (100 ms per frame), plus its frames"""
+    fname = str(tmp_path / 'clip.mp4')
+    # 16x16 keeps ffmpeg from resizing to its macro block size, which would
+    # make the file's frames a different shape than the ones written here:
+    frames = (255 * np.random.default_rng(0).random((20, 16, 16, 3)))
+    frames = frames.astype(np.uint8)
+    mimwrite(fname, frames, fps=10)
+    return fname, frames
+
+
+def test_VideoStimulus_stop_time(clip_source):
+    fname, _ = clip_source
+    full = VideoStimulus(fname)
+    clip = VideoStimulus(fname, stop_time=500)
+    npt.assert_equal(clip.vid_shape, (*full.vid_shape[:-1], 5))
+    npt.assert_almost_equal(clip.data, full.data[:, :5])
+    # The interval is half-open, so the frame starting at 500 ms is not in it:
+    npt.assert_almost_equal(clip.time, np.arange(5) * 100.0)
+
+
+def test_VideoStimulus_start_and_stop_time(clip_source):
+    fname, _ = clip_source
+    full = VideoStimulus(fname)
+    clip = VideoStimulus(fname, start_time=500, stop_time=1000)
+    npt.assert_almost_equal(clip.data, full.data[:, 5:10])
+    # A clip starts at t=0 wherever it was cut from, but keeps the frame
+    # interval of the source:
+    npt.assert_almost_equal(clip.time, np.arange(5) * 100.0)
+
+
+def test_VideoStimulus_clip_units(clip_source):
+    """Bare milliseconds and unitful times name the same frames"""
+    fname, _ = clip_source
+    bare = VideoStimulus(fname, start_time=500, stop_time=1500)
+    unitful = VideoStimulus(fname, start_time=0.5 * s, stop_time=1.5 * s)
+    npt.assert_almost_equal(unitful.data, bare.data)
+    npt.assert_almost_equal(unitful.time, bare.time)
+
+
+def test_VideoStimulus_clip_rgb2gray_and_resize(clip_source):
+    fname, frames = clip_source
+    clip = VideoStimulus(fname, start_time=300, stop_time=600, as_gray=True,
+                         resize=(8, 8))
+    npt.assert_equal(clip.vid_shape, (8, 8, 3))
+    npt.assert_equal(clip.shape, (64, 3))
+    expected = vid_resize(rgb2gray(frames[3:6] / 255.0), (3, 8, 8))
+    npt.assert_almost_equal(clip.data, expected.reshape((3, -1)).transpose(),
+                            decimal=1)
+
+
+def test_VideoStimulus_stop_time_past_eof(clip_source):
+    """A stop time past the end of the file yields what is there"""
+    fname, _ = clip_source
+    npt.assert_almost_equal(VideoStimulus(fname, stop_time=60 * s).data,
+                            VideoStimulus(fname).data)
+
+
+@pytest.mark.parametrize('kwargs, err', [
+    ({'start_time': -100}, ValueError),
+    ({'start_time': np.inf}, ValueError),
+    ({'stop_time': np.nan}, ValueError),
+    ({'start_time': 500, 'stop_time': 500}, ValueError),
+    ({'start_time': 500, 'stop_time': 200}, ValueError),
+    ({'stop_time': 1 * uA}, DimensionMismatchError),
+    # Past the end of the file, so nothing was loaded:
+    ({'start_time': 60 * s}, ValueError),
+    # Falls between two frame starts (100 and 200 ms), so it names no frame:
+    ({'start_time': 110, 'stop_time': 150}, ValueError),
+])
+def test_VideoStimulus_clip_invalid(clip_source, kwargs, err):
+    fname, _ = clip_source
+    with pytest.raises(err):
+        VideoStimulus(fname, **kwargs)
+
+
+@pytest.mark.parametrize('source', ['array', 'stimulus'])
+def test_VideoStimulus_clip_rejects_in_memory_source(clip_source, source):
+    """An in-memory video is shortened by crop(), not while decoding"""
+    fname, _ = clip_source
+    src = VideoStimulus(fname)
+    if source == 'array':
+        src = src.data.reshape(src.vid_shape)
+    with pytest.raises(ValueError):
+        VideoStimulus(src, stop_time=500)
+
+
+def test_VideoStimulus_clip_does_not_decode_the_whole_file(monkeypatch):
+    """Clipping must bound the read, not slice a fully decoded movie"""
+    requested = []
+
+    class FakeReader:
+        """Hands out 1000 frames of a 10 fps movie, recording each request"""
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            self.closed = True
+            return False
+
+        def get_meta_data(self):
+            return {'fps': 10, 'source_size': (4, 4)}
+
+        def set_image_index(self, index):
+            self.index = index
+
+        def get_next_data(self):
+            if self.index >= 1000:
+                raise IndexError(self.index)
+            requested.append(self.index)
+            self.index += 1
+            return np.full((4, 4, 3), self.index - 1, dtype=np.uint8)
+
+    reader = FakeReader()
+    reader.index = 0
+    reader.closed = False
+    monkeypatch.setattr('pulse2percept.stimuli.videos.video_reader',
+                        lambda *args, **kwargs: reader)
+
+    stim = VideoStimulus('fake.mp4', start_time=2 * s, stop_time=2.5 * s)
+    npt.assert_equal(requested, list(range(20, 25)))
+    npt.assert_equal(stim.vid_shape, (4, 4, 3, 5))
+    npt.assert_equal(reader.closed, True)
 
 
 def test_VideoStimulus_crop(tmp_path):

--- a/pulse2percept/stimuli/videos.py
+++ b/pulse2percept/stimuli/videos.py
@@ -14,12 +14,65 @@ from skimage import img_as_float32
 from imageio import get_reader as video_reader
 
 from .base import Stimulus, _adoptable
-from ..units import dimensionless
+from ..units import as_value, dimensionless, ms
 from .names import ElectrodeNames
 from ..utils import (center_image, shift_image, scale_image, trim_image,
                      frame_interval, HTMLAnimation)
 from ..utils.images import _as_writable
 from ..utils.constants import MS_PER_S
+
+
+#: Anything this close to a frame boundary is treated as being on it
+_FRAME_TOL = 1e-6
+
+
+def _read_video(source, format, start_time, stop_time):
+    """Decode the frames of a video file that start in [start, stop) ms"""
+    start_time = as_value(start_time, ms, 'start_time')
+    stop_time = as_value(stop_time, ms, 'stop_time')
+    clipped = start_time is not None or stop_time is not None
+    for name, t in (('start_time', start_time), ('stop_time', stop_time)):
+        if t is not None and not np.isfinite(t):
+            raise ValueError(f'"{name}" must be a finite time in ms, not {t}.')
+    if start_time is not None and start_time < 0:
+        raise ValueError(f'"start_time" cannot be negative, but is '
+                         f'{start_time} ms.')
+    if (start_time is not None and stop_time is not None and
+            stop_time <= start_time):
+        raise ValueError(f'"stop_time" ({stop_time} ms) must be greater than '
+                         f'"start_time" ({start_time} ms).')
+    with video_reader(source, format=format) as reader:
+        meta = reader.get_meta_data()
+        fps = meta.get('fps') if meta is not None else None
+        if clipped:
+            if not fps:
+                raise ValueError(f'"{source}" does not report a frame rate, '
+                                 f'so "start_time"/"stop_time" cannot be '
+                                 f'mapped onto frames.')
+            first = 0 if start_time is None else _frame_index(start_time, fps)
+            last = None if stop_time is None else _frame_index(stop_time, fps)
+        else:
+            first, last = 0, None
+        if last is not None and last <= first:
+            raise ValueError(f'No video frame starts in [{start_time}, '
+                             f'{stop_time}) ms.')
+        if first:
+            reader.set_image_index(first)
+        frames = []
+        while last is None or first + len(frames) < last:
+            try:
+                frames.append(reader.get_next_data())
+            except (IndexError, StopIteration, EOFError):
+                break  # End of file
+    if clipped and not frames:
+        raise ValueError(f'No video frame starts in [{start_time}, '
+                         f'{stop_time}) ms.')
+    return np.array(frames), meta
+
+
+def _frame_index(t, fps):
+    """Index of the first frame that starts at or after ``t`` ms"""
+    return int(np.ceil(t * fps / MS_PER_S - _FRAME_TOL))
 
 
 class VideoStimulus(Stimulus):
@@ -82,6 +135,18 @@ class VideoStimulus(Stimulus):
         * Remove electrodes with all-zero activation.
         * Retain only the time points at which the stimulus changes.
 
+    start_time, stop_time : float or Quantity, optional, default: None
+        Load only the frames that start in the half-open interval
+        ``[start_time, stop_time)`` of the source video, in milliseconds
+
+        .. note::
+           The clip starts at ``time[0] == 0`` no matter where it was cut
+           from. To shorten a video that is already in memory, and keep its
+           original time stamps, use
+           :py:meth:`~pulse2percept.stimuli.VideoStimulus.crop` instead.
+
+        .. versionadded:: 0.10
+
     """
     __slots__ = ('vid_shape', '_next_frame')
 
@@ -90,7 +155,8 @@ class VideoStimulus(Stimulus):
     _default_unit = dimensionless
 
     def __init__(self, source, format=None, resize=None, as_gray=False,
-                 electrodes=None, time=None, metadata=None, compress=False):
+                 electrodes=None, time=None, metadata=None, compress=False,
+                 start_time=None, stop_time=None):
         if metadata is None:
             metadata = {}
         elif not isinstance(metadata, dict):
@@ -98,26 +164,18 @@ class VideoStimulus(Stimulus):
         # The buffer the caller still holds, if any (see below):
         borrowed = None
         if isinstance(source, str):
-            # Filename provided, read the video:
-            reader = video_reader(source, format=format)
-            vid = np.array([frame for frame in reader])
-            # Move frame index to the last dimension. Take the copy here,
-            # while the frames are still 8-bit: a transposed view stays
-            # non-contiguous through the conversion to float below, and the
-            # Stimulus constructor would then have to make the same copy at
-            # four times the size.
+            vid, meta = _read_video(source, format, start_time, stop_time)
+            # Move frame index to the last dimension:
             if vid.ndim == 4:
                 vid = np.ascontiguousarray(vid.transpose((1, 2, 3, 0)))
             elif vid.ndim == 3:
                 vid = np.ascontiguousarray(vid.transpose((1, 2, 0)))
             # Combine video metadata with user-specified metadata:
-            meta = reader.get_meta_data()
             if meta is not None:
                 metadata.update(meta)
             metadata['source'] = source
             metadata['source_shape'] = vid.shape
-            # Infer the time points from the video frame rate. `fps` counts
-            # frames per second and a stimulus counts milliseconds:
+            # Infer the time points from the video frame rate:
             time = np.arange(vid.shape[-1]) * MS_PER_S / meta['fps']
         elif isinstance(source, VideoStimulus):
             vid = source.data.reshape(source.vid_shape)
@@ -136,6 +194,11 @@ class VideoStimulus(Stimulus):
         else:
             raise TypeError(f"Source must be a filename, a 3D NumPy array or "
                             f"another VideoStimulus, not {type(source)}.")
+        if not isinstance(source, str) and (start_time is not None or
+                                            stop_time is not None):
+            raise ValueError('"start_time"/"stop_time" only apply to a video '
+                             'read from a file. Use crop(idx_time=...) to '
+                             'shorten an array or another VideoStimulus.')
         if vid.ndim < 3 or vid.ndim > 4:
             raise ValueError(f"Videos must have 3 or 4 dimensions, not "
                              f"{vid.ndim}.")
@@ -192,12 +255,7 @@ class VideoStimulus(Stimulus):
         self.vid_shape = (*self.vid_shape[:-1], self.data.shape[-1])
 
     def _frames(self):
-        """The stimulus as a dense <rows x columns [x channels] x frames> array
-
-        Raises a ``ValueError`` if the video has been compressed in space,
-        which removes all-zero pixels and therefore leaves nothing that can be
-        reshaped back into a frame.
-        """
+        """The stim as a dense <rows x columns [x channels] x frames> array"""
         n_px = int(np.prod(self.vid_shape[:-1]))
         if self.data.shape[0] != n_px:
             raise ValueError(
@@ -213,16 +271,7 @@ class VideoStimulus(Stimulus):
         return params
 
     def _names_for(self, vid, electrodes):
-        """Electrode names for a video derived from this one
-
-        A pixel keeps its name across an operation that leaves the pixel grid
-        alone, which is what makes 'A1' refer to the same thing before and
-        after. An operation that resamples the grid (a resize, a rotation that
-        grows the canvas) has no such correspondence to preserve, so the result
-        is named afresh rather than inheriting names that no longer describe
-        it. Only the frame layout is compared; the number of frames is the time
-        axis, not an electrode count.
-        """
+        """Electrode names for a video derived from this one"""
         if electrodes is not None:
             return electrodes
         same = np.shape(vid)[:-1] == self.vid_shape[:-1]

--- a/pulse2percept/stimuli/videos.py
+++ b/pulse2percept/stimuli/videos.py
@@ -137,7 +137,8 @@ class VideoStimulus(Stimulus):
 
     start_time, stop_time : float or Quantity, optional, default: None
         Load only the frames that start in the half-open interval
-        ``[start_time, stop_time)`` of the source video, in milliseconds
+        ``[start_time, stop_time)`` of the source video, in milliseconds.
+        Time-based clipping requires the video reader to report a frame rate.
 
         .. note::
            The clip starts at ``time[0] == 0`` no matter where it was cut
@@ -145,7 +146,7 @@ class VideoStimulus(Stimulus):
            original time stamps, use
            :py:meth:`~pulse2percept.stimuli.VideoStimulus.crop` instead.
 
-        .. versionadded:: 0.10
+        .. versionadded:: 0.10.0
 
     """
     __slots__ = ('vid_shape', '_next_frame')
@@ -255,7 +256,12 @@ class VideoStimulus(Stimulus):
         self.vid_shape = (*self.vid_shape[:-1], self.data.shape[-1])
 
     def _frames(self):
-        """The stim as a dense <rows x columns [x channels] x frames> array"""
+        """The stimulus as a dense <rows x columns [x channels] x frames> array
+
+        Raises a ``ValueError`` if the video has been compressed in space,
+        which removes all-zero pixels and therefore leaves nothing that can be
+        reshaped back into a frame.
+        """
         n_px = int(np.prod(self.vid_shape[:-1]))
         if self.data.shape[0] != n_px:
             raise ValueError(
@@ -271,7 +277,16 @@ class VideoStimulus(Stimulus):
         return params
 
     def _names_for(self, vid, electrodes):
-        """Electrode names for a video derived from this one"""
+        """Electrode names for a video derived from this one
+
+        A pixel keeps its name across an operation that leaves the pixel grid
+        alone, which is what makes 'A1' refer to the same thing before and
+        after. An operation that resamples the grid (a resize, a rotation that
+        grows the canvas) has no such correspondence to preserve, so the result
+        is named afresh rather than inheriting names that no longer describe
+        it. Only the frame layout is compared; the number of frames is the time
+        axis, not an electrode count.
+        """
         if electrodes is not None:
             return electrodes
         same = np.shape(vid)[:-1] == self.vid_shape[:-1]


### PR DESCRIPTION
Closes #802.

- [x] Add `start_time` / `stop_time` to `VideoStimulus` for loading only part of a video file
- [x] Seek to the requested start frame and stop decoding at the requested end, avoiding a full-file read`
- [x] Rebase clipped videos to `t=0`
- [x] Add regression coverage for RGB videos assigned directly to implants