### PR TITLE
[FIX] Structured stimuli in EnsembleImplant

### DIFF
--- a/doc/topics/stimuli.rst
+++ b/doc/topics/stimuli.rst
@@ -374,10 +374,9 @@ before and after compression:
 Accessing stimulus metadata
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Stimuli can store additional relevant information in the ``metadata`` dictionary. 
-Users can also pass their own metadata, which will be stored in ``metadata["user"]``
-Stimuli built from a collection of sources store the metadata for each source 
-in ``metadata["electrodes"][electrode]["metadata"]``:
+Stimuli can store additional relevant information in the ``metadata``
+dictionary. What the user passes is stored in ``metadata["user"]``; each source
+of a multi-source stimulus keeps its own:
 
 .. ipython:: python
 
@@ -387,11 +386,11 @@ in ``metadata["electrodes"][electrode]["metadata"]``:
     stim = Stimulus([[0, 1, 2, 3]], metadata='user_metadata')
     stim.metadata
 
-    # Some objects store their own metadata
+    # Sources carry their own metadata
     stim = BiphasicPulseTrain(1,1,1, metadata='user_metadata')
     stim.metadata
 
-    # Multiple source metadata
+    # A collection keeps the metadata the whole stimulus was given
     stim = Stimulus({'A1' : BiphasicPulseTrain(1,1,1, metadata='A1 metadata'),
                      'B2' : BiphasicPulseTrain(1,1,1, metadata='B2 metadata')},
                     metadata='stimulus metadata')

--- a/doc/users/release_notes.rst
+++ b/doc/users/release_notes.rst
@@ -81,7 +81,7 @@ Bug fixes:
 * Stimulus timing, metadata propagation, and pulse-train handling are more
   robust. Time axes now use float64 precision, metadata survives model
   prediction and transformations, and Dynaphos uses the actual frequency and
-  phase duration of directly assigned biphasic pulse trains.
+  phase duration of the biphasic pulse trains a stimulus is made of.
 
 * Fixed several image/video issues, including accidental input mutation,
   argument forwarding to scikit-image, image centering, single-frame playback,
@@ -90,10 +90,6 @@ Bug fixes:
 * Fixed several visual-field-map issues, including equality and hashing,
   array-shaped inverse cortical mappings, exact mesh-vertex mappings, and
   incorrect cortical-coordinate units in the documentation.
-
-* :py:class:`~pulse2percept.implants.EnsembleImplant` now handles nearly
-  coincident stimulus time points consistently with
-  :py:class:`~pulse2percept.stimuli.Stimulus`.
 
 * Various smaller correctness, compatibility, and documentation fixes.
 

--- a/pulse2percept/implants/ensemble.py
+++ b/pulse2percept/implants/ensemble.py
@@ -245,9 +245,59 @@ class EnsembleImplant(ProsthesisSystem):
         self._earray = ElectrodeArray(electrodes)
         self.merge_stimuli()
         
+    def _structured_children(self):
+        """One source per ensemble electrode, or ``None``"""
+        sources = {}
+        for i, implant in self._implants.items():
+            if implant.stim is None:
+                return None
+            child = implant.stim._structured_sources()
+            if child is None:
+                return None
+            child = {str(e): src for e, src in child}
+            names = [str(e) for e in implant.electrode_names]
+            if len(child) != len(names) or any(e not in child for e in names):
+                return None
+            for name in names:
+                sources[f"{i}-{name}"] = child[name]
+        if sorted(sources) != sorted(self.electrode_names):
+            return None
+        # Ensemble order, not the order the children happened to be built in:
+        return {name: sources[name] for name in self.electrode_names}
+
     def merge_stimuli(self):
         """Constructs the combined stimulus for all implants in self._implants"""
         if any([i.stim for i in self._implants.values()]):
+            # An implant with no stimulus contributes zeros and no
+            # interpretation of them, so only the ones that have a stimulus
+            # decide what the merged numbers mean:
+            present = [i.stim for i in self._implants.values()
+                       if i.stim is not None]
+            if len({(s.unit, s.time_unit) for s in present}) > 1:
+                names = ', '.join(sorted({_describe_unit(s.unit)
+                                          for s in present}))
+                raise DimensionMismatchError(
+                    f"Cannot merge stimuli measured in different units "
+                    f"({names}). Convert them to a common unit first.")
+
+            # The metadata of each implant is stored under 'user'; concatenate
+            # those, keyed by which implant they came from:
+            user_metadata = {str(i): implant.stim.metadata['user']
+                             for i, implant in self._implants.items()
+                             if implant.stim is not None}
+
+            # runtime import to avoid circular import
+            from ..stimuli import Stimulus
+
+            sources = self._structured_children()
+            if sources is not None:
+                # Every electrode has a source of its own, so the ensemble is
+                # that collection
+                merged = Stimulus(sources, electrodes=self.electrode_names,
+                                  metadata=user_metadata)
+                self.stim = merged._inherit_units(present[0])
+                return
+
             # Need to combine all stimuli
             # The ith stim is a np array of shape (implant[i].n_electrodes, len(times[i]))
             # i.e. the amplitude of each electrode at each time point in times[i]
@@ -303,42 +353,10 @@ class EnsembleImplant(ProsthesisSystem):
                 
                 new_stims.append(new_stim)
             
-            # The metadata for each implant is stored in implant.metadata, and has 'electrodes' and 'user' keys
-            # We need to merge the 'electrodes' key across all implants, and simply concatenate the 'user' keys
-            metadata = {}
-            electrode_metadata = {}
-            user_metadata = {}
-            for i_name, implant in self._implants.items():
-                if implant.stim is None:
-                    continue
-                # in the new implant, the the electrode names are i_name + "-" + electrode_name
-                for e_name, e_metadata in implant.stim.metadata['electrodes'].items():
-                    electrode_metadata[str(i_name) + "-" + e_name] = e_metadata
-                user_metadata[str(i_name)] = implant.stim.metadata['user']
-            metadata['electrodes'] = electrode_metadata
-            metadata['user'] = user_metadata
-
             # Combine all new_stims into a final array (stack along a new axis if needed)
-            # runtime import to avoid circular import
-            from ..stimuli import Stimulus
             merged = Stimulus(np.concatenate(new_stims), time=new_times,
                               electrodes=self.electrode_names,
-                              metadata=metadata)
+                              metadata=user_metadata)
             # The merge concatenates raw data arrays, so the result would
-            # otherwise fall back to the default (current) reading of them.
-            # An implant with no stimulus contributes zeros and no
-            # interpretation of them, so only the ones that have a stimulus
-            # decide what the merged numbers mean -- and they have to agree,
-            # because a mix of image intensities and currents has no common
-            # reading to fall back on:
-            present = [s for s in stims if s is not None]
-            units = {(s.unit, s.time_unit) for s in present}
-            if len(units) > 1:
-                names = ', '.join(sorted({_describe_unit(s.unit)
-                                          for s in present}))
-                raise DimensionMismatchError(
-                    f"Cannot merge stimuli measured in different units "
-                    f"({names}). Convert them to a common unit first.")
-            if present:
-                merged._inherit_units(present[0])
-            self.stim = merged
+            # otherwise fall back to the default (current) reading of them:
+            self.stim = merged._inherit_units(present[0])

--- a/pulse2percept/implants/tests/test_ensemble.py
+++ b/pulse2percept/implants/tests/test_ensemble.py
@@ -131,13 +131,15 @@ def test_merge_stimuli():
     npt.assert_equal(implant.stim.data[:60], 1)
     npt.assert_equal(implant.stim.data[60:], 2)
 
-    # with time 
+    # with time
     implant = EnsembleImplant([Orion(stim=np.ones((60, 5))),
                                Orion(x=-35000, stim=np.ones((60, 2))*2)])
     npt.assert_equal(implant.stim.data.shape, (120, 5))
-    npt.assert_equal(implant.stim.data[:60], 1)  
+    npt.assert_equal(implant.stim.data[:60], 1)
     npt.assert_equal(implant.stim.data[60:, :2], 2)
     npt.assert_equal(implant.stim.data[60:, 2:], 0)
+    # A merge of sampled waveforms has no structure to keep:
+    npt.assert_equal(implant.stim._structured_sources(), None)
 
     # biphasic pulse trains
     implant1 = Orion()
