### PR TITLE
[FIX] Correctly handle lowercase Benson/Winawer subject IDs

### DIFF
--- a/pulse2percept/topography/neuropythy.py
+++ b/pulse2percept/topography/neuropythy.py
@@ -97,12 +97,21 @@ class NeuropythyMap(CorticalMap):
         except ValueError as ve:
             # For some reason, neuropythy won't download the dataset if the subject 
             # id isn't fsaverage. Download it manually in this case
-            if subject in benson_winawer_subjs or subject.upper() in benson_winawer_subjs:
-                # force the download (will go to cache_dir)
-                _ = ny.data['benson_winawer_2018'].subjects[subject]
-                return ny.freesurfer_subject(subject)
+            if subject in benson_winawer_subjs:
+                subject_id = subject
+            elif isinstance(subject, str) and subject.upper() in benson_winawer_subjs:
+                subject_id = subject.upper()
             else:
                 raise ve
+            if subject in benson_winawer_subjs:
+                subject_id = subject
+            elif isinstance(subject, str) and subject.upper() in benson_winawer_subjs:
+                subject_id = subject.upper()
+            else:
+                raise ve
+            # force the download (will go to cache_dir)
+            _ = ny.data['benson_winawer_2018'].subjects[subject_id]
+            return ny.freesurfer_subject(subject_id)
         
     def load_meshes(self, subject):
         """

--- a/pulse2percept/topography/tests/test_neuropythy.py
+++ b/pulse2percept/topography/tests/test_neuropythy.py
@@ -395,13 +395,15 @@ def test_parse_subject_configures_cache(neuropythy, tmp_path, monkeypatch):
     npt.assert_equal(len(config['freesurfer_subject_paths']), 1)
 
 
+@pytest.mark.parametrize(
+    ('subject', 'subject_id'),
+    [('S1201', 'S1201'),
+     ('s1201', 'S1201')],
+)
 def test_parse_subject_downloads_benson_winawer(neuropythy, tmp_path,
-                                                monkeypatch):
-    """Neuropythy only downloads the dataset for 'fsaverage' on its own
-
-    Every other Benson & Winawer subject comes back as a ValueError until the
-    dataset is on disk, so p2p asks for it and tries again.
-    """
+                                                monkeypatch, subject,
+                                                subject_id):
+    """Benson-Winawer subjects are downloaded using their canonical ID."""
     downloaded = []
     attempts = []
 
@@ -414,12 +416,13 @@ def test_parse_subject_downloads_benson_winawer(neuropythy, tmp_path,
     dataset = SimpleNamespace(subjects=DownloadOnAccess(downloaded))
     monkeypatch.setattr(neuropythy, 'config', fake_config())
     monkeypatch.setattr(neuropythy, 'freesurfer_subject', freesurfer_subject)
-    monkeypatch.setattr(neuropythy, 'data', {'benson_winawer_2018': dataset})
+    monkeypatch.setattr(neuropythy, 'data',
+                        {'benson_winawer_2018': dataset})
 
     nmap = ToyNeuropythyMap(cache_dir=str(tmp_path))
-    npt.assert_equal(nmap.parse_subject('S1201'), 'loaded S1201')
-    npt.assert_equal(downloaded, ['S1201'])
-    npt.assert_equal(attempts, ['S1201', 'S1201'])
+    npt.assert_equal(nmap.parse_subject(subject), f'loaded {subject_id}')
+    npt.assert_equal(downloaded, [subject_id])
+    npt.assert_equal(attempts, [subject, subject_id])
 
 
 def test_parse_subject_reraises_unknown_subject(neuropythy, tmp_path,


### PR DESCRIPTION
Closes #840.

Makes sure lowercase IDs such as "s1201" are converted to uppercase so the dataset is keyed correctly.