### PR TITLE
Release v0.10: Encoders

### DIFF
--- a/benchmarks/README.rst
+++ b/benchmarks/README.rst
@@ -1,8 +1,8 @@
 .. _dev-benchmarks:
 
-========================
-pulse2percept benchmarks
-========================
+======================
+Performance Benchmarks
+======================
 
 A small suite that measures the library's main job: predicting a percept from a
 stimulus, an implant and a phosphene model. It tracks **execution time** and

--- a/doc/developers/releases.rst
+++ b/doc/developers/releases.rst
@@ -4,84 +4,124 @@
 Preparing a New Release
 =======================
 
-Before the Release
-------------------
+A release is prepared on a short-lived release branch, merged into ``master``,
+tagged, and then mirrored to ``stable``. The tag is the canonical release
+commit; wheels and the source distribution must be built from that commit.
 
-*  Make a new PR to ``master`` with up-to-date Release Notes
-   "doc/users/release_notes.rst". You might have to go through all the past PRs
-   to make sure all work is adequately represented.
+Prepare the release
+-------------------
 
-*  Make sure the version number is set correctly in "pulse2percept/pyproject.toml".
-   In specific, the ``version`` variable should not contain a ``.dev0`` substring.
+Create a release branch from an up-to-date ``master``:
 
-Uploading the Release to PyPI
------------------------------
+.. code-block:: bash
 
-pulse2percept wheels are built using GitHub Actions ``wheels.yml``.
+    git checkout master
+    git pull
+    git checkout -b release-X.Y
 
-.. important::
+On the release branch:
 
-    Before uploading the wheels to PyPI, make sure they work! You don't have to
-    try all the wheels, but common problems are with Cython (and OpenMP) on
-    Windows vs Unix.
-    You can install a wheel via ``pip install <name>.wheel``
+* Update ``doc/users/release_notes.rst``.
+* Set the final version in ``pyproject.toml`` (for example, ``0.10.0`` rather
+  than ``0.10.0.dev0``).
+* Run the test suite and build the documentation.
 
-The following recipe will upload the files to TestPyPI:
+Open a PR from the release branch into ``master`` and merge it once CI passes.
 
-.. code-block:: python
+Tag the release
+---------------
 
-    cd pulse2percept
+Update your local ``master`` and tag the merged release commit:
 
-    # Clear out your 'dist' folder.
-    rm -rf dist
-    # Make a source distribution
-    python setup.py sdist
+.. code-block:: bash
 
-    # Go and download your wheel files from wherever you put them. e.g. your CI
-    # provider can be configured to store them for you. Put them all into the
-    # 'dist' folder.
-    wget ...
+    git checkout master
+    git pull
+    git tag -a vX.Y.Z -m "pulse2percept X.Y.Z"
+    git push origin vX.Y.Z
 
-    # Or for TestPyPI:
-    twine upload --repository-url https://test.pypi.org/legacy/ dist/*
+The ``v*`` tag triggers the GitHub Actions wheel build. These tag-built wheels,
+rather than wheels from an earlier PR or ``master`` build, are the release
+artifacts.
 
-Install the package from TestPyPI and make sure it works.
-If everything looks good, upload the wheels to the real PyPI:
+Update ``stable`` to point at the same commit:
 
-.. code-block:: python
+.. code-block:: bash
 
