### PR TITLE
[ENH] Add AlphaTemporal model

### DIFF
--- a/doc/topics/models.rst
+++ b/doc/topics/models.rst
@@ -22,6 +22,7 @@ pulse2percept provides the following computational models:
 Reference         Model                      Type
 ----------------  -------------------------  -------------------
 generic           `FadingTemporal`           temporal
+generic           `AlphaTemporal`            temporal
 [Thompson2003]_   `Thompson2003Model`        spatial
 [Thompson2003]_   `Thompson2003Spatial`      spatial
 [Horsager2009]_   `Horsager2009Model`        temporal

--- a/doc/users/release_notes.rst
+++ b/doc/users/release_notes.rst
@@ -65,8 +65,8 @@ API changes:
   rather than treating it as negative brightness, and enforces ``tau >= dt``.
 
 * New :py:class:`~pulse2percept.models.AlphaTemporal` provides a one-time-constant
-  alpha-shaped temporal response, rising to a peak at ``tau`` rather than
-  fading from stimulus onset.
+  alpha-shaped temporal response, whose impulse response rises to a peak at 
+  ``tau`` before decaying.
 
 * A bare :py:class:`~pulse2percept.stimuli.BiphasicPulseTrain` amplitude now
   consistently means microamps.

--- a/doc/users/release_notes.rst
+++ b/doc/users/release_notes.rst
@@ -64,6 +64,10 @@ API changes:
   :py:class:`~pulse2percept.models.FadingTemporal` now ignores anodic current
   rather than treating it as negative brightness, and enforces ``tau >= dt``.
 
+* New :py:class:`~pulse2percept.models.AlphaTemporal` provides a one-time-constant
+  alpha-shaped temporal response, rising to a peak at ``tau`` rather than
+  fading from stimulus onset.
+
 * A bare :py:class:`~pulse2percept.stimuli.BiphasicPulseTrain` amplitude now
   consistently means microamps.
   :py:class:`~pulse2percept.models.BiphasicAxonMapModel` amplitudes, which used

