### PR TITLE
[FIX] [ENH] Fix threshold-relative amplitudes in Granley model

### DIFF
--- a/benchmarks/README.rst
+++ b/benchmarks/README.rst
@@ -216,8 +216,10 @@ built that way exercises a sixtieth of the per-electrode work and barely moves
 when that work regresses. Use the ``array_ptrain`` helper, as above.
 
 **Match the stimulus to the model.** ``BiphasicAxonMapModel`` reads pulse
-parameters off each electrode and rejects an image; a temporal model given a
-single-frame stimulus measures nothing temporal.
+parameters off each electrode and rejects an image, and its amplitude is a
+multiple of threshold (``array_ptrain(..., amp=20 * p2p.units.xTh)``) rather
+than a current; a temporal model given a single-frame stimulus measures
+nothing temporal.
 
 **An image is not a stimulus.** Gray levels are dimensionless, and both
 ``implant.stim`` and ``predict_percept`` refuse them; user code turns an image

--- a/benchmarks/scenarios.py
+++ b/benchmarks/scenarios.py
@@ -35,7 +35,7 @@ from typing import Callable
 import pulse2percept as p2p
 
 
-def array_ptrain(implant_cls):
+def array_ptrain(implant_cls, amp=20):
     """A ``BiphasicPulseTrain`` on *every* electrode of ``implant_cls``.
 
     Handing a bare ``BiphasicPulseTrain`` to an implant assigns it to a single
@@ -49,10 +49,14 @@ def array_ptrain(implant_cls):
     ``stimulus`` benchmark carries about 2 ms of implant construction on top of
     the 15 ms of building the pulse trains. That is small, and the alternative
     -- hard-coding the electrode names -- would duplicate the implant.
+
+    ``amp`` defaults to microamps, which is what the current-based models
+    below read. Granley reads multiples of threshold instead, so its scenario
+    passes ``20 * xTh``; the workload is the same either way.
     """
     names = implant_cls().electrode_names
     return p2p.stimuli.Stimulus(
-        {e: p2p.stimuli.BiphasicPulseTrain(20, 20, 0.45, stim_dur=200)
+        {e: p2p.stimuli.BiphasicPulseTrain(20, amp, 0.45, stim_dur=200)
          for e in names})
 
 
@@ -170,10 +174,12 @@ SCENARIOS = [
     ),
     # Granley 2021. Its stimulus is a pulse train rather than an image because
     # the model reads amplitude, frequency and pulse duration off each
-    # electrode's BiphasicPulseTrain and rejects anything else.
+    # electrode's BiphasicPulseTrain and rejects anything else. Its amplitude
+    # is a multiple of threshold, unlike every other scenario here.
     Scenario(
         id='argus2_biphasic_ptrain',
-        stimulus=lambda: array_ptrain(p2p.implants.ArgusII),
+        stimulus=lambda: array_ptrain(p2p.implants.ArgusII,
+                                      amp=20 * p2p.units.xTh),
         implant=lambda stim: p2p.implants.ArgusII(stim=stim),
         model=lambda **kwargs: p2p.models.BiphasicAxonMapModel(
             xrange=(-12, 12), yrange=(-8, 8), **kwargs),

--- a/doc/topics/units.rst
+++ b/doc/topics/units.rst
@@ -186,10 +186,8 @@ has one it stays measured in ``xTh``:
     implant.thresholds = {'A4': 80 * uA}
     implant.stim = {'A4': BiphasicPulseTrain(20, 2 * xTh, 0.45)}  # 160 uA
 
-A train without a threshold is not a current, so an implant will hold it but
-the electrical safety checks refuse to answer questions about it, and a
-current-based model refuses it outright. Calibrating is what makes it
-answerable.
+Until a threshold is supplied, the train remains in ``xTh``. Electrical
+safety checks and current-based models require calibration to ``uA``.
 
 Shorthands that are not conversions
 -----------------------------------

--- a/doc/topics/units.rst
+++ b/doc/topics/units.rst
@@ -169,11 +169,12 @@ reading its gray levels as microamps. There is no default answer to *how much*
 current a gray level stands for, and choosing one is what an encoder is for.
 
 **Threshold multiples are not currents.** ``xTh`` ("times threshold") has its
-own dimension too. How much current ``2 * xTh`` is depends on the electrode
-and the subject, so a
-:py:class:`~pulse2percept.stimuli.BiphasicPulseTrain` accepts it only
-alongside a threshold -- its own ``threshold_amp``, or the implant's
-:py:attr:`~pulse2percept.implants.ProsthesisSystem.thresholds`:
+own dimension too. How much current ``2 * xTh`` represents depends on the
+reference threshold. A
+:py:class:`~pulse2percept.stimuli.BiphasicPulseTrain` can get that threshold
+from its ``threshold_amp`` or from
+:py:attr:`~pulse2percept.implants.ProsthesisSystem.thresholds`; otherwise it
+uses a nominal 100 uA reference:
 
 .. code-block:: python
 
@@ -185,8 +186,7 @@ alongside a threshold -- its own ``threshold_amp``, or the implant's
     implant.thresholds = {'A4': 80 * uA}
     implant.stim = {'A4': BiphasicPulseTrain(20, 2 * xTh, 0.45)}  # 160 uA
 
-The waveform stored is still a current; ``xTh`` only says which one. Without
-any threshold, ``xTh`` falls back on a nominal 100 uA reference.
+The waveform stored is still a current; ``xTh`` only says which one.
 
 Shorthands that are not conversions
 -----------------------------------

--- a/doc/topics/units.rst
+++ b/doc/topics/units.rst
@@ -168,6 +168,26 @@ Assigning the image to an implant *without* an encoder raises, rather than
 reading its gray levels as microamps. There is no default answer to *how much*
 current a gray level stands for, and choosing one is what an encoder is for.
 
+**Threshold multiples are not currents.** ``xTh`` ("times threshold") has its
+own dimension too. How much current ``2 * xTh`` is depends on the electrode
+and the subject, so a
+:py:class:`~pulse2percept.stimuli.BiphasicPulseTrain` accepts it only
+alongside a threshold -- its own ``threshold_amp``, or the implant's
+:py:attr:`~pulse2percept.implants.ProsthesisSystem.thresholds`:
+
+.. code-block:: python
+
+    from pulse2percept.implants import ArgusII
+    from pulse2percept.stimuli import BiphasicPulseTrain
+    from pulse2percept.units import uA, xTh
+
+    implant = ArgusII()
+    implant.thresholds = {'A4': 80 * uA}
+    implant.stim = {'A4': BiphasicPulseTrain(20, 2 * xTh, 0.45)}  # 160 uA
+
+The waveform stored is still a current; ``xTh`` only says which one. Without
+any threshold, ``xTh`` falls back on a nominal 100 uA reference.
+
 Shorthands that are not conversions
 -----------------------------------
 

--- a/doc/topics/units.rst
+++ b/doc/topics/units.rst
@@ -170,11 +170,11 @@ current a gray level stands for, and choosing one is what an encoder is for.
 
 **Threshold multiples are not currents.** ``xTh`` ("times threshold") has its
 own dimension too. How much current ``2 * xTh`` represents depends on the
-reference threshold. A
-:py:class:`~pulse2percept.stimuli.BiphasicPulseTrain` can get that threshold
-from its ``threshold_amp`` or from
-:py:attr:`~pulse2percept.implants.ProsthesisSystem.thresholds`; otherwise it
-uses a nominal 100 uA reference:
+reference threshold, which varies by electrode and by subject. A
+:py:class:`~pulse2percept.stimuli.BiphasicPulseTrain` gets that threshold from
+its ``threshold_amp`` or from
+:py:attr:`~pulse2percept.implants.ProsthesisSystem.thresholds`, and until it
+has one it stays measured in ``xTh``:
 
 .. code-block:: python
 
@@ -186,7 +186,10 @@ uses a nominal 100 uA reference:
     implant.thresholds = {'A4': 80 * uA}
     implant.stim = {'A4': BiphasicPulseTrain(20, 2 * xTh, 0.45)}  # 160 uA
 
-The waveform stored is still a current; ``xTh`` only says which one.
+A train without a threshold is not a current, so an implant will hold it but
+the electrical safety checks refuse to answer questions about it, and a
+current-based model refuses it outright. Calibrating is what makes it
+answerable.
 
 Shorthands that are not conversions
 -----------------------------------

--- a/doc/users/release_notes.rst
+++ b/doc/users/release_notes.rst
@@ -69,7 +69,9 @@ API changes:
   :py:class:`~pulse2percept.models.BiphasicAxonMapModel` amplitudes, which used
   to be read as multiples of threshold, must now say so with the new ``xTh``
   unit (``2 * xTh``) or supply a threshold via ``threshold_amp`` or
-  :py:attr:`~pulse2percept.implants.ProsthesisSystem.thresholds`.
+  :py:attr:`~pulse2percept.implants.ProsthesisSystem.thresholds`. A train given
+  in ``xTh`` with no threshold stays measured in ``xTh`` rather than being
+  turned into an invented current.
 
 * :py:class:`~pulse2percept.models.BiphasicAxonMapSpatial` can now be paired
   with a temporal model, in a space-time-separable approximation: Granley

--- a/doc/users/release_notes.rst
+++ b/doc/users/release_notes.rst
@@ -64,6 +64,13 @@ API changes:
   :py:class:`~pulse2percept.models.FadingTemporal` now ignores anodic current
   rather than treating it as negative brightness, and enforces ``tau >= dt``.
 
+* A bare :py:class:`~pulse2percept.stimuli.BiphasicPulseTrain` amplitude now
+  consistently means microamps.
+  :py:class:`~pulse2percept.models.BiphasicAxonMapModel` amplitudes, which used
+  to be read as multiples of threshold, must now say so with the new ``xTh``
+  unit (``2 * xTh``) or supply a threshold via ``threshold_amp`` or
+  :py:attr:`~pulse2percept.implants.ProsthesisSystem.thresholds`.
+
 * :py:class:`~pulse2percept.models.BiphasicAxonMapSpatial` can now be paired
   with a temporal model, in a space-time-separable approximation: Granley
   determines the peak spatial percept, the temporal model supplies a

--- a/doc/users/release_notes.rst
+++ b/doc/users/release_notes.rst
@@ -69,9 +69,9 @@ API changes:
   :py:class:`~pulse2percept.models.BiphasicAxonMapModel` amplitudes, which used
   to be read as multiples of threshold, must now say so with the new ``xTh``
   unit (``2 * xTh``) or supply a threshold via ``threshold_amp`` or
-  :py:attr:`~pulse2percept.implants.ProsthesisSystem.thresholds`. A train given
-  in ``xTh`` with no threshold stays measured in ``xTh`` rather than being
-  turned into an invented current.
+  :py:attr:`~pulse2percept.implants.ProsthesisSystem.thresholds`. An
+  uncalibrated ``xTh`` train remains in ``xTh`` until a threshold is
+  provided.
 
 * :py:class:`~pulse2percept.models.BiphasicAxonMapSpatial` can now be paired
   with a temporal model, in a space-time-separable approximation: Granley

--- a/examples/models/plot_granley2021_biphasic.py
+++ b/examples/models/plot_granley2021_biphasic.py
@@ -104,8 +104,8 @@ plt.show()
 # this model cannot interpret without a threshold to measure it against.
 #
 # You can easily assign BiphasicPulseTrains to electrodes with a dictionary
-# The following creates a train with 20Hz frequency, 1xTh amplitude, and 0.45ms
-# pulse / phase duration.
+# The following creates a train with 20Hz frequency, 1xTh amplitude, and
+# 0.45ms phase duration.
 
 implant.stim = {'A4' : BiphasicPulseTrain(20, 1 * xTh, 0.45)}
 implant.stim.plot()
@@ -130,7 +130,7 @@ new_percept = model.predict_percept(implant)
 new_percept.plot(ax=axes[1])
 percept.plot(ax=axes[0], vmax=new_percept.max())
 axes[0].set_title("20 Hz")
-axes[1].set_title("40 Hz")
+axes[1].set_title("50 Hz")
 plt.show()
 ##############################################################################
 # Note that without setting vmax, matplotlib automatically rescales images to
@@ -148,8 +148,8 @@ axes[1].set_title("3xTh")
 plt.show()
 
 ##############################################################################
-# Increasing pulse duration decreases threshold, thus indirectly causing an 
-# increase in size and brightness (amp factor is increased)
+# Increasing phase duration lowers threshold in the Granley model, so a fixed
+# ``xTh`` amplitude produces a larger and brighter percept
 fig, axes = plt.subplots(1, 2, sharex=True, sharey=True)
 implant.stim = {'A4' : BiphasicPulseTrain(20, 1 * xTh, 4)}
 new_percept = model.predict_percept(implant)
@@ -160,8 +160,8 @@ axes[1].set_title("4ms")
 plt.show()
 
 ##############################################################################
-# If you account for the change in threshold by decreasing amplitude, then 
-# the only affect of increasing pulse duration is the streak length decreasing
+# If you compensate for this threshold change by decreasing amplitude, the
+# remaining effect of increasing phase duration is a shorter streak
 fig, axes = plt.subplots(1, 2, sharex=True, sharey=True)
 implant.stim = {'A4' : BiphasicPulseTrain(20, 0.023835 * xTh, 20)}
 new_percept = model.predict_percept(implant)
@@ -173,16 +173,16 @@ plt.show()
 
 #################################################################################
 # This illustrates another important point: ``xTh`` here is relative to the
-# threshold current at 0.45ms pulse duration. Since larger pulse durations have
+# threshold current at 0.45ms phase duration. Since larger phase durations have
 # been shown to reduce the threshold amplitude needed, the 0.02xTh amplitude
 # used in the previous plot still is able to produce a phosphene.
 
 #################################################################################
 # Using measured thresholds
 # -------------------------
-# The 100 uA reference above is a stand-in. If you have measured an electrode's
-# threshold, give it to the implant and ``xTh`` is realized against the real
-# thing -- 2xTh on an 80 uA electrode delivers 160 uA:
+# The 100 uA reference above is a stand-in. If you know an electrode's
+# reference threshold at 0.45ms phase duration, give it to the implant: 2xTh
+# on an 80 uA electrode then delivers 160 uA.
 
 calibrated = ArgusII()
 calibrated.thresholds = {'A4': 80 * uA}
@@ -190,10 +190,9 @@ calibrated.stim = {'A4': BiphasicPulseTrain(20, 2 * xTh, 0.45)}
 print(f"{calibrated.stim.data.max():.0f} uA")
 
 #################################################################################
-# The same works per pulse train (``BiphasicPulseTrain(..., threshold_amp=80 *
-# uA)``), and it runs the other way too: a train given in microamps on a
-# calibrated electrode knows what multiple of threshold it is, so the model can
-# use it.
+# ``BiphasicPulseTrain(..., threshold_amp=80 * uA)`` does the same for one
+# train. Either way it works in both directions: a train given in microamps on
+# a calibrated electrode knows what multiple of threshold it is.
 
 ################################################################################
 #

--- a/examples/models/plot_granley2021_biphasic.py
+++ b/examples/models/plot_granley2021_biphasic.py
@@ -190,11 +190,9 @@ calibrated.stim = {'A4': BiphasicPulseTrain(20, 2 * xTh, 0.45)}
 print(f"{calibrated.stim.data.max():.0f} uA")
 
 #################################################################################
-# ``BiphasicPulseTrain(..., threshold_amp=80 * uA)`` does the same for one
-# train. Either way it works in both directions: a train given in microamps on
-# a calibrated electrode knows what multiple of threshold it is, and only a
-# calibrated stimulus is one an implant can check against ``max_current`` or
-# hand to a current-based model.
+# ``threshold_amp=80 * uA`` instead calibrates a single train. Calibration
+# also lets a current-valued train report its threshold multiple. Electrical
+# safety checks and current-based models require current units.
 
 ################################################################################
 #

--- a/examples/models/plot_granley2021_biphasic.py
+++ b/examples/models/plot_granley2021_biphasic.py
@@ -48,6 +48,7 @@ import numpy as np
 from pulse2percept.implants import ArgusII
 from pulse2percept.models import BiphasicAxonMapModel
 from pulse2percept.stimuli import BiphasicPulseTrain
+from pulse2percept.units import uA, xTh
 model = BiphasicAxonMapModel(rho=200, lam=800)
 
 ##############################################################################
@@ -96,17 +97,23 @@ plt.show()
 ##############################################################################
 # As mentioned above, the Biphasic Axon Map Model only accepts 
 # :py:class:`~pulse2percept.stimuli.BiphasicPulseTrain`
-# stimuli with no :py:attr:`~pulse2percept.stimuli.BiphasicPulseTrain.delay_dur`. 
-# The amplitude given to the BiphasicPulseTrain
-# is interpreted as amplitude as a factor of threshold (i.e. an amp of 1 means 
-# 1xTh)
+# stimuli with no :py:attr:`~pulse2percept.stimuli.BiphasicPulseTrain.delay_dur`.
+# This model works in multiples of perceptual threshold, so amplitude is given
+# in :py:data:`~pulse2percept.units.xTh` ("times threshold"): ``1 * xTh`` is
+# threshold, ``3 * xTh`` is three times it. A bare number is microamps, which
+# this model cannot interpret without a threshold to measure it against.
 #
 # You can easily assign BiphasicPulseTrains to electrodes with a dictionary
 # The following creates a train with 20Hz frequency, 1xTh amplitude, and 0.45ms
 # pulse / phase duration.
 
-implant.stim = {'A4' : BiphasicPulseTrain(20, 1, 0.45)}
+implant.stim = {'A4' : BiphasicPulseTrain(20, 1 * xTh, 0.45)}
 implant.stim.plot()
+
+##############################################################################
+# The plot is in microamps: the waveform an implant delivers is always a
+# current, and ``xTh`` only says which current. With no threshold measured,
+# ``1 * xTh`` falls back on a nominal 100 uA reference.
 
 ##############################################################################
 # Finally, you can predict the percept resulting from stimulation
@@ -118,7 +125,7 @@ plt.show()
 ##############################################################################
 # Increasing the frequency will make phosphenes brighter
 fig, axes = plt.subplots(1, 2, sharex=True, sharey=True)
-implant.stim = {'A4' : BiphasicPulseTrain(50, 1, 0.45)}
+implant.stim = {'A4' : BiphasicPulseTrain(50, 1 * xTh, 0.45)}
 new_percept = model.predict_percept(implant)
 new_percept.plot(ax=axes[1])
 percept.plot(ax=axes[0], vmax=new_percept.max())
@@ -132,7 +139,7 @@ plt.show()
 ##############################################################################
 # Increasing amplitude increases both size and brightness
 fig, axes = plt.subplots(1, 2, sharex=True, sharey=True)
-implant.stim = {'A4' : BiphasicPulseTrain(20, 3, 0.45)}
+implant.stim = {'A4' : BiphasicPulseTrain(20, 3 * xTh, 0.45)}
 new_percept = model.predict_percept(implant)
 new_percept.plot(ax=axes[1])
 percept.plot(ax=axes[0], vmax=new_percept.max())
@@ -144,7 +151,7 @@ plt.show()
 # Increasing pulse duration decreases threshold, thus indirectly causing an 
 # increase in size and brightness (amp factor is increased)
 fig, axes = plt.subplots(1, 2, sharex=True, sharey=True)
-implant.stim = {'A4' : BiphasicPulseTrain(20, 1, 4)}
+implant.stim = {'A4' : BiphasicPulseTrain(20, 1 * xTh, 4)}
 new_percept = model.predict_percept(implant)
 new_percept.plot(ax=axes[1])
 percept.plot(ax=axes[0], vmax=new_percept.max())
@@ -156,7 +163,7 @@ plt.show()
 # If you account for the change in threshold by decreasing amplitude, then 
 # the only affect of increasing pulse duration is the streak length decreasing
 fig, axes = plt.subplots(1, 2, sharex=True, sharey=True)
-implant.stim = {'A4' : BiphasicPulseTrain(20, 0.023835, 20)}
+implant.stim = {'A4' : BiphasicPulseTrain(20, 0.023835 * xTh, 20)}
 new_percept = model.predict_percept(implant)
 new_percept.plot(ax=axes[1])
 percept.plot(ax=axes[0], vmax=new_percept.max())
@@ -165,10 +172,28 @@ axes[1].set_title("20ms, 0.02xTh")
 plt.show()
 
 #################################################################################
-# This illustrates another important point: The amplitude used for the Biphasic
-# model is relative to the threshold current at 0.45ms pulse duration. Since larger 
-# pulse durations have been shown to reduce the threshold amplitude needed, the 
-# 0.02xTh amplitude used in the previous plot still is able to produce a phosphene.
+# This illustrates another important point: ``xTh`` here is relative to the
+# threshold current at 0.45ms pulse duration. Since larger pulse durations have
+# been shown to reduce the threshold amplitude needed, the 0.02xTh amplitude
+# used in the previous plot still is able to produce a phosphene.
+
+#################################################################################
+# Using measured thresholds
+# -------------------------
+# The 100 uA reference above is a stand-in. If you have measured an electrode's
+# threshold, give it to the implant and ``xTh`` is realized against the real
+# thing -- 2xTh on an 80 uA electrode delivers 160 uA:
+
+calibrated = ArgusII()
+calibrated.thresholds = {'A4': 80 * uA}
+calibrated.stim = {'A4': BiphasicPulseTrain(20, 2 * xTh, 0.45)}
+print(f"{calibrated.stim.data.max():.0f} uA")
+
+#################################################################################
+# The same works per pulse train (``BiphasicPulseTrain(..., threshold_amp=80 *
+# uA)``), and it runs the other way too: a train given in microamps on a
+# calibrated electrode knows what multiple of threshold it is, so the model can
+# use it.
 
 ################################################################################
 #
@@ -205,9 +230,9 @@ model.a0 = 0
 model.a1 = 1
 model.build()
 fig, axes = plt.subplots(1, 2, sharex=True, sharey=True)
-implant.stim = {'A4' : BiphasicPulseTrain(20, 1, 0.45)}
+implant.stim = {'A4' : BiphasicPulseTrain(20, 1 * xTh, 0.45)}
 percept = model.predict_percept(implant)
-implant.stim = {'A4' : BiphasicPulseTrain(20, 1, 20)}
+implant.stim = {'A4' : BiphasicPulseTrain(20, 1 * xTh, 20)}
 new_percept = model.predict_percept(implant)
 new_percept.plot(ax=axes[1])
 percept.plot(ax=axes[0], vmax=new_percept.max())
@@ -236,9 +261,9 @@ model.size_model = size_modulation
 model.build()
 
 fig, axes = plt.subplots(1, 2, sharex=True, sharey=True)
-implant.stim = {'A4' : BiphasicPulseTrain(20, 1, 0.45)}
+implant.stim = {'A4' : BiphasicPulseTrain(20, 1 * xTh, 0.45)}
 percept = model.predict_percept(implant)
-implant.stim = {'A4' : BiphasicPulseTrain(20, 3, 0.45)}
+implant.stim = {'A4' : BiphasicPulseTrain(20, 3 * xTh, 0.45)}
 new_percept = model.predict_percept(implant)
 new_percept.plot(ax=axes[1])
 percept.plot(ax=axes[0], vmax=new_percept.max())

--- a/examples/models/plot_granley2021_biphasic.py
+++ b/examples/models/plot_granley2021_biphasic.py
@@ -111,9 +111,8 @@ implant.stim = {'A4' : BiphasicPulseTrain(20, 1 * xTh, 0.45)}
 implant.stim.plot()
 
 ##############################################################################
-# The plot is in microamps: the waveform an implant delivers is always a
-# current, and ``xTh`` only says which current. With no threshold measured,
-# ``1 * xTh`` falls back on a nominal 100 uA reference.
+# The plot is in ``xTh``, not microamps: how much current 1xTh is depends on
+# the electrode, and no threshold has been given yet. See below.
 
 ##############################################################################
 # Finally, you can predict the percept resulting from stimulation
@@ -180,9 +179,10 @@ plt.show()
 #################################################################################
 # Using measured thresholds
 # -------------------------
-# The 100 uA reference above is a stand-in. If you know an electrode's
-# reference threshold at 0.45ms phase duration, give it to the implant: 2xTh
-# on an 80 uA electrode then delivers 160 uA.
+# Give the implant the electrode's threshold and ``xTh`` becomes a current:
+# 2xTh on an 80 uA electrode delivers 160 uA. Threshold here is the current at
+# which a train of the same frequency and 0.45ms phase duration is detected
+# half the time, so a different frequency may call for a different threshold.
 
 calibrated = ArgusII()
 calibrated.thresholds = {'A4': 80 * uA}
@@ -192,7 +192,9 @@ print(f"{calibrated.stim.data.max():.0f} uA")
 #################################################################################
 # ``BiphasicPulseTrain(..., threshold_amp=80 * uA)`` does the same for one
 # train. Either way it works in both directions: a train given in microamps on
-# a calibrated electrode knows what multiple of threshold it is.
+# a calibrated electrode knows what multiple of threshold it is, and only a
+# calibrated stimulus is one an implant can check against ``max_current`` or
+# hand to a current-based model.
 
 ################################################################################
 #

--- a/pulse2percept/implants/base.py
+++ b/pulse2percept/implants/base.py
@@ -12,18 +12,8 @@ from ..stimuli import (BiphasicPulseTrain, Stimulus, ImageStimulus,
                        StimulusEncoder, VideoStimulus)
 from ..stimuli.base import _describe_unit
 from ..stimuli.pulse_trains import _as_threshold_amp
-from ..units import DimensionMismatchError, as_value, uA, um, xTh
+from ..units import DimensionMismatchError, as_value, uA, um
 from ..utils import PrettyPrint
-
-
-def _recalibrated(source, threshold):
-    """A pulse train rebuilt for ``threshold``, or ``source`` if unaffected"""
-    if threshold is None or type(source) is not BiphasicPulseTrain:
-        return source
-    if source.threshold_amp == threshold:
-        return source
-    amp = source.amp_factor * xTh if source._amp_relative else source.amp
-    return source._rebuilt(amp, threshold)
 
 
 class ProsthesisSystem(PrettyPrint):
@@ -106,9 +96,8 @@ class ProsthesisSystem(PrettyPrint):
 
     """
     # Frozen class: User cannot add more class attributes
-    __slots__ = ('_earray', '_stim', '_stim_source', '_eye', 'safe_mode',
-                 'preprocess', '_encoder', '_raster', '_max_current',
-                 '_thresholds')
+    __slots__ = ('_earray', '_stim', '_eye', 'safe_mode', 'preprocess',
+                 '_encoder', '_raster', '_max_current', '_thresholds')
 
     #: The physical quantity this system delivers, mirroring
     #: :py:attr:`~pulse2percept.models.BaseModel.stimulus_unit`. An electrical
@@ -218,15 +207,16 @@ class ProsthesisSystem(PrettyPrint):
     def thresholds(self):
         """Perceptual threshold current (uA) for each electrode
 
-        Thresholds relate stimulation expressed in
-        :py:data:`~pulse2percept.units.xTh` to physical current. Assign a single
-        current to all electrodes, a dict for per-electrode values, or ``None`` to
-        clear the calibration.
+        Calibration of the electrode/subject interface, relating stimulation
+        expressed in :py:data:`~pulse2percept.units.xTh` to the current that
+        realizes it. Assign one current for the whole array, a dict for
+        per-electrode values (a partial dict leaves the rest uncalibrated), or
+        None to clear.
 
-        Changing thresholds recalibrates any structured
-        :py:class:`~pulse2percept.stimuli.BiphasicPulseTrain` already assigned to
-        :py:attr:`stim`. Threshold-relative trains preserve their ``xTh`` value;
-        current-valued trains preserve their current. Sampled stimuli are
+        Changing thresholds recalibrates any
+        :py:class:`~pulse2percept.stimuli.BiphasicPulseTrain` already assigned
+        to :py:attr:`stim`: ``xTh`` trains keep their multiple of threshold,
+        current-valued trains keep their current. Sampled stimuli are
         unchanged.
 
         .. versionadded:: 0.10.0
@@ -240,20 +230,23 @@ class ProsthesisSystem(PrettyPrint):
         >>> implant.stim = {'A1': BiphasicPulseTrain(20, 2 * xTh, 0.45),
         ...                 'A2': BiphasicPulseTrain(20, 2 * xTh, 0.45)}
         >>> implant.thresholds = {'A1': 80 * uA, 'A2': 120 * uA}
-        >>> [src.amp for _, src in implant.stim._structured_sources()]
-        [160.0, 240.0]
+        >>> float(abs(implant.stim['A1']).max())
+        160.0
+        >>> float(abs(implant.stim['A2']).max())
+        240.0
 
         """
         return dict(getattr(self, '_thresholds', None) or {})
 
     @thresholds.setter
     def thresholds(self, thresholds):
-        """Set perceptual threshold currents."""
+        """Threshold setter (called upon ``self.thresholds = ...``)"""
         previous = getattr(self, '_thresholds', {})
         self._thresholds = self._normalize_thresholds(thresholds)
         try:
             self._recalibrate_stim()
         except Exception:
+            # Thresholds and stimulus move together or not at all:
             self._thresholds = previous
             raise
 
@@ -268,35 +261,49 @@ class ProsthesisSystem(PrettyPrint):
         for name, threshold in thresholds.items():
             if name not in self.electrodes:
                 raise ValueError(f'Electrode "{name}" not found in implant.')
-            normalized[name] = _as_threshold_amp(
-                threshold, f'thresholds[{name!r}]')
+            threshold = _as_threshold_amp(threshold, f'thresholds[{name!r}]')
+            # Omitting an electrode already means "uncalibrated", so None is
+            # not stored as a second way of saying it:
+            if threshold is not None:
+                normalized[name] = threshold
         return normalized
 
     def _recalibrate_stim(self):
-        """Rebuild the stored structured stimulus using current thresholds."""
-        source = getattr(self, '_stim_source', None)
-        if source is None:
+        """Recalibrate the stored stimulus for the thresholds now in force"""
+        stim = getattr(self, '_stim', None)
+        if stim is None:
             return
-        stim = self._calibrated(source)
-        self.check_stim(stim)
-        self._stim = stim
+        calibrated = self._calibrated(stim)
+        if calibrated is stim:
+            return
+        # Checked before it is stored, so a rejected stimulus is not the one
+        # left behind:
+        self.check_stim(calibrated)
+        self._stim = calibrated
 
     def _calibrated(self, stim):
-        """Return ``stim`` with electrode thresholds applied where possible."""
-        thresholds = getattr(self, '_thresholds', None)
-        if not thresholds:
-            return stim
+        """``stim`` with this implant's thresholds applied to its pulse trains
+
+        Rebuilds the pulse trains the stimulus retains rather than rewriting
+        its samples, generating no waveform, and returns ``stim`` itself when
+        nothing needs rebuilding. An electrode the thresholds leave out gets
+        None, so this clears a calibration as readily as it applies one.
+        """
+        thresholds = getattr(self, '_thresholds', None) or {}
         sources = stim._structured_sources()
         if sources is None:
             return stim
         rebuilt, changed = {}, False
         for name, source in sources:
-            train = _recalibrated(source, thresholds.get(name))
+            train = (source._with_threshold(thresholds.get(name))
+                     if type(source) is BiphasicPulseTrain else source)
             changed = changed or train is not source
             rebuilt[name] = train
         if not changed:
             return stim
         if len(sources) == 1 and sources[0][1] is stim:
+            # The stimulus *is* the pulse train, and must stay that kind of
+            # object rather than become a collection of one:
             return rebuilt[sources[0][0]]
         return Stimulus(rebuilt,
                         metadata=deepcopy(stim.metadata.get('user')))
@@ -615,11 +622,11 @@ class ProsthesisSystem(PrettyPrint):
         """Stimulus setter (called upon ``self.stim = data``)"""
         # if stim is empty or None
         if data is None:
-            self._stim = self._stim_source = None
+            self._stim = None
         elif isinstance(data, (list, tuple, dict)) and not data:
-            self._stim = self._stim_source = None
+            self._stim = None
         elif isinstance(data, np.ndarray) and data.size == 0:
-            self._stim = self._stim_source = None
+            self._stim = None
         else:
             # Preprocess can be a function (callable) or True/False:
             if callable(self.preprocess):
@@ -676,17 +683,13 @@ class ProsthesisSystem(PrettyPrint):
                    if not e.activated and name in stim.electrodes]
             if off:
                 stim = stim._without_electrodes(off)
-            # The stimulus as it was asked for, kept alongside the calibrated
-            # one: `thresholds` can change later, and recalibrating has to
-            # start from what the user specified rather than from the currents
-            # the previous calibration worked out (see `_calibrated`).
-            source = deepcopy(stim)
-            stim = self._calibrated(source)
+            # Copied before calibration rewrites it: the caller's object is
+            # theirs.
+            stim = self._calibrated(deepcopy(stim))
             # Perform safety checks, etc. These are all questions about what
             # gets delivered, so they are asked of the calibrated pulse train:
             self.check_stim(stim)
             # Store stimulus:
-            self._stim_source = source
             self._stim = stim
 
     @property

--- a/pulse2percept/implants/base.py
+++ b/pulse2percept/implants/base.py
@@ -12,7 +12,7 @@ from ..stimuli import (BiphasicPulseTrain, Stimulus, ImageStimulus,
                        StimulusEncoder, VideoStimulus)
 from ..stimuli.base import _describe_unit
 from ..stimuli.pulse_trains import _as_threshold_amp
-from ..units import DimensionMismatchError, as_value, uA, um
+from ..units import DimensionMismatchError, as_value, uA, um, xTh
 from ..utils import PrettyPrint
 
 
@@ -301,6 +301,17 @@ class ProsthesisSystem(PrettyPrint):
             rebuilt[name] = train
         if not changed:
             return stim
+        # Said here rather than left to `Stimulus`, which cannot know that a
+        # threshold is what the mismatched units are missing:
+        units = {train.unit for train in rebuilt.values()}
+        if len(units) > 1:
+            missing = sorted(name for name, train in rebuilt.items()
+                             if train.unit == xTh)
+            raise DimensionMismatchError(
+                f"Calibrating only some electrodes would leave "
+                f"{', '.join(missing)} measured in threshold multiples and "
+                f"the rest in uA. Give every driven electrode a threshold, or "
+                f"none of them.")
         if len(sources) == 1 and sources[0][1] is stim:
             # The stimulus *is* the pulse train, and must stay that kind of
             # object rather than become a collection of one:
@@ -324,6 +335,11 @@ class ProsthesisSystem(PrettyPrint):
         """
         if stim.unit.dimension == self.stimulus_unit.dimension:
             return
+        # Stimulation in the terms the electrode is calibrated in, which
+        # assigning is what applies a threshold to (see `thresholds`). The
+        # electrical safety checks refuse it until one has been:
+        if stim.unit.dimension == xTh.dimension:
+            return
         raise DimensionMismatchError(
             f"{type(self).__name__} delivers "
             f"{_describe_unit(self.stimulus_unit)}, but this stimulus is "
@@ -342,13 +358,20 @@ class ProsthesisSystem(PrettyPrint):
         itself: ``check_stim`` is public, and is called directly by tests and
         by subclasses on stimuli that never went through the setter.
         """
-        if stim.unit.dimension != uA.dimension:
+        if stim.unit.dimension == uA.dimension:
+            return
+        if stim.unit.dimension == xTh.dimension:
             raise DimensionMismatchError(
                 f"Safety check '{check}' needs an electrical stimulus to "
-                f"check, and this one is measured in "
-                f"{_describe_unit(stim.unit)}. Encode it into current first "
-                f"(see pulse2percept.stimuli.StimulusEncoder), or give the "
-                f"implant a 'preprocess' function that does.")
+                f"check, and this one is a multiple of threshold. Set "
+                f"'thresholds' on the implant, or 'threshold_amp' on the "
+                f"pulse train, so that it names a current.")
+        raise DimensionMismatchError(
+            f"Safety check '{check}' needs an electrical stimulus to "
+            f"check, and this one is measured in "
+            f"{_describe_unit(stim.unit)}. Encode it into current first "
+            f"(see pulse2percept.stimuli.StimulusEncoder), or give the "
+            f"implant a 'preprocess' function that does.")
 
     @classmethod
     def _require_charge_balanced(cls, stim):

--- a/pulse2percept/implants/base.py
+++ b/pulse2percept/implants/base.py
@@ -8,10 +8,22 @@ from scipy.interpolate import RegularGridInterpolator
 from .electrodes import Electrode, DiskElectrode
 from .electrode_arrays import ElectrodeArray, ElectrodeGrid
 from .rasters import Raster
-from ..stimuli import Stimulus, ImageStimulus, StimulusEncoder, VideoStimulus
+from ..stimuli import (BiphasicPulseTrain, Stimulus, ImageStimulus,
+                       StimulusEncoder, VideoStimulus)
 from ..stimuli.base import _describe_unit
-from ..units import DimensionMismatchError, as_value, uA, um
+from ..stimuli.pulse_trains import _as_threshold_amp
+from ..units import DimensionMismatchError, as_value, uA, um, xTh
 from ..utils import PrettyPrint
+
+
+def _recalibrated(source, threshold):
+    """A pulse train rebuilt for ``threshold``, or ``source`` if unaffected"""
+    if threshold is None or type(source) is not BiphasicPulseTrain:
+        return source
+    if source.threshold_amp == threshold:
+        return source
+    amp = source.amp_factor * xTh if source._amp_relative else source.amp
+    return source._rebuilt(amp, threshold)
 
 
 class ProsthesisSystem(PrettyPrint):
@@ -94,8 +106,9 @@ class ProsthesisSystem(PrettyPrint):
 
     """
     # Frozen class: User cannot add more class attributes
-    __slots__ = ('_earray', '_stim', '_eye', 'safe_mode',
-                 'preprocess', '_encoder', '_raster', '_max_current')
+    __slots__ = ('_earray', '_stim', '_stim_source', '_eye', 'safe_mode',
+                 'preprocess', '_encoder', '_raster', '_max_current',
+                 '_thresholds')
 
     #: The physical quantity this system delivers, mirroring
     #: :py:attr:`~pulse2percept.models.BaseModel.stimulus_unit`. An electrical
@@ -135,6 +148,8 @@ class ProsthesisSystem(PrettyPrint):
             params['raster'] = self.raster
         if self.max_current is not None:
             params['max_current'] = self.max_current
+        if self.thresholds:
+            params['thresholds'] = self.thresholds
         return params
 
     @property
@@ -198,6 +213,93 @@ class ProsthesisSystem(PrettyPrint):
         if max_current is not None and max_current <= 0:
             raise ValueError("'max_current' must be positive.")
         self._max_current = max_current
+
+    @property
+    def thresholds(self):
+        """Perceptual threshold current (uA) for each electrode
+
+        Thresholds relate stimulation expressed in
+        :py:data:`~pulse2percept.units.xTh` to physical current. Assign a single
+        current to all electrodes, a dict for per-electrode values, or ``None`` to
+        clear the calibration.
+
+        Changing thresholds recalibrates any structured
+        :py:class:`~pulse2percept.stimuli.BiphasicPulseTrain` already assigned to
+        :py:attr:`stim`. Threshold-relative trains preserve their ``xTh`` value;
+        current-valued trains preserve their current. Sampled stimuli are
+        unchanged.
+
+        .. versionadded:: 0.10.0
+
+        Examples
+        --------
+        >>> from pulse2percept.implants import ArgusII
+        >>> from pulse2percept.stimuli import BiphasicPulseTrain
+        >>> from pulse2percept.units import uA, xTh
+        >>> implant = ArgusII()
+        >>> implant.stim = {'A1': BiphasicPulseTrain(20, 2 * xTh, 0.45),
+        ...                 'A2': BiphasicPulseTrain(20, 2 * xTh, 0.45)}
+        >>> implant.thresholds = {'A1': 80 * uA, 'A2': 120 * uA}
+        >>> [src.amp for _, src in implant.stim._structured_sources()]
+        [160.0, 240.0]
+
+        """
+        return dict(getattr(self, '_thresholds', None) or {})
+
+    @thresholds.setter
+    def thresholds(self, thresholds):
+        """Set perceptual threshold currents."""
+        previous = getattr(self, '_thresholds', {})
+        self._thresholds = self._normalize_thresholds(thresholds)
+        try:
+            self._recalibrate_stim()
+        except Exception:
+            self._thresholds = previous
+            raise
+
+    def _normalize_thresholds(self, thresholds):
+        """Return thresholds as a mapping of electrode names to uA."""
+        if thresholds is None:
+            return {}
+        if not isinstance(thresholds, dict):
+            threshold = _as_threshold_amp(thresholds, 'thresholds')
+            return {name: threshold for name in self.electrode_names}
+        normalized = {}
+        for name, threshold in thresholds.items():
+            if name not in self.electrodes:
+                raise ValueError(f'Electrode "{name}" not found in implant.')
+            normalized[name] = _as_threshold_amp(
+                threshold, f'thresholds[{name!r}]')
+        return normalized
+
+    def _recalibrate_stim(self):
+        """Rebuild the stored structured stimulus using current thresholds."""
+        source = getattr(self, '_stim_source', None)
+        if source is None:
+            return
+        stim = self._calibrated(source)
+        self.check_stim(stim)
+        self._stim = stim
+
+    def _calibrated(self, stim):
+        """Return ``stim`` with electrode thresholds applied where possible."""
+        thresholds = getattr(self, '_thresholds', None)
+        if not thresholds:
+            return stim
+        sources = stim._structured_sources()
+        if sources is None:
+            return stim
+        rebuilt, changed = {}, False
+        for name, source in sources:
+            train = _recalibrated(source, thresholds.get(name))
+            changed = changed or train is not source
+            rebuilt[name] = train
+        if not changed:
+            return stim
+        if len(sources) == 1 and sources[0][1] is stim:
+            return rebuilt[sources[0][0]]
+        return Stimulus(rebuilt,
+                        metadata=deepcopy(stim.metadata.get('user')))
 
     def _require_deliverable_stim(self, stim):
         """Refuse a stimulus this system cannot physically deliver
@@ -513,11 +615,11 @@ class ProsthesisSystem(PrettyPrint):
         """Stimulus setter (called upon ``self.stim = data``)"""
         # if stim is empty or None
         if data is None:
-            self._stim = None
+            self._stim = self._stim_source = None
         elif isinstance(data, (list, tuple, dict)) and not data:
-            self._stim = None
+            self._stim = self._stim_source = None
         elif isinstance(data, np.ndarray) and data.size == 0:
-            self._stim = None
+            self._stim = self._stim_source = None
         else:
             # Preprocess can be a function (callable) or True/False:
             if callable(self.preprocess):
@@ -574,11 +676,18 @@ class ProsthesisSystem(PrettyPrint):
                    if not e.activated and name in stim.electrodes]
             if off:
                 stim = stim._without_electrodes(off)
+            # The stimulus as it was asked for, kept alongside the calibrated
+            # one: `thresholds` can change later, and recalibrating has to
+            # start from what the user specified rather than from the currents
+            # the previous calibration worked out (see `_calibrated`).
+            source = deepcopy(stim)
+            stim = self._calibrated(source)
             # Perform safety checks, etc. These are all questions about what
-            # gets delivered, so they are asked of the pulse train:
+            # gets delivered, so they are asked of the calibrated pulse train:
             self.check_stim(stim)
             # Store stimulus:
-            self._stim = deepcopy(stim)
+            self._stim_source = source
+            self._stim = stim
 
     @property
     def eye(self):

--- a/pulse2percept/implants/base.py
+++ b/pulse2percept/implants/base.py
@@ -282,12 +282,9 @@ class ProsthesisSystem(PrettyPrint):
         self._stim = calibrated
 
     def _calibrated(self, stim):
-        """``stim`` with this implant's thresholds applied to its pulse trains
+        """Apply implant thresholds to retained BiphasicPulseTrain sources.
 
-        Rebuilds the pulse trains the stimulus retains rather than rewriting
-        its samples, generating no waveform, and returns ``stim`` itself when
-        nothing needs rebuilding. An electrode the thresholds leave out gets
-        None, so this clears a calibration as readily as it applies one.
+        Returns ``stim`` unchanged if no source needs recalibration.
         """
         thresholds = getattr(self, '_thresholds', None) or {}
         sources = stim._structured_sources()
@@ -301,8 +298,7 @@ class ProsthesisSystem(PrettyPrint):
             rebuilt[name] = train
         if not changed:
             return stim
-        # Said here rather than left to `Stimulus`, which cannot know that a
-        # threshold is what the mismatched units are missing:
+        # Give a threshold-specific error for mixed xTh/uA sources.
         units = {train.unit for train in rebuilt.values()}
         if len(units) > 1:
             missing = sorted(name for name, train in rebuilt.items()
@@ -335,9 +331,8 @@ class ProsthesisSystem(PrettyPrint):
         """
         if stim.unit.dimension == self.stimulus_unit.dimension:
             return
-        # Stimulation in the terms the electrode is calibrated in, which
-        # assigning is what applies a threshold to (see `thresholds`). The
-        # electrical safety checks refuse it until one has been:
+        # Threshold-relative pulse trains may be assigned before
+        # calibration.
         if stim.unit.dimension == xTh.dimension:
             return
         raise DimensionMismatchError(
@@ -706,8 +701,7 @@ class ProsthesisSystem(PrettyPrint):
                    if not e.activated and name in stim.electrodes]
             if off:
                 stim = stim._without_electrodes(off)
-            # Copied before calibration rewrites it: the caller's object is
-            # theirs.
+            # Calibrate a copy; do not mutate the caller's stimulus.
             stim = self._calibrated(deepcopy(stim))
             # Perform safety checks, etc. These are all questions about what
             # gets delivered, so they are asked of the calibrated pulse train:

--- a/pulse2percept/implants/tests/test_base.py
+++ b/pulse2percept/implants/tests/test_base.py
@@ -886,8 +886,7 @@ def test_ProsthesisSystem_thresholds_preserve_metadata():
 
 
 def test_ProsthesisSystem_thresholds_recalibrate_from_the_current_stimulus():
-    # The second threshold applies to the amplitude the user gave, not to the
-    # current the first one worked out:
+    # Recalibration preserves the original 2xTh basis.
     implant = ArgusII(stim={'A1': BiphasicPulseTrain(20, 2 * xTh, 0.45)})
     implant.thresholds = 80 * uA
     implant.thresholds = 50 * uA

--- a/pulse2percept/implants/tests/test_base.py
+++ b/pulse2percept/implants/tests/test_base.py
@@ -5,7 +5,8 @@ import numpy.testing as npt
 from pulse2percept import implants
 from pulse2percept.implants import cortex
 from pulse2percept.units import (DimensionMismatchError, Quantity,
-                                 dimensionless, dva, mA, mm, ms, nA, uA, um)
+                                 dimensionless, dva, mA, mm, ms, nA, uA, um,
+                                 xTh)
 from matplotlib.patches import Circle
 import matplotlib.pyplot as plt
 from skimage.measure import label, regionprops
@@ -741,3 +742,128 @@ def test_ProsthesisSystem_deactivated_electrode_does_not_render_the_others():
     # The waveform is still the one the trains describe:
     npt.assert_equal(implant.stim.data.shape[0], 2)
     npt.assert_almost_equal(implant.stim.time[-1], 200)
+
+
+def test_ProsthesisSystem_thresholds():
+    implant = ArgusII()
+    npt.assert_equal(implant.thresholds, {})
+    # One current calibrates the whole array:
+    implant.thresholds = 100 * uA
+    npt.assert_equal(len(implant.thresholds), implant.n_electrodes)
+    npt.assert_almost_equal(implant.thresholds['A1'], 100)
+    # A partial dict leaves the rest uncalibrated:
+    implant.thresholds = {'A1': 83 * uA, 'A2': 107 * uA}
+    npt.assert_equal(sorted(implant.thresholds), ['A1', 'A2'])
+    npt.assert_almost_equal(implant.thresholds['A2'], 107)
+    # The getter hands out a copy, not the dict the implant works from:
+    implant.thresholds['A1'] = 999
+    npt.assert_almost_equal(implant.thresholds['A1'], 83)
+    # None clears:
+    implant.thresholds = None
+    npt.assert_equal(implant.thresholds, {})
+
+
+def test_ProsthesisSystem_thresholds_are_validated():
+    implant = ArgusII()
+    with pytest.raises(ValueError):
+        implant.thresholds = {'ZZ9': 80 * uA}
+    for bad in (0, -5, np.nan, np.inf):
+        with pytest.raises(ValueError):
+            implant.thresholds = {'A1': bad}
+        with pytest.raises(ValueError):
+            implant.thresholds = bad
+    for bad in (5 * ms, 5 * mm):
+        with pytest.raises(DimensionMismatchError):
+            implant.thresholds = {'A1': bad}
+        with pytest.raises(DimensionMismatchError):
+            implant.thresholds = bad
+    # A rejected assignment leaves the implant as it was:
+    npt.assert_equal(implant.thresholds, {})
+
+
+def test_ProsthesisSystem_thresholds_calibrate_pulse_trains():
+    implant = ArgusII()
+    implant.stim = {'A1': BiphasicPulseTrain(20, 2 * xTh, 0.45),
+                    'A2': BiphasicPulseTrain(20, 2 * xTh, 0.45)}
+    # Without calibration, both fall back on the nominal reference:
+    npt.assert_almost_equal([src.amp for _, src
+                             in implant.stim._structured_sources()],
+                            [200, 200])
+    implant.thresholds = {'A1': 80 * uA, 'A2': 120 * uA}
+    # Same multiple of threshold, different currents:
+    for _, src in implant.stim._structured_sources():
+        npt.assert_almost_equal(src.amp_factor, 2)
+    npt.assert_almost_equal([src.amp for _, src
+                             in implant.stim._structured_sources()],
+                            [160, 240])
+    # ...and the waveform really is the recalibrated current:
+    npt.assert_almost_equal(np.abs(implant.stim['A1']).max(), 160, decimal=3)
+
+
+def test_ProsthesisSystem_thresholds_hold_current_stimuli_fixed():
+    # A current-valued train keeps its current and learns its threshold
+    # multiple, which is the opposite of what an xTh train does:
+    implant = ArgusII(stim={'A1': BiphasicPulseTrain(20, 160 * uA, 0.45)})
+    source = implant.stim._structured_sources()[0][1]
+    npt.assert_equal(source.amp_factor, None)
+    implant.thresholds = 80 * uA
+    source = implant.stim._structured_sources()[0][1]
+    npt.assert_almost_equal(source.amp, 160)
+    npt.assert_almost_equal(source.amp_factor, 2)
+
+
+@pytest.mark.parametrize('amp, cleared_amp',
+                         [(2 * xTh, 200), (160 * uA, 160)])
+def test_ProsthesisSystem_clearing_thresholds_restores_the_train(amp,
+                                                                 cleared_amp):
+    implant = ArgusII(stim={'A1': BiphasicPulseTrain(20, amp, 0.45)})
+    implant.thresholds = 40 * uA
+    implant.thresholds = None
+    source = implant.stim._structured_sources()[0][1]
+    npt.assert_almost_equal(source.amp, cleared_amp)
+    npt.assert_equal(source.amp_factor, None if cleared_amp == 160 else 2)
+
+
+def test_ProsthesisSystem_thresholds_beat_the_pulse_trains_own():
+    # Precedence: an implant that has been calibrated knows better than the
+    # threshold the pulse train was built with.
+    implant = ArgusII()
+    implant.thresholds = 100 * uA
+    implant.stim = {'A1': BiphasicPulseTrain(20, 2 * xTh, 0.45,
+                                             threshold_amp=50 * uA)}
+    npt.assert_almost_equal(implant.stim._structured_sources()[0][1].amp, 200)
+    # Clearing falls back to the train's own explicit threshold, not to the
+    # nominal reference:
+    implant.thresholds = None
+    source = implant.stim._structured_sources()[0][1]
+    npt.assert_almost_equal(source.amp, 100)
+    npt.assert_almost_equal(source.threshold_amp, 50)
+
+
+def test_ProsthesisSystem_thresholds_leave_raw_waveforms_alone():
+    implant = ArgusII(stim={'A1': 30})
+    before = implant.stim.data.copy()
+    implant.thresholds = 80 * uA
+    npt.assert_array_equal(implant.stim.data, before)
+    npt.assert_equal(implant.stim._structured_sources(), None)
+
+
+def test_ProsthesisSystem_thresholds_are_atomic():
+    implant = ArgusII(stim={'A1': BiphasicPulseTrain(20, 2 * xTh, 0.45)})
+    implant.max_current = 250
+    implant.thresholds = {'A1': 90 * uA}
+    npt.assert_almost_equal(implant.stim._structured_sources()[0][1].amp, 180)
+    # 2 * 200 uA is over the limit, so neither half of the change is kept:
+    with pytest.raises(ValueError):
+        implant.thresholds = {'A1': 200 * uA}
+    npt.assert_almost_equal(implant.thresholds['A1'], 90)
+    npt.assert_almost_equal(implant.stim._structured_sources()[0][1].amp, 180)
+
+
+def test_ProsthesisSystem_thresholds_do_not_render_the_stimulus():
+    implant = ArgusII(stim={'A1': BiphasicPulseTrain(20, 2 * xTh, 0.45)})
+    implant.thresholds = 80 * uA
+    source = implant.stim._structured_sources()[0][1]
+    # Recalibration rebuilds the train from its parameters; nothing along the
+    # way asks it for samples:
+    npt.assert_equal(source._Stimulus__stim['data'], None)

--- a/pulse2percept/implants/tests/test_base.py
+++ b/pulse2percept/implants/tests/test_base.py
@@ -747,18 +747,15 @@ def test_ProsthesisSystem_deactivated_electrode_does_not_render_the_others():
 def test_ProsthesisSystem_thresholds():
     implant = ArgusII()
     npt.assert_equal(implant.thresholds, {})
-    # One current calibrates the whole array:
     implant.thresholds = 100 * uA
     npt.assert_equal(len(implant.thresholds), implant.n_electrodes)
     npt.assert_almost_equal(implant.thresholds['A1'], 100)
-    # A partial dict leaves the rest uncalibrated:
     implant.thresholds = {'A1': 83 * uA, 'A2': 107 * uA}
     npt.assert_equal(sorted(implant.thresholds), ['A1', 'A2'])
     npt.assert_almost_equal(implant.thresholds['A2'], 107)
     # The getter hands out a copy, not the dict the implant works from:
     implant.thresholds['A1'] = 999
     npt.assert_almost_equal(implant.thresholds['A1'], 83)
-    # None clears:
     implant.thresholds = None
     npt.assert_equal(implant.thresholds, {})
 
@@ -779,30 +776,29 @@ def test_ProsthesisSystem_thresholds_are_validated():
             implant.thresholds = bad
     # A rejected assignment leaves the implant as it was:
     npt.assert_equal(implant.thresholds, {})
+    # None is normalized away rather than stored:
+    implant.thresholds = {'A1': 80 * uA, 'A2': None}
+    npt.assert_equal(sorted(implant.thresholds), ['A1'])
 
 
 def test_ProsthesisSystem_thresholds_calibrate_pulse_trains():
     implant = ArgusII()
     implant.stim = {'A1': BiphasicPulseTrain(20, 2 * xTh, 0.45),
                     'A2': BiphasicPulseTrain(20, 2 * xTh, 0.45)}
-    # Without calibration, both fall back on the nominal reference:
+    # Uncalibrated, both fall back on the nominal reference:
     npt.assert_almost_equal([src.amp for _, src
                              in implant.stim._structured_sources()],
                             [200, 200])
     implant.thresholds = {'A1': 80 * uA, 'A2': 120 * uA}
-    # Same multiple of threshold, different currents:
     for _, src in implant.stim._structured_sources():
         npt.assert_almost_equal(src.amp_factor, 2)
     npt.assert_almost_equal([src.amp for _, src
                              in implant.stim._structured_sources()],
                             [160, 240])
-    # ...and the waveform really is the recalibrated current:
     npt.assert_almost_equal(np.abs(implant.stim['A1']).max(), 160, decimal=3)
 
 
 def test_ProsthesisSystem_thresholds_hold_current_stimuli_fixed():
-    # A current-valued train keeps its current and learns its threshold
-    # multiple, which is the opposite of what an xTh train does:
     implant = ArgusII(stim={'A1': BiphasicPulseTrain(20, 160 * uA, 0.45)})
     source = implant.stim._structured_sources()[0][1]
     npt.assert_equal(source.amp_factor, None)
@@ -825,15 +821,12 @@ def test_ProsthesisSystem_clearing_thresholds_restores_the_train(amp,
 
 
 def test_ProsthesisSystem_thresholds_beat_the_pulse_trains_own():
-    # Precedence: an implant that has been calibrated knows better than the
-    # threshold the pulse train was built with.
     implant = ArgusII()
     implant.thresholds = 100 * uA
     implant.stim = {'A1': BiphasicPulseTrain(20, 2 * xTh, 0.45,
                                              threshold_amp=50 * uA)}
     npt.assert_almost_equal(implant.stim._structured_sources()[0][1].amp, 200)
-    # Clearing falls back to the train's own explicit threshold, not to the
-    # nominal reference:
+    # Clearing falls back to the train's own threshold, not the reference:
     implant.thresholds = None
     source = implant.stim._structured_sources()[0][1]
     npt.assert_almost_equal(source.amp, 100)
@@ -864,6 +857,41 @@ def test_ProsthesisSystem_thresholds_do_not_render_the_stimulus():
     implant = ArgusII(stim={'A1': BiphasicPulseTrain(20, 2 * xTh, 0.45)})
     implant.thresholds = 80 * uA
     source = implant.stim._structured_sources()[0][1]
-    # Recalibration rebuilds the train from its parameters; nothing along the
-    # way asks it for samples:
+    # `data is None` is what says no waveform has been generated:
     npt.assert_equal(source._Stimulus__stim['data'], None)
+
+
+def test_ProsthesisSystem_thresholds_do_not_revive_deactivated_electrodes():
+    implant = ArgusII()
+    implant.stim = {'A1': BiphasicPulseTrain(20, 2 * xTh, 0.45),
+                    'A2': BiphasicPulseTrain(20, 2 * xTh, 0.45)}
+    implant.deactivate('A1')
+    npt.assert_equal(list(implant.stim.electrodes), ['A2'])
+    implant.thresholds = 80 * uA
+    npt.assert_equal(list(implant.stim.electrodes), ['A2'])
+    npt.assert_almost_equal(implant.stim._structured_sources()[0][1].amp, 160)
+    implant.thresholds = None
+    npt.assert_equal(list(implant.stim.electrodes), ['A2'])
+
+
+def test_ProsthesisSystem_thresholds_preserve_metadata():
+    implant = ArgusII()
+    implant.stim = {'A1': BiphasicPulseTrain(20, 2 * xTh, 0.45,
+                                             metadata='train'),
+                    'A2': BiphasicPulseTrain(20, 2 * xTh, 0.45)}
+    implant.stim.metadata['user'] = 'collection'
+    implant.thresholds = 80 * uA
+    npt.assert_equal(implant.stim.metadata['user'], 'collection')
+    npt.assert_equal(implant.stim._structured_sources()[0][1].metadata['user'],
+                     'train')
+
+
+def test_ProsthesisSystem_thresholds_recalibrate_from_the_current_stimulus():
+    # The second threshold applies to the amplitude the user gave, not to the
+    # current the first one worked out:
+    implant = ArgusII(stim={'A1': BiphasicPulseTrain(20, 2 * xTh, 0.45)})
+    implant.thresholds = 80 * uA
+    implant.thresholds = 50 * uA
+    source = implant.stim._structured_sources()[0][1]
+    npt.assert_almost_equal(source.amp, 100)
+    npt.assert_almost_equal(source.amp_factor, 2)

--- a/pulse2percept/implants/tests/test_base.py
+++ b/pulse2percept/implants/tests/test_base.py
@@ -785,11 +785,10 @@ def test_ProsthesisSystem_thresholds_calibrate_pulse_trains():
     implant = ArgusII()
     implant.stim = {'A1': BiphasicPulseTrain(20, 2 * xTh, 0.45),
                     'A2': BiphasicPulseTrain(20, 2 * xTh, 0.45)}
-    # Uncalibrated, both fall back on the nominal reference:
-    npt.assert_almost_equal([src.amp for _, src
-                             in implant.stim._structured_sources()],
-                            [200, 200])
+    # Uncalibrated, the stimulus is not a current at all:
+    npt.assert_equal(implant.stim.unit, xTh)
     implant.thresholds = {'A1': 80 * uA, 'A2': 120 * uA}
+    npt.assert_equal(implant.stim.unit, uA)
     for _, src in implant.stim._structured_sources():
         npt.assert_almost_equal(src.amp_factor, 2)
     npt.assert_almost_equal([src.amp for _, src
@@ -809,7 +808,7 @@ def test_ProsthesisSystem_thresholds_hold_current_stimuli_fixed():
 
 
 @pytest.mark.parametrize('amp, cleared_amp',
-                         [(2 * xTh, 200), (160 * uA, 160)])
+                         [(2 * xTh, 2), (160 * uA, 160)])
 def test_ProsthesisSystem_clearing_thresholds_restores_the_train(amp,
                                                                  cleared_amp):
     implant = ArgusII(stim={'A1': BiphasicPulseTrain(20, amp, 0.45)})
@@ -895,3 +894,34 @@ def test_ProsthesisSystem_thresholds_recalibrate_from_the_current_stimulus():
     source = implant.stim._structured_sources()[0][1]
     npt.assert_almost_equal(source.amp, 100)
     npt.assert_almost_equal(source.amp_factor, 2)
+
+
+def test_ProsthesisSystem_uncalibrated_xTh_is_not_yet_a_current():
+    implant = ArgusII(stim={'A1': BiphasicPulseTrain(20, 2 * xTh, 0.45)})
+    npt.assert_equal(implant.stim.unit, xTh)
+    npt.assert_almost_equal(np.abs(implant.stim.data).max(), 2, decimal=3)
+    implant.max_current = 250
+    with pytest.raises(DimensionMismatchError):
+        implant.check_stim(implant.stim)
+    implant.safe_mode = True
+    with pytest.raises(DimensionMismatchError):
+        implant.check_stim(implant.stim)
+    implant.thresholds = 80 * uA
+    implant.check_stim(implant.stim)
+    npt.assert_almost_equal(np.abs(implant.stim.data).max(), 160, decimal=3)
+
+
+def test_ProsthesisSystem_partial_calibration_of_xTh_is_refused():
+    implant = ArgusII(stim={'A1': BiphasicPulseTrain(20, 2 * xTh, 0.45),
+                            'A2': BiphasicPulseTrain(20, 2 * xTh, 0.45)})
+    with pytest.raises(DimensionMismatchError) as err:
+        implant.thresholds = {'A1': 80 * uA}
+    npt.assert_equal('A2' in str(err.value), True)
+    npt.assert_equal(implant.thresholds, {})
+    npt.assert_equal(implant.stim.unit, xTh)
+    # A current-valued train is already a current, threshold or no threshold:
+    implant.stim = {'A1': BiphasicPulseTrain(20, 160 * uA, 0.45),
+                    'A2': BiphasicPulseTrain(20, 160 * uA, 0.45)}
+    implant.thresholds = {'A1': 80 * uA}
+    factors = [src.amp_factor for _, src in implant.stim._structured_sources()]
+    npt.assert_equal(factors, [2, None])

--- a/pulse2percept/models/base.py
+++ b/pulse2percept/models/base.py
@@ -244,7 +244,8 @@ def _require_stim_dimension(model, stim):
     """
     if not isinstance(stim, Stimulus):
         return
-    if stim.unit.dimension == model.stimulus_unit.dimension:
+    accepted = (model.stimulus_unit,) + tuple(model.extra_stimulus_units)
+    if stim.unit.dimension in {unit.dimension for unit in accepted}:
         return
     raise DimensionMismatchError(
         f"{type(model).__name__} reads its stimulus as "
@@ -388,6 +389,10 @@ class BaseModel(Parametrized, metaclass=ABCMeta):
 
     #: The unit stimulus values are expressed in
     stimulus_unit = uA
+    #: Further units this model reads, for a model that reads more than one
+    #: physical quantity (see
+    #: :py:class:`~pulse2percept.models.BiphasicAxonMapSpatial`)
+    extra_stimulus_units = ()
     #: The unit spatial coordinates are expressed in
     space_unit = um
     #: The unit time is expressed in
@@ -1575,6 +1580,19 @@ class Model(PrettyPrint):
         if self.has_time:
             return self.temporal.stimulus_unit
         return BaseModel.stimulus_unit
+
+    @property
+    def extra_stimulus_units(self):
+        """Further units this model reads
+
+        Follows :py:attr:`stimulus_unit` to whichever component the stimulus
+        goes to.
+        """
+        if self.has_space:
+            return self.spatial.extra_stimulus_units
+        if self.has_time:
+            return self.temporal.extra_stimulus_units
+        return BaseModel.extra_stimulus_units
 
     @property
     def space_unit(self):

--- a/pulse2percept/models/base.py
+++ b/pulse2percept/models/base.py
@@ -247,12 +247,10 @@ def _require_stim_dimension(model, stim):
     accepted = (model.stimulus_unit,) + tuple(model.extra_stimulus_units)
     if stim.unit.dimension in {unit.dimension for unit in accepted}:
         return
+    expected = ' or '.join(_describe_unit(unit) for unit in accepted)
     raise DimensionMismatchError(
-        f"{type(model).__name__} reads its stimulus as "
-        f"{_describe_unit(model.stimulus_unit)}, and this one is measured in "
-        f"{_describe_unit(stim.unit)}. Encode it with "
-        f"pulse2percept.stimuli.AmplitudeEncoder or FrequencyEncoder, which "
-        f"is what says how much current a gray level stands for.")
+        f"{type(model).__name__} expects {expected}, got "
+        f"{_describe_unit(stim.unit)}.")
 
 
 def _spatial_input(implant):
@@ -389,9 +387,7 @@ class BaseModel(Parametrized, metaclass=ABCMeta):
 
     #: The unit stimulus values are expressed in
     stimulus_unit = uA
-    #: Further units this model reads, for a model that reads more than one
-    #: physical quantity (see
-    #: :py:class:`~pulse2percept.models.BiphasicAxonMapSpatial`)
+    #: Additional stimulus units accepted by this model
     extra_stimulus_units = ()
     #: The unit spatial coordinates are expressed in
     space_unit = um
@@ -1583,11 +1579,7 @@ class Model(PrettyPrint):
 
     @property
     def extra_stimulus_units(self):
-        """Further units this model reads
-
-        Follows :py:attr:`stimulus_unit` to whichever component the stimulus
-        goes to.
-        """
+        """Additional stimulus units accepted by the active component"""
         if self.has_space:
             return self.spatial.extra_stimulus_units
         if self.has_time:

--- a/pulse2percept/models/granley2021.py
+++ b/pulse2percept/models/granley2021.py
@@ -17,10 +17,8 @@ from ._granley2021 import fast_biphasic_axon_map
 # Safety limit for locating delayed temporal peaks.
 _PEAK_SEARCH_DOUBLINGS = 4
 
-# `find_threshold` bisects on a scaled copy of the stimulus *data*. This model
-# reads amplitude off the pulse train instead, where it means a multiple of
-# threshold rather than a current, so scaling the data leaves the prediction
-# untouched and the search cannot converge:
+# `find_threshold` bisects on a scaled copy of the stimulus *data*, which this
+# model does not read, so the search cannot converge:
 _FIND_THRESHOLD_MSG = (
     "{cls} does not support find_threshold. It takes amplitude as a multiple "
     "of threshold and reads it from the pulse train the stimulus is made of, "
@@ -231,9 +229,8 @@ def _pulse_train_params(stim):
     the percept is zero.
 
     Amplitude comes back as a multiple of threshold
-    (:py:attr:`~pulse2percept.stimuli.BiphasicPulseTrain.amp_factor`), which
-    is what this model's effect models are fit in; the waveform itself stays
-    a current.
+    (:py:attr:`~pulse2percept.stimuli.BiphasicPulseTrain.amp_factor`), which is
+    what the effect models are fit in; the waveform itself stays a current.
 
     Raises
     ------
@@ -718,8 +715,12 @@ class BiphasicAxonMapModel(Model):
 
     .. important::
 
-        Stimuli should pass amplitude as a factor of threshold, NOT as raw
-        amplitude in microamps.
+        This model works in multiples of perceptual threshold at 0.45 ms pulse
+        duration, so give amplitude in
+        :py:data:`~pulse2percept.units.xTh` (``2 * xTh``), or calibrate the
+        electrode with ``threshold_amp`` or
+        :py:attr:`~pulse2percept.implants.ProsthesisSystem.thresholds` and give
+        it in microamps. The waveform stays a current either way.
 
         This model reads amplitude, frequency and pulse duration off the
         :py:class:`~pulse2percept.stimuli.BiphasicPulseTrain` objects the
@@ -862,8 +863,12 @@ class BiphasicAxonMapModel(Model):
 
         .. important::
 
-            Stimuli should pass amplitude as a factor of threshold,
-            NOT as raw amplitude in microamps.
+            This model works in multiples of perceptual threshold at 0.45 ms
+            pulse duration, so give amplitude in
+            :py:data:`~pulse2percept.units.xTh` (``2 * xTh``), or calibrate
+            the electrode with ``threshold_amp`` or
+            :py:attr:`~pulse2percept.implants.ProsthesisSystem.thresholds`
+            and give it in microamps.
 
             The model reads the intended amplitude, frequency and pulse
             duration off the

--- a/pulse2percept/models/granley2021.py
+++ b/pulse2percept/models/granley2021.py
@@ -218,19 +218,13 @@ _NO_THRESHOLD_MSG = (
 
 
 def _pulse_train_params(stim):
-    """``(electrode, freq, amp_factor, phase_dur, stim_dur)`` per electrode
+    """Return Granley pulse parameters for each driven electrode.
 
-    Read off the pulse trains the stimulus is made of rather than off a copy
-    of their numbers in its metadata: a stimulus whose samples were rewritten
-    has no train behind it any more, and this is what tells the two apart. No
-    waveform is generated to answer the question.
+    Parameters are read from retained ``BiphasicPulseTrain`` sources without
+    rendering the waveform. Amplitude is returned in multiples of threshold.
 
     Electrodes driven at zero amplitude are left out, so an empty list means
     the percept is zero.
-
-    Amplitude comes back as a multiple of threshold
-    (:py:attr:`~pulse2percept.stimuli.BiphasicPulseTrain.amp_factor`), which is
-    what the effect models are fit in; the waveform itself stays a current.
 
     Raises
     ------
@@ -404,9 +398,6 @@ class BiphasicAxonMapSpatial(AxonMapSpatial):
         n_jobs : int, optional
             Alias for ``n_threads``; ``None`` or ``-1`` uses every core.
     """
-    #: Amplitude reaches this model as a multiple of threshold, which a
-    #: current-valued train derives from its threshold and an `xTh` one
-    #: carries directly.
     extra_stimulus_units = (xTh,)
 
     def __init__(self, **params):
@@ -725,12 +716,11 @@ class BiphasicAxonMapModel(Model):
         :py:attr:`~pulse2percept.implants.ProsthesisSystem.thresholds` and
         give it in microamps.
 
-        Threshold here means the current at which a train of *this* frequency
-        and 0.45 ms phase duration is detected half the time [Granley2021]_.
-        A threshold measured at another frequency is a different number, so
-        changing ``freq`` may mean changing the threshold with it; the model
-        applies its own pulse-duration correction on top, and must not be
-        given a threshold that already includes one.
+        Threshold is the 50%-detection current for a train at the same
+        frequency and 0.45 ms phase duration [Granley2021]_. If frequency
+        changes, the threshold may change too. The model applies the
+        phase-duration correction itself; do not pre-correct the supplied
+        threshold.
 
         This model reads amplitude, frequency and pulse duration off the
         :py:class:`~pulse2percept.stimuli.BiphasicPulseTrain` objects the
@@ -877,9 +867,9 @@ class BiphasicAxonMapModel(Model):
             amplitude in :py:data:`~pulse2percept.units.xTh` (``2 * xTh``),
             or calibrate the electrode with ``threshold_amp`` or
             :py:attr:`~pulse2percept.implants.ProsthesisSystem.thresholds`
-            and give it in microamps. Threshold means the current at which a
-            train of *this* frequency and 0.45 ms phase duration is detected
-            half the time [Granley2021]_.
+            and give it in microamps. See
+            :py:class:`~pulse2percept.models.BiphasicAxonMapSpatial` for what
+            counts as threshold here.
 
             The model reads the intended amplitude, frequency and pulse
             duration off the

--- a/pulse2percept/models/granley2021.py
+++ b/pulse2percept/models/granley2021.py
@@ -8,7 +8,7 @@ from . import AxonMapSpatial, Model
 from ..implants import ProsthesisSystem, ElectrodeArray
 from ..stimuli import BiphasicPulseTrain, Stimulus
 from ..percepts import Percept
-from ..units import as_value, um
+from ..units import as_value, um, xTh
 from ..utils import FreezeError, rename_parameter
 from ..utils.base import has_own_attr
 from .base import NotBuiltError, BaseModel, _require_stim_dimension
@@ -404,6 +404,10 @@ class BiphasicAxonMapSpatial(AxonMapSpatial):
         n_jobs : int, optional
             Alias for ``n_threads``; ``None`` or ``-1`` uses every core.
     """
+    #: Amplitude reaches this model as a multiple of threshold, which a
+    #: current-valued train derives from its threshold and an `xTh` one
+    #: carries directly.
+    extra_stimulus_units = (xTh,)
 
     def __init__(self, **params):
         super(BiphasicAxonMapSpatial, self).__init__(**params)
@@ -715,12 +719,18 @@ class BiphasicAxonMapModel(Model):
 
     .. important::
 
-        This model works in multiples of perceptual threshold at 0.45 ms pulse
-        duration, so give amplitude in
-        :py:data:`~pulse2percept.units.xTh` (``2 * xTh``), or calibrate the
-        electrode with ``threshold_amp`` or
-        :py:attr:`~pulse2percept.implants.ProsthesisSystem.thresholds` and give
-        it in microamps. The waveform stays a current either way.
+        This model works in multiples of perceptual threshold, so give
+        amplitude in :py:data:`~pulse2percept.units.xTh` (``2 * xTh``), or
+        calibrate the electrode with ``threshold_amp`` or
+        :py:attr:`~pulse2percept.implants.ProsthesisSystem.thresholds` and
+        give it in microamps.
+
+        Threshold here means the current at which a train of *this* frequency
+        and 0.45 ms phase duration is detected half the time [Granley2021]_.
+        A threshold measured at another frequency is a different number, so
+        changing ``freq`` may mean changing the threshold with it; the model
+        applies its own pulse-duration correction on top, and must not be
+        given a threshold that already includes one.
 
         This model reads amplitude, frequency and pulse duration off the
         :py:class:`~pulse2percept.stimuli.BiphasicPulseTrain` objects the
@@ -863,12 +873,13 @@ class BiphasicAxonMapModel(Model):
 
         .. important::
 
-            This model works in multiples of perceptual threshold at 0.45 ms
-            pulse duration, so give amplitude in
-            :py:data:`~pulse2percept.units.xTh` (``2 * xTh``), or calibrate
-            the electrode with ``threshold_amp`` or
+            This model works in multiples of perceptual threshold, so give
+            amplitude in :py:data:`~pulse2percept.units.xTh` (``2 * xTh``),
+            or calibrate the electrode with ``threshold_amp`` or
             :py:attr:`~pulse2percept.implants.ProsthesisSystem.thresholds`
-            and give it in microamps.
+            and give it in microamps. Threshold means the current at which a
+            train of *this* frequency and 0.45 ms phase duration is detected
+            half the time [Granley2021]_.
 
             The model reads the intended amplitude, frequency and pulse
             duration off the

--- a/pulse2percept/models/granley2021.py
+++ b/pulse2percept/models/granley2021.py
@@ -208,8 +208,19 @@ class DefaultStreakModel(BaseModel):
         return np.maximum(F_streak, min_f_streak)
 
 
+#: What to do about a pulse whose amplitude is a current of unknown
+#: threshold. Formatted with the failing electrode.
+_NO_THRESHOLD_MSG = (
+    "This model takes amplitude as a multiple of perceptual threshold, and "
+    "electrode {electrode} is driven at {amp:.1f} uA with no threshold to "
+    "measure that against. Either give `amp` in threshold units (e.g. "
+    "`2 * xTh`), pass `threshold_amp` to the BiphasicPulseTrain, or set "
+    "`implant.thresholds`."
+)
+
+
 def _pulse_train_params(stim):
-    """``(electrode, freq, amp, phase_dur, stim_dur)`` per driven electrode
+    """``(electrode, freq, amp_factor, phase_dur, stim_dur)`` per electrode
 
     Read off the pulse trains the stimulus is made of rather than off a copy
     of their numbers in its metadata: a stimulus whose samples were rewritten
@@ -219,12 +230,20 @@ def _pulse_train_params(stim):
     Electrodes driven at zero amplitude are left out, so an empty list means
     the percept is zero.
 
+    Amplitude comes back as a multiple of threshold
+    (:py:attr:`~pulse2percept.stimuli.BiphasicPulseTrain.amp_factor`), which
+    is what this model's effect models are fit in; the waveform itself stays
+    a current.
+
     Raises
     ------
     TypeError
         If any electrode is driven by something other than a
         :py:class:`~pulse2percept.stimuli.BiphasicPulseTrain` with
         ``delay_dur=0``.
+    ValueError
+        If a driven electrode's amplitude is a current whose threshold is
+        unknown.
     """
     sources = stim._structured_sources()
     if sources is None:
@@ -246,7 +265,10 @@ def _pulse_train_params(stim):
                             f"no delay dur (Failing electrode: {electrode})")
         if source.amp == 0:
             continue
-        params.append((electrode, source.freq, source.amp,
+        if source.amp_factor is None:
+            raise ValueError(_NO_THRESHOLD_MSG.format(electrode=electrode,
+                                                      amp=source.amp))
+        params.append((electrode, source.freq, source.amp_factor,
                        source.phase_dur, source.stim_dur))
     return params
 

--- a/pulse2percept/models/tests/test_base.py
+++ b/pulse2percept/models/tests/test_base.py
@@ -1355,7 +1355,7 @@ def test_model_requires_a_current_stimulus():
     for model in (spatial, composite):
         with pytest.raises(DimensionMismatchError) as excinfo:
             model.predict_percept(implant)
-        npt.assert_equal('AmplitudeEncoder' in str(excinfo.value), True)
+        npt.assert_equal('electric current' in str(excinfo.value), True)
         npt.assert_equal('dimensionless' in str(excinfo.value), True)
     with pytest.raises(DimensionMismatchError):
         temporal.predict_percept(implant.stim)

--- a/pulse2percept/models/tests/test_granley2021.py
+++ b/pulse2percept/models/tests/test_granley2021.py
@@ -466,15 +466,12 @@ def test_find_threshold_not_supported(model_cls):
 
 @pytest.mark.parametrize('model_cls', [BiphasicAxonMapModel,
                                        BiphasicAxonMapSpatial])
-# Scaling the train itself, and scaling the stimulus the implant made of it -
-# the second is what a user reaches for, and it goes through the per-electrode
-# metadata rather than the train's own:
+# Scaling the train itself, and scaling the stimulus the implant made of it;
+# the second is what a user reaches for:
 @pytest.mark.parametrize('compose', [False, True])
 def test_scaled_pulse_train_changes_percept(model_cls, compose):
-    # This model reads amplitude off the stimulus metadata, so a scaled pulse
-    # train used to deliver twice the current and predict the very same
-    # percept. Scaling now updates the metadata, and has to give what building
-    # the train at that amplitude in the first place gives:
+    # Scaling has to give what building the train at that amplitude in the
+    # first place gives:
     model = model_cls(xrange=(-12, 12), yrange=(-8, 8), step=1,
                       n_ax_segments=30).build()
     implant = ArgusII(stim={'C5': BiphasicPulseTrain(20, 1 * xTh, 0.45,
@@ -513,9 +510,7 @@ def test_modified_pulse_train_rejected(model_cls, modify):
 
 def test_pulse_train_amp_sign_does_not_change_percept():
     # `BiphasicPulse` takes the magnitude of `amp`, so these two trains have
-    # the very same waveform. The model reads `amp` back from the metadata and
-    # is a function of it rather than of its magnitude, so the metadata has to
-    # store the magnitude - otherwise identical stimuli predict differently:
+    # the very same waveform, and must therefore predict the same percept:
     model = BiphasicAxonMapModel(xrange=(-12, 12), yrange=(-8, 8), step=1,
                                  n_ax_segments=30).build()
     pos = ArgusII(stim={'C5': BiphasicPulseTrain(20, 1 * xTh, 0.45,
@@ -792,9 +787,7 @@ def test_BiphasicAxonMap_predicts_without_a_waveform(model_cls, build_stim):
 @pytest.mark.parametrize('model_cls', [BiphasicAxonMapModel,
                                        BiphasicAxonMapSpatial])
 def test_BiphasicAxonMap_ignores_user_metadata(model_cls):
-    # The model is a function of the trains the stimulus is made of, and of
-    # nothing the user filed alongside them -- even metadata that happens to
-    # name pulse parameters:
+    # Metadata that happens to name pulse parameters is still just metadata:
     model = model_cls(xrange=(-3, 3), yrange=(-2, 2), step=1,
                       n_ax_segments=30).build()
     implant = ArgusII(stim={'C5': BiphasicPulseTrain(20, 1 * xTh, 0.45,

--- a/pulse2percept/models/tests/test_granley2021.py
+++ b/pulse2percept/models/tests/test_granley2021.py
@@ -19,7 +19,8 @@ from pulse2percept.models import (AxonMapSpatial, BiphasicAxonMapModel,
 from pulse2percept.models.granley2021 import DefaultBrightModel, \
     DefaultSizeModel, DefaultStreakModel
 from pulse2percept.units import (DimensionMismatchError, Quantity,
-                                 dimensionless, mm, ms, s, uA, um)
+                                 dimensionless, mm, ms, s, uA, um,
+                                 xTh)
 from pulse2percept.utils.base import FreezeError
 from pulse2percept.utils.testing import assert_warns_msg
 
@@ -243,7 +244,10 @@ def test_biphasicAxonMapSpatial():
     model.build()
     axon_map = AxonMapSpatial(step=2).build()
     implant = ArgusII()
-    implant.stim = Stimulus({'A5': BiphasicPulseTrain(20, 1, 0.45)})
+    # The axon map reads current and this model reads threshold multiples, so
+    # a 1 uA threshold is what makes the two numbers the same one:
+    implant.stim = Stimulus({'A5': BiphasicPulseTrain(20, 1 * xTh, 0.45,
+                                                      threshold_amp=1 * uA)})
     percept = model.predict_percept(implant)
     percept_axon = axon_map.predict_percept(implant)
     npt.assert_almost_equal(
@@ -259,7 +263,7 @@ def test_biphasicAxonMapSpatial():
     model = BiphasicAxonMapSpatial(step=2)
     model.build()
     implant = ArgusII()
-    implant.stim = Stimulus({'A5': BiphasicPulseTrain(20, 1, 0.45)})
+    implant.stim = Stimulus({'A5': BiphasicPulseTrain(20, 1 * xTh, 0.45)})
     percept = model.predict_percept(implant)
     npt.assert_equal(percept.time is None, True)
     # If t_percept is specified, only first frame should have data
@@ -274,7 +278,7 @@ def test_biphasicAxonMapSpatial():
                                    step=1, xrange=(-20, 20), yrange=(-15, 15))
     model.build()
     implant = ArgusII()
-    implant.stim = Stimulus({'A4': BiphasicPulseTrain(20, 1, 1)})
+    implant.stim = Stimulus({'A4': BiphasicPulseTrain(20, 1 * xTh, 1)})
     percept = model.predict_percept(implant)
     npt.assert_equal(np.sum(percept.data > 0.0813), 70)
     npt.assert_equal(np.sum(percept.data > 0.1626), 50)
@@ -450,7 +454,7 @@ def test_find_threshold_not_supported(model_cls):
     # rather than fail somewhere deeper with a confusing message.
     model = model_cls(xrange=(-3, 3), yrange=(-2, 2), step=1,
                       n_ax_segments=30).build()
-    implant = ArgusII(stim={'A1': BiphasicPulseTrain(20, 1, 0.45,
+    implant = ArgusII(stim={'A1': BiphasicPulseTrain(20, 1 * xTh, 0.45,
                                                      stim_dur=100)})
     with pytest.raises(NotImplementedError) as excinfo:
         model.find_threshold(implant, 0.5)
@@ -473,17 +477,17 @@ def test_scaled_pulse_train_changes_percept(model_cls, compose):
     # the train at that amplitude in the first place gives:
     model = model_cls(xrange=(-12, 12), yrange=(-8, 8), step=1,
                       n_ax_segments=30).build()
-    implant = ArgusII(stim={'C5': BiphasicPulseTrain(20, 1, 0.45,
+    implant = ArgusII(stim={'C5': BiphasicPulseTrain(20, 1 * xTh, 0.45,
                                                      stim_dur=100)})
     single = model.predict_percept(implant).data
     if compose:
         implant.stim = implant.stim * 2
     else:
-        implant.stim = {'C5': BiphasicPulseTrain(20, 1, 0.45,
+        implant.stim = {'C5': BiphasicPulseTrain(20, 1 * xTh, 0.45,
                                                  stim_dur=100) * 2}
     doubled = model.predict_percept(implant).data
     direct = model.predict_percept(ArgusII(
-        stim={'C5': BiphasicPulseTrain(20, 2, 0.45, stim_dur=100)})).data
+        stim={'C5': BiphasicPulseTrain(20, 2 * xTh, 0.45, stim_dur=100)})).data
     npt.assert_equal(np.any(single), True)
     npt.assert_array_almost_equal(doubled, direct)
     npt.assert_equal(np.allclose(doubled, single), False)
@@ -499,7 +503,7 @@ def test_modified_pulse_train_rejected(model_cls, modify):
     # than predict from pulse parameters that no longer describe the stimulus:
     model = model_cls(xrange=(-3, 3), yrange=(-2, 2), step=1,
                       n_ax_segments=30).build()
-    implant = ArgusII(stim={'C5': BiphasicPulseTrain(20, 1, 0.45,
+    implant = ArgusII(stim={'C5': BiphasicPulseTrain(20, 1 * xTh, 0.45,
                                                      stim_dur=100)})
     with np.errstate(divide='ignore', invalid='ignore'):
         implant.stim = modify(implant.stim)
@@ -514,8 +518,10 @@ def test_pulse_train_amp_sign_does_not_change_percept():
     # store the magnitude - otherwise identical stimuli predict differently:
     model = BiphasicAxonMapModel(xrange=(-12, 12), yrange=(-8, 8), step=1,
                                  n_ax_segments=30).build()
-    pos = ArgusII(stim={'C5': BiphasicPulseTrain(20, 1, 0.45, stim_dur=100)})
-    neg = ArgusII(stim={'C5': BiphasicPulseTrain(20, -1, 0.45, stim_dur=100)})
+    pos = ArgusII(stim={'C5': BiphasicPulseTrain(20, 1 * xTh, 0.45,
+                                                 stim_dur=100)})
+    neg = ArgusII(stim={'C5': BiphasicPulseTrain(20, -1 * xTh, 0.45,
+                                                 stim_dur=100)})
     npt.assert_almost_equal(pos.stim.data, neg.stim.data)
     npt.assert_array_almost_equal(model.predict_percept(pos).data,
                                   model.predict_percept(neg).data)
@@ -528,7 +534,8 @@ def test_BiphasicAxonMapModel_min_current_spread():
     ``BiphasicAxonMapSpatial`` inherits it; this pins that the biphasic
     kernel actually honours it rather than accepting it and ignoring it.
     """
-    stim = {e: BiphasicPulseTrain(20, 30, 0.45) for e in ('A2', 'C5', 'F8')}
+    stim = {e: BiphasicPulseTrain(20, 30 * xTh, 0.45)
+            for e in ('A2', 'C5', 'F8')}
     implant = ArgusII(stim=stim)
     kwargs = {'xrange': (-8, 8), 'yrange': (-8, 8), 'step': 0.5,
               'rho': 200, 'verbose': False}
@@ -562,7 +569,7 @@ def test_BiphasicAxonMapModel_min_current_spread_error_bound(amp):
     """
     min_spread = 1e-8
     freq, pdur = 20, 0.45
-    implant = ArgusII(stim={e: BiphasicPulseTrain(freq, amp, pdur)
+    implant = ArgusII(stim={e: BiphasicPulseTrain(freq, amp * xTh, pdur)
                             for e in ArgusII().electrode_names})
     kwargs = {'xrange': (-14, 14), 'yrange': (-10, 10), 'step': 0.75,
               'rho': 200, 'lam': 800, 'verbose': False}
@@ -591,7 +598,7 @@ def test_BiphasicAxonMapModel_rejects_nonpositive_effects(attr):
     model = BiphasicAxonMapModel(xrange=(-4, 4), yrange=(-4, 4), step=1,
                                  verbose=False).build()
     setattr(model.spatial, attr, lambda freq, amp, pdur: np.zeros_like(amp))
-    implant = ArgusII(stim={'A2': BiphasicPulseTrain(20, 30, 0.45)})
+    implant = ArgusII(stim={'A2': BiphasicPulseTrain(20, 30 * xTh, 0.45)})
     with pytest.raises(ValueError, match=attr):
         model.predict_percept(implant)
 
@@ -620,7 +627,7 @@ def test_BiphasicAxonMapModel_rejects_nonfinite_effects(attr, bad):
     setattr(model.spatial, attr,
             lambda freq, amp, pdur: np.full_like(np.asarray(amp, dtype=float),
                                                  bad))
-    implant = ArgusII(stim={'A2': BiphasicPulseTrain(20, 30, 0.45)})
+    implant = ArgusII(stim={'A2': BiphasicPulseTrain(20, 30 * xTh, 0.45)})
     with pytest.raises(ValueError, match=attr):
         model.predict_percept(implant)
 
@@ -649,7 +656,8 @@ def test_BiphasicAxonMapModel_reduces_to_AxonMapModel():
                                                                 dtype=float)))
     biphasic.build()
     got = biphasic.predict_percept(ArgusII(
-        stim={e: BiphasicPulseTrain(20, 30, 0.45) for e in electrodes})).data
+        stim={e: BiphasicPulseTrain(20, 30 * xTh, 0.45)
+              for e in electrodes})).data
 
     plain = AxonMapModel(**kwargs).build()
     stim = np.zeros(60)
@@ -663,7 +671,7 @@ def test_BiphasicAxonMapModel_reduces_to_AxonMapModel():
 
 def test_BiphasicAxonMap_t_percept_units():
     """This model overrides `predict_percept`, so it normalizes for itself"""
-    implant = ArgusII(stim={'A1': BiphasicPulseTrain(20, 1, 0.45,
+    implant = ArgusII(stim={'A1': BiphasicPulseTrain(20, 1 * xTh, 0.45,
                                                      stim_dur=100)})
     for model in (BiphasicAxonMapSpatial(step=2).build(),
                   BiphasicAxonMapModel(step=2).build()):
@@ -720,8 +728,8 @@ def test_BiphasicAxonMapSpatial_meridian_blend(ModelClass):
                           lam=400, n_axons=250, n_ax_segments=200,
                           ignore_pickle=True, **params).build()
 
-    implant = ArgusII(stim={'C4': BiphasicPulseTrain(20, 20, 0.45),
-                            'C8': BiphasicPulseTrain(20, 20, 0.45)})
+    implant = ArgusII(stim={'C4': BiphasicPulseTrain(20, 20 * xTh, 0.45),
+                            'C8': BiphasicPulseTrain(20, 20 * xTh, 0.45)})
     plain = make(meridian_blend=0)
     unblended = plain.predict_percept(implant).data
 
@@ -762,10 +770,12 @@ def _no_pulse_train_rendering():
 @pytest.mark.parametrize('model_cls', [BiphasicAxonMapModel,
                                        BiphasicAxonMapSpatial])
 @pytest.mark.parametrize('build_stim', [
-    lambda: BiphasicPulseTrain(20, 1, 0.45, stim_dur=100, electrode='C5'),
-    lambda: {'C5': BiphasicPulseTrain(20, 1, 0.45, stim_dur=100),
-             'A2': BiphasicPulseTrain(30, 2, 0.45, stim_dur=100)},
-    lambda: Stimulus({'C5': BiphasicPulseTrain(20, 1, 0.45, stim_dur=100)}) * 2,
+    lambda: BiphasicPulseTrain(20, 1 * xTh, 0.45, stim_dur=100,
+                               electrode='C5'),
+    lambda: {'C5': BiphasicPulseTrain(20, 1 * xTh, 0.45, stim_dur=100),
+             'A2': BiphasicPulseTrain(30, 2 * xTh, 0.45, stim_dur=100)},
+    lambda: Stimulus({'C5': BiphasicPulseTrain(20, 1 * xTh, 0.45,
+                                               stim_dur=100)}) * 2,
 ])
 def test_BiphasicAxonMap_predicts_without_a_waveform(model_cls, build_stim):
     # This model is a function of frequency, amplitude and phase duration, and
@@ -787,7 +797,7 @@ def test_BiphasicAxonMap_ignores_user_metadata(model_cls):
     # name pulse parameters:
     model = model_cls(xrange=(-3, 3), yrange=(-2, 2), step=1,
                       n_ax_segments=30).build()
-    implant = ArgusII(stim={'C5': BiphasicPulseTrain(20, 1, 0.45,
+    implant = ArgusII(stim={'C5': BiphasicPulseTrain(20, 1 * xTh, 0.45,
                                                      stim_dur=100)})
     expected = model.predict_percept(implant).data
     implant.stim.metadata['user'] = {'amp': 999, 'freq': 1}
@@ -800,10 +810,11 @@ def test_BiphasicAxonMap_ignores_user_metadata(model_cls):
     lambda: {'C5': MonophasicPulse(-1, 0.45, stim_dur=100)},
     lambda: {'C5': AsymmetricBiphasicPulseTrain(20, 1, 2, 0.45, 0.9,
                                                 stim_dur=100)},
-    lambda: {'C5': BiphasicPulseTrain(20, 1, 0.45, delay_dur=1,
+    lambda: {'C5': BiphasicPulseTrain(20, 1 * xTh, 0.45, delay_dur=1,
                                       stim_dur=100)},
-    lambda: (BiphasicPulseTrain(20, 1, 0.45, stim_dur=100, electrode='C5')
-             .append(BiphasicPulseTrain(50, 1, 0.45, stim_dur=100,
+    lambda: (BiphasicPulseTrain(20, 1 * xTh, 0.45, stim_dur=100,
+                                electrode='C5')
+             .append(BiphasicPulseTrain(50, 1 * xTh, 0.45, stim_dur=100,
                                         electrode='C5'))),
     lambda: {'C5': Stimulus([[0, 1, 1, 0]], time=[0, 1, 99, 100])},
 ])
@@ -826,20 +837,20 @@ def test_BiphasicAxonMap_zero_amplitude_is_inactive(model_cls):
     # than an error -- and is read off `amp`, not off the waveform:
     model = model_cls(xrange=(-3, 3), yrange=(-2, 2), step=1,
                       n_ax_segments=30).build()
-    implant = ArgusII(stim={'C5': BiphasicPulseTrain(20, 0, 0.45,
+    implant = ArgusII(stim={'C5': BiphasicPulseTrain(20, 0 * xTh, 0.45,
                                                      stim_dur=100),
-                            'A2': BiphasicPulseTrain(20, 0, 0.45,
+                            'A2': BiphasicPulseTrain(20, 0 * xTh, 0.45,
                                                      stim_dur=100)})
     with _no_pulse_train_rendering():
         percept = model.predict_percept(implant)
     npt.assert_almost_equal(percept.data, 0)
     # One driven electrode among zeros still predicts from that one alone:
-    implant.stim = {'C5': BiphasicPulseTrain(20, 0, 0.45, stim_dur=100),
-                    'A2': BiphasicPulseTrain(20, 1, 0.45, stim_dur=100)}
+    implant.stim = {'C5': BiphasicPulseTrain(20, 0 * xTh, 0.45, stim_dur=100),
+                    'A2': BiphasicPulseTrain(20, 1 * xTh, 0.45, stim_dur=100)}
     with _no_pulse_train_rendering():
         mixed = model.predict_percept(implant).data
     only = model.predict_percept(ArgusII(
-        stim={'A2': BiphasicPulseTrain(20, 1, 0.45, stim_dur=100)})).data
+        stim={'A2': BiphasicPulseTrain(20, 1 * xTh, 0.45, stim_dur=100)})).data
     npt.assert_array_almost_equal(mixed, only)
 
 
@@ -881,7 +892,7 @@ def _composite(temporal):
 
 
 def _composite_implant(stim_dur=_STIM_DUR):
-    return ArgusII(stim={'A5': BiphasicPulseTrain(20, 1, 0.45,
+    return ArgusII(stim={'A5': BiphasicPulseTrain(20, 1 * xTh, 0.45,
                                                   stim_dur=stim_dur)})
 
 
@@ -1001,11 +1012,11 @@ def test_BiphasicAxonMapSpatial_composite_ignores_inactive_stim_dur():
     # A train at zero amplitude is inactive everywhere, so it must not stretch
     # the envelope the active one rides on either:
     composite, _ = _composite(FadingTemporal())
-    short = ArgusII(stim={'A5': BiphasicPulseTrain(20, 1, 0.45,
+    short = ArgusII(stim={'A5': BiphasicPulseTrain(20, 1 * xTh, 0.45,
                                                    stim_dur=100)})
-    padded = ArgusII(stim={'A5': BiphasicPulseTrain(20, 1, 0.45,
+    padded = ArgusII(stim={'A5': BiphasicPulseTrain(20, 1 * xTh, 0.45,
                                                     stim_dur=100),
-                           'A2': BiphasicPulseTrain(20, 0, 0.45,
+                           'A2': BiphasicPulseTrain(20, 0 * xTh, 0.45,
                                                     stim_dur=1000)})
     t_percept = [40, 80, 100]
     npt.assert_array_almost_equal(
@@ -1019,9 +1030,9 @@ def test_BiphasicAxonMapSpatial_composite_rejects_unequal_stim_dur(
     # One separable envelope cannot have one electrode's contribution stop at
     # 100 ms and another's at 1000 ms:
     composite, _ = _composite(temporal_cls())
-    implant = ArgusII(stim={'A5': BiphasicPulseTrain(20, 1, 0.45,
+    implant = ArgusII(stim={'A5': BiphasicPulseTrain(20, 1 * xTh, 0.45,
                                                      stim_dur=100),
-                            'A2': BiphasicPulseTrain(20, 1, 0.45,
+                            'A2': BiphasicPulseTrain(20, 1 * xTh, 0.45,
                                                      stim_dur=1000)})
     with pytest.raises(NotImplementedError):
         composite.predict_percept(implant)
@@ -1047,3 +1058,77 @@ def test_BiphasicAxonMapSpatial_composite_rejects_an_unlocatable_peak():
     composite, _ = _composite(Horsager2009Temporal(tau3=300))
     with pytest.raises(ValueError):
         composite.predict_percept(_composite_implant())
+
+
+def _threshold_model():
+    return BiphasicAxonMapModel(xrange=(-3, 3), yrange=(-2, 2), step=1,
+                                n_ax_segments=30).build()
+
+
+def _percept_at(model, train, thresholds=None):
+    implant = ArgusII(stim={'A2': train})
+    if thresholds is not None:
+        implant.thresholds = thresholds
+    return model.predict_percept(implant).data
+
+
+def test_BiphasicAxonMap_reads_threshold_multiples_not_current():
+    model = _threshold_model()
+    # 200 uA against the nominal reference and 160 uA against an 80 uA
+    # threshold are both 2xTh, so they are the same stimulation to this model:
+    nominal = _percept_at(model, BiphasicPulseTrain(20, 2 * xTh, 0.45,
+                                                    stim_dur=100))
+    calibrated = _percept_at(model, BiphasicPulseTrain(20, 2 * xTh, 0.45,
+                                                       stim_dur=100),
+                             thresholds=80 * uA)
+    npt.assert_array_equal(nominal, calibrated)
+    npt.assert_equal(np.any(nominal), True)
+    # ...and so is 160 uA once the same 80 uA threshold is known:
+    as_current = _percept_at(model, BiphasicPulseTrain(20, 160 * uA, 0.45,
+                                                       stim_dur=100),
+                             thresholds=80 * uA)
+    npt.assert_array_equal(as_current, nominal)
+    on_the_train = _percept_at(model,
+                               BiphasicPulseTrain(20, 160 * uA, 0.45,
+                                                  stim_dur=100,
+                                                  threshold_amp=80 * uA))
+    npt.assert_array_equal(on_the_train, nominal)
+
+
+def test_BiphasicAxonMap_same_current_differs_by_threshold():
+    model = _threshold_model()
+    train = BiphasicPulseTrain(20, 160 * uA, 0.45, stim_dur=100)
+    npt.assert_equal(np.allclose(_percept_at(model, train, thresholds=80 * uA),
+                                 _percept_at(model, train,
+                                             thresholds=40 * uA)),
+                     False)
+
+
+@pytest.mark.parametrize('model_cls', [BiphasicAxonMapModel,
+                                       BiphasicAxonMapSpatial])
+def test_BiphasicAxonMap_uncalibrated_current_raises(model_cls):
+    model = model_cls(xrange=(-3, 3), yrange=(-2, 2), step=1,
+                      n_ax_segments=30).build()
+    implant = ArgusII(stim={'A2': BiphasicPulseTrain(20, 160 * uA, 0.45,
+                                                     stim_dur=100)})
+    with pytest.raises(ValueError) as err:
+        model.predict_percept(implant)
+    for remedy in ('2 * xTh', 'threshold_amp', 'implant.thresholds'):
+        npt.assert_equal(remedy in str(err.value), True)
+    # Any one of the three fixes it:
+    implant.thresholds = 80 * uA
+    npt.assert_equal(np.any(model.predict_percept(implant).data), True)
+
+
+@pytest.mark.parametrize('model_cls', [BiphasicAxonMapModel,
+                                       BiphasicAxonMapSpatial])
+def test_BiphasicAxonMap_zero_current_needs_no_threshold(model_cls):
+    # An electrode that is not driven has no threshold multiple either, but
+    # asking for one would turn a zero percept into an error:
+    model = model_cls(xrange=(-3, 3), yrange=(-2, 2), step=1,
+                      n_ax_segments=30).build()
+    implant = ArgusII(stim={'A2': BiphasicPulseTrain(20, 0 * uA, 0.45,
+                                                     stim_dur=100)})
+    with _no_pulse_train_rendering():
+        percept = model.predict_percept(implant)
+    npt.assert_almost_equal(percept.data, 0)

--- a/pulse2percept/models/tests/test_granley2021.py
+++ b/pulse2percept/models/tests/test_granley2021.py
@@ -702,7 +702,10 @@ def test_BiphasicAxonMap_dimension_before_waveform():
                   BiphasicAxonMapModel(step=2).build()):
         with pytest.raises(DimensionMismatchError) as excinfo:
             model.predict_percept(implant)
-        npt.assert_equal('AmplitudeEncoder' in str(excinfo.value), True)
+        # Both dimensions this model reads are named, not just the one:
+        for accepted in ('electric current', 'threshold ratio'):
+            npt.assert_equal(accepted in str(excinfo.value), True)
+        npt.assert_equal('dimensionless' in str(excinfo.value), True)
     # A current-valued stimulus of the wrong waveform still gets the
     # model-specific message:
     with pytest.raises(TypeError) as excinfo:
@@ -1115,8 +1118,7 @@ def test_BiphasicAxonMap_uncalibrated_current_raises(model_cls):
 @pytest.mark.parametrize('model_cls', [BiphasicAxonMapModel,
                                        BiphasicAxonMapSpatial])
 def test_BiphasicAxonMap_zero_current_needs_no_threshold(model_cls):
-    # An electrode that is not driven has no threshold multiple either, but
-    # asking for one would turn a zero percept into an error:
+    # Zero-current electrodes need no threshold.
     model = model_cls(xrange=(-3, 3), yrange=(-2, 2), step=1,
                       n_ax_segments=30).build()
     implant = ArgusII(stim={'A2': BiphasicPulseTrain(20, 0 * uA, 0.45,

--- a/pulse2percept/models/tests/test_granley2021.py
+++ b/pulse2percept/models/tests/test_granley2021.py
@@ -1067,25 +1067,24 @@ def _percept_at(model, train, thresholds=None):
 
 def test_BiphasicAxonMap_reads_threshold_multiples_not_current():
     model = _threshold_model()
-    # 200 uA against the nominal reference and 160 uA against an 80 uA
-    # threshold are both 2xTh, so they are the same stimulation to this model:
-    nominal = _percept_at(model, BiphasicPulseTrain(20, 2 * xTh, 0.45,
-                                                    stim_dur=100))
+    # Uncalibrated 2xTh and 160 uA on an 80 uA electrode are the same
+    # stimulation to this model, though only the second is a current:
+    relative = _percept_at(model, BiphasicPulseTrain(20, 2 * xTh, 0.45,
+                                                     stim_dur=100))
+    npt.assert_equal(np.any(relative), True)
     calibrated = _percept_at(model, BiphasicPulseTrain(20, 2 * xTh, 0.45,
                                                        stim_dur=100),
                              thresholds=80 * uA)
-    npt.assert_array_equal(nominal, calibrated)
-    npt.assert_equal(np.any(nominal), True)
-    # ...and so is 160 uA once the same 80 uA threshold is known:
+    npt.assert_array_equal(calibrated, relative)
     as_current = _percept_at(model, BiphasicPulseTrain(20, 160 * uA, 0.45,
                                                        stim_dur=100),
                              thresholds=80 * uA)
-    npt.assert_array_equal(as_current, nominal)
+    npt.assert_array_equal(as_current, relative)
     on_the_train = _percept_at(model,
                                BiphasicPulseTrain(20, 160 * uA, 0.45,
                                                   stim_dur=100,
                                                   threshold_amp=80 * uA))
-    npt.assert_array_equal(on_the_train, nominal)
+    npt.assert_array_equal(on_the_train, relative)
 
 
 def test_BiphasicAxonMap_same_current_differs_by_threshold():

--- a/pulse2percept/stimuli/pulse_trains.py
+++ b/pulse2percept/stimuli/pulse_trains.py
@@ -405,12 +405,10 @@ class BiphasicPulseTrain(Stimulus):
         # to `BiphasicPulse` is what keeps the properties below in the units a
         # model reading them back expects:
         freq = as_value(freq, Hz, 'freq')
-        # Which of the two numbers the caller knew is remembered, not just the
-        # current it works out to: rescaling and recalibration both have to
-        # keep the one they were given (see `_scaled`).
+        # Preserve whether amp was specified as current or threshold
+        # multiple.
         self._explicit_threshold_amp = _as_threshold_amp(threshold_amp)
-        # Set only by `_with_threshold`; kept apart from the caller's
-        # threshold so that clearing a calibration restores theirs.
+        # Keep an implant override separate so it can be cleared later.
         self._threshold_override = None
         self._amp_relative = _is_threshold_relative(amp)
         if self._amp_relative:
@@ -419,7 +417,6 @@ class BiphasicPulseTrain(Stimulus):
                 amp = amp * self.threshold_amp
         else:
             amp = as_value(amp, uA, 'amp')
-        # Which of the two numbers the train ends up holding:
         unit = xTh if self._amp_relative and self.threshold_amp is None else uA
         phase_dur = as_value(phase_dur, ms, 'phase_dur')
         interphase_dur = as_value(interphase_dur, ms, 'interphase_dur')
@@ -536,11 +533,10 @@ class BiphasicPulseTrain(Stimulus):
         return train
 
     def _with_threshold(self, override):
-        """This train, calibrated to an implant's threshold (None to clear)
+        """Return this train with an implant threshold override.
 
-        Whichever number the user specified survives: an ``xTh`` train keeps
-        its multiple and changes current, a current-valued train keeps its
-        current and changes multiple.
+        Threshold-relative trains preserve ``amp_factor``; current-valued
+        trains preserve ``amp``.
         """
         if override == self._threshold_override:
             return self
@@ -568,14 +564,15 @@ class BiphasicPulseTrain(Stimulus):
 
     def _pprint_params(self):
         """Return a dict of class arguments to pretty-print"""
-        params = {'freq': self.freq, 'amp': self.amp,
+        # The amplitude as given, not as resolved: two trains that deliver the
+        # same current recalibrate differently (see `_with_threshold`).
+        amp = self.amp_factor * xTh if self._amp_relative else self.amp
+        params = {'freq': self.freq, 'amp': amp,
                   'phase_dur': self.phase_dur,
                   'interphase_dur': self.interphase_dur,
                   'delay_dur': self.delay_dur, 'stim_dur': self.stim_dur,
                   'cathodic_first': self.cathodic_first,
                   'electrodes': self.electrodes, 'metadata': self.metadata}
-        if self.amp_factor is not None:
-            params['amp_factor'] = self.amp_factor
         if self.threshold_amp is not None:
             params['threshold_amp'] = self.threshold_amp
         return params

--- a/pulse2percept/stimuli/pulse_trains.py
+++ b/pulse2percept/stimuli/pulse_trains.py
@@ -13,14 +13,10 @@ from .pulses import (AsymmetricBiphasicPulse, BiphasicPulse,
 from ..units import Hz, as_value, ms, uA, xTh
 from ..utils.constants import DT, MS_PER_S
 
-#: Threshold (uA) assumed for an amplitude given in
-#: :py:data:`~pulse2percept.units.xTh` when nothing better is known. It is a
-#: stand-in for a measurement, not one: real thresholds vary by electrode and
-#: subject, so pass ``threshold_amp`` (or calibrate the implant) as soon as
-#: they are known.
-#:
-#: .. versionadded:: 0.10.0
-REFERENCE_THRESHOLD_AMP = 100.0
+# Nominal threshold (uA) an `xTh` amplitude falls back on when nothing better
+# is known. A stand-in for a measurement, not one: real thresholds vary by
+# electrode and by subject, so pass `threshold_amp` as soon as they are known.
+_XTH_REFERENCE_AMP = 100.0
 
 
 def _as_threshold_amp(threshold_amp):
@@ -376,11 +372,11 @@ class BiphasicPulseTrain(Stimulus):
        train built from ``2 * xTh`` has ``unit == uA`` and plots in
        microamps. What ``xTh`` changes is *which* number the user knew, and
        that is what is preserved when the train is rescaled or recalibrated.
-    *  An ``xTh`` amplitude with no threshold in sight falls back to
-       :py:data:`REFERENCE_THRESHOLD_AMP` (100 uA). A current amplitude does
-       not get the same treatment: an uncalibrated current has no threshold
-       multiple at all, and :py:attr:`amp_factor` answers None rather than
-       guessing.
+    *  An ``xTh`` amplitude with no threshold in sight is realized against a
+       nominal 100 uA reference, so that the train still has a waveform. A
+       current amplitude does not get the same treatment: an uncalibrated
+       current has no threshold multiple at all, and :py:attr:`amp_factor`
+       answers None rather than guessing one.
 
     Examples
     --------
@@ -474,7 +470,7 @@ class BiphasicPulseTrain(Stimulus):
         """
         if self._explicit_threshold_amp is not None:
             return self._explicit_threshold_amp
-        return REFERENCE_THRESHOLD_AMP if self._amp_relative else None
+        return _XTH_REFERENCE_AMP if self._amp_relative else None
 
     @property
     def amp_factor(self):

--- a/pulse2percept/stimuli/pulse_trains.py
+++ b/pulse2percept/stimuli/pulse_trains.py
@@ -19,15 +19,15 @@ from ..utils.constants import DT, MS_PER_S
 _XTH_REFERENCE_AMP = 100.0
 
 
-def _as_threshold_amp(threshold_amp):
+def _as_threshold_amp(threshold_amp, name='threshold_amp'):
     """Normalize a threshold to a plain, strictly positive value in uA"""
-    threshold_amp = as_value(threshold_amp, uA, 'threshold_amp')
+    threshold_amp = as_value(threshold_amp, uA, name)
     if threshold_amp is None:
         return None
     threshold_amp = float(threshold_amp)
     if not np.isfinite(threshold_amp) or threshold_amp <= 0:
-        raise ValueError(f"'threshold_amp' must be a positive, finite "
-                         f"current, not {threshold_amp}.")
+        raise ValueError(f"'{name}' must be a positive, finite current, not "
+                         f"{threshold_amp}.")
     return threshold_amp
 
 

--- a/pulse2percept/stimuli/pulse_trains.py
+++ b/pulse2percept/stimuli/pulse_trains.py
@@ -13,10 +13,6 @@ from .pulses import (AsymmetricBiphasicPulse, BiphasicPulse,
 from ..units import Hz, as_value, ms, uA, xTh
 from ..utils.constants import DT, MS_PER_S
 
-# Nominal threshold (uA) an `xTh` amplitude falls back on when none is known.
-_XTH_REFERENCE_AMP = 100.0
-
-
 def _as_threshold_amp(threshold_amp, name='threshold_amp'):
     """Normalize a threshold to a plain, strictly positive value in uA"""
     threshold_amp = as_value(threshold_amp, uA, name)
@@ -325,8 +321,9 @@ class BiphasicPulseTrain(Stimulus):
         ``cathodic_first``.
 
         May also be given as a multiple of perceptual threshold, e.g.
-        ``2 * xTh`` (see :py:data:`~pulse2percept.units.xTh`), in which case
-        the current delivered is ``amp * threshold_amp``.
+        ``2 * xTh`` (see :py:data:`~pulse2percept.units.xTh`). The current
+        that realizes it is ``amp * threshold_amp``, so without a threshold
+        the train stays measured in ``xTh``.
     phase_dur : float
         Duration (ms) of the cathodic/anodic phase.
     interphase_dur : float, optional, default: 0
@@ -347,8 +344,9 @@ class BiphasicPulseTrain(Stimulus):
     metadata : dict
         A dictionary of meta-data
     threshold_amp : float, optional
-        Perceptual threshold (uA) of the electrode this train drives, relating
-        the current in the waveform to :py:attr:`amp_factor`.
+        Perceptual threshold (uA) of the electrode this train drives. It is
+        what converts between :py:attr:`amp_factor` and a current, in either
+        direction.
 
         .. versionadded:: 0.10.0
 
@@ -365,11 +363,10 @@ class BiphasicPulseTrain(Stimulus):
     *  Arguments may be given as plain numbers in the units documented above,
        or as unitful quantities (e.g. ``0.05 * mA``, ``450 * us``), which are
        converted to those units. See :py:mod:`pulse2percept.units`.
-    *  The waveform is always a current, whichever way ``amp`` was given, so
-       ``unit`` is ``uA`` and :py:meth:`plot` shows microamps either way.
-    *  An ``xTh`` amplitude with no threshold known is realized against a
-       nominal 100 uA reference. A current amplitude gets no such fallback:
-       :py:attr:`amp_factor` is None until a threshold is supplied.
+    *  A train holds a current or a multiple of threshold, and ``unit`` says
+       which. Converting between them takes a threshold, so an ``xTh`` train
+       without one stays measured in ``xTh`` -- and is not yet something an
+       implant can deliver.
 
     Examples
     --------
@@ -386,6 +383,12 @@ class BiphasicPulseTrain(Stimulus):
     >>> pt = BiphasicPulseTrain(20, 160.0 * uA, 0.45, threshold_amp=80 * uA)
     >>> pt.amp, pt.amp_factor
     (160.0, 2.0)
+
+    With no threshold it is still 2xTh, but it is no longer a current:
+
+    >>> pt = BiphasicPulseTrain(20, 2.0 * xTh, 0.45)
+    >>> pt.amp_factor, pt.unit, pt.threshold_amp
+    (2.0, xTh, None)
 
     """
     #: Defined by the pulse it repeats rather than by its samples
@@ -411,9 +414,13 @@ class BiphasicPulseTrain(Stimulus):
         self._threshold_override = None
         self._amp_relative = _is_threshold_relative(amp)
         if self._amp_relative:
-            amp = as_value(amp, xTh, 'amp') * self.threshold_amp
+            amp = as_value(amp, xTh, 'amp')
+            if self.threshold_amp is not None:
+                amp = amp * self.threshold_amp
         else:
             amp = as_value(amp, uA, 'amp')
+        # Which of the two numbers the train ends up holding:
+        unit = xTh if self._amp_relative and self.threshold_amp is None else uA
         phase_dur = as_value(phase_dur, ms, 'phase_dur')
         interphase_dur = as_value(interphase_dur, ms, 'interphase_dur')
         delay_dur = as_value(delay_dur, ms, 'delay_dur')
@@ -428,7 +435,7 @@ class BiphasicPulseTrain(Stimulus):
         # generates a waveform until one is asked for.
         self._train = PulseTrain(freq, pulse, n_pulses=n_pulses,
                                  stim_dur=stim_dur)
-        self._defer(_electrode_names(electrode))
+        self._defer(_electrode_names(electrode), unit=unit)
         self.metadata = {'user': metadata}
 
     @property
@@ -453,7 +460,7 @@ class BiphasicPulseTrain(Stimulus):
 
     @property
     def amp(self):
-        """Magnitude (uA) of both phases of each pulse"""
+        """Magnitude of both phases of each pulse, in :py:attr:`unit`"""
         return self._train._pulse.amp
 
     @property
@@ -461,27 +468,27 @@ class BiphasicPulseTrain(Stimulus):
         """Perceptual threshold (uA) this train's amplitude is relative to
 
         The implant calibration in force, else the threshold this train was
-        built with, else the nominal reference for an ``xTh`` amplitude. None
-        if the amplitude was a current and no threshold is known.
+        built with, else None.
 
         .. versionadded:: 0.10.0
         """
         if self._threshold_override is not None:
             return self._threshold_override
-        if self._explicit_threshold_amp is not None:
-            return self._explicit_threshold_amp
-        return _XTH_REFERENCE_AMP if self._amp_relative else None
+        return self._explicit_threshold_amp
 
     @property
     def amp_factor(self):
         """Amplitude as a multiple of :py:attr:`threshold_amp`
 
-        None when :py:attr:`threshold_amp` is unknown.
+        None only for a current with no threshold to measure it against: an
+        ``xTh`` amplitude is the multiple, threshold or no threshold.
 
         .. versionadded:: 0.10.0
         """
         threshold_amp = self.threshold_amp
-        return None if threshold_amp is None else self.amp / threshold_amp
+        if threshold_amp is None:
+            return self.amp if self._amp_relative else None
+        return self.amp / threshold_amp
 
     @property
     def phase_dur(self):
@@ -569,6 +576,7 @@ class BiphasicPulseTrain(Stimulus):
                   'electrodes': self.electrodes, 'metadata': self.metadata}
         if self.amp_factor is not None:
             params['amp_factor'] = self.amp_factor
+        if self.threshold_amp is not None:
             params['threshold_amp'] = self.threshold_amp
         return params
 

--- a/pulse2percept/stimuli/pulse_trains.py
+++ b/pulse2percept/stimuli/pulse_trains.py
@@ -10,8 +10,34 @@ from math import isclose
 from .base import Stimulus
 from .pulses import (AsymmetricBiphasicPulse, BiphasicPulse,
                      MonophasicPulse, _electrode_names)
-from ..units import Hz, as_value, ms, uA
+from ..units import Hz, as_value, ms, uA, xTh
 from ..utils.constants import DT, MS_PER_S
+
+#: Threshold (uA) assumed for an amplitude given in
+#: :py:data:`~pulse2percept.units.xTh` when nothing better is known. It is a
+#: stand-in for a measurement, not one: real thresholds vary by electrode and
+#: subject, so pass ``threshold_amp`` (or calibrate the implant) as soon as
+#: they are known.
+#:
+#: .. versionadded:: 0.10.0
+REFERENCE_THRESHOLD_AMP = 100.0
+
+
+def _as_threshold_amp(threshold_amp):
+    """Normalize a threshold to a plain, strictly positive value in uA"""
+    threshold_amp = as_value(threshold_amp, uA, 'threshold_amp')
+    if threshold_amp is None:
+        return None
+    threshold_amp = float(threshold_amp)
+    if not np.isfinite(threshold_amp) or threshold_amp <= 0:
+        raise ValueError(f"'threshold_amp' must be a positive, finite "
+                         f"current, not {threshold_amp}.")
+    return threshold_amp
+
+
+def _is_threshold_relative(amp):
+    """Whether an amplitude was expressed as a multiple of threshold"""
+    return getattr(amp, 'dimension', None) == xTh.dimension
 
 
 def _tile_pulse(pulse, shift, n_pulses):
@@ -303,6 +329,10 @@ class BiphasicPulseTrain(Stimulus):
         Current amplitude (uA). Negative currents: cathodic, positive: anodic.
         The sign will be converted automatically depending on
         ``cathodic_first``.
+
+        May also be given as a multiple of perceptual threshold, e.g.
+        ``2 * xTh`` (see :py:data:`~pulse2percept.units.xTh`), in which case
+        the current delivered is ``amp * threshold_amp``.
     phase_dur : float
         Duration (ms) of the cathodic/anodic phase.
     interphase_dur : float, optional, default: 0
@@ -322,6 +352,12 @@ class BiphasicPulseTrain(Stimulus):
         Optionally, you can provide your own electrode name.
     metadata : dict
         A dictionary of meta-data
+    threshold_amp : float, optional
+        The perceptual threshold (uA) of the electrode this train drives. It
+        is what relates the current in the waveform to
+        :py:attr:`amp_factor`; it never appears in the waveform itself.
+
+        .. versionadded:: 0.10.0
 
     Notes
     -----
@@ -336,22 +372,55 @@ class BiphasicPulseTrain(Stimulus):
     *  Arguments may be given as plain numbers in the units documented above,
        or as unitful quantities (e.g. ``0.05 * mA``, ``450 * us``), which are
        converted to those units. See :py:mod:`pulse2percept.units`.
+    *  The waveform is always a current, whichever way ``amp`` was given: a
+       train built from ``2 * xTh`` has ``unit == uA`` and plots in
+       microamps. What ``xTh`` changes is *which* number the user knew, and
+       that is what is preserved when the train is rescaled or recalibrated.
+    *  An ``xTh`` amplitude with no threshold in sight falls back to
+       :py:data:`REFERENCE_THRESHOLD_AMP` (100 uA). A current amplitude does
+       not get the same treatment: an uncalibrated current has no threshold
+       multiple at all, and :py:attr:`amp_factor` answers None rather than
+       guessing.
+
+    Examples
+    --------
+    Twice threshold, on an electrode whose threshold has been measured:
+
+    >>> from pulse2percept.stimuli import BiphasicPulseTrain
+    >>> from pulse2percept.units import uA, xTh
+    >>> pt = BiphasicPulseTrain(20, 2 * xTh, 0.45, threshold_amp=80 * uA)
+    >>> pt.amp, pt.amp_factor
+    (160.0, 2.0)
+
+    The same stimulation, expressed as the current it delivers:
+
+    >>> pt = BiphasicPulseTrain(20, 160.0 * uA, 0.45, threshold_amp=80 * uA)
+    >>> pt.amp, pt.amp_factor
+    (160.0, 2.0)
 
     """
     #: Defined by the pulse it repeats rather than by its samples
     #: (see `Stimulus._is_parametric`):
     _is_parametric = True
 
-    __slots__ = ('_train',)
+    __slots__ = ('_train', '_amp_relative', '_explicit_threshold_amp')
 
     def __init__(self, freq, amp, phase_dur, interphase_dur=0, delay_dur=0,
                  n_pulses=None, stim_dur=1000.0, cathodic_first=True,
-                 electrode=None, metadata=None):
+                 electrode=None, metadata=None, threshold_amp=None):
         # See `PulseTrain.__init__`. Normalizing here rather than leaving it
         # to `BiphasicPulse` is what keeps the properties below in the units a
         # model reading them back expects:
         freq = as_value(freq, Hz, 'freq')
-        amp = as_value(amp, uA, 'amp')
+        # Which of the two numbers the caller knew is remembered, not just the
+        # current it works out to: rescaling and recalibration both have to
+        # keep the one they were given (see `_scaled`).
+        self._explicit_threshold_amp = _as_threshold_amp(threshold_amp)
+        self._amp_relative = _is_threshold_relative(amp)
+        if self._amp_relative:
+            amp = as_value(amp, xTh, 'amp') * self.threshold_amp
+        else:
+            amp = as_value(amp, uA, 'amp')
         phase_dur = as_value(phase_dur, ms, 'phase_dur')
         interphase_dur = as_value(interphase_dur, ms, 'interphase_dur')
         delay_dur = as_value(delay_dur, ms, 'delay_dur')
@@ -395,6 +464,32 @@ class BiphasicPulseTrain(Stimulus):
         return self._train._pulse.amp
 
     @property
+    def threshold_amp(self):
+        """Perceptual threshold (uA) this train's amplitude is relative to
+
+        None when no threshold is known, which can only happen for a train
+        whose amplitude was given as a current.
+
+        .. versionadded:: 0.10.0
+        """
+        if self._explicit_threshold_amp is not None:
+            return self._explicit_threshold_amp
+        return REFERENCE_THRESHOLD_AMP if self._amp_relative else None
+
+    @property
+    def amp_factor(self):
+        """Amplitude as a multiple of :py:attr:`threshold_amp`
+
+        None for a train whose amplitude was given as a current and whose
+        threshold is unknown: how far above threshold such a train is
+        stimulating is simply not known.
+
+        .. versionadded:: 0.10.0
+        """
+        threshold_amp = self.threshold_amp
+        return None if threshold_amp is None else self.amp / threshold_amp
+
+    @property
     def phase_dur(self):
         """Duration (ms) of the cathodic/anodic phase"""
         return self._train._pulse.phase_dur
@@ -419,28 +514,48 @@ class BiphasicPulseTrain(Stimulus):
         return {'data': self._train.data, 'electrodes': self.electrodes,
                 'time': self._train.time}
 
-    def _scaled(self, factor):
-        """This train with every amplitude multiplied by ``factor``"""
+    def _rebuilt(self, amp, threshold_amp, cathodic_first=None):
+        """This train, with a different amplitude and/or threshold"""
+        if cathodic_first is None:
+            cathodic_first = self.cathodic_first
         return BiphasicPulseTrain(
-            self.freq, self.amp * abs(factor), self.phase_dur,
+            self.freq, amp, self.phase_dur,
             interphase_dur=self.interphase_dur, delay_dur=self.delay_dur,
             n_pulses=self._train._n_pulses_asked,
-            stim_dur=self.stim_dur,
-            # A negative factor swaps the two phases, which is exactly what
-            # this flag says:
-            cathodic_first=(self.cathodic_first if factor >= 0
-                            else not self.cathodic_first),
+            stim_dur=self.stim_dur, cathodic_first=cathodic_first,
             electrode=self.electrodes[0],
-            metadata=deepcopy(self.metadata.get('user')))
+            metadata=deepcopy(self.metadata.get('user')),
+            threshold_amp=threshold_amp)
+
+    def _scaled(self, factor):
+        """This train with every amplitude multiplied by ``factor``
+
+        Scaling keeps the amplitude in the terms it was given in: doubling a
+        ``2 * xTh`` train gives ``4 * xTh`` at the same threshold, not 400 uA
+        pinned to whatever threshold happened to be in force.
+        """
+        if self._amp_relative:
+            amp = self.amp_factor * abs(factor) * xTh
+        else:
+            amp = self.amp * abs(factor)
+        # A negative factor swaps the two phases, which is exactly what the
+        # `cathodic_first` flag says:
+        return self._rebuilt(amp, self._explicit_threshold_amp,
+                             cathodic_first=(self.cathodic_first if factor >= 0
+                                             else not self.cathodic_first))
 
     def _pprint_params(self):
         """Return a dict of class arguments to pretty-print"""
-        return {'freq': self.freq, 'amp': self.amp,
-                'phase_dur': self.phase_dur,
-                'interphase_dur': self.interphase_dur,
-                'delay_dur': self.delay_dur, 'stim_dur': self.stim_dur,
-                'cathodic_first': self.cathodic_first,
-                'electrodes': self.electrodes, 'metadata': self.metadata}
+        params = {'freq': self.freq, 'amp': self.amp,
+                  'phase_dur': self.phase_dur,
+                  'interphase_dur': self.interphase_dur,
+                  'delay_dur': self.delay_dur, 'stim_dur': self.stim_dur,
+                  'cathodic_first': self.cathodic_first,
+                  'electrodes': self.electrodes, 'metadata': self.metadata}
+        if self.amp_factor is not None:
+            params['amp_factor'] = self.amp_factor
+            params['threshold_amp'] = self.threshold_amp
+        return params
 
 
 class AsymmetricBiphasicPulseTrain(Stimulus):

--- a/pulse2percept/stimuli/pulse_trains.py
+++ b/pulse2percept/stimuli/pulse_trains.py
@@ -13,9 +13,7 @@ from .pulses import (AsymmetricBiphasicPulse, BiphasicPulse,
 from ..units import Hz, as_value, ms, uA, xTh
 from ..utils.constants import DT, MS_PER_S
 
-# Nominal threshold (uA) an `xTh` amplitude falls back on when nothing better
-# is known. A stand-in for a measurement, not one: real thresholds vary by
-# electrode and by subject, so pass `threshold_amp` as soon as they are known.
+# Nominal threshold (uA) an `xTh` amplitude falls back on when none is known.
 _XTH_REFERENCE_AMP = 100.0
 
 
@@ -349,9 +347,8 @@ class BiphasicPulseTrain(Stimulus):
     metadata : dict
         A dictionary of meta-data
     threshold_amp : float, optional
-        The perceptual threshold (uA) of the electrode this train drives. It
-        is what relates the current in the waveform to
-        :py:attr:`amp_factor`; it never appears in the waveform itself.
+        Perceptual threshold (uA) of the electrode this train drives, relating
+        the current in the waveform to :py:attr:`amp_factor`.
 
         .. versionadded:: 0.10.0
 
@@ -368,15 +365,11 @@ class BiphasicPulseTrain(Stimulus):
     *  Arguments may be given as plain numbers in the units documented above,
        or as unitful quantities (e.g. ``0.05 * mA``, ``450 * us``), which are
        converted to those units. See :py:mod:`pulse2percept.units`.
-    *  The waveform is always a current, whichever way ``amp`` was given: a
-       train built from ``2 * xTh`` has ``unit == uA`` and plots in
-       microamps. What ``xTh`` changes is *which* number the user knew, and
-       that is what is preserved when the train is rescaled or recalibrated.
-    *  An ``xTh`` amplitude with no threshold in sight is realized against a
-       nominal 100 uA reference, so that the train still has a waveform. A
-       current amplitude does not get the same treatment: an uncalibrated
-       current has no threshold multiple at all, and :py:attr:`amp_factor`
-       answers None rather than guessing one.
+    *  The waveform is always a current, whichever way ``amp`` was given, so
+       ``unit`` is ``uA`` and :py:meth:`plot` shows microamps either way.
+    *  An ``xTh`` amplitude with no threshold known is realized against a
+       nominal 100 uA reference. A current amplitude gets no such fallback:
+       :py:attr:`amp_factor` is None until a threshold is supplied.
 
     Examples
     --------
@@ -399,7 +392,8 @@ class BiphasicPulseTrain(Stimulus):
     #: (see `Stimulus._is_parametric`):
     _is_parametric = True
 
-    __slots__ = ('_train', '_amp_relative', '_explicit_threshold_amp')
+    __slots__ = ('_train', '_amp_relative', '_explicit_threshold_amp',
+                 '_threshold_override')
 
     def __init__(self, freq, amp, phase_dur, interphase_dur=0, delay_dur=0,
                  n_pulses=None, stim_dur=1000.0, cathodic_first=True,
@@ -412,6 +406,9 @@ class BiphasicPulseTrain(Stimulus):
         # current it works out to: rescaling and recalibration both have to
         # keep the one they were given (see `_scaled`).
         self._explicit_threshold_amp = _as_threshold_amp(threshold_amp)
+        # Set only by `_with_threshold`; kept apart from the caller's
+        # threshold so that clearing a calibration restores theirs.
+        self._threshold_override = None
         self._amp_relative = _is_threshold_relative(amp)
         if self._amp_relative:
             amp = as_value(amp, xTh, 'amp') * self.threshold_amp
@@ -463,11 +460,14 @@ class BiphasicPulseTrain(Stimulus):
     def threshold_amp(self):
         """Perceptual threshold (uA) this train's amplitude is relative to
 
-        None when no threshold is known, which can only happen for a train
-        whose amplitude was given as a current.
+        The implant calibration in force, else the threshold this train was
+        built with, else the nominal reference for an ``xTh`` amplitude. None
+        if the amplitude was a current and no threshold is known.
 
         .. versionadded:: 0.10.0
         """
+        if self._threshold_override is not None:
+            return self._threshold_override
         if self._explicit_threshold_amp is not None:
             return self._explicit_threshold_amp
         return _XTH_REFERENCE_AMP if self._amp_relative else None
@@ -476,9 +476,7 @@ class BiphasicPulseTrain(Stimulus):
     def amp_factor(self):
         """Amplitude as a multiple of :py:attr:`threshold_amp`
 
-        None for a train whose amplitude was given as a current and whose
-        threshold is unknown: how far above threshold such a train is
-        stimulating is simply not known.
+        None when :py:attr:`threshold_amp` is unknown.
 
         .. versionadded:: 0.10.0
         """
@@ -511,10 +509,14 @@ class BiphasicPulseTrain(Stimulus):
                 'time': self._train.time}
 
     def _rebuilt(self, amp, threshold_amp, cathodic_first=None):
-        """This train, with a different amplitude and/or threshold"""
+        """This train, with a different amplitude and/or threshold
+
+        ``threshold_amp`` is only what ``amp`` is resolved against; the
+        caller's threshold and any implant calibration carry across unchanged.
+        """
         if cathodic_first is None:
             cathodic_first = self.cathodic_first
-        return BiphasicPulseTrain(
+        train = BiphasicPulseTrain(
             self.freq, amp, self.phase_dur,
             interphase_dur=self.interphase_dur, delay_dur=self.delay_dur,
             n_pulses=self._train._n_pulses_asked,
@@ -522,21 +524,38 @@ class BiphasicPulseTrain(Stimulus):
             electrode=self.electrodes[0],
             metadata=deepcopy(self.metadata.get('user')),
             threshold_amp=threshold_amp)
+        train._explicit_threshold_amp = self._explicit_threshold_amp
+        train._threshold_override = self._threshold_override
+        return train
+
+    def _with_threshold(self, override):
+        """This train, calibrated to an implant's threshold (None to clear)
+
+        Whichever number the user specified survives: an ``xTh`` train keeps
+        its multiple and changes current, a current-valued train keeps its
+        current and changes multiple.
+        """
+        if override == self._threshold_override:
+            return self
+        amp = self.amp_factor * xTh if self._amp_relative else self.amp
+        resolved = (override if override is not None
+                    else self._explicit_threshold_amp)
+        train = self._rebuilt(amp, resolved)
+        train._threshold_override = override
+        return train
 
     def _scaled(self, factor):
         """This train with every amplitude multiplied by ``factor``
 
         Scaling keeps the amplitude in the terms it was given in: doubling a
-        ``2 * xTh`` train gives ``4 * xTh`` at the same threshold, not 400 uA
-        pinned to whatever threshold happened to be in force.
+        ``2 * xTh`` train gives ``4 * xTh``, not a pinned current.
         """
         if self._amp_relative:
             amp = self.amp_factor * abs(factor) * xTh
         else:
             amp = self.amp * abs(factor)
-        # A negative factor swaps the two phases, which is exactly what the
-        # `cathodic_first` flag says:
-        return self._rebuilt(amp, self._explicit_threshold_amp,
+        # A negative factor swaps the two phases:
+        return self._rebuilt(amp, self.threshold_amp,
                              cathodic_first=(self.cathodic_first if factor >= 0
                                              else not self.cathodic_first))
 

--- a/pulse2percept/stimuli/tests/test_pulse_trains.py
+++ b/pulse2percept/stimuli/tests/test_pulse_trains.py
@@ -783,12 +783,12 @@ def test_append_still_rejects_what_it_always_did():
 
 
 @pytest.mark.parametrize('amp, threshold_amp, expected',
-                         [(50, None, (50, None, None)),
-                          (0.05 * mA, None, (50, None, None)),
-                          (2 * xTh, None, (200, 100, 2)),
-                          (2 * xTh, 80 * uA, (160, 80, 2)),
-                          (160 * uA, 80 * uA, (160, 80, 2)),
-                          (2 * xTh, 80, (160, 80, 2))])
+                         [(50, None, (50, None, None, uA)),
+                          (0.05 * mA, None, (50, None, None, uA)),
+                          (2 * xTh, None, (2, None, 2, xTh)),
+                          (2 * xTh, 80 * uA, (160, 80, 2, uA)),
+                          (160 * uA, 80 * uA, (160, 80, 2, uA)),
+                          (2 * xTh, 80, (160, 80, 2, uA))])
 def test_BiphasicPulseTrain_threshold_relative_amp(amp, threshold_amp,
                                                    expected):
     pt = BiphasicPulseTrain(20, amp, 0.45, stim_dur=100,
@@ -796,7 +796,8 @@ def test_BiphasicPulseTrain_threshold_relative_amp(amp, threshold_amp,
     npt.assert_almost_equal(pt.amp, expected[0])
     npt.assert_equal(pt.threshold_amp, expected[1])
     npt.assert_equal(pt.amp_factor, expected[2])
-    npt.assert_equal(pt.unit, uA)
+    # A threshold multiple only becomes a current once a threshold says so:
+    npt.assert_equal(pt.unit, expected[3])
     npt.assert_almost_equal(np.abs(pt.data).max(), expected[0], decimal=3)
 
 
@@ -834,7 +835,7 @@ def test_BiphasicPulseTrain_amp_basis_survives_a_round_trip():
 
 
 @pytest.mark.parametrize('amp, threshold_amp, overridden, restored',
-                         [(2 * xTh, None, (200, 2), (200, 2)),
+                         [(2 * xTh, None, (200, 2), (2, 2)),
                           (2 * xTh, 50 * uA, (200, 2), (100, 2)),
                           (160 * uA, None, (160, 1.6), (160, None)),
                           (160 * uA, 50 * uA, (160, 1.6), (160, 3.2))])
@@ -867,3 +868,17 @@ def test_BiphasicPulseTrain_scaling_keeps_the_override():
     npt.assert_almost_equal((current * 2).amp, 320)
     npt.assert_almost_equal((current * 2).amp_factor, 4)
     npt.assert_equal((current * 2)._with_threshold(None).amp_factor, None)
+
+
+def test_BiphasicPulseTrain_xTh_amp_is_not_a_current():
+    # No threshold, no current: the train must not invent one.
+    pt = BiphasicPulseTrain(20, 2 * xTh, 0.45, stim_dur=100)
+    npt.assert_equal(pt.unit, xTh)
+    npt.assert_almost_equal(pt.amp, 2)
+    npt.assert_almost_equal(pt.amp_factor, 2)
+    npt.assert_equal(pt.threshold_amp, None)
+    npt.assert_almost_equal(np.abs(pt.data).max(), 2, decimal=3)
+    calibrated = pt._with_threshold(80)
+    npt.assert_equal(calibrated.unit, uA)
+    npt.assert_almost_equal(calibrated.amp, 160)
+    npt.assert_almost_equal(calibrated.amp_factor, 2)

--- a/pulse2percept/stimuli/tests/test_pulse_trains.py
+++ b/pulse2percept/stimuli/tests/test_pulse_trains.py
@@ -796,7 +796,6 @@ def test_BiphasicPulseTrain_threshold_relative_amp(amp, threshold_amp,
     npt.assert_almost_equal(pt.amp, expected[0])
     npt.assert_equal(pt.threshold_amp, expected[1])
     npt.assert_equal(pt.amp_factor, expected[2])
-    # Whichever way the amplitude was given, the waveform is a current:
     npt.assert_equal(pt.unit, uA)
     npt.assert_almost_equal(np.abs(pt.data).max(), expected[0], decimal=3)
 
@@ -805,25 +804,21 @@ def test_BiphasicPulseTrain_threshold_amp_is_validated():
     for bad in (0, -80, np.nan, np.inf):
         with pytest.raises(ValueError):
             BiphasicPulseTrain(20, 2 * xTh, 0.45, threshold_amp=bad)
-    # A threshold is a current, not a threshold multiple or a time:
     for bad in (2 * xTh, 5 * ms):
         with pytest.raises(DimensionMismatchError):
             BiphasicPulseTrain(20, 50, 0.45, threshold_amp=bad)
 
 
 def test_BiphasicPulseTrain_scaling_preserves_amp_basis():
-    # Doubling a 2xTh train gives 4xTh at the same threshold...
     relative = BiphasicPulseTrain(20, 2 * xTh, 0.45, stim_dur=100,
                                   threshold_amp=80 * uA)
     npt.assert_almost_equal((relative * 2).amp_factor, 4)
     npt.assert_almost_equal((relative * 2).amp, 320)
     npt.assert_equal((relative * 2)._amp_relative, True)
-    # ...while doubling a 160 uA train gives 320 uA:
     current = BiphasicPulseTrain(20, 160 * uA, 0.45, stim_dur=100)
     npt.assert_almost_equal((current * 2).amp, 320)
     npt.assert_equal((current * 2).amp_factor, None)
     npt.assert_equal((current * 2)._amp_relative, False)
-    # Negative scaling still swaps the phases, whichever basis is in force:
     npt.assert_equal((-relative).cathodic_first, not relative.cathodic_first)
     npt.assert_almost_equal((-relative).amp_factor, 2)
     npt.assert_almost_equal((-current).amp, 160)
@@ -836,3 +831,39 @@ def test_BiphasicPulseTrain_amp_basis_survives_a_round_trip():
         npt.assert_equal(copied._amp_relative, True)
         npt.assert_almost_equal(copied.threshold_amp, 80)
         npt.assert_almost_equal(copied.amp_factor, 2)
+
+
+@pytest.mark.parametrize('amp, threshold_amp, overridden, restored',
+                         [(2 * xTh, None, (200, 2), (200, 2)),
+                          (2 * xTh, 50 * uA, (200, 2), (100, 2)),
+                          (160 * uA, None, (160, 1.6), (160, None)),
+                          (160 * uA, 50 * uA, (160, 1.6), (160, 3.2))])
+def test_BiphasicPulseTrain_threshold_override(amp, threshold_amp, overridden,
+                                               restored):
+    pt = BiphasicPulseTrain(20, amp, 0.45, stim_dur=100,
+                            threshold_amp=threshold_amp)
+    calibrated = pt._with_threshold(100)
+    npt.assert_almost_equal(calibrated.amp, overridden[0])
+    npt.assert_almost_equal(calibrated.amp_factor, overridden[1])
+    npt.assert_almost_equal(calibrated.threshold_amp, 100)
+    cleared = calibrated._with_threshold(None)
+    npt.assert_almost_equal(cleared.amp, restored[0])
+    npt.assert_equal(cleared.amp_factor, restored[1])
+    npt.assert_almost_equal(pt.amp, restored[0])
+    # A no-op override hands back the same object rather than a rebuild:
+    npt.assert_equal(pt._with_threshold(None) is pt, True)
+
+
+def test_BiphasicPulseTrain_scaling_keeps_the_override():
+    pt = BiphasicPulseTrain(20, 2 * xTh, 0.45, stim_dur=100,
+                            threshold_amp=50 * uA)._with_threshold(100)
+    scaled = pt * 2
+    npt.assert_almost_equal(scaled.amp, 400)
+    npt.assert_almost_equal(scaled.amp_factor, 4)
+    # Clearing after scaling still restores the train's own threshold:
+    npt.assert_almost_equal(scaled._with_threshold(None).amp, 200)
+    current = BiphasicPulseTrain(20, 160 * uA, 0.45,
+                                 stim_dur=100)._with_threshold(80)
+    npt.assert_almost_equal((current * 2).amp, 320)
+    npt.assert_almost_equal((current * 2).amp_factor, 4)
+    npt.assert_equal((current * 2)._with_threshold(None).amp_factor, None)

--- a/pulse2percept/stimuli/tests/test_pulse_trains.py
+++ b/pulse2percept/stimuli/tests/test_pulse_trains.py
@@ -15,7 +15,7 @@ from pulse2percept.stimuli import (Stimulus, PulseTrain, BiphasicPulse,
 from pulse2percept.stimuli.pulse_trains import _tile_pulse
 from pulse2percept.utils.constants import DT
 from pulse2percept.units import (DimensionMismatchError, Hz, Quantity,
-                                 kHz, mA, ms, uA, us)
+                                 kHz, mA, ms, uA, us, xTh)
 from pulse2percept.units import s as sec
 
 
@@ -780,3 +780,59 @@ def test_append_still_rejects_what_it_always_did():
         pt.append(Stimulus([[5, 5]], electrodes=pt.electrodes, time=[0, 10]))
     with pytest.raises(DimensionMismatchError):
         pt.append(VideoStimulus(np.ones((1, 1, 3))))
+
+
+@pytest.mark.parametrize('amp, threshold_amp, expected',
+                         [(50, None, (50, None, None)),
+                          (0.05 * mA, None, (50, None, None)),
+                          (2 * xTh, None, (200, 100, 2)),
+                          (2 * xTh, 80 * uA, (160, 80, 2)),
+                          (160 * uA, 80 * uA, (160, 80, 2)),
+                          (2 * xTh, 80, (160, 80, 2))])
+def test_BiphasicPulseTrain_threshold_relative_amp(amp, threshold_amp,
+                                                   expected):
+    pt = BiphasicPulseTrain(20, amp, 0.45, stim_dur=100,
+                            threshold_amp=threshold_amp)
+    npt.assert_almost_equal(pt.amp, expected[0])
+    npt.assert_equal(pt.threshold_amp, expected[1])
+    npt.assert_equal(pt.amp_factor, expected[2])
+    # Whichever way the amplitude was given, the waveform is a current:
+    npt.assert_equal(pt.unit, uA)
+    npt.assert_almost_equal(np.abs(pt.data).max(), expected[0], decimal=3)
+
+
+def test_BiphasicPulseTrain_threshold_amp_is_validated():
+    for bad in (0, -80, np.nan, np.inf):
+        with pytest.raises(ValueError):
+            BiphasicPulseTrain(20, 2 * xTh, 0.45, threshold_amp=bad)
+    # A threshold is a current, not a threshold multiple or a time:
+    for bad in (2 * xTh, 5 * ms):
+        with pytest.raises(DimensionMismatchError):
+            BiphasicPulseTrain(20, 50, 0.45, threshold_amp=bad)
+
+
+def test_BiphasicPulseTrain_scaling_preserves_amp_basis():
+    # Doubling a 2xTh train gives 4xTh at the same threshold...
+    relative = BiphasicPulseTrain(20, 2 * xTh, 0.45, stim_dur=100,
+                                  threshold_amp=80 * uA)
+    npt.assert_almost_equal((relative * 2).amp_factor, 4)
+    npt.assert_almost_equal((relative * 2).amp, 320)
+    npt.assert_equal((relative * 2)._amp_relative, True)
+    # ...while doubling a 160 uA train gives 320 uA:
+    current = BiphasicPulseTrain(20, 160 * uA, 0.45, stim_dur=100)
+    npt.assert_almost_equal((current * 2).amp, 320)
+    npt.assert_equal((current * 2).amp_factor, None)
+    npt.assert_equal((current * 2)._amp_relative, False)
+    # Negative scaling still swaps the phases, whichever basis is in force:
+    npt.assert_equal((-relative).cathodic_first, not relative.cathodic_first)
+    npt.assert_almost_equal((-relative).amp_factor, 2)
+    npt.assert_almost_equal((-current).amp, 160)
+
+
+def test_BiphasicPulseTrain_amp_basis_survives_a_round_trip():
+    pt = BiphasicPulseTrain(20, 2 * xTh, 0.45, stim_dur=100,
+                            threshold_amp=80 * uA)
+    for copied in (deepcopy(pt), pt * 1):
+        npt.assert_equal(copied._amp_relative, True)
+        npt.assert_almost_equal(copied.threshold_amp, 80)
+        npt.assert_almost_equal(copied.amp_factor, 2)

--- a/pulse2percept/stimuli/tests/test_pulse_trains.py
+++ b/pulse2percept/stimuli/tests/test_pulse_trains.py
@@ -882,3 +882,19 @@ def test_BiphasicPulseTrain_xTh_amp_is_not_a_current():
     npt.assert_equal(calibrated.unit, uA)
     npt.assert_almost_equal(calibrated.amp, 160)
     npt.assert_almost_equal(calibrated.amp_factor, 2)
+
+
+def test_BiphasicPulseTrain_repr_keeps_the_amp_basis():
+    # Same current, different basis, so different behavior under
+    # recalibration -- the repr has to tell them apart:
+    relative = repr(BiphasicPulseTrain(20, 2 * xTh, 0.45,
+                                       threshold_amp=80 * uA))
+    current = repr(BiphasicPulseTrain(20, 160 * uA, 0.45,
+                                      threshold_amp=80 * uA))
+    npt.assert_equal(relative == current, False)
+    npt.assert_equal('xTh' in relative, True)
+    npt.assert_equal('xTh' in current, False)
+    for shown in (relative, current):
+        npt.assert_equal('threshold_amp' in shown, True)
+    npt.assert_equal('threshold_amp' in repr(BiphasicPulseTrain(20, 50, 0.45)),
+                     False)

--- a/pulse2percept/units/__init__.py
+++ b/pulse2percept/units/__init__.py
@@ -41,10 +41,9 @@ threshold ratio   ``xTh``
 dimensionless     ``dimensionless``
 ================  ==========================
 
-``xTh`` ("times threshold") is a p2p-specific dimension, not a dimensionless
-alias: ``2 * xTh`` is a stimulation strength relative to a subject's
-perceptual threshold, and becomes a current only once that threshold is known
-(see :py:class:`~pulse2percept.stimuli.BiphasicPulseTrain`).
+``xTh`` ("times threshold") has its own dimension rather than being a
+dimensionless alias, because turning ``2 * xTh`` into a current takes a
+calibration (see :py:class:`~pulse2percept.stimuli.BiphasicPulseTrain`).
 
 .. autosummary::
     :toctree: _api

--- a/pulse2percept/units/__init__.py
+++ b/pulse2percept/units/__init__.py
@@ -37,8 +37,14 @@ current           ``A``, ``mA``, ``uA``, ``nA``
 voltage           ``V``, ``mV``, ``uV``
 charge            ``C``, ``mC``, ``uC``, ``nC``
 visual angle      ``dva``
+threshold ratio   ``xTh``
 dimensionless     ``dimensionless``
 ================  ==========================
+
+``xTh`` ("times threshold") is a p2p-specific dimension, not a dimensionless
+alias: ``2 * xTh`` is a stimulation strength relative to a subject's
+perceptual threshold, and becomes a current only once that threshold is known
+(see :py:class:`~pulse2percept.stimuli.BiphasicPulseTrain`).
 
 .. autosummary::
     :toctree: _api
@@ -60,7 +66,9 @@ from .base import (Dimension, Unit, Quantity, DimensionMismatchError, as_value,
                    # charge
                    C, mC, uC, nC,
                    # visual angle
-                   dva)
+                   dva,
+                   # threshold ratio
+                   xTh)
 
 __all__ = [
     'as_value',
@@ -76,4 +84,5 @@ __all__ = [
     'V', 'mV', 'uV',
     'C', 'mC', 'uC', 'nC',
     'dva',
+    'xTh',
 ]

--- a/pulse2percept/units/base.py
+++ b/pulse2percept/units/base.py
@@ -8,7 +8,7 @@ from copy import deepcopy
 import numpy as np
 
 # Primitive dimensions. This is deliberately *not* the seven-dimensional SI
-# system: p2p only ever needs these five, and every other dimension we care
+# system: p2p only ever needs these six, and every other dimension we care
 # about is derived from them (frequency = time^-1, charge = current * time,
 # current density = current / length^2).
 #
@@ -16,7 +16,14 @@ import numpy as np
 # physical angle: converting degrees of visual angle to retinal or cortical
 # distance is a coordinate transformation owned by a visual field map, not a
 # unit conversion.
-BASE_DIMENSIONS = ('time', 'length', 'current', 'voltage', 'visual_angle')
+#
+# ``threshold`` is p2p-specific too, and primitive for the same reason: a
+# multiple of perceptual threshold is not a plain number. Threshold varies by
+# electrode and by subject, so turning ``2 * xTh`` into a current takes a
+# calibration, not a scale factor -- and a dimensionless ``2`` must not be
+# mistaken for it.
+BASE_DIMENSIONS = ('time', 'length', 'current', 'voltage', 'visual_angle',
+                   'threshold')
 
 # How the primitive dimensions are spelled in error messages:
 _BASE_LABELS = {
@@ -25,6 +32,7 @@ _BASE_LABELS = {
     'current': 'electric current',
     'voltage': 'voltage',
     'visual_angle': 'visual angle',
+    'threshold': 'threshold ratio',
 }
 
 # Names for the handful of derived dimensions that have one. A dimension earns
@@ -34,11 +42,11 @@ _BASE_LABELS = {
 # energy are deliberately absent: the algebra derives them from voltage and
 # current already, but no p2p API takes them yet.
 _DERIVED_LABELS = {
-    (0, 0, 0, 0, 0): 'dimensionless',
-    (-1, 0, 0, 0, 0): 'frequency',
-    (1, 0, 1, 0, 0): 'charge',
-    (0, -2, 1, 0, 0): 'current density',
-    (1, -2, 1, 0, 0): 'charge density',
+    (0, 0, 0, 0, 0, 0): 'dimensionless',
+    (-1, 0, 0, 0, 0, 0): 'frequency',
+    (1, 0, 1, 0, 0, 0): 'charge',
+    (0, -2, 1, 0, 0, 0): 'current density',
+    (1, -2, 1, 0, 0, 0): 'charge density',
 }
 
 
@@ -835,6 +843,7 @@ LENGTH = Dimension(length=1)
 CURRENT = Dimension(current=1)
 VOLTAGE = Dimension(voltage=1)
 VISUAL_ANGLE = Dimension(visual_angle=1)
+THRESHOLD = Dimension(threshold=1)
 FREQUENCY = TIME ** -1
 CHARGE = CURRENT * TIME
 
@@ -896,6 +905,11 @@ nC = Unit(CHARGE, 1e-9, 'nC')
 #: on the retina or cortex requires a visual field map, not a scale factor.
 dva = Unit(VISUAL_ANGLE, 1, 'dva')
 
+#: Multiple of perceptual threshold ("times threshold"). Not a plain number:
+#: ``2 * xTh`` becomes a current only once a threshold is known, either from
+#: the pulse train itself or from the implant it is delivered on.
+xTh = Unit(THRESHOLD, 1, 'xTh')
+
 
 # The canonical spelling of each predefined unit, for `Unit._display_symbol`.
 # Written out here rather than harvested from this module's namespace: should
@@ -911,7 +925,7 @@ _CANONICAL_UNITS = (dimensionless,
                     A, mA, uA, nA,
                     V, mV, uV,
                     C, mC, uC, nC,
-                    dva)
+                    dva, xTh)
 
 for _unit in _CANONICAL_UNITS:
     _key = (_unit.dimension, _unit.scale)

--- a/pulse2percept/units/base.py
+++ b/pulse2percept/units/base.py
@@ -7,40 +7,30 @@ import math
 from copy import deepcopy
 import numpy as np
 
-# Primitive dimensions. This is deliberately *not* the seven-dimensional SI
-# system: p2p only ever needs these six, and every other dimension we care
-# about is derived from them (frequency = time^-1, charge = current * time,
-# current density = current / length^2).
+# Primitive dimensions used by p2p. Derived dimensions such as frequency,
+# charge, and current density are formed from these.
 #
-# ``visual_angle`` is a p2p-specific primitive dimension, not an ordinary
-# physical angle: converting degrees of visual angle to retinal or cortical
-# distance is a coordinate transformation owned by a visual field map, not a
-# unit conversion.
+# ``visual_angle`` is kept separate from physical angle because converting
+# visual angle to retinal or cortical distance requires a visual field map.
 #
-# ``threshold`` is p2p-specific too, and primitive for the same reason: a
-# multiple of perceptual threshold is not a plain number. Threshold varies by
-# electrode and by subject, so turning ``2 * xTh`` into a current takes a
-# calibration, not a scale factor -- and a dimensionless ``2`` must not be
-# mistaken for it.
+# ``threshold_ratio`` represents amplitudes relative to perceptual threshold
+# (e.g. ``2 * xTh``). The threshold itself is a current and may vary across
+# electrodes and subjects, so converting a threshold ratio to current requires
+# calibration rather than a fixed unit conversion.
 BASE_DIMENSIONS = ('time', 'length', 'current', 'voltage', 'visual_angle',
-                   'threshold')
+                   'threshold_ratio')
 
-# How the primitive dimensions are spelled in error messages:
+# Human-readable names used in error messages:
 _BASE_LABELS = {
     'time': 'time',
     'length': 'length',
     'current': 'electric current',
     'voltage': 'voltage',
     'visual_angle': 'visual angle',
-    'threshold': 'threshold ratio',
+    'threshold_ratio': 'threshold ratio',
 }
 
-# Names for the handful of derived dimensions that have one. A dimension earns
-# an entry here when p2p actually talks about it -- these names are what error
-# messages say, and "expected charge density, got time * electric current /
-# length^2" is the difference between a diagnostic and a puzzle. Power and
-# energy are deliberately absent: the algebra derives them from voltage and
-# current already, but no p2p API takes them yet.
+# Human-readable names used in error messages:
 _DERIVED_LABELS = {
     (0, 0, 0, 0, 0, 0): 'dimensionless',
     (-1, 0, 0, 0, 0, 0): 'frequency',
@@ -51,42 +41,23 @@ _DERIVED_LABELS = {
 
 
 def _snap_scale(scale):
-    """Snap a scale factor to an exact power of ten
+    """Snap near-exact decimal scale factors to powers of ten.
 
-    Every unit p2p exposes is a decimal multiple of its base unit, so scale
-    factors and conversion ratios are powers of ten in exact arithmetic. In
-    floating point they are not: ``1e-6 * 1e-3`` is ``1.0000000000000002e-09``,
-    which would leave ``uA * ms`` a hair away from ``nC``. Snapping keeps the
-    *units* canonical, so that unit algebra lands on the predefined units
-    exactly rather than approximately.
-
-    It does not, and cannot, make every conversion exact: ``0.0041 * 1000`` is
-    ``4.1000000000000005`` no matter how exact the 1000 is. Converted
-    magnitudes agree to floating-point precision, which is why
-    :py:meth:`Quantity.__eq__` compares with a tight relative tolerance rather
-    than bit-for-bit.
-
-    The tolerance is deliberately much tighter than the noise this is meant to
-    remove (a few ulps from multiplying units together), so a scale that is
-    merely *near* a power of ten is left alone.
+    Unit algebra can introduce small floating-point errors, e.g.
+    ``1e-6 * 1e-3 != 1e-9`` exactly. Snapping removes that noise so equivalent
+    compound units resolve to the same predefined unit.
     """
     if not math.isfinite(scale) or scale <= 0:
         return scale
     rounded = round(math.log10(scale))
     if abs(rounded) < 300:
-        # Build the float from its decimal literal rather than with ``**``, so
-        # that the result is the correctly rounded power of ten:
         candidate = float(f'1e{rounded:d}')
         if math.isclose(scale, candidate, rel_tol=1e-12, abs_tol=0.0):
             return candidate
     return scale
 
 
-#: Relative tolerance for comparing quantities. Converting a magnitude between
-#: units is a multiplication, and multiplication rounds: ``0.0041 * mA`` and
-#: ``4.1 * uA`` are the same current but not the same float. This is tight
-#: enough that only rounding noise slips through -- values that differ in the
-#: 12th significant digit are different values, not different spellings.
+#: Relative tolerance used when comparing converted quantity magnitudes.
 _EQ_RTOL = 1e-12
 
 
@@ -843,7 +814,7 @@ LENGTH = Dimension(length=1)
 CURRENT = Dimension(current=1)
 VOLTAGE = Dimension(voltage=1)
 VISUAL_ANGLE = Dimension(visual_angle=1)
-THRESHOLD = Dimension(threshold=1)
+THRESHOLD_RATIO = Dimension(threshold_ratio=1)
 FREQUENCY = TIME ** -1
 CHARGE = CURRENT * TIME
 
@@ -908,7 +879,7 @@ dva = Unit(VISUAL_ANGLE, 1, 'dva')
 #: Multiple of perceptual threshold ("times threshold"). Not a plain number:
 #: ``2 * xTh`` becomes a current only once a threshold is known, either from
 #: the pulse train itself or from the implant it is delivered on.
-xTh = Unit(THRESHOLD, 1, 'xTh')
+xTh = Unit(THRESHOLD_RATIO, 1, 'xTh')
 
 
 # The canonical spelling of each predefined unit, for `Unit._display_symbol`.

--- a/pulse2percept/units/base.py
+++ b/pulse2percept/units/base.py
@@ -876,9 +876,9 @@ nC = Unit(CHARGE, 1e-9, 'nC')
 #: on the retina or cortex requires a visual field map, not a scale factor.
 dva = Unit(VISUAL_ANGLE, 1, 'dva')
 
-#: Multiple of perceptual threshold ("times threshold"). Not a plain number:
-#: ``2 * xTh`` becomes a current only once a threshold is known, either from
-#: the pulse train itself or from the implant it is delivered on.
+#: Multiple of perceptual threshold ("times threshold"). Becomes a current
+#: only once a threshold is known; see
+#: :py:class:`~pulse2percept.stimuli.BiphasicPulseTrain`.
 xTh = Unit(THRESHOLD_RATIO, 1, 'xTh')
 
 

--- a/pulse2percept/units/tests/test_units.py
+++ b/pulse2percept/units/tests/test_units.py
@@ -9,7 +9,8 @@ from pulse2percept.units import (Dimension, Unit, Quantity,
                                  DimensionMismatchError, as_value,
                                  dimensionless,
                                  s, ms, us, ns, Hz, kHz, m, cm, mm, um, nm,
-                                 A, mA, uA, nA, V, mV, uV, C, mC, uC, nC, dva)
+                                 A, mA, uA, nA, V, mV, uV, C, mC, uC, nC, dva,
+                                 xTh)
 from pulse2percept.units.base import (TIME, _CANONICAL_SYMBOLS,
                                       _CANONICAL_UNITS)
 
@@ -159,7 +160,8 @@ def test_unit_vocabulary():
                              (uV, 1e-6, 'voltage'),
                              (C, 1, 'charge'), (mC, 1e-3, 'charge'),
                              (uC, 1e-6, 'charge'), (nC, 1e-9, 'charge'),
-                             (dva, 1, 'visual angle')]:
+                             (dva, 1, 'visual angle'),
+                             (xTh, 1, 'threshold ratio')]:
         npt.assert_almost_equal(unit.scale, scale)
         npt.assert_equal(unit.dimension.name, dim)
     npt.assert_equal(dimensionless.dimension, Dimension())
@@ -376,6 +378,23 @@ def test_dva_is_not_a_length():
     # dva is still a perfectly good unit on its own:
     npt.assert_equal((5 * dva).to_value(dva), 5)
     npt.assert_equal(dva.dimension.name, 'visual angle')
+
+
+def test_xTh_is_not_dimensionless():
+    # A multiple of threshold is not a plain number: turning it into a current
+    # takes a calibration, so nothing may convert between the two silently.
+    npt.assert_equal(xTh == dimensionless, False)
+    npt.assert_equal(2 * xTh == 2, False)
+    with pytest.raises(DimensionMismatchError):
+        (2 * xTh).to_value(uA)
+    with pytest.raises(DimensionMismatchError):
+        as_value(2 * xTh, dimensionless)
+    with pytest.raises(DimensionMismatchError):
+        (2 * xTh) + (2 * uA)
+    # It is still a perfectly good unit on its own:
+    npt.assert_equal((2 * xTh).to_value(xTh), 2)
+    npt.assert_equal(str(2 * xTh), '2 xTh')
+    npt.assert_equal(xTh.dimension.name, 'threshold ratio')
 
 
 def test_as_value():


### PR DESCRIPTION
Granley & Beyeler (2021) interprets stimulation amplitude as a multiple of perceptual threshold, while `BiphasicPulseTrain` amplitudes otherwise represent physical current. This was handled implicitly/inaccurately since the `Units` PR, so this PR fixes the inconsistency/ambiguity by making the unit explicit.

- [x] Adds `xTh` for threshold-relative amplitude
- [x] Adds optional pulse-level and per-electrode threshold calibration
- [x] Keeps calibrated implant stimuli in `uA`; uncalibrated threshold-relative stimuli remain in `xTh`
- [x] Updates Granley to use threshold multiples instead of raw current
- [x] Updates tests, examples, docs, and benchmarks accordingly

Bare `BiphasicPulseTrain` amplitudes continue to mean `uA`. But Granley users can now specify either `2 * xTh` directly or provide a threshold for a current-valued stimulus.