-    # Upload using 'twine' (you may need to 'pip install twine')
-    twine upload dist/*
+    git push origin vX.Y.Z:stable --force
 
-Make sure the ``pip install`` command works e.g. on Google Colab.
-If not, you will need to fix the wheels and upload them under a new 
-patch number (e.g., v0.9.1 instead of v0.9.0).
+After this step,
 
-.. _cibuildwheel: https://github.com/joerick/cibuildwheel
-.. _PR194: https://github.com/joerick/cibuildwheel/pull/194
+.. code-block:: text
 
-Releasing the code on GitHub
+    stable == vX.Y.Z == release commit
+
+This keeps the ReadTheDocs ``stable`` branch tied to a released version even if
+new commits are merged into ``master`` immediately afterward.
+
+Build and test the artifacts
 ----------------------------
 
-*  Make ``stable`` identical to ``master`` with a reset + force push:
+While GitHub Actions builds the wheels, create the source distribution from the
+tagged commit:
 
-   .. code-block:: bash
+.. code-block:: bash
 
-       git checkout stable
-       git reset --hard master
-       git push origin stable --force
+    git checkout vX.Y.Z
+    rm -rf dist
+    python -m build --sdist
 
-   This is cleaner than squash and merge. Either way, it's important
-   for ReadTheDocs that every single commit on the ``stable`` branch 
-   matches a release.
+Download the wheels produced by the tag-triggered ``Wheels`` workflow and place
+them alongside the source distribution in ``dist/``:
 
-*  Draft a new release on PR and tag it with "vX.Y".
-   Upload all the wheels you downloaded as artifacts from GitHub Actions
-   above.
+.. code-block:: text
+
+    dist/
+    ├── pulse2percept-X.Y.Z.tar.gz
+    ├── pulse2percept-X.Y.Z-cp311-...whl
+    ├── pulse2percept-X.Y.Z-cp312-...whl
+    └── ...
+
+Check the artifacts before uploading them:
+
+.. code-block:: bash
+
+    twine check dist/*
+
+It is strongly recommended to upload to TestPyPI first:
+
+.. code-block:: bash
+
+    twine upload --repository testpypi dist/*
+
+Install the package from TestPyPI and smoke-test it on at least one common
+platform. Pay particular attention to Cython/OpenMP behavior on Windows,
+Linux, and macOS.
+
+If the artifacts are good, upload the same files to PyPI:
+
+.. code-block:: bash
+
+    twine upload dist/*
+
+Once a version has been uploaded to PyPI, its files cannot be replaced. If a
+release artifact is broken, fix the problem and publish a new patch release.
+
+Publish the GitHub release
+--------------------------
+
+Create a GitHub Release for ``vX.Y.Z`` using the release notes. Attach the same
+source distribution and wheels if desired.
 
 After the release
 -----------------
 
-*  Bump the version number in "pulse2percept/pyproject.toml", add back the ".0dev"
-   appendix, and add an entry for the next release in 
-   "doc/users/release_notes.rst". Then commit to ``master``.
+Return to ``master`` and prepare the next development version:
+
+* Set the version in ``pyproject.toml`` to the next ``.dev0`` version.
+* Add an empty section for the next release to
+  ``doc/users/release_notes.rst``.
+* Commit these changes to ``master``.
+
+For example, after releasing ``0.10.0``, development continues as
+``0.11.0.dev0``.

--- a/doc/getting_started.rst
+++ b/doc/getting_started.rst
@@ -1,8 +1,11 @@
 .. _getting-started:
 
 ===============
-Getting started
+Getting Started
 ===============
+
+Hello world
+-----------
 
 A pulse2percept simulation usually has three parts:
 
@@ -36,7 +39,7 @@ what is delivered, and the model predicts the resulting response.
 Physical quantities can be written explicitly with :mod:pulse2percept.units; 
 bare numbers are also accepted in the documented canonical units.
 
-Images and videos
+Images and Videos
 -----------------
 
 Images and videos must first be translated into electrical stimulation. The

--- a/doc/getting_started.rst
+++ b/doc/getting_started.rst
@@ -1,0 +1,60 @@
+.. _getting-started:
+
+===============
+Getting started
+===============
+
+A pulse2percept simulation usually has three parts:
+
+1. Choose a visual prosthesis.
+2. Assign it a stimulus.
+3. Use a model to predict the resulting percept.
+
+For example:
+
+.. code-block:: python
+
+    import pulse2percept as p2p
+    from pulse2percept.units import Hz, ms, uA
+
+    implant = p2p.implants.ArgusII(
+        stim={'A5': p2p.stimuli.BiphasicPulseTrain(
+            freq=20 * Hz,
+            amp=50 * uA,
+            phase_dur=0.45 * ms,
+        )}
+    )
+
+    model = p2p.models.AxonMapModel().build()
+    percept = model.predict_percept(implant)
+
+    percept.plot()
+
+The implant describes where stimulation is delivered, the stimulus describes
+what is delivered, and the model predicts the resulting response.
+
+Physical quantities can be written explicitly with :mod:pulse2percept.units; 
+bare numbers are also accepted in the documented canonical units.
+
+Images and videos
+-----------------
+
+Images and videos must first be translated into electrical stimulation. The
+easiest way is to give the implant an encoder:
+
+.. code-block:: python
+
+    implant = p2p.implants.ArgusII(
+        encoder=p2p.stimuli.AmplitudeEncoder(
+            amp_range=(0, 50 * uA),
+            freq=20 * Hz,
+        )
+    )
+    implant.stim = p2p.stimuli.BostonTrain()
+
+    percept = model.predict_percept(implant)
+    percept.play()
+
+From here, the :ref:`basic concepts <topics-index>` explain each part of the
+pipeline in more detail, and the :ref:`examples <sphx_glr_examples>` show
+complete simulations.

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -1,12 +1,13 @@
 .. _topics-index:
 
 .. toctree::
-   :caption: First steps
+   :caption: Getting started
    :hidden:
    :maxdepth: 1
 
    Overview <self>
    install
+   getting_started
    examples/index
 
 .. toctree::

--- a/doc/topics/datasets.rst
+++ b/doc/topics/datasets.rst
@@ -4,64 +4,41 @@
 Datasets
 ========
 
-The :py:mod:`~pulse2percept.datasets` module provides two kinds of helper
-functions that can be used to load datasets from the bionic vision community:
+The :py:mod:`~pulse2percept.datasets` module provides loaders for small bundled
+datasets and fetchers for larger downloadable datasets.
 
-*  **Dataset loaders** can be used to load small datasets that come
-   pre-packaged with the pulse2percept software.
+.. list-table::
+   :header-rows: 1
 
-   *  :py:func:`~pulse2percept.datasets.load_horsager2009`: Load the threshold
-      data from [Horsager2009]_.
+   * - Function
+     - Dataset
+   * - :py:func:`~pulse2percept.datasets.load_horsager2009`
+     - Threshold data from [Horsager2009]_
+   * - :py:func:`~pulse2percept.datasets.load_nanduri2012`
+     - Brightness ratings from [Nanduri2012]_
+   * - :py:func:`~pulse2percept.datasets.load_perezfornos2012`
+     - Phosphene fading from [PerezFornos2012]_
+   * - :py:func:`~pulse2percept.datasets.fetch_beyeler2019`
+     - Phosphene drawings from [Beyeler2019]_
+   * - :py:func:`~pulse2percept.datasets.fetch_han2021`
+     - Outdoor scenes from [Han2021]_
 
-   *  :py:func:`~pulse2percept.datasets.load_nanduri2012`: Load the brightness
-      rating data from [Nanduri2012]_.
+Pandas is required for tabular datasets; some datasets also require HDF5 via
+``h5py``.
 
-   *  :py:func:`~pulse2percept.datasets.load_perezfornos2012`: Load the phosphene
-      fading data from [PerezFornos2012]_.
+Downloaded data
+---------------
 
-*  **Dataset fetchers** can be used to download larger datasets from a given
-   URL and directly import them into pulse2percept.
-
-   *  :py:func:`~pulse2percept.datasets.fetch_beyeler2019`: Download and load
-      the phosphene drawing dataset from [Beyeler2019]_.
-
-   *  :py:func:`~pulse2percept.datasets.fetch_han2021`: Download and load
-      the outdoor scenes from [Han2021]_.
-
-.. note::
-
-    You will need Pandas (``pip install pandas``) to load the data.
-    Some datasets also require HDF5 (``pip install h5py``).
-
-Local data directory
---------------------
-
-By default, all datasets are downloaded to a directory called
-'pulse2percept_data' located in the user home directory.
-This directory is used as a cache so that large datasets don't have to be
-downloaded repeatedly.
-
-Alternatively, the directory can be set by a `PULSE2PERCEPT_DATA` environment
-variable, or passed directly to the fetcher.
-
-You can retrieve the current data directory as follows:
+Fetched datasets are cached in ``~/pulse2percept_data`` by default. Set the
+``PULSE2PERCEPT_DATA`` environment variable or pass a data directory directly
+to a fetcher to use another location.
 
 .. code-block:: python
 
     import pulse2percept as p2p
+
     p2p.datasets.get_data_dir()
-
-You can delete the folder and all its contents as follows:
-
-.. code-block:: python
-
-    import pulse2percept as p2p
     p2p.datasets.clear_data_dir()
 
-.. note ::
-
-    Make sure you have write access to the specified data directory.
-
-.. .. minigallery:: pulse2percept.datasets.load_horsager2009
-..     :add-heading: Examples using datasets
-..     :heading-level: -
+``clear_data_dir`` removes the cached files, so the next fetch downloads them
+again.

--- a/doc/topics/encoders.rst
+++ b/doc/topics/encoders.rst
@@ -6,71 +6,45 @@ Stimulus Encoders
 
 .. versionadded:: 0.10.0
 
-A visual prosthesis does not stimulate with pixels. It stimulates with
-electrical pulses. An :py:class:`~pulse2percept.stimuli.StimulusEncoder` defines how
-the gray levels of an image or video are turned into those pulses:
+A visual source contains gray levels; an implant delivers electrical pulses. A
+:py:class:`~pulse2percept.stimuli.StimulusEncoder` defines the mapping between
+the two.
 
-::
+Basic usage
+-----------
 
-    image / video -> Encoder -> electrical Stimulus -> implant -> model -> Percept
-
-The encoder is therefore **not a perceptual model**. It produces the electrical
-:py:class:`~pulse2percept.stimuli.Stimulus` that a model receives through an
-implant.
-
-The usual workflow
-------------------
-
-For example, an :py:class:`~pulse2percept.stimuli.AmplitudeEncoder` maps image
-brightness onto pulse amplitude while keeping pulse frequency fixed. Give the
-implant an encoder, and assigning an image or a video encodes it:
+Attach an encoder to an implant, then assign an image or video:
 
 .. code-block:: python
 
     import pulse2percept as p2p
-    from pulse2percept.units import uA, Hz
 
     implant = p2p.implants.ArgusII()
     implant.encoder = p2p.stimuli.AmplitudeEncoder(
-        amp_range=(0, 50 * uA),
-        freq=20 * Hz,
+        amp_range=(0, 50),
+        freq=20,
     )
+    implant.stim = p2p.stimuli.BostonTrain()
 
-    source = p2p.stimuli.BostonTrain()
-    implant.stim = source
+Dimensionless input is encoded on assignment. Electrical stimuli bypass the
+encoder.
 
-    model = p2p.models.ScoreboardModel().build()
-    percept = model.predict_percept(implant)
-
-Here a gray level of 0 maps to 0 uA, a gray level of 1 maps to 50 uA, and every
-electrode is driven at 20 Hz. ``implant.stim`` is the actual biphasic pulse
-trains that result.
-
-Encoding explicitly
--------------------
-
-You can also encode a source yourself and assign the result:
+Encoding can also be explicit:
 
 .. code-block:: python
 
-    encoder = p2p.stimuli.AmplitudeEncoder(
-        amp_range=(0, 50 * uA),
-        freq=20 * Hz,
-    )
-    stim = encoder.encode(source, implant=implant)
+    source = p2p.stimuli.BostonTrain()
+    stim = implant.encoder.encode(source, implant=implant)
     implant.stim = stim
 
-Passing ``implant`` samples the image or video at the implant's electrode
-locations before pulse trains are constructed. This is usually what you want:
-the resulting stimulus has one row per electrode, with electrode names that
-match the implant. Leave it out and every source pixel is treated as its own
-electrode instead, which can be useful for custom workflows but can also
-produce unnecessarily large stimuli.
+Passing the implant samples the source at its electrode locations before pulse
+trains are constructed, so the resulting Stimulus has one row per implant
+electrode.
 
-Amplitude or frequency?
------------------------
+Amplitude and frequency encoding
+--------------------------------
 
-pulse2percept currently provides two basic encoders:
+pulse2percept provides two basic encoders:
 
 .. list-table::
    :header-rows: 1
@@ -78,118 +52,44 @@ pulse2percept currently provides two basic encoders:
    * - Encoder
      - Gray level controls
    * - :py:class:`~pulse2percept.stimuli.AmplitudeEncoder`
-     - Pulse amplitude; frequency is fixed.
+     - Pulse amplitude
    * - :py:class:`~pulse2percept.stimuli.FrequencyEncoder`
-     - Pulse frequency; amplitude is fixed.
+     - Pulse frequency
 
-Amplitude encoding is the simplest place to start. Frequency encoding works the
-same way from the user's point of view:
+Amplitude encoding keeps frequency fixed. Frequency encoding keeps amplitude
+fixed:
 
 .. code-block:: python
 
     implant.encoder = p2p.stimuli.FrequencyEncoder(
-        amp=50 * uA,
-        freq_range=(0, 60 * Hz),
-    )
-    implant.stim = source
-
-A gray level of 0 then maps to 0 Hz and a gray level of 1 to 60 Hz, with pulse
-amplitude fixed at 50 uA. How high the range can go depends on the implant's
-raster: a sweep through its groups has to fit inside the shortest pulse period
-requested. See :ref:`topics-rasters`.
-
-Frames and pulses have separate clocks
---------------------------------------
-
-For video, a new frame changes the gray level seen by each electrode and hence
-the amplitude or frequency being requested. It does **not** restart the pulse
-train. Pulses run on their own continuous clock, so video frame rate and pulse
-frequency are independent quantities.
-
-This means, for example, that a 30 fps video can be encoded at 20 Hz or 100 Hz.
-If the pulse rate is lower than the frame rate, some frames may never coincide
-with a pulse and therefore contribute no stimulation; the encoder warns when
-that happens.
-
-What the encoded stimulus is
-----------------------------
-
-:py:meth:`~pulse2percept.stimuli.StimulusEncoder.encode` returns the **delivered
-electrical stimulus**: the biphasic pulse trains the device would actually
-emit, on the device's own timing. Its waveform is generated only when
-something asks for samples, so encoding a video onto a large implant is cheap
-until a model needs the pulses.
-
-The stimulus also remembers what was *asked* of each electrode, which is what
-lets each kind of model read the half it can express:
-
-* A purely spatial model (:py:class:`~pulse2percept.models.ScoreboardModel`,
-  :py:class:`~pulse2percept.models.AxonMapModel`) has no clock, so it reads the
-  frame-level modulation: one amplitude per electrode per frame of the source.
-  It never sees the pulse timing, and never generates the waveform.
-* A temporal or combined model integrates the delivered pulses, because that
-  is what such a model is for.
-
-This does not depend on how the stimulus got to the implant. Encoding by hand
-and assigning the result is the same thing as letting the implant encode:
-
-.. code-block:: python
-
-    implant.stim = encoder.encode(source, implant=implant)   # these two
-
-    implant.encoder = encoder                                # ... are the same
-    implant.stim = source
-
-.. versionchanged:: 0.10.0
-    A spatial model reads the frame-level modulation of any encoded stimulus.
-    Previously only stimuli encoded during assignment to an implant were read
-    that way, and a hand-encoded one came out as a sequence of raster slots.
-
-Hardware constraints, when you need them
-----------------------------------------
-
-The defaults describe the requested stimulation without imposing a particular
-stimulator. Optional parameters let you add hardware constraints later:
-
-``clock``
-    Quantizes pulse timing to the stimulator's time base.
-
-``n_levels``
-    Quantizes input gray levels before they are mapped onto stimulation.
-
-The raster -- which groups of electrodes may stimulate at the same time -- is
-a property of the device rather than of the encoder, so it is set on the
-implant (``implant.raster``) and picked up from there. See
-:ref:`topics-rasters`.
-
-These constraints never make an electrode pulse faster than requested. Timing
-is rounded conservatively so that an unrealizable pulse period becomes a
-slower realizable one rather than a faster one.
-
-Physical units
---------------
-
-Encoder parameters accept both the usual bare numbers and unitful quantities:
-
-.. code-block:: python
-
-    import pulse2percept.units as u
-
-    encoder = p2p.stimuli.AmplitudeEncoder(
-        amp_range=(0 * u.uA, 0.05 * u.mA),
-        freq=20 * u.Hz,
-        phase_dur=460 * u.us,
+        amp=50,
+        freq_range=(0, 60),
     )
 
-The encoded stimulus itself uses pulse2percept's canonical stimulus units:
-current in microamps and time in milliseconds. See :ref:`topics-units` for the
-full units convention.
+For video, pulse timing is continuous across frame boundaries. The video frame
+rate determines when requested modulation changes; it does not restart the
+pulse train.
 
-.. seealso::
+What an encoded stimulus contains
+---------------------------------
 
-    * :py:class:`pulse2percept.stimuli.StimulusEncoder` for the common encoder options
-    * :py:class:`pulse2percept.stimuli.AmplitudeEncoder`
-    * :py:class:`pulse2percept.stimuli.FrequencyEncoder`
-    * :ref:`Electrical Stimuli <topics-stimuli>`
-    * :ref:`Physical Units <topics-units>`
-    * :ref:`Computational Models <topics-models>`
+An encoded Stimulus retains both the requested frame-level modulation and the
+delivered pulse schedule. Spatial-only models use the frame-level modulation;
+temporal models use the delivered electrical pulses. The result is the same
+whether encoding happened explicitly or during assignment to the implant.
+
+Waveform samples are generated lazily, so encoding a large image or video does
+not allocate the full electrical waveform until something needs it.
+
+Device constraints
+------------------
+
+An implant's :py:class:`~pulse2percept.implants.Raster` determines which
+electrodes may pulse together; see :ref:`topics-rasters`.
+
+Encoders can also quantize timing with ``clock`` and gray levels with
+``n_levels``. These constraints are conservative: quantization may lower a
+requested pulse rate, but never increases it.
+
+Encoder amplitudes, frequencies, and durations follow the physical-unit
+conventions in :ref:`topics-units`.

--- a/doc/topics/implants.rst
+++ b/doc/topics/implants.rst
@@ -4,58 +4,33 @@
 Visual Prostheses
 =================
 
-An implant in pulse2percept describes **where stimulation is delivered**:
-the electrodes, their geometry, their location, and the stimulus assigned to
-them. It fits into the modeling pipeline like so:
+An implant describes where stimulation is delivered: its electrodes, their
+geometry and location, and the stimulus assigned to them. The implant does not
+predict vision; that is the model's job.
 
-::
+All implants derive from
+:py:class:`~pulse2percept.implants.ProsthesisSystem`. The attributes used most
+often are:
 
-    electrical Stimulus -> implant -> model -> Percept
+``earray``
+    The :py:class:`~pulse2percept.implants.ElectrodeArray`.
 
-The implant says where the stimulation goes. The
-:ref:`percept model <topics-models>` says how that stimulation is transformed
-into a visual percept.
+``stim``
+    The :py:class:`~pulse2percept.stimuli.Stimulus` assigned to the implant.
 
-Choosing an implant and model
------------------------------
+``eye``
+    The implanted eye for retinal systems.
 
-The best model depends first on **where the implant stimulates**. A useful
-starting point is:
+``encoder`` and ``raster``
+    Optional device behavior used when visual input is converted to electrical
+    stimulation. These are covered later in :ref:`topics-encoders` and
+    :ref:`topics-rasters`.
 
-.. list-table::
-   :header-rows: 1
+Basic use
+---------
 
-   * - Implant location
-     - Good starting model
-     - Why
-   * - Epiretinal
-     - :py:class:`~pulse2percept.models.AxonMapModel`
-     - Epiretinal stimulation can activate retinal ganglion-cell axons,
-       producing elongated percepts that follow nerve fiber bundles.
-   * - Subretinal
-     - :py:class:`~pulse2percept.models.ScoreboardModel`
-     - A local "one electrode, one blob" model is a useful first approximation
-       when axonal activation is not the main effect of interest.
-   * - Suprachoroidal
-     - :py:class:`~pulse2percept.models.ScoreboardModel`
-     - pulse2percept does not currently provide a dedicated suprachoroidal
-       phosphene model, so the scoreboard model is a simple geometry-first
-       baseline.
-   * - Cortical
-     - :py:class:`~pulse2percept.models.cortex.ScoreboardModel`
-     - Cortical stimulation is mapped through cortical retinotopy rather than
-       the retinal nerve fiber layer.
-
-These are **starting points, not compatibility rules**. For example,
-:py:class:`~pulse2percept.models.ScoreboardModel` is also a useful baseline for
-an epiretinal implant when axonal streaking is not part of the question. More
-detailed retinal models should be chosen because their physiological
-assumptions match the experiment, not simply because they are more complex.
-
-A minimal example
------------------
-
-For an epiretinal implant such as Argus II, a typical simulation looks like:
+Electrodes can be accessed by name or index, and the array can be plotted
+directly:
 
 .. code-block:: python
 
@@ -63,403 +38,75 @@ For an epiretinal implant such as Argus II, a typical simulation looks like:
 
     implant = p2p.implants.ArgusII()
 
-    implant.encoder = p2p.stimuli.AmplitudeEncoder(
-        amp_range=(0, 50), freq=20
-    )
-    implant.stim = p2p.stimuli.BostonTrain()
-
-    model = p2p.models.AxonMapModel().build()
-    percept = model.predict_percept(implant)
-
-    percept.play()
-
-Changing the implant changes the electrode geometry. Changing the model changes
-the assumptions about how stimulation becomes vision.
+    implant['A8']
+    implant[0]
+    implant.electrode_names
+    implant.earray.coordinates()
+    implant.plot()
 
 Available implants
 ------------------
 
 pulse2percept includes software representations of several published visual
-prostheses. The table below emphasizes **array geometry** and **which model to
-start with**, rather than device manufacturer.
+prostheses:
 
 .. list-table::
    :header-rows: 1
-   :widths: 18 22 18 42
 
-   * - Implant
-     - Array
-     - Location
-     - Suggested starting model
+   * - Location
+     - Implants
+   * - Epiretinal
+     - :py:class:`~pulse2percept.implants.ArgusI`,
+       :py:class:`~pulse2percept.implants.ArgusII`,
+       :py:class:`~pulse2percept.implants.IMIE`
+   * - Subretinal
+     - :py:class:`~pulse2percept.implants.AlphaIMS`,
+       :py:class:`~pulse2percept.implants.AlphaAMS`,
+       :py:class:`~pulse2percept.implants.PRIMA`,
+       :py:class:`~pulse2percept.implants.PRIMA75`,
+       :py:class:`~pulse2percept.implants.PRIMA55`,
+       :py:class:`~pulse2percept.implants.PRIMA40`
+   * - Suprachoroidal
+     - :py:class:`~pulse2percept.implants.BVT24`,
+       :py:class:`~pulse2percept.implants.BVT44`
+   * - Cortical
+     - :py:class:`~pulse2percept.implants.cortex.Orion`,
+       :py:class:`~pulse2percept.implants.cortex.Cortivis`,
+       :py:class:`~pulse2percept.implants.cortex.ICVP`,
+       :py:class:`~pulse2percept.implants.cortex.Neuralink`
 
-   * - :py:class:`~pulse2percept.implants.ArgusI`
-     -
-       .. plot::
-          :width: 110px
-          :align: center
-          :include-source: false
-          :show-source-link: false
-          :caption:
-
-          import matplotlib.pyplot as plt
-          import pulse2percept as p2p
-          p2p.implants.ArgusI().plot(annotate=False)
-          plt.axis("off")
-
-     - Epiretinal
-     - :py:class:`~pulse2percept.models.AxonMapModel`
-
-   * - :py:class:`~pulse2percept.implants.ArgusII`
-     -
-       .. plot::
-          :width: 110px
-          :align: center
-          :include-source: false
-          :show-source-link: false
-          :caption:
-
-          import matplotlib.pyplot as plt
-          import pulse2percept as p2p
-          p2p.implants.ArgusII().plot(annotate=False)
-          plt.axis("off")
-
-     - Epiretinal
-     - :py:class:`~pulse2percept.models.AxonMapModel`
-
-   * - :py:class:`~pulse2percept.implants.IMIE`
-     -
-       .. plot::
-          :width: 110px
-          :align: center
-          :include-source: false
-          :show-source-link: false
-          :caption:
-
-          import matplotlib.pyplot as plt
-          import pulse2percept as p2p
-          p2p.implants.IMIE().plot(annotate=False)
-          plt.axis("off")
-
-     - Epiretinal
-     - :py:class:`~pulse2percept.models.AxonMapModel`
-
-   * - :py:class:`~pulse2percept.implants.AlphaIMS`
-     -
-       .. plot::
-          :width: 110px
-          :align: center
-          :include-source: false
-          :show-source-link: false
-          :caption:
-
-          import matplotlib.pyplot as plt
-          import pulse2percept as p2p
-          p2p.implants.AlphaIMS().plot(annotate=False)
-          plt.axis("off")
-
-     - Subretinal
-     - :py:class:`~pulse2percept.models.ScoreboardModel`
-
-   * - :py:class:`~pulse2percept.implants.AlphaAMS`
-     -
-       .. plot::
-          :width: 110px
-          :align: center
-          :include-source: false
-          :show-source-link: false
-          :caption:
-
-          import matplotlib.pyplot as plt
-          import pulse2percept as p2p
-          p2p.implants.AlphaAMS().plot(annotate=False)
-          plt.axis("off")
-
-     - Subretinal
-     - :py:class:`~pulse2percept.models.ScoreboardModel`
-
-   * - :py:class:`~pulse2percept.implants.PRIMA`
-     -
-       .. plot::
-          :width: 110px
-          :align: center
-          :include-source: false
-          :show-source-link: false
-          :caption:
-
-          import matplotlib.pyplot as plt
-          import pulse2percept as p2p
-          p2p.implants.PRIMA().plot(annotate=False)
-          plt.axis("off")
-
-     - Subretinal
-     - :py:class:`~pulse2percept.models.ScoreboardModel`
-
-   * - :py:class:`~pulse2percept.implants.PRIMA75`
-     -
-       .. plot::
-          :width: 110px
-          :align: center
-          :include-source: false
-          :show-source-link: false
-          :caption:
-
-          import matplotlib.pyplot as plt
-          import pulse2percept as p2p
-          p2p.implants.PRIMA75().plot(annotate=False)
-          plt.axis("off")
-
-     - Subretinal
-     - :py:class:`~pulse2percept.models.ScoreboardModel`
-
-   * - :py:class:`~pulse2percept.implants.PRIMA55`
-     -
-       .. plot::
-          :width: 110px
-          :align: center
-          :include-source: false
-          :show-source-link: false
-          :caption:
-
-          import matplotlib.pyplot as plt
-          import pulse2percept as p2p
-          p2p.implants.PRIMA55().plot(annotate=False)
-          plt.axis("off")
-
-     - Subretinal
-     - :py:class:`~pulse2percept.models.ScoreboardModel`
-
-   * - :py:class:`~pulse2percept.implants.PRIMA40`
-     -
-       .. plot::
-          :width: 110px
-          :align: center
-          :include-source: false
-          :show-source-link: false
-          :caption:
-
-          import matplotlib.pyplot as plt
-          import pulse2percept as p2p
-          p2p.implants.PRIMA40().plot(annotate=False)
-          plt.axis("off")
-
-     - Subretinal
-     - :py:class:`~pulse2percept.models.ScoreboardModel`
-
-   * - :py:class:`~pulse2percept.implants.BVT24`
-     -
-       .. plot::
-          :width: 110px
-          :align: center
-          :include-source: false
-          :show-source-link: false
-          :caption:
-
-          import matplotlib.pyplot as plt
-          import pulse2percept as p2p
-          p2p.implants.BVT24().plot(annotate=False)
-          plt.axis("off")
-
-     - Suprachoroidal
-     - :py:class:`~pulse2percept.models.ScoreboardModel`
-
-   * - :py:class:`~pulse2percept.implants.BVT44`
-     -
-       .. plot::
-          :width: 110px
-          :align: center
-          :include-source: false
-          :show-source-link: false
-          :caption:
-
-          import matplotlib.pyplot as plt
-          import pulse2percept as p2p
-          p2p.implants.BVT44().plot(annotate=False)
-          plt.axis("off")
-
-     - Suprachoroidal
-     - :py:class:`~pulse2percept.models.ScoreboardModel`
-
-   * - :py:class:`~pulse2percept.implants.cortex.Orion`
-     -
-       .. plot::
-          :width: 110px
-          :align: center
-          :include-source: false
-          :show-source-link: false
-          :caption:
-
-          import matplotlib.pyplot as plt
-          import pulse2percept as p2p
-          p2p.implants.cortex.Orion().plot(annotate=False)
-          plt.axis("off")
-
-     - Cortical
-     - :py:class:`~pulse2percept.models.cortex.ScoreboardModel`
-
-   * - :py:class:`~pulse2percept.implants.cortex.Cortivis`
-     -
-       .. plot::
-          :width: 110px
-          :align: center
-          :include-source: false
-          :show-source-link: false
-          :caption:
-
-          import matplotlib.pyplot as plt
-          import pulse2percept as p2p
-          p2p.implants.cortex.Cortivis().plot(annotate=False)
-          plt.axis("off")
-
-     - Cortical
-     - :py:class:`~pulse2percept.models.cortex.ScoreboardModel`
-
-   * - :py:class:`~pulse2percept.implants.cortex.ICVP`
-     -
-       .. plot::
-          :width: 110px
-          :align: center
-          :include-source: false
-          :show-source-link: false
-          :caption:
-
-          import matplotlib.pyplot as plt
-          import pulse2percept as p2p
-          p2p.implants.cortex.ICVP().plot(annotate=False)
-          plt.axis("off")
-
-     - Cortical
-     - :py:class:`~pulse2percept.models.cortex.ScoreboardModel`
-
-   * - :py:class:`~pulse2percept.implants.cortex.Neuralink`
-     -
-       .. plot::
-          :width: 110px
-          :align: center
-          :include-source: false
-          :show-source-link: false
-          :caption:
-
-          import matplotlib.pyplot as plt
-          import pulse2percept as p2p
-          # Threads are placed by hand (or by ``from_neuropythy``) and run into
-          # cortex, so a top-down 2D plot would collapse each one to a dot:
-          threads = [p2p.implants.cortex.LinearEdgeThread(x, y)
-                     for x in (-500, 500) for y in (-500, 500)]
-          p2p.implants.cortex.Neuralink(threads).plot3D()
-          plt.axis("off")
-
-     - Cortical
-     - :py:class:`~pulse2percept.models.cortex.ScoreboardModel`
-
-These classes are **research software representations based on published
-descriptions**, not manufacturer-validated device simulators. Some geometries
-necessarily rely on assumptions where complete device specifications are not
-public; the API documentation for each class records those details.
-
-What an implant contains
-------------------------
-
-Every visual prosthesis derives from
-:py:class:`~pulse2percept.implants.ProsthesisSystem`. The pieces you will use
-most often are:
-
-``earray``
-    The :py:class:`~pulse2percept.implants.ElectrodeArray` containing the
-    electrodes and their locations.
-
-``stim``
-    The electrical :py:class:`~pulse2percept.stimuli.Stimulus` currently
-    assigned to the implant.
-
-``eye``
-    The implanted eye for retinal systems.
-
-``raster``
-    An optional :py:class:`~pulse2percept.implants.Raster` describing which
-    electrodes may stimulate at the same time.
-
-Electrodes can be accessed by name or index:
-
-.. code-block:: python
-
-    implant = p2p.implants.ArgusII()
-
-    implant['A1']
-    implant[0]
-    implant.electrode_names
-    implant.earray.coordinates()
-
-The easiest way to understand an implant geometry is often simply to plot it:
-
-.. code-block:: python
-
-    implant.plot(annotate=True)
+These classes are research-software representations based on published device
+descriptions, not manufacturer-validated simulators. See each class's API
+documentation for geometry-specific assumptions.
 
 Coordinate systems
 ------------------
 
-Retinal implants use a coordinate system centered on the fovea. Distances are
-stored in microns:
+Retinal implants are centered on the fovea and store distances in microns.
+Positive ``x`` points toward nasal retina, positive ``y`` toward superior
+retina, and positive ``z`` away from the retina into the vitreous. ``eye``
+handles left- versus right-eye geometry where needed.
 
-* positive ``x`` points toward the nasal retina;
-* positive ``y`` points toward the superior retina;
-* positive ``z`` moves away from the retina and into the vitreous.
+Cortical implants use physical cortical coordinates. A cortical model combines
+those coordinates with a
+:py:class:`~pulse2percept.topography.VisualFieldMap` to place stimulation in
+the visual field.
 
-The ``eye`` parameter handles the corresponding left- versus right-eye
-geometry where needed.
+Custom implants
+---------------
 
-Cortical implants live in physical cortical coordinates instead. A cortical
-model combines those electrode locations with a
-:py:class:`~pulse2percept.topography.VisualFieldMap` to determine where
-stimulation falls in the visual field. That is why cortical implants use the
-models in :py:mod:`pulse2percept.models.cortex`, rather than retinal models
-such as the Axon Map Model.
-
-Building your own implant
--------------------------
-
-For a custom array, you usually do not need a new implant class. An
-:py:class:`~pulse2percept.implants.ElectrodeGrid` can be wrapped directly in a
+A custom array usually does not need a new implant class. Wrap an
+:py:class:`~pulse2percept.implants.ElectrodeGrid` in a
 :py:class:`~pulse2percept.implants.ProsthesisSystem`:
 
 .. code-block:: python
 
     from pulse2percept.implants import ElectrodeGrid, ProsthesisSystem
 
-    earray = ElectrodeGrid(
-        shape=(10, 10),
-        spacing=500,
-    )
+    earray = ElectrodeGrid(shape=(10, 10), spacing=500)
     implant = ProsthesisSystem(earray=earray)
 
 For irregular arrays, build an
-:py:class:`~pulse2percept.implants.ElectrodeArray` from individual electrode
-objects. :py:class:`~pulse2percept.implants.EnsembleImplant` can combine
-multiple implants into one system.
-
-The implant geometry and percept model remain separate, so a custom implant can
-be paired with whichever model best matches the stimulation target and the
-scientific question.
-
-Rastering
----------
-
-Some stimulators cannot drive every electrode simultaneously. Raster strategies
-split an array into groups that take turns:
-
-.. code-block:: python
-
-    implant.raster = p2p.implants.CheckerboardRaster(n_groups=5)
-
-The encoder uses that schedule when constructing the electrical stimulus. See
-:ref:`topics-rasters` for the details.
-
-.. seealso::
-
-    * :py:mod:`pulse2percept.implants` for the implant API
-    * :py:mod:`pulse2percept.implants.cortex` for cortical implant classes
-    * :ref:`Stimulus Encoders <topics-encoders>`
-    * :ref:`Raster Strategies <topics-rasters>`
-    * :ref:`Electrical Stimuli <topics-stimuli>`
-    * :ref:`Computational Models <topics-models>`
-    * :ref:`Physical Units <topics-units>`
+:py:class:`~pulse2percept.implants.ElectrodeArray` from individual electrodes.
+:py:class:`~pulse2percept.implants.EnsembleImplant` combines multiple implants
+into one system.

--- a/doc/topics/models.rst
+++ b/doc/topics/models.rst
@@ -4,247 +4,108 @@
 Computational Models
 ====================
 
-The :py:mod:`~pulse2percept.models` module provides a number of published
-and verified computational models that can be used to predict neural responses
-or visual percepts resulting from electrical stimulation.
+A model predicts the response to stimulation. Most users work with
+:py:class:`~pulse2percept.models.Model`, which can contain a spatial component,
+a temporal component, or both:
 
-A :py:class:`~pulse2percept.models.Model` object consists of:
+* :py:class:`~pulse2percept.models.SpatialModel` determines where stimulation
+  appears in the visual field.
+* :py:class:`~pulse2percept.models.TemporalModel` determines how the response
+  evolves over time.
 
-*  a :py:class:`~pulse2percept.models.SpatialModel`, describing how electrical
-   stimulation affects the neural tissue or elicited phosphene
-   *in different spatial locations of the visual field*, and/or
-*  a :py:class:`~pulse2percept.models.TemporalModel`, describing how the
-   response of the neural tissue or elicited phosphene evolves *over time*.
+Available models
+----------------
 
-pulse2percept provides the following computational models:
+.. list-table::
+   :header-rows: 1
 
-================  =========================  ===================
-Reference         Model                      Type
-----------------  -------------------------  -------------------
-generic           `FadingTemporal`           temporal
-generic           `AlphaTemporal`            temporal
-[Thompson2003]_   `Thompson2003Model`        spatial
-[Thompson2003]_   `Thompson2003Spatial`      spatial
-[Horsager2009]_   `Horsager2009Model`        temporal
-[Horsager2009]_   `Horsager2009Temporal`     temporal
-[Nanduri2012]_    `Nanduri2012Model`         spatial + temporal
-[Nanduri2012]_    `Nanduri2012Spatial`       spatial
-[Nanduri2012]_    `Nanduri2012Temporal`      temporal
-[Beyeler2019]_    `AxonMapModel`             spatial
-[Beyeler2019]_    `ScoreboardModel`          spatial
-[Granley2021]_    `BiphasicAxonMapModel`     spatiotemporal
-[Grinten2023]_    `DynaphosModel`            spatiotemporal
-================  =========================  ===================
+   * - Reference
+     - Model
+     - Type
+   * - generic
+     - :py:class:`~pulse2percept.models.FadingTemporal`
+     - temporal
+   * - generic
+     - :py:class:`~pulse2percept.models.AlphaTemporal`
+     - temporal
+   * - [Thompson2003]_
+     - :py:class:`~pulse2percept.models.Thompson2003Model`
+     - spatial
+   * - [Horsager2009]_
+     - :py:class:`~pulse2percept.models.Horsager2009Model`
+     - temporal
+   * - [Nanduri2012]_
+     - :py:class:`~pulse2percept.models.Nanduri2012Model`
+     - spatial + temporal
+   * - [Beyeler2019]_
+     - :py:class:`~pulse2percept.models.ScoreboardModel`
+     - spatial
+   * - [Beyeler2019]_
+     - :py:class:`~pulse2percept.models.AxonMapModel`
+     - spatial
+   * - [Granley2021]_
+     - :py:class:`~pulse2percept.models.BiphasicAxonMapModel`
+     - spatiotemporal
+   * - [Grinten2023]_
+     - :py:class:`~pulse2percept.models.cortex.DynaphosModel`
+     - spatiotemporal
 
-.. note::
+Cortical stimulation also has
+:py:class:`~pulse2percept.models.cortex.ScoreboardModel`, a spatial baseline
+that maps cortical electrode locations through cortical retinotopy.
 
-    Spatial and temporal models can be mix-and-matched to create new models.
-    See `Creating your own model <topics-models-building-your-own>`.
+Which model to use depends on the scientific question. The scoreboard model is
+a simple local baseline. The axon-map model adds retinal nerve-fiber effects
+for epiretinal stimulation. Published temporal and spatiotemporal models add
+assumptions specific to their experiments and should be chosen when those
+assumptions are relevant.
 
 Basic usage
 -----------
 
-All models follow the same basic work flow:
-
-*  **Initialize** the model with the desired model parameters.
-*  **Build** the model to perform one-time heavy computations such as building
-   the axon map in :py:class:`~pulse2percept.models.AxonMapModel`.
-*  **Predict a percept** by passing an implant that contains a stimulus. The
-   model will return a :py:class:`~pulse2percept.percepts.Percept` object that
-   acts as a data container with labeled axes.
-
-Here is how to run the :py:class:`~pulse2percept.models.ScoreboardModel`:
-
-.. ipython:: python
-
-    # Initialize the model:
-    from pulse2percept.models import ScoreboardModel
-    model = ScoreboardModel(rho=200)
-
-    # Build the model:
-    model.build()
-
-    # Predict the percept resulting from stimulating Electrode
-    # A8 in Argus II with 30 uA:
-    from pulse2percept.implants import ArgusII
-    percept = model.predict_percept(ArgusII(stim={'A8': 30}))
-
-.. _topics-models-building-your-own:
-
-Building your own model
------------------------
-
-To build your own model, you can mix and match spatial and temporal models at
-will.
-
-For example, to create a model that combines the scoreboard model
-described in [Beyeler2019]_ with the temporal model cascade described in
-[Nanduri2012]_, use the following:
+Models follow the same workflow: initialize, build, then predict a percept from
+an implant containing a stimulus.
 
 .. code-block:: python
 
-    # Instantiate:
-    model = Model(spatial=ScoreboardSpatial(),
-                  temporal=Nanduri2012Temporal())
+    import pulse2percept as p2p
 
-    # Build:
-    model.build()
-    # etc.
+    implant = p2p.implants.ArgusII(stim={'A8': 30})
+    model = p2p.models.ScoreboardModel(rho=200).build()
+    percept = model.predict_percept(implant)
 
-To create a more advanced model, you will need to subclass the appropriate base
-class. For example, to create a new spatial model, you will need to subclass
-:py:class:`~pulse2percept.models.SpatialModel` and provide implementations for
-the following methods:
+``build()`` performs one-time setup such as constructing an axon map. The result
+of ``predict_percept`` is a
+:py:class:`~pulse2percept.percepts.Percept`.
 
-*  ``_predict_spatial``: a method that accepts an
-   :py:class:`~pulse2percept.implants.ElectrodeArray` as well as a
-   :py:class:`~pulse2percept.stimuli.Stimulus` and computes the brightness at
-   all spatial coordinates of ``self.grid``, returned as a 2D NumPy array
-   (space x time).
+Spatial and temporal components
+-------------------------------
 
-In addition, you can customize the following methods:
-
-*  ``__init__``: the constructor can be used to define additional parameters
-   (note that you cannot add parameters on-the-fly)
-*  ``get_default_params``: all settable model parameters must be listed by
-   this method
-*  ``_build`` (optional): a way to add one-time computations to the build
-   process
-
-A full working example:
+Classes ending in ``Model`` are complete model objects. Classes ending in
+``Spatial`` or ``Temporal`` are components that can be composed:
 
 .. code-block:: python
 
-    class MySpatialModel(SpatialModel):
-        def __init__(self, **params):
-            """Constructor"""
-            # Make sure to call the parent's (SpatialModel's constructor):
-            super(MySpatialModel, self).__init__(self, **params)
-            # You can set additional parameters here (e.g., stuff you will
-            # need later on in ``_build``). You will not be able to add
-            # parameters outside the constructor or ``get_default_params``.
-            self.n_fib = 100
+    model = p2p.models.Model(
+        spatial=p2p.models.ScoreboardSpatial(),
+        temporal=p2p.models.Nanduri2012Temporal(),
+    ).build()
 
-        def get_default_params(self):
-            """Return a dictionary of settable model parameters"""
-            # Get all parameters already set by the parent (SpatialModel):
-            params = super(MySpatialModel, self).get_default_params()
-            # Add our own:
-            params.update(myparam=1)
-            # Return the combined dictionary:
-            return params
-            
-        def _build(self):
-            """Perform heavy computations during the build process"""
-            # Perform some expensive computation using parameters you
-            # initialized in the constructor:
-            self.heavy = some_heavy_comp(self.n_fib)
+This is useful when the spatial and temporal assumptions come from different
+models. The combined model handles the intermediate representation and returns
+a Percept like any other Model.
 
-        def _predict_spatial(self, earray, stim):
-            """Calculate the spatial response at different time points"""
-            resp = np.zeros(self.grid.size, stim.time.size)
-            for idx_t, t in enumerate(stim.time):
-                for idx_xy, (x, y) in enumerate(self.grid):
-                    # Response at (x,y,t) is the sum of x,y coordinates and
-                    # all the stimuli at time t (an arbitrary, silly choice):
-                    resp[idx_xy, idx_t] = x + y + np.sum(stim[:, t])
-            return resp
+Components may also be used directly, but normal simulations are simpler
+through the complete Model interface.
 
-Similarly, a new temporal model needs to subclass from
-:py:class:`~pulse2percept.models.TemporalModel` and provide a
-:py:meth:`~pulse2percept.models.TemporalModel._predict_temporal` method:
+Parameters
+----------
 
-.. code-block:: python
+A combined Model forwards parameters to its components. For example,
+``model.rho`` may belong to the spatial component and ``model.dt`` to the
+temporal component. If both components define the same parameter, setting it on
+the parent updates both; set ``model.spatial.<name>`` or
+``model.temporal.<name>`` when you need to distinguish them.
 
-    class MyTemporalModel(TemporalModel):
-        def _predict_temporal(self, stim, t_percept):
-            """Calculates the temporal response at different time points"""
-            # Response at (x,y,t) is the stimulus at (x,y,t). Use stim's smart
-            # indexing to do automatic interpolation:
-            return stim[:, t_percept]
-
-Stand-alone models vs. spatial/temporal model components
---------------------------------------------------------
-
-In general, you will want to work with :py:class:`~pulse2percept.models.Model`
-objects, which provide all the necessary glue between a spatial and/or a 
-temporal model component. Objects are named accordingly:
-
-*  An object named **\*Model** is based on
-   :py:class:`~pulse2percept.models.Model`
-*  An object named **\*Spatial** is based on
-   :py:class:`~pulse2percept.models.SpatialModel`
-*  An object named **\*Temporal** is based on 
-   :py:class:`~pulse2percept.models.TemporalModel`
-
-However, nobody stops you from instantiating a spatial or temporal model
-directly:
-
-.. code-block:: python
-
-    # Option 1 (preferred): Work with Model objects:
-    from pulse2percept.models import Model, Nanduri2012Temporal
-    model = Model(temporal=Nanduri2012Temporal())
-    model.build()
-    model.predict_percept(implant)
-
-    # Option 2: Work directly with a temporal model:
-    model = Nanduri2012Temporal()
-    model.build()
-    model.predict_percept(implant.stim)
-
-The differences between the two are subtle:
-
-*  As you can see from the example above, a temporal model will expect a
-   :py:class:`~pulse2percept.stimuli.Stimulus` object in its
-   :py:meth:`~pulse2percept.models.TemporalModel.predict_percept` method
-   (because it has no notion of space).
-   It will return a 2-D NumPy array (space x time).
-
-*  In contrast, the stand-alone model will expect a
-   :py:class:`~pulse2percept.implants.ProsthesisSystem` object (which provides
-   a notion of space and itself contains a
-   :py:class:`~pulse2percept.stimuli.Stimulus`), and will return a
-   :py:class:`~pulse2percept.percepts.Percept` object.
-
-Getting and setting parameters
-------------------------------
-
-A :py:class:`~pulse2percept.models.Model` will hide the complexity that some
-parameters exist only in the spatial or temporal model component.
-
-Consider the following model:
-
-.. ipython:: python
-
-    from pulse2percept.models import (Model, ScoreboardSpatial,
-                                      Nanduri2012Temporal)
-    model = Model(spatial=ScoreboardSpatial(),
-                  temporal=Nanduri2012Temporal())
-
-    # Set `rho` param of the scoreboard model (works even though it's really
-    # `model.spatial.rho`):
-    model.rho = 123
-    
-    # Print the simulation time step of the Nanduri model (works even though
-    # it's really `model.temporal.dt`):
-    print(model.dt)
-
-Although ``rho`` exists only in the scoreboard model, and ``dt`` exists only
-in the temporal model, you can get and set them as if they were part of the
-main model.
-
-.. warning::
-
-    If a parameter exists in both spatial and temporal models (e.g.,
-    ``thresh_percept``), then calling ``model.thresh_percept = 0`` will update
-    both the spatial and temporal model.
-
-    Alternatively, use ``model.spatial.thresh_percept = 0`` or
-    ``model.temporal.thresh_percept = 0``.
-
-
-.. .. minigallery:: pulse2percept.models.Model
-..     :add-heading: Examples using ``Model``
-..     :heading-level: -
-
+The API reference for each model documents its assumptions, parameters, input
+requirements, and numerical units.

--- a/doc/topics/models.rst
+++ b/doc/topics/models.rst
@@ -46,7 +46,7 @@ Available models
    * - [Granley2021]_
      - :py:class:`~pulse2percept.models.BiphasicAxonMapModel`
      - spatiotemporal
-   * - [Grinten2023]_
+   * - [vanderGrinten2023]_
      - :py:class:`~pulse2percept.models.cortex.DynaphosModel`
      - spatiotemporal
 

--- a/doc/topics/rasters.rst
+++ b/doc/topics/rasters.rst
@@ -6,190 +6,83 @@ Raster Strategies
 
 .. versionadded:: 0.10.0
 
-A stimulator may not be able to drive every electrode at the same time. A
-:py:class:`~pulse2percept.implants.Raster` splits the electrode array into
-groups that take turns, limiting how much current has to be delivered at any
-one instant.
+Some stimulators cannot drive every electrode simultaneously. A
+:py:class:`~pulse2percept.implants.Raster` divides an array into groups that
+take turns. It is a scheduling constraint used by an encoder, not a stimulus by
+itself.
 
-A raster is a **scheduling constraint**, not a stimulus by itself:
+Basic usage
+-----------
 
-::
-
-    image / video -> Encoder -> electrical Stimulus
-                         ^
-                         |
-                       Raster
-
-The raster says **which electrodes may pulse together**. The
-:py:class:`~pulse2percept.stimuli.StimulusEncoder` decides when the pulses occur and
-what their amplitudes or frequencies are.
-
-The usual workflow
-------------------
-
-Raster strategies are attached to an implant and are picked up automatically
-by an encoder:
+Rasters are attached to an implant:
 
 .. code-block:: python
 
     import pulse2percept as p2p
-    from pulse2percept.units import uA, Hz
 
     implant = p2p.implants.ArgusII()
     implant.raster = p2p.implants.CheckerboardRaster(n_groups=5)
-
-    encoder = p2p.stimuli.AmplitudeEncoder(
-        amp_range=(0, 50 * uA),
-        freq=20 * Hz,
+    implant.encoder = p2p.stimuli.AmplitudeEncoder(
+        amp_range=(0, 50),
+        freq=20,
     )
-    implant.stim = encoder.encode(
-        p2p.stimuli.BostonTrain(),
-        implant=implant,
-    )
+    implant.stim = p2p.stimuli.BostonTrain()
 
-Here the 60 electrodes are split into five groups. Electrodes within one group
-may pulse together, while different groups receive different time slots.
-
-You can inspect the grouping directly:
-
-.. code-block:: python
-
-    implant.raster.plot()
-    implant.raster.members(implant.electrode_names, 0)
+Electrodes in one group may pulse together; different groups occupy different
+time slots.
 
 Built-in strategies
 -------------------
-
-pulse2percept provides three raster strategies:
 
 .. list-table::
    :header-rows: 1
 
    * - Raster
-     - Strategy
+     - Grouping
    * - :py:class:`~pulse2percept.implants.SequentialRaster`
-     - Split electrodes into sequential groups. On a regular grid this can
-       reproduce a row or line raster.
+     - Sequential or interleaved groups
    * - :py:class:`~pulse2percept.implants.CheckerboardRaster`
-     - Spread electrodes in each group as far apart as possible across a
-       regular grid.
+     - Spatially distributed grid groups
    * - :py:class:`~pulse2percept.implants.CustomRaster`
-     - Assign electrodes to groups explicitly.
+     - Explicit user-defined groups
 
-A sequential raster is the simplest:
+For example:
 
 .. code-block:: python
 
     implant.raster = p2p.implants.SequentialRaster(n_groups=6)
-
-For Argus II, whose electrodes are ordered row by row,
-``SequentialRaster(6)`` puts one row in each group. Setting
-``interleave=True`` instead distributes consecutive electrodes across
-different groups.
-
-A checkerboard raster is usually more spatially distributed:
-
-.. code-block:: python
-
+    implant.raster = p2p.implants.SequentialRaster(
+        n_groups=6, interleave=True
+    )
     implant.raster = p2p.implants.CheckerboardRaster(n_groups=5)
 
-It derives the grouping from the electrode locations, so it works with square,
-rectangular, rotated, and hexagonal grids. The array must actually lie on a
-regular grid, and not every number of groups is possible for every geometry.
+A CustomRaster is useful when the hardware already defines the groups. Every
+electrode must belong to exactly one group.
 
-For complete control, specify the groups yourself:
+Use ``raster.plot()`` to inspect the pattern and ``raster.members(...)`` to
+retrieve the electrodes in a group.
 
-.. code-block:: python
+Timing
+------
 
-    corners = ['A1', 'A10', 'F1', 'F10']
-    rest = [e for e in implant.electrode_names if e not in corners]
-
-    implant.raster = p2p.implants.CustomRaster([corners, rest])
-
-Every electrode must belong to exactly one group.
-
-How the timing works
---------------------
-
-Groups take their turns one after another. The spacing between turns is the
-raster's ``group_dur``.
-
-By default, ``group_dur=None``. The encoder then spreads the groups evenly
-across the pulse period. For example, six groups driven at 20 Hz share the
-50 ms period, so their slots begin one-sixth of a period apart.
-
-You can instead specify the slot duration explicitly:
+Groups fire in order. ``group_dur`` sets the spacing between group starts. If
+it is ``None``, the encoder spreads the groups across the pulse period. An
+explicit value fixes the raster sweep duration:
 
 .. code-block:: python
 
-    from pulse2percept.units import ms
-
-    raster = p2p.implants.SequentialRaster(
-        n_groups=6, group_dur=1 * ms
+    implant.raster = p2p.implants.SequentialRaster(
+        n_groups=6,
+        group_dur=1,
     )
 
-This gives a 6 ms raster sweep: group 0 starts at 0 ms, group 1 at 1 ms, and so
-on.
+The slot must be long enough for a pulse, and the full sweep must fit within the
+relevant pulse period.
 
-The slot must be long enough to contain a pulse, and the whole sweep must fit
-within the relevant pulse period.
+With amplitude encoding, all electrodes share a pulse period, so rastering
+only offsets the groups. With frequency encoding, electrodes may request
+different periods; those schedules are constrained to whole raster sweeps and
+may therefore run more slowly than requested, never faster.
 
-Amplitude versus frequency encoding
------------------------------------
-
-Rastering behaves differently depending on what the encoder modulates.
-
-With :py:class:`~pulse2percept.stimuli.AmplitudeEncoder`, every electrode has
-the same pulse period. Their group offsets therefore remain fixed and cannot
-drift into one another. **Rastering does not lower the requested pulse
-frequency in this case.**
-
-With :py:class:`~pulse2percept.stimuli.FrequencyEncoder`, electrodes can have
-different pulse periods. Those schedules would eventually drift into one
-another, so the encoder constrains differing periods to whole raster sweeps.
-Periods are always rounded **up**, never down, so rastering may make an
-electrode pulse more slowly than requested but never faster.
-
-A shorter explicit ``group_dur`` produces a shorter sweep and therefore finer
-frequency resolution when this matters.
-
-Choosing a strategy
--------------------
-
-For most simulations:
-
-* use :py:class:`~pulse2percept.implants.SequentialRaster` when you want a
-  simple line, block, or interleaved schedule;
-* use :py:class:`~pulse2percept.implants.CheckerboardRaster` when you want
-  simultaneously active electrodes spread across a regular array;
-* use :py:class:`~pulse2percept.implants.CustomRaster` when the hardware
-  already defines the groups or you need a specific pattern.
-
-If rastering is not part of the question you are studying, you can leave it
-unset. The encoder will then stimulate all electrodes on the same schedule.
-
-Physical units
---------------
-
-``group_dur`` accepts either a bare number in milliseconds or a unitful
-quantity:
-
-.. code-block:: python
-
-    from pulse2percept.units import us
-
-    raster = p2p.implants.SequentialRaster(
-        n_groups=6, group_dur=1000 * us
-    )
-
-See :ref:`topics-units` for the full units convention.
-
-.. seealso::
-
-    * :py:class:`pulse2percept.implants.Raster`
-    * :py:class:`pulse2percept.implants.SequentialRaster`
-    * :py:class:`pulse2percept.implants.CheckerboardRaster`
-    * :py:class:`pulse2percept.implants.CustomRaster`
-    * :ref:`Stimulus Encoders <topics-encoders>`
-    * :ref:`Electrical Stimuli <topics-stimuli>`
-    * :ref:`Physical Units <topics-units>`
+If rastering is not part of the device or question being modeled, leave
+``implant.raster`` unset.

--- a/doc/topics/stimuli.rst
+++ b/doc/topics/stimuli.rst
@@ -1,8 +1,8 @@
 .. _topics-stimuli:
 
-=======
-Stimuli
-=======
+==================
+Electrical Stimuli
+==================
 
 A :py:class:`~pulse2percept.stimuli.Stimulus` is labeled two-dimensional data:
 rows are electrodes and columns are points in time. Electrical stimuli contain

--- a/doc/topics/stimuli.rst
+++ b/doc/topics/stimuli.rst
@@ -1,54 +1,36 @@
 .. _topics-stimuli:
 
-==================
-Electrical Stimuli
-==================
+=======
+Stimuli
+=======
 
-A :py:class:`~pulse2percept.stimuli.Stimulus` describes what is delivered to
-one or more electrodes. For electrical stimulation, its rows are electrodes,
-its columns are points in time, and its values are current amplitudes:
+A :py:class:`~pulse2percept.stimuli.Stimulus` is labeled two-dimensional data:
+rows are electrodes and columns are points in time. Electrical stimuli contain
+current amplitudes; images and videos contain dimensionless visual intensity.
 
-::
+Electrical waveforms
+--------------------
 
-    electrical Stimulus -> implant -> model -> Percept
-
-Most users do not need to build this array by hand. pulse2percept provides
-pulse and pulse-train classes for common stimulation waveforms, and
-:ref:`stimulus encoders <topics-encoders>` for turning images and videos into
-multi-electrode stimulation.
-
-The usual workflow
-------------------
-
-A :py:class:`~pulse2percept.stimuli.BiphasicPulseTrain` is a good place to
-start:
+For most electrical stimulation, start with a
+:py:class:`~pulse2percept.stimuli.BiphasicPulseTrain`:
 
 .. code-block:: python
 
     import pulse2percept as p2p
-    from pulse2percept.units import Hz, ms, uA
-
-    implant = p2p.implants.ArgusII()
 
     pulse_train = p2p.stimuli.BiphasicPulseTrain(
-        freq=20 * Hz,
-        amp=50 * uA,
-        phase_dur=0.45 * ms,
-        stim_dur=500 * ms,
+        freq=20,
+        amp=50,
+        phase_dur=0.45,
+        stim_dur=500,
     )
 
-    implant.stim = {'A5': pulse_train}
+    implant = p2p.implants.ArgusII(stim={'A5': pulse_train})
 
-    model = p2p.models.AxonMapModel().build()
-    percept = model.predict_percept(implant)
-
-The dictionary key identifies the electrode. Electrodes not listed receive no
+The dictionary key selects the electrode; unlisted electrodes receive no
 stimulation.
 
-Pulses and pulse trains
------------------------
-
-pulse2percept provides a small set of common electrical waveforms:
+Common waveform classes include:
 
 .. list-table::
    :header-rows: 1
@@ -56,357 +38,104 @@ pulse2percept provides a small set of common electrical waveforms:
    * - Stimulus
      - Description
    * - :py:class:`~pulse2percept.stimuli.BiphasicPulse`
-     - One symmetric, charge-balanced biphasic pulse.
+     - One symmetric biphasic pulse
    * - :py:class:`~pulse2percept.stimuli.BiphasicPulseTrain`
-     - Repeated symmetric biphasic pulses. The usual starting point.
+     - Repeated biphasic pulses
    * - :py:class:`~pulse2percept.stimuli.MonophasicPulse`
-     - One cathodic or anodic phase; generally not charge-balanced.
+     - One cathodic or anodic phase
    * - :py:class:`~pulse2percept.stimuli.AsymmetricBiphasicPulse`
-     - A biphasic pulse whose two phases may differ in amplitude or duration.
+     - Unequal biphasic phases
    * - :py:class:`~pulse2percept.stimuli.AsymmetricBiphasicPulseTrain`
-     - A train of asymmetric biphasic pulses.
+     - Repeated asymmetric pulses
    * - :py:class:`~pulse2percept.stimuli.BiphasicTripletTrain`
-     - Repeated triplets of biphasic pulses.
+     - Repeated biphasic triplets
    * - :py:class:`~pulse2percept.stimuli.PulseTrain`
-     - Repeat an arbitrary single-pulse Stimulus.
+     - Repeats an arbitrary pulse
 
-For example, a single cathodic-first biphasic pulse is:
-
-.. code-block:: python
-
-    pulse = p2p.stimuli.BiphasicPulse(
-        amp=50 * uA,
-        phase_dur=0.45 * ms,
-        interphase_dur=0.1 * ms,
-    )
-
-The amplitude specifies the magnitude; ``cathodic_first=True`` by default
-determines the sign of the first phase.
-
-A generic :py:class:`~pulse2percept.stimuli.PulseTrain` can repeat any
-single-pulse stimulus:
-
-.. code-block:: python
-
-    train = p2p.stimuli.PulseTrain(
-        freq=20 * Hz,
-        pulse=pulse,
-        stim_dur=500 * ms,
-    )
-
-Only whole pulses are delivered. If the final pulse would extend beyond
-``stim_dur``, it is omitted rather than cut in half.
-
-Stimulating multiple electrodes
--------------------------------
-
-The easiest way to specify different stimulation on different electrodes is a
-dictionary:
-
-.. code-block:: python
-
-    implant.stim = {
-        'A5': p2p.stimuli.BiphasicPulseTrain(
-            20 * Hz, 50 * uA, 0.45 * ms, stim_dur=500 * ms
-        ),
-        'B5': p2p.stimuli.BiphasicPulseTrain(
-            20 * Hz, 25 * uA, 0.45 * ms, stim_dur=500 * ms
-        ),
-    }
-
-pulse2percept combines the individual waveforms into one
-:py:class:`~pulse2percept.stimuli.Stimulus`, merging their time axes as
-needed.
-
-You can also construct a Stimulus directly from scalar values, arrays, lists,
-or dictionaries:
-
-.. code-block:: python
-
-    static = p2p.stimuli.Stimulus({
-        'A1': 10 * uA,
-        'A2': 20 * uA,
-        'A3': 30 * uA,
-    })
-
-A one-dimensional sequence means one value per electrode and has no time
-component. A two-dimensional array has shape ``(n_electrodes, n_times)``.
+Pulse trains deliver only complete pulses. A pulse that would extend beyond
+``stim_dur`` is omitted rather than truncated.
 
 The Stimulus container
 ----------------------
 
-Every Stimulus exposes the same basic pieces:
+Every Stimulus exposes:
 
-``stim.data``
-    A 2D NumPy array with shape ``(n_electrodes, n_times)``.
+``data``
+    A NumPy array with shape ``(n_electrodes, n_times)``.
 
-``stim.electrodes``
-    The electrode names corresponding to the rows.
+``electrodes``
+    The labels corresponding to the rows.
 
-``stim.time``
-    The time axis, or ``None`` for a stimulus without a time component.
+``time``
+    The time axis, or ``None`` for a timeless stimulus.
 
-Stimuli can also be indexed by electrode name and time:
+A Stimulus can be built from arrays, scalars, lists, dictionaries, or other
+Stimulus objects:
 
 .. code-block:: python
 
-    stim = implant.stim
+    stim = p2p.stimuli.Stimulus({'A1': 10, 'A2': 20, 'A3': 30})
 
-    stim['A5']
-    stim['A5', 10 * ms]
+Stimulus indexing uses electrode labels and physical time:
 
-The second index is a **time**, not a column number. If that exact time is not
-stored, pulse2percept interpolates the waveform there. Use ``stim.data`` when
-you want ordinary NumPy indexing by row and column.
+.. code-block:: python
 
-The time axis does not need to be uniformly sampled. Pulse classes store the
-important transition points rather than a dense sample at every simulation
-step, which keeps long pulse trains compact.
+    stim['A1']
+    stim['A1', 10]
 
-Read-only, and sampled when asked
----------------------------------
+The second index is a time, not a column number. If the exact time is not
+stored, pulse2percept interpolates the waveform there. Use ``stim.data`` for
+ordinary NumPy indexing.
+
+Structured and read-only stimuli
+--------------------------------
 
 .. versionchanged:: 0.10.0
 
-A Stimulus owns its scientific state. Its ``data``, ``time`` and
-``electrodes`` arrays are read-only, so a stimulus you hand to an implant or a
-model is the one you get back.
-
-For an arbitrary stimulus, that sampled waveform *is* the stimulus. Pulses,
-pulse trains and encoded images and videos are different: they retain the
-parameters or the schedule that define them, and only generate their waveform
-when samples are asked for.
+Stimulus state is read-only. Pulse classes retain their defining parameters and
+generate waveform samples only when needed:
 
 .. code-block:: python
 
-    pt = p2p.stimuli.BiphasicPulseTrain(20 * Hz, 50 * uA, 0.45 * ms)
+    pt = p2p.stimuli.BiphasicPulseTrain(20, 50, 0.45)
 
-    pt.freq, pt.amp, pt.phase_dur   # free -- the parameters are the stimulus
-    pt.data                         # generates the waveform, then caches it
+    pt.freq, pt.amp, pt.phase_dur
+    pt.data  # generate and cache the waveform
 
-So pulse parameters are first-class and read-only, and reading them never
-costs a waveform. ``stim.data`` remains the public sampled waveform, and
-reading it may be what generates it.
+Operations preserve the structured form when that remains truthful. For
+example, ``pt * 2`` is still a pulse train, while ``pt + 5`` becomes a plain
+Stimulus because a DC offset is no longer a pulse train.
 
-Most operations return a **new** stimulus rather than modifying one. Where
-the result is still describable in the same terms, it keeps that form:
-
-.. code-block:: python
-
-    pt * 2          # still a BiphasicPulseTrain, at twice the amplitude
-    pt + 5          # a plain Stimulus: a DC offset is not a pulse train
-
-An operation that cannot be represented truthfully -- a DC offset, a shift in
-time, appending a second train -- falls back to an ordinary waveform-backed
-Stimulus rather than reporting parameters that no longer describe it.
-
+Most operations return a new object. The older
 :py:meth:`~pulse2percept.stimuli.Stimulus.compress` and
-:py:meth:`~pulse2percept.stimuli.Stimulus.remove` are the exceptions. Both
-predate this and still replace the stimulus' own state in place.
+:py:meth:`~pulse2percept.stimuli.Stimulus.remove` methods still modify the
+Stimulus in place.
 
-Looking at a stimulus
----------------------
-
-:py:meth:`~pulse2percept.stimuli.Stimulus.plot` draws either an overview of
-the whole stimulus or the waveforms of the electrodes you name:
-
-.. code-block:: python
-
-    stim.plot()                          # compact overview
-    stim.plot(time=(0, 50 * ms))         # the same overview, zoomed in time
-    stim.plot(electrodes=['A5', 'B5'])   # inspect individual waveforms
-
-The overview is an electrode-by-time heatmap: one row per electrode, color for
-current, zero in the middle of a diverging colormap so that cathodic and
-anodic phases are told apart. An encoded Argus II stimulus drives 60
-electrodes, and 60 stacked waveforms show nothing useful; the heatmap shows
-which electrodes fire, how strongly, and in what order. Because it plots
-against the real time axis rather than against column number, the
-sub-millisecond phases of a pulse stay sub-millisecond next to the long gaps
-between pulses.
-
-Naming electrodes means "show me these signals in detail", so it draws
-waveforms instead, one subplot per electrode. So does a single-electrode
-stimulus such as a pulse or a pulse train.
-
-Pass ``kind='traces'`` or ``kind='heatmap'`` to overrule that choice.
-
-Images and videos are different
--------------------------------
+Images and videos
+-----------------
 
 :py:class:`~pulse2percept.stimuli.ImageStimulus` and
-:py:class:`~pulse2percept.stimuli.VideoStimulus` are also Stimulus objects, but
-their values are **dimensionless gray levels, not electrical current**.
+:py:class:`~pulse2percept.stimuli.VideoStimulus` are visual sources, not
+currents. Their values are dimensionless gray levels. A
+:py:class:`~pulse2percept.stimuli.StimulusEncoder` defines how those gray
+levels become electrical stimulation; see :ref:`topics-encoders`.
 
-For example:
+Plotting and time operations
+----------------------------
 
-.. code-block:: python
-
-    source = p2p.stimuli.BostonTrain()
-
-That object is a visual source. It should be passed through an
-:py:class:`~pulse2percept.stimuli.StimulusEncoder` before it is used as electrical
-stimulation:
-
-.. code-block:: python
-
-    implant.encoder = p2p.stimuli.AmplitudeEncoder(
-        amp_range=(0, 50 * uA),
-        freq=20 * Hz,
-    )
-
-    implant.stim = source
-
-This distinction matters. A gray level of 0.5 is not 0.5 uA; the encoder is
-what defines how image intensity maps onto stimulation. See
-:ref:`topics-encoders` for the full workflow.
-
-Physical units
---------------
-
-Electrical stimulus amplitudes are stored in microamps and time in
-milliseconds. Pulse-train frequency is measured in hertz. You can use those
-canonical units directly or pass compatible quantities:
+:py:meth:`~pulse2percept.stimuli.Stimulus.plot` shows a heatmap for
+multi-electrode stimuli and waveform traces for a single or explicitly selected
+electrode:
 
 .. code-block:: python
 
-    from pulse2percept.units import mA, us
+    stim.plot()
+    stim.plot(electrodes=['A1', 'A2'])
 
-    pulse = p2p.stimuli.BiphasicPulse(
-        amp=0.05 * mA,
-        phase_dur=450 * us,
-    )
+:py:meth:`~pulse2percept.stimuli.Stimulus.shift` moves a stimulus in time, and
+:py:meth:`~pulse2percept.stimuli.Stimulus.pad` adds zero-valued endpoints to a
+requested end time. ``stim >> dt`` and ``stim << dt`` are shorthand for
+positive and negative shifts.
 
-This is equivalent to ``50 * uA`` and ``0.45 * ms``. Bare numbers continue to
-mean the documented canonical units. See :ref:`topics-units` for the full
-convention.
-
-Charge balance and safety
--------------------------
-
-For implanted stimulation, charge balance matters. Symmetric
-:py:class:`~pulse2percept.stimuli.BiphasicPulse` and
-:py:class:`~pulse2percept.stimuli.BiphasicPulseTrain` objects are
-charge-balanced by construction.
-
-The :py:class:`~pulse2percept.stimuli.Stimulus` API also exposes charge-balance
-information for arbitrary waveforms, and implants can apply additional safety
-checks when ``safe_mode=True``. These checks are useful guardrails, but they
-are not a substitute for the safety limits of a particular experimental or
-clinical device.
-
-You can change the coordinates of an existing
-:py:class:`~pulse2percept.stimuli.Stimulus` object, but retain all its data,
-by wrapping it in a second Stimulus object:
-
-.. ipython:: python
-
-    import numpy as np
-    from pulse2percept.stimuli import Stimulus
-
-    # Say you have a Stimulus object with unlabeled axes:
-    stim = Stimulus(np.ones((2, 5)))
-    stim
-
-    # You can create a new object from it with named electrodes:
-    Stimulus(stim, electrodes=['A1', 'F10'])
-
-    # Same goes for time points:
-    Stimulus(stim, time=[0, 0.1, 0.2, 0.3, 0.4])
-
-Shifting and padding a stimulus
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-:py:meth:`~pulse2percept.stimuli.Stimulus.shift` moves a stimulus along the
-time axis, and :py:meth:`~pulse2percept.stimuli.Stimulus.pad` adds
-zero-valued endpoints at ``t=0`` and ``t=duration`` as needed.
-Note that ``pad`` takes the time the padded stimulus should *end* at, not an
-amount of time to add:
-
-.. ipython:: python
-
-    from pulse2percept.stimuli import BiphasicPulse
-
-    # A pulse that starts 3 ms in, ending at 10 ms:
-    stim = BiphasicPulse(-20, 1).shift(3).pad(10)
-    stim.time
-
-    stim.data
-
-Because a stimulus is interpolated between its time points, an endpoint can
-only be added next to a data point that is already zero (as it is for all
-built-in pulses and pulse trains); otherwise ``pad`` raises a ``ValueError``
-rather than adding a ramp.
-
-Shifts may be negative, which moves the stimulus into the past
-(``stim.shift(-3)``).
-``stim >> dt`` and ``stim << dt`` are supported shorthand for
-``stim.shift(dt)`` and ``stim.shift(-dt)``.
-
-Compressing a stimulus
-^^^^^^^^^^^^^^^^^^^^^^
-
-The :py:meth:`~pulse2percept.stimuli.Stimulus.compress` method automatically
-compresses the data in two ways:
-
-* Removes electrodes with all-zero activation.
-* Retains only the time points at which the stimulus changes.
-
-For example, only the signal edges of a pulse train are saved.
-That is, rather than saving the current amplitude at every 0.1ms time step,
-only the non-redundant values are retained.
-This drastically reduces the memory footprint of the stimulus.
-You can convince yourself of that by inspecting the size of a Stimulus object
-before and after compression:
-
-.. ipython:: python
-
-    # An uncompressed stimulus:
-    stim = Stimulus([[0, 0, 0, 1, 2, 0, 0, 0]], time=[0, 1, 2, 3, 4, 5, 6, 7])
-    stim
-
-    # Now compress the data:
-    stim.compress()
-
-    # Notice how the time axis have changed:
-    stim
-
-Accessing stimulus metadata
-^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Stimuli can store additional relevant information in the ``metadata``
-dictionary. What the user passes is stored in ``metadata["user"]``; each source
-of a multi-source stimulus keeps its own:
-
-.. ipython:: python
-
-    from pulse2percept.stimuli import BiphasicPulseTrain
-
-    # Accessing metadata
-    stim = Stimulus([[0, 1, 2, 3]], metadata='user_metadata')
-    stim.metadata
-
-    # Sources carry their own metadata
-    stim = BiphasicPulseTrain(1,1,1, metadata='user_metadata')
-    stim.metadata
-
-    # A collection keeps the metadata the whole stimulus was given
-    stim = Stimulus({'A1' : BiphasicPulseTrain(1,1,1, metadata='A1 metadata'),
-                     'B2' : BiphasicPulseTrain(1,1,1, metadata='B2 metadata')},
-                    metadata='stimulus metadata')
-    stim.metadata
-    
-.. seealso::
-
-    * :py:class:`pulse2percept.stimuli.Stimulus`
-    * :py:class:`pulse2percept.stimuli.BiphasicPulse`
-    * :py:class:`pulse2percept.stimuli.BiphasicPulseTrain`
-    * :ref:`Stimulus Encoders <topics-encoders>`
-    * :ref:`Visual Prostheses <topics-implants>`
-    * :ref:`Raster Strategies <topics-rasters>`
-    * :ref:`Physical Units <topics-units>`
-    * :ref:`Computational Models <topics-models>`
-
-.. .. minigallery:: pulse2percept.stimuli.Stimulus
-..     :add-heading: Examples using ``Stimulus``
-..     :heading-level: -
+Electrical amplitudes, time, and frequency use the unit conventions described
+in :ref:`topics-units`.

--- a/doc/topics/units.rst
+++ b/doc/topics/units.rst
@@ -6,136 +6,74 @@ Physical Units
 
 .. versionadded:: 0.10.0
 
-Many numbers in pulse2percept stand for physical quantities: a current, a
-duration, a distance on the retina, or a position in the visual field. The
-:py:mod:`~pulse2percept.units` module lets you say which, so that the library
-can make sure you meant it:
+Many pulse2percept parameters represent physical quantities. The
+:py:mod:`~pulse2percept.units` module adds dimensional checking and automatic
+conversion while keeping bare numbers fully supported.
 
 .. code-block:: python
 
     from pulse2percept.stimuli import BiphasicPulse
     from pulse2percept.units import mA, us
 
-    pulse = BiphasicPulse(50, 0.45)             # microamps and milliseconds
-    pulse = BiphasicPulse(0.05 * mA, 450 * us)  # exactly the same pulse
+    BiphasicPulse(50, 0.45)
+    BiphasicPulse(0.05 * mA, 450 * us)  # equivalent
 
-Both lines mean the same thing and produce the same numbers. **Units are
-optional.** Bare numbers remain valid and are interpreted in the documented
-canonical unit. Supplying units adds dimensional checking and automatic
-conversion.
+Bare numbers use the canonical unit documented by the API.
 
-.. code-block:: python
+Canonical units
+---------------
 
-    # To import a few units:
-    from pulse2percept.units import ms, uA
-    pulse = BiphasicPulse(50 * uA, 0.45 * ms)
+.. list-table::
+   :header-rows: 1
 
-    # To import many units:
-    import pulse2percept.units as u
-    pulse = BiphasicPulse(50 * u.uA, 0.45 * u.ms)
+   * - Quantity
+     - Bare number means
+   * - stimulus current
+     - microamps (uA)
+   * - stimulus and percept time
+     - milliseconds (ms)
+   * - electrode and tissue geometry
+     - microns (um)
+   * - visual-field coordinates
+     - degrees of visual angle (dva)
+   * - frequency
+     - hertz (Hz)
+   * - image and video intensity
+     - dimensionless
+   * - implant rotation
+     - degrees
 
-pulse2percept does not check magnitudes (e.g., ``450 * ms`` where you meant
-``450 * us``), but it will alert you when you passed the wrong units:
+Objects that use a different unit, such as a Percept with its own time base,
+record that unit explicitly.
 
-.. doctest::
-    :options: +IGNORE_EXCEPTION_DETAIL
+Quantities and conversion
+-------------------------
 
-    >>> from pulse2percept.stimuli import BiphasicPulse
-    >>> from pulse2percept.units import ms, uA
-    >>> BiphasicPulse(0.45 * ms, 50 * uA)  # arguments swapped
-    Traceback (most recent call last):
-      ...
-    DimensionMismatchError: Parameter 'amp' expects electric current (uA), got time (ms).
-
-What bare numbers mean
-----------------------
-
-Each domain has one canonical unit. A bare number is read as being in it, and
-a unitful value is converted into it:
-
-=============================  =====================================
-Quantity                       A bare number means
-=============================  =====================================
-stimulus current               microamps (µA) [#f1]_
-stimulus and percept time      milliseconds (ms) [#f1]_
-electrode and tissue geometry  microns (µm) [#f1]_
-visual field coordinates       degrees of visual angle (dva)
-frequency                      hertz (Hz)
-image and video intensity      dimensionless
-rotation of an implant         plain degrees [#f2]_
-=============================  =====================================
-
-.. [#f1] Unless the object says otherwise. A
-   :py:class:`~pulse2percept.percepts.Percept` records its own
-   :py:attr:`~pulse2percept.percepts.Percept.time_unit`, and a model declares
-   the unit its kernels count in; see `For model authors`_.
-
-.. [#f2] ``rot`` is the angle an array is rotated by in its own plane. It is
-   not a visual angle, so ``dva`` is refused there.
-
-Working with quantities
------------------------
-
-Multiply a number by a unit to get a
+Multiply a number or array by a unit to create a
 :py:class:`~pulse2percept.units.Quantity`:
 
 .. doctest::
 
-    >>> from pulse2percept.units import uA, mA
+    >>> from pulse2percept.units import mA, uA
     >>> q = 500 * uA
-    >>> q
-    500 uA
     >>> q.to(mA)
     0.5 mA
     >>> q.to_value(mA)
     0.5
 
-:py:meth:`~pulse2percept.units.Quantity.to` gives you another quantity;
-:py:meth:`~pulse2percept.units.Quantity.to_value` gives you a plain number and
-is the explicit way to remove a unit. Nothing removes one implicitly.
+``to`` returns another Quantity; ``to_value`` returns a plain number or array.
+Compatible quantities can be added, multiplied, divided, and raised to powers.
 
-Lists and arrays work too, and quantities do arithmetic:
+Dimensional boundaries
+----------------------
 
-.. doctest::
+Units prevent physically different quantities from being confused. For
+example, retinal distance is not visual angle, and image intensity is not
+current.
 
-    >>> from pulse2percept.units import mA, ms, nC, s, uA
-    >>> amps = [10, 20, 50] * uA
-    >>> amps.to_value(mA)
-    array([0.01, 0.02, 0.05])
-    >>> 20 * ms + 0.03 * s
-    50.0 ms
-    >>> (3 * uA * (2 * ms)).to(nC)
-    6 nC
-
-Units compose, so a quantity the vocabulary does not name directly can still
-be built out of the ones it does:
-
-.. doctest::
-
-    >>> from pulse2percept.units import uA, mm
-    >>> 675 * uA / mm ** 2
-    675 uA/mm^2
-
-Boundaries you cannot cross
----------------------------
-
-Dimensions are checked, so a quantity of the wrong kind is refused rather than
-reinterpreted:
-
-.. doctest::
-
-    >>> from pulse2percept.implants import DiskElectrode
-    >>> from pulse2percept.units import dva
-    >>> DiskElectrode(2 * dva, 0, 0, 100)  # doctest: +IGNORE_EXCEPTION_DETAIL
-    Traceback (most recent call last):
-      ...
-    DimensionMismatchError: Parameter 'x' expects length (um), got visual angle (dva).
-
-**Visual angle is not a length.** ``dva`` has its own dimension. There is no
-factor that turns degrees of visual angle into microns of tissue, because the
-relationship is (usually) not a constant: it depends on where in the visual
-field you are, and on which retinotopic map you believe in. That is what a
-:py:class:`~pulse2percept.topography.VisualFieldMap` is for:
+``dva`` therefore does not convert directly to ``um``. Use a
+:py:class:`~pulse2percept.topography.VisualFieldMap` when mapping between
+visual-field and tissue coordinates:
 
 .. code-block:: python
 
@@ -144,180 +82,66 @@ field you are, and on which retinotopic map you believe in. That is what a
 
     x_um, y_um = Watson2014Map().dva_to_ret(2 * dva, 3 * dva)
 
-**Gray levels are not small currents.** An image or a video is dimensionless,
-and a model that stimulates tissue will refuse one. A
-:py:class:`~pulse2percept.stimuli.StimulusEncoder` is what says how much
-current a gray level stands for, and an implant that has one encodes on
-assignment:
+Likewise, :py:class:`~pulse2percept.stimuli.ImageStimulus` and
+:py:class:`~pulse2percept.stimuli.VideoStimulus` are dimensionless. A
+:py:class:`~pulse2percept.stimuli.StimulusEncoder` defines how their gray
+levels become electrical stimulation.
+
+Threshold-relative amplitude
+----------------------------
+
+``xTh`` means a multiple of perceptual threshold, not a current. This matters
+for :py:class:`~pulse2percept.models.BiphasicAxonMapModel`, whose amplitude
+terms are defined relative to threshold.
 
 .. code-block:: python
 
-    from pulse2percept.stimuli import AmplitudeEncoder, ImageStimulus
-    from pulse2percept.implants import ArgusII
-    from pulse2percept.models import ScoreboardModel
-
-    img = ImageStimulus('path-to-image.png')
-
-    implant = ArgusII(encoder=AmplitudeEncoder(amp_range=(0, 50)))
-    implant.stim = img            # encoded here, and now measured in uA
-
-    model = ScoreboardModel().build()
-    percept = model.predict_percept(implant)
-
-Assigning the image to an implant *without* an encoder raises, rather than
-reading its gray levels as microamps. There is no default answer to *how much*
-current a gray level stands for, and choosing one is what an encoder is for.
-
-**Threshold multiples are not currents.** ``xTh`` ("times threshold") has its
-own dimension too. How much current ``2 * xTh`` represents depends on the
-reference threshold, which varies by electrode and by subject. A
-:py:class:`~pulse2percept.stimuli.BiphasicPulseTrain` gets that threshold from
-its ``threshold_amp`` or from
-:py:attr:`~pulse2percept.implants.ProsthesisSystem.thresholds`, and until it
-has one it stays measured in ``xTh``:
-
-.. code-block:: python
-
-    from pulse2percept.implants import ArgusII
     from pulse2percept.stimuli import BiphasicPulseTrain
     from pulse2percept.units import uA, xTh
 
-    implant = ArgusII()
+    train = BiphasicPulseTrain(20, 2 * xTh, 0.45)
+
     implant.thresholds = {'A4': 80 * uA}
-    implant.stim = {'A4': BiphasicPulseTrain(20, 2 * xTh, 0.45)}  # 160 uA
+    implant.stim = {'A4': train}  # calibrated to 160 uA
 
-Until a threshold is supplied, the train remains in ``xTh``. Electrical
-safety checks and current-based models require calibration to ``uA``.
+Without a threshold, the train remains in ``xTh``. Current-based safety checks
+and models require calibration to a physical current.
 
-Shorthands that are not conversions
------------------------------------
+Documented shorthands
+---------------------
 
-A few arguments accept a quantity of a dimension they do not store, because
-there is exactly one thing it can mean there. These are shorthands resolved at
-the boundary, not conversions: what is stored afterwards is the ordinary
-number it always was.
+A few APIs accept another dimension when there is one unambiguous physical
+interpretation. In particular:
 
-**A retinal extent, for a visual field range.** A spatial model simulates a
-patch of the visual field, sampled uniformly in dva. On a retinal model you
-may name that patch by the piece of retina it lands on, and the model's own
-:py:class:`~pulse2percept.topography.VisualFieldMap` resolves it:
+* retinal-model ``xrange`` and ``yrange`` may be specified as retinal lengths;
+  the model's visual-field map converts the endpoints to visual angle;
+* frame-rate arguments such as ``fps`` accept frequency quantities such as
+  ``30 * Hz``.
 
-.. doctest::
+These are API-level interpretations, not general unit conversions.
 
-    >>> from pulse2percept.models import ScoreboardModel
-    >>> from pulse2percept.topography import Curcio1990Map
-    >>> from pulse2percept.units import mm
-    >>> model = ScoreboardModel(xrange=(-2.8 * mm, 2.8 * mm),
-    ...                         vfmap=Curcio1990Map())
-    >>> model.xrange  # 280 um to the degree
-    (-10.0, 10.0)
+Inspecting units
+----------------
 
-Each range is converted along its corresponding retinal meridian: ``xrange``
-through ``ret_to_dva(x, 0)`` and ``yrange`` through ``ret_to_dva(0, y)``. The
-resulting grid is still rectangular and uniformly sampled in dva, exactly as
-if you had typed those degrees yourself. Under a nonlinear map such as
-:py:class:`~pulse2percept.topography.Watson2014Map` it is therefore not the
-image of a retinal rectangle: naming retinal lengths says how far to simulate,
-it does not make the grid uniform in retinal space.
-
-For the same reason ``step`` has no such spelling -- a grid spaced evenly on
-the retina is a different grid, not a different spelling of this one -- and
-neither has a cortical model, where a length is not shorthand for anything.
-The range is resolved once, when it is assigned, so a map installed afterwards
-does not reinterpret it.
-
-**A frequency, for a frame rate.** ``fps`` counts frames per second, so it
-takes hertz as readily as a bare number: ``percept.play(fps=30)``,
-``percept.play(fps=30 * Hz)`` and ``percept.play(fps=0.03 * kHz)`` are the same
-call, and ``percept.play(fps=30 * ms)`` raises.
-
-Asking what an object's numbers mean
-------------------------------------
-
-Objects store plain numbers, and separately record what those numbers are.
-Reading them back in another unit never changes what is stored:
+Objects expose the units of their stored numbers and methods for reading them
+in another compatible unit:
 
 .. code-block:: python
 
-    stim.unit                            # uA
-    stim.values(mA)                      # the data, in milliamps
-    stim.time_unit                       # ms
-    stim.time_quantity                   # the time axis, with its unit
+    stim.unit
+    stim.values(mA)
+    stim.time_unit
+    stim.time_quantity
 
-    implant.earray.coordinates()         # (n, 3) array of microns
-    implant.earray.coordinates(mm)       # the same array, in millimeters
+    implant.earray.coordinates()
+    implant.earray.coordinates(mm)
 
-    percept.time_unit                    # the model's own time unit
-    percept.times(s)                     # the time axis, in seconds
+    percept.time_unit
+    percept.times(s)
 
-Model parameters answer the same question through
-:py:meth:`~pulse2percept.utils.Parametrized.get_param_units`:
+Model parameter units are available through
+:py:meth:`~pulse2percept.utils.Parametrized.get_param_units`.
 
-.. doctest::
-
-    >>> from pulse2percept.models import ScoreboardModel
-    >>> ScoreboardModel().get_param_units()['rho']
-    um
-
-.. _units-for-model-authors:
-
-For model authors
------------------
-
-A model declares the units its numerical implementation works in:
-
-.. code-block:: python
-
-    from pulse2percept.models import SpatialModel
-    from pulse2percept.units import ms, uA, um
-
-    class MyModel(SpatialModel):
-        stimulus_unit = uA
-        space_unit = um
-        time_unit = ms
-
-These are not decoration, but required to make sure physical units stay out
-of the computationally heavy code sections (e.g., Cython/Torch kernel).
-Each model has private methods to convert from physical units to the raw
-numbers a kernel expects:
-
-.. code-block:: python
-
-    def _predict_spatial(self, earray, stim):
-        x, y, z = self._electrode_coords(earray, stim)  # in space_unit
-        amp = self._stim_values(stim)                   # in stimulus_unit
-        t = self._stim_times(stim)                      # in time_unit
-        return my_kernel(amp, x, y, z, t)               # plain float arrays
-
-If your model has parameters of its own, declare them in
-``get_param_units()`` and they will be normalized on assignment, whether
-they arrive through the constructor, ``build()``, or a plain attribute set.
-
-The rule for everything else: **convert at the Python boundary and keep
-numerical kernels unitless.** By the time an array reaches Cython, NumPy or
-Torch it is ordinary contiguous numeric data, exactly as it always has been.
-
-Deliberately not supported
---------------------------
-
-.. important::
-
-    This is a small, fixed unit system, not a general one. It does not have:
-
-    *  a unit registry or user-defined units — the vocabulary is the handful
-       of units that appear in pulse2percept's own APIs, plus whatever you
-       build out of them with ``*``, ``/`` and ``**``;
-    *  string parsing — ``"5 mA"`` is a string, ``5 * mA`` is a quantity;
-    *  automatic propagation through NumPy — a
-       :py:class:`~pulse2percept.units.Quantity` is not an ``ndarray`` and
-       does not survive ``np.mean`` or ``np.concatenate``;
-    *  conversion between visual angle and length — that is a visual field
-       map, not a unit;
-    *  quantities inside Cython or Torch kernels;
-    *  any requirement that you use units at all.
-
-.. seealso::
-
-    *  :py:mod:`pulse2percept.units` for the full API
-    *  :ref:`Electrical Stimuli <topics-stimuli>`
-    *  :ref:`Computational Models <topics-models>`
+The unit system is intentionally small. It has no unit registry, string
+parsing, or automatic NumPy propagation, and physical units do not enter
+Cython or Torch kernels.

--- a/doc/users/release_notes.rst
+++ b/doc/users/release_notes.rst
@@ -4,7 +4,7 @@
 Release Notes
 =============
 
-v0.10.0 Encoders (unreleased)
+v0.10.0 Encoders (2026-08-23)
 -----------------------------
 
 Highlights:
@@ -29,9 +29,9 @@ Highlights:
   and percept playback now supports irregular time axes (:pull:`809`,
   :pull:`834`)
 
-* New :py:class:`~pulse2percept.models.AlphaTemporal` and
-  :py:class:`~pulse2percept.models.TorchFadingTemporal` temporal models
-  (:pull:`849`, :pull:`626`)
+* New :py:class:`~pulse2percept.models.AlphaTemporal` and much faster
+  :py:class:`~pulse2percept.models.FadingTemporal` temporal models
+  (:pull:`849`)
 
 * New :py:meth:`~pulse2percept.percepts.Percept.load` reads percepts from image
   and video files (:pull:`835`)

--- a/doc/users/release_notes.rst
+++ b/doc/users/release_notes.rst
@@ -9,113 +9,89 @@ v0.10.0 Encoders (unreleased)
 
 Highlights:
 
-* New :py:class:`~pulse2percept.stimuli.StimulusEncoder` classes translate
-  images and videos into electrical stimulation using amplitude or frequency
-  modulation (see :ref:`Stimulus Encoders <topics-encoders>`).
-  New :py:class:`~pulse2percept.implants.Raster` classes describe how
-  stimulators multiplex electrodes that cannot be driven simultaneously
-  (see :ref:`Raster Strategies <topics-rasters>`).
+* New stimulus encoders support amplitude and frequency modulation of images and
+  videos, with implant-specific raster strategies for multiplexed stimulation
+  (:pull:`810`, :pull:`820`, :pull:`833`)
 
-* Stimuli now retain their scientific representation instead of eagerly
-  reducing everything to waveform samples. Pulse parameters and stimulus arrays
-  are read-only; pulses, pulse trains, multi-electrode collections, and encoder
-  output generate and cache their waveform only when needed. This substantially
-  reduces the time and memory required to construct large stimuli.
+* Stimuli now retain structured pulse and encoder representations and generate
+  waveform samples lazily, substantially reducing construction time and memory
+  use (:pull:`842`)
 
-* New :py:mod:`~pulse2percept.units` support adds dimension-checked physical
-  quantities (``50 * uA``, ``450 * us``, ``15 * mm``, ``2 * dva``) throughout
-  the public API. Bare numbers retain their documented meaning.
-  See :ref:`Physical Units <topics-units>`.
+* New :py:mod:`~pulse2percept.units` support for dimension-checked physical
+  quantities throughout the public API (:pull:`828`)
 
-* Temporal modeling and playback have been substantially improved:
-  temporal models can summarize percepts over an interval rather than sampling
-  a single instant, and :py:meth:`~pulse2percept.percepts.Percept.play` and
-  :py:meth:`~pulse2percept.stimuli.VideoStimulus.play` are much faster and
-  produce smaller notebooks and documentation pages.
+* Major performance improvements for stimulus handling, spatial models, temporal
+  models, and large-array simulations (:pull:`800`, :pull:`805`, :pull:`808`,
+  :pull:`821`, :pull:`850`)
 
-* :py:class:`~pulse2percept.models.FadingTemporal`,
-  :py:class:`~pulse2percept.models.AlphaTemporal` and
-  :py:class:`~pulse2percept.models.AxonMapSpatial` are substantially faster for
-  long stimuli and large electrode arrays. Results may differ from previous
-  versions by floating-point roundoff.
+* :py:meth:`~pulse2percept.percepts.Percept.play` and
+  :py:meth:`~pulse2percept.stimuli.VideoStimulus.play` are substantially faster,
+  and percept playback now supports irregular time axes (:pull:`809`,
+  :pull:`834`)
 
-* New :py:meth:`~pulse2percept.percepts.Percept.load` reads percepts back from
-  image and video files.
+* New :py:class:`~pulse2percept.models.AlphaTemporal` and
+  :py:class:`~pulse2percept.models.TorchFadingTemporal` temporal models
+  (:pull:`849`, :pull:`626`)
 
-* Python 3.14 is supported. Python 3.11 and NumPy 2 are now required.
+* New :py:meth:`~pulse2percept.percepts.Percept.load` reads percepts from image
+  and video files (:pull:`835`)
+
+* Python 3.14 is supported. Python 3.11 and NumPy 2 are now required
+  (:pull:`790`)
 
 
 API changes:
 
-* Stimulus handling was overhauled. ``Stimulus.data``, ``time`` and
-  ``electrodes`` are read-only, pulse and pulse-train parameters such as
-  ``amp``, ``freq`` and ``phase_dur`` are first-class attributes, and exact
-  transformations such as scaling preserve structured pulse representations
-  when possible. New :py:meth:`~pulse2percept.stimuli.Stimulus.shift` and
-  :py:meth:`~pulse2percept.stimuli.Stimulus.pad` provide explicit time-axis
-  transformations. ``compress`` and ``remove`` remain in-place operations.
+* ``Stimulus.data``, ``time``, ``electrodes``, and pulse parameters are now
+  read-only. New :py:meth:`~pulse2percept.stimuli.Stimulus.pad` and
+  :py:meth:`~pulse2percept.stimuli.Stimulus.shift` methods provide explicit
+  time-axis transformations (:pull:`837`, :pull:`842`)
 
-* Encoded stimuli now carry both the delivered electrical stimulation and the
-  frame-level modulation it realizes. Purely spatial models read the latter,
-  while temporal models use the delivered pulses. This behavior no longer
-  depends on whether encoding happened explicitly or during assignment to an
-  implant.
+* Image and video stimuli now use grid-style electrode names such as ``'A1'``
+  and ``'C12_G'`` instead of integer pixel indices (:pull:`805`)
 
-* :py:class:`~pulse2percept.implants.ProsthesisSystem` now supports encoders,
-  raster strategies, and maximum-current limits. Raster strategies are attached
-  to the implant and bound to its electrode array.
+* :py:class:`~pulse2percept.implants.ProsthesisSystem` now supports stimulus
+  encoders, raster strategies, and maximum-current limits. Dimensionless
+  image/video stimuli can be encoded automatically when assigned to an implant
+  (:pull:`810`, :pull:`833`)
 
-* Temporal models gained a ``reduce`` parameter for choosing how automatically
-  selected output times summarize the preceding interval. In addition,
-  :py:class:`~pulse2percept.models.FadingTemporal` now ignores anodic current
-  rather than treating it as negative brightness, and enforces ``tau >= dt``.
+* Temporal models gained a ``reduce`` parameter for summarizing automatically
+  selected output intervals. :py:class:`~pulse2percept.models.FadingTemporal`
+  now responds only to cathodic current (:pull:`818`)
 
-* New :py:class:`~pulse2percept.models.AlphaTemporal` provides a one-time-constant
-  alpha-shaped temporal response, whose impulse response rises to a peak at 
-  ``tau`` before decaying.
+* :py:class:`~pulse2percept.models.BiphasicAxonMapModel` now distinguishes
+  physical current from threshold-relative amplitude via the new ``xTh`` unit
+  (:pull:`848`)
 
-* A bare :py:class:`~pulse2percept.stimuli.BiphasicPulseTrain` amplitude now
-  consistently means microamps.
-  :py:class:`~pulse2percept.models.BiphasicAxonMapModel` amplitudes, which used
-  to be read as multiples of threshold, must now say so with the new ``xTh``
-  unit (``2 * xTh``) or supply a threshold via ``threshold_amp`` or
-  :py:attr:`~pulse2percept.implants.ProsthesisSystem.thresholds`. An
-  uncalibrated ``xTh`` train remains in ``xTh`` until a threshold is
-  provided.
+* :py:class:`~pulse2percept.models.BiphasicAxonMapSpatial` can now be composed
+  with temporal models using a space-time-separable approximation (:pull:`847`)
 
-* :py:class:`~pulse2percept.models.BiphasicAxonMapSpatial` can now be paired
-  with a temporal model, in a space-time-separable approximation: Granley
-  determines the peak spatial percept, the temporal model supplies a
-  normalized envelope for it to evolve along (:issue:`565`).
+* Model parameter ``xystep`` was renamed to ``step`` and ``axlambda`` to
+  ``lam``; the old names are deprecated until v0.11 (:pull:`824`, :pull:`830`)
 
-* Spatial-model APIs were cleaned up: ``xystep`` was renamed to ``step`` and
-  ``axlambda`` to ``lam``. Axon-map and cortical scoreboard models also gained
-  configurable smoothing across their relevant visual-field meridians.
+* Axon-map and cortical scoreboard models can smooth predictions across
+  visual-field meridians (:pull:`838`)
 
-* ``predict_percept`` and implant safety checks now enforce physical stimulus
-  dimensions instead of silently interpreting image gray levels as electrical
-  current.
+* Multi-electrode stimuli now plot as electrode-by-time heatmaps by default;
+  percept playback and saving gained ``vmin``/``vmax`` controls
+  (:pull:`835`, :pull:`841`)
 
-* Stimulus and percept visualization gained several usability improvements,
-  including multi-electrode stimulus heatmaps and ``vmin``/``vmax`` controls
-  for percept playback and saving.
 
 Bug fixes:
 
-* Stimulus timing, metadata propagation, and pulse-train handling are more
-  robust. Time axes now use float64 precision, metadata survives model
-  prediction and transformations, and Dynaphos uses the actual frequency and
-  phase duration of the biphasic pulse trains a stimulus is made of.
+* Fixed stimulus timing, metadata propagation, pulse scheduling, and structured
+  stimulus handling across implants and models (:pull:`804`, :pull:`810`,
+  :pull:`818`, :pull:`825`, :pull:`846`)
 
-* Fixed several image/video issues, including accidental input mutation,
-  argument forwarding to scikit-image, image centering, single-frame playback,
-  and handling of nonuniform time axes.
+* Fixed several image and video issues, including argument forwarding,
+  centering, single-frame playback, irregular timing, and efficient partial
+  video loading (:pull:`815`, :pull:`822`, :pull:`834`, :pull:`844`)
 
-* Fixed several visual-field-map issues, including equality and hashing,
-  array-shaped inverse cortical mappings, exact mesh-vertex mappings, and
-  incorrect cortical-coordinate units in the documentation.
+* Fixed several Neuropythy and cortical-map issues involving shapes, NaNs,
+  scalar inputs, mesh vertices, subject IDs, and coordinate units
+  (:pull:`826`, :pull:`836`, :pull:`845`)
 
-* Various smaller correctness, compatibility, and documentation fixes.
+* Various smaller correctness fixes (:pull:`814`)
 
 v0.9.1 (2026-08-06)
 -------------------

--- a/pulse2percept/implants/base.py
+++ b/pulse2percept/implants/base.py
@@ -99,14 +99,7 @@ class ProsthesisSystem(PrettyPrint):
     __slots__ = ('_earray', '_stim', '_eye', 'safe_mode', 'preprocess',
                  '_encoder', '_raster', '_max_current', '_thresholds')
 
-    #: The physical quantity this system delivers, mirroring
-    #: :py:attr:`~pulse2percept.models.BaseModel.stimulus_unit`. An electrical
-    #: prosthesis delivers current, so a stimulus that is not a current is not
-    #: a stimulus it can deliver, and is refused when it is assigned rather
-    #: than when a model eventually tries to read it. Only the *dimension* has
-    #: to match: `Stimulus` has already converted an amplitude given as
-    #: ``0.05 * mA`` into 50 uA by the time it gets here. A device that
-    #: delivered something else (light, say) would override this.
+    #: Physical quantity delivered by the implant. Subclasses may override.
     stimulus_unit = uA
 
     def __init__(self, earray, stim=None, eye='RE', preprocess=False,
@@ -118,9 +111,8 @@ class ProsthesisSystem(PrettyPrint):
         self.encoder = encoder
         self.raster = raster
         self.max_current = max_current
-        # Beware of race condition: the stimulus goes last, because assigning
-        # it may have to encode a picture, which needs the encoder, the raster
-        # and the electrode array to be in place already.
+        # Assign stimulus last because encoding depends on the initialized
+        # encoder, raster, and electrode array.
         self.stim = stim
 
     def _pprint_params(self):
@@ -143,13 +135,10 @@ class ProsthesisSystem(PrettyPrint):
 
     @property
     def encoder(self):
-        """Stimulus encoder
+        """Stimulus encoder used for image or video input.
 
-        How this device turns a picture into stimulation. Most implants do not
-        set one in their constructor, so the slot backing it may never have
-        been written to; no encoder means an image or a video assigned to
-        :py:attr:`~pulse2percept.implants.ProsthesisSystem.stim` is refused
-        rather than silently given a modulation scheme nobody chose.
+        If None, dimensionless image/video stimuli are not encoded
+        automatically.
         """
         return getattr(self, '_encoder', None)
 
@@ -163,18 +152,9 @@ class ProsthesisSystem(PrettyPrint):
 
     @property
     def raster(self):
-        """Raster pattern
+        """Raster pattern used to schedule stimulation across electrodes.
 
-        Most implants do not set this in their constructor, so the slot backing
-        it may never have been written to; an unset raster means all electrodes
-        may fire at once.
-
-        Assigning a raster binds it to this implant (see
-        :py:meth:`~pulse2percept.implants.Raster.bind`), which is what lets a
-        geometry-dependent pattern such as
-        :py:class:`~pulse2percept.implants.CheckerboardRaster` work itself out
-        and what lets :py:meth:`~pulse2percept.implants.Raster.plot` be called
-        without an argument.
+        Assigning a raster binds it to this implant.
         """
         return getattr(self, '_raster', None)
 
@@ -205,36 +185,13 @@ class ProsthesisSystem(PrettyPrint):
 
     @property
     def thresholds(self):
-        """Perceptual threshold current (uA) for each electrode
+        """Perceptual threshold current (uA) for each electrode.
 
-        Calibration of the electrode/subject interface, relating stimulation
-        expressed in :py:data:`~pulse2percept.units.xTh` to the current that
-        realizes it. Assign one current for the whole array, a dict for
-        per-electrode values (a partial dict leaves the rest uncalibrated), or
-        None to clear.
-
-        Changing thresholds recalibrates any
-        :py:class:`~pulse2percept.stimuli.BiphasicPulseTrain` already assigned
-        to :py:attr:`stim`: ``xTh`` trains keep their multiple of threshold,
-        current-valued trains keep their current. Sampled stimuli are
-        unchanged.
+        Assign a single current for the whole array, a per-electrode dict,
+        or None to clear the calibration. Threshold-relative pulse trains
+        are recalibrated when this property changes.
 
         .. versionadded:: 0.10.0
-
-        Examples
-        --------
-        >>> from pulse2percept.implants import ArgusII
-        >>> from pulse2percept.stimuli import BiphasicPulseTrain
-        >>> from pulse2percept.units import uA, xTh
-        >>> implant = ArgusII()
-        >>> implant.stim = {'A1': BiphasicPulseTrain(20, 2 * xTh, 0.45),
-        ...                 'A2': BiphasicPulseTrain(20, 2 * xTh, 0.45)}
-        >>> implant.thresholds = {'A1': 80 * uA, 'A2': 120 * uA}
-        >>> float(abs(implant.stim['A1']).max())
-        160.0
-        >>> float(abs(implant.stim['A2']).max())
-        240.0
-
         """
         return dict(getattr(self, '_thresholds', None) or {})
 
@@ -282,9 +239,9 @@ class ProsthesisSystem(PrettyPrint):
         self._stim = calibrated
 
     def _calibrated(self, stim):
-        """Apply implant thresholds to retained BiphasicPulseTrain sources.
+        """Apply implant thresholds to retained ``BiphasicPulseTrain`` sources.
 
-        Returns ``stim`` unchanged if no source needs recalibration.
+        Return ``stim`` unchanged if no source needs recalibration.
         """
         thresholds = getattr(self, '_thresholds', None) or {}
         sources = stim._structured_sources()
@@ -316,19 +273,7 @@ class ProsthesisSystem(PrettyPrint):
                         metadata=deepcopy(stim.metadata.get('user')))
 
     def _require_deliverable_stim(self, stim):
-        """Refuse a stimulus this system cannot physically deliver
-
-        The implant's half of the boundary that
-        :py:func:`~pulse2percept.models.base._require_stim_dimension` guards on
-        the model's side. Both are needed: a model must not read gray levels as
-        microamps whatever produced them, and an implant that accepted a
-        picture would only fail once a model got hold of it, several steps
-        away from the assignment that was actually wrong.
-
-        Checked on the *final* stimulus, after ``preprocess`` and after any
-        reshaping onto the electrode grid, so that a preprocessing step that
-        turns an image into current is exactly as valid as encoding it first.
-        """
+        """Require a stimulus with a physical dimension this implant can deliver."""
         if stim.unit.dimension == self.stimulus_unit.dimension:
             return
         # Threshold-relative pulse trains may be assigned before
@@ -346,13 +291,7 @@ class ProsthesisSystem(PrettyPrint):
 
     @staticmethod
     def _require_current_stim(stim, check):
-        """Refuse to run an electrical safety check on something that isn't
-
-        Called by each check rather than by ``check_stim``, because a safety
-        check is a claim about electricity and each one has to say so for
-        itself: ``check_stim`` is public, and is called directly by tests and
-        by subclasses on stimuli that never went through the setter.
-        """
+        """Require electrical current before applying an electrical safety check."""
         if stim.unit.dimension == uA.dimension:
             return
         if stim.unit.dimension == xTh.dimension:
@@ -508,7 +447,7 @@ class ProsthesisSystem(PrettyPrint):
             return Stimulus(
                 pixel_values, electrodes=self.electrode_names,
                 time=stim.time, metadata=stim.metadata)._inherit_units(stim)
-        
+
         else:
             raise ValueError(
                 f"Number of electrodes in the stimulus ({len(stim.electrodes)}) "
@@ -528,7 +467,7 @@ class ProsthesisSystem(PrettyPrint):
             A Matplotlib axes object. If None, will either use the current axes
             (if exists) or create a new Axes object.
         stim_cmap : bool, str, or matplotlib colormap, optional
-            If not false, the fill color of the plotted electrodes will vary based 
+            If not false, the fill color of the plotted electrodes will vary based
             on maximum stimulus amplitude on each electrode. The chosen colormap
             will be used if provided
 
@@ -823,7 +762,7 @@ class RectangleImplant(ProsthesisSystem):
         self.earray = ElectrodeGrid(self.shape, spacing, x=x, y=y, z=z, r=r,
                                     rot=rot, names=names, etype=DiskElectrode)
         self.stim = stim
-        
+
         # Set left/right eye:
         if not isinstance(eye, str):
             raise TypeError("'eye' must be a string, either 'LE' or 'RE'.")

--- a/pulse2percept/implants/rasters.py
+++ b/pulse2percept/implants/rasters.py
@@ -30,11 +30,7 @@ def _whole(name, value):
 
 
 def _electrode_array(implant):
-    """The electrode array of a prosthesis system, or the array itself
-
-    Duck-typed rather than imported, since ``implants.base`` imports this
-    module.
-    """
+    """Return the electrode array of an implant, or the array itself."""
     earray = getattr(implant, 'earray', implant)
     if (getattr(earray, 'electrode_names', None) is None or
             getattr(earray, 'coordinates', None) is None):
@@ -44,101 +40,24 @@ def _electrode_array(implant):
 
 
 class Raster(PrettyPrint, metaclass=ABCMeta):
-    """Abstract base class for all raster patterns
+    """Abstract base class for raster patterns.
 
-    A stimulator usually cannot drive every electrode at once, because the
-    total current it can source at any instant is limited. Electrodes are
-    therefore split into *raster groups* that take turns.
+    A raster partitions electrodes into groups that take turns
+    stimulating. Different groups must not be active at the same time.
+    Raster timing is applied by :class:`~pulse2percept.stimuli.StimulusEncoder`.
 
-    A raster is a **scheduling constraint, not a hardware state machine**. What
-    it has to deliver is one property: no two groups are ever active at the same
-    instant, so that the stimulator sources at most one group's worth of current
-    however the video is modulated. It is not a switch that cyclically enables
-    group 0, then group 1, then group 0 again forever, and a group's pulses do
-    not have to land at the same phase of a repeating cycle.
-
-    Taking turns is described by a **raster sweep**: group *g* starts its pulse
-    ``g * group_dur`` after group 0 does, so a sweep spans ``n_groups *
-    group_dur``. Two things then keep groups apart for good (see
-    :py:class:`~pulse2percept.stimuli.StimulusEncoder`):
-
-    1.  A pulse has to be short enough to finish before the next group's turn
-        begins.
-    2.  Electrodes on *different* pulse periods drift relative to one another,
-        and would eventually collide however they started out. Their periods are
-        therefore pinned to whole numbers of the sweep, which fixes their
-        relative phase. Pinning rounds the period *up*, so multiplexing never
-        drives an electrode faster -- and so never delivers more charge -- than
-        asked.
-
-        Electrodes that share one period cannot drift in the first place: their
-        onsets stay ``group_dur`` apart forever, whatever that period is.
-        Nothing is quantized in that case and the requested rate is delivered
-        exactly, even when the period is not a whole number of sweeps. This is
-        the usual case under amplitude modulation, and it is why rastering costs
-        no frequency there.
-
-        So with two groups 1.5 ms apart on a common 10 ms period, group 0 pulses
-        at 0, 10, 20, ... and group 1 at 1.5, 11.5, 21.5, ... -- collision-free,
-        but not a repeating 3 ms schedule, and the 10 ms period is left alone.
-
-    The sweep belongs to the *stimulation* schedule, not to the video: it is
-    tied to the pulse period, not to the frame rate. Two rules settle how long
-    it is and what it costs:
-
-    *  With ``group_dur=None`` the groups divide the *shortest* pulse period
-       between them, so the sweep is exactly that period. Under frequency
-       modulation that means the fastest electrode pulses once per sweep and
-       slower ones every *m*-th sweep.
-    *  With an explicit ``group_dur`` the sweep is ``n_groups * group_dur``
-       whatever rate the electrodes run at -- six groups of 1 ms sweep in 6 ms.
-       It is then generally much shorter than a pulse period, so even the
-       fastest electrode may pulse only every *m*-th sweep.
-
-    Either way, only periods that *differ* from one another are rounded up onto
-    the sweep; a period they all share is delivered exactly, since fixed group
-    offsets cannot drift into one another.
-
-    A raster is *bound* to the implant it schedules. Assigning it to
-    :py:attr:`~pulse2percept.implants.ProsthesisSystem.raster` binds it, which
-    is what lets a subclass whose pattern depends on where the electrodes are
-    (:py:class:`~pulse2percept.implants.CheckerboardRaster`) work the geometry
-    out, and what lets :py:meth:`plot` draw the array without being handed it
-    again:
-
-    .. code::
-
-        implant.raster = CheckerboardRaster(5)
-        implant.raster.plot()
-
-    Subclasses only implement ``groups``, and override ``bind`` if their
-    pattern depends on the implant.
+    Assigning a raster to ``implant.raster`` binds it to that implant.
+    Subclasses implement :meth:`groups` and may override :meth:`bind`
+    when the grouping depends on electrode geometry.
 
     .. versionadded:: 0.10.0
 
     Parameters
     ----------
     group_dur : float, optional
-        Duration (ms) of a single group's slot, and hence the spacing between
-        one group's turn and the next. If None, the groups are spread evenly
-        over the pulse period, so that a sweep takes exactly one period to
-        complete -- which is what an encoder wants whenever every electrode
-        pulses at the same rate.
-
-        Setting it explicitly makes the sweep ``n_groups * group_dur``
-        regardless of the pulse period, which is how you buy back frequency
-        resolution under frequency modulation: a shorter slot means a shorter
-        sweep, and the periods that have to be pinned are pinned onto a finer
-        grid. It cannot be shorter than a single pulse.
-
-        An encoder with a ``clock`` rounds the slot onto it and rebuilds the
-        sweep from the result, so every group keeps a turn of the same length.
-
-        May be given as a plain number of milliseconds or as a unitful
-        quantity (e.g. ``1000 * us``); the same goes for the ``period``
-        argument of :py:meth:`slot_dur` and :py:meth:`offsets`. See
-        :py:mod:`pulse2percept.units`.
-
+        Duration of one group's slot (ms). If None, groups divide the
+        shortest pulse period evenly. An explicit value fixes the
+        raster sweep to ``n_groups * group_dur``.
     """
     __slots__ = ('group_dur', '_implant')
 
@@ -170,31 +89,20 @@ class Raster(PrettyPrint, metaclass=ABCMeta):
         return getattr(self, '_implant', None)
 
     def bind(self, implant):
-        """Bind the raster to an implant
+        r"""Bind the raster to an implant or electrode array.
 
-        A raster describes how one particular device takes turns between its
-        electrodes, so it is bound to that device rather than handed to every
-        method that needs it. This is called for you when the raster is
-        assigned to
-        :py:attr:`~pulse2percept.implants.ProsthesisSystem.raster`.
-
-        Binding is also where a pattern that depends on the electrode geometry
-        is worked out, so a subclass that has such a pattern overrides this and
-        recomputes. Rebinding therefore always recomputes: the same raster
-        object assigned to a second implant describes *that* implant.
+        Geometry-dependent rasters may override this method to recompute
+        their grouping.
 
         Parameters
         ----------
-        implant : :py:class:`~pulse2percept.implants.ProsthesisSystem`
-            The implant to bind to, or its
-            :py:class:`~pulse2percept.implants.ElectrodeArray`.
+        implant : :class:`~pulse2percept.implants.ProsthesisSystem` or \
+                  :class:`~pulse2percept.implants.ElectrodeArray`
+            Implant or electrode array to bind.
 
         Returns
         -------
-        self : :py:class:`~pulse2percept.implants.Raster`
-            The raster, so that ``CheckerboardRaster(5).bind(implant)`` reads
-            as one expression.
-
+        self : :class:`~pulse2percept.implants.Raster`
         """
         _electrode_array(implant)
         self._implant = implant
@@ -234,32 +142,19 @@ class Raster(PrettyPrint, metaclass=ABCMeta):
         raise NotImplementedError
 
     def members(self, electrodes, group):
-        """The electrodes that take their turn together in one group
-
-        The inverse of :py:meth:`groups`, which says what group each electrode
-        is in. This says which electrodes are in a group.
+        """Return the electrodes in one raster group.
 
         Parameters
         ----------
         electrodes : array_like
-            Electrode names, in the order they appear in the stimulus.
+            Electrode names.
         group : int
-            Which group to look up, in ``0..n_groups-1``. Groups take their
-            turns in index order, so group 0 is the one that goes first.
+            Group index in ``0..n_groups-1``.
 
         Returns
         -------
         members : array
-            The entries of ``electrodes`` belonging to ``group``, in the order
-            they were given: names in, names out.
-
-        Examples
-        --------
-        >>> from pulse2percept.implants import ArgusII, SequentialRaster
-        >>> names = ArgusII().electrode_names
-        >>> SequentialRaster(6).members(names, 0)[:4]
-        array(['A1', 'A2', 'A3', 'A4'], dtype='<U3')
-
+            Electrode names belonging to ``group``.
         """
         group = _whole('group', group)
         if group < 0 or group >= self.n_groups:
@@ -269,43 +164,26 @@ class Raster(PrettyPrint, metaclass=ABCMeta):
 
     def plot(self, implant=None, annotate=None, ax=None, cmap='viridis',
              autoscale=True):
-        """Plot the electrode array, colored by raster group
-
-        What a raster does is spatial, so the quickest way to tell whether it
-        does what was wanted is to look at it. Colors run in the order the
-        groups take their turns, so the picture shows the schedule as well as
-        the pattern: with
-        :py:class:`~pulse2percept.implants.CheckerboardRaster` a group's
-        electrodes should be scattered over the whole array rather than
-        gathered into a line, and neighboring colors should not lie next to
-        one another in a consistent direction.
+        """Plot electrodes colored by raster group.
 
         Parameters
         ----------
-        implant : :py:class:`~pulse2percept.implants.ProsthesisSystem`, optional
-            The implant to draw, or its
-            :py:class:`~pulse2percept.implants.ElectrodeArray`. Its electrodes
-            are the ones the raster is asked about, so this has to be an
-            implant the raster covers. If None, the implant the raster is
-            bound to is drawn (see :py:meth:`bind`).
+        implant : :class:`~pulse2percept.implants.ProsthesisSystem`, optional
+            Implant to draw. If None, use the bound implant.
         annotate : bool, optional
-            Whether to write the group index into each electrode. If None,
-            they are written whenever there are few enough electrodes
-            (at most 120) for the numbers to be readable.
+            Write group indices on electrodes. If None, annotate arrays
+            with at most 120 electrodes.
         ax : matplotlib.axes.Axes, optional
-            Axes to draw on. If None, uses the current axes.
+            Axes to draw on.
         cmap : str, optional
-            Matplotlib colormap the group colors are taken from, evenly
-            spaced. A sequential map is the useful default, since the order
-            the colors run in is the order the groups fire in.
+            Matplotlib colormap.
         autoscale : bool, optional
-            Whether to fit the x/y limits to the implant.
+            Fit the axes to the implant.
 
         Returns
         -------
         ax : matplotlib.axes.Axes
             The axes drawn on.
-
         """
         earray = self._bound(implant)
         names = list(earray.electrode_names)

--- a/pulse2percept/models/base.py
+++ b/pulse2percept/models/base.py
@@ -1,4 +1,4 @@
-""":py:class:`~pulse2percept.models.BaseModel`, 
+""":py:class:`~pulse2percept.models.BaseModel`,
    :py:class:`~pulse2percept.models.Model`,
    :py:class:`~pulse2percept.models.NotBuiltError`,
    :py:class:`~pulse2percept.models.SpatialModel`,
@@ -25,11 +25,9 @@ from ..utils.constants import ZORDER
 
 
 def _n_jobs_alias():
-    """Build the ``n_jobs`` property, an alias for ``n_threads``
+    """Build ``n_jobs`` as an alias for ``n_threads``.
 
-    Both names refer to the same OpenMP thread count, and both read and write
-    the same storage, so they can never drift apart. ``None`` and ``-1`` mean
-    "use every core", following the scikit-learn convention.
+    ``None`` and ``-1`` select all available CPU cores.
     """
     def getter(self):
         return self.n_threads
@@ -53,53 +51,27 @@ def _n_jobs_alias():
                         "names read and write the same value.")
 
 
-#: How many instants inside each video frame a percept is sampled at before
-#: being reduced to one value for that frame. Electrical stimulation is
-#: pulsatile, so the brightness a frame produces rises and falls within it; a
-#: single instant lands wherever the pulse cycle happens to be and can differ
-#: from its neighbours by two orders of magnitude for no reason a viewer would
-#: recognize. Sampling across the frame and keeping the peak reports what the
-#: frame actually did.
-#:
-#: This is the fallback for models whose kernel cannot track the peak itself
-#: (``_reduces_intervals``), and it is only approximate: dynamics much faster
-#: than ``frame_dur`` divided by this are under-reported, because no finite
-#: sampling can summarize a transient shorter than its own step. A 0.92 ms
-#: pulse against a 33.4 ms frame needs 37 samples to be caught reliably; eight
-#: of them catch it about one frame in seven, which is enough for a model whose
-#: output is already smooth on the millisecond scale and not enough for one
-#: whose output is not.
+#: Samples per video frame used when a temporal kernel cannot reduce an
+#: interval internally. This fallback is approximate for sub-frame transients.
 _FRAME_SUBSAMPLES = 8
 
 
 def _subsample(t_out, dt, n_sub, start=None):
-    """Sample the interval leading up to each output point ``n_sub`` times
+    """Sample each output interval at up to ``n_sub`` points.
 
-    The fallback for a model that cannot summarize an interval inside its own
-    integrator (see ``_FRAME_SUBSAMPLES``): ask it for several instants per
-    interval and keep the largest. Samples are evenly spaced and land exactly
-    on the output point, so the value there is always among them -- the peak of
-    an interval is then never below the instant it ends on, whatever the
-    sampling does.
+    Used by temporal models that cannot reduce an interval internally.
 
     Parameters
     ----------
     start : float, optional
-        Where the interval summarized by the *first* output point begins (ms).
-        A frame clock puts its output points on frame *ends*, so the first one
-        summarizes an interval reaching back to the start of frame 0. If None,
-        the first output point has no interval and stands for its own instant.
+        Start of the first interval (ms).
 
     Returns
     -------
     t : array
-        The instants to evaluate at (ms), strictly increasing.
+        Sample times (ms).
     idx : array
-        Where each output point's samples begin in ``t``, ready to pass
-        straight to ``np.maximum.reduceat``.
-
-    .. versionadded:: 0.10.0
-
+        Start index of each interval in ``t``.
     """
     ticks = np.round(np.asarray(t_out, dtype=np.float64) / dt).astype(np.int64)
     # An interval runs from the previous output point up to and including this
@@ -122,33 +94,21 @@ def _subsample(t_out, dt, n_sub, start=None):
 
 
 def _frame_clock(stim, dt, unit=ms):
-    """When to sample a percept for the video an encoded stimulus came from
+    """Return percept output times for an encoded video stimulus.
 
-    An encoder separates the clock that decides *when the picture changes* from
-    the clock that decides *when the electrodes pulse*, and records the former
-    in the stimulus' metadata. That is the rate at which a percept is worth
-    reporting: one frame in, one frame out. The pulse train's own time points
-    are far finer and carry no extra picture.
-
-    A percept point lands on the end of each frame. Everything is rounded onto
-    the model's ``dt`` grid (a 29.97 fps frame is 33.3667 ms, which is not a
-    multiple of the default dt=0.005 ms). It is the frame *interval* that is
-    rounded rather than each frame time on its own, so that the percept keeps
-    an evenly spaced time axis -- ``play`` and ``save`` infer a frame rate from
-    it and refuse a ragged one.
+    Encoders record source-frame timing in stimulus metadata. Output
+    times are rounded to the model's ``dt`` grid.
 
     Returns
     -------
-    t : (n_frames,) array
-        The time at which each frame ends, expressed in ``unit``.
+    t : array
+        Frame-end times in ``unit``.
     start : float
-        The time (in ``unit``) at which the first frame begins, which is where
-        the interval summarized by ``t[0]`` starts.
+        Start time of the first frame.
 
-    Returns None for anything that did not come out of an encoder.
+    Returns None for stimuli without encoder frame metadata.
 
     .. versionadded:: 0.10.0
-
     """
     meta = getattr(stim, 'metadata', None)
     if not isinstance(meta, dict):
@@ -188,22 +148,7 @@ def _frame_clock(stim, dt, unit=ms):
 
 
 def _vfmap_first(params):
-    """Order parameters so that ``vfmap`` is applied before the others
-
-    A retinal extent assigned to ``xrange``/``yrange`` is resolved through the
-    model's visual field map at assignment time (see
-    :py:meth:`SpatialModel._retinal_range_to_dva`), so which map is installed
-    when that happens decides what the range comes out as. Parameters are
-    otherwise applied in the order they were given, and
-
-    .. code-block:: python
-
-        AxonMapModel(xrange=(-2.8 * mm, 2.8 * mm), vfmap=Curcio1990Map())
-
-    has to use the map the caller asked for rather than whichever one was
-    already there. Only ``vfmap`` is moved; everything else keeps its order,
-    so nothing else becomes order-sensitive.
-    """
+    """Apply ``vfmap`` before parameters whose units depend on that map."""
     if 'vfmap' not in params:
         return params
     return {'vfmap': params['vfmap'],
@@ -211,36 +156,17 @@ def _vfmap_first(params):
 
 
 def _length_valued(value):
-    """Whether a value, or either half of a pair, is a physical length
-
-    What tells a retinal extent apart from a visual one is the *dimension* of
-    what was passed, not the unit: ``mm``, ``um`` and ``m`` are all the same
-    shorthand, and a bare number is no shorthand at all.
-    """
+    """Return whether a value or pair contains a physical length."""
     values = value if isinstance(value, (list, tuple)) else [value]
     return any(isinstance(v, (Quantity, Unit)) and v.dimension == um.dimension
                for v in values)
 
 
 def _require_stim_dimension(model, stim):
-    """Refuse a stimulus that is not the physical quantity a model reads
+    """Require a stimulus with a physical dimension accepted by ``model``.
 
-    Only the *dimension* has to match; a stimulus in a compatible unit is
-    converted rather than refused. In practice there is nothing left for a
-    model to convert, because :py:class:`~pulse2percept.stimuli.Stimulus`
-    canonicalizes to microamps when it is built -- an amplitude given as
-    ``0.05 * mA`` is already 50 by the time any model sees it.
-
-    The dimension is another matter, and is the model's to insist on. Gray
-    levels are not small currents, so a model that multiplied them by a
-    Gaussian current spread and called the result brightness would be doing
-    exactly the silent reinterpretation ``stimulus_unit`` exists to declare
-    away. A picture becomes a stimulus by being encoded (see
-    :py:class:`~pulse2percept.stimuli.StimulusEncoder`), which is where the
-    gray levels are given a current to stand for.
-
-    A :py:class:`~pulse2percept.percepts.Percept` is not checked: it is
-    brightness, the output of a spatial model, and carries no unit.
+    Percepts are not checked because they represent model output rather
+    than electrical stimulation.
     """
     if not isinstance(stim, Stimulus):
         return
@@ -254,30 +180,18 @@ def _require_stim_dimension(model, stim):
 
 
 def _spatial_input(implant):
-    """The stimulus a model with no temporal component reads off an implant
+    """Return the spatial view of an implant stimulus.
 
-    A pulse train says *when* current flows and a raster says which electrodes
-    may flow at once. Both are facts about time that such a model has no
-    machinery to express -- handed the delivered train, it would report an
-    encoded image as a sequence of raster slots. So an encoded stimulus is
-    read for the modulation it realizes instead: one amplitude per electrode
-    per frame of the source. Anything else is its own answer.
+    Encoded stimuli expose frame-level modulation to spatial-only
+    models instead of the time-resolved pulse schedule.
     """
     return implant.stim._spatial_view()
 
 
 def _rescale(stim, scale):
-    """A copy of ``stim`` with every amplitude multiplied by ``scale``
+    """Return a sampled copy of ``stim`` scaled by ``scale``.
 
-    Rebuilt from the data rather than scaled through the operator, because a
-    stimulus with no time component picks one up on the way through: that is
-    what lets a temporal model be handed one at all, and
-    :py:meth:`TemporalModel.find_threshold` has always relied on it.
-
-    The metadata is carried across: it is what tells ``predict_percept`` which
-    video the stimulus was encoded from, and hence when to report a percept.
-    Without it every trial of a ``find_threshold`` search would be evaluated
-    on a different time base than the caller's own ``predict_percept`` uses.
+    Metadata and units are preserved.
     """
     return Stimulus(scale * stim.data, electrodes=stim.electrodes,
                     time=stim.time,
@@ -285,29 +199,14 @@ def _rescale(stim, scale):
 
 
 def _rescaled_implant(implant, amp):
-    """A copy of ``implant`` whose stimulus peaks at ``amp``
-
-    What ``find_threshold`` varies from trial to trial. Scaling the stimulus
-    scales every description of it at once: an encoded one is still the
-    schedule it was, delivering less current, and what a spatial model reads
-    off it moves with what a temporal one does. A search run on only one of
-    them would not be a search for the threshold of what the caller's own
-    ``predict_percept`` reports.
-    """
+    """Return a copy of ``implant`` with its stimulus scaled to peak at ``amp``."""
     trial = deepcopy(implant)
     trial.stim = implant.stim * (amp / implant.stim.data.max())
     return trial
 
 
 def _delivered(implant):
-    """The same implant, made to hand a spatial model the pulse train
-
-    The other side of :py:func:`_spatial_input`: when a temporal stage follows,
-    integrating the pulses is the point, so they are what has to get through.
-    An ordinary :py:class:`~pulse2percept.stimuli.Stimulus` is its own spatial
-    view, so wrapping in one is how the delivered pulses are asked for -- and
-    the wrapper stays unmaterialized until something reads them.
-    """
+    """Return an implant whose spatial input is the delivered pulse train."""
     if implant.stim is None or not implant.stim._has_spatial_view:
         return implant
     stand_in = copy(implant)
@@ -558,7 +457,7 @@ class SpatialModel(BaseModel, metaclass=ABCMeta):
     provide an implementation for:
 
     *  ``_predict_spatial``: This method should accept an ElectrodeArray as well
-       as a Stimulus, and compute the brightness at all spatial coordinates of 
+       as a Stimulus, and compute the brightness at all spatial coordinates of
        ``self.grid``, returned as a 2D NumPy array (space x time).
 
        .. note ::
@@ -1100,7 +999,7 @@ class SpatialModel(BaseModel, metaclass=ABCMeta):
 
         ax = self.grid.plot(autoscale=autoscale, ax=ax, style=style, zorder=zorder,
                             figsize=figsize, use_dva=use_dva)
-        
+
         if use_dva:
             ax.set_xlabel('x (dva)')
             ax.set_ylabel('y (dva)')

--- a/pulse2percept/models/granley2021.py
+++ b/pulse2percept/models/granley2021.py
@@ -29,21 +29,21 @@ _FIND_THRESHOLD_MSG = (
 class DefaultBrightModel(BaseModel):
     """
     Default model to be used for brightness scaling in BiphasicAxonMapModel
-    Implements Eq 4 from [Granley2021]_ 
+    Implements Eq 4 from [Granley2021]_
     Fit using data from [Nanduri2012]_ and [Weitz2015]_
 
     Parameters:
     ------------
     do_thresholding : bool, optional
-        Set to true to enable probabilistic phosphene appearance at near-threshold 
+        Set to true to enable probabilistic phosphene appearance at near-threshold
         amplitudes
     a0, a1 : float, optional
         Linear regression coefficients (slope and intercept) of pulse_duration
-        vs threshold curve (Eq 3). Amplitude factor will be scaled by 
+        vs threshold curve (Eq 3). Amplitude factor will be scaled by
         a0*pdur + a1.
     a2, a3, a4: float, optional
         Linear regression coefficients for brightness vs amplitude and frequency (Eq 4)
-        F_bright = a2*scaled_amp + a3*freq + a4 
+        F_bright = a2*scaled_amp + a3*freq + a4
     """
 
     def __init__(self, **params):
@@ -61,7 +61,7 @@ class DefaultBrightModel(BaseModel):
         return params
 
     def scale_threshold(self, pdur):
-        """ 
+        """
         Based on eq 3 in paper, this function produces the factor that amplitude
         will be scaled by to produce a_tilde. Computes A_0 * t + A_1 (1/threshold)
         .. note::
@@ -89,7 +89,7 @@ class DefaultBrightModel(BaseModel):
 class DefaultSizeModel(BaseModel):
     """
     Default model to be used for size (rho) scaling in BiphasicAxonMapModel
-    Implements Eq 5 from [Granley2021]_ 
+    Implements Eq 5 from [Granley2021]_
     Fit using data from [Nanduri2012]_ and [Weitz2015]_
 
     Parameters:
@@ -98,7 +98,7 @@ class DefaultSizeModel(BaseModel):
         Rho parameter of BiphasicAxonMapModel (spatial decay rate)
     a0, a1 : float, optional
         Linear regression coefficients (slope and intercept) of pulse_duration
-        vs threshold curve (Eq 3). Amplitude factor will be scaled by 
+        vs threshold curve (Eq 3). Amplitude factor will be scaled by
         a0*pdur + a1.
     a5, a6 : float, optional
         Linear regression coefficients for size vs amplitude (Eq 5)
@@ -130,7 +130,7 @@ class DefaultSizeModel(BaseModel):
         return {**super().get_param_units(), 'rho': um, 'min_rho': um}
 
     def scale_threshold(self, pdur):
-        """ 
+        """
         Based on eq 3 in paper, this function produces the factor that amplitude
         will be scaled by to produce a_tilde. Computes A_0 * t + A_1 (1/threshold)
         .. note::
@@ -153,7 +153,7 @@ class DefaultSizeModel(BaseModel):
 class DefaultStreakModel(BaseModel):
     """
     Default model to be used for streak length (lambda) scaling in BiphasicAxonMapModel
-    Implements Eq 6 from [Granley2021]_ 
+    Implements Eq 6 from [Granley2021]_
     Fit using data from [Weitz2015]_
 
     Parameters:
@@ -219,21 +219,17 @@ _NO_THRESHOLD_MSG = (
 def _pulse_train_params(stim):
     """Return Granley pulse parameters for each driven electrode.
 
-    Parameters are read from retained ``BiphasicPulseTrain`` sources without
-    rendering the waveform. Amplitude is returned in multiples of threshold.
-
-    Electrodes driven at zero amplitude are left out, so an empty list means
-    the percept is zero.
+    Parameters are read from retained ``BiphasicPulseTrain`` objects
+    without rendering their waveforms. Amplitudes are returned in
+    multiples of threshold; zero-amplitude electrodes are omitted.
 
     Raises
     ------
     TypeError
-        If any electrode is driven by something other than a
-        :py:class:`~pulse2percept.stimuli.BiphasicPulseTrain` with
-        ``delay_dur=0``.
+        If a driven electrode is not a zero-delay
+        :class:`~pulse2percept.stimuli.BiphasicPulseTrain`.
     ValueError
-        If a driven electrode's amplitude is a current whose threshold is
-        unknown.
+        If a current-valued amplitude has no threshold calibration.
     """
     sources = stim._structured_sources()
     if sources is None:
@@ -311,7 +307,7 @@ class BiphasicAxonMapSpatial(AxonMapSpatial):
         Model used to modulate percept streak length with amplitude, frequency,
         and pulse duration
     **params: optional
-        Additional params for AxonMapModel. 
+        Additional params for AxonMapModel.
 
         Options:
         --------
@@ -369,8 +365,8 @@ class BiphasicAxonMapSpatial(AxonMapSpatial):
             ``n_gray`` bins. If None, no compression is performed.
         noise : float or int, optional
             Adds salt-and-pepper noise to each percept frame. An integer will be
-            interpreted as the number of pixels to subject to noise in each 
-            frame. A float between 0 and 1 will be interpreted as a ratio of 
+            interpreted as the number of pixels to subject to noise in each
+            frame. A float between 0 and 1 will be interpreted as a ratio of
             pixels to subject to noise in each frame.
         loc_od, loc_od: (x,y), optional
             Location of the optic disc in degrees of visual angle. Note that the
@@ -565,7 +561,7 @@ class BiphasicAxonMapSpatial(AxonMapSpatial):
 
     def predict_percept(self, implant, t_percept=None):
         """ Predicts the spatial response
-        Override base predict percept to have desired timesteps and 
+        Override base predict percept to have desired timesteps and
         remove unneccesary computation
 
         Parameters
@@ -701,8 +697,8 @@ class BiphasicAxonMapModel(Model):
     one representative percept from all time steps of the stimulus.
 
     Brightness, size, and streak length scaling are controlled by the
-    parameters bright_model, size_model, and streak model respectively. 
-    By default, these are set to classes that implement Eqs 3-6 from 
+    parameters bright_model, size_model, and streak model respectively.
+    By default, these are set to classes that implement Eqs 3-6 from
     [Granley2021]_. These models can be individually customized by setting
     the bright_model, size_model, or streak_model to any python callable
     with signature ``f(freq, amp, pdur)``.
@@ -807,8 +803,8 @@ class BiphasicAxonMapModel(Model):
             ``n_gray`` bins. If None, no compression is performed.
         noise : float or int, optional
             Adds salt-and-pepper noise to each percept frame. An integer will be
-            interpreted as the number of pixels to subject to noise in each 
-            frame. A float between 0 and 1 will be interpreted as a ratio of 
+            interpreted as the number of pixels to subject to noise in each
+            frame. A float between 0 and 1 will be interpreted as a ratio of
             pixels to subject to noise in each frame.
         loc_od, loc_od: (x,y), optional
             Location of the optic disc in degrees of visual angle. Note that the

--- a/pulse2percept/models/temporal.py
+++ b/pulse2percept/models/temporal.py
@@ -7,68 +7,43 @@ from ._temporal import alpha_fast, fading_fast
 
 
 class FadingTemporal(TemporalModel):
-    """A generic temporal model for phosphene fading
+    r"""Generic temporal model for phosphene fading.
 
-    Implements phosphene fading using a leaky integrator driven by the
-    cathodic half of the stimulus:
+    The model is a leaky integrator driven by cathodic current:
 
     .. math::
 
-        \\frac{dB}{dt} = \\frac{\\max(-A, 0) - B}{\\tau}
+        \frac{dB}{dt} = \frac{\max(-A, 0) - B}{\tau}
 
-    where :math:`A` is the stimulus amplitude, :math:`B` is the perceived
-    brightness, and :math:`\\tau` is the exponential decay constant (``tau``).
+    where :math:`A` is stimulus amplitude, :math:`B` is brightness,
+    and :math:`\tau` is the time constant. Anodic current is ignored.
 
-    The model makes the following assumptions:
-
-    *  Cathodic currents (negative amplitudes) increase perceived brightness
-    *  Anodic currents (positive amplitudes) do not, and are ignored
-    *  Brightness is bounded below by zero. What is reported is then
-       thresholded, so an output value is either 0 or at least
-       :math:`\\theta` (``thresh_percept``, a nonnegative scalar)
+    This is a generic response model, not a perceptually validated fit.
 
     .. versionchanged:: 0.10.0
 
-        The drive is now half-wave rectified, driven by the cathodic phase.
-        A stimulus that is purely cathodic is unaffected.
-
-    .. note::
-
-        This is the simplest sensical temporal model, not a perceptually
-        validated model of phosphene fading.
+        The drive is half-wave rectified, so only cathodic current
+        increases brightness.
 
     Parameters
     ----------
     dt : float, optional
-        Sampling time step of the simulation (ms)
+        Simulation time step (ms).
     tau : float, optional
-        Time decay constant for the exponential decay (ms).
-        Larger values lead to slower decay.
-        Brightness should decay to half its peak ("half-life") after
-        :math:`\\ln(2) \\tau` milliseconds.
-
-        It cannot be shorter than ``dt``. The integrator steps explicitly, so
-        a time constant of one step already carries brightness all the way to
-        its drive; anything shorter overshoots and oscillates. ``tau`` also
-        sets the *rise*, not just the decay, so raising it does not make a
-        percept persist -- it makes it dimmer, as :math:`1/\\tau`.
-    thresh_percept: float, optional
-        Below threshold, the percept has brightness zero.
+        Leaky-integrator time constant (ms). Larger values slow both
+        rise and decay; for brief pulses they also reduce peak
+        brightness. Must be at least ``dt``.
+    thresh_percept : float, optional
+        Brightness values below threshold are set to zero.
     reduce : {'peak', 'last'}, optional
-        How a percept time point summarizes the interval since the previous
-        one, when ``predict_percept`` chooses the output times itself; see
-        :py:class:`~pulse2percept.models.TemporalModel`. This model tracks the
-        peak inside the integrator, so it is exact at any output rate.
-    n_threads: int, optional
-            Number of CPU threads to use during parallelization using OpenMP. 
-            Defaults to max number of user CPU cores.
+        How each output point summarizes the preceding interval.
+    n_threads : int, optional
+        Number of OpenMP threads.
 
     .. versionadded:: 0.7.1
-
     """
 
-    #: The peak is tracked over whole intervals inside `fading_fast`, so
-    #: `predict_percept` does not have to subsample the interval itself.
+    #: The kernel tracks interval peaks directly.
     _reduces_intervals = True
 
     def get_default_params(self):
@@ -76,15 +51,10 @@ class FadingTemporal(TemporalModel):
         params = {
             # Time constant for the exponential decay:
             'tau': 100,
-            # This model is generic rather than a published fit, so it is free
-            # to report the more useful summary by default. The peak is tracked
-            # inside `fading_fast`, so it costs nothing and is exact:
+            # Report the exact interval peak by default.
             'reduce': 'peak',
         }
-        # This is subtle: Rather than calling `params.update(base_params)`, we
-        # call `base_params.update(params)`. This will overwrite `base_params`
-        # with values from `params`, which allows us to set `thresh_percept`=0
-        # rather than what the BaseModel dictates:
+        # Override base defaults with this model's defaults.
         base_params.update(params)
         return base_params
 
@@ -93,15 +63,10 @@ class FadingTemporal(TemporalModel):
         return {**super().get_param_units(), 'tau': ms}
 
     def _build(self):
-        # Zero is as unusable as a negative value: the integrator divides by
-        # `tau`, so it does not decay infinitely fast, it produces inf/nan.
+        # The integrator divides by ``tau``.
         if self.tau <= 0:
             raise ValueError(f'"tau" must be positive, not {self.tau}.')
-        # The integrator steps explicitly, so `dt / tau` is the fraction of the
-        # remaining gap it closes per step. Above 1 it overshoots and then
-        # oscillates, and the overshoot is `dt / tau` -- at tau=dt/4 brightness
-        # alternates between four times its drive and zero, which is not a
-        # leaky integrator in any useful sense:
+        # Explicit Euler is unstable here when ``tau < dt``.
         if self.tau < self.dt:
             raise ValueError(
                 f'"tau" must be at least dt={self.dt}, not {self.tau}. A time '
@@ -116,10 +81,7 @@ class FadingTemporal(TemporalModel):
         # Pass the stimulus as a 2D NumPy array to the fast Cython function:
         time = self._stim_times(stim)
         stim_data = self._stim_values(stim).reshape((-1, len(time)))
-        # Calculate at which simulation time steps we need to output a percept.
-        # This is basically t_percept/self.dt, but we need to beware of
-        # floating point rounding errors! 29.999 will be rounded down to 29 by
-        # np.uint32, so we need to np.round it first:
+        # Round before casting so floating-point noise cannot shift a sample.
         idx_percept = np.uint32(np.round(t_percept / self.dt))
         if np.unique(idx_percept).size < t_percept.size:
             raise ValueError(f"All times 't_percept' must be distinct multiples "
@@ -133,80 +95,46 @@ class FadingTemporal(TemporalModel):
 
 
 class AlphaTemporal(TemporalModel):
-    """A generic alpha-shaped temporal model
+    r"""Generic alpha-shaped temporal model.
 
-    Two leaky integrators in series, both with the same time constant
-    :math:`\\tau`, driven by the cathodic half of the stimulus:
-
-    .. math::
-
-        \\tau \\frac{dx}{dt} = \\max(-A, 0) - x
+    Two identical leaky integrators are cascaded:
 
     .. math::
 
-        \\tau \\frac{dy}{dt} = x - y
-
-    where :math:`A` is the stimulus amplitude, :math:`x` is the (hidden) first
-    stage, and :math:`y` is the perceived brightness.
-
-    :py:class:`~pulse2percept.models.FadingTemporal` has an exponentially
-    decaying impulse response. Here, cascading two identical leaky integrators
-    adds a finite rise time: the impulse response starts at zero, peaks, and
-    then decays. Its impulse response is
+        \tau \frac{dx}{dt} = \max(-A, 0) - x
 
     .. math::
 
-        h(t) = \\frac{t}{\\tau^2} e^{-t/\\tau},
+        \tau \frac{dy}{dt} = x - y
 
-    proportional to the standard alpha function, peaking at :math:`t = \\tau`.
+    Their impulse response is proportional to
 
-    The model makes the following assumptions:
+    .. math::
 
-    *  Cathodic currents (negative amplitudes) increase perceived brightness
-    *  Anodic currents (positive amplitudes) do not, and are ignored
-    *  ``tau`` sets the rise and the decay together; there is only the one
-       constant, so a later peak is also a slower decay
-    *  Brightness is bounded below by zero. What is reported is then
-       thresholded, so an output value is either 0 or at least
-       :math:`\\theta` (``thresh_percept``, a nonnegative scalar)
+        h(t) = \frac{t}{\tau^2} e^{-t/\tau},
 
-    .. note::
+    which rises from zero, peaks at :math:`t=\tau`, and then decays.
+    Cathodic current drives the response; anodic current is ignored.
 
-        This is a generic alpha-shaped temporal response, not a perceptually
-        validated model. Use it where a percept should build up over tens of
-        milliseconds rather than appear instantaneously.
+    This is a generic response model, not a perceptually validated fit.
 
     Parameters
     ----------
     dt : float, optional
-        Sampling time step of the simulation (ms)
+        Simulation time step (ms).
     tau : float, optional
-        Time constant of both leaky stages (ms). The impulse response peaks
-        approximately ``tau`` milliseconds after an impulse, and decays with
-        the same constant afterwards.
-
-        It cannot be shorter than ``dt``, for the same reason as in
-        :py:class:`~pulse2percept.models.FadingTemporal`: the stages step
-        explicitly, so a time constant of one step already carries each stage
-        all the way to its input, and anything shorter overshoots and
-        oscillates.
-    thresh_percept: float, optional
-        Below threshold, the percept has brightness zero.
+        Time constant of both stages (ms). Must be at least ``dt``.
+    thresh_percept : float, optional
+        Brightness values below threshold are set to zero.
     reduce : {'peak', 'last'}, optional
-        How a percept time point summarizes the interval since the previous
-        one, when ``predict_percept`` chooses the output times itself; see
-        :py:class:`~pulse2percept.models.TemporalModel`. This model tracks the
-        peak inside the cascade, so it is exact at any output rate.
-    n_threads: int, optional
-        Number of CPU threads to use during parallelization using OpenMP.
-        Defaults to max number of user CPU cores.
+        How each output point summarizes the preceding interval.
+    n_threads : int, optional
+        Number of OpenMP threads.
 
     .. versionadded:: 0.10.0
-
     """
 
-    #: The peak is tracked over whole intervals inside `alpha_fast`, so
-    #: `predict_percept` does not have to subsample the interval itself.
+    #: The kernel tracks interval peaks directly.
     _reduces_intervals = True
 
     def get_default_params(self):
@@ -214,8 +142,7 @@ class AlphaTemporal(TemporalModel):
         params = {
             # Time constant of both stages:
             'tau': 100,
-            # Generic rather than a published fit, so it is free to report the
-            # more useful summary by default; see `FadingTemporal`:
+            # Report the exact interval peak by default.
             'reduce': 'peak',
         }
         base_params.update(params)
@@ -228,9 +155,7 @@ class AlphaTemporal(TemporalModel):
     def _build(self):
         if self.tau <= 0:
             raise ValueError(f'"tau" must be positive, not {self.tau}.')
-        # Both stages step explicitly, so `dt / tau` is the fraction of the
-        # remaining gap each closes per step. Above 1 they overshoot and
-        # oscillate; see `FadingTemporal._build`:
+        # Explicit Euler is unstable here when ``tau < dt``.
         if self.tau < self.dt:
             raise ValueError(
                 f'"tau" must be at least dt={self.dt}, not {self.tau}. A time '

--- a/pulse2percept/percepts/base.py
+++ b/pulse2percept/percepts/base.py
@@ -48,13 +48,7 @@ def _parse_range_tag(text):
 
 
 def _range_tagged_path(fname, vmin, vmax):
-    """``fname`` with the brightness range written into its own name
-
-    The fallback for the containers :py:func:`_metadata_kwargs` cannot record
-    a range in. A name that already carries a tag has it replaced rather than
-    added to, so that no file is left named for a range it was not written
-    with.
-    """
+    """Return ``fname`` with its stored brightness range in the filename."""
     head, tail = os.path.split(os.fspath(fname))
     root, ext = os.path.splitext(tail)
     tag = _range_tag(vmin, vmax)
@@ -63,13 +57,7 @@ def _range_tagged_path(fname, vmin, vmax):
 
 
 def _media_metadata(fname):
-    """Whatever metadata imageio can read off a media file
-
-    Pillow carries the text chunks and comments that
-    :py:meth:`~pulse2percept.percepts.Percept.save` writes, but cannot open a
-    video; FFMPEG can, and reports the frame rate. Whichever opens the file
-    wins, so this yields at most one dictionary per backend that can read it.
-    """
+    """Yield metadata dictionaries from imageio backends that can read ``fname``."""
     for kwargs in ({'plugin': 'pillow'}, {}):
         try:
             yield dict(iio.immeta(fname, **kwargs))
@@ -129,12 +117,7 @@ def _media_fps(fname, n_frames):
 
 
 def _metadata_kwargs(fname, tag):
-    """Writer arguments that record ``tag`` in the file's own metadata
-
-    Only for the containers whose writer already has a comment field to put it
-    in. A percept saved in any other format can still carry its range in the
-    file name, which is the caller's to choose.
-    """
+    """Return writer arguments that store ``tag`` in supported media metadata."""
     ext = os.path.splitext(os.fspath(fname))[1].lower()
     if ext == '.png':
         try:
@@ -163,12 +146,7 @@ def _check_clim(vmin, vmax):
 
 
 def _resolve_clim(data, vmin, vmax, auto_vmin):
-    """Fill omitted display limits in from the whole percept
-
-    Resolving against all of ``data`` rather than against the frames a display
-    or export clock happens to sample is what keeps the brightness scale
-    independent of ``fps``.
-    """
+    """Fill omitted display limits from the full percept."""
     vmin = auto_vmin if vmin is None else vmin
     vmax = np.max(data) if vmax is None else vmax
     vmin, vmax = float(vmin), float(vmax)
@@ -266,17 +244,15 @@ class Percept(Data):
         }
 
     def __getitem__(self, item):
-        """Return percept data, interpolated in time where necessary
+        """Return percept data, interpolating requested time points as needed.
 
-        Space is indexed the NumPy way, but a number that reaches the time
-        axis is a *time* rather than a frame index; see the class docstring
-        for the forms that takes. Returns a NumPy array or a scalar, never a
-        new :py:class:`~pulse2percept.percepts.Percept`.
+        Spatial dimensions use normal NumPy indexing. A numeric index that
+        reaches the final axis is interpreted as time rather than a frame
+        number. Returns an array or scalar, not a new :class:`Percept`.
 
         .. versionadded:: 0.10.0
-
         """
-        # STEP 1: DOES THE INDEX REACH THE TIME AXIS?
+        # Determine whether the index reaches the time axis.
         # ``percept[0, 1]`` asks for the time series of a pixel, so only an
         # index that reaches the last axis can be naming a time point:
         space, time = item, None
@@ -285,7 +261,7 @@ class Percept(Data):
             if (any(idx is Ellipsis for idx in head) or
                     len(head) == self.data.ndim - 1):
                 space, time = head, item[-1]
-        # STEP 2: AVOID CONFUSING TIME POINTS WITH FRAME INDICES
+        # Distinguish time values from ordinary NumPy frame indices.
         scalar_time = mask_time = False
         if isinstance(time, slice):
             sliced = _slice_times(time, self.time, self.time_unit)
@@ -304,7 +280,7 @@ class Percept(Data):
                 # Convert to float so time is not mistaken for a frame index:
                 time = np.float64(time)
                 scalar_time = time.ndim == 0
-        # STEP 3: NUMPY HANDLES MOST INDEXING AND SLICING
+        # Let NumPy handle ordinary indexing first.
         try:
             return self.data[space if time is None else (*space, time)]
         except IndexError:
@@ -314,7 +290,7 @@ class Percept(Data):
             # question instead of raising:
             if time is None or mask_time:
                 raise
-        # STEP 4: INTERPOLATE TIME
+        # Interpolate explicit time values.
         frames = self.data[space]
         times = np.array([time], dtype=np.float64).ravel()
         # ``_interp_rows`` interpolates rows, and a percept's rows are its
@@ -331,24 +307,20 @@ class Percept(Data):
 
     @property
     def time_unit(self):
-        """The unit ``time`` is expressed in
+        """Unit in which ``time`` is stored.
 
-        Milliseconds unless the percept was built with a different
-        ``time_unit``. Read-only: the stored numbers mean what they meant when
-        they were written down. Ask for another unit with
-        :py:meth:`~pulse2percept.percepts.Percept.times`.
+        The property is read-only; use :meth:`times` to request another
+        unit.
 
         .. versionadded:: 0.10.0
-
         """
         return self._time_unit
 
     @property
     def time_quantity(self):
-        """The time axis with its unit attached, or None
+        """Time axis with its unit attached, or None.
 
         .. versionadded:: 0.10.0
-
         """
         if self.time is None:
             return None

--- a/pulse2percept/stimuli/encoders.py
+++ b/pulse2percept/stimuli/encoders.py
@@ -12,20 +12,14 @@ from .videos import VideoStimulus
 from ..units import (DimensionMismatchError, Hz, as_value, dimensionless, ms,
                      uA)
 from ..utils import PrettyPrint, frame_interval
-# Every warning below is about the *caller's* choice of source, frequency, or
-# implant, so it has to point at their line rather than at this file:
+# Point encoder warnings at the caller.
 from ..utils.deprecation import _warn_external
 from ..utils.constants import DT, MS_PER_S
 
-# Encoding a source that still has one row per *pixel* rather than one per
-# electrode produces a data container this many elements large before anyone
-# notices. Warn past that, because the fix (pass ``implant``) is a one-liner:
+# Warn when encoding an unsampled pixel grid would create a huge stimulus.
 _BIG_STIM = 5e7
 
-# Every model downstream of the encoder allocates something proportional to the
-# number of time points in the stimulus -- a spatial model, one float per grid
-# point per time point. Warn past this many, because the fixes (``clock``,
-# ``n_levels``) are not obvious:
+# Warn before an encoded stimulus grows to an impractical number of time points.
 _BIG_TIME = 20000
 
 # Duration (ms) of a source that has no time axis of its own, such as an image:
@@ -86,12 +80,11 @@ class _EncodedStimulus(Stimulus):
         self._pulse_ticks = self._own(pulse_ticks, pulse_ticks.dtype)
         self._pulse_vals = self._own(pulse_vals, pulse_vals.dtype)
         self._total = float(total)
-        # Which electrode-frames were asked for a pulse rate at all:
+        # Electrode-frames with a nonzero requested rate:
         self._firing = self._own(firing, bool)
         self._frame_time = self._own(frame_time, frame_time.dtype)
         self._frame_dur = float(frame_dur)
-        # Built on demand by `time`, which is cheap enough to be worth not
-        # expanding a waveform for:
+        # Built lazily without rendering the waveform:
         self._time = None
         self._defer(electrodes)
         self.metadata['encoder'] = {'frame_time': self._frame_time,
@@ -148,7 +141,7 @@ class _EncodedStimulus(Stimulus):
         return self._time
 
     def _render(self):
-        """Expand the schedule into the pulse trains it describes"""
+        """Expand the schedule into pulse trains."""
         data = np.zeros((len(self.electrodes), self._ticks.size),
                         dtype=np.float32)
         for s, (onset, frame) in enumerate(zip(self._onsets, self._frames)):
@@ -161,8 +154,7 @@ class _EncodedStimulus(Stimulus):
             at = np.searchsorted(onset, self._ticks, side='right') - 1
             np.clip(at, 0, onset.size - 1, out=at)
             data[rows] = self._amp[rows][:, frame[at]] * wave
-        # Allocated here for this stimulus and returned straight to it, so
-        # `Stimulus` need not copy it away from anyone:
+        # The newly allocated array can be adopted without another copy:
         return {'data': _adoptable(data), 'electrodes': self.electrodes,
                 'time': self.time}
 
@@ -177,144 +169,41 @@ class _EncodedStimulus(Stimulus):
 
 
 class StimulusEncoder(PrettyPrint, metaclass=ABCMeta):
-    """Abstract base class for all stimulus encoders
+    """Abstract base class for stimulus encoders.
 
-    An encoder translates the gray levels of an image or a video into the
-    electrical stimulus that a retinal implant would actually deliver: each
-    electrode emits a train of biphasic pulses, and the gray level of the pixel
-    that the electrode sees determines some property of that train.
+    Encoders map image or video gray levels to electrical pulse trains.
+    If an implant is supplied, the source is sampled at its electrode
+    locations and scheduled using its raster pattern.
 
-    Three clocks are involved, and they are deliberately independent of one
-    another:
-
-    *  The **frame clock** belongs to the video. It says when the modulation
-       parameters update; that is, a new frame is a new gray level, and hence
-       a new amplitude or a new frequency. It is also the rate at which a
-       percept is worth reporting, which is why it is recorded in the encoded
-       stimulus' metadata for 
-       :py:meth:`~pulse2percept.models.Model.predict_percept` to
-       pick up. It takes no part in the timing of the pulses themselves.
-
-    *  The **pulse clock** belongs to ``freq``. It runs continuously for the
-       whole stimulus rather than restarting at every frame, so the frame rate
-       has no say in the rate delivered. A pulse takes the modulation
-       parameters of the frame its *onset* falls into, so it is never cut in
-       half by a frame boundary.
-
-       The rate can still come out below the one requested, but only where the
-       hardware you described cannot express it: ``clock``, and a raster with
-       electrodes on differing rates, both round a pulse period *up*. Neither
-       ever rounds down, so an electrode is never driven faster, and so never
-       given more charge, than was asked for.
-
-    *  The **raster sweep** belongs to the
-       :py:class:`~pulse2percept.implants.Raster`, and says which electrodes
-       may pulse when, so that no two raster groups are ever active at the same
-       instant.
-
-    All encoders share the same two-step structure, and the seam between the
-    steps is where time enters:
-
-    1.  **Modulation.** Reduce the source to one gray level per electrode per
-        frame -- sampled at the electrode locations, if :py:meth:`encode` was
-        given an ``implant`` -- and map those gray levels onto the amplitude
-        and frequency each electrode is to run at (``_modulate``). Nothing
-        here is time-resolved.
-    2.  **Realization.** Turn those parameters into an actual train of pulses
-        (``_assemble``), which is where the pulse shape, the pulse clock and
-        the raster come in.
-
-    :py:meth:`encode` runs both steps and hands back the train. The seam is
-    not only an implementation detail, though: a model with no temporal
-    component has no way to express a pulse train, and reads what came out of
-    the first step instead (see
-    :py:meth:`~pulse2percept.models.SpatialModel.predict_percept`).
-
-    An encoder describes a *modulation scheme*, not a device: it holds no
-    implant of its own, and the implant it encodes for is named at
-    :py:meth:`encode` time (or, more usually, by assigning the encoder to
-    :py:attr:`~pulse2percept.implants.ProsthesisSystem.encoder` and letting the
-    implant do it). Everything about the device -- which electrodes there are,
-    where they sit, and how they take turns -- therefore comes from that one
-    implant, including the :py:class:`~pulse2percept.implants.Raster`.
-
-    Subclasses only implement ``_modulate``; everything else is provided here.
+    Subclasses implement :meth:`_modulate`, which maps gray levels to
+    pulse amplitude and frequency.
 
     .. versionadded:: 0.10.0
 
     Parameters
     ----------
     phase_dur : float, optional
-        Duration (ms) of the cathodic/anodic phase of each pulse.
+        Duration of each pulse phase (ms).
     interphase_dur : float, optional
-        Duration (ms) of the gap between the cathodic and anodic phases.
+        Gap between cathodic and anodic phases (ms).
     cathodic_first : bool, optional
-        If True, the cathodic phase of each pulse is delivered first. Most
-        temporal models in :py:mod:`pulse2percept.models` treat cathodic 
-        current as brightness-increasing, so bright pixels map onto 
-        cathodic-first pulses.
-    pulse : :py:class:`~pulse2percept.stimuli.Stimulus`, optional
-        A single pulse to repeat, in place of the symmetric biphasic pulse
-        built from ``phase_dur``, ``interphase_dur`` and ``cathodic_first``
-        (which are then ignored). Only its *shape* is used: its amplitude is
-        normalized away, since that is what the encoder sets, and its time axis
-        is shifted to start at zero. It must start and end at zero amplitude,
-        since it is tiled into a train.
+        If True, deliver the cathodic phase first.
+    pulse : :class:`~pulse2percept.stimuli.Stimulus`, optional
+        Pulse shape to repeat. Its amplitude is normalized away.
     clock : float, optional
-        Period (ms) of the stimulator's time base. Pulse periods and raster
-        offsets are rounded to a whole number of clock cycles, as they would be
-        on real hardware. If None, they are placed at the full resolution of
-        the simulation (``DT`` = 1e-3 ms).
-
-        .. important::
-
-           Every timing constraint here (the clock, and the raster sweep) may
-           *lower* the rate an electrode ends up on, and none of them may
-           raise it. Rounding a period down would deliver more charge than was
-           asked for, so a time base that cannot represent a rate exactly gives
-           back the nearest slower one it can.
-
-           That makes a coarse clock expensive in frequency: realizable periods
-           are ``clock``, ``2*clock``, ``3*clock``, ... , so with ``clock=1`` 
-           a requested 300 Hz (3.33 ms) is delivered as 250 Hz (4 ms), and with
-           ``clock=3`` as 166.7 Hz.
-           Choose it against the top of your frequency range rather than in the
-           abstract.
+        Stimulator clock period (ms). Pulse periods and raster offsets
+        are rounded to whole clock cycles.
     n_levels : int, optional
-        Number of gray levels the encoder can distinguish, mimicking the
-        resolution of the device's input stage. Gray levels are rounded onto
-        ``n_levels`` values evenly spaced over [0, 1] before being modulated.
-        If None, they are taken at full precision.
+        Number of gray levels used before modulation.
     frame_dur : float, optional
-        Duration (ms) of a single frame. If None, it is inferred from the
-        source's frame rate (or, failing that, from its time axis). A source
-        without a time axis, such as an
-        :py:class:`~pulse2percept.stimuli.ImageStimulus`, is treated as a
-        single frame lasting 500 ms.
+        Frame duration (ms). If None, infer it from the source.
     stretch : bool, optional
-        If True, the gray levels of the source are stretched to fill [0, 1]
-        before they are modulated, so that the darkest pixel maps onto the
-        bottom of the modulation range and the brightest onto the top.
-        If False (the default), gray levels are taken at face value: a gray
-        level of 0.5 always maps onto the middle of the range no matter how
-        bright the rest of the source is.
-
-        .. note::
-
-           Stretching makes the encoding depend on the content of the source.
-           A uniform image has no range to stretch, and encodes to a stimulus
-           of zero amplitude everywhere.
+        If True, stretch source gray levels to [0, 1].
 
     Notes
     -----
-    *  Arguments may be given as plain numbers in the units documented above,
-       or as unitful quantities (e.g. ``0.05 * mA``, ``460 * us``,
-       ``0.02 * kHz``), which are converted to those units. See
-       :py:mod:`pulse2percept.units`.
-    *  ``pulse`` is the exception: only its shape is borrowed and its
-       amplitude is normalized away, so what that amplitude was measured in
-       does not matter. A dimensionless waveform is a perfectly good template.
-
+    Plain numbers use the units documented above; unitful values are
+    converted automatically. See :mod:`pulse2percept.units`.
     """
     __slots__ = ('phase_dur', 'interphase_dur', 'cathodic_first', 'pulse',
                  'clock', 'n_levels', 'frame_dur', 'stretch')
@@ -322,11 +211,7 @@ class StimulusEncoder(PrettyPrint, metaclass=ABCMeta):
     def __init__(self, phase_dur=0.46, interphase_dur=0,
                  cathodic_first=True, pulse=None, clock=None, n_levels=None,
                  frame_dur=None, stretch=False):
-        # Strip the units first; every schedule computed below is in plain
-        # milliseconds, as it has always been. `pulse` is deliberately not
-        # checked: only its shape is borrowed, and its amplitude is normalized
-        # away in `_unit_pulse`, so what that amplitude was measured in does
-        # not enter the encoding.
+        # Normalize timing inputs; a custom pulse contributes shape only.
         phase_dur = as_value(phase_dur, ms, 'phase_dur')
         interphase_dur = as_value(interphase_dur, ms, 'interphase_dur')
         clock = as_value(clock, ms, 'clock')
@@ -354,9 +239,7 @@ class StimulusEncoder(PrettyPrint, metaclass=ABCMeta):
                                  f"time step DT={DT} ms.")
         if n_levels is not None:
             _finite('n_levels', n_levels)
-            # A fractional `n_levels` would quietly become a fractional step
-            # size, and the number of levels you got back would not be the
-            # number you asked for:
+            # ``n_levels`` is a count.
             if int(n_levels) != n_levels:
                 raise ValueError(f"'n_levels' must be a whole number, not "
                                  f"{n_levels}.")
@@ -385,39 +268,36 @@ class StimulusEncoder(PrettyPrint, metaclass=ABCMeta):
 
     @abstractmethod
     def _modulate(self, gray):
-        """Map gray levels onto pulse train parameters
+        """Map gray levels to pulse amplitude and frequency.
 
         Parameters
         ----------
         gray : (n_electrodes, n_frames) array
-            Gray levels in [0, 1], one per electrode per frame.
+            Gray levels in [0, 1].
 
         Returns
         -------
         amp : array
-            Pulse amplitude (uA), broadcastable to ``gray.shape``. The sign is
-            supplied by ``cathodic_first``, so this should be nonnegative.
+            Nonnegative pulse amplitudes (uA), broadcastable to
+            ``gray.shape``.
         freq : array
-            Pulse train frequency (Hz), broadcastable to ``gray.shape``.
-
+            Pulse frequencies (Hz), broadcastable to ``gray.shape``.
         """
         raise NotImplementedError
 
     def _as_frames(self, source, implant=None):
-        """Reduce the source to one gray level per electrode per frame
+        """Reduce a source to one gray level per electrode per frame.
 
         Returns
         -------
         gray : (n_electrodes, n_frames) array
-            Gray levels in [0, 1]. Values outside that range (an edge filter
-            can produce them) are clipped.
+            Gray levels clipped to [0, 1].
         electrodes : array
-            Electrode names, one per row of ``gray``.
+            Electrode names.
         frame_time : (n_frames,) array
-            The time (ms) at which each frame starts.
+            Frame onset times (ms).
         frame_dur : float
-            The duration (ms) of a single frame.
-
+            Frame duration (ms).
         """
         if not isinstance(source, Stimulus):
             raise TypeError(f"'source' must be a Stimulus object, not "

--- a/pulse2percept/stimuli/pulse_trains.py
+++ b/pulse2percept/stimuli/pulse_trains.py
@@ -1,5 +1,5 @@
-""":py:class:`~pulse2percept.stimuli.PulseTrain`, 
-   :py:class:`~pulse2percept.stimuli.BiphasicPulseTrain`, 
+""":py:class:`~pulse2percept.stimuli.PulseTrain`,
+   :py:class:`~pulse2percept.stimuli.BiphasicPulseTrain`,
    :py:class:`~pulse2percept.stimuli.AsymmetricBiphasicPulseTrain`"""
 import numpy as np
 from copy import deepcopy
@@ -31,26 +31,14 @@ def _is_threshold_relative(amp):
 
 
 def _tile_pulse(pulse, shift, n_pulses):
-    """Concatenate ``n_pulses`` copies of ``pulse``, spaced by ``shift`` ms
+    """Tile ``pulse`` ``n_pulses`` times with ``shift`` ms between copies.
 
-    Vectorized equivalent of repeatedly calling
-    ``pt = pt.append(pulse >> shift)``, which copies the ever-growing data
-    container once per pulse (and is therefore quadratic in ``n_pulses``).
-
-    Parameters
-    ----------
-    pulse : :py:class:`~pulse2percept.stimuli.Stimulus`
-        A stimulus containing a single pulse, with a time component.
-    shift : float
-        Time (ms) by which each copy is shifted with respect to the previous
-        one, in addition to the duration of the pulse itself.
-    n_pulses : int
-        Number of copies to concatenate.
+    This is the vectorized equivalent of repeated ``Stimulus.append``.
 
     Returns
     -------
     data, time : np.ndarray
-        The data container and time axis of the concatenated pulse train.
+        Waveform and time axis of the tiled train.
     """
     time, data = pulse.time, pulse.data
     # The time axis of each appended copy, i.e. of ``pulse >> shift``:
@@ -138,8 +126,7 @@ class PulseTrain(Stimulus):
 
     def __init__(self, freq, pulse, n_pulses=None, stim_dur=1000.0,
                  electrode=None, metadata=None):
-        # Strip the units first; everything below is plain numbers in Hz and
-        # ms, exactly as it has always been:
+        # Normalize frequency and duration.
         freq = as_value(freq, Hz, 'freq')
         stim_dur = as_value(stim_dur, ms, 'stim_dur')
         if not isinstance(pulse, Stimulus):
@@ -149,14 +136,10 @@ class PulseTrain(Stimulus):
         if n_rows == 0:
             raise ValueError(f"'pulse' has invalid shape "
                              f"({pulse.shape[0]}, {pulse.shape[1]}).")
-        # Every parameter-backed stimulus in the library is a pulse, and a
-        # pulse always has a time axis. So this only has to ask a raw
-        # stimulus, whose waveform is already there to be asked:
+        # Raw pulses must carry a time axis.
         if not pulse._is_parametric and pulse.time is None:
             raise ValueError("'pulse' does not have a time component.")
-        # `duration` rather than `time[-1]`: a parametric pulse knows how long
-        # it is from its parameters, so none of the arithmetic below has to
-        # generate a waveform to find out.
+        # ``duration`` avoids rendering a parametric pulse.
         pulse_dur = pulse.duration
 
         # How many pulses fit into stim dur. `freq` counts cycles per second
@@ -208,10 +191,7 @@ class PulseTrain(Stimulus):
                                  f"({len(names)}) does not match the number "
                                  f"of electrodes in the pulse ({n_rows}).")
         self._freq = freq
-        # A snapshot, not the caller's object: tiling used to copy the pulse's
-        # values into the train there and then, so a pulse the caller goes on
-        # to replace must not change a train already built from it. Immutable
-        # waveform state makes this share arrays rather than duplicate them.
+        # Snapshot the pulse so later caller changes cannot affect this train.
         self._pulse = deepcopy(pulse)
         self._n_pulses = n_pulses
         self._stim_dur = stim_dur

--- a/pulse2percept/units/__init__.py
+++ b/pulse2percept/units/__init__.py
@@ -1,49 +1,7 @@
-"""Physical units.
+"""Physical units used by pulse2percept.
 
-A deliberately small unit system, inspired by
-`Brian2 <https://brian2.readthedocs.io/en/stable/user/units.html>`_, that lets
-p2p's public API accept unitful values::
-
-    import pulse2percept.units as u
-
-    pulse = BiphasicPulse(50 * u.uA, 0.45 * u.ms)
-    implant = Orion(x=15 * u.mm)
-
-For just a few units, importing them directly is also convenient::
-
-    from pulse2percept.units import uA, ms
-
-Three rules describe the whole system:
-
-1. Bare numbers keep working, and keep their documented meaning. p2p never
-   warns about them.
-2. Unitful values are dimension-checked and rescaled to the unit the code
-   expects, so ``50 * uA`` and ``0.05 * mA`` are the same input (up to
-   floating-point precision).
-3. Units are stripped at the API boundary, before any numerical work. Cython
-   kernels and NumPy arrays never see a
-   :py:class:`~pulse2percept.units.Quantity`.
-
-Available units
----------------
-
-================  ==========================
-Quantity          Units
-================  ==========================
-time              ``s``, ``ms``, ``us``, ``ns``
-frequency         ``Hz``, ``kHz``
-length            ``m``, ``cm``, ``mm``, ``um``, ``nm``
-current           ``A``, ``mA``, ``uA``, ``nA``
-voltage           ``V``, ``mV``, ``uV``
-charge            ``C``, ``mC``, ``uC``, ``nC``
-visual angle      ``dva``
-threshold ratio   ``xTh``
-dimensionless     ``dimensionless``
-================  ==========================
-
-``xTh`` ("times threshold") has its own dimension rather than being a
-dimensionless alias, because turning ``2 * xTh`` into a current takes a
-calibration (see :py:class:`~pulse2percept.stimuli.BiphasicPulseTrain`).
+Bare numbers retain their documented units. Unitful values are checked
+for dimensional compatibility and converted at API boundaries.
 
 .. autosummary::
     :toctree: _api

--- a/pulse2percept/units/base.py
+++ b/pulse2percept/units/base.py
@@ -7,16 +7,8 @@ import math
 from copy import deepcopy
 import numpy as np
 
-# Primitive dimensions used by p2p. Derived dimensions such as frequency,
-# charge, and current density are formed from these.
-#
-# ``visual_angle`` is kept separate from physical angle because converting
-# visual angle to retinal or cortical distance requires a visual field map.
-#
-# ``threshold_ratio`` represents amplitudes relative to perceptual threshold
-# (e.g. ``2 * xTh``). The threshold itself is a current and may vary across
-# electrodes and subjects, so converting a threshold ratio to current requires
-# calibration rather than a fixed unit conversion.
+# Visual angle and threshold ratio are distinct dimensions because converting
+# either requires model- or subject-specific calibration.
 BASE_DIMENSIONS = ('time', 'length', 'current', 'voltage', 'visual_angle',
                    'threshold_ratio')
 
@@ -30,7 +22,7 @@ _BASE_LABELS = {
     'threshold_ratio': 'threshold ratio',
 }
 
-# Human-readable names used in error messages:
+# Names for common derived dimensions:
 _DERIVED_LABELS = {
     (0, 0, 0, 0, 0, 0): 'dimensionless',
     (-1, 0, 0, 0, 0, 0): 'frequency',
@@ -43,9 +35,7 @@ _DERIVED_LABELS = {
 def _snap_scale(scale):
     """Snap near-exact decimal scale factors to powers of ten.
 
-    Unit algebra can introduce small floating-point errors, e.g.
-    ``1e-6 * 1e-3 != 1e-9`` exactly. Snapping removes that noise so equivalent
-    compound units resolve to the same predefined unit.
+    This removes floating-point noise from equivalent compound units.
     """
     if not math.isfinite(scale) or scale <= 0:
         return scale
@@ -62,11 +52,10 @@ _EQ_RTOL = 1e-12
 
 
 def _isclose(a, b):
-    """Compare magnitudes up to floating-point conversion noise
+    """Compare magnitudes up to floating-point conversion noise.
 
-    Returns ``NotImplemented`` if the two are not comparable as numbers at
-    all, so that ``5 * dimensionless == 'foo'`` answers the question with
-    False rather than raising: equality is asked, not asserted.
+    Return ``NotImplemented`` for values that cannot be compared
+    numerically.
     """
     try:
         result = np.isclose(a, b, rtol=_EQ_RTOL, atol=0.0)
@@ -77,13 +66,9 @@ def _isclose(a, b):
 
 
 class DimensionMismatchError(TypeError):
-    """Raised when quantities of incompatible dimensions are combined
-
-    Subclasses ``TypeError`` because a dimension mismatch is a type error in
-    the physical sense: microamps are simply not a kind of millisecond.
+    """Raised when quantities have incompatible physical dimensions.
 
     .. versionadded:: 0.10.0
-
     """
 
 
@@ -106,28 +91,24 @@ def _mismatch(expected, got, name=None):
 
 
 class Dimension(object):
-    """Physical dimensionality of a unit or quantity
+    """Physical dimensionality of a unit or quantity.
 
-    A dimension is a vector of integer exponents over the primitive dimensions
-    in ``BASE_DIMENSIONS``. Dimensions are immutable, hashable, and support
-    multiplication, division, and integer powers.
+    Dimensions are immutable vectors of integer exponents over
+    ``BASE_DIMENSIONS``.
 
     .. versionadded:: 0.10.0
 
     Parameters
     ----------
     **exponents : int
-        Exponent for each primitive dimension, e.g. ``Dimension(current=1,
-        length=-2)`` for a current density. Omitted dimensions have exponent 0.
+        Exponents of the primitive dimensions. Omitted dimensions have
+        exponent zero.
 
     Examples
     --------
     >>> from pulse2percept.units import Dimension
     >>> Dimension(current=1) * Dimension(time=1)
     Dimension('charge')
-    >>> Dimension(time=-1).name
-    'frequency'
-
     """
     __slots__ = ('_exponents',)
 
@@ -210,19 +191,14 @@ class Dimension(object):
     def __hash__(self):
         return hash(self._exponents)
 
-    # An immutable value object has nothing to copy: sharing one is
-    # indistinguishable from duplicating it, and a stimulus or model that gets
-    # deep-copied on every prediction should not be allocating dimensions
-    # along the way.
+    # Immutable value objects can be shared across copies.
     def __copy__(self):
         return self
 
     def __deepcopy__(self, memodict=None):
         return self
 
-    # `copy` and `pickle` restore an object's state by assigning to it, which
-    # ``__setattr__`` refuses to allow. Go around it the way the object's own
-    # constructor does:
+    # Restore state without going through the immutability guard.
     def __getstate__(self):
         return {'_exponents': self._exponents}
 
@@ -256,63 +232,32 @@ def _symbol_mul(a, b):
 
 
 def _symbol_group(sym):
-    """Parenthesize a compound symbol so it composes unambiguously
-
-    Exponents bind tighter than products and quotients, so ``mm^2`` needs no
-    parentheses; ``uA*ms`` does.
-    """
+    """Parenthesize a compound unit symbol when needed for composition."""
     if any(c in sym for c in '*/'):
         return f'({sym})'
     return sym
 
 
 class Unit(object):
