### PR TITLE
[FIX] [ENH] Fix and enable Granley spatial + temporal model composition

### DIFF
--- a/doc/users/release_notes.rst
+++ b/doc/users/release_notes.rst
@@ -64,6 +64,11 @@ API changes:
   :py:class:`~pulse2percept.models.FadingTemporal` now ignores anodic current
   rather than treating it as negative brightness, and enforces ``tau >= dt``.
 
+* :py:class:`~pulse2percept.models.BiphasicAxonMapSpatial` can now be paired
+  with a temporal model, in a space-time-separable approximation: Granley
+  determines the peak spatial percept, the temporal model supplies a
+  normalized envelope for it to evolve along (:issue:`565`).
+
 * Spatial-model APIs were cleaned up: ``xystep`` was renamed to ``step`` and
   ``axlambda`` to ``lam``. Axon-map and cortical scoreboard models also gained
   configurable smoothing across their relevant visual-field meridians.

--- a/pulse2percept/models/base.py
+++ b/pulse2percept/models/base.py
@@ -1203,42 +1203,23 @@ class TemporalModel(BaseModel, metaclass=ABCMeta):
     #: ``n_jobs`` is an alias for ``n_threads``; see ``_n_jobs_alias``.
     n_jobs = _n_jobs_alias()
 
-    #: Sign of the stimulus current that drives brightness in this model: -1 if
-    #: cathodic (negative) current does, +1 if anodic (positive) current does.
-    #: The two conventions are both in use -- ``FadingTemporal`` and
-    #: ``Horsager2009Temporal`` are cathodic-driven, ``Nanduri2012Temporal`` is
-    #: anodic-driven -- and a stimulus of the wrong polarity produces a blank
-    #: percept rather than an error. This is what lets ``predict_percept`` say
-    #: so; nothing else reads it.
+    #: Polarity that drives brightness: -1 for cathodic, +1 for anodic.
+    #: Used when checking stimulus polarity and constructing canonical drives.
     _drive_sign = -1
 
-    #: Whether ``_predict_temporal`` accepts a ``reduce`` argument and honors it
-    #: itself, tracking the peak across every ``dt`` step of the interval. That
-    #: is exact and costs one compare per step. Models that leave this False
-    #: fall back to sampling each interval ``_FRAME_SUBSAMPLES`` times, which
-    #: costs memory proportional to the sample count and still misses
-    #: transients shorter than the resulting step.
+    #: Whether ``_predict_temporal`` can return an exact peak over each interval
+    #: instead of relying on subsampling in ``predict_percept``.
     _reduces_intervals = False
 
     def get_default_params(self):
-        """Return a dictionary of default values for all model parameters"""
+        """Return default model parameters."""
         params = {
-            # Simulation time step (ms):
-            'dt': 0.005,
-            # Below threshold, percept has brightness zero:
+            'dt': 0.005,  # Simulation time step (ms)
             'thresh_percept': 0,
-            # How to summarize an output interval when `predict_percept` picks
-            # the output times itself; see `predict_percept`. The published
-            # models default to 'last', which is what they have always
-            # reported; a model is free to override it, as `FadingTemporal`
-            # does:
-            'reduce': 'last',
-            # True: print status messages, False: silent
+            'reduce': 'last',  # How automatically chosen intervals are summarized
             'verbose': True,
-            # `n_jobs` is an alias that writes through to `n_threads`, so it
-            # has to be applied *after* it:
             'n_threads': multiprocessing.cpu_count(),
-            'n_jobs': None,
+            'n_jobs': None,  # Alias for n_threads; must be applied last
         }
         return params
 

--- a/pulse2percept/models/base.py
+++ b/pulse2percept/models/base.py
@@ -13,7 +13,7 @@ from scipy.ndimage import gaussian_filter1d
 
 from ..implants import ProsthesisSystem
 from ..stimuli import Stimulus
-from ..stimuli.base import _describe_unit
+from ..stimuli.base import _describe_unit, _has_time_axis
 from ..percepts import Percept
 from ..topography import Curcio1990Map, Grid2D, RetinalMap
 from ..units import (DimensionMismatchError, Quantity, Unit, as_value, dva, ms,
@@ -1902,7 +1902,11 @@ class Model(PrettyPrint):
             # Nothing to see here:
             return None
         _require_stim_dimension(self, implant.stim)
-        if implant.stim.time is None and t_percept is not None:
+        # `_has_time_axis`, not `stim.time`: whether there is a time axis is a
+        # question a stimulus can answer from its structure, and asking it for
+        # the axis itself would generate the waveform behind it.
+        has_time_axis = _has_time_axis(implant.stim)
+        if not has_time_axis and t_percept is not None:
             raise ValueError(f"Cannot calculate temporal response at times "
                              f"t_percept={t_percept}, because stimulus/percept does not "
                              f"have a time component.")
@@ -1912,7 +1916,7 @@ class Model(PrettyPrint):
             # (i.e., whenever the stimulus changes)
             resp = self.spatial.predict_percept(_delivered(implant),
                                                 t_percept=None)
-            if implant.stim.time is not None:
+            if has_time_axis:
                 combine = getattr(self.spatial, '_combine_temporal', None)
                 if resp.time is None and combine is not None:
                     # A spatial model hands over a percept with no time axis,

--- a/pulse2percept/models/base.py
+++ b/pulse2percept/models/base.py
@@ -1909,16 +1909,21 @@ class Model(PrettyPrint):
 
         if self.has_space and self.has_time:
             # Need to calculate the spatial response at all stimulus points
-            # (i.e., whenever the stimulus changes). Of the delivered pulse
-            # train, not of the modulation behind it: the pulses are what the
-            # temporal model integrates, and dropping them here would leave it
-            # nothing to do (see `_delivered`).
+            # (i.e., whenever the stimulus changes)
             resp = self.spatial.predict_percept(_delivered(implant),
                                                 t_percept=None)
             if implant.stim.time is not None:
-                # Then pass that to the temporal model, which will output at
-                # all `t_percept` time steps:
-                resp = self.temporal.predict_percept(resp, t_percept=t_percept)
+                combine = getattr(self.spatial, '_combine_temporal', None)
+                if resp.time is None and combine is not None:
+                    # A spatial model hands over a percept with no time axis,
+                    # so the spatial model decides what to do with it:
+                    resp = combine(resp, self.temporal, implant.stim,
+                                   t_percept)
+                else:
+                    # Then pass that to the temporal model, which will output
+                    # at all `t_percept` time steps:
+                    resp = self.temporal.predict_percept(resp,
+                                                         t_percept=t_percept)
         elif self.has_space:
             resp = self.spatial.predict_percept(implant, t_percept=t_percept)
         elif self.has_time:

--- a/pulse2percept/models/granley2021.py
+++ b/pulse2percept/models/granley2021.py
@@ -14,10 +14,7 @@ from ..utils.base import has_own_attr
 from .base import NotBuiltError, BaseModel, _require_stim_dimension
 from ._granley2021 import fast_biphasic_axon_map
 
-#: How many times the window searched for the peak of the canonical temporal
-#: response may be doubled before the largest sample seen is accepted as the
-#: peak. A response still rising after this much silence is not one a finite
-#: drive can produce; see ``BiphasicAxonMapSpatial._envelope_peak``.
+# Safety limit for locating delayed temporal peaks.
 _PEAK_SEARCH_DOUBLINGS = 4
 
 # `find_threshold` bisects on a scaled copy of the stimulus *data*. This model
@@ -276,7 +273,9 @@ class BiphasicAxonMapSpatial(AxonMapSpatial):
         When combined with a temporal model, the Granley prediction is treated
         as the peak spatial percept. The temporal model supplies a normalized
         brightness time course, yielding a space-time-separable percept
-        ``P(x, y, t) = G(x, y) k(t)``.
+        ``P(x, y, t) = G(x, y) k(t)``. ``thresh_percept`` of the temporal
+        model is ignored, because its response is normalized before being
+        applied to the Granley percept.
 
     Parameters
     ----------
@@ -631,23 +630,26 @@ class BiphasicAxonMapSpatial(AxonMapSpatial):
         """Return the peak response to the canonical temporal drive."""
         dt = temporal.dt
         episode = envelope.times(temporal.time_unit)[-1]
+
         for _ in range(_PEAK_SEARCH_DOUBLINGS):
-            # Find the peak independently of t_percept, since different
-            # temporal models may peak before, at, or after stimulus
-            # offset.
             t = np.arange(int(round(episode / dt)) + 1) * dt
             resp = temporal.predict_percept(envelope, t_percept=t).data
             if np.argmax(resp) < resp.size - 1:
                 break
             episode *= 2
+        else:
+            raise ValueError(
+                f"Could not locate the peak response of "
+                f"{type(temporal).__name__} within {t[-1]:g} "
+                f"{temporal.time_unit}."
+            )
+
         peak = resp.max()
         if not np.isfinite(peak) or peak <= 0:
             raise ValueError(
-                f"{type(temporal).__name__} answers a unit drive with no "
-                f"finite positive peak ({peak}), so there is no envelope to "
-                f"normalize. A temporal model can only scale this model's "
-                f"percept over time, and one that never responds leaves "
-                f"nothing to scale.")
+                f"{type(temporal).__name__} produced no finite positive "
+                f"response to the canonical drive."
+            )
         return peak
 
     def _envelope_dur(self, stim):

