### PR TITLE
[MNT] Remove stack-frame inspection from Frozen/model state handling

### DIFF
--- a/pulse2percept/models/base.py
+++ b/pulse2percept/models/base.py
@@ -3,7 +3,6 @@
    :py:class:`~pulse2percept.models.NotBuiltError`,
    :py:class:`~pulse2percept.models.SpatialModel`,
    :py:class:`~pulse2percept.models.TemporalModel`"""
-import sys
 import warnings
 from abc import ABCMeta, abstractmethod
 from copy import deepcopy, copy
@@ -18,9 +17,10 @@ from ..percepts import Percept
 from ..topography import Curcio1990Map, Grid2D, RetinalMap
 from ..units import (DimensionMismatchError, Quantity, Unit, as_value, dva, ms,
                      um, uA)
-from ..utils import (PrettyPrint, FreezeError, Parametrized, bisect,
+from ..utils import (PrettyPrint, FreezeError, Frozen, Parametrized, bisect,
                      deprecated_alias, warn_deprecated_params,
                      rename_deprecated_params)
+from ..utils.base import _is_constructing
 from ..utils.constants import ZORDER
 
 
@@ -520,29 +520,13 @@ class BaseModel(Parametrized, metaclass=ABCMeta):
         # constructor:
         self.set_params(**build_params)
         self._build()
-        self.is_built = True
+        self._is_built = True
         return self
 
     @property
     def is_built(self):
-        """A flag indicating whether the model has been built"""
+        """A read-only flag indicating whether the model has been built"""
         return self._is_built
-
-    @is_built.setter
-    def is_built(self, val):
-        """This flag can only be set in the constructor or ``build``"""
-        # getframe(0) is '_is_built', getframe(1) is 'set_attr'.
-        # getframe(2) is the one we are looking for, and has to be either the
-        # construct or ``build``:
-        f_caller_2 = sys._getframe(2).f_code.co_name
-        f_caller_3 = sys._getframe(3).f_code.co_name
-        if f_caller_2 in ["__init__", "build"] or \
-           f_caller_3 in ["__init__", "build"]:
-            self._is_built = val
-        else:
-            err_s = (f"The attribute `is_built` can only be set in the "
-                     f"constructor or in ``build``, not in ``{f_caller_2}``.")
-            raise AttributeError(err_s)
 
     def __deepcopy__(self, memodict=None):
         if memodict is None:
@@ -854,7 +838,7 @@ class SpatialModel(BaseModel, metaclass=ABCMeta):
                            grid_type=self.grid_type)
         self.grid.build(self.vfmap)
         self._build()
-        self.is_built = True
+        self._is_built = True
         return self
 
     @abstractmethod
@@ -1527,7 +1511,7 @@ class TemporalModel(BaseModel, metaclass=ABCMeta):
                       y_tol=bright_tol, max_iter=max_iter)
 
 
-class Model(PrettyPrint):
+class Model(Frozen, PrettyPrint):
     """Computational model
 
     To build your own model, you can mix and match spatial and temporal models
@@ -1700,14 +1684,22 @@ class Model(PrettyPrint):
         and / or ``model.temporal.a``.
 
         """
-        if sys._getframe(1).f_code.co_name == '__init__':
-            # Allow setting new attributes in the constructor:
-            if isinstance(sys._getframe(1).f_locals['self'], self.__class__):
-                super().__setattr__(name, value)
-                return
-        # Outside the constructor, we cannot add new attributes (FreezeError).
-        # But, we have to check whether the attribute is part of the spatial
-        # model, the temporal model, or both:
+        if _is_constructing(self):
+            # `self.spatial = ...`, and whatever attributes a subclass
+            # constructor creates, belong to the composite object. User
+            # parameters do not: `set_params` forwards those explicitly, so
+            # that `rho` passed to the constructor still reaches the
+            # sub-models rather than shadowing them here.
+            super().__setattr__(name, value)
+            return
+        self._set_component_param(name, value)
+
+    def _set_component_param(self, name, value):
+        """Forward an assignment to the spatial and/or temporal model
+
+        Raises a ``FreezeError`` if neither sub-model knows the name; outside
+        the constructor there is nowhere else for it to go.
+        """
         found = False
         try:
             self.spatial.__setattr__(name, value)
@@ -1831,8 +1823,12 @@ class Model(PrettyPrint):
         # Each parameter is forwarded to the sub-models one at a time, so the
         # order they are applied in is decided here rather than by
         # `SpatialModel.set_params`. See `_vfmap_first`:
+        #
+        # Forwarding directly rather than via `setattr`: `set_params` also
+        # runs from inside `__init__`, where an assignment to `self` would
+        # land on the composite object instead of the sub-models.
         for key, val in _vfmap_first(params).items():
-            setattr(self, key, val)
+            self._set_component_param(key, val)
 
     def build(self, **build_params):
         """Build the model