-    """A unit of measurement
+    """A physical unit.
 
-    A unit is a dimension plus a scale factor relative to the base unit of
-    that dimension (seconds, meters, amperes, volts, or degrees of visual
-    angle) plus a symbol used for display.
+    A unit combines a :class:`Dimension`, a scale relative to its base
+    unit, and a display symbol. Multiplying a value by a unit produces a
+    :class:`Quantity`; units may also be multiplied, divided, and raised
+    to integer powers.
 
-    Multiplying a number, list, or NumPy array by a unit produces a
-    :py:class:`~pulse2percept.units.Quantity`. Multiplying, dividing, or
-    exponentiating units produces another unit, so derived units such as
-    ``uA / mm ** 2`` need not be predefined.
-
-    A composed unit that is exactly a predefined one is displayed as that unit,
-    since ``uA * ms`` and ``nC`` are the same unit rather than convertible
-    ones. This is a spelling choice applied at display time; it never rescales
-    a magnitude, so a composed unit that is *not* exactly a predefined one
-    keeps its composed symbol. Use :py:meth:`Quantity.to` to change scale.
-
-    Units are immutable. p2p does not maintain a unit registry, parse unit
-    strings, or generate SI prefixes automatically: the vocabulary exported by
-    :py:mod:`pulse2percept.units` is the whole of it.
+    Units are immutable.
 
     .. versionadded:: 0.10.0
 
     Parameters
     ----------