--- a/pulse2percept/models/granley2021.py
+++ b/pulse2percept/models/granley2021.py
@@ -206,7 +206,7 @@ class DefaultStreakModel(BaseModel):
 
 
 def _pulse_train_params(stim):
-    """``(electrode, freq, amp, phase_dur)`` for every electrode driven
+    """``(electrode, freq, amp, phase_dur, stim_dur)`` per driven electrode
 
     Read off the pulse trains the stimulus is made of rather than off a copy
     of their numbers in its metadata: a stimulus whose samples were rewritten
@@ -243,7 +243,8 @@ def _pulse_train_params(stim):
                             f"no delay dur (Failing electrode: {electrode})")
         if source.amp == 0:
             continue
-        params.append((electrode, source.freq, source.amp, source.phase_dur))
+        params.append((electrode, source.freq, source.amp,
+                       source.phase_dur, source.stim_dur))
     return params
 
 
@@ -500,8 +501,8 @@ class BiphasicAxonMapSpatial(AxonMapSpatial):
             raise TypeError(
                 "Stim must be of type Stimulus but it is " + str(type(stim)))
         params = _pulse_train_params(stim)
-        active = [electrode for electrode, _, _, _ in params]
-        elec_params = np.array([p[1:] for p in params],
+        active = [p[0] for p in params]
+        elec_params = np.array([p[1:4] for p in params],
                                dtype=np.float32).reshape((-1, 3))
         # Only the electrodes that are actually driven, in the order they were
         # collected above:
@@ -613,26 +614,16 @@ class BiphasicAxonMapSpatial(AxonMapSpatial):
                        metadata={'stim': stim.metadata})
 
     def _combine_temporal(self, percept, temporal, stim, t_percept):
-        """Fade this model's one representative frame over time
+        """Apply ``FadingTemporal`` as a normalized temporal envelope
 
         What ``Model.predict_percept`` delegates to when this model is paired
-        with a temporal one (see there). This model reports a single frame
-        computed from amplitude, frequency and phase duration, so there is no
-        time course left for a temporal model to integrate. Offered instead is
-        the space-time-separable approximation
-
-        .. math::
-
-            P(x, y, t) = G(x, y) \\frac{k(t)}{\\max_t k(t)},
-
-        where :math:`G` is the percept this model predicts on its own and
-        :math:`k` is :py:class:`~pulse2percept.models.FadingTemporal`'s
-        response to a unit cathodic envelope that is on for as long as the
-        stimulus lasts. The stimulus waveform is deliberately not passed
-        through: :math:`G` already accounts for amplitude, frequency and phase
-        duration, and integrating the pulses again would count them twice.
+        with a temporal one; the approximation is documented on the class.
         """
-        if not isinstance(temporal, FadingTemporal):
+        # The exact class, not a subclass, for the same reason
+        # `_pulse_train_params` insists on `BiphasicPulseTrain`: the peak below
+        # is located by hand from what `fading_fast` does, and a subclass is
+        # free to integrate differently or to count time in another unit.
+        if type(temporal) is not FadingTemporal:
             raise NotImplementedError(
                 f"{type(self).__name__} can only be combined with "
                 f"FadingTemporal, not {type(temporal).__name__}. It predicts "
@@ -645,7 +636,7 @@ class BiphasicAxonMapSpatial(AxonMapSpatial):
                 f"{type(self).__name__}, not {temporal.thresh_percept}. The "
                 f"envelope it is applied to is normalized to a peak of 1, so "
                 f"a threshold in brightness units has no meaning there.")
-        dur = float(stim.time[-1])
+        dur = self._envelope_dur(stim)
         # A unit cathodic step: `fading_fast` holds each sample until the next
         # one, so amplitude -1 at t=0 and 0 at t=dur is "on" for exactly the
         # stimulation duration.
@@ -662,6 +653,34 @@ class BiphasicAxonMapSpatial(AxonMapSpatial):
                        space=self.grid, time=resp.time,
                        time_unit=self.time_unit,
                        metadata={'stim': stim.metadata})
+
+    def _envelope_dur(self, stim):
+        """How long the envelope handed to the temporal model stays on
+
+        Read off the driven pulse trains rather than off ``stim.time``, which
+        would generate the waveform this model never needs -- and which would
+        let an electrode at zero amplitude, ignored everywhere else, stretch
+        the envelope.
+        """
+        durs = {p[4] for p in _pulse_train_params(stim)}
+        if len(durs) > 1:
+            raise NotImplementedError(
+                f"{type(self).__name__} combined with FadingTemporal needs "
+                f"every driven electrode to share one stim_dur, and these are "
+                f"{sorted(durs)}. One envelope cannot have contributions stop "
+                f"at different times; the percept would then not be separable "
+                f"into a spatial and a temporal factor at all.")
+        if durs:
+            return float(durs.pop())
+        # Nothing is driven above zero amplitude, so the percept is zero
+        # whatever envelope it rides on and all that is left to settle is the
+        # time axis. A stimulus with no retained trains at all has already been
+        # read for its samples by `_pulse_train_params`, so asking it for its
+        # time costs no waveform here either:
+        sources = stim._structured_sources()
+        if sources:
+            return float(max(src.stim_dur for _, src in sources))
+        return float(stim.time[-1])
 
     def find_threshold(self, implant, bright_th, amp_range=(0, 999), amp_tol=1,
                        bright_tol=0.1, max_iter=100):

--- a/pulse2percept/models/granley2021.py
+++ b/pulse2percept/models/granley2021.py
@@ -2,6 +2,7 @@
    :py:class:`~pulse2percept.models.BiphasicAxonMapSpatial` [Granley2021]_"""
 import numpy as np
 import sys
