### PR TITLE
[OPT] Speed up large implant simulations

### DIFF
--- a/doc/users/release_notes.rst
+++ b/doc/users/release_notes.rst
@@ -33,7 +33,8 @@ Highlights:
   :py:meth:`~pulse2percept.stimuli.VideoStimulus.play` are much faster and
   produce smaller notebooks and documentation pages.
 
-* :py:class:`~pulse2percept.models.FadingTemporal` and
+* :py:class:`~pulse2percept.models.FadingTemporal`,
+  :py:class:`~pulse2percept.models.AlphaTemporal` and
   :py:class:`~pulse2percept.models.AxonMapSpatial` are substantially faster for
   long stimuli and large electrode arrays. Results may differ from previous
   versions by floating-point roundoff.

--- a/doc/users/release_notes.rst
+++ b/doc/users/release_notes.rst
@@ -94,6 +94,11 @@ API changes:
   including multi-electrode stimulus heatmaps and ``vmin``/``vmax`` controls
   for percept playback and saving.
 
+* :py:class:`~pulse2percept.models.FadingTemporal` and
+  :py:class:`~pulse2percept.models.AxonMapSpatial` are substantially faster
+  and agree with their previous output to within float32 rounding rather than
+  bit for bit.
+
 Bug fixes:
 
 * Stimulus timing, metadata propagation, and pulse-train handling are more

--- a/doc/users/release_notes.rst
+++ b/doc/users/release_notes.rst
@@ -33,6 +33,11 @@ Highlights:
   :py:meth:`~pulse2percept.stimuli.VideoStimulus.play` are much faster and
   produce smaller notebooks and documentation pages.
 
+* :py:class:`~pulse2percept.models.FadingTemporal` and
+  :py:class:`~pulse2percept.models.AxonMapSpatial` are substantially faster for
+  long stimuli and large electrode arrays. Results may differ from previous
+  versions by floating-point roundoff.
+
 * New :py:meth:`~pulse2percept.percepts.Percept.load` reads percepts back from
   image and video files.
 
@@ -93,11 +98,6 @@ API changes:
 * Stimulus and percept visualization gained several usability improvements,
   including multi-electrode stimulus heatmaps and ``vmin``/``vmax`` controls
   for percept playback and saving.
-
-* :py:class:`~pulse2percept.models.FadingTemporal` and
-  :py:class:`~pulse2percept.models.AxonMapSpatial` are substantially faster
-  and agree with their previous output to within float32 rounding rather than
-  bit for bit.
 
 Bug fixes:
 

--- a/pulse2percept/models/_beyeler2019.pyx
+++ b/pulse2percept/models/_beyeler2019.pyx
@@ -319,22 +319,20 @@ cpdef fast_axon_map(const float32[:, ::1] stim,
     once per (segment, electrode) pair and reused across every time point.
     A time-innermost ordering would evaluate it ``n_time`` times over.
 
-    Only electrodes within ``cutoff_r2`` of a segment can contribute to it,
-    and for an array of any size that is a small fraction of them. Rather
-    than test every electrode and reject nearly all of them, the electrodes
-    are sorted by x once per call and each segment binary-searches the band
-    ``[ax_x - r, ax_x + r]``, leaving the loop over electrodes proportional
-    to the width of that band instead of to the size of the array. Sorting
-    also lets the inactive electrodes be dropped outright rather than
-    branched past. The band is one-dimensional, so it still admits electrodes
-    that are far away in y; those are rejected by the ``r2`` test as before.
+    Only electrodes within ``cutoff_r2`` of a segment can contribute to it.
+    The active electrodes are sorted by x once per call and each segment
+    binary-searches the band ``[ax_x - r, ax_x + r]``; with a finite cutoff
+    that leaves the electrode loop walking the band rather than the whole
+    array. Sorting also lets the inactive electrodes be dropped outright
+    rather than branched past. The band is one-dimensional, so the exact
+    ``r2 <= cutoff_r2`` test still decides which of its electrodes count; an
+    infinite cutoff puts every electrode in the band and rejects none.
 
     The innermost loop over time accumulates into independent slots of a
     scratch buffer, so it vectorizes without relaxed floating-point
     semantics. Nothing of size ``n_segments x n_electrodes`` or
     ``n_segments x n_time`` is ever materialized: each thread holds two
-    buffers of ``n_time`` floats, and ``stim`` is small enough to stay in
-    cache while every pixel streams past it.
+    buffers of ``n_time`` floats.
 
     .. note::
 

--- a/pulse2percept/models/_beyeler2019.pyx
+++ b/pulse2percept/models/_beyeler2019.pyx
@@ -1,6 +1,6 @@
 from libc.math cimport(powf as c_pow, expf as c_exp, tanhf as c_tanh,
                        sinf as c_sin, cosf as c_cos, fabsf as c_abs,
-                       isnan as c_isnan)
+                       isnan as c_isnan, sqrtf as c_sqrt)
 from cython.parallel import prange
 from cython.parallel cimport threadid
 from cython import cdivision  # for modulo operator
@@ -14,6 +14,19 @@ ctypedef cnp.int32_t int32
 ctypedef Py_ssize_t index_t
 
 cdef float32 deg2rad = <float32>(3.14159265358979323846 / 180.0)
+
+
+cdef inline index_t _lower_bound(const float32[::1] xs, index_t n,
+                                 float32 value) noexcept nogil:
+    """Index of the first entry of sorted ``xs[:n]`` at or above ``value``."""
+    cdef index_t lo = 0, hi = n, mid
+    while lo < hi:
+        mid = lo + ((hi - lo) >> 1)
+        if xs[mid] < value:
+            lo = mid + 1
+        else:
+            hi = mid
+    return lo
 
 
 cdef cnp.uint8_t[::1] _active_electrodes(const float32[:, ::1] stim):