@@ -145,16 +147,20 @@ def test_merge_stimuli():
     implant2 = Orion(x=-35000)
     implant2.stim = {e : BiphasicPulseTrain(20, 2, .85) for e in implant2.electrode_names}
     implant = EnsembleImplant([implant1, implant2])
+    # Asked before `.data`: reading the waveform must not be what builds it.
+    # Each child electrode keeps the train that drives it, under the name the
+    # ensemble gives it, so a model still sees two clocks and not one array:
+    sources = implant.stim._structured_sources()
+    npt.assert_equal([e for e, _ in sources], implant.electrode_names)
+    sources = dict(sources)
+    npt.assert_equal((sources['0-96'].freq, sources['0-96'].phase_dur),
+                     (50, .45))
+    npt.assert_equal((sources['1-96'].freq, sources['1-96'].phase_dur),
+                     (20, .85))
     npt.assert_equal(implant.stim.data.shape, (120, 471))
     # Two implants that pulse at the same instant get there by accumulating
-    # their own way, so merging their time axes needs a tolerance. An exact
-    # union would keep both copies and leave the merged axis with pairs of
-    # points closer together than a time step:
+    # their own way, so merging their time axes needs a tolerance:
     npt.assert_equal(np.all(np.diff(implant.stim.time) > 0.95 * DT), True)