+from copy import deepcopy
 
 from . import AxonMapSpatial, Model
 from ..implants import ProsthesisSystem, ElectrodeArray
@@ -11,8 +12,13 @@ from ..units import as_value, um
 from ..utils import FreezeError, rename_parameter
 from ..utils.base import has_own_attr
 from .base import NotBuiltError, BaseModel, _require_stim_dimension
-from .temporal import FadingTemporal
 from ._granley2021 import fast_biphasic_axon_map
+
+#: How many times the window searched for the peak of the canonical temporal
+#: response may be doubled before the largest sample seen is accepted as the
+#: peak. A response still rising after this much silence is not one a finite
+#: drive can produce; see ``BiphasicAxonMapSpatial._envelope_peak``.
+_PEAK_SEARCH_DOUBLINGS = 4
 
 # `find_threshold` bisects on a scaled copy of the stimulus *data*. This model
 # reads amplitude off the pulse train instead, where it means a multiple of
@@ -267,15 +273,10 @@ class BiphasicAxonMapSpatial(AxonMapSpatial):
 
     .. note::
 
-        Of the temporal models, only
-        :py:class:`~pulse2percept.models.FadingTemporal` can be combined with
-        this one, and it is combined in a space-time-separable approximation:
-        Granley supplies the peak spatial percept :math:`G(x, y)` and fading
-        supplies a normalized envelope, so that
-        :math:`P(x, y, t) = G(x, y) k(t) / \\max_t k(t)`. The pulse train is
-        not integrated; :math:`k` is the response to a unit cathodic envelope
-        lasting as long as the stimulus does. Any other temporal model is
-        refused.
+        When combined with a temporal model, the Granley prediction is treated
+        as the peak spatial percept. The temporal model supplies a normalized
+        brightness time course, yielding a space-time-separable percept
+        ``P(x, y, t) = G(x, y) k(t)``.
 
     Parameters
     ----------
@@ -583,20 +584,12 @@ class BiphasicAxonMapSpatial(AxonMapSpatial):
                              f"was built for {self.eye}.")
         if implant.stim is None:
             return None
-        # What physical quantity the stimulus is comes before what waveform
-        # it is: a picture is not an unsuitable pulse train, it is not a
-        # current at all, and saying so is more use than asking it for pulse
-        # metadata it was never going to have.
+        # Determine what physical quantity the stimulus is:
         _require_stim_dimension(self, implant.stim)
-        # Which pulse trains this stimulus is made of, and whether it is made
-        # of pulse trains at all. Asked here so that an unreadable stimulus is
-        # refused before any of the work below:
+        # Determine which pulse trains the stimulus is made of:
         params = _pulse_train_params(implant.stim)
         t_percept = as_value(t_percept, self.time_unit, 't_percept')
         stim = implant.stim
-        # `np.array([t]).size` rather than `len(t)`, so that the documented
-        # scalar spelling `t_percept=20` counts as one time point instead
-        # of raising -- the same idiom `SpatialModel.predict_percept` uses:
         n_time = 1 if t_percept is None else np.array([t_percept]).size
         if not params:
             # Nothing is driven above zero amplitude:
@@ -614,69 +607,61 @@ class BiphasicAxonMapSpatial(AxonMapSpatial):
                        metadata={'stim': stim.metadata})
 
     def _combine_temporal(self, percept, temporal, stim, t_percept):
-        """Apply ``FadingTemporal`` as a normalized temporal envelope
-
-        What ``Model.predict_percept`` delegates to when this model is paired
-        with a temporal one; the approximation is documented on the class.
-        """
-        # The exact class, not a subclass, for the same reason
-        # `_pulse_train_params` insists on `BiphasicPulseTrain`: the peak below
-        # is located by hand from what `fading_fast` does, and a subclass is
-        # free to integrate differently or to count time in another unit.
-        if type(temporal) is not FadingTemporal:
-            raise NotImplementedError(
-                f"{type(self).__name__} can only be combined with "
-                f"FadingTemporal, not {type(temporal).__name__}. It predicts "
-                f"a single frame from amplitude, frequency and phase "
-                f"duration, so a temporal model can only supply a normalized "
-                f"brightness envelope, not integrate the pulse train.")
-        if temporal.thresh_percept != 0:
-            raise ValueError(
-                f"FadingTemporal.thresh_percept must be 0 when combined with "
-                f"{type(self).__name__}, not {temporal.thresh_percept}. The "
-                f"envelope it is applied to is normalized to a peak of 1, so "
-                f"a threshold in brightness units has no meaning there.")
+        """Apply a normalized temporal response to the spatial percept."""
         dur = self._envelope_dur(stim)