@@ -306,12 +319,28 @@ cpdef fast_axon_map(const float32[:, ::1] stim,
     once per (segment, electrode) pair and reused across every time point.
     A time-innermost ordering would evaluate it ``n_time`` times over.
 
+    Only electrodes within ``cutoff_r2`` of a segment can contribute to it,
+    and for an array of any size that is a small fraction of them. Rather
+    than test every electrode and reject nearly all of them, the electrodes
+    are sorted by x once per call and each segment binary-searches the band
+    ``[ax_x - r, ax_x + r]``, leaving the loop over electrodes proportional
+    to the width of that band instead of to the size of the array. Sorting
+    also lets the inactive electrodes be dropped outright rather than
+    branched past. The band is one-dimensional, so it still admits electrodes
+    that are far away in y; those are rejected by the ``r2`` test as before.
+
     The innermost loop over time accumulates into independent slots of a
     scratch buffer, so it vectorizes without relaxed floating-point
     semantics. Nothing of size ``n_segments x n_electrodes`` or
     ``n_segments x n_time`` is ever materialized: each thread holds two
     buffers of ``n_time`` floats, and ``stim`` is small enough to stay in
     cache while every pixel streams past it.
+
+    .. note::
+
+        Electrodes are summed in order of increasing x rather than in the
+        order they were passed, so results can differ in the last bits from
+        a version that summed them in array order.
 
     Parameters
     ----------
@@ -348,14 +377,15 @@ cpdef fast_axon_map(const float32[:, ::1] stim,
 
     """
     cdef:
-        index_t idx_el, idx_time, idx_space, idx_ax, tid, row
+        index_t idx_el, idx_time, idx_space, idx_ax, tid, row, lo_el
         index_t n_el, n_time, n_space, stride
         float32[:, ::1] bright
         float32[:, ::1] scratch
-        float32 xdiff, ydiff, r2, gauss, sens, ax_x, ax_y, sgm
-        cnp.uint8_t[::1] active
+        const float32[:, ::1] stim_s
+        const float32[::1] xs
+        const float32[::1] ys
+        float32 xdiff, ydiff, r2, gauss, sens, ax_x, ax_y, sgm, cutoff_r, x_hi
 
-    n_el = stim.shape[0]
     n_time = stim.shape[1]
     n_space = len(idx_start)
     # `num_threads(0)` is not conforming OpenMP, and the scratch buffer below
@@ -365,7 +395,19 @@ cpdef fast_axon_map(const float32[:, ::1] stim,
 
     # A flattened array containing n_space x n_time entries:
     bright = np.empty((n_space, n_time), dtype=np.float32)  # Py overhead
-    active = _active_electrodes(stim)  # Py overhead
+
+    # Keep the electrodes that carry current at some point, in order of
+    # increasing x. `stim` is permuted alongside so that the band the loop
+    # below walks is contiguous in all three arrays.  # Py overhead follows
+    keep = np.asarray(_active_electrodes(stim)).view(np.bool_).nonzero()[0]
+    keep = keep[np.argsort(np.asarray(xel)[keep], kind='stable')]
+    xs = np.ascontiguousarray(np.asarray(xel)[keep])
+    ys = np.ascontiguousarray(np.asarray(yel)[keep])
+    stim_s = np.ascontiguousarray(np.asarray(stim)[keep])
+    n_el = len(keep)
+    # Half-width of the x band to search. `inf` (no cutoff) carries through:
+    # every electrode then sorts into the band and none is ever rejected.
+    cutoff_r = c_sqrt(cutoff_r2)
 
     # Per-thread scratch: row `tid` holds this thread's running per-time-point
     # segment brightness (first `n_time` entries) and pixel brightness (next
@@ -409,18 +451,22 @@ cpdef fast_axon_map(const float32[:, ::1] stim,
             # contribution of each electrode:
             for idx_time in range(n_time):
                 scratch[tid, idx_time] = <float32>0.0
-            for idx_el in range(n_el):
-                # An electrode that is zero for the whole stimulus
-                # contributes nothing at any time point:
-                if active[idx_el] == 0:
-                    continue
+            # Only the electrodes whose x lies within `cutoff_r` of this
+            # segment can clear the cutoff, and `xs` is sorted, so they are
+            # one contiguous run. Seek its start, then walk until x leaves the
+            # band -- no electrode outside it is ever looked at:
+            lo_el = _lower_bound(xs, n_el, ax_x - cutoff_r)
+            x_hi = ax_x + cutoff_r
+            for idx_el in range(lo_el, n_el):
+                if xs[idx_el] > x_hi:
+                    break
                 # Calculate the distance between this axon segment and the
                 # center of the stimulating electrode:
-                xdiff = ax_x - xel[idx_el]
-                ydiff = ax_y - yel[idx_el]
+                xdiff = ax_x - xs[idx_el]
+                ydiff = ax_y - ys[idx_el]
                 r2 = xdiff * xdiff + ydiff * ydiff
-                # Past the cutoff radius. Note this drops `gauss * stim`, not
-                # just `gauss`:
+                # In the band on x, but still too far in y. Note this drops
+                # `gauss * stim`, not just `gauss`:
                 if r2 > cutoff_r2:
                     continue
                 # Activation as a function of distance to the stimulating
@@ -429,7 +475,7 @@ cpdef fast_axon_map(const float32[:, ::1] stim,
                 gauss = sens * c_exp(-r2 / (<float32>2.0 * rho * rho))
                 for idx_time in range(n_time):
                     scratch[tid, idx_time] = (scratch[tid, idx_time] +
-                                              gauss * stim[idx_el, idx_time])
+                                              gauss * stim_s[idx_el, idx_time])
             # After summing up the currents from all the electrodes, we
             # compare the brightness of the segment to the previously
             # brightest segment. The brightest segment overall determines the

--- a/pulse2percept/models/_temporal.pyx
+++ b/pulse2percept/models/_temporal.pyx
@@ -56,8 +56,8 @@ cpdef fading_fast(const float32[:, ::1] stim,
     ``q**n`` and ``1 - q**n`` are both carried because neither alone stays
     accurate: for a short run ``q**n`` is near 1 and ``drive + (b - drive) *
     q**n`` cancels, while for a long one ``1 - q**n`` rounds to 1 and the
-    decaying tail is lost. Weighting the two endpoints instead keeps the
-    error at one rounding of the larger term either way.
+    decaying tail is lost. Weighting the two endpoints avoids both, and
+    ``expm1`` supplies ``1 - q**n`` without cancelling when it is small.
 
     Parameters
     ----------

--- a/pulse2percept/models/_temporal.pyx
+++ b/pulse2percept/models/_temporal.pyx
@@ -1,5 +1,5 @@
 from libc.math cimport(pow as c_pow, exp as c_exp, fabs as c_abs,
-                       sqrt as c_sqrt)
+                       sqrt as c_sqrt, log1p as c_log1p, expm1 as c_expm1)
 from cython.parallel import prange
 from cython.parallel cimport threadid
 from pulse2percept.utils._fpmode cimport c_denormals_off, c_fpmode_restore
@@ -42,6 +42,23 @@ cpdef fading_fast(const float32[:, ::1] stim,
     vectorize. Threads take a block of locations each and run the whole time
     loop over it, so the parallel region is still entered only once.
 
+    The outer loop runs over *runs* of simulation steps rather than over the
+    steps themselves. Within a run the stimulus frame does not change, so the
+    drive is constant and the Euler recurrence
+    ``b <- b + (dt / tau) * (drive - b)`` is a fixed affine map; ``n`` of them
+    compose into ``b <- b * q**n + drive * (1 - q**n)``, for
+    ``q = 1 - dt/tau``.
+    That is the closed form of the *discrete* recurrence, not of the ODE it
+    approximates, so a pulse falling entirely between two simulation steps is
+    still missed exactly as before -- which frame each step reads is settled
+    by the same comparison, one step at a time, in the pre-pass below.
+
+    ``q**n`` and ``1 - q**n`` are both carried because neither alone stays
+    accurate: for a short run ``q**n`` is near 1 and ``drive + (b - drive) *
+    q**n`` cancels, while for a long one ``1 - q**n`` rounds to 1 and the
+    decaying tail is lost. Weighting the two endpoints instead keeps the
+    error at one rounding of the larger term either way.
+
     Parameters
     ----------
     stim : 2D float32 array
@@ -79,13 +96,21 @@ cpdef fading_fast(const float32[:, ::1] stim,
 
     """
     cdef:
-        float32 t_sim, amp, drive, bright, peak, dt_tau
+        float32 t_sim, amp, drive, bright, peak, dt_tau, q, p
         float32[:, ::1] percept
-        float32[:, ::1] stim_t
+        # `const`: the caller's stimulus can be read-only, and the transpose
+        # below is a no-op for a single location, so this is not always a copy
+        const float32[:, ::1] stim_t
         float32[:, ::1] scratch
         float32[:, ::1] running
-        index_t idx_space, idx_sim, idx_stim, idx_frame, idx_block
+        float32[::1] run_q
+        float32[::1] run_p
+        int32[::1] run_frame
+        int32[::1] run_out
+        index_t idx_space, idx_sim, idx_stim, idx_frame, idx_block, idx_run
         index_t n_space, n_stim, n_percept, n_sim, n_blocks, lo, hi, tid
+        index_t n_runs, run_len, prev_frame, max_runs
+        double log_q, n_log_q
         unsigned long long fpmode
 
     n_percept = len(idx_t_percept)  # Py overhead
@@ -96,16 +121,13 @@ cpdef fading_fast(const float32[:, ::1] stim,
         n_threads = 1
 
     percept = np.zeros((n_space, n_percept), dtype=np.float32)  # Py overhead
-    # The integrator below steps by `dt * (drive - bright) / tau`, and `dt/tau`
-    # is the same number on every step at every location. Written that way it
-    # is still a division per step, because reassociating it is not a
-    # transformation a C compiler may make on its own: the two forms round
-    # differently, and neither `/fp:fast` nor `-ffast-math` is on. Dividing
-    # once here takes ~14 cycles of latency off the dependency chain that the
-    # loop cannot start the next step without:
+    # `dt / tau` is the step of the recurrence being composed below. Rounding
+    # it to float32 here rather than carrying `dt` and `tau` separately is what
+    # keeps the composed map a power of the step the per-step loop would have
+    # taken:
     dt_tau = dt / tau
-    # One simulation step reads the same stimulus frame for every location, so
-    # transpose once and that read becomes a contiguous run:
+    # One run reads the same stimulus frame for every location, so transpose
+    # once and that read becomes a contiguous run:
     stim_t = np.ascontiguousarray(np.asarray(stim).T)  # Py overhead
     n_blocks = (n_space + BLOCK - 1) // BLOCK
     # Running brightness, one row per thread. Rows are BLOCK floats apart, so
@@ -115,6 +137,55 @@ cpdef fading_fast(const float32[:, ::1] stim,
     # Allocated even when it is not used, so that the loop below can be written
     # once:
     running = np.empty((n_threads, BLOCK), dtype=np.float32)  # Py overhead
+
+    # A run ends when the frame changes or a percept lands on it, so there can
+    # be no more runs than there are frames plus output points -- nor, of
+    # course, than there are simulation steps:
+    max_runs = n_stim + n_percept + 1
+    if max_runs > n_sim:
+        max_runs = n_sim
+    run_frame = np.empty(max_runs, dtype=np.int32)  # Py overhead
+    run_q = np.empty(max_runs, dtype=np.float32)  # Py overhead
+    run_p = np.empty(max_runs, dtype=np.float32)  # Py overhead
+    # Which percept column to write at the end of the run, or -1 for none:
+    run_out = np.empty(max_runs, dtype=np.int32)  # Py overhead
+
+    # Pre-pass, serial and location-independent: walk the simulation clock once
+    # and record the runs. This is the only place the per-step frame rule
+    # lives, and it is the same comparison the per-step loop used to make, so
+    # a frame that no step ever lands on is skipped here exactly as it was
+    # skipped there. O(n_sim) once, against O(n_sim x n_space) before.
+    log_q = c_log1p(-<double>dt_tau)
+    idx_stim = 0
+    idx_frame = 0
+    n_runs = 0
+    run_len = 0
+    prev_frame = -1
+    with nogil:
+        for idx_sim in range(n_sim):
+            t_sim = idx_sim * dt
+            while idx_stim + 1 < n_stim and t_sim >= t_stim[idx_stim + 1]:
+                idx_stim = idx_stim + 1
+            if run_len > 0 and idx_stim != prev_frame:
+                n_log_q = run_len * log_q
+                run_frame[n_runs] = <int32>prev_frame
+                run_q[n_runs] = <float32>c_exp(n_log_q)
+                run_p[n_runs] = <float32>(-c_expm1(n_log_q))
+                run_out[n_runs] = -1
+                n_runs = n_runs + 1
+                run_len = 0
+            prev_frame = idx_stim
+            run_len = run_len + 1
+            if (idx_frame < n_percept and
+                    idx_sim == <index_t>idx_t_percept[idx_frame]):
+                n_log_q = run_len * log_q
+                run_frame[n_runs] = <int32>idx_stim
+                run_q[n_runs] = <float32>c_exp(n_log_q)
+                run_p[n_runs] = <float32>(-c_expm1(n_log_q))
+                run_out[n_runs] = <int32>idx_frame
+                n_runs = n_runs + 1
+                run_len = 0
+                idx_frame = idx_frame + 1
 
     for idx_block in prange(n_blocks, schedule='static', nogil=True,
                             num_threads=n_threads):
@@ -131,28 +202,10 @@ cpdef fading_fast(const float32[:, ::1] stim,
         for idx_space in range(hi - lo):
             scratch[tid, idx_space] = <float32>0.0
             running[tid, idx_space] = <float32>0.0
-        idx_stim = 0
-        idx_frame = 0
-        for idx_sim in range(n_sim):
-            t_sim = idx_sim * dt
-            # Since the stimulus is compressed ('sparse'), we need to access
-            # the right frame. Each frame is associated with a time, `t_stim`.
-            # We use that frame until `t_sim` advances past it. In other words,
-            # we use the `idx_stim`-th frame for all times
-            # t_stim[idx_stim] <= t_sim < t_stim[idx_stim + 1]. Which frame
-            # that is does not depend on the location, so it is settled here
-            # rather than inside the loop below.
-            #
-            # `while`, not `if`: more than one stimulus frame can fall inside a
-            # single simulation step, and skipping only one of them leaves the
-            # integrator reading a frame that is already in the past. Encoded
-            # pulses make that the normal case rather than a corner case --
-            # their edges sit on the DT=1e-3 ms grid while `dt` defaults to
-            # 5e-3 ms, so a pulse edge and the sample after it routinely share
-            # a step. Advancing one frame per step would let a blip that has
-            # already ended drive brightness at a later instant:
-            while idx_stim + 1 < n_stim and t_sim >= t_stim[idx_stim + 1]:
-                idx_stim = idx_stim + 1
+        for idx_run in range(n_runs):
+            idx_stim = run_frame[idx_run]
+            q = run_q[idx_run]
+            p = run_p[idx_run]
             for idx_space in range(hi - lo):
                 amp = stim_t[idx_stim, lo + idx_space]
                 bright = scratch[tid, idx_space]
@@ -162,20 +215,24 @@ cpdef fading_fast(const float32[:, ::1] stim,
                 drive = -amp
                 if drive < 0.0:
                     drive = 0.0
-                bright = bright + dt_tau * (drive - bright)
-                # Brightness is bounded in [0, \inf[
-                if bright < 0.0:
-                    bright = 0.0
+                # The whole run in one affine step. Brightness stays in
+                # [0, inf[ without a clamp: `q` and `p` are both in [0, 1]
+                # (`tau >= dt` is enforced), so this is a convex combination
+                # of two nonnegative numbers.
+                bright = bright * q + drive * p
                 scratch[tid, idx_space] = bright
-                # One compare per step, and it keeps the peak exact however
-                # coarse the output rate is:
+                # `drive` is constant across the run, so brightness moves
+                # monotonically from one end of it to the other and the peak
+                # over the run is at an endpoint. Comparing here therefore
+                # tracks the same peak the per-step compare did:
                 if bright > running[tid, idx_space]:
                     running[tid, idx_space] = bright
-            if idx_sim == idx_t_percept[idx_frame]:
+            idx_frame = run_out[idx_run]
+            if idx_frame >= 0:
                 # `idx_t_percept` stores the time points at which we need to
-                # output a percept. We compare `idx_sim` to `idx_t_percept`
-                # rather than `t_sim` to `t_percept` because there is no good
-                # (fast) way to compare two floating point numbers:
+                # output a percept. The pre-pass ended a run on each of them,
+                # so reaching one is a property of the run rather than a
+                # comparison to make here:
                 for idx_space in range(hi - lo):
                     if reduce == REDUCE_PEAK:
                         bright = running[tid, idx_space]
@@ -188,7 +245,6 @@ cpdef fading_fast(const float32[:, ::1] stim,
                     # value carried across the boundary is a floor on what the
                     # next interval reaches:
                     running[tid, idx_space] = scratch[tid, idx_space]
-                idx_frame = idx_frame + 1
         # Hand the thread back in the floating-point mode it arrived in:
         c_fpmode_restore(fpmode)
 

--- a/pulse2percept/models/_temporal.pyx
+++ b/pulse2percept/models/_temporal.pyx
@@ -86,8 +86,9 @@ cpdef fading_fast(const float32[:, ::1] stim,
         to end on samples a signal whose energy lives in sub-millisecond
         transients, and the sampling phase then walks through the pulse cycle:
         neighbouring frames come out orders of magnitude apart for no reason a
-        viewer would recognize. The peak is tracked across every ``dt`` step,
-        so it costs one compare per step and is exact at any output rate.
+        viewer would recognize. Within a constant-drive run brightness is
+        monotonic, so checking the run endpoints gives the exact interval
+        peak without evaluating every simulation step.
 
     Returns
     -------
@@ -267,9 +268,12 @@ cpdef alpha_fast(const float32[:, ::1] stim,
     impulse response is ``t / tau**2 * exp(-t / tau)``, which starts at zero,
     peaks at ``t = tau`` and decays afterwards.
 
-    Loop structure, sparse stimulus advancement, blocking, denormal handling
-    and interval peak tracking all work exactly as in ``fading_fast``; see
-    there. The only difference is that each location carries two states.
+    Blocking, sparse stimulus advancement, denormal handling and interval
+    peak tracking follow the same principles as ``fading_fast``; see there.
+    Each location carries two states rather than one, and unlike
+    ``fading_fast`` this kernel still advances one simulation step at a time:
+    a two-stage response need not be monotonic within a constant-drive run,
+    so neither its value nor its peak can be read off the endpoints.
 
     Parameters
     ----------

--- a/pulse2percept/models/_temporal.pyx
+++ b/pulse2percept/models/_temporal.pyx
@@ -24,6 +24,67 @@ cdef uint32 REDUCE_LAST = 0
 cdef uint32 REDUCE_PEAK = 1
 
 
+cdef index_t _build_runs(const float32[::1] t_stim,
+                         const uint32[::1] idx_t_percept,
+                         float32 dt,
+                         index_t n_sim,
+                         index_t n_stim,
+                         index_t n_percept,
+                         int32[::1] run_frame,
+                         int32[::1] run_len,
+                         int32[::1] run_out) noexcept nogil:
+    """Group the simulation clock into runs of steps that share one frame.
+
+    Serial and location-independent, so it is walked once per call rather than
+    once per location: O(n_sim) against the O(n_sim x n_space) it saves.
+
+    A run ends where the frame changes or where a percept is due, so within
+    one run the drive is constant and an integrator can be advanced across it
+    in closed form. ``run_out`` carries the percept column to write at the end
+    of the run, or -1.
+
+    This is the only place the per-step frame rule lives. Each step is asked
+    which frame it reads with the same comparison the per-step loops used to
+    make, so a frame that no step ever lands on is skipped here exactly as it
+    was skipped there.
+
+    ``while``, not ``if``: more than one stimulus frame can fall inside a
+    single simulation step, and skipping only one of them leaves the
+    integrator reading a frame that is already in the past. Encoded pulses
+    make that the normal case rather than a corner case -- their edges sit on
+    the DT=1e-3 ms grid while ``dt`` defaults to 5e-3 ms, so a pulse edge and
+    the sample after it routinely share a step.
+
+    Returns the number of runs written.
+    """
+    cdef:
+        index_t idx_sim, idx_stim = 0, idx_frame = 0
+        index_t n_runs = 0, length = 0, prev_frame = -1
+        float32 t_sim
+
+    for idx_sim in range(n_sim):
+        t_sim = idx_sim * dt
+        while idx_stim + 1 < n_stim and t_sim >= t_stim[idx_stim + 1]:
+            idx_stim = idx_stim + 1
+        if length > 0 and idx_stim != prev_frame:
+            run_frame[n_runs] = <int32>prev_frame
+            run_len[n_runs] = <int32>length
+            run_out[n_runs] = -1
+            n_runs = n_runs + 1
+            length = 0
+        prev_frame = idx_stim
+        length = length + 1
+        if (idx_frame < n_percept and
+                idx_sim == <index_t>idx_t_percept[idx_frame]):
+            run_frame[n_runs] = <int32>idx_stim
+            run_len[n_runs] = <int32>length
+            run_out[n_runs] = <int32>idx_frame
+            n_runs = n_runs + 1
+            length = 0
+            idx_frame = idx_frame + 1
+    return n_runs
+
+
 @cdivision(True)
 cpdef fading_fast(const float32[:, ::1] stim,
                   const float32[::1] t_stim,
@@ -107,10 +168,11 @@ cpdef fading_fast(const float32[:, ::1] stim,
         float32[::1] run_q
         float32[::1] run_p
         int32[::1] run_frame
+        int32[::1] run_len
         int32[::1] run_out
         index_t idx_space, idx_sim, idx_stim, idx_frame, idx_block, idx_run
         index_t n_space, n_stim, n_percept, n_sim, n_blocks, lo, hi, tid
-        index_t n_runs, run_len, prev_frame, max_runs
+        index_t n_runs, max_runs
         double log_q, n_log_q
         unsigned long long fpmode
 
@@ -146,47 +208,22 @@ cpdef fading_fast(const float32[:, ::1] stim,
     if max_runs > n_sim:
         max_runs = n_sim
     run_frame = np.empty(max_runs, dtype=np.int32)  # Py overhead
+    run_len = np.empty(max_runs, dtype=np.int32)  # Py overhead
+    run_out = np.empty(max_runs, dtype=np.int32)  # Py overhead
     run_q = np.empty(max_runs, dtype=np.float32)  # Py overhead
     run_p = np.empty(max_runs, dtype=np.float32)  # Py overhead
-    # Which percept column to write at the end of the run, or -1 for none:
-    run_out = np.empty(max_runs, dtype=np.int32)  # Py overhead
 
-    # Pre-pass, serial and location-independent: walk the simulation clock once
-    # and record the runs. This is the only place the per-step frame rule
-    # lives, and it is the same comparison the per-step loop used to make, so
-    # a frame that no step ever lands on is skipped here exactly as it was
-    # skipped there. O(n_sim) once, against O(n_sim x n_space) before.
     log_q = c_log1p(-<double>dt_tau)
-    idx_stim = 0
-    idx_frame = 0
-    n_runs = 0
-    run_len = 0
-    prev_frame = -1
     with nogil:
-        for idx_sim in range(n_sim):
-            t_sim = idx_sim * dt
-            while idx_stim + 1 < n_stim and t_sim >= t_stim[idx_stim + 1]:
-                idx_stim = idx_stim + 1
-            if run_len > 0 and idx_stim != prev_frame:
-                n_log_q = run_len * log_q
-                run_frame[n_runs] = <int32>prev_frame
-                run_q[n_runs] = <float32>c_exp(n_log_q)
-                run_p[n_runs] = <float32>(-c_expm1(n_log_q))
-                run_out[n_runs] = -1
-                n_runs = n_runs + 1
-                run_len = 0
-            prev_frame = idx_stim
-            run_len = run_len + 1
-            if (idx_frame < n_percept and
-                    idx_sim == <index_t>idx_t_percept[idx_frame]):
-                n_log_q = run_len * log_q
-                run_frame[n_runs] = <int32>idx_stim
-                run_q[n_runs] = <float32>c_exp(n_log_q)
-                run_p[n_runs] = <float32>(-c_expm1(n_log_q))
-                run_out[n_runs] = <int32>idx_frame
-                n_runs = n_runs + 1
-                run_len = 0
-                idx_frame = idx_frame + 1
+        n_runs = _build_runs(t_stim, idx_t_percept, dt, n_sim, n_stim,
+                             n_percept, run_frame, run_len, run_out)
+        # `q**n` and `1 - q**n` for each run. Both are the same number at
+        # every location, so they are settled here rather than inside the
+        # parallel loop:
+        for idx_run in range(n_runs):
+            n_log_q = run_len[idx_run] * log_q
+            run_q[idx_run] = <float32>c_exp(n_log_q)
+            run_p[idx_run] = <float32>(-c_expm1(n_log_q))
 
     for idx_block in prange(n_blocks, schedule='static', nogil=True,
                             num_threads=n_threads):
@@ -268,12 +305,32 @@ cpdef alpha_fast(const float32[:, ::1] stim,
     impulse response is ``t / tau**2 * exp(-t / tau)``, which starts at zero,
     peaks at ``t = tau`` and decays afterwards.
 
-    Blocking, sparse stimulus advancement, denormal handling and interval
-    peak tracking follow the same principles as ``fading_fast``; see there.
-    Each location carries two states rather than one, and unlike
-    ``fading_fast`` this kernel still advances one simulation step at a time:
-    a two-stage response need not be monotonic within a constant-drive run,
-    so neither its value nor its peak can be read off the endpoints.
+    Blocking, the run schedule, denormal handling and interval peak tracking
+    follow the same principles as ``fading_fast``; see there. Each location
+    carries two states rather than one, and both compose across a run of
+    ``n`` steps at constant drive ``d``. Writing ``a = dt/tau``, ``q = 1 - a``
+    and taking the run's starting states as ``x0``, ``y0``::
+
+        x_n = d + q**n * (x0 - d)
+        y_n = d + q**n * (y0 - d) + n * a * q**(n - 1) * (x0 - d)
+
+    the second term on ``y`` being what the first stage feeds in over the run.
+
+    The peak needs more care than it does for one stage, because ``y`` is not
+    monotonic within a run: the cascade is what gives the model a rise time,
+    so brightness can climb after the drive has gone. It is however
+    *unimodal*, which is enough. Since ``y[k+1] - y[k] = a * (x[k] - y[k])``
+    and::
+
+        x[k] - y[k] = q**(k - 1) * (q * (x0 - y0) - k * a * (x0 - d))
+
+    the bracket is linear in ``k`` and ``q**(k-1)`` is positive, so the
+    difference changes sign at most once across the run. A strictly interior
+    maximum therefore exists only when ``x0 > d`` -- stage one above the
+    drive, brightness still catching up -- and sits at the crossing
+    ``k* = q * (x0 - y0) / (a * (x0 - d))``. Evaluating ``y`` at the two ends
+    and either side of ``k*`` gives the exact interval peak in O(1), so no
+    part of this kernel walks the simulation clock per location.
 
     Parameters
     ----------
@@ -305,14 +362,30 @@ cpdef alpha_fast(const float32[:, ::1] stim,
 
     """
     cdef:
-        float32 t_sim, amp, drive, stage1, stage1_old, bright, dt_tau
+        float32 amp, drive, x0, y0, xn, yn, u0, kstar, cand, dt_tau, q
+        float32 qn, pn, cn, rn
+        double d_qn, d_pn, d_cn
         float32[:, ::1] percept
-        float32[:, ::1] stim_t
+        # `const`: the caller's response can be read-only, and the transpose
+        # below is a no-op for a single location, so this is not always a copy
+        const float32[:, ::1] stim_t
         float32[:, ::1] first
         float32[:, ::1] second
         float32[:, ::1] running
-        index_t idx_space, idx_sim, idx_stim, idx_frame, idx_block
+        float32[::1] run_q
+        float32[::1] run_p
+        float32[::1] run_c
+        float32[::1] run_r
+        float32[::1] pow_q
+        float32[::1] pow_c
+        float32[::1] pow_r
+        int32[::1] run_frame
+        int32[::1] run_len
+        int32[::1] run_out
+        index_t idx_space, idx_frame, idx_block, idx_run, idx_stim
         index_t n_space, n_stim, n_percept, n_sim, n_blocks, lo, hi, tid
+        index_t n_runs, max_runs, max_len, n_run, k, kk, j
+        double log_q, n_log_q
         unsigned long long fpmode
 
     n_percept = len(idx_t_percept)  # Py overhead
@@ -324,6 +397,7 @@ cpdef alpha_fast(const float32[:, ::1] stim,
 
     percept = np.zeros((n_space, n_percept), dtype=np.float32)  # Py overhead
     dt_tau = dt / tau
+    q = <float32>1.0 - dt_tau
     stim_t = np.ascontiguousarray(np.asarray(stim).T)  # Py overhead
     n_blocks = (n_space + BLOCK - 1) // BLOCK
     # One row per thread for each of the two stages and for the running peak,
@@ -331,6 +405,82 @@ cpdef alpha_fast(const float32[:, ::1] stim,
     first = np.empty((n_threads, BLOCK), dtype=np.float32)  # Py overhead
     second = np.empty((n_threads, BLOCK), dtype=np.float32)  # Py overhead
     running = np.empty((n_threads, BLOCK), dtype=np.float32)  # Py overhead
+
+    max_runs = n_stim + n_percept + 1
+    if max_runs > n_sim:
+        max_runs = n_sim
+    run_frame = np.empty(max_runs, dtype=np.int32)  # Py overhead
+    run_len = np.empty(max_runs, dtype=np.int32)  # Py overhead
+    run_out = np.empty(max_runs, dtype=np.int32)  # Py overhead
+    run_q = np.empty(max_runs, dtype=np.float32)  # Py overhead
+    run_p = np.empty(max_runs, dtype=np.float32)  # Py overhead
+    run_c = np.empty(max_runs, dtype=np.float32)  # Py overhead
+    run_r = np.empty(max_runs, dtype=np.float32)  # Py overhead
+
+    # Both states come out of a run as a weighted average of where the run
+    # started and the drive it ran at, never as a difference of two larger
+    # numbers. That matters most at the onset of a response, where `y` is
+    # orders of magnitude below both `drive` and the terms an algebraically
+    # equal grouping would subtract. The three weights on `y` are
+    # nonnegative and sum to one -- `1 - q**n - n*a*q**(n-1)` is the chance
+    # of at least two successes in `n` Bernoulli(`a`) trials -- so the result
+    # is bracketed by the values going in.
+    log_q = c_log1p(-<double>dt_tau)
+    with nogil:
+        n_runs = _build_runs(t_stim, idx_t_percept, dt, n_sim, n_stim,
+                             n_percept, run_frame, run_len, run_out)
+        max_len = 1
+        for idx_run in range(n_runs):
+            n_run = run_len[idx_run]
+            if n_run > max_len:
+                max_len = n_run
+            if n_run == 1:
+                # A single step is the plain recurrence, and its weights are
+                # exact: `1 - q - a` is zero, not the 1-ulp residue `expm1`
+                # would leave. That residue is the whole output of the first
+                # step of a response, which has to be exactly zero -- stage
+                # two reads a stage one that has not moved yet.
+                run_q[idx_run] = q
+                run_p[idx_run] = dt_tau
+                run_c[idx_run] = dt_tau
+                run_r[idx_run] = <float32>0.0
+            else:
+                n_log_q = n_run * log_q
+                d_qn = c_exp(n_log_q)
+                d_pn = -c_expm1(n_log_q)
+                d_cn = n_run * <double>dt_tau * c_exp((n_run - 1) * log_q)
+                run_q[idx_run] = <float32>d_qn
+                run_p[idx_run] = <float32>d_pn
+                run_c[idx_run] = <float32>d_cn
+                # Differenced in double, where the two are still far enough
+                # apart to leave the small result its significant digits:
+                run_r[idx_run] = <float32>(d_pn - d_cn)
+
+    # The same three weights at every k a peak can land on. Only the peak
+    # search indexes these, and only at the steps either side of the turning
+    # point:
+    if reduce == REDUCE_PEAK:
+        pow_q = np.empty(max_len + 1, dtype=np.float32)  # Py overhead
+        pow_c = np.empty(max_len + 1, dtype=np.float32)  # Py overhead
+        pow_r = np.empty(max_len + 1, dtype=np.float32)  # Py overhead
+        with nogil:
+            pow_q[0] = <float32>1.0
+            pow_c[0] = <float32>0.0
+            pow_r[0] = <float32>0.0
+            pow_q[1] = q
+            pow_c[1] = dt_tau
+            pow_r[1] = <float32>0.0
+            for k in range(2, max_len + 1):
+                d_qn = c_exp(k * log_q)
+                d_pn = -c_expm1(k * log_q)
+                d_cn = k * <double>dt_tau * c_exp((k - 1) * log_q)
+                pow_q[k] = <float32>d_qn
+                pow_c[k] = <float32>d_cn
+                pow_r[k] = <float32>(d_pn - d_cn)
+    else:
+        pow_q = np.empty(1, dtype=np.float32)  # Py overhead
+        pow_c = np.empty(1, dtype=np.float32)  # Py overhead
+        pow_r = np.empty(1, dtype=np.float32)  # Py overhead
 
     for idx_block in prange(n_blocks, schedule='static', nogil=True,
                             num_threads=n_threads):
@@ -344,47 +494,76 @@ cpdef alpha_fast(const float32[:, ::1] stim,
             first[tid, idx_space] = <float32>0.0
             second[tid, idx_space] = <float32>0.0
             running[tid, idx_space] = <float32>0.0
-        idx_stim = 0
-        idx_frame = 0
-        for idx_sim in range(n_sim):
-            t_sim = idx_sim * dt
-            while idx_stim + 1 < n_stim and t_sim >= t_stim[idx_stim + 1]:
-                idx_stim = idx_stim + 1
+        for idx_run in range(n_runs):
+            idx_stim = run_frame[idx_run]
+            n_run = run_len[idx_run]
+            qn = run_q[idx_run]
+            pn = run_p[idx_run]
+            cn = run_c[idx_run]
+            rn = run_r[idx_run]
             for idx_space in range(hi - lo):
                 amp = stim_t[idx_stim, lo + idx_space]
-                stage1 = first[tid, idx_space]
-                bright = second[tid, idx_space]
+                x0 = first[tid, idx_space]
+                y0 = second[tid, idx_space]
                 # Half-wave rectify: only cathodic (negative) current drives
                 # the cascade.
                 drive = -amp
                 if drive < 0.0:
                     drive = 0.0
-                # The second stage reads the first stage as it was at the
-                # start of the step. Feeding it the already-updated value
-                # would let a drive reach the output within a single step and
-                # remove the rise delay the cascade exists for:
-                stage1_old = stage1
-                stage1 = stage1 + dt_tau * (drive - stage1)
-                bright = bright + dt_tau * (stage1_old - bright)
-                # Brightness is bounded in [0, \inf[
-                if bright < 0.0:
-                    bright = 0.0
-                first[tid, idx_space] = stage1
-                second[tid, idx_space] = bright
-                if bright > running[tid, idx_space]:
-                    running[tid, idx_space] = bright
-            if idx_sim == idx_t_percept[idx_frame]:
+                # How far stage one starts above the drive. This is what the
+                # first stage feeds the second over the run, and its sign is
+                # also what decides whether the run can peak in its interior:
+                u0 = x0 - drive
+                xn = x0 * qn + drive * pn
+                yn = y0 * qn + x0 * cn + drive * rn
+                # Brightness is bounded in [0, inf[. Both stages are convex
+                # combinations of nonnegative quantities, so this only ever
+                # catches rounding:
+                if yn < 0.0:
+                    yn = 0.0
+                first[tid, idx_space] = xn
+                second[tid, idx_space] = yn
+                if reduce == REDUCE_PEAK:
+                    # `y` is unimodal across the run, so the ends always have
+                    # to be looked at. The first is one plain step from the
+                    # state the run began in:
+                    cand = y0 + dt_tau * (x0 - y0)
+                    if cand > running[tid, idx_space]:
+                        running[tid, idx_space] = cand
+                    if yn > running[tid, idx_space]:
+                        running[tid, idx_space] = yn
+                    # An interior maximum needs stage one to start above the
+                    # drive; otherwise the interior turning point is a
+                    # minimum and the ends already have it:
+                    if u0 > 0.0 and n_run > 2:
+                        kstar = q * (x0 - y0) / (dt_tau * u0)
+                        if kstar >= 1.0:
+                            kk = <index_t>kstar + 1
+                            # Either side of the crossing, since which of the
+                            # two neighbouring steps is higher is decided by
+                            # a rounding of `kstar`:
+                            for j in range(3):
+                                k = kk - 1 + j
+                                if k < 1:
+                                    k = 1
+                                if k > n_run:
+                                    k = n_run
+                                cand = (y0 * pow_q[k] + x0 * pow_c[k] +
+                                        drive * pow_r[k])
+                                if cand > running[tid, idx_space]:
+                                    running[tid, idx_space] = cand
+            idx_frame = run_out[idx_run]
+            if idx_frame >= 0:
                 for idx_space in range(hi - lo):
                     if reduce == REDUCE_PEAK:
-                        bright = running[tid, idx_space]
+                        yn = running[tid, idx_space]
                     else:
-                        bright = second[tid, idx_space]
-                    if c_abs(bright) >= thresh_percept:
-                        percept[lo + idx_space, idx_frame] = bright
+                        yn = second[tid, idx_space]
+                    if c_abs(yn) >= thresh_percept:
+                        percept[lo + idx_space, idx_frame] = yn
                     # Brightness is continuous, so the value carried across
                     # the boundary is a floor on the next interval's peak:
                     running[tid, idx_space] = second[tid, idx_space]
-                idx_frame = idx_frame + 1
         c_fpmode_restore(fpmode)
 
     return np.asarray(percept)  # Py overhead

--- a/pulse2percept/models/_temporal.pyx
+++ b/pulse2percept/models/_temporal.pyx
@@ -33,27 +33,14 @@ cdef index_t _build_runs(const float32[::1] t_stim,
                          int32[::1] run_frame,
                          int32[::1] run_len,
                          int32[::1] run_out) noexcept nogil:
-    """Group the simulation clock into runs of steps that share one frame.
+    """Group simulation steps into constant-frame runs.
 
-    Serial and location-independent, so it is walked once per call rather than
-    once per location: O(n_sim) against the O(n_sim x n_space) it saves.
+    A run ends when the stimulus frame changes or a percept is due. Within a
+    run, the drive is constant and can be advanced in closed form. ``run_out``
+    is the percept column to write at the end of the run, or -1.
 
-    A run ends where the frame changes or where a percept is due, so within
-    one run the drive is constant and an integrator can be advanced across it
-    in closed form. ``run_out`` carries the percept column to write at the end
-    of the run, or -1.
-
-    This is the only place the per-step frame rule lives. Each step is asked
-    which frame it reads with the same comparison the per-step loops used to
-    make, so a frame that no step ever lands on is skipped here exactly as it
-    was skipped there.
-
-    ``while``, not ``if``: more than one stimulus frame can fall inside a
-    single simulation step, and skipping only one of them leaves the
-    integrator reading a frame that is already in the past. Encoded pulses
-    make that the normal case rather than a corner case -- their edges sit on
-    the DT=1e-3 ms grid while ``dt`` defaults to 5e-3 ms, so a pulse edge and
-    the sample after it routinely share a step.
+    Stimulus frames are advanced with ``while`` because multiple frame changes
+    may occur within one simulation step.
 
     Returns the number of runs written.
     """
@@ -96,29 +83,21 @@ cpdef fading_fast(const float32[:, ::1] stim,
                   uint32 reduce=REDUCE_LAST):
     """Cython implementation of the generic fading model
 
-    The leaky integrator has to be stepped in order, so the loop over time is
-    serial. But, each spatial location integrates independently of every
-    other. Time is therefore the *outer* loop and space the inner one, which
-    leaves the inner loop free of any carried dependency and lets it
-    vectorize. Threads take a block of locations each and run the whole time
-    loop over it, so the parallel region is still entered only once.
+    The model applies the discrete recurrence
 
-    The outer loop runs over *runs* of simulation steps rather than over the
-    steps themselves. Within a run the stimulus frame does not change, so the
-    drive is constant and the Euler recurrence
-    ``b <- b + (dt / tau) * (drive - b)`` is a fixed affine map; ``n`` of them
-    compose into ``b <- b * q**n + drive * (1 - q**n)``, for
-    ``q = 1 - dt/tau``.
-    That is the closed form of the *discrete* recurrence, not of the ODE it
-    approximates, so a pulse falling entirely between two simulation steps is
-    still missed exactly as before -- which frame each step reads is settled
-    by the same comparison, one step at a time, in the pre-pass below.
+    ``b <- b + (dt / tau) * (drive - b)``.
 
-    ``q**n`` and ``1 - q**n`` are both carried because neither alone stays
-    accurate: for a short run ``q**n`` is near 1 and ``drive + (b - drive) *
-    q**n`` cancels, while for a long one ``1 - q**n`` rounds to 1 and the
-    decaying tail is lost. Weighting the two endpoints avoids both, and
-    ``expm1`` supplies ``1 - q**n`` without cancelling when it is small.
+    Consecutive simulation steps with the same drive are grouped into runs.
+    Writing ``q = 1 - dt/tau``, a run of ``n`` steps composes to
+
+    ``b_n = b_0 * q**n + drive * (1 - q**n)``.
+
+    This is the closed form of the discrete recurrence, not of the
+    continuous-time ODE. Stimulus-frame selection therefore follows the same
+    simulation-step timing as before.
+
+    Because brightness is monotonic under constant drive, the peak within a
+    run is at one of its endpoints.
 
     Parameters
     ----------
@@ -184,13 +163,9 @@ cpdef fading_fast(const float32[:, ::1] stim,
         n_threads = 1
 
     percept = np.zeros((n_space, n_percept), dtype=np.float32)  # Py overhead
-    # `dt / tau` is the step of the recurrence being composed below. Rounding
-    # it to float32 here rather than carrying `dt` and `tau` separately is what
-    # keeps the composed map a power of the step the per-step loop would have
-    # taken:
+    # Match the float32 step used by the original recurrence.
     dt_tau = dt / tau
-    # One run reads the same stimulus frame for every location, so transpose
-    # once and that read becomes a contiguous run:
+    # Make spatial reads contiguous within each run.
     stim_t = np.ascontiguousarray(np.asarray(stim).T)  # Py overhead
     n_blocks = (n_space + BLOCK - 1) // BLOCK
     # Running brightness, one row per thread. Rows are BLOCK floats apart, so
@@ -201,9 +176,7 @@ cpdef fading_fast(const float32[:, ::1] stim,
     # once:
     running = np.empty((n_threads, BLOCK), dtype=np.float32)  # Py overhead
 
-    # A run ends when the frame changes or a percept lands on it, so there can
-    # be no more runs than there are frames plus output points -- nor, of
-    # course, than there are simulation steps:
+    # Runs end at frame changes or output points:
     max_runs = n_stim + n_percept + 1
     if max_runs > n_sim:
         max_runs = n_sim
@@ -217,9 +190,7 @@ cpdef fading_fast(const float32[:, ::1] stim,
     with nogil:
         n_runs = _build_runs(t_stim, idx_t_percept, dt, n_sim, n_stim,
                              n_percept, run_frame, run_len, run_out)
-        # `q**n` and `1 - q**n` for each run. Both are the same number at
-        # every location, so they are settled here rather than inside the
-        # parallel loop:
+        # Precompute run coefficients shared by all spatial locations:
         for idx_run in range(n_runs):
             n_log_q = run_len[idx_run] * log_q
             run_q[idx_run] = <float32>c_exp(n_log_q)
@@ -253,16 +224,11 @@ cpdef fading_fast(const float32[:, ::1] stim,
                 drive = -amp
                 if drive < 0.0:
                     drive = 0.0
-                # The whole run in one affine step. Brightness stays in
-                # [0, inf[ without a clamp: `q` and `p` are both in [0, 1]
-                # (`tau >= dt` is enforced), so this is a convex combination
-                # of two nonnegative numbers.
+                # Compose the constant-drive run:
                 bright = bright * q + drive * p
                 scratch[tid, idx_space] = bright
-                # `drive` is constant across the run, so brightness moves
-                # monotonically from one end of it to the other and the peak
-                # over the run is at an endpoint. Comparing here therefore
-                # tracks the same peak the per-step compare did:
+                # Brightness is monotonic within a run, so its endpoint is
+                # sufficient for peak tracking:
                 if bright > running[tid, idx_space]:
                     running[tid, idx_space] = bright
             idx_frame = run_out[idx_run]
@@ -301,36 +267,27 @@ cpdef alpha_fast(const float32[:, ::1] stim,
     """Cython implementation of the generic alpha model
 
     Two leaky integrators in series, both with time constant ``tau`` and unit
-    DC gain, driven by the cathodic half of the stimulus. The cascade's
-    impulse response is ``t / tau**2 * exp(-t / tau)``, which starts at zero,
-    peaks at ``t = tau`` and decays afterwards.
+    DC gain, driven by the cathodic half of the stimulus.
 
-    Blocking, the run schedule, denormal handling and interval peak tracking
-    follow the same principles as ``fading_fast``; see there. Each location
-    carries two states rather than one, and both compose across a run of
-    ``n`` steps at constant drive ``d``. Writing ``a = dt/tau``, ``q = 1 - a``
-    and taking the run's starting states as ``x0``, ``y0``::
+    For a constant drive ``d``, write ``a = dt/tau`` and ``q = 1 - a``. After
+    ``n`` discrete steps from states ``x0`` and ``y0``:
 
         x_n = d + q**n * (x0 - d)
         y_n = d + q**n * (y0 - d) + n * a * q**(n - 1) * (x0 - d)
 
-    the second term on ``y`` being what the first stage feeds in over the run.
+    The second-stage response can peak inside a run. Its successive difference is
 
-    The peak needs more care than it does for one stage, because ``y`` is not
-    monotonic within a run: the cascade is what gives the model a rise time,
-    so brightness can climb after the drive has gone. It is however
-    *unimodal*, which is enough. Since ``y[k+1] - y[k] = a * (x[k] - y[k])``
-    and::
+        y[k+1] - y[k] = a * (x[k] - y[k])
 
-        x[k] - y[k] = q**(k - 1) * (q * (x0 - y0) - k * a * (x0 - d))
+    with
 
-    the bracket is linear in ``k`` and ``q**(k-1)`` is positive, so the
-    difference changes sign at most once across the run. A strictly interior
-    maximum therefore exists only when ``x0 > d`` -- stage one above the
-    drive, brightness still catching up -- and sits at the crossing
-    ``k* = q * (x0 - y0) / (a * (x0 - d))``. Evaluating ``y`` at the two ends
-    and either side of ``k*`` gives the exact interval peak in O(1), so no
-    part of this kernel walks the simulation clock per location.
+        x[k] - y[k]
+            = q**(k - 1) * (q * (x0 - y0) - k * a * (x0 - d)).
+
+    The term in parentheses is linear in ``k``, so the response has at most one
+    interior maximum. The kernel therefore evaluates the run endpoints and the
+    samples around that turning point instead of stepping through the whole run.
+
 
     Parameters
     ----------
@@ -417,14 +374,8 @@ cpdef alpha_fast(const float32[:, ::1] stim,
     run_c = np.empty(max_runs, dtype=np.float32)  # Py overhead
     run_r = np.empty(max_runs, dtype=np.float32)  # Py overhead
 
-    # Both states come out of a run as a weighted average of where the run
-    # started and the drive it ran at, never as a difference of two larger
-    # numbers. That matters most at the onset of a response, where `y` is
-    # orders of magnitude below both `drive` and the terms an algebraically
-    # equal grouping would subtract. The three weights on `y` are
-    # nonnegative and sum to one -- `1 - q**n - n*a*q**(n-1)` is the chance
-    # of at least two successes in `n` Bernoulli(`a`) trials -- so the result
-    # is bracketed by the values going in.
+    # Use nonnegative weights on y0, x0, and drive. This avoids cancellation
+    # between O(a) terms when the response first rises.
     log_q = c_log1p(-<double>dt_tau)
     with nogil:
         n_runs = _build_runs(t_stim, idx_t_percept, dt, n_sim, n_stim,
@@ -435,11 +386,8 @@ cpdef alpha_fast(const float32[:, ::1] stim,
             if n_run > max_len:
                 max_len = n_run
             if n_run == 1:
-                # A single step is the plain recurrence, and its weights are
-                # exact: `1 - q - a` is zero, not the 1-ulp residue `expm1`
-                # would leave. That residue is the whole output of the first
-                # step of a response, which has to be exactly zero -- stage
-                # two reads a stage one that has not moved yet.
+                # Preserve the exact one-step recurrence: stage two sees x0,
+                # so the drive coefficient is exactly zero
                 run_q[idx_run] = q
                 run_p[idx_run] = dt_tau
                 run_c[idx_run] = dt_tau
@@ -452,13 +400,10 @@ cpdef alpha_fast(const float32[:, ::1] stim,
                 run_q[idx_run] = <float32>d_qn
                 run_p[idx_run] = <float32>d_pn
                 run_c[idx_run] = <float32>d_cn
-                # Differenced in double, where the two are still far enough
-                # apart to leave the small result its significant digits:
+                # Form the small residual in double to avoid cancellation:
                 run_r[idx_run] = <float32>(d_pn - d_cn)
 
-    # The same three weights at every k a peak can land on. Only the peak
-    # search indexes these, and only at the steps either side of the turning
-    # point:
+    # Coefficients used to evaluate candidates around the turning point
     if reduce == REDUCE_PEAK:
         pow_q = np.empty(max_len + 1, dtype=np.float32)  # Py overhead
         pow_c = np.empty(max_len + 1, dtype=np.float32)  # Py overhead
@@ -510,38 +455,29 @@ cpdef alpha_fast(const float32[:, ::1] stim,
                 drive = -amp
                 if drive < 0.0:
                     drive = 0.0
-                # How far stage one starts above the drive. This is what the
-                # first stage feeds the second over the run, and its sign is
-                # also what decides whether the run can peak in its interior:
+                # An interior maximum is possible only when stage one starts
+                # above the drive:
                 u0 = x0 - drive
                 xn = x0 * qn + drive * pn
                 yn = y0 * qn + x0 * cn + drive * rn
-                # Brightness is bounded in [0, inf[. Both stages are convex
-                # combinations of nonnegative quantities, so this only ever
-                # catches rounding:
+                # # Guard against negative roundoff:
                 if yn < 0.0:
                     yn = 0.0
                 first[tid, idx_space] = xn
                 second[tid, idx_space] = yn
                 if reduce == REDUCE_PEAK:
-                    # `y` is unimodal across the run, so the ends always have
-                    # to be looked at. The first is one plain step from the
-                    # state the run began in:
+                    # Check the first and last samples of the run:
                     cand = y0 + dt_tau * (x0 - y0)
                     if cand > running[tid, idx_space]:
                         running[tid, idx_space] = cand
                     if yn > running[tid, idx_space]:
                         running[tid, idx_space] = yn
-                    # An interior maximum needs stage one to start above the
-                    # drive; otherwise the interior turning point is a
-                    # minimum and the ends already have it:
+                    # If an interior maximum exists, check the discrete samples
+                    # around its turning point:
                     if u0 > 0.0 and n_run > 2:
                         kstar = q * (x0 - y0) / (dt_tau * u0)
                         if kstar >= 1.0:
                             kk = <index_t>kstar + 1
-                            # Either side of the crossing, since which of the
-                            # two neighbouring steps is higher is decided by
-                            # a rounding of `kstar`:
                             for j in range(3):
                                 k = kk - 1 + j
                                 if k < 1:

--- a/pulse2percept/models/base.py
+++ b/pulse2percept/models/base.py
@@ -346,8 +346,13 @@ def _blend_meridian(resp, grid, meridian, width):
                                 mode='nearest')
     weight = np.exp(-dist ** 2 / (2.0 * width ** 2))[..., np.newaxis]
     weight = weight.astype(work.dtype, copy=False)
-    blended = weight * blurred + (1 - weight) * work
-    return blended.reshape(resp.shape).astype(resp.dtype, copy=False)
+    # `work + weight * (blurred - work)`, accumulated into the buffer
+    # `gaussian_filter1d` already returned. Written as one expression it costs
+    # three more arrays the size of the whole response:
+    np.subtract(blurred, work, out=blurred)
+    np.multiply(blurred, weight, out=blurred)
+    np.add(blurred, work, out=blurred)
+    return blurred.reshape(resp.shape).astype(resp.dtype, copy=False)
 
 
 class NotBuiltError(ValueError, AttributeError):

--- a/pulse2percept/models/temporal.py
+++ b/pulse2percept/models/temporal.py
@@ -124,9 +124,12 @@ class FadingTemporal(TemporalModel):
         if np.unique(idx_percept).size < t_percept.size:
             raise ValueError(f"All times 't_percept' must be distinct multiples "
                              f"of `dt`={self.dt:.2e}")
-        # Cython returns a 2D (space x time) NumPy array:
-        return fading_fast(stim_data.astype(np.float32),
-                           time.astype(np.float32),
+        # Cython returns a 2D (space x time) NumPy array. `copy=False`: a
+        # spatial stage upstream already hands this over as float32, and the
+        # array is the whole space x time response, so copying it to the dtype
+        # it is already in is the largest allocation in the call:
+        return fading_fast(stim_data.astype(np.float32, copy=False),
+                           time.astype(np.float32, copy=False),
                            idx_percept, self.dt, self.tau, self.thresh_percept,
                            self.n_threads, 1 if reduce == 'peak' else 0)
 

--- a/pulse2percept/models/temporal.py
+++ b/pulse2percept/models/temporal.py
@@ -205,7 +205,7 @@ class AlphaTemporal(TemporalModel):
 
     """
 
-    #: The peak is tracked across every `dt` step inside `alpha_fast`, so
+    #: The peak is tracked over whole intervals inside `alpha_fast`, so
     #: `predict_percept` does not have to subsample the interval itself.
     _reduces_intervals = True
 
@@ -248,8 +248,9 @@ class AlphaTemporal(TemporalModel):
         if np.unique(idx_percept).size < t_percept.size:
             raise ValueError(f"All times 't_percept' must be distinct "
                              f"multiples of `dt`={self.dt:.2e}")
-        # Cython returns a 2D (space x time) NumPy array:
-        return alpha_fast(stim_data.astype(np.float32),
-                          time.astype(np.float32),
+        # Cython returns a 2D (space x time) NumPy array. `copy=False`:
+        # avoid copying an already-float32 spatial response.
+        return alpha_fast(stim_data.astype(np.float32, copy=False),
+                          time.astype(np.float32, copy=False),
                           idx_percept, self.dt, self.tau, self.thresh_percept,
                           self.n_threads, 1 if reduce == 'peak' else 0)

--- a/pulse2percept/models/temporal.py
+++ b/pulse2percept/models/temporal.py
@@ -67,7 +67,7 @@ class FadingTemporal(TemporalModel):
 
     """
 
-    #: The peak is tracked across every `dt` step inside `fading_fast`, so
+    #: The peak is tracked over whole intervals inside `fading_fast`, so
     #: `predict_percept` does not have to subsample the interval itself.
     _reduces_intervals = True
 
@@ -124,10 +124,8 @@ class FadingTemporal(TemporalModel):
         if np.unique(idx_percept).size < t_percept.size:
             raise ValueError(f"All times 't_percept' must be distinct multiples "
                              f"of `dt`={self.dt:.2e}")
-        # Cython returns a 2D (space x time) NumPy array. `copy=False`: a
-        # spatial stage upstream already hands this over as float32, and the
-        # array is the whole space x time response, so copying it to the dtype
-        # it is already in is the largest allocation in the call:
+        # Cython returns a 2D (space x time) NumPy array. `copy=False`:
+        # avoid copying an already-float32 spatial response.
         return fading_fast(stim_data.astype(np.float32, copy=False),
                            time.astype(np.float32, copy=False),
                            idx_percept, self.dt, self.tau, self.thresh_percept,

--- a/pulse2percept/models/tests/test_beyeler2019.py
+++ b/pulse2percept/models/tests/test_beyeler2019.py
@@ -17,6 +17,7 @@ from pulse2percept.stimuli import Stimulus
 from pulse2percept.models import (AxonMapSpatial, AxonMapModel,
                                   ScoreboardSpatial, ScoreboardModel)
 from pulse2percept.models.beyeler2019 import _AXON_CACHE_VERSION
+from pulse2percept.models._beyeler2019 import fast_axon_map
 from pulse2percept.topography import Watson2014Map, Watson2014DisplaceMap
 from pulse2percept.utils.testing import assert_warns_msg
 
@@ -791,6 +792,44 @@ def test_predict_percept_all_zero_stim(ModelClass):
     model = ModelClass(step=1, xrange=(-10, 10), yrange=(-8, 8)).build()
     percept = model.predict_percept(ArgusII(stim=np.zeros(60)))
     npt.assert_equal(np.all(percept.data == 0), True)
+
+
+def test_fast_axon_map_cutoff_band_boundaries():
+    """An electrode exactly on either edge of the cutoff still contributes.
+
+    ``fast_axon_map`` binary-searches the x band ``[ax_x - r, ax_x + r]`` and
+    walks it until x leaves, so both ends are places an off-by-one can hide.
+    ``cutoff_r2`` is an exact float32 square here, so that what is being
+    pinned is the band's boundary rather than the rounding of its ``sqrt``.
+    """
+    rho = np.float32(200.0)
+    cutoff_r2 = np.float32(360000.0)  # r = 600 um, exactly
+    # One pixel whose axon is a single segment at the origin, sensitivity 1:
+    segments = np.array([[0.0, 0.0, 1.0]], dtype=np.float32)
+    start = np.array([0], dtype=np.uint32)
+    end = np.array([1], dtype=np.uint32)
+
+    def bright(x_el):
+        x_el = np.ascontiguousarray(x_el, dtype=np.float32)
+        stim = np.full((len(x_el), 1), -1.0, dtype=np.float32)
+        return fast_axon_map(stim, x_el, np.zeros_like(x_el), segments,
+                             start, end, rho, np.float32(0.0), cutoff_r2,
+                             1).ravel()[0]
+
+    for x in (-600.0, 600.0):
+        npt.assert_array_less(0.0, abs(bright([x])))
+    for x in (-600.5, 600.5):
+        npt.assert_equal(bright([x]), 0.0)
+
+    # ... and the walk in between drops exactly the electrodes outside it:
+    x_el = np.array([-900., -600.5, -600., -300., 0., 300., 600., 600.5,
+                     900.], dtype=np.float32)
+    # Summed in increasing x, which is the order the kernel visits them in:
+    want = np.float32(0.0)
+    two_rho2 = 2.0 * rho * rho
+    for x in x_el[np.abs(x_el) <= 600.0]:
+        want = np.float32(want - np.float32(np.exp(-x * x / two_rho2)))
+    npt.assert_allclose(bright(x_el), want, rtol=1e-6)
 
 
 @pytest.mark.parametrize('ModelClass', (ScoreboardModel, AxonMapModel))

--- a/pulse2percept/models/tests/test_temporal.py
+++ b/pulse2percept/models/tests/test_temporal.py
@@ -594,29 +594,38 @@ def test_AlphaTemporal_rectifies_the_drive():
     npt.assert_equal(cathodic.data.max() > 0, True)
 
 
-def _alpha_reference(data, t_stim, idx_percept, dt, tau):
-    """Two-state explicit Euler, one location at a time, in float32.
+def _alpha_reference(data, t_stim, idx_percept, dt, tau, reduce_peak=False):
+    """Two-state explicit Euler, one location at a time, in float64.
 
     Stage 2 reads stage 1 as it was at the *start* of the step, which is what
     gives the cascade its rise delay.
+
+    float64 on purpose. `alpha_fast` composes the steps of a constant-drive
+    run into one update rather than taking them one at a time, so it cannot
+    reproduce a float32 replay of those steps bit for bit -- and should not be
+    asked to, since the replay is the less accurate of the two. What both are
+    implementations *of* is this recurrence, so this is what they are pinned
+    against.
     """
-    dt, tau = np.float32(dt), np.float32(tau)
-    dt_tau = np.float32(dt / tau)
+    a = float(np.float32(np.float32(dt) / np.float32(tau)))
     n_stim = len(t_stim)
-    out = np.zeros((data.shape[0], len(idx_percept)), dtype=np.float32)
+    out = np.zeros((data.shape[0], len(idx_percept)))
     for s in range(data.shape[0]):
-        x = y = np.float32(0.0)
+        x = y = 0.0
+        running = 0.0
         idx_stim, frame = 0, 0
         for i in range(int(idx_percept[-1]) + 1):
             while (idx_stim + 1 < n_stim and
-                   np.float32(i) * dt >= t_stim[idx_stim + 1]):
+                   np.float32(i) * np.float32(dt) >= t_stim[idx_stim + 1]):
                 idx_stim += 1
-            drive = np.float32(max(-data[s, idx_stim], 0.0))
+            drive = max(-float(data[s, idx_stim]), 0.0)
             x_old = x
-            x = np.float32(x + dt_tau * (drive - x))
-            y = np.float32(y + dt_tau * (x_old - y))
-            if i == idx_percept[frame]:
-                out[s, frame] = y
+            x = x + a * (drive - x)
+            y = y + a * (x_old - y)
+            running = max(running, y)
+            if frame < len(idx_percept) and i == idx_percept[frame]:
+                out[s, frame] = running if reduce_peak else y
+                running = y
                 frame += 1
     return out
 
@@ -641,10 +650,10 @@ def test_AlphaTemporal_matches_reference_recurrence():
 
     idx_p = np.uint32(np.round(t_percept / model.dt))
     want = _alpha_reference(data, t_stim, idx_p, model.dt, model.tau)
-    # Close, not equal: `x + dt_tau * d` may be contracted into one fused
-    # multiply-add by the C compiler but never is by NumPy here. See
-    # `test_FadingTemporal_matches_reference_integrator`.
-    npt.assert_allclose(got, want, rtol=1e-6)
+    # Close, not equal: the kernel composes each constant-drive run into one
+    # update and works in float32, so it lands within a few parts in 1e6 of
+    # the float64 recurrence rather than on it.
+    npt.assert_allclose(got, want, rtol=1e-5)
 
     # Stage 2 must use the previous stage-1 value:
     dt, tau = 0.01, 50.0
@@ -705,8 +714,59 @@ def test_AlphaTemporal_dc_gain_is_unity():
             rtol=5e-3)
 
 
+#: Constant-drive runs that stress each shape the composed update has to
+#: reproduce, as (data, t_stim, tau, t_percept). ``dt`` is 0.05 throughout.
+_ALPHA_RUNS = {
+    'rising': ([[-40.0, -40.0]], [0.0, 1e6], 20.0, [1.0, 10.0, 40.0]),
+    'falling': ([[-40.0, 0.0]], [0.0, 3.0], 20.0, [3.0, 20.0, 60.0]),
+    # Drive gone at 2 ms but stage 1 still above stage 2, so brightness keeps
+    # climbing for several tau afterwards and peaks mid-interval:
+    'interior_peak': ([[-60.0, 0.0]], [0.0, 2.0], 8.0, [2.0, 20.0, 60.0]),
+    # An output point one step either side of where the drive changes:
+    'peak_at_transition': ([[-50.0, -1.0, 0.0]], [0.0, 4.9, 5.0], 6.0,
+                           [4.85, 4.9, 4.95, 5.0, 5.05, 30.0]),
+    'tau_eq_dt': ([[-30.0, 0.0, -10.0]], [0.0, 1.0, 2.0], 0.05,
+                  [1.0, 2.0, 3.0]),
+    # Frame times 50x closer together than one simulation step:
+    'frames_inside_one_dt': ([[0.0, -90.0, 0.0, -20.0, 0.0]],
+                             [0.0, 0.001, 0.002, 0.02, 9.0], 15.0,
+                             [0.05, 1.0, 9.0]),
+}
+
+
+@pytest.mark.parametrize('case', sorted(_ALPHA_RUNS))
+def test_AlphaTemporal_run_composition_matches_recurrence(case):
+    """Composing a run must land where stepping it would.
+
+    `alpha_fast` advances both stages across a whole constant-drive run at
+    once. What that has to agree with is the recurrence, so the reference is
+    that recurrence in float64 rather than a float32 replay of it.
+    """
+    data, t_stim, tau, t_percept = _ALPHA_RUNS[case]
+    dt = 0.05
+    data = np.array(data, dtype=np.float32)
+    t_stim = np.array(t_stim, dtype=np.float32)
+    idx = np.uint32(np.round(np.array(t_percept) / dt))
+    got = {}
+    for reduce_peak in (0, 1):
+        got[reduce_peak] = np.asarray(
+            alpha_fast(data, t_stim, idx, dt, tau, 0.0, 1, reduce_peak))
+        npt.assert_allclose(
+            got[reduce_peak],
+            _alpha_reference(data, t_stim, idx, dt, tau, bool(reduce_peak)),
+            rtol=1e-5, atol=1e-6)
+    # Exactly, not approximately: the peak is a max over a set of candidates
+    # that always includes the instant the interval ends on.
+    npt.assert_equal(np.all(got[1] >= got[0]), True)
+
+
 def test_AlphaTemporal_peak_is_exact():
-    """The in-kernel peak must equal a dense scan of the same interval."""
+    """The in-kernel peak must equal a dense scan of the same interval.
+
+    Close, not equal: `alpha_fast` composes the steps between two output
+    points into one update, so asking for every step and asking for five
+    points do not put the same number of roundings between two output times.
+    """
     rng = np.random.default_rng(3)
     data = (rng.random((5, 12)) - 0.5).astype(np.float32) * 40
     t_stim = (np.arange(12) * 4.0).astype(np.float32)
@@ -723,9 +783,25 @@ def test_AlphaTemporal_peak_is_exact():
     lo = np.r_[0, out[:-1]]
     brute = np.stack([dense[:, a:b + 1].max(axis=1)
                       for a, b in zip(lo, out)], axis=1)
-    npt.assert_array_equal(peak, brute)
-    npt.assert_array_equal(last, dense[:, out])
+    npt.assert_allclose(peak, brute, rtol=1e-5)
+    npt.assert_allclose(last, dense[:, out], rtol=1e-5)
+    npt.assert_equal(np.all(peak >= last), True)
     npt.assert_equal(np.any(peak > last), True)
+
+    # The case the O(1) search exists for: an interval whose largest value is
+    # at neither of its ends, so nothing but the turning point will do.
+    single = np.array([[-60.0, 0.0]], dtype=np.float32)
+    edges = np.array([0.0, 2.0], dtype=np.float32)
+    fine = np.asarray(alpha_fast(single, edges,
+                                 np.arange(1201, dtype=np.uint32), dt, 8.0,
+                                 0.0, 1, 0)).ravel()
+    npt.assert_equal(0 < int(fine.argmax()) < 1200, True)
+    span = np.array([40, 400, 1200], dtype=np.uint32)
+    got = np.asarray(alpha_fast(single, edges, span, dt, 8.0, 0.0, 1,
+                                1)).ravel()
+    lo = np.r_[0, span[:-1]]
+    npt.assert_allclose(
+        got, [fine[a:b + 1].max() for a, b in zip(lo, span)], rtol=1e-5)
 
 
 def test_AlphaTemporal_reduce():

--- a/pulse2percept/models/tests/test_temporal.py
+++ b/pulse2percept/models/tests/test_temporal.py
@@ -233,6 +233,44 @@ def test_FadingTemporal_thread_count_invariant():
         npt.assert_array_equal(parallel, serial)
 
 
+def test_FadingTemporal_long_run_matches_closed_form():
+    """A long constant drive lands on the recurrence, not on its drift.
+
+    Stepping a run one `dt` at a time in float32 is what loses accuracy here:
+    each step adds about `dt / tau` of the running value, and approaching the
+    fixed point those additions round away entirely. At the default
+    `dt=0.005`, `tau=100`, a one-second constant drive stepped that way sits
+    ~9000 ulps below the recurrence it is meant to implement. So the
+    reference is that recurrence in float64, not the trajectory the per-step
+    float32 loop used to produce.
+    """
+    dt, tau, amp = 0.005, 100.0, 50.0
+    # One frame outlasting every output point, so the drive never changes and
+    # the only run boundaries are the output points themselves:
+    stim = Stimulus(np.array([[-amp, 0.0]]), time=[0.0, 1e6])
+    t_percept = np.array([200.0, 700.0, 1500.0])
+    got = FadingTemporal(dt=dt, tau=tau, thresh_percept=0,
+                         reduce='last').build().predict_percept(
+        stim, t_percept=t_percept).data.ravel()
+
+    # `q` from the float32 `dt / tau` the kernel divides once and reuses, but
+    # composed in float64. Run `k` covers the steps after the previous output
+    # point up to and including this one:
+    q = 1.0 - float(np.float32(dt / tau))
+    idx = np.round(t_percept / dt).astype(np.int64)
+    want, bright, prev = [], 0.0, -1
+    for i in idx:
+        bright = amp + (bright - amp) * q ** (i - prev)
+        want.append(bright)
+        prev = i
+    npt.assert_allclose(got, want, rtol=1e-6)
+    # Not a vacuous comparison: brightness is still climbing at every one of
+    # these points, so a wrong `q**n` cannot hide behind the fixed point:
+    npt.assert_array_less(want[0], want[1])
+    npt.assert_array_less(want[1], want[2])
+    npt.assert_array_less(want[2], amp)
+
+
 def test_FadingTemporal_peak_is_exact():
     """The in-kernel peak must equal a dense scan of the same interval.
 
@@ -244,8 +282,9 @@ def test_FadingTemporal_peak_is_exact():
     Close, not equal: `fading_fast` composes the runs of simulation steps that
     share a stimulus frame into one affine map, so asking for every step and
     asking for five points do not put the same number of roundings between two
-    output times. Both stay within a few ulps of the recurrence they compose,
-    but neither is obliged to reproduce the other bit for bit.
+    output times, and neither is obliged to reproduce the other bit for bit.
+    See `test_FadingTemporal_long_run_matches_closed_form` for which of the
+    two tracks the recurrence over a long run.
     """
     rng = np.random.default_rng(3)
     data = (rng.random((5, 12)) - 0.5).astype(np.float32) * 40

--- a/pulse2percept/models/tests/test_temporal.py
+++ b/pulse2percept/models/tests/test_temporal.py
@@ -237,9 +237,16 @@ def test_FadingTemporal_peak_is_exact():
     """The in-kernel peak must equal a dense scan of the same interval.
 
     Sampling an interval a fixed number of times cannot summarize a transient
-    shorter than its own step, which is why the peak is tracked across every
-    `dt` step instead. That makes it exact however coarse the output rate is,
-    and this pins it against brightness computed at every single step.
+    shorter than its own step, which is why the peak is tracked across the
+    whole interval instead. That makes it exact however coarse the output rate
+    is, and this pins it against brightness computed at every single step.
+
+    Close, not equal: `fading_fast` composes the runs of simulation steps that
+    share a stimulus frame into one affine map, so asking for every step and
+    asking for five points do not put the same number of roundings between two
+    output times. Both stay within a few ulps of the recurrence they compose
+    -- the composed form is in fact the closer of the two -- but neither is
+    obliged to reproduce the other bit for bit.
     """
     rng = np.random.default_rng(3)
     data = (rng.random((5, 12)) - 0.5).astype(np.float32) * 40
@@ -258,9 +265,11 @@ def test_FadingTemporal_peak_is_exact():
     lo = np.r_[0, out[:-1]]
     brute = np.stack([dense[:, a:b + 1].max(axis=1)
                       for a, b in zip(lo, out)], axis=1)
-    npt.assert_array_equal(peak, brute)
+    npt.assert_allclose(peak, brute, rtol=1e-5)
     # Reducing to the closing instant is what the model always did:
-    npt.assert_array_equal(last, dense[:, out])
+    npt.assert_allclose(last, dense[:, out], rtol=1e-5)
+    # Exactly, not approximately: the interval contains the instant it ends
+    # on, so the peak is a max taken over a set including `last` itself:
     npt.assert_equal(np.all(peak >= last), True)
     npt.assert_equal(np.any(peak > last), True)
     # Threads take a block of locations each; the peak must not depend on how

--- a/pulse2percept/models/tests/test_temporal.py
+++ b/pulse2percept/models/tests/test_temporal.py
@@ -244,9 +244,8 @@ def test_FadingTemporal_peak_is_exact():
     Close, not equal: `fading_fast` composes the runs of simulation steps that
     share a stimulus frame into one affine map, so asking for every step and
     asking for five points do not put the same number of roundings between two
-    output times. Both stay within a few ulps of the recurrence they compose
-    -- the composed form is in fact the closer of the two -- but neither is
-    obliged to reproduce the other bit for bit.
+    output times. Both stay within a few ulps of the recurrence they compose,
+    but neither is obliged to reproduce the other bit for bit.
     """
     rng = np.random.default_rng(3)
     data = (rng.random((5, 12)) - 0.5).astype(np.float32) * 40
@@ -460,6 +459,17 @@ def test_FadingTemporal_tau_limits():
     # rectifier and not a pass-through:
     npt.assert_equal(np.any(np.asarray(stim.data) > 0), True)
     npt.assert_equal(got.max(), 50.0)
+
+    # Asking for the percept less often does not make it a different model.
+    # This is the one `tau` at which the decay per step is total, so the runs
+    # of steps the kernel composes decay by `exp(-inf)` rather than by a
+    # power of something in ]0, 1[ -- and a run of 100 such steps still has to
+    # land exactly on the drive:
+    coarse = np.round(np.arange(0, 4, 0.5), 5)
+    npt.assert_array_equal(
+        FadingTemporal(tau=dt, dt=dt, reduce='last').build().predict_percept(
+            stim, t_percept=coarse).data.ravel(),
+        rectified[np.searchsorted(t, coarse)])
 
     # Slower than that and brightness lags its drive, so the two part company.
     # Lagging cuts both ways: brightness never catches the drive while it is on,


### PR DESCRIPTION
Speed up large-array simulations by avoiding unnecessary work in the `AxonMap` and `FadingTemporal` kernels.

- [x] Skip inactive electrodes and restrict `AxonMap` distance checks to nearby electrodes
- [x] Compose constant-drive runs in `FadingTemporal` and `AlphaTemporal` instead of stepping every `dt`
- [x] Avoid unnecessary temporal-response copies
- [x] Reduce `_blend_meridian` memory allocations

On representative large-implant examples, retinal prediction is 2.7x faster and cortical video prediction 63x faster, with lower peak memory use. Output differences are limited to floating-point roundoff.