-    # make sure that implant.metadata['electrodes'] is also merged
-    npt.assert_equal(list(implant.stim.metadata['electrodes'].keys()), implant.electrode_names)
-    npt.assert_equal(implant.stim.metadata['electrodes']['0-96'], implant1.stim.metadata['electrodes']['96'])
-    npt.assert_equal(implant.stim.metadata['electrodes']['1-96'], implant2.stim.metadata['electrodes']['96'])
 
     # with cortivis and orion
     implant = EnsembleImplant([Orion(stim=np.ones(60)),

--- a/pulse2percept/models/base.py
+++ b/pulse2percept/models/base.py
@@ -998,10 +998,8 @@ class SpatialModel(BaseModel, metaclass=ABCMeta):
                 uniq_time = stim.time[t_unique]
                 if len(uniq_time) == 1:
                     uniq_time = None
-                # Carry the metadata across: `_predict_spatial` is where
-                # BiphasicAxonMapSpatial and DynaphosModel look up amplitude,
-                # frequency and phase duration, and they only ever see this
-                # de-duplicated copy:
+                # `_predict_spatial` only ever sees this de-duplicated
+                # copy, so the caller's metadata has to come along:
                 stim_unique = Stimulus(
                     stim[:, stim.time[t_unique]], electrodes=stim.electrodes,
                     time=uniq_time,

--- a/pulse2percept/models/base.py
+++ b/pulse2percept/models/base.py
@@ -972,9 +972,10 @@ class SpatialModel(BaseModel, metaclass=ABCMeta):
                 # np.asarray: indexing a single-electrode stimulus returns a
                 # scalar, which has no `reshape`:
                 at = self._to_stim_time(t_percept, stim)
-                stim = Stimulus(np.asarray(stim[:, at]).reshape((-1, n_time)),
-                                electrodes=stim.electrodes, time=at,
-                                metadata=stim.metadata)._inherit_units(stim)
+                stim = Stimulus(
+                    np.asarray(stim[:, at]).reshape((-1, n_time)),
+                    electrodes=stim.electrodes, time=at
+                )._inherit_units(stim)._inherit_metadata(stim)
                 # find unique stimulus points
                 _, t_unique, inverse = np.unique(stim.data.T, axis=0,
                                                  return_index=True,
@@ -999,11 +1000,11 @@ class SpatialModel(BaseModel, metaclass=ABCMeta):
                 if len(uniq_time) == 1:
                     uniq_time = None
                 # `_predict_spatial` only ever sees this de-duplicated
-                # copy, so the caller's metadata has to come along:
+                # copy, so the stimulus' metadata has to come along:
                 stim_unique = Stimulus(
                     stim[:, stim.time[t_unique]], electrodes=stim.electrodes,
-                    time=uniq_time,
-                    metadata=stim.metadata)._inherit_units(stim)
+                    time=uniq_time
+                )._inherit_units(stim)._inherit_metadata(stim)
                 resp_unique = self._predict_spatial(implant.earray, stim_unique)
                 # reconstruct original time points, making sure to preserve C ordering
                 resp = resp_unique[..., inverse].copy(order='C')

--- a/pulse2percept/models/cortex/dynaphos.py
+++ b/pulse2percept/models/cortex/dynaphos.py
@@ -25,42 +25,11 @@ def _pulse_train_clocks(stim):
     describe it.
     """
     sources = stim._structured_sources()
-    if sources is not None:
-        if any(type(src) is not BiphasicPulseTrain for _, src in sources):
-            return None
-        return {str(e): (src.freq, src.phase_dur) for e, src in sources}
-    return _legacy_clocks(stim)
-
-
-def _legacy_clocks(stim):
-    """The same clocks, from a container that kept only a copy of them
-
-    Compatibility for the one thing that still builds a stimulus this way:
-    :py:meth:`~pulse2percept.implants.EnsembleImplant.merge_stimuli`
-    interpolates its members into a single raw array and records what each
-    electrode was driven by alongside it. That record is all that is left of
-    the pulse trains, and without it this model would silently drop each
-    member's clock for its own default.
-
-    Not the preferred representation, and deliberately strict: only entries
-    that say they came from a
-    :py:class:`~pulse2percept.stimuli.BiphasicPulseTrain` count, so that user
-    metadata which happens to have a ``freq`` key cannot change what this
-    model simulates. Anything short of a clock for every electrode falls back
-    to the model's own.
-    """
-    try:
-        entries = stim.metadata['electrodes']
-        clocks = {}
-        for electrode in stim.electrodes:
-            entry = entries[str(electrode)]
-            if entry['type'] is not BiphasicPulseTrain:
-                return None
-            params = entry['metadata']
-            clocks[str(electrode)] = (params['freq'], params['phase_dur'])
-        return clocks
-    except (KeyError, TypeError):
+    if sources is None:
         return None
+    if any(type(src) is not BiphasicPulseTrain for _, src in sources):
+        return None
+    return {str(e): (src.freq, src.phase_dur) for e, src in sources}
 
 
 #: Amperes in a microamp (1e-6). The activation cascade below is the published

--- a/pulse2percept/models/cortex/tests/test_dynaphos.py
+++ b/pulse2percept/models/cortex/tests/test_dynaphos.py
@@ -230,11 +230,10 @@ def test_DynaphosModel_deprecated_xystep():
         npt.assert_almost_equal(model.step, 2)
 
 
-def test_dynaphos_reads_the_pulse_train_not_its_metadata():
-    # The same train has to predict the same percept however it is assigned,
-    # and whatever its metadata says. Both used to be false: a bare train
-    # carried no per-electrode metadata and was simulated on the model's
-    # default clock instead of its own.
+def test_dynaphos_reads_the_pulse_train_itself():
+    # The same train has to predict the same percept however it is assigned.
+    # That used to be false: a bare train carried no per-electrode metadata
+    # and was simulated on the model's default clock instead of its own.
     model = DynaphosModel(step=0.5, xrange=(-2, 2), yrange=(-2, 2)).build()
     model.dt = 20
     t_percept = np.arange(0, 200, 20)
@@ -251,13 +250,10 @@ def test_dynaphos_reads_the_pulse_train_not_its_metadata():
     npt.assert_array_equal(bare, predict({0: train()}))
     npt.assert_equal(np.any(bare), True)
 
-    # Corrupting the compatibility metadata changes nothing:
+    # User metadata says nothing about the clock, however it is written:
     corrupt = train()
-    corrupt.metadata.update(freq=1, amp=0, phase_dur=99)
+    corrupt.metadata['user'] = {'freq': 1, 'amp': 0, 'phase_dur': 99}
     npt.assert_array_equal(bare, predict(corrupt))
-    wiped = train()
-    wiped.metadata.clear()
-    npt.assert_array_equal(bare, predict(wiped))
 
 
 def test_dynaphos_uses_its_defaults_for_an_arbitrary_waveform():
@@ -298,12 +294,7 @@ def test_dynaphos_reads_the_clock_before_compression():
 
 
 def _ensemble_of_two_clocks():
-    """Two implants driven at different frequencies, merged into one
-
-    `merge_stimuli` interpolates its members into a single raw array, so the
-    trains themselves do not survive -- only the record of them that this
-    model's legacy fallback reads.
-    """
+    """Two implants driven at different frequencies, merged into one"""
     fast = Orion(stim={e: BiphasicPulseTrain(50, 300, 0.45, stim_dur=100)
                        for e in Orion().electrode_names})
     slow = Orion(x=-35000,
@@ -312,12 +303,11 @@ def _ensemble_of_two_clocks():
     return EnsembleImplant([fast, slow])
 
 
-def test_dynaphos_recovers_ensemble_clocks():
-    # An ensemble keeps no pulse trains, so without the compatibility path
-    # every member would silently be simulated at the model's own default
-    # clock instead of the one it was built with.
+def test_dynaphos_reads_ensemble_clocks():
+    # An ensemble keeps its members' trains rather than sampling them away,
+    # so every member is simulated at the clock it was built with instead of
+    # the model's own default.
     ensemble = _ensemble_of_two_clocks()
-    npt.assert_equal(ensemble.stim._structured_sources(), None)
     clocks = _pulse_train_clocks(ensemble.stim)
     npt.assert_equal(len(clocks), len(ensemble.stim.electrodes))
     npt.assert_equal(sorted(set(clocks.values())), [(20, 0.85), (50, 0.45)])
@@ -331,44 +321,28 @@ def test_dynaphos_ensemble_prediction_uses_those_clocks():
     ensemble = _ensemble_of_two_clocks()
     with_clocks = model.predict_percept(ensemble).data
     npt.assert_equal(np.any(with_clocks), True)
-    # Take the record away and the model is back on its own default clock.
-    # That the answer moves is what says the recovered clocks reached the
-    # simulation rather than merely being collected:
-    ensemble.stim.metadata['electrodes'].clear()
-    npt.assert_equal(_pulse_train_clocks(ensemble.stim), None)
-    npt.assert_equal(np.allclose(with_clocks,
-                                 model.predict_percept(ensemble).data), False)
+    # The same waveform with the trains behind it taken away is back on the
+    # model's default clock
+    waveform_only = _ensemble_of_two_clocks()
+    waveform_only.stim = Stimulus(ensemble.stim.data,
+                                  electrodes=ensemble.stim.electrodes,
+                                  time=ensemble.stim.time)
+    npt.assert_equal(_pulse_train_clocks(waveform_only.stim), None)
+    npt.assert_equal(
+        np.allclose(with_clocks,
+                    model.predict_percept(waveform_only).data), False)
 
 
-@pytest.mark.parametrize('build_stim', [
-    # No record of a pulse train at all:
-    lambda: Stimulus([[0, 100, 100, 0]], time=[0, 1, 99, 100]),
-    # A record that says the source was something else:
-    lambda: Stimulus([[0, 100, 100, 0]], time=[0, 1, 99, 100],
-                     metadata={'electrodes': {'0': {'type': Stimulus,
-                                                    'metadata': {}}},
-                               'user': None}),
-    # User metadata that merely happens to have the right keys:
-    lambda: Stimulus([[0, 100, 100, 0]], time=[0, 1, 99, 100],
-                     metadata={'electrodes': {'0': {'type': dict,
-                                                    'metadata': {
-                                                        'freq': 1,
-                                                        'phase_dur': 9}}},
-                               'user': None}),
-])
-def test_dynaphos_legacy_clocks_are_strict(build_stim):
-    # The fallback exists for containers that really did hold pulse trains.
-    # Anything else leaves the model on its own clock:
-    npt.assert_equal(_pulse_train_clocks(build_stim()), None)
-
-
-def test_dynaphos_legacy_clocks_are_not_read_when_structure_says_otherwise():
-    # A DC offset leaves no train behind, and drops the parameters with it --
-    # the fallback must not resurrect them from a leftover record:
+def test_dynaphos_clocks_are_not_read_when_structure_says_otherwise():
+    # Samples with nothing behind them leave the model on its own clock:
+    npt.assert_equal(
+        _pulse_train_clocks(Stimulus([[0, 100, 100, 0]],
+                                     time=[0, 1, 99, 100])), None)
+    # A DC offset leaves no train behind, and drops the parameters with it:
     stim = Stimulus({'0': BiphasicPulseTrain(20, 100, 0.45, stim_dur=100)})
     npt.assert_equal(_pulse_train_clocks(stim + 5), None)
     # A stimulus made of something other than biphasic trains stays on the
-    # defaults too, rather than falling through to whatever was recorded:
+    # defaults too:
     asym = Stimulus({'0': AsymmetricBiphasicPulseTrain(20, 100, 50, 0.45, 0.9,
                                                        stim_dur=100)})
     npt.assert_equal(_pulse_train_clocks(asym), None)
@@ -376,8 +350,7 @@ def test_dynaphos_legacy_clocks_are_not_read_when_structure_says_otherwise():
 
 def test_dynaphos_uses_its_defaults_for_an_encoded_stimulus():
     # An encoder's schedule can change frequency from frame to frame, so there
-    # is no per-electrode clock to take from it. The model stays on its own,
-    # and does not fall through to whatever the metadata happens to hold:
+    # is no per-electrode clock to take from it. The model stays on its own:
     implant = Cortivis(x=1000)
     encoded = AmplitudeEncoder().encode(
         ImageStimulus(np.linspace(0, 1, 64).reshape(8, 8)), implant=implant)

--- a/pulse2percept/models/tests/test_base.py
+++ b/pulse2percept/models/tests/test_base.py
@@ -186,10 +186,8 @@ def test_SpatialModel_predict_percept_deduplicates_frames():
 
 
 def test_SpatialModel_predict_percept_keeps_metadata():
-    # `_predict_spatial` only ever sees the de-duplicated copy of the stimulus,
-    # and that copy is where BiphasicAxonMapSpatial and DynaphosModel look up
-    # amplitude, frequency and phase duration. The per-electrode metadata has
-    # to survive the trip:
+    # `_predict_spatial` only ever sees the de-duplicated copy of the
+    # stimulus, so the caller's metadata has to survive the trip:
     seen_metadata = []
 
     class RecordingSpatialModel(ValidSpatialModel):
@@ -200,17 +198,16 @@ def test_SpatialModel_predict_percept_keeps_metadata():
                             dtype=np.float32)
 
     model = RecordingSpatialModel(step=2).build()
-    implant = ArgusI(stim={'A1': BiphasicPulseTrain(20, 10, 0.45,
-                                                    stim_dur=20)})
+    implant = ArgusI(stim=Stimulus({'A1': BiphasicPulseTrain(20, 10, 0.45,
+                                                             stim_dur=20)},
+                                   metadata='mine'))
     model.predict_percept(implant)
     npt.assert_equal(len(seen_metadata), 1)
-    npt.assert_equal(list(seen_metadata[0]['electrodes'].keys()), ['A1'])
-    npt.assert_equal(seen_metadata[0]['electrodes']['A1']['metadata']['amp'],
-                     10)
+    npt.assert_equal(seen_metadata[0]['user'], 'mine')
     # ...also when the caller asks for time points of their own:
     seen_metadata.clear()
     model.predict_percept(implant, t_percept=[0, 5, 10])
-    npt.assert_equal(list(seen_metadata[0]['electrodes'].keys()), ['A1'])
+    npt.assert_equal(seen_metadata[0]['user'], 'mine')
 
 
 @pytest.mark.parametrize('param, value', [('engine', 'serial'),

--- a/pulse2percept/models/tests/test_granley2021.py
+++ b/pulse2percept/models/tests/test_granley2021.py
@@ -779,22 +779,16 @@ def test_BiphasicAxonMap_predicts_without_a_waveform(model_cls, build_stim):
 
 @pytest.mark.parametrize('model_cls', [BiphasicAxonMapModel,
                                        BiphasicAxonMapSpatial])
-@pytest.mark.parametrize('corrupt', [
-    lambda m: m.clear(),
-    lambda m: m['electrodes'].clear(),
-    lambda m: m['electrodes']['C5']['metadata'].update(amp=999, freq=1),
-    lambda m: m['electrodes']['C5'].update(type=object),
-])
-def test_BiphasicAxonMap_ignores_pulse_metadata(model_cls, corrupt):
-    # The metadata is a copy of what the trains say, kept for compatibility.
-    # Corrupting it must not move the percept, and must not change whether the
-    # stimulus is accepted:
+def test_BiphasicAxonMap_ignores_user_metadata(model_cls):
+    # The model is a function of the trains the stimulus is made of, and of
+    # nothing the user filed alongside them -- even metadata that happens to
+    # name pulse parameters:
     model = model_cls(xrange=(-3, 3), yrange=(-2, 2), step=1,
                       n_ax_segments=30).build()
     implant = ArgusII(stim={'C5': BiphasicPulseTrain(20, 1, 0.45,
                                                      stim_dur=100)})
     expected = model.predict_percept(implant).data
-    corrupt(implant.stim.metadata)
+    implant.stim.metadata['user'] = {'amp': 999, 'freq': 1}
     npt.assert_array_equal(model.predict_percept(implant).data, expected)
 
 

--- a/pulse2percept/stimuli/base.py
+++ b/pulse2percept/stimuli/base.py
@@ -277,10 +277,13 @@ class Stimulus(PrettyPrint):
 
     @staticmethod
     def _wrap_metadata(metadata):
-        """File the caller's metadata under user, unless it is already ours"""
-        if isinstance(metadata, dict) and set(metadata) == {'user'}:
-            return metadata
+        """File the caller's metadata under ``user``"""
         return {'user': metadata}
+
+    def _inherit_metadata(self, other):
+        """Take on another stimulus' metadata dict, as it stands"""
+        self.metadata = other.metadata
+        return self
 
     def _defer(self, electrodes, unit=None, time_unit=None, metadata=None):
         """Set this stimulus up to generate its waveform later"""
@@ -504,7 +507,7 @@ class Stimulus(PrettyPrint):
             if isinstance(source, Stimulus):
                 # Re-wrapping or renaming a stimulus keeps the metadata it
                 # came with:
-                self.metadata = self._wrap_metadata(source.metadata)
+                self._inherit_metadata(source)
 
         if _electrodes is None:
             # The source did not name its electrodes, so they are 0..N-1 --

--- a/pulse2percept/stimuli/base.py
+++ b/pulse2percept/stimuli/base.py
@@ -114,11 +114,8 @@ def _strip_units(source, unit):
     return source
 
 
-def _scale_factor(op, scalar, reverse=False, field='data'):
+def _scale_factor(op, scalar, reverse=False):
     """The factor by which an arithmetic operator scales the stimulus data"""
-    if field == 'time':
-        # Shifting in time moves the whole stim but amps remain:
-        return 1.0
     if op is ops.mul:
         factor = scalar
     elif op is ops.truediv:
@@ -281,9 +278,9 @@ class Stimulus(PrettyPrint):
     @staticmethod
     def _wrap_metadata(metadata):
         """File the caller's metadata under user, unless it is already ours"""
-        if isinstance(metadata, dict) and 'electrodes' in metadata.keys():
+        if isinstance(metadata, dict) and set(metadata) == {'user'}:
             return metadata
-        return {'electrodes': {}, 'user': metadata}
+        return {'user': metadata}
 
     def _defer(self, electrodes, unit=None, time_unit=None, metadata=None):
         """Set this stimulus up to generate its waveform later"""
@@ -485,16 +482,6 @@ class Stimulus(PrettyPrint):
                     # In all other cases, use the electrode names specified by
                     # the source (unless they're None):
                     _electrodes.append(e if e is not None else ele)
-                try:
-                    # Compatibility channel: what described this electrode,
-                    # for a reader that ends up with only the samples (see
-                    # `_rescale_params`)
-                    self.metadata['electrodes'][str(ele)] = {
-                        'metadata': src.metadata,
-                        'type': type(src)
-                    }
-                except AttributeError:
-                    pass
             if self._components is None:
                 _data, _time = self._merge_sources(_data, _time)
                 _n_rows = _data.shape[0]
@@ -515,23 +502,20 @@ class Stimulus(PrettyPrint):
                 _data, _time, _electrodes = self._parse_source(source)
                 _n_rows = _data.shape[0]
             if isinstance(source, Stimulus):
-                if 'electrodes' not in source.metadata.keys():
-                    self.metadata['electrodes'][str(_electrodes[0])] = {
-                        'metadata': source.metadata, 'type': type(source)}
-                else:
-                    self.metadata = source.metadata
+                # Re-wrapping or renaming a stimulus keeps the metadata it
+                # came with:
+                self.metadata = self._wrap_metadata(source.metadata)
 
         if _electrodes is None:
             # The source did not name its electrodes, so they are 0..N-1 --
             # unique by construction. Only build that array if something will
             # read it
             _auto_electrodes = True
-            if electrodes is None or self.metadata.get('electrodes'):
+            if electrodes is None:
                 _electrodes = np.arange(_n_rows)
 
         # User can overwrite the names of the electrodes:
         if electrodes is not None:
-            _renamed_from = _electrodes
             if isinstance(electrodes, ElectrodeNames):
                 # Names generated from a grid pattern:
                 _electrodes = electrodes.ravel()
@@ -540,7 +524,6 @@ class Stimulus(PrettyPrint):
                 _electrodes = np.array([electrodes]).flatten()
                 _auto_electrodes = False
         else:
-            _renamed_from = None
             if isinstance(_electrodes, ElectrodeNames):
                 # The source brought its own generated names along:
                 _electrodes = _electrodes.ravel()
@@ -575,23 +558,6 @@ class Stimulus(PrettyPrint):
                     _electrodes = _electrodes.astype(
                         np.result_type(_electrodes.dtype, f'U{n_digits}'))
                 _electrodes[idx] = idx
-
-        # Per-electrode metadata is addressed by electrode name (that is how
-        # BiphasicAxonMapModel finds its stimulus parameters), so renaming the
-        # electrodes has to rename those keys too:
-        elec_meta = self.metadata.get('electrodes')
-        if (elec_meta and _renamed_from is not None and
-                len(_renamed_from) == len(_electrodes)):
-            # Keys that do not belong to any electrode are left alone, and
-            # `metadata` may be shared with the source stimulus, so never
-            # rename in place:
-            rename = {str(old): str(new)
-                      for old, new in zip(_renamed_from, _electrodes)
-                      if str(old) != str(new)}
-            if rename:
-                self.metadata = dict(self.metadata)
-                self.metadata['electrodes'] = {rename.get(k, k): v
-                                               for k, v in elec_meta.items()}
 
         # User can overwrite time:
         if time is not None:
@@ -651,41 +617,6 @@ class Stimulus(PrettyPrint):
         memo[id(self)] = stim
         stim.metadata = deepcopy(self.metadata, memo)
         return stim
-
-    @classmethod
-    def _rescale_params(cls, metadata, factor):
-        """Rewrite waveform parameters for a waveform scaled by ``factor``
-
-        Compatibility only. A pulse-based stimulus owns its parameters and
-        the models read them off it (see :py:meth:`_structured_sources`); this
-        files a copy under ``metadata`` for waveform-only containers, which is
-        what :py:class:`~pulse2percept.implants.EnsembleImplant` interpolates
-        its children into. There the copy is the only surviving description of
-        the pulse trains, and
-        :py:class:`~pulse2percept.models.cortex.DynaphosModel` still reads it.
-        """
-        return metadata
-
-    def _rescale_result(self, stim, factor):
-        """Keep the metadata of a transformed copy in step with its data"""
-        stim._rescale_metadata(factor)
-        if self._is_parametric:
-            stim.metadata = type(self)._rescale_params(stim.metadata, factor)
-
-    def _rescale_metadata(self, factor):
-        """Keep the metadata in sync with data that was scaled by ``factor``"""
-        if factor == 1:
-            return
-        elec_meta = self.metadata.get('electrodes')
-        if not elec_meta:
-            return
-        for entry in elec_meta.values():
-            if not isinstance(entry, dict):
-                continue
-            src, meta = entry.get('type'), entry.get('metadata')
-            if isinstance(meta, dict) and isinstance(src, type) and \
-                    issubclass(src, Stimulus):
-                entry['metadata'] = src._rescale_params(meta, factor)
 
     def compress(self):
         """Compress the source data in place"""
@@ -779,7 +710,6 @@ class Stimulus(PrettyPrint):
         stim._stim = {'data': data,
                       'electrodes': self.electrodes,
                       'time': time}
-        self._rescale_result(stim, None)
         return stim
 
     def remove(self, electrodes):
@@ -1194,11 +1124,6 @@ class Stimulus(PrettyPrint):
         stim._stim = {'data': op(a, b) if field == 'data' else stim.data.copy(),
                       'electrodes': stim.electrodes.copy(),
                       'time': time}
-        # Parameters that describe the waveform (a pulse train's amplitude,
-        # say) have to follow the data:
-        reverse = bool(a_supported)
-        self._rescale_result(stim, _scale_factor(op, a if reverse else b,
-                                                 reverse, field))
         return stim
 
     def _scaled(self, factor):
@@ -1214,7 +1139,6 @@ class Stimulus(PrettyPrint):
         stim = self._shallow_copy()
         stim._components = [(src * factor, n) for src, n in self._components]
         stim._forget_waveform(self.electrodes)
-        stim._rescale_metadata(factor)
         return stim
 
     def _operate(self, op, scalar, reverse=False):

--- a/pulse2percept/stimuli/pulse_trains.py
+++ b/pulse2percept/stimuli/pulse_trains.py
@@ -347,9 +347,9 @@ class BiphasicPulseTrain(Stimulus):
     def __init__(self, freq, amp, phase_dur, interphase_dur=0, delay_dur=0,
                  n_pulses=None, stim_dur=1000.0, cathodic_first=True,
                  electrode=None, metadata=None):
-        # See `PulseTrain.__init__`. Normalizing here rather than leaving it to
-        # `BiphasicPulse` is what keeps the metadata below in the units a model
-        # reading it back expects:
+        # See `PulseTrain.__init__`. Normalizing here rather than leaving it
+        # to `BiphasicPulse` is what keeps the properties below in the units a
+        # model reading them back expects:
         freq = as_value(freq, Hz, 'freq')
         amp = as_value(amp, uA, 'amp')
         phase_dur = as_value(phase_dur, ms, 'phase_dur')
@@ -367,19 +367,7 @@ class BiphasicPulseTrain(Stimulus):
         self._train = PulseTrain(freq, pulse, n_pulses=n_pulses,
                                  stim_dur=stim_dur)
         self._defer(_electrode_names(electrode))
-
-        # Compatibility copy of the parameters this train owns outright
-        # (see `Stimulus._rescale_params`). `amp` is a magnitude, because that
-        # is all of it that reaches the data:
-        # `BiphasicPulse` takes `np.abs(amp)` and reads the polarity off
-        # `cathodic_first`. Storing the sign the caller happened to type would
-        # have two identical waveforms predict two different percepts, since
-        # the models are functions of `amp` and not of `abs(amp)`.
-        self.metadata = {'freq': freq,
-                         'amp': abs(amp),
-                         'phase_dur': phase_dur,
-                         'delay_dur': delay_dur,
-                         'user': metadata}
+        self.metadata = {'user': metadata}
 
     @property
     def freq(self):
@@ -443,19 +431,7 @@ class BiphasicPulseTrain(Stimulus):
             cathodic_first=(self.cathodic_first if factor >= 0
                             else not self.cathodic_first),
             electrode=self.electrodes[0],
-            # The compatibility metadata is rebuilt by the constructor, from
-            # the new amplitude. Only what the user put there is theirs to
-            # carry across:
             metadata=deepcopy(self.metadata.get('user')))
-
-    @classmethod
-    def _rescale_params(cls, metadata, factor):
-        """Return a scaled copy of the meta parameters"""
-        if 'amp' not in metadata:
-            return metadata
-        if factor is None:
-            return {'user': metadata.get('user')}
-        return dict(metadata, amp=abs(metadata['amp'] * factor))
 
     def _pprint_params(self):
         """Return a dict of class arguments to pretty-print"""

--- a/pulse2percept/stimuli/tests/test_base.py
+++ b/pulse2percept/stimuli/tests/test_base.py
@@ -1192,35 +1192,24 @@ def test_Stimulus___eq___tolerance():
                      True)
 
 
-def test_Stimulus_rename_electrodes_metadata():
-    # Per-electrode metadata is keyed by electrode name (BiphasicAxonMapModel
-    # reads its stimulus parameters from there), so renaming the electrodes
-    # has to rename those keys as well.
-    stim = Stimulus({'A1': BiphasicPulseTrain(20, 30, 0.45, stim_dur=100),
-                     'B3': BiphasicPulseTrain(40, 20, 0.45, stim_dur=100)})
-    npt.assert_equal(sorted(stim.metadata['electrodes'].keys()), ['A1', 'B3'])
-
-    renamed = Stimulus(stim, electrodes=['Z9', 'Y8'])
-    npt.assert_equal(sorted(renamed.metadata['electrodes'].keys()), ['Y8', 'Z9'])
-    for old, new in [('A1', 'Z9'), ('B3', 'Y8')]:
-        npt.assert_equal(renamed.metadata['electrodes'][new],
-                         stim.metadata['electrodes'][old])
-    # The source must not be touched (its metadata may be shared):
-    npt.assert_equal(sorted(stim.metadata['electrodes'].keys()), ['A1', 'B3'])
-
-    # Swapping two names is a simultaneous remap, not two sequential ones:
-    swapped = Stimulus(stim, electrodes=['B3', 'A1'])
-    npt.assert_equal(swapped.metadata['electrodes']['B3'],
-                     stim.metadata['electrodes']['A1'])
-    npt.assert_equal(swapped.metadata['electrodes']['A1'],
-                     stim.metadata['electrodes']['B3'])
-
-    # Renaming a stimulus that has no per-electrode metadata is a no-op:
+def test_Stimulus_rename_keeps_the_sources_with_their_electrodes():
+    # Renaming addresses the sources by position, so it must not shuffle which
+    # train drives which electrode:
+    def build():
+        return {'A1': BiphasicPulseTrain(20, 30, 0.45, stim_dur=100),
+                'B3': BiphasicPulseTrain(40, 20, 0.45, stim_dur=100)}
+    renamed = dict(Stimulus(build(), electrodes=['Z9', 'Y8'])
+                   ._structured_sources())
+    npt.assert_equal(renamed['Z9'].freq, 20)
+    npt.assert_equal(renamed['Y8'].freq, 40)
+    swapped = dict(Stimulus(build(), electrodes=['B3', 'A1'])
+                   ._structured_sources())
+    npt.assert_equal(swapped['B3'].freq, 20)
+    npt.assert_equal(swapped['A1'].freq, 40)
+    # A waveform-only stimulus has no sources to keep, and renames anyway:
     plain = Stimulus(np.ones((2, 3)))
     npt.assert_equal(Stimulus(plain, electrodes=['P1', 'P2']).electrodes,
                      ['P1', 'P2'])
-    npt.assert_equal(Stimulus(plain, electrodes=['P1', 'P2'])
-                     .metadata['electrodes'], {})
 
 
 def test_Stimulus_data_is_contiguous():
@@ -1807,7 +1796,6 @@ def test_Stimulus_collection_defers_the_merge(name, build):
     npt.assert_equal(len(stim.electrodes) > 1, True)
     npt.assert_equal(stim.unit, uA)
     npt.assert_equal(stim.time_unit, ms)
-    npt.assert_equal(sorted(stim.metadata['electrodes']) != [], True)
     npt.assert_equal(stim.is_compressed, False)
     copies = [copy(stim), deepcopy(stim)]
     npt.assert_equal(_n_renders(stim), 0)
@@ -1930,7 +1918,6 @@ def test_Stimulus_collection_renames_without_rendering():
                        electrodes=['X', 'Y'])
     npt.assert_equal(_lazy(renamed), True)
     npt.assert_equal(list(renamed.electrodes), ['X', 'Y'])