-        # A unit cathodic step: `fading_fast` holds each sample until the next
-        # one, so amplitude -1 at t=0 and 0 at t=dur is "on" for exactly the
-        # stimulation duration.
-        envelope = Stimulus(np.array([[-1.0, 0.0]]), electrodes=['envelope'],
-                            time=[0, dur], metadata=stim.metadata.get('user'))
-        # The drive is constant while it is on, so brightness rises
-        # monotonically until it stops and decays from there: the peak is the
-        # last simulation step before `dur`.
-        t_peak = max(0.0, (np.ceil(dur / temporal.dt) - 1.0) * temporal.dt)
-        peak = temporal.predict_percept(envelope, t_percept=t_peak).data.max()
-        resp = temporal.predict_percept(envelope, t_percept=t_percept)
+        # A unit drive of the polarity this temporal model responds to (see
+        # `TemporalModel._drive_sign`), held for exactly the stimulation
+        # duration:
+        envelope = Stimulus(np.array([[float(temporal._drive_sign), 0.0]]),
+                            electrodes=['envelope'], time=[0, dur],
+                            metadata=stim.metadata.get('user'))
+        # Leave the caller's own model untouched:
+        probe = deepcopy(temporal)
+        probe.thresh_percept = 0
+        peak = self._envelope_peak(probe, envelope)
+        resp = probe.predict_percept(envelope, t_percept=t_percept)
         fade = resp.data.reshape(-1) / peak
         return Percept(percept.data[..., 0][..., np.newaxis] * fade,
                        space=self.grid, time=resp.time,
-                       time_unit=self.time_unit,
+                       time_unit=probe.time_unit,
                        metadata={'stim': stim.metadata})
 
-    def _envelope_dur(self, stim):
-        """How long the envelope handed to the temporal model stays on
+    @staticmethod
+    def _envelope_peak(temporal, envelope):
+        """Return the peak response to the canonical temporal drive."""
+        dt = temporal.dt
+        episode = envelope.times(temporal.time_unit)[-1]
+        for _ in range(_PEAK_SEARCH_DOUBLINGS):
+            # Find the peak independently of t_percept, since different
+            # temporal models may peak before, at, or after stimulus
+            # offset.
+            t = np.arange(int(round(episode / dt)) + 1) * dt
+            resp = temporal.predict_percept(envelope, t_percept=t).data
+            if np.argmax(resp) < resp.size - 1:
+                break
+            episode *= 2
+        peak = resp.max()
+        if not np.isfinite(peak) or peak <= 0:
+            raise ValueError(
+                f"{type(temporal).__name__} answers a unit drive with no "
+                f"finite positive peak ({peak}), so there is no envelope to "
+                f"normalize. A temporal model can only scale this model's "
+                f"percept over time, and one that never responds leaves "
+                f"nothing to scale.")
+        return peak
 
-        Read off the driven pulse trains rather than off ``stim.time``, which
-        would generate the waveform this model never needs -- and which would
-        let an electrode at zero amplitude, ignored everywhere else, stretch
-        the envelope.
-        """
+    def _envelope_dur(self, stim):
+        """Return the common duration of the active pulse trains."""
         durs = {p[4] for p in _pulse_train_params(stim)}
         if len(durs) > 1:
             raise NotImplementedError(
-                f"{type(self).__name__} combined with FadingTemporal needs "
-                f"every driven electrode to share one stim_dur, and these are "
-                f"{sorted(durs)}. One envelope cannot have contributions stop "
-                f"at different times; the percept would then not be separable "
-                f"into a spatial and a temporal factor at all.")
+                f"{type(self).__name__} requires active electrodes to share "
+                f"one stim_dur, not {sorted(durs)}."
+            )
         if durs:
             return float(durs.pop())
-        # Nothing is driven above zero amplitude, so the percept is zero
-        # whatever envelope it rides on and all that is left to settle is the
-        # time axis. A stimulus with no retained trains at all has already been
-        # read for its samples by `_pulse_train_params`, so asking it for its
-        # time costs no waveform here either:
+
+        # No active electrodes; duration only determines the output time axis.
         sources = stim._structured_sources()
         if sources:
             return float(max(src.stim_dur for _, src in sources))
@@ -684,12 +669,7 @@ class BiphasicAxonMapSpatial(AxonMapSpatial):
 
     def find_threshold(self, implant, bright_th, amp_range=(0, 999), amp_tol=1,
                        bright_tol=0.1, max_iter=100):
-        """Not supported by this model
-
-        Raises
-        ------
-        NotImplementedError
-        """
+        """Not supported by this model"""
         raise NotImplementedError(_FIND_THRESHOLD_MSG.format(
             cls=type(self).__name__))
 
@@ -705,11 +685,12 @@ class BiphasicAxonMapModel(Model):
     This model is different than other spatial models in that it calculates
     one representative percept from all time steps of the stimulus.
 
-    Brightness, size, and streak length scaling are controlled by the parameters
-    bright_model, size_model, and streak model respectively. By default, these are
-    set to classes that implement Eqs 3-6 from Granley 2021. These models can be
-    individually customized by setting the bright_model, size_model, or streak_model
-    to any python callable with signature f(freq, amp, pdur).
+    Brightness, size, and streak length scaling are controlled by the
+    parameters bright_model, size_model, and streak model respectively. 
+    By default, these are set to classes that implement Eqs 3-6 from 
+    [Granley2021]_. These models can be individually customized by setting
+    the bright_model, size_model, or streak_model to any python callable
+    with signature ``f(freq, amp, pdur)``.
 
     .. important::
 

--- a/pulse2percept/models/granley2021.py
+++ b/pulse2percept/models/granley2021.py
@@ -11,6 +11,7 @@ from ..units import as_value, um
 from ..utils import FreezeError, rename_parameter
 from ..utils.base import has_own_attr
 from .base import NotBuiltError, BaseModel, _require_stim_dimension
+from .temporal import FadingTemporal
 from ._granley2021 import fast_biphasic_axon_map
 
 # `find_threshold` bisects on a scaled copy of the stimulus *data*. This model
@@ -263,10 +264,17 @@ class BiphasicAxonMapSpatial(AxonMapSpatial):
     individually customized by setting the bright_model, size_model, or streak_model
     to any python callable with signature f(freq, amp, pdur)
 
-    .. important::
-    
-        Using this model in combination with a temporal model is not currently
-        supported and will give unexpected results
+    .. note::
+
+        Of the temporal models, only
+        :py:class:`~pulse2percept.models.FadingTemporal` can be combined with
+        this one, and it is combined in a space-time-separable approximation:
+        Granley supplies the peak spatial percept :math:`G(x, y)` and fading
+        supplies a normalized envelope, so that
+        :math:`P(x, y, t) = G(x, y) k(t) / \\max_t k(t)`. The pulse train is
+        not integrated; :math:`k` is the response to a unit cathodic envelope
+        lasting as long as the stimulus does. Any other temporal model is
+        refused.
 
     Parameters
     ----------