--- a/pulse2percept/models/cortex/dynaphos.py
+++ b/pulse2percept/models/cortex/dynaphos.py
@@ -248,7 +248,7 @@ class DynaphosModel(BaseModel):
                            grid_type=self.grid_type)
         self.grid.build(self.vfmap)
         self._build()
-        self.is_built = True
+        self._is_built = True
         return self
                     
     def _predict_percept(self, earray, stim, t_percept, clocks=None):

--- a/pulse2percept/models/granley2021.py
+++ b/pulse2percept/models/granley2021.py
@@ -1,7 +1,6 @@
 """:py:class:`~pulse2percept.models.BiphasicAxonMapModel`,
    :py:class:`~pulse2percept.models.BiphasicAxonMapSpatial` [Granley2021]_"""
 import numpy as np
-import sys
 from copy import deepcopy
 
 from . import AxonMapSpatial, Model
@@ -264,6 +263,11 @@ def _pulse_train_params(stim):
     return params
 
 
+#: The three effect models are set up by ``BiphasicAxonMapSpatial.__init__``
+#: and are excluded from its attribute forwarding, in both directions.
+_EFFECT_MODELS = ('bright_model', 'size_model', 'streak_model')
+
+
 class BiphasicAxonMapSpatial(AxonMapSpatial):
     """ BiphasicAxonMapModel of [Granley2021]_ (spatial model)
 
@@ -422,20 +426,16 @@ class BiphasicAxonMapSpatial(AxonMapSpatial):
             setattr(self, spec.new_name if spec else key, val)
 
     def __getattr__(self, attr):
-        # Called when normal get attribute fails
-        # If we are in the initializer, or if trying to access
-        # an effects model, raise an error which is caught and causes
-        # the parameter to be created.
-        if (sys._getframe(3).f_code.co_name == '__init__' and
-                "pulse2percept/models/base.py" in
-                sys._getframe(3).f_code.co_filename) or \
-                (attr in ['bright_model', 'streak_model', 'size_model']):
-            # We can set new class attributes in the constructor. Reaching this
-            # point means the default attribute access failed - most likely
-            # because we are trying to create a variable. In this case, simply
-            # raise an exception:
-            # Note that this gets called from __init__ of BaseModel, not directly from
-            # BiphasicAxonMap
+        # Called when normal attribute access fails. The effect models
+        # themselves are never forwarded through: asking one of them for
+        # itself would recurse.
+        if attr in _EFFECT_MODELS:
+            raise AttributeError(f"{attr} not found")
+        # `has_own_attr` rather than `getattr`, which would re-enter this
+        # method: until the constructor has set all three, there is nothing to
+        # forward through, and the caller (`Parametrized.__init__` setting a
+        # default, say) wants the AttributeError anyway.
+        if not all(has_own_attr(self, name) for name in _EFFECT_MODELS):
             raise AttributeError(f"{attr} not found")
         # Check if bright/size/streak model has param
         for m in [self.bright_model, self.size_model, self.streak_model]:
@@ -463,8 +463,10 @@ class BiphasicAxonMapSpatial(AxonMapSpatial):
             except AttributeError:
                 pass
         # Check whether the attribute is a part of any
-        # bright/size/streak model
-        if name not in ['bright_model', 'size_model', 'streak_model', 'is_built', '_is_built']:
+        # bright/size/streak model. Note that this runs even when the spatial
+        # model already took the assignment above: `rho` and `lam` live in
+        # both places and have to stay in step.
+        if name not in _EFFECT_MODELS + ('is_built', '_is_built'):
             try:
                 for m in [self.bright_model, self.size_model, self.streak_model]:
                     if hasattr(m, name):
@@ -473,18 +475,10 @@ class BiphasicAxonMapSpatial(AxonMapSpatial):
             except (AttributeError, FreezeError):
                 pass
         if not found:
-            try:
-                if sys._getframe(2).f_code.co_name == '__init__' or  \
-                        sys._getframe(3).f_code.co_name == '__init__':
-                    super().__setattr__(name, value)
-                    return
-            except FreezeError:
-                pass
-
-        if not found:
-            err_str = (f"'{name}' not found. You cannot add attributes to "
-                       f"{self.__class__.__name__} outside the constructor.")
-            raise FreezeError(err_str)
+            # No legitimate destination, so let `Frozen` decide: a new
+            # attribute is fine during construction and a `FreezeError`
+            # afterwards.
+            super().__setattr__(name, value)
 
     def get_default_params(self):
         base_params = super(BiphasicAxonMapSpatial, self).get_default_params()

--- a/pulse2percept/models/tests/test_base.py
+++ b/pulse2percept/models/tests/test_base.py
@@ -868,6 +868,39 @@ def test_Model_set_params():
     npt.assert_equal(hasattr(model.spatial, 'dt'), False)
 
 
+class ValidCompositeModel(Model):
+    """A Model subclass that owns an attribute of its own"""
+
+    def __init__(self, **params):
+        super().__init__(spatial=ValidSpatialModel(), temporal=None, **params)
+        self.n_calls = 0
+
+
+def test_Model_subclass_constructor_owns_its_attributes():
+    model = ValidCompositeModel()
+    npt.assert_equal(model.n_calls, 0)
+    npt.assert_equal('n_calls' in model.__dict__, True)
+    npt.assert_equal(hasattr(model.spatial, 'n_calls'), False)
+    # Nothing new may be added once the constructor is done:
+    with pytest.raises(FreezeError):
+        model.n_misses = 0
+
+
+def test_Model_subclass_params_go_to_the_component_model():
+    # A user parameter belongs to the sub-model, even when it is passed to a
+    # subclass constructor that is free to create attributes of its own:
+    model = ValidCompositeModel(step=2.5)
+    npt.assert_almost_equal(model.spatial.step, 2.5)
+    npt.assert_equal('step' in model.__dict__, False)
+    model.set_params({'step': 0.5})
+    npt.assert_almost_equal(model.spatial.step, 0.5)
+    npt.assert_equal('step' in model.__dict__, False)
+    # A parameter no sub-model knows has nowhere to go, and must not quietly
+    # become an attribute of the composite instead:
+    with pytest.raises(FreezeError):
+        ValidCompositeModel(nonexistent=1)
+
+
 def test_Model_build():
     # A None model:
     model = Model()

--- a/pulse2percept/utils/base.py
+++ b/pulse2percept/utils/base.py
@@ -7,7 +7,6 @@
    :py:class:`~pulse2percept.utils.gamma`,
    :py:class:`~pulse2percept.utils.unique`"""
 import numpy as np