-    dimension : :py:class:`~pulse2percept.units.Dimension`
-        The dimensionality of the unit.
+    dimension : :class:`~pulse2percept.units.Dimension`
+        Physical dimension.
     scale : float
-        Size of the unit relative to the base unit of its dimension. For
-        example, ``ms`` has ``scale=1e-3`` because the base unit of time is
-        the second.
+        Scale relative to the base unit of that dimension.
     symbol : str
-        Short symbol used when printing quantities, e.g. ``'uA'``.
-
-    Examples
-    --------
-    >>> from pulse2percept.units import uA, mm, ms
-    >>> uA / mm ** 2
-    uA/mm^2
-    >>> 50 * uA
-    50 uA
-    >>> uA * ms
-    nC
-    >>> uA * ms / mm ** 2
-    uA*ms/mm^2
-
+        Display symbol, e.g. ``'uA'``.
     """
     __slots__ = ('_dimension', '_scale', '_symbol')
 
@@ -327,9 +272,7 @@ class Unit(object):
             raise TypeError(f"'dimension' must be a Dimension object, not "
                             f"{type(dimension)}.")
         scale = float(scale)
-        # A unit is how big something is, so its scale is a positive, finite
-        # number. Anything else makes conversion and hashing meaningless, and
-        # is much easier to diagnose here than three operations later:
+        # Unit scales must be positive and finite.
         if not math.isfinite(scale) or scale <= 0:
             raise ValueError(f"'scale' must be a positive, finite number, not "
                              f"{scale}.")
@@ -357,20 +300,7 @@ class Unit(object):
 
     @property
     def _display_symbol(self):
-        """The symbol to print, preferring a predefined unit's spelling
-
-        A composed unit that lands *exactly* on a predefined one is printed as
-        that unit: ``uA * ms`` prints as ``nC`` because the two are the same
-        unit, not merely convertible ones. `_snap_scale` has already made their
-        scales the same float, so this is a dict hit on the pair that
-        :py:meth:`__eq__` and :py:meth:`__hash__` already agree on.
-
-        It is a spelling choice and nothing more. It never touches a magnitude
-        and never picks a different scale, so ``uA * ms / um ** 2`` keeps its
-        composed symbol: no predefined unit is that size, and printing it as
-        ``uC/mm^2`` would mean silently rescaling 0.00225 to 2.25. Choosing a
-        different scale is what :py:meth:`Quantity.to` is for.
-        """
+        """Display symbol, preferring an exactly equivalent predefined unit."""
         return _CANONICAL_SYMBOLS.get((self._dimension, self._scale),
                                       self._symbol)
 

--- a/pulse2percept/utils/base.py
+++ b/pulse2percept/utils/base.py
@@ -119,26 +119,15 @@ class FreezeError(AttributeError):
 
 
 def has_own_attr(obj, name):
-    """Whether ``obj`` has an attribute ``name``, without running its getter
+    """Return whether ``obj`` owns ``name`` without invoking its getter.
 
-    ``hasattr`` *invokes* a property or other descriptor just to answer the
-    question, which for a :py:class:`~pulse2percept.utils.deprecated_alias`
-    means a spurious deprecation warning every time an attribute is merely
-    probed. Looking the name up on the type instead settles the same question
-    without ever reading the instance's value.
-
-    Note that this does not consult ``__getattr__``, so it answers "does the
-    object own this attribute", not the broader "can this attribute be read".
-
-    .. versionadded:: 0.10.0
-
+    Unlike ``hasattr``, this avoids triggering properties such as
+    deprecated aliases.
     """
     return name in getattr(obj, '__dict__', {}) or hasattr(type(obj), name)
 
 