@@ -601,6 +609,57 @@ class BiphasicAxonMapSpatial(AxonMapSpatial):
         # This override bypasses SpatialModel.predict_percept:
         resp = self._postprocess_spatial(resp)
         return Percept(resp, space=self.grid, time=t_percept,
+                       time_unit=self.time_unit,
+                       metadata={'stim': stim.metadata})
+
+    def _combine_temporal(self, percept, temporal, stim, t_percept):
+        """Fade this model's one representative frame over time
+
+        What ``Model.predict_percept`` delegates to when this model is paired
+        with a temporal one (see there). This model reports a single frame
+        computed from amplitude, frequency and phase duration, so there is no
+        time course left for a temporal model to integrate. Offered instead is
+        the space-time-separable approximation
+
+        .. math::
+
+            P(x, y, t) = G(x, y) \\frac{k(t)}{\\max_t k(t)},
+
+        where :math:`G` is the percept this model predicts on its own and
+        :math:`k` is :py:class:`~pulse2percept.models.FadingTemporal`'s
+        response to a unit cathodic envelope that is on for as long as the
+        stimulus lasts. The stimulus waveform is deliberately not passed
+        through: :math:`G` already accounts for amplitude, frequency and phase
+        duration, and integrating the pulses again would count them twice.
+        """
+        if not isinstance(temporal, FadingTemporal):
+            raise NotImplementedError(
+                f"{type(self).__name__} can only be combined with "
+                f"FadingTemporal, not {type(temporal).__name__}. It predicts "
+                f"a single frame from amplitude, frequency and phase "
+                f"duration, so a temporal model can only supply a normalized "
+                f"brightness envelope, not integrate the pulse train.")
+        if temporal.thresh_percept != 0:
+            raise ValueError(
+                f"FadingTemporal.thresh_percept must be 0 when combined with "
+                f"{type(self).__name__}, not {temporal.thresh_percept}. The "
+                f"envelope it is applied to is normalized to a peak of 1, so "
+                f"a threshold in brightness units has no meaning there.")
+        dur = float(stim.time[-1])
+        # A unit cathodic step: `fading_fast` holds each sample until the next
+        # one, so amplitude -1 at t=0 and 0 at t=dur is "on" for exactly the
+        # stimulation duration.
+        envelope = Stimulus(np.array([[-1.0, 0.0]]), electrodes=['envelope'],
+                            time=[0, dur], metadata=stim.metadata.get('user'))
+        # The drive is constant while it is on, so brightness rises
+        # monotonically until it stops and decays from there: the peak is the
+        # last simulation step before `dur`.
+        t_peak = max(0.0, (np.ceil(dur / temporal.dt) - 1.0) * temporal.dt)
+        peak = temporal.predict_percept(envelope, t_percept=t_peak).data.max()
+        resp = temporal.predict_percept(envelope, t_percept=t_percept)
+        fade = resp.data.reshape(-1) / peak
+        return Percept(percept.data[..., 0][..., np.newaxis] * fade,
+                       space=self.grid, time=resp.time,
                        time_unit=self.time_unit,
                        metadata={'stim': stim.metadata})
 

--- a/pulse2percept/models/tests/test_granley2021.py
+++ b/pulse2percept/models/tests/test_granley2021.py
@@ -1025,3 +1025,25 @@ def test_BiphasicAxonMapSpatial_composite_rejects_unequal_stim_dur(
                                                      stim_dur=1000)})
     with pytest.raises(NotImplementedError):
         composite.predict_percept(implant)
+
+
+def test_BiphasicAxonMapSpatial_composite_normalizes_a_delayed_peak():
+    # This one peaks ~226 ms after a 50 ms drive, several windows past the
+    # first one searched. Normalizing by a value found before the peak would
+    # let the percept outshine the Granley frame it is supposed to peak at:
+    temporal = Horsager2009Temporal(tau3=100)
+    composite, granley = _composite(temporal)
+    implant = _composite_implant()
+    granley_frame = granley.predict_percept(implant).data[..., 0]
+    percept = composite.predict_percept(implant,
+                                        t_percept=_every_dt(temporal, 400))
+    npt.assert_equal(percept.data.max() <= granley_frame.max(), True)
+    npt.assert_array_almost_equal(percept.max(axis='frames'), granley_frame)
+
+
+def test_BiphasicAxonMapSpatial_composite_rejects_an_unlocatable_peak():
+    # Still rising where the search gives up (~624 ms for a 50 ms drive):
+    # saying so beats normalizing by a value known not to be the peak.
+    composite, _ = _composite(Horsager2009Temporal(tau3=300))
+    with pytest.raises(ValueError):
+        composite.predict_percept(_composite_implant())

--- a/pulse2percept/models/tests/test_granley2021.py
+++ b/pulse2percept/models/tests/test_granley2021.py
@@ -878,7 +878,10 @@ def test_BiphasicAxonMapSpatial_with_FadingTemporal_runs():
     # Issue #565: the spatial model collapses time, so the percept it hands
     # over has no time axis for a temporal model to integrate.
     composite, _ = _fading_models()
-    percept = composite.predict_percept(_fading_implant())
+    # Fading is driven by an envelope built from the retained pulse-train
+    # parameters, so pairing the two still asks for no waveform:
+    with _no_pulse_train_rendering():
+        percept = composite.predict_percept(_fading_implant())
     npt.assert_equal(percept.data.ndim, 3)
     npt.assert_equal(percept.data.shape[-1] > 1, True)
     npt.assert_equal(np.all(np.isfinite(percept.data)), True)
@@ -964,3 +967,31 @@ def test_BiphasicAxonMapSpatial_fading_rejects_thresh_percept():
     composite, _ = _fading_models(thresh_percept=0.1)
     with pytest.raises(ValueError):
         composite.predict_percept(_fading_implant())
+
+
+def test_BiphasicAxonMapSpatial_fading_ignores_inactive_stim_dur():
+    # A train at zero amplitude is inactive everywhere, so it must not stretch
+    # the envelope the active one rides on either:
+    composite, _ = _fading_models(tau=100)
+    short = ArgusII(stim={'A5': BiphasicPulseTrain(20, 1, 0.45,
+                                                   stim_dur=100)})
+    padded = ArgusII(stim={'A5': BiphasicPulseTrain(20, 1, 0.45,
+                                                    stim_dur=100),
+                           'A2': BiphasicPulseTrain(20, 0, 0.45,
+                                                    stim_dur=1000)})
+    t_percept = [40, 80, 100]
+    npt.assert_array_almost_equal(
+        composite.predict_percept(padded, t_percept=t_percept).data,
+        composite.predict_percept(short, t_percept=t_percept).data)
+
+
+def test_BiphasicAxonMapSpatial_fading_rejects_unequal_stim_dur():
+    # One separable envelope cannot have one electrode's contribution stop at
+    # 100 ms and another's at 1000 ms:
+    composite, _ = _fading_models()
+    implant = ArgusII(stim={'A5': BiphasicPulseTrain(20, 1, 0.45,
+                                                     stim_dur=100),
+                            'A2': BiphasicPulseTrain(20, 1, 0.45,
+                                                     stim_dur=1000)})
+    with pytest.raises(NotImplementedError):
+        composite.predict_percept(implant)