-import sys
 import abc
 from copy import copy, deepcopy
 from scipy.integrate import trapezoid
@@ -137,11 +136,22 @@ def has_own_attr(obj, name):
     return name in getattr(obj, '__dict__', {}) or hasattr(type(obj), name)
 
 
+#: ``id()`` of every object whose constructor is currently running. Kept
+#: outside the instances themselves: some ``Frozen`` subclasses are slotted,
+#: and a flag living on the object would double as a way to unfreeze it.
+_constructing = set()
+
+
+def _is_constructing(obj):
+    """Whether ``obj``'s constructor is currently running"""
+    return id(obj) in _constructing
+
+
 def freeze_class(set, normalize=None):
     """Freezes a class
-    Raise an error when trying to set an undeclared name, or when calling from
-    a method other than ``Frozen.__init__`` or the ``__init__`` method of a
-    class derived from Frozen
+
+    Raise an error when trying to set an undeclared name from anywhere but
+    the object's own constructor.
 
     Parameters
     ----------
@@ -153,34 +163,26 @@ def freeze_class(set, normalize=None):
         See ``_normalize_param``, which dispatches to the object's own
         ``_normalize_param_value``.
 
-        This is a parameter rather than a wrapper around ``set_attr`` on
-        purpose: both this function and
-        :py:meth:`~pulse2percept.models.BaseModel.is_built` locate their
-        caller by stack depth, and inserting another ``__setattr__`` frame
-        between the caller and this one would move it.
-
     """
 
     def set_attr(self, name, value):
         if normalize is not None and has_units(value):
             # Units are stripped here, at the last moment before storage, so