-    npt.assert_equal(sorted(renamed.metadata['electrodes']), ['X', 'Y'])
     npt.assert_equal(child.n_renders, 0)
     # Re-wrapping a single deferred stimulus is a rename too:
     solo = Stimulus(CountingLazy(4, ['A1']), electrodes=['Z'])
@@ -2049,17 +2036,10 @@ def test_Stimulus_collection_scaling_stays_deferred(factor):
                      [BiphasicPulseTrain, BiphasicPulseTrain])
     npt.assert_almost_equal([c.amp for c, _ in scaled._components],
                             [10 * abs(factor), 20 * abs(factor)])
-    # ...and so is what the models read off the metadata:
-    npt.assert_almost_equal(
-        [v['metadata']['amp'] for v in scaled.metadata['electrodes'].values()],
-        [10 * abs(factor), 20 * abs(factor)])
     npt.assert_allclose(scaled.data, factor * Stimulus(build()).data,
                         rtol=1e-6, atol=1e-6)
-    # The original is untouched, in both descriptions:
+    # The original is untouched:
     npt.assert_almost_equal([c.amp for c, _ in stim._components], [10, 20])
-    npt.assert_almost_equal(
-        [v['metadata']['amp'] for v in stim.metadata['electrodes'].values()],
-        [10, 20])
 
 
 def test_Stimulus_collection_scaling_needs_every_entry_to_be_a_stimulus():