-#: ``id()`` of every object whose constructor is currently running. Kept
-#: outside the instances themselves: some ``Frozen`` subclasses are slotted,
-#: and a flag living on the object would double as a way to unfreeze it.
+#: ``id()`` values of ``Frozen`` objects currently under construction.
 _constructing = set()
 
 
@@ -167,18 +156,12 @@ def freeze_class(set, normalize=None):
 
     def set_attr(self, name, value):
         if normalize is not None and has_units(value):
-            # Units are stripped here, at the last moment before storage, so
-            # that every path into a parameter goes through the same conversion
+            # Normalize unitful parameters before storage.
             value = normalize(self, name, value)
         if _is_constructing(self):
             set(self, name, value)
             return
-        # Deliberately after the construction check: probing a half-built
-        # object can run a forwarding `__getattr__` before the state it
-        # forwards through exists. The cheap check comes first so that
-        # assigning to an attribute never *reads* it (see ``has_own_attr``);
-        # `hasattr` then covers the names that only a ``__getattr__`` knows
-        # about:
+        # Avoid probing descriptors while the object is only half-built.
         if has_own_attr(self, name) or hasattr(self, name):
             # If attribute already exists, simply set it
             set(self, name, value)
@@ -198,12 +181,7 @@ class Frozen(object):
     __slots__ = ()
 
     def __init_subclass__(cls, **kwargs):