-            # that every path into a parameter -- constructor, `set_params`,
-            # `build`, a direct assignment, or a composite `Model` forwarding
-            # one to its sub-models -- goes through the same conversion:
+            # that every path into a parameter goes through the same conversion
             value = normalize(self, name, value)
-        # The cheap check comes first so that assigning to an attribute never
-        # *reads* it (see ``has_own_attr``); `hasattr` then covers the names
-        # that only a ``__getattr__`` knows about:
+        if _is_constructing(self):
+            set(self, name, value)
+            return
+        # Deliberately after the construction check: probing a half-built
+        # object can run a forwarding `__getattr__` before the state it
+        # forwards through exists. The cheap check comes first so that
+        # assigning to an attribute never *reads* it (see ``has_own_attr``);
+        # `hasattr` then covers the names that only a ``__getattr__`` knows
+        # about:
         if has_own_attr(self, name) or hasattr(self, name):
             # If attribute already exists, simply set it
             set(self, name, value)
             return
-        elif sys._getframe(1).f_code.co_name == '__init__' or \
-             sys._getframe(2).f_code.co_name == '__init__':
-            # Allow __setattr__ calls in __init__ calls of proper object types
-            if isinstance(sys._getframe(1).f_locals['self'], self.__class__):
-                set(self, name, value)
-                return
         err_str = (f"'{name}' not found. You cannot add attributes "
                    f"to {self.__class__.__name__} outside the constructor.")
         raise FreezeError(err_str)
@@ -194,6 +196,32 @@ class Frozen(object):
     class will raise a FreezeError.
     """
     __slots__ = ()
+
+    def __init_subclass__(cls, **kwargs):
+        """Register the object under construction for the whole constructor
+
+        Wrapping every subclass's own ``__init__`` -- not just the base one --
+        is what keeps a subclass that calls ``super().__init__()`` and then
+        adds an attribute of its own counting as "under construction".
+        """
+        super().__init_subclass__(**kwargs)
+        init = cls.__dict__.get('__init__')
+        if init is None:
+            return
+
+        @wraps(init)
+        def wrapped_init(self, *args, **kwargs):
+            # Nested `super().__init__` calls all see the same id, so only the
+            # outermost one may unregister it:
+            outermost = id(self) not in _constructing
+            _constructing.add(id(self))
+            try:
+                return init(self, *args, **kwargs)
+            finally:
+                if outermost:
+                    _constructing.discard(id(self))
+
+        cls.__init__ = wrapped_init
 
     __setattr__ = freeze_class(object.__setattr__)
 

--- a/pulse2percept/utils/tests/test_base.py
+++ b/pulse2percept/utils/tests/test_base.py
@@ -50,6 +50,37 @@ def test_Frozen():
         frozen_child.c = 3
 
 
+class FrozenGrandChild(FrozenChild):
+
+    def __init__(self, a, c):
+        super().__init__(a)
+        self.c = c
+
+
+def test_Frozen_derived_constructor():
+    # The whole most-derived constructor counts as construction, not just the
+    # base one it delegates to:
+    grandchild = FrozenGrandChild(1, 2)
+    npt.assert_almost_equal(grandchild.a, 1)
+    npt.assert_almost_equal(grandchild.c, 2)
+    with pytest.raises(FreezeError):
+        grandchild.d = 3
+
+
+class Impostor:
+    """Anything whose constructor touches an already-built Frozen object"""
+
+    def __init__(self, victim):
+        victim.newvar = 0
+
+
+def test_Frozen_other_object_constructor():
+    # Being called from *some* `__init__` is not permission to add an
+    # attribute to a finished object (#801):
+    with pytest.raises(FreezeError):
+        Impostor(FrozenChild(1))
+
+
 class ParametrizedChild(Parametrized):
 
     def get_default_params(self):


### PR DESCRIPTION
Closes #801.

Replaces the brittle `sys._getframe` checks used by `Frozen`, `Model`, `BaseModel.is_built`, and the Granley model with explicit construction state.

The main changes are:

- [x] track whether a `Frozen` object is currently being constructed
- [x] use that state to allow new attributes only during construction
- [x] make `BaseModel.is_built` read-only and update `_is_built` internally
- [x] simplify `Model` parameter forwarding without caller inspection
- [x] replace Granley's stack/filename checks with object-state checks
- [x] add regressions for inherited constructors, unrelated `__init__` callers, and composite-model parameter forwarding