--- a/pulse2percept/models/tests/test_granley2021.py
+++ b/pulse2percept/models/tests/test_granley2021.py
@@ -861,43 +861,71 @@ def test_BiphasicAxonMap_rejects_an_encoded_stimulus(model_cls):
         model.predict_percept(implant)
 
 
-def _fading_models(tau=100, **temporal_params):
-    """A Granley+fading composite and the standalone Granley model beside it"""
+# The temporal models a Granley composite is expected to work with. Their
+# responses to one canonical drive peak at quite different moments, which is
+# what most of these tests are about.
+_TEMPORALS = [FadingTemporal, Nanduri2012Temporal, Horsager2009Temporal]
+
+# Stimulation lasts this long, and the whole episode -- including the tail in
+# which a lagging cascade can still be rising -- fits in this window (ms):
+_STIM_DUR = 50
+_EPISODE = 200
+
+
+def _composite(temporal):
+    """A Granley spatial model paired with ``temporal``, and Granley alone"""
     grid = dict(xrange=(-3, 3), yrange=(-2, 2), step=1, n_ax_segments=30)
     composite = Model(spatial=BiphasicAxonMapSpatial(**grid),
-                      temporal=FadingTemporal(tau=tau, **temporal_params))
+                      temporal=temporal)
     return composite.build(), BiphasicAxonMapModel(**grid).build()
 
 
-def _fading_implant(stim_dur=200):
+def _composite_implant(stim_dur=_STIM_DUR):
     return ArgusII(stim={'A5': BiphasicPulseTrain(20, 1, 0.45,
                                                   stim_dur=stim_dur)})
 
 
-def test_BiphasicAxonMapSpatial_with_FadingTemporal_runs():
+def _every_dt(temporal, until=_EPISODE):
+    """Every instant ``temporal`` integrates, up to ``until`` (ms)
+
+    Anything coarser reports the peak of the samples rather than the peak.
+    """
+    return np.arange(int(round(until / temporal.dt)) + 1) * temporal.dt
+
+
+@pytest.mark.parametrize('temporal_cls', _TEMPORALS)
+def test_BiphasicAxonMapSpatial_with_temporal_model_runs(temporal_cls):
     # Issue #565: the spatial model collapses time, so the percept it hands
     # over has no time axis for a temporal model to integrate.
-    composite, _ = _fading_models()
-    # Fading is driven by an envelope built from the retained pulse-train
-    # parameters, so pairing the two still asks for no waveform:
+    composite, _ = _composite(temporal_cls())
+    # The drive is built from the retained pulse-train parameters, so pairing
+    # the two still asks for no waveform:
     with _no_pulse_train_rendering():
-        percept = composite.predict_percept(_fading_implant())
+        percept = composite.predict_percept(_composite_implant())
     npt.assert_equal(percept.data.ndim, 3)
     npt.assert_equal(percept.data.shape[-1] > 1, True)
     npt.assert_equal(np.all(np.isfinite(percept.data)), True)
 
 
-def test_BiphasicAxonMapSpatial_fading_peak_frame_is_the_granley_percept():
-    composite, granley = _fading_models()
-    implant = _fading_implant()
-    peak = composite.predict_percept(implant).max(axis='frames')
+@pytest.mark.parametrize('temporal_cls', _TEMPORALS)
+def test_BiphasicAxonMapSpatial_composite_peaks_at_the_granley_percept(
+        temporal_cls):
+    temporal = temporal_cls()
+    composite, granley = _composite(temporal)
+    implant = _composite_implant()
+    percept = composite.predict_percept(implant,
+                                        t_percept=_every_dt(temporal))
     npt.assert_array_almost_equal(
-        peak, granley.predict_percept(implant).data[..., 0])
+        percept.max(axis='frames'),
+        granley.predict_percept(implant).data[..., 0])
 
 
-def test_BiphasicAxonMapSpatial_fading_is_space_time_separable():
-    composite, _ = _fading_models()
-    percept = composite.predict_percept(_fading_implant())
+@pytest.mark.parametrize('temporal_cls', _TEMPORALS)
+def test_BiphasicAxonMapSpatial_composite_is_space_time_separable(
+        temporal_cls):
+    composite, _ = _composite(temporal_cls())
+    percept = composite.predict_percept(_composite_implant(),
+                                        t_percept=[10, 20, 40, 80, 160])
     lit = percept.data[percept.data.max(axis=-1) > 0]
     npt.assert_equal(len(lit) > 1, True)
     # Every pixel rides the same envelope, so the spatial scale is all that
@@ -906,73 +934,73 @@ def test_BiphasicAxonMapSpatial_fading_is_space_time_separable():
     npt.assert_array_almost_equal(shapes - shapes[0], 0)
 
 
-def test_BiphasicAxonMapSpatial_fading_tau_changes_only_the_time_course():
-    implant = _fading_implant()
-    fast, granley = _fading_models(tau=50)
-    slow, _ = _fading_models(tau=400)
-    fast_percept = fast.predict_percept(implant)
-    slow_percept = slow.predict_percept(implant)
-    granley_percept = granley.predict_percept(implant).data[..., 0]
-    npt.assert_array_almost_equal(fast_percept.max(axis='frames'),
-                                  granley_percept)
-    npt.assert_array_almost_equal(slow_percept.max(axis='frames'),
-                                  granley_percept)
-    brightest = np.unravel_index(np.argmax(granley_percept),
-                                 granley_percept.shape)
-    fast_trace = fast_percept.data[brightest]
-    slow_trace = slow_percept.data[brightest]
-    npt.assert_equal(np.allclose(fast_trace, slow_trace), False)
-    # A shorter time constant fills in sooner, so it is brighter throughout
-    # the rise:
-    npt.assert_equal(np.all(fast_trace[1:-1] > slow_trace[1:-1]), True)
-
-
-def test_BiphasicAxonMapSpatial_fading_peak_ignores_requested_sampling():
-    composite, granley = _fading_models(tau=100)
-    implant = _fading_implant()
+@pytest.mark.parametrize('temporal_cls', _TEMPORALS)
+def test_BiphasicAxonMapSpatial_composite_peak_ignores_requested_sampling(
+        temporal_cls):
+    composite, granley = _composite(temporal_cls())
+    implant = _composite_implant()
     granley_max = granley.predict_percept(implant).data.max()