-        """Register the object under construction for the whole constructor
-
-        Wrapping every subclass's own ``__init__`` -- not just the base one --
-        is what keeps a subclass that calls ``super().__init__()`` and then
-        adds an attribute of its own counting as "under construction".
-        """
+        """Track construction across a subclass's complete ``__init__`` call."""
         super().__init_subclass__(**kwargs)
         init = cls.__dict__.get('__init__')
         if init is None:
@@ -211,8 +189,7 @@ class Frozen(object):
 
         @wraps(init)
         def wrapped_init(self, *args, **kwargs):
-            # Nested `super().__init__` calls all see the same id, so only the
-            # outermost one may unregister it:
+            # Only the outermost constructor unregisters the object.
             outermost = id(self) not in _constructing
             _constructing.add(id(self))
             try:
@@ -230,33 +207,18 @@ class Frozen(object):
 
 
 def _normalize_param(obj, name, value):
-    """Hand a unitful value to the object's own normalization hook
-
-    Kept as a module-level function because ``freeze_class`` takes the
-    normalizer as an argument rather than looking it up on the class; see
-    :py:meth:`~pulse2percept.utils.Parametrized._normalize_param_value` for
-    what actually happens to the value, and for how a subclass extends it.
-    """
+    """Dispatch unit normalization to the object's parameter hook."""
     return obj._normalize_param_value(name, value)
 
 
 class Parametrized(Frozen, PrettyPrint, metaclass=abc.ABCMeta):