--- a/pulse2percept/stimuli/tests/test_base.py
+++ b/pulse2percept/stimuli/tests/test_base.py
@@ -12,8 +12,8 @@ from matplotlib.axes import Subplot
 import matplotlib.pyplot as plt
 
 from pulse2percept.stimuli import Stimulus
-from pulse2percept.stimuli import (BiphasicPulse, BiphasicPulseTrain,
-                                   MonophasicPulse)
+from pulse2percept.stimuli import (AmplitudeEncoder, BiphasicPulse,
+                                   BiphasicPulseTrain, MonophasicPulse)
 from pulse2percept.stimuli import ImageStimulus
 from pulse2percept.stimuli import VideoStimulus
 from pulse2percept.stimuli._merge import merge_time_axes
@@ -1190,6 +1190,33 @@ def test_Stimulus___eq___tolerance():
                      False)
     npt.assert_equal(Stimulus([[np.inf, 1.0]]) == Stimulus([[np.inf, 1.0]]),
                      True)
+
+
+def test_Stimulus_user_metadata_is_never_unpacked():
+    # `metadata` is the caller's, whatever it holds
+    for metadata in ({'user': 'Michael'}, {'user': None},
+                     {'user': 'Michael', 'encoder': 'not ours'}):
+        npt.assert_equal(Stimulus(1, metadata=metadata).metadata,
+                         {'user': metadata})
+
+
+def test_Stimulus_rewrap_keeps_the_metadata_structure():
+    # Re-wrapping a stimulus carries its metadata dict across as it stands
+    plain = Stimulus([[1, 2, 3]], time=[0, 1, 2], metadata='mine')
+    npt.assert_equal(Stimulus(plain).metadata, {'user': 'mine'})
+    npt.assert_equal(Stimulus(plain, electrodes=['Z']).metadata,
+                     {'user': 'mine'})
+    # An encoder records its frame clock at the top level, next to `user`:
+    encoded = AmplitudeEncoder().encode(
+        ImageStimulus(np.linspace(0, 1, 4).reshape(2, 2), metadata='mine'))
+    npt.assert_equal('encoder' in encoded.metadata, True)
+    rewrapped = Stimulus(encoded)
+    npt.assert_equal(rewrapped.metadata['encoder'],
+                     encoded.metadata['encoder'])
+    npt.assert_equal(rewrapped.metadata['user'], encoded.metadata['user'])
+    # ...and a video's own `fps` is not the caller's metadata either:
+    video = VideoStimulus(np.ones((2, 2, 3)), metadata={'fps': 10})
+    npt.assert_equal(Stimulus(video).metadata['fps'], 10)
 
 
 def test_Stimulus_rename_keeps_the_sources_with_their_electrodes():