-    # Asked for instants that all fall during the rise, the percept must stay
-    # below the Granley maximum rather than renormalizing onto it:
-    early = composite.predict_percept(implant, t_percept=[20, 40])
+    # Asked only for instants that fall well before the peak, the percept must
+    # stay below the Granley maximum rather than renormalizing onto it:
+    early = composite.predict_percept(implant, t_percept=[10, 20])
     npt.assert_equal(early.data.max() < 0.9 * granley_max, True)
-    # And the samples it does report are the same ones the full run reports:
-    full = composite.predict_percept(implant)
-    npt.assert_array_almost_equal(early.data[..., 0], full.data[..., 1])
-    npt.assert_array_almost_equal(early.data[..., 1], full.data[..., 2])
+    # And those samples are the ones a longer run reports at the same times:
+    longer = composite.predict_percept(implant, t_percept=[10, 20, 40, 80])
+    npt.assert_array_almost_equal(early.data, longer.data[..., :2])
 
 
-def test_BiphasicAxonMapSpatial_fading_decays_after_stimulation():
-    composite, _ = _fading_models(tau=100)
-    percept = composite.predict_percept(_fading_implant(stim_dur=200),
-                                        t_percept=[200, 400, 600])
+@pytest.mark.parametrize('temporal_cls', _TEMPORALS)
+def test_BiphasicAxonMapSpatial_composite_decays_after_stimulation(
+        temporal_cls):
+    composite, _ = _composite(temporal_cls())
+    percept = composite.predict_percept(_composite_implant(),
+                                        t_percept=[100, 150, 200])
     frame_max = percept.data.max(axis=(0, 1))
     npt.assert_equal(np.all(np.diff(frame_max) < 0), True)
     npt.assert_equal(frame_max[-1] > 0, True)
 
 
-@pytest.mark.parametrize('temporal', [Nanduri2012Temporal(),
-                                      Horsager2009Temporal()])
-def test_BiphasicAxonMapSpatial_rejects_other_temporal_models(temporal):
-    model = Model(spatial=BiphasicAxonMapSpatial(xrange=(-2, 2),
-                                                 yrange=(-2, 2), step=1,
-                                                 n_ax_segments=30),
-                  temporal=temporal).build()
-    with pytest.raises(NotImplementedError):
-        model.predict_percept(_fading_implant())
+@pytest.mark.parametrize('temporal_cls, param', [(FadingTemporal, 'tau'),
+                                                 (Nanduri2012Temporal, 'tau3'),
+                                                 (Horsager2009Temporal,
+                                                  'tau3')])
+def test_BiphasicAxonMapSpatial_composite_temporal_params_only_move_time(
+        temporal_cls, param):
+    implant = _composite_implant()
+    traces = []
+    for value in (10, 60):
+        temporal = temporal_cls(**{param: value})
+        composite, granley = _composite(temporal)
+        percept = composite.predict_percept(implant,
+                                            t_percept=_every_dt(temporal))
+        peak_frame = percept.max(axis='frames')
+        npt.assert_array_almost_equal(
+            peak_frame, granley.predict_percept(implant).data[..., 0])
+        brightest = np.unravel_index(np.argmax(peak_frame), peak_frame.shape)
+        traces.append(percept.data[brightest])
+    npt.assert_equal(np.allclose(traces[0], traces[1]), False)
 
 
-def test_BiphasicAxonMapSpatial_fading_rejects_thresh_percept():
-    # The envelope is normalized to a peak of 1, so a threshold in brightness
-    # units would be applied to the wrong quantity:
-    composite, _ = _fading_models(thresh_percept=0.1)
-    with pytest.raises(ValueError):
-        composite.predict_percept(_fading_implant())
+@pytest.mark.parametrize('temporal_cls', _TEMPORALS)
+def test_BiphasicAxonMapSpatial_composite_ignores_temporal_thresh_percept(
+        temporal_cls):
+    # The envelope is normalized, so a floor in the temporal model's own
+    # brightness units would apply to the wrong quantity. Brightness is
+    # Granley's to set, and the caller's own model is left alone:
+    temporal = temporal_cls(thresh_percept=0.1)
+    composite, _ = _composite(temporal)
+    plain, _ = _composite(temporal_cls())
+    implant = _composite_implant()
+    npt.assert_array_almost_equal(
+        composite.predict_percept(implant, t_percept=[10, 20, 40]).data,
+        plain.predict_percept(implant, t_percept=[10, 20, 40]).data)
+    npt.assert_almost_equal(temporal.thresh_percept, 0.1)
 
 
-def test_BiphasicAxonMapSpatial_fading_ignores_inactive_stim_dur():
+def test_BiphasicAxonMapSpatial_composite_ignores_inactive_stim_dur():
     # A train at zero amplitude is inactive everywhere, so it must not stretch
     # the envelope the active one rides on either:
-    composite, _ = _fading_models(tau=100)
+    composite, _ = _composite(FadingTemporal())
     short = ArgusII(stim={'A5': BiphasicPulseTrain(20, 1, 0.45,
                                                    stim_dur=100)})
     padded = ArgusII(stim={'A5': BiphasicPulseTrain(20, 1, 0.45,
@@ -985,10 +1013,12 @@ def test_BiphasicAxonMapSpatial_fading_ignores_inactive_stim_dur():
         composite.predict_percept(short, t_percept=t_percept).data)
 
 
-def test_BiphasicAxonMapSpatial_fading_rejects_unequal_stim_dur():
+@pytest.mark.parametrize('temporal_cls', _TEMPORALS)
+def test_BiphasicAxonMapSpatial_composite_rejects_unequal_stim_dur(
+        temporal_cls):
     # One separable envelope cannot have one electrode's contribution stop at
     # 100 ms and another's at 1000 ms:
-    composite, _ = _fading_models()
+    composite, _ = _composite(temporal_cls())
     implant = ArgusII(stim={'A5': BiphasicPulseTrain(20, 1, 0.45,
                                                      stim_dur=100),
                             'A2': BiphasicPulseTrain(20, 1, 0.45,

--- a/pulse2percept/models/tests/test_granley2021.py
+++ b/pulse2percept/models/tests/test_granley2021.py
@@ -12,8 +12,10 @@ from pulse2percept.stimuli import (AmplitudeEncoder,
                                    AsymmetricBiphasicPulseTrain,
                                    BiphasicPulseTrain, ImageStimulus,
                                    MonophasicPulse, Stimulus)
-from pulse2percept.models import BiphasicAxonMapModel, BiphasicAxonMapSpatial, \
-    AxonMapSpatial
+from pulse2percept.models import (AxonMapSpatial, BiphasicAxonMapModel,
+                                  BiphasicAxonMapSpatial, FadingTemporal,
+                                  Horsager2009Temporal, Model,
+                                  Nanduri2012Temporal)
 from pulse2percept.models.granley2021 import DefaultBrightModel, \
     DefaultSizeModel, DefaultStreakModel
 from pulse2percept.units import (DimensionMismatchError, Quantity,
@@ -857,3 +859,108 @@ def test_BiphasicAxonMap_rejects_an_encoded_stimulus(model_cls):
     implant.stim = encoded
     with pytest.raises(TypeError):
         model.predict_percept(implant)
+
+
+def _fading_models(tau=100, **temporal_params):
+    """A Granley+fading composite and the standalone Granley model beside it"""
+    grid = dict(xrange=(-3, 3), yrange=(-2, 2), step=1, n_ax_segments=30)
+    composite = Model(spatial=BiphasicAxonMapSpatial(**grid),
+                      temporal=FadingTemporal(tau=tau, **temporal_params))
+    return composite.build(), BiphasicAxonMapModel(**grid).build()
+
+
+def _fading_implant(stim_dur=200):
+    return ArgusII(stim={'A5': BiphasicPulseTrain(20, 1, 0.45,
+                                                  stim_dur=stim_dur)})
+
+
+def test_BiphasicAxonMapSpatial_with_FadingTemporal_runs():
+    # Issue #565: the spatial model collapses time, so the percept it hands
+    # over has no time axis for a temporal model to integrate.
+    composite, _ = _fading_models()
+    percept = composite.predict_percept(_fading_implant())
+    npt.assert_equal(percept.data.ndim, 3)
+    npt.assert_equal(percept.data.shape[-1] > 1, True)
+    npt.assert_equal(np.all(np.isfinite(percept.data)), True)
+
+
+def test_BiphasicAxonMapSpatial_fading_peak_frame_is_the_granley_percept():
+    composite, granley = _fading_models()
+    implant = _fading_implant()
+    peak = composite.predict_percept(implant).max(axis='frames')
+    npt.assert_array_almost_equal(
+        peak, granley.predict_percept(implant).data[..., 0])
+
+
+def test_BiphasicAxonMapSpatial_fading_is_space_time_separable():
+    composite, _ = _fading_models()
+    percept = composite.predict_percept(_fading_implant())
+    lit = percept.data[percept.data.max(axis=-1) > 0]
+    npt.assert_equal(len(lit) > 1, True)
+    # Every pixel rides the same envelope, so the spatial scale is all that
+    # told the pixels apart:
+    shapes = lit / lit.max(axis=-1, keepdims=True)
+    npt.assert_array_almost_equal(shapes - shapes[0], 0)
+
+
+def test_BiphasicAxonMapSpatial_fading_tau_changes_only_the_time_course():
+    implant = _fading_implant()
+    fast, granley = _fading_models(tau=50)
+    slow, _ = _fading_models(tau=400)
+    fast_percept = fast.predict_percept(implant)
+    slow_percept = slow.predict_percept(implant)
+    granley_percept = granley.predict_percept(implant).data[..., 0]
+    npt.assert_array_almost_equal(fast_percept.max(axis='frames'),
+                                  granley_percept)
+    npt.assert_array_almost_equal(slow_percept.max(axis='frames'),
+                                  granley_percept)
+    brightest = np.unravel_index(np.argmax(granley_percept),
+                                 granley_percept.shape)
+    fast_trace = fast_percept.data[brightest]
+    slow_trace = slow_percept.data[brightest]
+    npt.assert_equal(np.allclose(fast_trace, slow_trace), False)
+    # A shorter time constant fills in sooner, so it is brighter throughout
+    # the rise:
+    npt.assert_equal(np.all(fast_trace[1:-1] > slow_trace[1:-1]), True)
+
+
+def test_BiphasicAxonMapSpatial_fading_peak_ignores_requested_sampling():
+    composite, granley = _fading_models(tau=100)
+    implant = _fading_implant()
+    granley_max = granley.predict_percept(implant).data.max()
+    # Asked for instants that all fall during the rise, the percept must stay
+    # below the Granley maximum rather than renormalizing onto it:
+    early = composite.predict_percept(implant, t_percept=[20, 40])
+    npt.assert_equal(early.data.max() < 0.9 * granley_max, True)
+    # And the samples it does report are the same ones the full run reports:
+    full = composite.predict_percept(implant)
+    npt.assert_array_almost_equal(early.data[..., 0], full.data[..., 1])
+    npt.assert_array_almost_equal(early.data[..., 1], full.data[..., 2])
+
+
+def test_BiphasicAxonMapSpatial_fading_decays_after_stimulation():
+    composite, _ = _fading_models(tau=100)
+    percept = composite.predict_percept(_fading_implant(stim_dur=200),
+                                        t_percept=[200, 400, 600])
+    frame_max = percept.data.max(axis=(0, 1))
+    npt.assert_equal(np.all(np.diff(frame_max) < 0), True)
+    npt.assert_equal(frame_max[-1] > 0, True)
+
+
+@pytest.mark.parametrize('temporal', [Nanduri2012Temporal(),
+                                      Horsager2009Temporal()])
+def test_BiphasicAxonMapSpatial_rejects_other_temporal_models(temporal):
+    model = Model(spatial=BiphasicAxonMapSpatial(xrange=(-2, 2),
+                                                 yrange=(-2, 2), step=1,
+                                                 n_ax_segments=30),
+                  temporal=temporal).build()
+    with pytest.raises(NotImplementedError):
+        model.predict_percept(_fading_implant())
+
+
+def test_BiphasicAxonMapSpatial_fading_rejects_thresh_percept():
+    # The envelope is normalized to a peak of 1, so a threshold in brightness
+    # units would be applied to the wrong quantity:
+    composite, _ = _fading_models(thresh_percept=0.1)
+    with pytest.raises(ValueError):
+        composite.predict_percept(_fading_implant())


### PR DESCRIPTION
Closes #565.

`BiphasicAxonMapSpatial` now supports composition with temporal models using a space-time-separable percept: Granley defines the peak spatial appearance, while the temporal model supplies a normalized brightness time course.

Also preserves lazy `BiphasicPulseTrain` handling, ignores inactive electrodes when determining stimulation duration, and rejects unequal active durations that cannot be represented by a single temporal envelope.