--- a/pulse2percept/models/__init__.py
+++ b/pulse2percept/models/__init__.py
@@ -21,7 +21,7 @@ Computational models of the prosthetic vision, such as phosphene and neural resp
 """
 from .base import (BaseModel, Model, NotBuiltError, SpatialModel,
                    TemporalModel)
-from .temporal import FadingTemporal
+from .temporal import AlphaTemporal, FadingTemporal
 from .beyeler2019 import (ScoreboardModel, ScoreboardSpatial, AxonMapSpatial,
                           AxonMapModel)
 from .horsager2009 import Horsager2009Model, Horsager2009Temporal
@@ -33,6 +33,7 @@ from .thompson2003 import Thompson2003Model, Thompson2003Spatial
 from . import cortex
 
 __all__ = [
+    'AlphaTemporal',
     'AxonMapModel',
     'AxonMapSpatial',
     'BaseModel',

--- a/pulse2percept/models/_temporal.pyx
+++ b/pulse2percept/models/_temporal.pyx
@@ -193,3 +193,138 @@ cpdef fading_fast(const float32[:, ::1] stim,
         c_fpmode_restore(fpmode)
 
     return np.asarray(percept)  # Py overhead
+
+
+@cdivision(True)
+cpdef alpha_fast(const float32[:, ::1] stim,
+                 const float32[::1] t_stim,
+                 const uint32[::1] idx_t_percept,
+                 float32 dt,
+                 float32 tau,
+                 float32 thresh_percept,
+                 uint32 n_threads,
+                 uint32 reduce=REDUCE_LAST):
+    """Cython implementation of the generic alpha model
+
+    Two leaky integrators in series, both with time constant ``tau`` and unit
+    DC gain, driven by the cathodic half of the stimulus. The cascade's
+    impulse response is ``t / tau**2 * exp(-t / tau)``, which starts at zero,
+    peaks at ``t = tau`` and decays afterwards.
+
+    Loop structure, sparse stimulus advancement, blocking, denormal handling
+    and interval peak tracking all work exactly as in ``fading_fast``; see
+    there. The only difference is that each location carries two states.
+
+    Parameters
+    ----------
+    stim : 2D float32 array
+        A ``Stimulus.data`` container that contains spatial locations as rows
+        and time points as columns. This is the output of the spatial model.
+        The time points are specified in ``t_stim``.
+    t_stim : 1D float32 array
+        The time points for ``stim`` above.
+    dt : float32
+        Sampling time step (ms)
+    tau : float32
+        Time constant of both leaky stages (ms).
+    thresh_percept : float32
+        Spatial responses smaller than ``thresh_percept`` will be set to zero
+    n_threads : uint32
+        Number of CPU threads to use during parallelization using OpenMP.
+        Defaults to maximum number of cores on user CPU
+    reduce : uint32
+        How each percept time point summarizes the interval since the previous
+        one: 0 reports the brightness at that instant, 1 reports the peak
+        brightness reached over the interval. The second stage is what is
+        reported and what the peak is tracked on.
+
+    Returns
+    -------
+    percept : 2D float32 array
+        space x time
+
+    """
+    cdef:
+        float32 t_sim, amp, drive, stage1, stage1_old, bright, dt_tau
+        float32[:, ::1] percept
+        float32[:, ::1] stim_t
+        float32[:, ::1] first
+        float32[:, ::1] second
+        float32[:, ::1] running
+        index_t idx_space, idx_sim, idx_stim, idx_frame, idx_block
+        index_t n_space, n_stim, n_percept, n_sim, n_blocks, lo, hi, tid
+        unsigned long long fpmode
+
+    n_percept = len(idx_t_percept)  # Py overhead
+    n_stim = len(t_stim)  # Py overhead
+    n_sim = idx_t_percept[n_percept - 1] + 1  # no negative indices
+    n_space = stim.shape[0]
+    if n_threads < 1:  # `num_threads(0)` is not conforming OpenMP
+        n_threads = 1
+
+    percept = np.zeros((n_space, n_percept), dtype=np.float32)  # Py overhead
+    dt_tau = dt / tau
+    stim_t = np.ascontiguousarray(np.asarray(stim).T)  # Py overhead
+    n_blocks = (n_space + BLOCK - 1) // BLOCK
+    # One row per thread for each of the two stages and for the running peak,
+    # so no two threads share a cache line:
+    first = np.empty((n_threads, BLOCK), dtype=np.float32)  # Py overhead
+    second = np.empty((n_threads, BLOCK), dtype=np.float32)  # Py overhead
+    running = np.empty((n_threads, BLOCK), dtype=np.float32)  # Py overhead
+
+    for idx_block in prange(n_blocks, schedule='static', nogil=True,
+                            num_threads=n_threads):
+        fpmode = c_denormals_off()
+        tid = threadid()
+        lo = idx_block * BLOCK
+        hi = lo + BLOCK
+        if hi > n_space:
+            hi = n_space
+        for idx_space in range(hi - lo):
+            first[tid, idx_space] = <float32>0.0
+            second[tid, idx_space] = <float32>0.0
+            running[tid, idx_space] = <float32>0.0
+        idx_stim = 0
+        idx_frame = 0
+        for idx_sim in range(n_sim):
+            t_sim = idx_sim * dt
+            while idx_stim + 1 < n_stim and t_sim >= t_stim[idx_stim + 1]:
+                idx_stim = idx_stim + 1
+            for idx_space in range(hi - lo):
+                amp = stim_t[idx_stim, lo + idx_space]
+                stage1 = first[tid, idx_space]
+                bright = second[tid, idx_space]
+                # Half-wave rectify: only cathodic (negative) current drives
+                # the cascade.
+                drive = -amp
+                if drive < 0.0:
+                    drive = 0.0
+                # The second stage reads the first stage as it was at the
+                # start of the step. Feeding it the already-updated value
+                # would let a drive reach the output within a single step and
+                # remove the rise delay the cascade exists for:
+                stage1_old = stage1
+                stage1 = stage1 + dt_tau * (drive - stage1)
+                bright = bright + dt_tau * (stage1_old - bright)
+                # Brightness is bounded in [0, \inf[
+                if bright < 0.0:
+                    bright = 0.0
+                first[tid, idx_space] = stage1
+                second[tid, idx_space] = bright
+                if bright > running[tid, idx_space]:
+                    running[tid, idx_space] = bright
+            if idx_sim == idx_t_percept[idx_frame]:
+                for idx_space in range(hi - lo):
+                    if reduce == REDUCE_PEAK:
+                        bright = running[tid, idx_space]
+                    else:
+                        bright = second[tid, idx_space]
+                    if c_abs(bright) >= thresh_percept:
+                        percept[lo + idx_space, idx_frame] = bright
+                    # Brightness is continuous, so the value carried across
+                    # the boundary is a floor on the next interval's peak:
+                    running[tid, idx_space] = second[tid, idx_space]
+                idx_frame = idx_frame + 1
+        c_fpmode_restore(fpmode)
+
+    return np.asarray(percept)  # Py overhead

--- a/pulse2percept/models/granley2021.py
+++ b/pulse2percept/models/granley2021.py
@@ -290,6 +290,11 @@ class BiphasicAxonMapSpatial(AxonMapSpatial):
         model is ignored, because its response is normalized before being
         applied to the Granley percept.
 
+        :py:class:`~pulse2percept.models.FadingTemporal` and
+        :py:class:`~pulse2percept.models.AlphaTemporal` are the generic
+        envelopes to reach for: the first fades from stimulus onset, the
+        second rises to a peak first.
+
     Parameters
     ----------
     bright_model: callable, optional

--- a/pulse2percept/models/temporal.py
+++ b/pulse2percept/models/temporal.py
@@ -148,8 +148,9 @@ class AlphaTemporal(TemporalModel):
     where :math:`A` is the stimulus amplitude, :math:`x` is the (hidden) first
     stage, and :math:`y` is the perceived brightness.
 
-    Whereas :py:class:`~pulse2percept.models.FadingTemporal` jumps at stimulus
-    onset and decays from there, this cascade starts at zero, rises, peaks and
+    :py:class:`~pulse2percept.models.FadingTemporal` has an exponentially
+    decaying impulse response. Here, cascading two identical leaky integrators
+    adds a finite rise time: the impulse response starts at zero, peaks, and
     then decays. Its impulse response is
 
     .. math::
@@ -180,7 +181,7 @@ class AlphaTemporal(TemporalModel):
         Sampling time step of the simulation (ms)
     tau : float, optional
         Time constant of both leaky stages (ms). The impulse response peaks
-        approximately ``tau`` milliseconds after the stimulus, and decays with
+        approximately ``tau`` milliseconds after an impulse, and decays with
         the same constant afterwards.
 
         It cannot be shorter than ``dt``, for the same reason as in

--- a/pulse2percept/models/temporal.py
+++ b/pulse2percept/models/temporal.py
@@ -1,8 +1,9 @@
-""":py:class:`~pulse2percept.models.FadingTemporal`"""
+""":py:class:`~pulse2percept.models.FadingTemporal`,
+:py:class:`~pulse2percept.models.AlphaTemporal`"""
 import numpy as np
 from .base import TemporalModel
 from ..units import ms
-from ._temporal import fading_fast
+from ._temporal import alpha_fast, fading_fast
 
 
 class FadingTemporal(TemporalModel):
@@ -128,3 +129,125 @@ class FadingTemporal(TemporalModel):
                            time.astype(np.float32),
                            idx_percept, self.dt, self.tau, self.thresh_percept,
                            self.n_threads, 1 if reduce == 'peak' else 0)
+
+
+class AlphaTemporal(TemporalModel):
+    """A generic alpha-shaped temporal model
+
+    Two leaky integrators in series, both with the same time constant
+    :math:`\\tau`, driven by the cathodic half of the stimulus:
+
+    .. math::
+
+        \\tau \\frac{dx}{dt} = \\max(-A, 0) - x
+
+    .. math::
+
+        \\tau \\frac{dy}{dt} = x - y
+
+    where :math:`A` is the stimulus amplitude, :math:`x` is the (hidden) first
+    stage, and :math:`y` is the perceived brightness.
+
+    Whereas :py:class:`~pulse2percept.models.FadingTemporal` jumps at stimulus
+    onset and decays from there, this cascade starts at zero, rises, peaks and
+    then decays. Its impulse response is
+
+    .. math::
+
+        h(t) = \\frac{t}{\\tau^2} e^{-t/\\tau},
+
+    proportional to the standard alpha function, peaking at :math:`t = \\tau`.
+
+    The model makes the following assumptions:
+
+    *  Cathodic currents (negative amplitudes) increase perceived brightness
+    *  Anodic currents (positive amplitudes) do not, and are ignored
+    *  ``tau`` sets the rise and the decay together; there is only the one
+       constant, so a later peak is also a slower decay
+    *  Brightness is bounded below by zero. What is reported is then
+       thresholded, so an output value is either 0 or at least
+       :math:`\\theta` (``thresh_percept``, a nonnegative scalar)
+
+    .. note::
+
+        This is a generic alpha-shaped temporal response, not a perceptually
+        validated model. Use it where a percept should build up over tens of
+        milliseconds rather than appear instantaneously.
+
+    Parameters
+    ----------
+    dt : float, optional
+        Sampling time step of the simulation (ms)
+    tau : float, optional
+        Time constant of both leaky stages (ms). The impulse response peaks
+        approximately ``tau`` milliseconds after the stimulus, and decays with
+        the same constant afterwards.
+
+        It cannot be shorter than ``dt``, for the same reason as in
+        :py:class:`~pulse2percept.models.FadingTemporal`: the stages step
+        explicitly, so a time constant of one step already carries each stage
+        all the way to its input, and anything shorter overshoots and
+        oscillates.
+    thresh_percept: float, optional
+        Below threshold, the percept has brightness zero.
+    reduce : {'peak', 'last'}, optional
+        How a percept time point summarizes the interval since the previous
+        one, when ``predict_percept`` chooses the output times itself; see
+        :py:class:`~pulse2percept.models.TemporalModel`. This model tracks the
+        peak inside the cascade, so it is exact at any output rate.
+    n_threads: int, optional
+        Number of CPU threads to use during parallelization using OpenMP.
+        Defaults to max number of user CPU cores.
+
+    .. versionadded:: 0.10.0
+
+    """
+
+    #: The peak is tracked across every `dt` step inside `alpha_fast`, so
+    #: `predict_percept` does not have to subsample the interval itself.
+    _reduces_intervals = True
+
+    def get_default_params(self):
+        base_params = super(AlphaTemporal, self).get_default_params()
+        params = {
+            # Time constant of both stages:
+            'tau': 100,
+            # Generic rather than a published fit, so it is free to report the
+            # more useful summary by default; see `FadingTemporal`:
+            'reduce': 'peak',
+        }
+        base_params.update(params)
+        return base_params
+
+    def get_param_units(self):
+        """Return a dict of the units that parameters are stored in"""
+        return {**super().get_param_units(), 'tau': ms}
+
+    def _build(self):
+        if self.tau <= 0:
+            raise ValueError(f'"tau" must be positive, not {self.tau}.')
+        # Both stages step explicitly, so `dt / tau` is the fraction of the
+        # remaining gap each closes per step. Above 1 they overshoot and
+        # oscillate; see `FadingTemporal._build`:
+        if self.tau < self.dt:
+            raise ValueError(
+                f'"tau" must be at least dt={self.dt}, not {self.tau}. A time '
+                f'constant shorter than one simulation step makes each stage '
+                f'overshoot its input by dt/tau and oscillate. Shorten "dt" '
+                f'to go faster than that.')
+
+    def _predict_temporal(self, stim, t_percept, reduce='last'):
+        """Predict the temporal response"""
+        # Pass the stimulus as a 2D NumPy array to the fast Cython function:
+        time = self._stim_times(stim)
+        stim_data = self._stim_values(stim).reshape((-1, len(time)))
+        # Round before casting: 29.999 would otherwise truncate to 29.
+        idx_percept = np.uint32(np.round(t_percept / self.dt))
+        if np.unique(idx_percept).size < t_percept.size:
+            raise ValueError(f"All times 't_percept' must be distinct "
+                             f"multiples of `dt`={self.dt:.2e}")
+        # Cython returns a 2D (space x time) NumPy array:
+        return alpha_fast(stim_data.astype(np.float32),
+                          time.astype(np.float32),
+                          idx_percept, self.dt, self.tau, self.thresh_percept,
+                          self.n_threads, 1 if reduce == 'peak' else 0)

--- a/pulse2percept/models/tests/test_granley2021.py
+++ b/pulse2percept/models/tests/test_granley2021.py
@@ -12,7 +12,8 @@ from pulse2percept.stimuli import (AmplitudeEncoder,
                                    AsymmetricBiphasicPulseTrain,
                                    BiphasicPulseTrain, ImageStimulus,
                                    MonophasicPulse, Stimulus)
-from pulse2percept.models import (AxonMapSpatial, BiphasicAxonMapModel,
+from pulse2percept.models import (AlphaTemporal, AxonMapSpatial,
+                                  BiphasicAxonMapModel,
                                   BiphasicAxonMapSpatial, FadingTemporal,
                                   Horsager2009Temporal, Model,
                                   Nanduri2012Temporal)
@@ -1032,6 +1033,40 @@ def test_BiphasicAxonMapSpatial_composite_rejects_unequal_stim_dur(
                                                      stim_dur=1000)})
     with pytest.raises(NotImplementedError):
         composite.predict_percept(implant)
+
+
+def test_BiphasicAxonMapSpatial_composite_rides_an_alpha_envelope():
+    """`AlphaTemporal` gives the Granley percept a rise, not just a fade.
+
+    Sampled at every `dt`, so the peak the model normalizes by is one of the
+    samples rather than something between two of them.
+    """
+    temporal = AlphaTemporal(tau=20)
+    composite, granley = _composite(temporal)
+    implant = _composite_implant()
+    t = _every_dt(temporal)
+    percept = composite.predict_percept(implant, t_percept=t)
+
+    # Time-varying, and still peaking at the Granley frame:
+    granley_frame = granley.predict_percept(implant).data[..., 0]
+    npt.assert_equal(percept.data.shape[-1], len(t))
+    npt.assert_array_almost_equal(percept.max(axis='frames'), granley_frame)
+
+    trace = percept.data[np.unravel_index(np.argmax(granley_frame),
+                                          granley_frame.shape)]
+    # An alpha envelope, not an exponential fade: it starts at zero and peaks
+    # well after onset, where `FadingTemporal` is already at its brightest one
+    # step in.
+    npt.assert_equal(trace[0], 0)
+    peak = int(np.argmax(trace))
+    npt.assert_equal(0 < peak < len(trace) - 1, True)
+    npt.assert_array_less(_STIM_DUR, t[peak])
+    npt.assert_array_less(trace[-1], trace[peak])
+
+    fading, _ = _composite(FadingTemporal(tau=20))
+    fade = fading.predict_percept(implant, t_percept=t).data[
+        np.unravel_index(np.argmax(granley_frame), granley_frame.shape)]
+    npt.assert_array_less(np.argmax(fade), peak)
 
 
 def test_BiphasicAxonMapSpatial_composite_normalizes_a_delayed_peak():

--- a/pulse2percept/models/tests/test_temporal.py
+++ b/pulse2percept/models/tests/test_temporal.py
@@ -4,8 +4,9 @@ import warnings
 import numpy.testing as npt
 import pytest
 
-from pulse2percept.models import FadingTemporal, Nanduri2012Temporal
-from pulse2percept.models._temporal import fading_fast
+from pulse2percept.models import (AlphaTemporal, FadingTemporal,
+                                  Nanduri2012Temporal)
+from pulse2percept.models._temporal import alpha_fast, fading_fast
 from pulse2percept.stimuli import (Stimulus, MonophasicPulse, BiphasicPulse,
                                    BiphasicPulseTrain)
 from pulse2percept.percepts import Percept
@@ -56,19 +57,23 @@ def test_FadingTemporal():
     percept = model.predict_percept(stim, np.arange(stim.duration))
     npt.assert_almost_equal(percept.data, 0)
 
+
+@pytest.mark.parametrize('model_cls', (FadingTemporal, AlphaTemporal))
+def test_generic_temporal_tau_at_least_one_step(model_cls):
     # tau has to be at least one simulation step. Zero and negatives divide the
     # integrator by zero; anything under `dt` makes it overshoot its drive by
     # dt/tau and then oscillate, so at tau=dt/2 brightness alternates between
     # twice the drive and nothing. All of these used to build happily:
     for tau in (-1, 0, 0.005 / 2, 0.004):
         with pytest.raises(ValueError):
-            FadingTemporal(tau=tau, dt=0.005).build()
-    # ... and exactly one step is fine, being the rectifier limit:
-    FadingTemporal(tau=0.005, dt=0.005).build()
+            model_cls(tau=tau, dt=0.005).build()
+    # ... and exactly one step is fine, being the fastest stable setting:
+    model_cls(tau=0.005, dt=0.005).build()
 
 
-def test_deepcopy_FadingTemporal():
-    original = FadingTemporal()
+@pytest.mark.parametrize('model_cls', (FadingTemporal, AlphaTemporal))
+def test_deepcopy_generic_temporal(model_cls):
+    original = model_cls()
     copied = copy.deepcopy(original)
 
     # Assert they are different objects
@@ -91,6 +96,7 @@ def test_deepcopy_FadingTemporal():
     # Assert "destroying" the original doesn't affect the copied
     original = None
     npt.assert_equal(copied is not None, True)
+
 
 def test_FadingTemporal_matches_reference_integrator():
     """Pin the leaky integrator against a plain Python reference.