--- a/pulse2percept/stimuli/tests/test_pulse_trains.py
+++ b/pulse2percept/stimuli/tests/test_pulse_trains.py
@@ -275,71 +275,60 @@ def test_BiphasicTripletTrain(amp, interphase_dur, interpulse_dur, delay_dur, ca
 
 
 def test_metadata():
+    # A train stores what the user put there and nothing else:
     stim = BiphasicPulseTrain(10, 10, 1, metadata='userdata')
-    npt.assert_equal(stim.metadata['user'], 'userdata')
-    npt.assert_equal(stim.metadata['freq'], 10)
-    npt.assert_equal(stim.metadata['amp'], 10)
-    npt.assert_equal(stim.metadata['phase_dur'], 1)
-    npt.assert_equal(stim.metadata['delay_dur'], 0)
+    npt.assert_equal(stim.metadata, {'user': 'userdata'})
 
     stim = Stimulus({'A2': BiphasicPulseTrain(10, 10, 1, metadata='userdataA2'),
                      'B1': BiphasicPulseTrain(11, 9, 2, metadata='userdataB1'),
                      'C3': BiphasicPulseTrain(12, 8, 3, metadata='userdataC3')}, metadata='stimulus_userdata')
     npt.assert_equal(stim.metadata['user'], 'stimulus_userdata')
-    npt.assert_equal(stim.metadata['electrodes']
-                     ['A2']['type'], BiphasicPulseTrain)
-    npt.assert_equal(stim.metadata['electrodes']['B1']['metadata']['freq'], 11)
-    npt.assert_equal(stim.metadata['electrodes']
-                     ['C3']['metadata']['user'], 'userdataC3')
+    sources = dict(stim._structured_sources())
+    npt.assert_equal(type(sources['A2']), BiphasicPulseTrain)
+    npt.assert_equal(sources['B1'].freq, 11)
+    npt.assert_equal(sources['C3'].metadata['user'], 'userdataC3')
 
 
 @pytest.mark.parametrize('scale', [2, 0.5, 1, 0])
-def test_BiphasicPulseTrain_metadata_scaling(scale):
-    # BiphasicAxonMapModel reads amp/freq/phase_dur off the metadata rather
-    # than off the data, so scaling the data has to scale `amp` with it.
-    # Otherwise `pt * 2` delivers twice the current and predicts the very same
-    # percept:
+def test_BiphasicPulseTrain_scaling(scale):
+    # A model reads `amp` off the train, so scaling the data has to scale the
+    # parameter with it:
     pt = BiphasicPulseTrain(20, 10, 0.45, stim_dur=100)
     scaled = pt * scale
-    npt.assert_almost_equal(scaled.metadata['amp'], 10 * scale)
+    npt.assert_almost_equal(scaled.amp, 10 * scale)
     npt.assert_almost_equal(scaled.data, scale * pt.data)
-    # Same data and same metadata as the pulse train built that way directly:
+    # Same data as the pulse train built that way directly:
     direct = BiphasicPulseTrain(20, 10 * scale, 0.45, stim_dur=100)
     npt.assert_almost_equal(scaled.data, direct.data)
-    npt.assert_equal(scaled.metadata, direct.metadata)
     # Every route to a scaled train agrees, and none of them touches the
     # original:
-    npt.assert_almost_equal((scale * pt).metadata['amp'], 10 * scale)
+    npt.assert_almost_equal((scale * pt).amp, 10 * scale)
     if scale != 0:
-        npt.assert_almost_equal((pt / (1 / scale)).metadata['amp'], 10 * scale)
-    npt.assert_equal(pt.metadata['amp'], 10)
+        npt.assert_almost_equal((pt / (1 / scale)).amp, 10 * scale)
+    npt.assert_equal(pt.amp, 10)
     # The other pulse parameters are untouched:
-    for key in ('freq', 'phase_dur', 'delay_dur', 'user'):
-        npt.assert_equal(scaled.metadata[key], pt.metadata[key])
+    for name in ('freq', 'phase_dur', 'delay_dur'):
+        npt.assert_equal(getattr(scaled, name), getattr(pt, name))
 
 
-def test_BiphasicPulseTrain_metadata_amp_is_a_magnitude():
+def test_BiphasicPulseTrain_amp_is_a_magnitude():
     # `BiphasicPulse` takes the magnitude of `amp` and reads the polarity off
-    # `cathodic_first`, so the sign of `amp` never reaches the data. The
-    # metadata has to record it the same way: the models are functions of
-    # `amp`, not of `abs(amp)`, so a stored sign would have two identical
-    # waveforms predict two different percepts.
+    # `cathodic_first`, so the sign of `amp` never reaches the data
     pos = BiphasicPulseTrain(20, 10, 0.45, stim_dur=100)
     neg = BiphasicPulseTrain(20, -10, 0.45, stim_dur=100)
     npt.assert_almost_equal(pos.data, neg.data)
-    npt.assert_equal(pos.metadata, neg.metadata)
-    npt.assert_equal(pos.metadata['amp'], 10)
-    # ...and it stays a magnitude under scaling:
-    npt.assert_equal((neg * 2).metadata['amp'], 20)
+    npt.assert_equal(pos.amp, neg.amp)
+    npt.assert_equal(pos.amp, 10)
+    npt.assert_equal((neg * 2).amp, 20)
 
 
-def test_BiphasicPulseTrain_metadata_polarity():
+def test_BiphasicPulseTrain_polarity():
     # A negative factor swaps the two phases, which is what `cathodic_first`
     # records; the amplitude keeps its magnitude:
     pt = BiphasicPulseTrain(20, 10, 0.45, stim_dur=100)
     for flipped in (-pt, pt * -1, 0 - pt, pt / -1):
         npt.assert_almost_equal(flipped.data, -pt.data)
-        npt.assert_equal(flipped.metadata['amp'], 10)
+        npt.assert_equal(flipped.amp, 10)
         npt.assert_equal(type(flipped), BiphasicPulseTrain)
         npt.assert_equal(flipped.cathodic_first, not pt.cathodic_first)
     # Flipping twice comes back to where it started:
@@ -348,7 +337,7 @@ def test_BiphasicPulseTrain_metadata_polarity():
     direct = BiphasicPulseTrain(20, 10, 0.45, stim_dur=100,
                                 cathodic_first=False)
     npt.assert_almost_equal((-pt).data, direct.data)
-    npt.assert_equal((-pt).metadata, direct.metadata)
+    npt.assert_equal((-pt).cathodic_first, direct.cathodic_first)
 
 
 @pytest.mark.parametrize('modify', [lambda pt: pt + 5, lambda pt: pt - 5,
@@ -357,153 +346,57 @@ def test_BiphasicPulseTrain_metadata_polarity():
                                     lambda pt: pt * np.inf,
                                     lambda pt: pt * np.nan,
                                     lambda pt: pt / 0])
-def test_BiphasicPulseTrain_metadata_invalidated(modify):
+def test_BiphasicPulseTrain_stops_being_a_train(modify):
     # A DC offset is neither biphasic nor charge-balanced, and a non-finite
-    # factor leaves a waveform of infinities
+    # factor leaves a waveform of infinities. Neither is a pulse train, so
+    # neither may go on advertising one to a model:
     pt = BiphasicPulseTrain(20, 10, 0.45, stim_dur=100, metadata='userdata')
     with np.errstate(divide='ignore', invalid='ignore'):
         modified = modify(pt)
-    for key in ('amp', 'freq', 'phase_dur', 'delay_dur'):
-        npt.assert_equal(key in modified.metadata, False)
+    npt.assert_equal(type(modified), Stimulus)
+    npt.assert_equal(modified._structured_sources(), None)
     # The user's own metadata is theirs, and survives:
     npt.assert_equal(modified.metadata['user'], 'userdata')
-    npt.assert_equal(pt.metadata['amp'], 10)
+    npt.assert_equal(pt.amp, 10)
 
 
-def test_BiphasicPulseTrain_metadata_shift():
-    # A shift moves the whole train, but every pulse in it keeps its
-    # amplitude, frequency and duration:
-    pt = BiphasicPulseTrain(20, 10, 0.45, stim_dur=100)
+def test_BiphasicPulseTrain_shift():
+    pt = BiphasicPulseTrain(20, 10, 0.45, stim_dur=100, metadata='userdata')
     for shifted in (pt >> 5, pt << 5):
-        npt.assert_equal(shifted.metadata, pt.metadata)
-        # ...on a plain Stimulus, though: a shifted train no longer ends where
-        # its `stim_dur` says (see `Stimulus._derived`).
+        npt.assert_equal(shifted.metadata['user'], 'userdata')
+        # A shifted train no longer ends where its `stim_dur` says, so what
+        # comes back is a plain Stimulus (see `Stimulus._derived`):
         npt.assert_equal(type(shifted), Stimulus)
     # Adding zero changes nothing at all, so what comes back is still a train:
     for same in (pt + 0, pt - 0):
-        npt.assert_equal(same.metadata, pt.metadata)
+        npt.assert_equal(same.metadata['user'], 'userdata')
         npt.assert_equal(type(same), BiphasicPulseTrain)
+        npt.assert_equal(same.amp, pt.amp)
         npt.assert_equal(same.cathodic_first, pt.cathodic_first)
     npt.assert_almost_equal((pt >> 5).time, pt.time + 5)
 
 
-@pytest.mark.parametrize('modify, expected', [
-    (lambda s: s * 2, 20), (lambda s: 2 * s, 20), (lambda s: s / 2, 5),
-    (lambda s: -s, 10), (lambda s: s >> 5, 10), (lambda s: s + 0, 10),
-    (lambda s: s * -2, 20), (lambda s: -2 * s, 20), (lambda s: s / -0.5, 20)])
-def test_Stimulus_rescales_electrode_metadata(modify, expected):
-    # A pulse train handed to an implant becomes one row of a plain Stimulus
-    stim = Stimulus({'A1': BiphasicPulseTrain(20, 10, 0.45, stim_dur=100),
-                     'B2': BiphasicPulseTrain(20, 4, 0.45, stim_dur=100)})
-    modified = modify(stim)
-    npt.assert_almost_equal(
-        modified.metadata['electrodes']['A1']['metadata']['amp'], expected)
-    # Every electrode is scaled, not just the first:
-    npt.assert_almost_equal(
-        modified.metadata['electrodes']['B2']['metadata']['amp'],
-        expected * 0.4)
-    # The source class is still recorded, and the original is untouched:
-    npt.assert_equal(modified.metadata['electrodes']['A1']['type'],
-                     BiphasicPulseTrain)
-    npt.assert_equal(stim.metadata['electrodes']['A1']['metadata']['amp'], 10)
-    # Scaling leaves the entry describable
-    for key, value in (('freq', 20), ('phase_dur', 0.45), ('delay_dur', 0)):
-        npt.assert_equal(
-            modified.metadata['electrodes']['A1']['metadata'][key], value)
-
-
-@pytest.mark.parametrize('modify', [lambda s: s + 5, lambda s: 5 - s,
-                                    lambda s: s * np.inf,
-                                    lambda s: s.append(s >> 1)])
-def test_Stimulus_invalidates_electrode_metadata(modify):
-    stim = Stimulus({'A1': BiphasicPulseTrain(20, 10, 0.45, stim_dur=100)})
-    with np.errstate(divide='ignore', invalid='ignore'):
-        modified = modify(stim)
-    npt.assert_equal(
-        'amp' in modified.metadata['electrodes']['A1']['metadata'], False)
-    npt.assert_equal(stim.metadata['electrodes']['A1']['metadata']['amp'], 10)
-
-
-def test_Stimulus_rescale_metadata_leaves_the_source_alone():
-    # A composed stimulus files the very dict its source carries
-    pt = BiphasicPulseTrain(20, 10, 0.45, stim_dur=100)
-    composed = Stimulus({'A1': pt})
-    scaled = composed * 2
-    npt.assert_almost_equal(
-        scaled.metadata['electrodes']['A1']['metadata']['amp'], 20)
-    # Neither the composition nor the train it was built from moved:
-    npt.assert_equal(
-        composed.metadata['electrodes']['A1']['metadata']['amp'], 10)
-    npt.assert_equal(pt.metadata['amp'], 10)
-    # Invalidation is the other way to rewrite the entry, and it must not
-    # reach back either:
-    dropped = composed + 5
-    npt.assert_equal(
-        'amp' in dropped.metadata['electrodes']['A1']['metadata'], False)
-    npt.assert_equal(pt.metadata['amp'], 10)
-    npt.assert_equal(
-        composed.metadata['electrodes']['A1']['metadata']['amp'], 10)
-
-
-@pytest.mark.parametrize('factor', [2, -2, None])
-def test_BiphasicPulseTrain_metadata_rescale_params_does_not_mutate(factor):
-    # `_rescale_params` returns the rewritten metadata
-    meta = {'freq': 20, 'amp': 10, 'phase_dur': 0.45, 'delay_dur': 0,
-            'user': None}
-    before = dict(meta)
-    BiphasicPulseTrain._rescale_params(meta, factor)
-    npt.assert_equal(meta, before)
-
-
-def test_Stimulus_rescale_metadata_mixed_sources():
-    # An implant's stimulus need not be all pulse trains
-    plain = {'electrodes': {}, 'user': {'note': 'mine'}}
-    stim = Stimulus({'A1': BiphasicPulseTrain(20, 10, 0.45, stim_dur=100),
-                     'B2': Stimulus([[1, 2, 3]], time=[0, 1, 2],
-                                    metadata={'note': 'mine'})})
-    npt.assert_equal(stim.metadata['electrodes']['A1']['type'],
-                     BiphasicPulseTrain)
-    npt.assert_equal(stim.metadata['electrodes']['B2']['type'], Stimulus)
-    npt.assert_equal(stim.metadata['electrodes']['B2']['metadata'], plain)
-
-    # Scaling transforms the train's parameters and leaves the plain entry:
-    scaled = (stim * 3).metadata['electrodes']
-    npt.assert_almost_equal(scaled['A1']['metadata']['amp'], 30)
-    npt.assert_equal(scaled['B2']['metadata'], plain)
-
-    # ...and so does an operation that invalidates instead of rescaling:
-    offset = (stim + 5).metadata['electrodes']
-    npt.assert_equal('amp' in offset['A1']['metadata'], False)
-    npt.assert_equal(offset['B2']['metadata'], plain)
-
-
-@pytest.mark.parametrize('entry', [
-    # A type that is not a class, and so has no hook to call:
-    {'metadata': {'amp': 3}, 'type': 'BiphasicPulseTrain'},
-    # A class that is not a Stimulus, whose `_rescale_params` means something
-    # else entirely (or does not exist):
-    {'metadata': {'amp': 3}, 'type': dict},
-    {'metadata': {'amp': 3}},                            # no type recorded
-    {'metadata': 'not-a-dict', 'type': BiphasicPulseTrain},
-    {'type': BiphasicPulseTrain},                        # no metadata recorded
-    'not-an-entry-at-all'])
-def test_Stimulus_rescale_metadata_tolerates_odd_entries(entry):
-    stim = Stimulus({'A1': BiphasicPulseTrain(20, 10, 0.45, stim_dur=100)})
-    stim.metadata['electrodes']['A1'] = entry
-    for modified in (stim * 2, stim * -2, stim + 5, stim.append(stim >> 1)):
-        npt.assert_equal(modified.metadata['electrodes']['A1'], entry)
-
-
-def test_Stimulus_rescale_metadata_leaves_plain_metadata_alone():
-    # A stimulus that describes no pulse parameters has nothing to keep in
-    # sync, and its metadata must survive the operators untouched:
+def test_Stimulus_operators_leave_user_metadata_alone():
+    # What the user filed is theirs, whatever the operator does to the data:
     stim = Stimulus(np.ones((2, 3)), metadata={'note': 'mine'})
     for modified in (stim * 2, stim + 5, -stim, stim >> 1):
         npt.assert_equal(modified.metadata['user'], {'note': 'mine'})
-    # Same for a source type that records no parameters of its own:
-    pulse = Stimulus({'A1': BiphasicPulse(10, 0.45)})
-    npt.assert_equal((pulse * 2).metadata['electrodes']['A1']['type'],
-                     BiphasicPulse)
+
+
+def test_Stimulus_collection_of_mixed_sources():
+    # An implant's stimulus need not be all pulse trains, and the entries that
+    # are keep their identity next to the ones that are not:
+    stim = Stimulus({'A1': BiphasicPulseTrain(20, 10, 0.45, stim_dur=100),
+                     'B2': Stimulus([[1, 2, 3]], time=[0, 1, 2],
+                                    metadata={'note': 'mine'})})
+    sources = dict(stim._structured_sources())
+    npt.assert_equal(type(sources['A1']), BiphasicPulseTrain)
+    npt.assert_equal(type(sources['B2']), Stimulus)
+    npt.assert_equal(sources['B2'].metadata['user'], {'note': 'mine'})
+    # Scaling scales the train and leaves the plain entry describing itself:
+    scaled = dict((stim * 3)._structured_sources())
+    npt.assert_almost_equal(scaled['A1'].amp, 30)
+    npt.assert_equal(scaled['B2'].metadata['user'], {'note': 'mine'})
 
 
 @pytest.mark.parametrize('freq, phase_dur, interphase_dur',
@@ -564,7 +457,6 @@ def test_PulseTrain_electrode_name(cls, args, kwargs):
     # And the name has to survive the trip through Stimulus():
     stim = Stimulus(cls(*args, stim_dur=100, electrode='A1', **kwargs))
     npt.assert_equal(stim.electrodes, ['A1'])
-    npt.assert_equal('A1' in stim.metadata['electrodes'], True)
 
 
 def test_pulse_train_units():
@@ -607,30 +499,25 @@ def test_pulse_train_units():
         PulseTrain(20 * uA, pulse)
 
 
-def test_pulse_train_metadata_units():
-    """Metadata keeps storing plain numbers in its historical units
+def test_pulse_train_parameter_units():
+    """A train reports plain numbers in its historical units
 
     BiphasicAxonMapModel and DynaphosModel read amplitude, frequency and phase
-    duration back off the metadata and feed them straight into their
-    equations, so a Quantity landing there would break them.
+    duration off the train and feed them straight into their equations, so a
+    Quantity coming back would break them.
     """
     train = BiphasicPulseTrain(0.02 * kHz, 0.05 * mA, 450 * us,
                                delay_dur=100 * us, stim_dur=0.2 * sec)
-    npt.assert_almost_equal(train.metadata['freq'], 20)
-    npt.assert_almost_equal(train.metadata['amp'], 50)
-    npt.assert_almost_equal(train.metadata['phase_dur'], 0.45)
-    npt.assert_almost_equal(train.metadata['delay_dur'], 0.1)
-    for key in ('freq', 'amp', 'phase_dur', 'delay_dur'):
-        npt.assert_equal(isinstance(train.metadata[key], Quantity), False)
-        npt.assert_equal(np.isscalar(train.metadata[key]), True)
-    # The same goes for the attributes a model or a plot might read:
-    npt.assert_equal(isinstance(train.freq, Quantity), False)
-    npt.assert_almost_equal(train.freq, 20)
+    for name, value in (('freq', 20), ('amp', 50), ('phase_dur', 0.45),
+                        ('delay_dur', 0.1)):
+        npt.assert_almost_equal(getattr(train, name), value)
+        npt.assert_equal(isinstance(getattr(train, name), Quantity), False)
+        npt.assert_equal(np.isscalar(getattr(train, name)), True)
     npt.assert_equal(isinstance(PulseTrain(0.02 * kHz,
                                            BiphasicPulse(50, 0.45)).freq,
                                 Quantity), False)
     # And scaling still rewrites the amplitude it advertises:
-    npt.assert_almost_equal((train * 2).metadata['amp'], 100)
+    npt.assert_almost_equal((train * 2).amp, 100)
 
 
 def test_PulseTrain_unit_provenance():
@@ -764,7 +651,7 @@ def test_PulseTrain_pulse_is_not_a_way_into_the_train():
 
 
 @pytest.mark.parametrize('factor', [2, 0.5, -1, -2, 1, 0, 1e-3])
-def test_BiphasicPulseTrain_scaling_rebuilds_its_model_metadata(factor):
+def test_BiphasicPulseTrain_scaling_rebuilds_the_train(factor):
     pt = BiphasicPulseTrain(20, 10, 0.45, interphase_dur=0.2, delay_dur=1,
                             stim_dur=100, metadata='userdata')
     routes = [pt * factor, factor * pt]
@@ -780,10 +667,8 @@ def test_BiphasicPulseTrain_scaling_rebuilds_its_model_metadata(factor):
         for name in ('freq', 'phase_dur', 'interphase_dur', 'delay_dur',
                      'n_pulses', 'stim_dur'):
             npt.assert_almost_equal(getattr(scaled, name), getattr(pt, name))
-        # What the user put in the metadata is theirs; the compatibility keys
-        # are rebuilt by the constructor, from the new amplitude:
+        # What the user put in the metadata is theirs, and comes along:
         npt.assert_equal(scaled.metadata['user'], 'userdata')
-        npt.assert_almost_equal(scaled.metadata['amp'], pt.amp * abs(factor))
         # ...and the waveform is the scaled one, to within float32 rounding:
         npt.assert_allclose(scaled.data, factor * pt.data, rtol=1e-6,
                             atol=1e-6)


### PR DESCRIPTION
Closes #843.

`EnsembleImplant.merge_stimuli()` now preserves structured child stimuli when they map cleanly onto the ensemble electrode array, instead of immediately collapsing them into sampled waveforms. This lets models such as `DynaphosModel` read pulse-train parameters directly.

This also removes the now-obsolete per-electrode metadata copies and Dynaphos metadata fallback. 