-    """Abstract base class for objects with user-settable parameters
+    """Base class for objects with user-settable parameters.
 
-    Provides the following functionality:
-
-    *  Pretty-print class attributes (via ``_pprint_params`` and
-       ``PrettyPrint``)
-    *  User-settable parameters must be listed in ``get_default_params``
-    *  New class attributes can only be added in the constructor
-       (enforced via ``Frozen`` and ``FreezeError``)
-    *  Value-based equality and deep copying that understand NumPy arrays
-    *  Parameters can declare the physical unit they are stored in (via
-       ``get_param_units``), so that a unitful value assigned to one is
-       converted before it is stored
+    Parameters are declared by :meth:`get_default_params`; subclasses
+    may declare their storage units with :meth:`get_param_units`.
+    ``Frozen`` prevents adding new attributes after construction.
 
     .. versionadded:: 0.10.0
-
     """
 
     #: Units are stripped on the way in; see ``_normalize_param``.
@@ -306,52 +268,25 @@ class Parametrized(Frozen, PrettyPrint, metaclass=abc.ABCMeta):
         raise NotImplementedError
 
     def _normalize_param_value(self, name, value):
-        """Convert a unitful value into the unit its parameter is stored in
+        """Normalize a unitful parameter value before storing it.
 
-        Called on the way into every attribute assignment whose value carries
-        a physical unit -- from the constructor, ``set_params``, ``build``, a
-        direct assignment, or a composite
-        :py:class:`~pulse2percept.models.Model` forwarding one to its
-        sub-models -- and returns the value to store.
-
-        Model equations operate on ordinary numbers, so a
-        :py:class:`~pulse2percept.units.Quantity` must never survive into a
-        parameter. Which unit a parameter is stored in is declared by
-        ``get_param_units``; a parameter that declares none takes a plain
-        number, and saying so is more useful than storing an object the
-        equations cannot use.
-
-        Attributes that are not user-settable parameters at all are left
-        alone: it is the parameter contract this enforces, not a rule about
-        what a ``Parametrized`` object may hold.
-
-        This is the extension point for a parameter whose unit is not the
-        whole story. ``SpatialModel`` overrides it so that a retinal *length*
-        assigned to ``xrange``/``yrange`` is resolved through the model's
-        visual field map into the degrees of visual angle the parameter is
-        actually stored in -- a conversion that needs the object, not just the
-        unit, and so cannot live in ``get_param_units``. An override handles
-        the names it knows about and defers the rest::
-
-            def _normalize_param_value(self, name, value):
-                if name == 'mine' and ...:
-                    return ...
-                return super()._normalize_param_value(name, value)
+        Parameters declared by :meth:`get_param_units` are converted to
+        their storage unit. Other declared parameters must be dimensionless.
+        Non-parameter attributes are returned unchanged.
 
         .. versionadded:: 0.10.0
 
         Parameters
         ----------
         name : str
-            Name of the attribute being assigned.
-        value : Quantity, Unit, or sequence of them
-            The value being assigned. Only unitful values reach this method.
+            Attribute name.
+        value : Quantity, Unit, or sequence
+            Unitful value being assigned.
 
         Returns
         -------
-        value : float, np.ndarray, or tuple
-            The plain numerical value to store.
-
+        value
+            Plain value to store.
         """
         units = self.get_param_units()
         if name in units:
@@ -361,41 +296,12 @@ class Parametrized(Frozen, PrettyPrint, metaclass=abc.ABCMeta):
         return value
 
     def get_param_units(self):
-        """Return a dict of the units that parameters are stored in
+        """Return storage units for physical parameters.
 
-        Maps a parameter name to the :py:class:`~pulse2percept.units.Unit`
-        that the implementation assumes it is expressed in. A
-        :py:class:`~pulse2percept.units.Quantity` assigned to such a parameter
-        is checked against that unit and rescaled to it, so that
-
-        .. code-block:: python
-
-            FadingTemporal(tau=100)
-            FadingTemporal(tau=100 * ms)
-            FadingTemporal(tau=0.1 * s)
-
-        all store the same float. Bare numbers keep their documented meaning
-        and are passed through untouched.
-
-        Parameters absent from this dict take plain numbers: they are either
-        dimensionless (``thresh_percept``) or empirical fit parameters whose
-        dimension the implementation does not actually commit to. Declaring a
-        unit is a statement about what the equations assume, so a parameter
-        should only appear here when that is documented or unambiguous.
-
-        This dict is not restricted to the names in ``get_default_params``: it
-        describes every physical attribute this object normalizes. A
-        constructor argument assigned straight to ``self`` --
-        :py:class:`~pulse2percept.models.granley2021.DefaultSizeModel` takes
-        ``rho`` that way -- belongs here too, and is converted like any other.
-
-        Subclasses extend rather than replace it::
-
-            def get_param_units(self):
-                return {**super().get_param_units(), 'dt': ms, 'tau': ms}
+        Subclasses should extend this mapping. Parameters not listed here
+        take plain dimensionless values.
 
         .. versionadded:: 0.10.0
-
         """
         return {}
 

--- a/pulse2percept/utils/constants.py
+++ b/pulse2percept/utils/constants.py
@@ -14,27 +14,10 @@ MIN_AMP = 1e-5
 #: transitions.
 DT = 1e-3
 
-#: Milliseconds in a second (1000).
-#:
-#: p2p counts durations in milliseconds and frequencies in hertz, so anything
-#: that turns one into the other needs this factor: a pulse train's window is
-#: ``MS_PER_S / freq`` ms, and a duration in ms is ``dur / MS_PER_S`` seconds.
-#: Derived from the unit system once, at import time, rather than written down
-#: as a bare 1000 at each site -- those are the conversions that go wrong
-#: silently. Numerical code divides by it and stays plain floats; nothing here
-#: puts a :py:class:`~pulse2percept.units.Quantity` inside a loop.
-#:
-#: .. versionadded:: 0.10.0
+#: Milliseconds per second.
 MS_PER_S = Quantity(1, s).to_value(ms)
 
-#: Microns in a millimeter (1000).
-#:
-#: p2p stores tissue coordinates in microns, while published cortical and
-#: retinal fits are written in millimeters and plots are labelled in them.
-#: Same idea as :py:data:`MS_PER_S`: derive the factor from the unit system
-#: once, then do plain arithmetic with it.
-#:
-#: .. versionadded:: 0.10.0
+#: Microns per millimeter.
 UM_PER_MM = Quantity(1, mm).to_value(um)
 
 # Block size for saving videos: width/height must be divisible by 16 for most

--- a/pulse2percept/utils/deprecation.py
+++ b/pulse2percept/utils/deprecation.py
@@ -11,11 +11,7 @@ import functools
 
 
 def _version_clause(deprecated_version=None, removed_version=None):
-    """Build the " since version X, and will be removed in version Y" clause
-
-    Shared by :py:class:`deprecated` and :py:class:`deprecate_parameter` so
-    that all deprecation messages are worded the same way.
-    """
+    """Build the version clause shared by deprecation warnings."""
     dep_msg = ""
     if deprecated_version is not None:
         dep_msg = f" since version {deprecated_version}"
@@ -36,25 +32,16 @@ def _callable_name(func):
 
 
 def _is_internal_module(name):
-    """Whether a module name belongs to pulse2percept itself
-
-    Test modules are deliberately excluded, so that a warning raised from the
-    test suite is blamed on the test rather than on the machinery underneath
-    it -- which is what lets the tests check where a warning points.
-    """
+    """Return whether a module belongs to pulse2percept, excluding tests."""
     return ((name == 'pulse2percept' or name.startswith('pulse2percept.')) and
             '.tests.' not in name)
 
 
 def _warn_external(message, category=DeprecationWarning):
-    """Warn, blaming the innermost frame outside pulse2percept
+    """Warn from the innermost stack frame outside pulse2percept.
 
-    A deprecation warning is only actionable if it points at the line that
-    used the deprecated name, and no fixed ``stacklevel`` can do that here:
-    the same alias is reached directly (``spatial.axlambda``), through a
-    composite model's ``__getattr__`` or ``__setattr__``, and through a chain
-    of ``super().__init__`` calls whose depth differs per subclass. So walk
-    out of the package instead, and blame the first frame that is not ours.
+    A fixed ``stacklevel`` is insufficient because deprecated aliases
+    can be reached through different model and inheritance paths.
 
     .. seealso::
 
@@ -63,10 +50,9 @@ def _warn_external(message, category=DeprecationWarning):
     Parameters
     ----------
     message : str
-        The warning message.
+        Warning message.
     category : warning class, optional
-        The class of warning to raise.
-
+        Warning category.
     """
     frame = sys._getframe()
     stacklevel = 1
@@ -196,56 +182,24 @@ class deprecated:
         return wrapped
 
 class deprecate_parameter:
-    """Decorator to mark a single function or method parameter as deprecated
+    """Decorator for a deprecated function or method parameter.
 
-    The decorated callable keeps *accepting* the parameter, so that existing
-    code does not break, but the value is ignored. A ``DeprecationWarning`` is
-    raised whenever the parameter is passed explicitly, whether by keyword or
-    by position.
-
-    Use this when a parameter is going away but the callable itself stays. To
-    deprecate an entire function, class, or property, use
-    :py:class:`~pulse2percept.utils.deprecated` instead. To keep a parameter
-    that is merely being *renamed* working under its old name, use
-    :py:class:`~pulse2percept.utils.rename_parameter` instead.
+    The parameter remains accepted but is ignored, and explicit use
+    raises ``DeprecationWarning``. Use :class:`rename_parameter` when
+    the parameter is only being renamed.
 
     .. versionadded:: 0.9.1
-
-    .. note::
-
-        This decorator only produces the *warning*. Document the parameter
-        itself by adding a ``.. deprecated::`` directive to its entry in the
-        docstring's ``Parameters`` section, which is where numpydoc expects it.
-
-    .. seealso::
-
-        Modeled on matplotlib's ``matplotlib._api.delete_parameter``.
 
     Parameters
     ----------
     name : str
-        Name of the deprecated parameter. Must appear in the signature of the
-        decorated callable, otherwise a ``ValueError`` is raised at decoration
-        time (which catches the parameter being renamed or dropped).
+        Deprecated parameter name.
     deprecated_version : float or str
-        The package version in which the parameter was first marked as
-        deprecated.
+        Version in which it was deprecated.
     removed_version : float or str
-        The package version in which the parameter will be removed.
+        Version in which it will be removed.
     addendum : str, optional
-        Text appended to the warning, e.g. to spell out what the parameter
-        used to do or how the behavior differs now that it is ignored.
-
-    Examples
-    --------
-    >>> from pulse2percept.utils import deprecate_parameter
-    >>> @deprecate_parameter('engine', deprecated_version='0.9.1',
-    ...                      removed_version='0.10.0')
-    ... def predict(data, engine=None):
-    ...     return data
-    >>> predict([1, 2])  # no warning
-    [1, 2]
-
+        Additional warning text.
     """
 
     def __init__(self, name, deprecated_version=None, removed_version=None,
@@ -295,52 +249,23 @@ class deprecate_parameter:
 
 
 class rename_parameter:
-    """Decorator to rename a single function or method parameter
+    """Decorator for a renamed function or method parameter.
 
-    Calls that use the old name keep working: the value is forwarded to the
-    new parameter, so the callable behaves exactly as it did before, but a
-    ``DeprecationWarning`` is raised. Use this when a parameter is only being
-    renamed; when its value is no longer read at all, use
-    :py:class:`~pulse2percept.utils.deprecate_parameter` instead.
-
-    Only *keyword* use of the old name is forwarded, which is the only way it
-    can be recognized: a positional argument is bound by position and never
-    mentions either name.
+    Keyword use of the old name is forwarded to the new name and emits
+    ``DeprecationWarning``.
 
     .. versionadded:: 0.10.0
-
-    .. note::
-
-        Models take their parameters as ``**params``, validated against
-        ``get_default_params`` rather than declared in a signature, so this
-        decorator cannot see them. Rename those with a
-        :py:class:`~pulse2percept.utils.deprecated_alias` instead.
 
     Parameters
     ----------
     old_name : str
-        The name being retired. Must *not* appear in the signature of the
-        decorated callable, otherwise a ``ValueError`` is raised at decoration
-        time (which catches the rename never having been made).
+        Deprecated parameter name.
     new_name : str
-        The name that replaces it. Must appear in the signature, otherwise a
-        ``ValueError`` is raised at decoration time.
+        Replacement parameter name.
     deprecated_version : float or str
-        The package version in which the old name was first marked as
-        deprecated.
+        Version in which the old name was deprecated.
     removed_version : float or str
-        The package version in which the old name will stop working.
-
-    Examples
-    --------
-    >>> from pulse2percept.utils import rename_parameter
-    >>> @rename_parameter('axlambda', 'lam', deprecated_version='0.10.0',
-    ...                   removed_version='0.11.0')
-    ... def decay(lam=1):
-    ...     return lam
-    >>> decay(lam=3)  # no warning
-    3
-
+        Version in which the old name will be removed.
     """
 
     def __init__(self, old_name, new_name, deprecated_version=None,
@@ -387,50 +312,13 @@ class rename_parameter:
 
 
 class deprecated_alias:
-    """Class attribute that keeps a renamed parameter usable under its old name
+    """Descriptor that keeps a renamed model parameter usable by its old name.
 
-    Assign one in the class body, under the *old* name, to a
-    :py:class:`~pulse2percept.utils.Parametrized` subclass whose parameters
-    live in ``get_default_params`` rather than in a signature:
-
-    .. code-block:: python
-
-        class MyModel(BaseModel):
-
-            axlambda = deprecated_alias('lam', deprecated_version='0.10.0')
-
-            def get_default_params(self):
-                return {'lam': 500}
-
-    Reading or writing ``model.axlambda`` then reads or writes ``model.lam``
-    and raises a ``DeprecationWarning``. The alias also registers itself in
-    the owner's ``_renamed_params``, which is what lets the constructor,
-    ``set_params`` and ``build`` keep accepting the old name as a keyword
-    argument (see
-    :py:func:`~pulse2percept.utils.rename_deprecated_params`).
-
-    To rename a parameter that *is* declared in a signature, use
-    :py:class:`~pulse2percept.utils.rename_parameter` instead.
+    Use this for parameters stored in ``get_default_params``. For
+    parameters declared in a function signature, use
+    :class:`rename_parameter`.
 
     .. versionadded:: 0.10.0
-
-    .. note::
-
-        Document the rename by adding a ``.. versionchanged::`` directive to
-        the *new* parameter's entry in the docstring's ``Parameters`` section.
-        The old name has no entry of its own, since nothing should be written
-        against it any more.
-
-    Parameters
-    ----------
-    new_name : str
-        Name of the parameter that replaces the alias.
-    deprecated_version : float or str
-        The package version in which the old name was first marked as
-        deprecated.
-    removed_version : float or str
-        The package version in which the old name will stop working.
-
     """
 
     def __init__(self, new_name, deprecated_version=None,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pulse2percept"
-version = "0.10.0.dev0"
+version = "0.10.0"
 description = "A Python-based simulation framework for bionic vision"
 readme = "README.rst"
 license = { file = "LICENSE" }


### PR DESCRIPTION
Highlights
-----------

* New stimulus encoders support amplitude and frequency modulation of images and  videos, with implant-specific raster strategies for multiplexed stimulation

* Stimuli now retain structured pulse and encoder representations and generate  waveform samples lazily, substantially reducing construction time and memory  use

* New `units` support for dimension-checked physical  quantities throughout the public API

* Major performance improvements for stimulus handling, spatial models, temporal  models, and large-array simulations

* `Percept.play` and `stimuli.VideoStimulus.play` are substantially faster, and percept playback now supports irregular time axes 

* New `models.AlphaTemporal` and much faster `FadingTemporal` temporal models

* New `Percept.load` reads percepts from image and video files 

* Python 3.14 is supported. Python 3.11 and NumPy 2 are now required