@@ -488,3 +494,229 @@ def test_FadingTemporal_reduce_limits():
         train)
     npt.assert_equal(np.any(peak.data != last.data), True)
     npt.assert_array_less(last.data - 1e-9, peak.data)
+
+
+def test_AlphaTemporal():
+    model = AlphaTemporal()
+    npt.assert_equal(model.tau, 100)
+    npt.assert_equal(model.reduce, 'peak')
+    model.dt = 0.1
+    npt.assert_equal(model.dt, 0.1)
+    model.build(dt=1e-3)
+    npt.assert_equal(model.dt, 1e-3)
+    with pytest.raises(FreezeError):
+        model.rho = 100
+
+    # Nothing in, None out:
+    npt.assert_equal(model.predict_percept(None), None)
+
+    # Zero in = zero out. Both stages start empty, so there is nothing to
+    # release either:
+    percept = model.predict_percept(BiphasicPulse(0, 1), t_percept=[0, 1, 2])
+    npt.assert_equal(isinstance(percept, Percept), True)
+    npt.assert_equal(percept.shape, (1, 1, 3))
+    npt.assert_almost_equal(percept.data, 0)
+
+    with pytest.raises(ValueError):
+        model.predict_percept(Stimulus(np.ones((1, 100))),
+                              t_percept=[0.2, 0.2])
+
+
+def test_AlphaTemporal_rectifies_the_drive():
+    """Only the cathodic half of the stimulus drives the cascade."""
+    model = AlphaTemporal(tau=20, thresh_percept=0).build()
+    t = np.round(np.arange(0, 100, 0.5), 5)
+
+    anodic = model.predict_percept(MonophasicPulse(1, 1, stim_dur=100),
+                                   t_percept=t)
+    npt.assert_array_equal(anodic.data, 0)
+
+    cathodic = model.predict_percept(MonophasicPulse(-1, 1, stim_dur=100),
+                                     t_percept=t)
+    npt.assert_equal(cathodic.data.max() > 0, True)
+
+
+def _alpha_reference(data, t_stim, idx_percept, dt, tau):
+    """Two-state explicit Euler, one location at a time, in float32.
+
+    Stage 2 reads stage 1 as it was at the *start* of the step, which is what
+    gives the cascade its rise delay.
+    """
+    dt, tau = np.float32(dt), np.float32(tau)
+    dt_tau = np.float32(dt / tau)
+    n_stim = len(t_stim)
+    out = np.zeros((data.shape[0], len(idx_percept)), dtype=np.float32)
+    for s in range(data.shape[0]):
+        x = y = np.float32(0.0)
+        idx_stim, frame = 0, 0
+        for i in range(int(idx_percept[-1]) + 1):
+            while (idx_stim + 1 < n_stim and
+                   np.float32(i) * dt >= t_stim[idx_stim + 1]):
+                idx_stim += 1
+            drive = np.float32(max(-data[s, idx_stim], 0.0))
+            x_old = x
+            x = np.float32(x + dt_tau * (drive - x))
+            y = np.float32(y + dt_tau * (x_old - y))
+            if i == idx_percept[frame]:
+                out[s, frame] = y
+                frame += 1
+    return out
+
+
+def test_AlphaTemporal_matches_reference_recurrence():
+    """Pin the two-state cascade against a plain Python reference.
+
+    The stimulus straddles zero, so this also pins the half-wave
+    rectification, and the reference stages the update the way the kernel
+    does: feeding stage 2 the already-updated stage 1 would pass a drive
+    through in a single step and remove the rise the model exists for.
+    """
+    model = AlphaTemporal(dt=0.01, tau=50, thresh_percept=0).build()
+    n_space, n_stim = 3, 5
+    rng = np.random.default_rng(0)
+    data = (rng.random((n_space, n_stim)) - 0.5).astype(np.float32)
+    npt.assert_equal(np.any(data > 0) and np.any(data < 0), True)
+    t_stim = np.arange(n_stim, dtype=np.float32) * 2.0
+    t_percept = np.array([0.0, 2.0, 4.0, 8.0])
+    got = model.predict_percept(Stimulus(data, time=t_stim),
+                                t_percept=t_percept).data.reshape(n_space, -1)
+
+    idx_p = np.uint32(np.round(t_percept / model.dt))
+    want = _alpha_reference(data, t_stim, idx_p, model.dt, model.tau)
+    # Close, not equal: `x + dt_tau * d` may be contracted into one fused
+    # multiply-add by the C compiler but never is by NumPy here. See
+    # `test_FadingTemporal_matches_reference_integrator`.
+    npt.assert_allclose(got, want, rtol=1e-6)
+
+    # Wiring stage 2 to the *new* stage 1 is the mistake this test exists to
+    # catch. Switch a cathodic drive on at t=0 and the first step settles it:
+    # stage 2 saw stage 1 at zero, so brightness is still exactly zero, where
+    # the other wiring would already report `(dt/tau)**2` of it.
+    dt, tau = 0.01, 50.0
+    step = alpha_fast(np.array([[-1.0]], dtype=np.float32),
+                      np.array([0.0], dtype=np.float32),
+                      np.arange(3, dtype=np.uint32), dt, tau, 0.0, 1, 0)
+    npt.assert_array_equal(step[0, 0], 0)
+    npt.assert_allclose(step[0, 1], (dt / tau) ** 2, rtol=1e-6)
+
+
+def test_AlphaTemporal_impulse_is_alpha_shaped():
+    """A brief pulse produces a delayed hump, not an instant jump.
+
+    `dt` is 200x shorter than `tau`, so the pulse is effectively an impulse
+    and the continuous-time response `t/tau**2 exp(-t/tau)` applies: zero at
+    onset, a single interior maximum at `t = tau`, monotone either side.
+    """
+    tau, dt = 20.0, 0.1
+    model = AlphaTemporal(tau=tau, dt=dt, thresh_percept=0).build()
+    # One `dt` step of cathodic current, on the simulation grid:
+    stim = Stimulus(np.array([[0.0, -1.0, 0.0]]), time=[0.0, dt, 2 * dt])
+    t = np.round(np.arange(0, 6 * tau, dt), 5)
+    y = model.predict_percept(stim, t_percept=t).data.ravel()
+
+    # Zero at onset, and zero one step later too: stage 2 only ever sees
+    # stage 1 as it was at the start of the step.
+    npt.assert_array_equal(y[:2], 0)
+    npt.assert_array_less(0, y[2:].min())
+    peak = int(np.argmax(y))
+    # An interior maximum, not the first or last sample -- that is the whole
+    # difference from an exponential fade. Discretization may move it a step
+    # or two off `tau`:
+    npt.assert_equal(0 < peak < len(y) - 1, True)
+    npt.assert_allclose(t[peak], tau, rtol=0.05)
+    npt.assert_equal(np.all(np.diff(y[1:peak + 1]) > 0), True)
+    # Not strict on the way down: float32 leaves the top of the hump flat for
+    # a step or two, and `argmax` reports the first of them.
+    npt.assert_equal(np.all(np.diff(y[peak:]) <= 0), True)
+    npt.assert_array_less(y[-1], y[peak])
+    # Its shape is the alpha function scaled by the impulse area (`dt` here),
+    # which is what unit DC gain leaves the impulse peak at:
+    npt.assert_allclose(y[peak], dt / (np.e * tau), rtol=0.02)
+
+
+def test_AlphaTemporal_dc_gain_is_unity():
+    """Sustained drive approaches the drive amplitude, not a multiple of it.
+
+    Both stages are unit-gain leaky integrators; normalizing the impulse
+    response to peak at 1 would multiply this by `e * tau` instead.
+    """
+    for tau in (10.0, 100.0):
+        model = AlphaTemporal(tau=tau, thresh_percept=0).build()
+        drive = 3.0
+        stim = Stimulus(np.array([[-drive, -drive]]), time=[0.0, 40 * tau])
+        t = np.round(np.arange(0, 30 * tau, tau / 10), 5)
+        # Loose enough for float32 to accumulate 3000 steps in, tight
+        # enough that a gain of `e * tau` could not hide in it:
+        npt.assert_allclose(
+            model.predict_percept(stim, t_percept=t).data.ravel()[-1], drive,
+            rtol=5e-3)
+
+
+def test_AlphaTemporal_peak_is_exact():
+    """The in-kernel peak must equal a dense scan of the same interval."""
+    rng = np.random.default_rng(3)
+    data = (rng.random((5, 12)) - 0.5).astype(np.float32) * 40
+    t_stim = (np.arange(12) * 4.0).astype(np.float32)
+    dt, tau = 0.05, 20.0
+    n_sim = int(round(44 / dt)) + 1
+    dense = alpha_fast(data, t_stim, np.arange(n_sim, dtype=np.uint32), dt,
+                       tau, 0.0, 1, 0)
+    out = np.array([37, 210, 400, 601, 880], dtype=np.uint32)
+    peak = alpha_fast(data, t_stim, out, dt, tau, 0.0, 1, 1)
+    last = alpha_fast(data, t_stim, out, dt, tau, 0.0, 1, 0)
+    # The interval a percept point summarizes runs from the previous one up to
+    # and including it; brightness is continuous, so the value carried across
+    # the boundary is a floor on what the next interval reaches:
+    lo = np.r_[0, out[:-1]]
+    brute = np.stack([dense[:, a:b + 1].max(axis=1)
+                      for a, b in zip(lo, out)], axis=1)
+    npt.assert_array_equal(peak, brute)
+    npt.assert_array_equal(last, dense[:, out])
+    npt.assert_equal(np.any(peak > last), True)
+
+
+def test_AlphaTemporal_reduce():
+    """`reduce` governs the times the model picks, not the ones you name."""
+    stim = BiphasicPulseTrain(20, -50, 0.46, stim_dur=200)
+    # Short enough that the cascade still ripples between pulses of a 20 Hz
+    # train; at `tau=100` the second stage smooths them into one ramp and the
+    # two settings have nothing to disagree about:
+    peak_model = AlphaTemporal(tau=10).build()
+    last_model = AlphaTemporal(tau=10, reduce='last').build()
+
+    t = [0, 50, 100, 150]
+    npt.assert_array_equal(peak_model.predict_percept(stim, t_percept=t).data,
+                           last_model.predict_percept(stim, t_percept=t).data)
+
+    got = last_model.predict_percept(stim)
+    peaked = peak_model.predict_percept(stim)
+    npt.assert_almost_equal(peaked.time, got.time)
+    npt.assert_equal(np.all(peaked.data >= got.data), True)
+    npt.assert_equal(np.any(peaked.data > got.data), True)
+
+
+@pytest.mark.parametrize('n_space', (1, 63, 64, 65, 130))
+def test_AlphaTemporal_block_boundaries(n_space):
+    """Locations are integrated in fixed-size blocks; the last one is partial.
+
+    `alpha_fast` carries two states per location, so it has its own block
+    bookkeeping to get wrong.
+    """
+    model = AlphaTemporal(dt=0.05, tau=30).build()
+    rng = np.random.default_rng(n_space)
+    data = (rng.random((n_space, 4)) - 0.7).astype(np.float32)
+    stim = Stimulus(data, time=np.arange(4, dtype=float) * 5)
+    t = [0, 5, 10, 15]
+    percept = model.predict_percept(stim, t_percept=t)
+    npt.assert_equal(percept.data.shape, (n_space, 1, 4))
+    single = np.stack([
+        model.predict_percept(Stimulus(data[i:i + 1], time=stim.time),
+                              t_percept=t).data.ravel()
+        for i in range(n_space)])
+    npt.assert_array_equal(percept.data.reshape(n_space, -1), single)
+    # Threads take a block of locations each; the result must not depend on
+    # how many of them there are:
+    for n_threads in (2, 3, 8):
+        parallel = AlphaTemporal(dt=0.05, tau=30, n_threads=n_threads).build(
+        ).predict_percept(stim, t_percept=t).data
+        npt.assert_array_equal(parallel, percept.data)

--- a/pulse2percept/models/tests/test_temporal.py
+++ b/pulse2percept/models/tests/test_temporal.py
@@ -588,10 +588,7 @@ def test_AlphaTemporal_matches_reference_recurrence():
     # `test_FadingTemporal_matches_reference_integrator`.
     npt.assert_allclose(got, want, rtol=1e-6)
 
-    # Wiring stage 2 to the *new* stage 1 is the mistake this test exists to
-    # catch. Switch a cathodic drive on at t=0 and the first step settles it:
-    # stage 2 saw stage 1 at zero, so brightness is still exactly zero, where
-    # the other wiring would already report `(dt/tau)**2` of it.
+    # Stage 2 must use the previous stage-1 value:
     dt, tau = 0.01, 50.0
     step = alpha_fast(np.array([[-1.0]], dtype=np.float32),
                       np.array([0.0], dtype=np.float32),
@@ -619,9 +616,7 @@ def test_AlphaTemporal_impulse_is_alpha_shaped():
     npt.assert_array_equal(y[:2], 0)
     npt.assert_array_less(0, y[2:].min())
     peak = int(np.argmax(y))
-    # An interior maximum, not the first or last sample -- that is the whole
-    # difference from an exponential fade. Discretization may move it a step
-    # or two off `tau`:
+    # The impulse response peaks near tau:
     npt.assert_equal(0 < peak < len(y) - 1, True)
     npt.assert_allclose(t[peak], tau, rtol=0.05)
     npt.assert_equal(np.all(np.diff(y[1:peak + 1]) > 0), True)
@@ -695,7 +690,7 @@ def test_AlphaTemporal_reduce():
     npt.assert_equal(np.any(peaked.data > got.data), True)
 
 
-@pytest.mark.parametrize('n_space', (1, 63, 64, 65, 130))
+@pytest.mark.parametrize('n_space', (1, 64, 65))
 def test_AlphaTemporal_block_boundaries(n_space):
     """Locations are integrated in fixed-size blocks; the last one is partial.
 

--- a/pulse2percept/units/tests/test_integration.py
+++ b/pulse2percept/units/tests/test_integration.py
@@ -15,8 +15,8 @@ import pytest
 from pulse2percept.implants import (ArgusII, DiskElectrode, ElectrodeGrid,
                                     EnsembleImplant, ProsthesisSystem)
 from pulse2percept.implants.cortex import Cortivis
-from pulse2percept.models import (AxonMapSpatial, FadingTemporal, Model,
-                                  ScoreboardSpatial)
+from pulse2percept.models import (AlphaTemporal, AxonMapSpatial,
+                                  FadingTemporal, Model, ScoreboardSpatial)
 from pulse2percept.models.cortex import (ScoreboardSpatial as
                                          CortexScoreboardSpatial)
 from pulse2percept.percepts import Percept
@@ -143,6 +143,8 @@ def test_every_spelling_builds_the_same_object():
           lambda p: p.time, 'Percept.time')
     _same(lambda t: FadingTemporal(tau=t).build(), dur, durs,
           lambda m: m.tau, 'FadingTemporal.tau')
+    _same(lambda t: AlphaTemporal(tau=t).build(), dur, durs,
+          lambda m: m.tau, 'AlphaTemporal.tau')
     pulse = BiphasicPulseTrain(20, 41.7, 0.45, stim_dur=100)
     temporal = FadingTemporal().build()
     _same(lambda t: temporal.predict_percept(pulse, t_percept=[0, t]),


### PR DESCRIPTION
Adds a generic alpha-shaped temporal model, which is two leaky integrators in series, both with the same time constant `tau`, driven by the cathodic half of the stimulus.