### PR TITLE
[ENH] Add deg/rad as units

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -24,7 +24,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      # Linux system deps
       - name: Install dependencies (Linux)
         if: runner.os == 'Linux'
         run: |
@@ -34,113 +33,78 @@ jobs:
       - name: Build wheels
         uses: pypa/cibuildwheel@1828c10ab37f080699c7b81cea34097c684a7074 # v4.2.0
         env:
-          # ---------- macOS: OpenMP runtime independent of the runner image ----------
-          # Do NOT use Homebrew's libomp. Homebrew bottles are built for the
-          # runner's own macOS version, so the dylib's minimum-OS tracks
-          # whatever image GitHub happens to ship (`macos-latest` moved to the
-          # macOS 26 Apple-silicon image in June 2026). delocate then refuses
-          # to vendor it into a wheel tagged for an older macOS -- correctly,
-          # since that wheel would crash for anyone on an older system.
-          #
-          # conda-forge's llvm-openmp is built against an old deployment
-          # target, so it can be bundled into wheels that still install on
-          # macOS 11+. Both arch slices are merged into one universal binary
-          # so a single OMP_PREFIX serves the x86_64 and arm64 builds.
+          # macOS: use conda-forge libomp rather than Homebrew so the
+          # deployment target does not depend on the GitHub runner image.
           CIBW_BEFORE_ALL_MACOS: |
             set -eux
-            # Pinned rather than `latest`: an unpinned URL is how these
-            # builds moved from micromamba 1.x to 2.x without anyone
-            # deciding to. Bump it deliberately.
             MICROMAMBA_VERSION=2.9.0
-            # Downloaded to a file rather than piped into tar: `set -e`
-            # without `pipefail` takes only tar's exit status, so a failed
-            # or truncated download surfaced as a confusing tar error, or
-            # as no error at all. `--fail` likewise keeps an HTTP error
-            # page from reaching tar as though it were an archive.
             curl --fail --location --silent --show-error \
               --retry 5 --retry-all-errors \
               -o micromamba.tar.bz2 \
               "https://micro.mamba.pm/api/micromamba/osx-arm64/${MICROMAMBA_VERSION}"
             tar -xvjf micromamba.tar.bz2 bin/micromamba
             rm micromamba.tar.bz2
+
             for arch in osx-arm64 osx-64; do
               ./bin/micromamba create -y -p "/tmp/omp-${arch}" \
                 --platform "${arch}" -c conda-forge llvm-openmp
             done
+
             mkdir -p /tmp/omp/lib /tmp/omp/include
             cp -R /tmp/omp-osx-arm64/include/. /tmp/omp/include/
             lipo -create /tmp/omp-osx-arm64/lib/libomp.dylib \
                          /tmp/omp-osx-64/lib/libomp.dylib \
                  -output /tmp/omp/lib/libomp.dylib
-            # Give libomp an absolute install name. The extension records
-            # whatever LC_ID_DYLIB says, and conda-forge ships `@rpath/...`,
-            # which delocate cannot resolve because setup.py links without an
-            # -rpath. An absolute path is what Homebrew's libomp provides and
-            # what delocate expects; it is rewritten to @loader_path when the
-            # dylib is vendored into the wheel.
-            install_name_tool -id /tmp/omp/lib/libomp.dylib /tmp/omp/lib/libomp.dylib
+
+            # delocate needs a resolvable install name before vendoring.
+            install_name_tool -id /tmp/omp/lib/libomp.dylib \
+              /tmp/omp/lib/libomp.dylib
             lipo -info /tmp/omp/lib/libomp.dylib
             otool -D /tmp/omp/lib/libomp.dylib
+
           CIBW_BEFORE_BUILD_MACOS: |
             set -eux
-            # CIBW_ENVIRONMENT only keeps the *first* assignment when the
-            # value spans multiple lines, which silently dropped the
-            # deployment target for a long time. Fail with a clear message if
-            # that ever regresses:
-            : "${OMP_PREFIX:?not set - check CIBW_ENVIRONMENT_MACOS is one line}"
-            : "${MACOSX_DEPLOYMENT_TARGET:?not set - check CIBW_ENVIRONMENT_MACOS is one line}"
+            : "${OMP_PREFIX:?not set - check CIBW_ENVIRONMENT_MACOS}"
+            : "${MACOSX_DEPLOYMENT_TARGET:?not set - check CIBW_ENVIRONMENT_MACOS}"
+
             ls -l "${OMP_PREFIX}/include/omp.h"
-            # Fail loudly here rather than deep inside delocate if the OpenMP
-            # runtime ever requires a newer macOS than the wheels target:
+
             MINOS=$(otool -l "${OMP_PREFIX}/lib/libomp.dylib" \
                     | awk '/LC_BUILD_VERSION/{f=1} f && /minos/{print $2; exit}')
             echo "libomp minos='${MINOS}' deployment target=${MACOSX_DEPLOYMENT_TARGET}"
+
             if [ -z "${MINOS}" ]; then
-              echo "note: no LC_BUILD_VERSION found, skipping the minimum-OS check"
+              echo "note: no LC_BUILD_VERSION found, skipping minimum-OS check"
             elif [ "${MINOS%%.*}" -gt "${MACOSX_DEPLOYMENT_TARGET%%.*}" ]; then
               echo "ERROR: libomp needs macOS ${MINOS}, wheels target ${MACOSX_DEPLOYMENT_TARGET}."
-              echo "delocate cannot vendor it; pick an OpenMP build with an older minimum."
               exit 1
             fi
-            python -m pip install --upgrade pip setuptools wheel cython delocate "numpy>=2.0"
-          # NOTE: must stay a *folded* scalar (>-), i.e. a single line of
-          # space-separated assignments. With a literal block (|),
-          # cibuildwheel keeps only the first assignment and silently drops
-          # the rest -- which is how the deployment target below went missing
-          # for so long. setup.py derives the OpenMP compile/link flags from
-          # OMP_PREFIX, so nothing else needs setting here.
-          #
-          # A fixed target for both arches, so the ABI floor is a decision we
-          # make rather than a side effect of the runner image. macOS 11 is
-          # the oldest release Apple silicon supports.
+
+            python -m pip install --upgrade \
+              pip setuptools wheel cython delocate "numpy>=2.0"
+
+          # Keep this as a folded scalar: cibuildwheel otherwise retains only
+          # the first assignment. macOS 11 is the minimum for Apple silicon.
           CIBW_ENVIRONMENT_MACOS: >-
             OMP_PREFIX=/tmp/omp
             MACOSX_DEPLOYMENT_TARGET=11.0
-          # Same as cibuildwheel's default repair, but prints the dependency
-          # graph first: when delocate fails, cibuildwheel reports only the
-          # exit code, and `listdeps` shows which library went unresolved.
+
           CIBW_REPAIR_WHEEL_COMMAND_MACOS: >-
             delocate-listdeps --all --depending {wheel} &&
             delocate-wheel --require-archs {delocate_archs} -w {dest_dir} -v {wheel}
 
-          # ---------- Linux: enable OpenMP ----------
-          # NumPy comes from the build requirements in pyproject.toml, which
-          # pin 2.x so the wheels import under both NumPy 1.x and 2.x.
+          # Linux
           CIBW_ENVIRONMENT_LINUX: "CFLAGS='-fopenmp'"
           CIBW_BEFORE_BUILD_LINUX: "python -m pip install --upgrade pip setuptools wheel cython 'numpy>=2.0'"
 
-          # ---------- Windows: enable OpenMP ----------
+          # Windows
           CIBW_ENVIRONMENT_WINDOWS: "CFLAGS='/openmp'"
           CIBW_BEFORE_BUILD_WINDOWS: "python -m pip install --upgrade pip setuptools wheel cython \"numpy>=2.0\""
 
-          # ---------- Python versions / skips ----------
-          # Free-threaded builds are a separate set of identifiers (cp314t-*),
-          # so this does not pick them up. That is deliberate: the extensions
-          # use OpenMP and have not been audited for the no-GIL build.
+          # Free-threaded cp314t builds are intentionally excluded.
           CIBW_BUILD: "cp311-* cp312-* cp313-* cp314-*"
           CIBW_SKIP: "*-manylinux_i686 *-win32 *musllinux*"
 
-          # Build separate wheels for both Apple architectures
           CIBW_ARCHS_MACOS: "x86_64 arm64"
 
       - name: Upload wheels

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -48,8 +48,21 @@ jobs:
           # so a single OMP_PREFIX serves the x86_64 and arm64 builds.
           CIBW_BEFORE_ALL_MACOS: |
             set -eux
-            curl -Ls https://micro.mamba.pm/api/micromamba/osx-arm64/latest \
-              | tar -xvj bin/micromamba
+            # Pinned rather than `latest`: an unpinned URL is how these
+            # builds moved from micromamba 1.x to 2.x without anyone
+            # deciding to. Bump it deliberately.
+            MICROMAMBA_VERSION=2.9.0
+            # Downloaded to a file rather than piped into tar: `set -e`
+            # without `pipefail` takes only tar's exit status, so a failed
+            # or truncated download surfaced as a confusing tar error, or
+            # as no error at all. `--fail` likewise keeps an HTTP error
+            # page from reaching tar as though it were an archive.
+            curl --fail --location --silent --show-error \
+              --retry 5 --retry-all-errors \
+              -o micromamba.tar.bz2 \
+              "https://micro.mamba.pm/api/micromamba/osx-arm64/${MICROMAMBA_VERSION}"
+            tar -xvjf micromamba.tar.bz2 bin/micromamba
+            rm micromamba.tar.bz2
             for arch in osx-arm64 osx-64; do
               ./bin/micromamba create -y -p "/tmp/omp-${arch}" \
                 --platform "${arch}" -c conda-forge llvm-openmp

--- a/doc/topics/units.rst
+++ b/doc/topics/units.rst
@@ -8,7 +8,8 @@ Physical Units
 
 Many pulse2percept parameters represent physical quantities. The
 :py:mod:`~pulse2percept.units` module adds dimensional checking and automatic
-conversion while keeping bare numbers fully supported.
+conversion while keeping bare numbers fully supported and consistent with
+older p2p versions.
 
 .. code-block:: python
 
@@ -29,17 +30,17 @@ Canonical units
    * - Quantity
      - Bare number means
    * - stimulus current
-     - microamps (uA)
+     - microamps (``uA``)
    * - stimulus and percept time
      - milliseconds (ms)
    * - electrode and tissue geometry
-     - microns (um)
+     - microns (``um``)
    * - visual-field coordinates
-     - degrees of visual angle (dva)
+     - degrees of visual angle (``dva``)
    * - geometric angle
-     - degrees (deg)
+     - degrees (``deg``)
    * - frequency
-     - hertz (Hz)
+     - hertz (``Hz``)
    * - image and video intensity
      - dimensionless
 
@@ -92,7 +93,7 @@ Geometric angle
 
 ``deg`` and ``rad`` measure ordinary geometric angle: implant rotation, image
 rotation, grating direction and phase, and axon polar angle. They convert into
-each other freely, and bare numbers still mean degrees.
+each other freely, and bare numbers still mean degrees:
 
 .. code-block:: python
 
@@ -104,16 +105,21 @@ each other freely, and bare numbers still mean degrees.
     ArgusII(rot=45 * deg)        # equivalent
     ArgusII(rot=np.pi / 4 * rad) # equivalent
 
-``dva`` is deliberately a different dimension: it measures visual angle, which
-only becomes a rotation or a retinal distance through a visual field map. So
-``rot=45 * dva`` raises rather than being read as 45 degrees.
+``dva`` is deliberately a different dimension: it describes coordinates or
+extent in the visual field, whereas ``deg`` and ``rad`` describe geometric
+rotation.
+A visual field map converts visual-field coordinates to retinal or cortical
+positions; it does not make ``dva`` interchangeable with geometric angle.
 
 Threshold-relative amplitude
 ----------------------------
 
-``xTh`` means a multiple of perceptual threshold, not a current. This matters
-for :py:class:`~pulse2percept.models.BiphasicAxonMapModel`, whose amplitude
-terms are defined relative to threshold.
+Some models (e.g., :py:class:`~pulse2percept.models.BiphasicAxonMapModel`)
+operate on ``xTh``, which means a multiple of perceptual threshold, rather
+than raw current.
+
+Thresholds can be stored in ``implant.thresholds``. When they are set,
+pulses expressed in ``xTh`` will be automatically converted to microamps:
 
 .. code-block:: python
 

--- a/doc/topics/units.rst
+++ b/doc/topics/units.rst
@@ -32,7 +32,7 @@ Canonical units
    * - stimulus current
      - microamps (``uA``)
    * - stimulus and percept time
-     - milliseconds (ms)
+     - milliseconds (``ms``)
    * - electrode and tissue geometry
      - microns (``um``)
    * - visual-field coordinates

--- a/doc/topics/units.rst
+++ b/doc/topics/units.rst
@@ -36,12 +36,12 @@ Canonical units
      - microns (um)
    * - visual-field coordinates
      - degrees of visual angle (dva)
+   * - geometric angle
+     - degrees (deg)
    * - frequency
      - hertz (Hz)
    * - image and video intensity
      - dimensionless
-   * - implant rotation
-     - degrees
 
 Objects that use a different unit, such as a Percept with its own time base,
 record that unit explicitly.
@@ -86,6 +86,27 @@ Likewise, :py:class:`~pulse2percept.stimuli.ImageStimulus` and
 :py:class:`~pulse2percept.stimuli.VideoStimulus` are dimensionless. A
 :py:class:`~pulse2percept.stimuli.StimulusEncoder` defines how their gray
 levels become electrical stimulation.
+
+Geometric angle
+---------------
+
+``deg`` and ``rad`` measure ordinary geometric angle: implant rotation, image
+rotation, grating direction and phase, and axon polar angle. They convert into
+each other freely, and bare numbers still mean degrees.
+
+.. code-block:: python
+
+    import numpy as np
+    from pulse2percept.implants import ArgusII
+    from pulse2percept.units import deg, rad
+
+    ArgusII(rot=45)              # degrees, as before
+    ArgusII(rot=45 * deg)        # equivalent
+    ArgusII(rot=np.pi / 4 * rad) # equivalent
+
+``dva`` is deliberately a different dimension: it measures visual angle, which
+only becomes a rotation or a retinal distance through a visual field map. So
+``rot=45 * dva`` raises rather than being read as 45 degrees.
 
 Threshold-relative amplitude
 ----------------------------

--- a/doc/users/release_notes.rst
+++ b/doc/users/release_notes.rst
@@ -13,13 +13,11 @@ Highlights:
   :py:class:`~pulse2percept.vision.Scene` and
   :py:class:`~pulse2percept.vision.Scotoma` for gaze-aware simulation of
   residual vision and retinal prostheses (:pull:`854`).
-* New ``deg`` and ``rad`` units for ordinary geometric angle, accepted
-  wherever p2p already took an angle in degrees.
 
 API changes:
 
-* ``dva`` remains a separate dimension from ``deg``: it measures visual angle,
-  so it is still rejected by angle-valued parameters.
+* New ``deg`` and ``rad`` units for ordinary geometric angle, accepted
+  wherever p2p already took an angle in degrees.
 
 Bug fixes:
 

--- a/doc/users/release_notes.rst
+++ b/doc/users/release_notes.rst
@@ -14,8 +14,7 @@ Highlights:
   :py:class:`~pulse2percept.vision.Scotoma` for gaze-aware simulation of
   residual vision and retinal prostheses (:pull:`854`).
 * New ``deg`` and ``rad`` units for ordinary geometric angle, accepted
-  wherever p2p already took an angle in degrees (``rot``, ``rotate``, grating
-  ``direction``/``phase``, ``orient_mode='angle'``, ``axons_range``).
+  wherever p2p already took an angle in degrees.
 
 API changes:
 

--- a/doc/users/release_notes.rst
+++ b/doc/users/release_notes.rst
@@ -13,8 +13,14 @@ Highlights:
   :py:class:`~pulse2percept.vision.Scene` and
   :py:class:`~pulse2percept.vision.Scotoma` for gaze-aware simulation of
   residual vision and retinal prostheses (:pull:`854`).
+* New ``deg`` and ``rad`` units for ordinary geometric angle, accepted
+  wherever p2p already took an angle in degrees (``rot``, ``rotate``, grating
+  ``direction``/``phase``, ``orient_mode='angle'``, ``axons_range``).
 
 API changes:
+
+* ``dva`` remains a separate dimension from ``deg``: it measures visual angle,
+  so it is still rejected by angle-valued parameters.
 
 Bug fixes:
 

--- a/pulse2percept/implants/alpha.py
+++ b/pulse2percept/implants/alpha.py
@@ -45,7 +45,7 @@ class AlphaIMS(ProsthesisSystem):
         to all electrodes.
         May be given as unitful quantities (e.g. ``z=100 * um``); see
         :py:mod:`pulse2percept.units`.
-    rot : float
+    rot : float or Quantity
         Rotation angle of the array (deg). Positive values denote
         counter-clock-wise (CCW) rotations in the retinal coordinate
         system.
@@ -190,7 +190,7 @@ class AlphaAMS(ProsthesisSystem):
         to all electrodes.
         May be given as unitful quantities (e.g. ``z=100 * um``); see
         :py:mod:`pulse2percept.units`.
-    rot : float
+    rot : float or Quantity
         Rotation angle of the array (deg). Positive values denote
         counter-clock-wise (CCW) rotations in the retinal coordinate
         system.

--- a/pulse2percept/implants/argus.py
+++ b/pulse2percept/implants/argus.py
@@ -64,7 +64,7 @@ class ArgusI(ProsthesisSystem):
         vitreous humor (sometimes called electrode-retina distance).
         ``z`` can either be a list with 16 entries or a scalar that is applied
         to all electrodes.
-    rot : float, optional
+    rot : float or Quantity, optional
         Rotation angle of the array (deg). Positive values denote
         counter-clock-wise (CCW) rotations in the retinal coordinate
         system.
@@ -205,7 +205,7 @@ class ArgusII(ProsthesisSystem):
         vitreous humor (sometimes called electrode-retina distance).
         ``z`` can either be a list with 60 entries or a scalar that is applied
         to all electrodes.
-    rot : float
+    rot : float or Quantity
         Rotation angle of the array (deg). Positive values denote
         counter-clock-wise (CCW) rotations in the retinal coordinate
         system.

--- a/pulse2percept/implants/base.py
+++ b/pulse2percept/implants/base.py
@@ -733,7 +733,7 @@ class RectangleImplant(ProsthesisSystem):
     ----------
     x, y, z : float, optional
         The x, y, z coordinates (um) of the center of the implant
-    rot : float, optional
+    rot : float or Quantity, optional
         The rotation of the implant in degrees
     shape : tuple, optional
         The number of rows and columns in the implant

--- a/pulse2percept/implants/bvt.py
+++ b/pulse2percept/implants/bvt.py
@@ -5,9 +5,8 @@ from skimage.transform import SimilarityTransform
 
 from .base import ProsthesisSystem
 from .electrodes import DiskElectrode
-from .electrode_arrays import (ElectrodeArray, ElectrodeGrid,
-                               _require_plain_angle)
-from ..units import as_value, um
+from .electrode_arrays import ElectrodeArray, ElectrodeGrid
+from ..units import as_value, deg, um
 
 
 class BVT24(ProsthesisSystem):
@@ -55,7 +54,7 @@ class BVT24(ProsthesisSystem):
         to all electrodes.
         May be given as unitful quantities (e.g. ``z=100 * um``); see
         :py:mod:`pulse2percept.units`.
-    rot : float
+    rot : float or Quantity
         Rotation angle of the array (deg). Positive values denote
         counter-clock-wise (CCW) rotations in the retinal coordinate
         system.
@@ -84,7 +83,7 @@ class BVT24(ProsthesisSystem):
         x = as_value(x, um, 'x')
         y = as_value(y, um, 'y')
         z = as_value(z, um, 'z')
-        _require_plain_angle(rot)
+        rot = as_value(rot, deg, 'rot')
 
         # the positions of the electrodes 1-20, 21a-21m, R1-R2
         x_arr = np.array([1275.0, 850.0, 1275.0, 850.0, 1275.0,
@@ -179,7 +178,7 @@ class BVT44(ProsthesisSystem):
         to all electrodes.
         May be given as unitful quantities (e.g. ``z=100 * um``); see
         :py:mod:`pulse2percept.units`.
-    rot : float
+    rot : float or Quantity
         Rotation angle of the array (deg). Positive values denote
         counter-clock-wise (CCW) rotations in the retinal coordinate
         system.
@@ -207,7 +206,7 @@ class BVT44(ProsthesisSystem):
         x = as_value(x, um, 'x')
         y = as_value(y, um, 'y')
         z = as_value(z, um, 'z')
-        _require_plain_angle(rot)
+        rot = as_value(rot, deg, 'rot')
 
         # The 44 stimulating electrodes are arranged in a hex grid; two return
         # electrodes are added as well:

--- a/pulse2percept/implants/cortex/cortivis.py
+++ b/pulse2percept/implants/cortex/cortivis.py
@@ -29,7 +29,7 @@ class Cortivis(ProsthesisSystem):
         to all electrodes.
         May be given as unitful quantities (e.g. ``Cortivis(x=20 * mm)``); see
         :py:mod:`pulse2percept.units`.
-    rot : float
+    rot : float or Quantity
         Rotation angle of the array (deg). Positive values denote
         counter-clock-wise (CCW) rotations in the retinal coordinate
         system.

--- a/pulse2percept/implants/cortex/icvp.py
+++ b/pulse2percept/implants/cortex/icvp.py
@@ -32,7 +32,7 @@ class ICVP(ProsthesisSystem):
         to all electrodes.
         May be given as unitful quantities (e.g. ``ICVP(x=15 * mm)``); see
         :py:mod:`pulse2percept.units`.
-    rot : float
+    rot : float or Quantity
         Rotation angle of the array (deg). Positive values denote
         counter-clock-wise (CCW) rotations in the retinal coordinate
         system.

--- a/pulse2percept/implants/cortex/neuralink.py
+++ b/pulse2percept/implants/cortex/neuralink.py
@@ -10,7 +10,7 @@ from ..ensemble import EnsembleImplant
 from ..electrodes import Electrode
 from ..electrode_arrays import ElectrodeArray
 from ..base import ProsthesisSystem
-from ...units import as_value, dva, um
+from ...units import as_value, deg, dva, um
 from ...utils import parse_3d_orient, rename_parameter
 
 
@@ -292,10 +292,9 @@ class Neuralink(EnsembleImplant):
                 Renamed from ``xystep``, which suggested that one step size
                 applies to both axes. The old name still works as a keyword
                 argument, but is deprecated and will be removed in v0.11.0.
-        rand_insertion_angle : float, optional
+        rand_insertion_angle : float or Quantity, optional
             If not none, insert threads at a random offset from perpendicular,
             with a maximum azimuthal rotation of rand_insertion_angle degrees.
-            A plain number of degrees; this one is not unit-aware.
         region : str, optional
             Region of cortex to create implant in.
         Thread : NeuralinkThread, optional
@@ -327,6 +326,9 @@ class Neuralink(EnsembleImplant):
         xrange = as_value(xrange, dva, 'xrange')
         yrange = as_value(yrange, dva, 'yrange')
         step = as_value(step, dva, 'step')
+        # An ordinary rotation, unlike the visual-field coordinates above:
+        rand_insertion_angle = as_value(rand_insertion_angle, deg,
+                                        'rand_insertion_angle')
 
         if locs is None:
             if xrange is None:

--- a/pulse2percept/implants/cortex/neuralink.py
+++ b/pulse2percept/implants/cortex/neuralink.py
@@ -295,8 +295,7 @@ class Neuralink(EnsembleImplant):
         rand_insertion_angle : float, optional
             If not none, insert threads at a random offset from perpendicular,
             with a maximum azimuthal rotation of rand_insertion_angle degrees.
-            A plain rotation in degrees, not a unitful quantity: ``dva``
-            measures visual angle, which is a different thing.
+            A plain number of degrees; this one is not unit-aware.
         region : str, optional
             Region of cortex to create implant in.
         Thread : NeuralinkThread, optional

--- a/pulse2percept/implants/cortex/orion.py
+++ b/pulse2percept/implants/cortex/orion.py
@@ -30,7 +30,7 @@ class Orion(ProsthesisSystem):
         to all electrodes.
         May be given as unitful quantities (e.g. ``Orion(x=15 * mm)``); see
         :py:mod:`pulse2percept.units`.
-    rot : float
+    rot : float or Quantity
         Rotation angle of the array (deg). Positive values denote
         counter-clock-wise (CCW) rotations in the retinal coordinate
         system.

--- a/pulse2percept/implants/cortex/tests/test_neuralink.py
+++ b/pulse2percept/implants/cortex/tests/test_neuralink.py
@@ -2,8 +2,8 @@ from string import ascii_uppercase
 import warnings
 
 import numpy.testing as npt
-from pulse2percept.units import (DimensionMismatchError, Quantity, dva,
-                                 mm, ms, uA, um)
+from pulse2percept.units import (DimensionMismatchError, Quantity, deg, dva,
+                                 mm, ms, rad, uA, um)
 import numpy as np
 import pytest
 import matplotlib.pyplot as plt
@@ -523,6 +523,26 @@ def test_Neuralink_from_neuropythy_rand_insertion_angle():
                                       rand_insertion_angle=0)
     npt.assert_almost_equal([t.direction for t in nlink.implants.values()],
                             perpendicular)
+
+
+def test_Neuralink_from_neuropythy_rand_insertion_angle_units():
+    """The insertion tilt is an ordinary angle, unlike the dva locations"""
+    locs = np.array([[1., 2.], [-2., 1.], [0., 1.], [2., -2.]])
+
+    def directions(angle):
+        # The tilt is drawn at random, so the seed has to be reset for every
+        # spelling of the same angle:
+        np.random.seed(0)
+        nlink = Neuralink.from_neuropythy(StubNeuropythyMap(), locs=locs,
+                                          rand_insertion_angle=angle)
+        return [t.direction for t in nlink.implants.values()]
+
+    bare = directions(20)
+    npt.assert_allclose(directions(20 * deg), bare, rtol=1e-12)
+    npt.assert_allclose(directions(np.pi / 9 * rad), bare, rtol=1e-12)
+    with pytest.raises(DimensionMismatchError):
+        Neuralink.from_neuropythy(StubNeuropythyMap(), locs=locs,
+                                  rand_insertion_angle=20 * dva)
 
 
 def test_Neuralink_from_neuropythy_surface_mismatch():

--- a/pulse2percept/implants/electrode_arrays.py
+++ b/pulse2percept/implants/electrode_arrays.py
@@ -11,7 +11,7 @@ from copy import deepcopy
 
 from .electrodes import Electrode, PointSource, DiskElectrode
 from ..stimuli.names import ElectrodeNames
-from ..units import DimensionMismatchError, Quantity, Unit, as_value, um
+from ..units import Quantity, as_value, deg, um
 from ..utils import PrettyPrint, bijective26_name
 from ..utils.constants import ZORDER
 
@@ -366,23 +366,6 @@ class ElectrodeArray(PrettyPrint):
         return list(self.electrodes.values())
 
 
-def _require_plain_angle(rot):
-    """Refuse a unitful rotation
-
-    ``rot`` is an ordinary rotation of the array in degrees. ``dva`` is the one
-    angle p2p has a unit for, and it means something else entirely: degrees of
-    *visual* angle, converted to a position on the retina or cortex by a visual
-    field map. Without this, a unitful ``rot`` reaches ``np.deg2rad`` and comes
-    back as "operand 'Quantity' does not support ufuncs".
-    """
-    if isinstance(rot, (Quantity, Unit)):
-        raise DimensionMismatchError(
-            f"'rot' is a plain rotation of the array in degrees, not a "
-            f"unitful quantity ({rot}). Note that 'dva' is a unit of visual "
-            f"angle, which is a different thing.")
-    return rot
-
-
 def _get_alphabetic_names(n_electrodes):
     """Create alphabetic electrode names: A-Z, AA-AZ, BA-BZ, etc. """
     return [bijective26_name(i) for i in range(n_electrodes)]
@@ -586,16 +569,16 @@ class ElectrodeGrid(ElectrodeArray):
         # the pitch from `spacing`, translates by (x, y), broadcasts `z` and
         # `r` over the electrodes, and stores `spacing` on the grid itself.
         # Every other electrode keyword travels through **kwargs untouched and
-        # is normalized by the electrode class it belongs to. `rot` is
-        # deliberately not among them: it is a plain angle in degrees, and
-        # `dva` is a unit of *visual* angle, which is a different thing.
+        # is normalized by the electrode class it belongs to.
         spacing = as_value(spacing, um, 'spacing')
         x = as_value(x, um, 'x')
         y = as_value(y, um, 'y')
         z = as_value(z, um, 'z')
         if 'r' in kwargs:
             kwargs['r'] = as_value(kwargs['r'], um, 'r')
-        _require_plain_angle(rot)
+        # `deg` is an ordinary geometric angle; `dva` is visual angle, and is
+        # rejected here:
+        rot = as_value(rot, deg, 'rot')
         self.shape = shape
         self.type = type
         self.spacing = spacing

--- a/pulse2percept/implants/imie.py
+++ b/pulse2percept/implants/imie.py
@@ -34,7 +34,7 @@ class IMIE(ProsthesisSystem):
         vitreous humor (sometimes called electrode-retina distance).
         ``z`` can either be a list with 35 entries or a scalar that is applied
         to all electrodes.
-    rot : float
+    rot : float or Quantity
         Rotation angle of the array (deg). Positive values denote
         counter-clock-wise (CCW) rotations in the retinal coordinate
         system.

--- a/pulse2percept/implants/prima.py
+++ b/pulse2percept/implants/prima.py
@@ -112,7 +112,7 @@ class PRIMA(ProsthesisSystem):
         to all electrodes.
         May be given as unitful quantities (e.g. ``z=100 * um``); see
         :py:mod:`pulse2percept.units`.
-    rot : float, optional
+    rot : float or Quantity, optional
         Rotation angle of the array (deg). Positive values denote
         counter-clock-wise (CCW) rotations in the retinal coordinate
         system.
@@ -218,7 +218,7 @@ class PRIMA75(ProsthesisSystem):
         to all electrodes.
         May be given as unitful quantities (e.g. ``z=100 * um``); see
         :py:mod:`pulse2percept.units`.
-    rot : float, optional
+    rot : float or Quantity, optional
         Rotation angle of the array (deg). Positive values denote
         counter-clock-wise (CCW) rotations in the retinal coordinate
         system.
@@ -327,7 +327,7 @@ class PRIMA55(ProsthesisSystem):
         to all electrodes.
         May be given as unitful quantities (e.g. ``z=100 * um``); see
         :py:mod:`pulse2percept.units`.
-    rot : float, optional
+    rot : float or Quantity, optional
         Rotation angle of the array (deg). Positive values denote
         counter-clock-wise (CCW) rotations in the retinal coordinate
         system.
@@ -441,7 +441,7 @@ class PRIMA40(ProsthesisSystem):
         to all electrodes.
         May be given as unitful quantities (e.g. ``z=100 * um``); see
         :py:mod:`pulse2percept.units`.
-    rot : float, optional
+    rot : float or Quantity, optional
         Rotation angle of the array (deg). Positive values denote
         counter-clock-wise (CCW) rotations in the retinal coordinate
         system.

--- a/pulse2percept/implants/tests/test_base.py
+++ b/pulse2percept/implants/tests/test_base.py
@@ -4,9 +4,9 @@ import pytest
 import numpy.testing as npt
 from pulse2percept import implants
 from pulse2percept.implants import cortex
-from pulse2percept.units import (DimensionMismatchError, Quantity,
-                                 dimensionless, dva, mA, mm, ms, nA, uA, um,
-                                 xTh)
+from pulse2percept.units import (DimensionMismatchError, Quantity, deg,
+                                 dimensionless, dva, mA, mm, ms, nA, rad, uA,
+                                 um, xTh)
 from matplotlib.patches import Circle
 import matplotlib.pyplot as plt
 from skimage.measure import label, regionprops
@@ -368,6 +368,14 @@ def test_implant_geometry_units():
     npt.assert_allclose(
         implants.ArgusII(x=0.8625 * mm, z=0.0417 * mm).earray.coordinates(),
         implants.ArgusII(x=862.5, z=41.7).earray.coordinates(), rtol=1e-12)
+
+
+def test_implant_rot_units():
+    """`rot` is an ordinary angle; the grid does the conversion for everyone"""
+    bare = implants.ArgusII(rot=45).earray.coordinates()
+    for rot in (45 * deg, np.pi / 4 * rad):
+        npt.assert_allclose(implants.ArgusII(rot=rot).earray.coordinates(),
+                            bare, rtol=1e-12)
 
 
 def test_implant_per_electrode_z_units():

--- a/pulse2percept/implants/tests/test_bvt.py
+++ b/pulse2percept/implants/tests/test_bvt.py
@@ -3,6 +3,7 @@ import pytest
 import numpy.testing as npt
 from pulse2percept.implants.base import ProsthesisSystem
 from pulse2percept.implants.bvt import BVT24, BVT44
+from pulse2percept.units import DimensionMismatchError, deg, dva, rad
 
 
 @pytest.mark.parametrize('x', (-100, 200))
@@ -149,3 +150,15 @@ def test_BVT44_stim():
     implant = BVT44(stim=np.ones(46))
     npt.assert_equal(implant.stim.shape, (46, 1))
     npt.assert_almost_equal(implant.stim.data, 1)
+
+
+@pytest.mark.parametrize('cls', (BVT24, BVT44))
+def test_BVT_rot_units(cls):
+    """BVT lays out its own electrodes, so it owns this conversion"""
+    bare = cls(rot=30).earray.coordinates()
+    for rot in (30 * deg, np.pi / 6 * rad):
+        npt.assert_allclose(cls(rot=rot).earray.coordinates(), bare,
+                            rtol=1e-12)
+    # Visual angle is a different dimension and is refused:
+    with pytest.raises(DimensionMismatchError):
+        cls(rot=30 * dva)

--- a/pulse2percept/implants/tests/test_electrode_arrays.py
+++ b/pulse2percept/implants/tests/test_electrode_arrays.py
@@ -7,8 +7,8 @@ from pulse2percept.implants import (DiskElectrode, PointSource,
                                     ElectrodeArray, ElectrodeGrid)
 from pulse2percept.implants import ArgusII
 from pulse2percept.stimuli import ElectrodeNames, Stimulus
-from pulse2percept.units import (DimensionMismatchError, Quantity, cm, dva,
-                                 mm, ms, uA, um)
+from pulse2percept.units import (DimensionMismatchError, Quantity, cm, deg,
+                                 dva, mm, ms, rad, uA, um)
 
 
 def test_ElectrodeArray():
@@ -518,15 +518,27 @@ def test_ElectrodeGrid_dimension_errors():
             ElectrodeGrid(**{'shape': (2, 2), 'spacing': 400, **kwargs})
     with pytest.raises(DimensionMismatchError):
         ElectrodeGrid((2, 2), 400, r=10 * uA, etype=DiskElectrode)
-    # A rotation is a plain angle in degrees. `dva` is visual angle, which is
-    # not the same thing, so it is refused rather than quietly reinterpreted:
+    # A rotation is an ordinary angle. `dva` is visual angle, which is not the
+    # same thing, so it is refused rather than quietly reinterpreted:
     with pytest.raises(DimensionMismatchError) as excinfo:
         ElectrodeGrid((2, 2), 400, rot=5 * dva)
-    npt.assert_equal("'rot' is a plain rotation" in str(excinfo.value), True)
+    npt.assert_equal("expects angle (deg)" in str(excinfo.value), True)
     # A bare `rot` still means degrees, exactly as it always has:
-    rad = np.deg2rad(5)
+    phi = np.deg2rad(5)
     npt.assert_allclose(ElectrodeGrid((2, 2), 400, rot=5)['A1'].x,
-                        -200 * np.cos(rad) + 200 * np.sin(rad), rtol=1e-12)
+                        -200 * np.cos(phi) + 200 * np.sin(phi), rtol=1e-12)
+
+
+def test_ElectrodeGrid_rot_units():
+    """`rot` accepts bare degrees, `deg`, and the equivalent `rad`"""
+    bare = ElectrodeGrid((2, 3), 575.0, x=1200.0, rot=45)
+    for rot in (45 * deg, np.pi / 4 * rad):
+        npt.assert_allclose(ElectrodeGrid((2, 3), 575.0, x=1200.0,
+                                          rot=rot).coordinates(),
+                            bare.coordinates(), rtol=1e-12)
+    # The grid stores a plain number of degrees, whatever it was given:
+    npt.assert_almost_equal(
+        ElectrodeGrid((2, 2), 400, rot=np.pi / 4 * rad).rot, 45)
 
 
 def test_ElectrodeArray_coordinates_subset():

--- a/pulse2percept/models/beyeler2019.py
+++ b/pulse2percept/models/beyeler2019.py
@@ -9,7 +9,7 @@ from scipy.spatial import cKDTree
 import matplotlib.pyplot as plt
 from matplotlib.patches import Ellipse
 
-from ..units import dva, um
+from ..units import deg, dva, um
 from ..utils import deprecated_alias
 from ..utils.constants import UM_PER_MM, ZORDER
 from ..topography import Watson2014Map
@@ -337,7 +337,7 @@ class AxonMapSpatial(SpatialModel):
         coordinate.
     n_axons : int, optional
         Number of axons to generate.
-    axons_range : (min, max), optional
+    axons_range : (min, max) of float or Quantity, optional
         The range of angles(in degrees) at which axons exit the optic disc.
         This corresponds to the range of $\\phi_0$ values used in
         [Jansonius2009]_.
@@ -420,11 +420,11 @@ class AxonMapSpatial(SpatialModel):
 
     def get_param_units(self):
         """Return a dict of the units that parameters are stored in"""
-        # `axons_range` is a range of polar angles in degrees rather than a
-        # visual angle, and `ax_segments_range` a radial position in the
-        # Jansonius model's own coordinates, so neither is declared here:
+        # `axons_range` is a range of ordinary polar angles, not visual angle;
+        # `ax_segments_range` is a radial position in the Jansonius model's own
+        # coordinates, so it stays undeclared:
         return {**super().get_param_units(), 'rho': um, 'lam': um,
-                'loc_od': dva, 'meridian_blend': dva}
+                'loc_od': dva, 'meridian_blend': dva, 'axons_range': deg}
 
     def _jansonius2009(self, phi0, beta_sup=-1.9, beta_inf=0.5, eye='RE'):
         """Grows a single axon bundle based on the model by Jansonius (2009)
@@ -1191,7 +1191,7 @@ class AxonMapModel(Model):
         coordinate.
     n_axons : int, optional
         Number of axons to generate.
-    axons_range : (min, max), optional
+    axons_range : (min, max) of float or Quantity, optional
         The range of angles(in degrees) at which axons exit the optic disc.
         This corresponds to the range of $\\phi_0$ values used in
         [Jansonius2009]_.

--- a/pulse2percept/models/granley2021.py
+++ b/pulse2percept/models/granley2021.py
@@ -374,7 +374,7 @@ class BiphasicAxonMapSpatial(AxonMapSpatial):
             coordinate.
         n_axons: int, optional
             Number of axons to generate.
-        axons_range: (min, max), optional
+        axons_range: (min, max) of float or Quantity, optional
             The range of angles(in degrees) at which axons exit the optic disc.
             This corresponds to the range of $\\phi_0$ values used in
             [Jansonius2009]_.
@@ -812,7 +812,7 @@ class BiphasicAxonMapModel(Model):
             coordinate.
         n_axons: int, optional
             Number of axons to generate.
-        axons_range: (min, max), optional
+        axons_range: (min, max) of float or Quantity, optional
             The range of angles(in degrees) at which axons exit the optic disc.
             This corresponds to the range of $\\phi_0$ values used in
             [Jansonius2009]_.

--- a/pulse2percept/models/tests/test_beyeler2019.py
+++ b/pulse2percept/models/tests/test_beyeler2019.py
@@ -19,6 +19,7 @@ from pulse2percept.models import (AxonMapSpatial, AxonMapModel,
 from pulse2percept.models.beyeler2019 import _AXON_CACHE_VERSION
 from pulse2percept.models._beyeler2019 import fast_axon_map
 from pulse2percept.topography import Watson2014Map, Watson2014DisplaceMap
+from pulse2percept.units import DimensionMismatchError, deg, dva, rad
 from pulse2percept.utils.testing import assert_warns_msg
 
 # Building an axon map writes a cache to a relative path; keep it in a
@@ -1040,3 +1041,16 @@ def test_AxonMapSpatial_meridian_blend_over_time():
         npt.assert_allclose(percept.data[..., t],
                             model.predict_percept(frame).data[..., 0],
                             atol=1e-6)
+
+
+def test_AxonMapSpatial_axons_range_units():
+    """`axons_range` is a range of ordinary polar angles, stored in degrees"""
+    npt.assert_equal(AxonMapSpatial().get_param_units()['axons_range'], deg)
+    bare = AxonMapSpatial(axons_range=(-30, 30))
+    npt.assert_equal(AxonMapSpatial(axons_range=(-30 * deg, 30 * deg)).
+                     axons_range, bare.axons_range)
+    npt.assert_allclose(
+        AxonMapSpatial(axons_range=np.array([-np.pi, np.pi]) / 6 * rad).
+        axons_range, bare.axons_range, rtol=1e-12)
+    with pytest.raises(DimensionMismatchError):
+        AxonMapSpatial(axons_range=(-30 * dva, 30 * dva))

--- a/pulse2percept/stimuli/images.py
+++ b/pulse2percept/stimuli/images.py
@@ -19,7 +19,7 @@ from skimage.feature import canny
 
 from .base import Stimulus, _adoptable
 from .names import ElectrodeNames
-from ..units import dimensionless
+from ..units import as_value, deg, dimensionless
 from ..utils import center_image, shift_image, scale_image, trim_image
 from ..utils.images import _as_writable
 
@@ -473,7 +473,7 @@ class ImageStimulus(Stimulus):
 
         Parameters
         ----------
-        angle : float
+        angle : float or Quantity
             Angle by which to rotate the image (degrees).
             Positive: counter-clockwise, negative: clockwise
         mode : str, optional
@@ -499,6 +499,7 @@ class ImageStimulus(Stimulus):
         # Rotating in place is the common case, and keeps the pixel names
         # meaningful; ``resize=True`` is available through kwargs:
         kwargs.setdefault('resize', False)
+        angle = as_value(angle, deg, 'angle')
         img = img_rotate(_as_writable(self.data.reshape(self.img_shape)),
                          angle, mode=mode, **kwargs)
         return ImageStimulus(img, electrodes=self._names_for(img, electrodes),

--- a/pulse2percept/stimuli/psychophysics.py
+++ b/pulse2percept/stimuli/psychophysics.py
@@ -119,7 +119,7 @@ class BarStimulus(VideoStimulus):
         A tuple specifying the desired height (pixels) and the width (pixels)
         of the grating stimulus.
 
-    direction : scalar in [0, 360) degrees, optional
+    direction : scalar in [0, 360) degrees or Quantity, optional
         Drift direction of the bar.
 
     speed : scalar in pixels/frame, optional

--- a/pulse2percept/stimuli/psychophysics.py
+++ b/pulse2percept/stimuli/psychophysics.py
@@ -4,7 +4,7 @@
 import numpy as np
 
 from .videos import VideoStimulus
-from ..units import as_value, ms
+from ..units import as_value, deg, ms
 from ..utils import radial_mask
 
 
@@ -21,7 +21,7 @@ class GratingStimulus(VideoStimulus):
         A tuple specifying the desired height (pixels) and the width (pixels)
         of the grating stimulus.
 
-    direction : scalar in [0, 360) degrees, optional
+    direction : scalar in [0, 360) degrees or Quantity, optional
         Drift direction of the grating.
 
     spatial_freq : scalar (cycles/pixel), optional
@@ -30,7 +30,7 @@ class GratingStimulus(VideoStimulus):
     temporal_freq : scalar (cycles/frame), optional
         Temporal frequency of the grating in cycles per frame
 
-    phase : scalar (degrees), optional
+    phase : scalar (degrees) or Quantity, optional
         The initial phase of the grating in degrees
 
     contrast : scalar in [0, 1], optional
@@ -73,8 +73,8 @@ class GratingStimulus(VideoStimulus):
         # `time` is a point (or an end point) in time, so it may be given as
         # a quantity; everything below works on plain milliseconds:
         time = as_value(time, ms, 'time')
-        direction = np.deg2rad(direction)
-        phase = np.deg2rad(phase)
+        direction = np.deg2rad(as_value(direction, deg, 'direction'))
+        phase = np.deg2rad(as_value(phase, deg, 'phase'))
         height, width = shape
         x = np.arange(width) - np.ceil(width / 2.0)
         y = np.arange(height) - np.ceil(height / 2.0)

--- a/pulse2percept/stimuli/tests/test_images.py
+++ b/pulse2percept/stimuli/tests/test_images.py
@@ -9,6 +9,7 @@ from skimage.transform import resize as img_resize
 
 from pulse2percept.stimuli import (AmplitudeEncoder, ImageStimulus, LogoBVL,
                                    LogoUCSB, SnellenChart)
+from pulse2percept.units import DimensionMismatchError, deg, dva, ms, rad
 
 
 def create_dummy_img(fname, shape, mode, gray=1.0, return_data=False):
@@ -285,6 +286,21 @@ def test_ImageStimulus_rotate():
     npt.assert_almost_equal(diag.data.reshape(stim.img_shape)[0, 4], 0)
     npt.assert_almost_equal(diag.data.reshape(stim.img_shape)[4, 0], 0)
     os.remove(fname)
+
+
+def test_ImageStimulus_rotate_units():
+    """`angle` is an ordinary angle, not a visual angle"""
+    ndarray = np.zeros((5, 5), dtype=np.float32)
+    ndarray[2, :] = 1
+    stim = ImageStimulus(ndarray)
+    bare = stim.rotate(90, mode='reflect').data
+    npt.assert_allclose(stim.rotate(90 * deg, mode='reflect').data, bare,
+                        rtol=1e-12)
+    npt.assert_allclose(stim.rotate(np.pi / 2 * rad, mode='reflect').data,
+                        bare, rtol=1e-12)
+    for bad in (90 * dva, 90 * ms):
+        with pytest.raises(DimensionMismatchError):
+            stim.rotate(bad)
 
 
 def test_ImageStimulus_rotate_kwargs():

--- a/pulse2percept/stimuli/tests/test_psychophysics.py
+++ b/pulse2percept/stimuli/tests/test_psychophysics.py
@@ -3,8 +3,8 @@ import numpy.testing as npt
 import pytest
 
 from pulse2percept.stimuli import GratingStimulus, BarStimulus
-from pulse2percept.units import (DimensionMismatchError, dimensionless,
-                                 ms, uA)
+from pulse2percept.units import (DimensionMismatchError, deg, dimensionless,
+                                 dva, ms, rad, uA)
 from pulse2percept.units import s as sec
 
 
@@ -87,3 +87,18 @@ def test_psychophysics_time_units():
         npt.assert_equal(unitful.time_unit, ms)
         with pytest.raises(DimensionMismatchError):
             cls((4, 4), time=5 * uA, **kwargs)
+
+
+def test_GratingStimulus_angle_units():
+    """`direction` and `phase` are ordinary angles, not visual angle"""
+    bare = GratingStimulus((4, 4), direction=45, phase=90, time=100)
+    unitful = GratingStimulus((4, 4), direction=45 * deg, phase=90 * deg,
+                              time=100)
+    in_rad = GratingStimulus((4, 4), direction=np.pi / 4 * rad,
+                             phase=np.pi / 2 * rad, time=100)
+    npt.assert_allclose(unitful.data, bare.data, rtol=1e-12)
+    npt.assert_allclose(in_rad.data, bare.data, rtol=1e-12)
+    for kwargs in ({'direction': 10 * dva}, {'phase': 10 * dva},
+                   {'phase': 10 * ms}):
+        with pytest.raises(DimensionMismatchError):
+            GratingStimulus((4, 4), time=100, **kwargs)

--- a/pulse2percept/stimuli/tests/test_videos.py
+++ b/pulse2percept/stimuli/tests/test_videos.py
@@ -1,8 +1,8 @@
 from pulse2percept.stimuli import (AmplitudeEncoder, VideoStimulus,
                                    BostonTrain, GirlPool)
 from pulse2percept.stimuli.videos import _frame_index
-from pulse2percept.units import (DimensionMismatchError, Hz, kHz, ms, s,
-                                 uA)
+from pulse2percept.units import (DimensionMismatchError, Hz, kHz, deg, dva,
+                                 ms, rad, s, uA)
 from skimage.color import rgb2gray
 from skimage.io import imsave
 from skimage.transform import resize as vid_resize
@@ -381,6 +381,22 @@ def test_VideoStimulus_rotate():
         npt.assert_almost_equal(data[3, 3, i], 1)
         npt.assert_almost_equal(data[0, 4, i], 0)
         npt.assert_almost_equal(data[4, 0, i], 0)
+
+
+@pytest.mark.parametrize('shape', [(5, 5, 3), (5, 5, 3, 2)])
+def test_VideoStimulus_rotate_units(shape):
+    """Both the grayscale and the frame-by-frame path normalize `angle`"""
+    ndarray = np.zeros(shape, dtype=np.float32)
+    ndarray[2, ...] = 1
+    stim = VideoStimulus(ndarray)
+    bare = stim.rotate(90, mode='constant').data
+    npt.assert_allclose(stim.rotate(90 * deg, mode='constant').data, bare,
+                        rtol=1e-12)
+    npt.assert_allclose(stim.rotate(np.pi / 2 * rad, mode='constant').data,
+                        bare, rtol=1e-12)
+    for bad in (90 * dva, 90 * ms):
+        with pytest.raises(DimensionMismatchError):
+            stim.rotate(bad)
 
 
 @pytest.mark.parametrize('shape', [(5, 5, 3), (5, 5, 3, 3)])

--- a/pulse2percept/stimuli/videos.py
+++ b/pulse2percept/stimuli/videos.py
@@ -14,7 +14,7 @@ from skimage import img_as_float32
 from imageio import get_reader as video_reader
 
 from .base import Stimulus, _adoptable
-from ..units import as_value, dimensionless, ms
+from ..units import as_value, deg, dimensionless, ms
 from .names import ElectrodeNames
 from ..utils import (center_image, shift_image, scale_image, trim_image,
                      frame_interval, HTMLAnimation)
@@ -584,7 +584,7 @@ class VideoStimulus(Stimulus):
 
         Parameters
         ----------
-        angle : float
+        angle : float or Quantity
             Angle by which to rotate each video frame (degrees).
             Positive: counter-clockwise, negative: clockwise
         mode : str, optional
@@ -610,6 +610,7 @@ class VideoStimulus(Stimulus):
         # Rotating in place is the common case, and keeps the pixel names
         # meaningful; ``resize=True`` is available through kwargs:
         kwargs.setdefault('resize', False)
+        angle = as_value(angle, deg, 'angle')
         data = self.data.reshape(self.vid_shape)
         if len(self.vid_shape) == 3:
             # A grayscale video can be fed to `rotate` in one go, with its

--- a/pulse2percept/units/__init__.py
+++ b/pulse2percept/units/__init__.py
@@ -22,6 +22,8 @@ from .base import (Dimension, Unit, Quantity, DimensionMismatchError, as_value,
                    V, mV, uV,
                    # charge
                    C, mC, uC, nC,
+                   # angle
+                   rad, deg,
                    # visual angle
                    dva,
                    # threshold ratio
@@ -40,6 +42,7 @@ __all__ = [
     'A', 'mA', 'uA', 'nA',
     'V', 'mV', 'uV',
     'C', 'mC', 'uC', 'nC',
+    'rad', 'deg',
     'dva',
     'xTh',
 ]

--- a/pulse2percept/units/base.py
+++ b/pulse2percept/units/base.py
@@ -7,10 +7,11 @@ import math
 from copy import deepcopy
 import numpy as np
 
-# Visual angle and threshold ratio are distinct dimensions because converting
-# either requires model- or subject-specific calibration.
-BASE_DIMENSIONS = ('time', 'length', 'current', 'voltage', 'visual_angle',
-                   'threshold_ratio')
+# Angle, visual angle and threshold ratio are three distinct dimensions: an
+# ordinary geometric angle is a pure ratio, whereas converting visual angle or
+# threshold ratio requires model- or subject-specific calibration.
+BASE_DIMENSIONS = ('time', 'length', 'current', 'voltage', 'angle',
+                   'visual_angle', 'threshold_ratio')
 
 # Human-readable names used in error messages:
 _BASE_LABELS = {
@@ -18,17 +19,18 @@ _BASE_LABELS = {
     'length': 'length',
     'current': 'electric current',
     'voltage': 'voltage',
+    'angle': 'angle',
     'visual_angle': 'visual angle',
     'threshold_ratio': 'threshold ratio',
 }
 
 # Names for common derived dimensions:
 _DERIVED_LABELS = {
-    (0, 0, 0, 0, 0, 0): 'dimensionless',
-    (-1, 0, 0, 0, 0, 0): 'frequency',
-    (1, 0, 1, 0, 0, 0): 'charge',
-    (0, -2, 1, 0, 0, 0): 'current density',
-    (1, -2, 1, 0, 0, 0): 'charge density',
+    (0, 0, 0, 0, 0, 0, 0): 'dimensionless',
+    (-1, 0, 0, 0, 0, 0, 0): 'frequency',
+    (1, 0, 1, 0, 0, 0, 0): 'charge',
+    (0, -2, 1, 0, 0, 0, 0): 'current density',
+    (1, -2, 1, 0, 0, 0, 0): 'charge density',
 }
 
 
@@ -743,6 +745,7 @@ TIME = Dimension(time=1)
 LENGTH = Dimension(length=1)
 CURRENT = Dimension(current=1)
 VOLTAGE = Dimension(voltage=1)
+ANGLE = Dimension(angle=1)
 VISUAL_ANGLE = Dimension(visual_angle=1)
 THRESHOLD_RATIO = Dimension(threshold_ratio=1)
 FREQUENCY = TIME ** -1
@@ -802,8 +805,15 @@ uC = Unit(CHARGE, 1e-6, 'uC')
 #: Nanocoulomb
 nC = Unit(CHARGE, 1e-9, 'nC')
 
+#: Radian, the base scale of ordinary angle
+rad = Unit(ANGLE, 1, 'rad')
+#: Degree of ordinary (geometric) angle. p2p's angle-valued APIs are spelled in
+#: degrees, so this is the unit their bare numbers are read in.
+deg = Unit(ANGLE, np.pi / 180, 'deg')
+
 #: Degree of visual angle. Not an ordinary angle: converting dva to a distance
-#: on the retina or cortex requires a visual field map, not a scale factor.
+#: on the retina or cortex requires a visual field map, not a scale factor, so
+#: ``dva`` and ``deg`` are deliberately incompatible.
 dva = Unit(VISUAL_ANGLE, 1, 'dva')
 
 #: Multiple of perceptual threshold ("times threshold"). Becomes a current
@@ -826,6 +836,7 @@ _CANONICAL_UNITS = (dimensionless,
                     A, mA, uA, nA,
                     V, mV, uV,
                     C, mC, uC, nC,
+                    rad, deg,
                     dva, xTh)
 
 for _unit in _CANONICAL_UNITS:

--- a/pulse2percept/units/base.py
+++ b/pulse2percept/units/base.py
@@ -7,9 +7,6 @@ import math
 from copy import deepcopy
 import numpy as np
 
-# Angle, visual angle and threshold ratio are three distinct dimensions: an
-# ordinary geometric angle is a pure ratio, whereas converting visual angle or
-# threshold ratio requires model- or subject-specific calibration.
 BASE_DIMENSIONS = ('time', 'length', 'current', 'voltage', 'angle',
                    'visual_angle', 'threshold_ratio')
 
@@ -54,11 +51,7 @@ _EQ_RTOL = 1e-12
 
 
 def _isclose(a, b):
-    """Compare magnitudes up to floating-point conversion noise.
-
-    Return ``NotImplemented`` for values that cannot be compared
-    numerically.
-    """
+    """Compare magnitudes up to floating-point conversion noise."""
     try:
         result = np.isclose(a, b, rtol=_EQ_RTOL, atol=0.0)
     except (TypeError, ValueError):

--- a/pulse2percept/units/base.py
+++ b/pulse2percept/units/base.py
@@ -198,8 +198,15 @@ class Dimension(object):
         return {'_exponents': self._exponents}
 
     def __setstate__(self, state):
-        for key, value in state.items():
-            object.__setattr__(self, key, value)
+        # An exponent tuple is only meaningful against the `BASE_DIMENSIONS`
+        # it was written with. One from a release with a different set of base
+        # dimensions would unpickle happily and mean something else, so refuse
+        # it rather than restore a quietly wrong dimension:
+        exponents = state['_exponents']
+        if len(exponents) != len(BASE_DIMENSIONS):
+            raise ValueError("Cannot restore Dimension with an incompatible "
+                             "base-dimension layout.")
+        object.__setattr__(self, '_exponents', exponents)
 
     def __str__(self):
         return self.name

--- a/pulse2percept/units/tests/test_units.py
+++ b/pulse2percept/units/tests/test_units.py
@@ -507,11 +507,7 @@ def test_units_copy_and_pickle():
 
 
 class StaleDimension(object):
-    """Pickles as a Dimension whose exponent tuple has the wrong length
-
-    That is what a pickle from p2p 0.10 holds: six base dimensions, no
-    ``angle``.
-    """
+    """Pickles as a Dimension whose exponent tuple has the wrong length"""
 
     def __reduce__(self):
         return (copyreg._reconstructor, (Dimension, object, None),
@@ -520,7 +516,7 @@ class StaleDimension(object):
 
 def test_Dimension_rejects_stale_pickle():
     # An exponent tuple written against a different set of base dimensions
-    # would restore into the wrong dimensions, so it fails loudly instead:
+    # would restore into the wrong dimensions:
     with pytest.raises(ValueError):
         pickle.loads(pickle.dumps(StaleDimension()))
 

--- a/pulse2percept/units/tests/test_units.py
+++ b/pulse2percept/units/tests/test_units.py
@@ -9,8 +9,8 @@ from pulse2percept.units import (Dimension, Unit, Quantity,
                                  DimensionMismatchError, as_value,
                                  dimensionless,
                                  s, ms, us, ns, Hz, kHz, m, cm, mm, um, nm,
-                                 A, mA, uA, nA, V, mV, uV, C, mC, uC, nC, dva,
-                                 xTh)
+                                 A, mA, uA, nA, V, mV, uV, C, mC, uC, nC, deg,
+                                 rad, dva, xTh)
 from pulse2percept.units.base import (TIME, _CANONICAL_SYMBOLS,
                                       _CANONICAL_UNITS)
 
@@ -33,6 +33,7 @@ def test_Dimension():
     # Names:
     npt.assert_equal(Dimension(time=1).name, 'time')
     npt.assert_equal(Dimension(current=1).name, 'electric current')
+    npt.assert_equal(Dimension(angle=1).name, 'angle')
     npt.assert_equal(Dimension(visual_angle=1).name, 'visual angle')
     npt.assert_equal(Dimension(time=-1).name, 'frequency')
     npt.assert_equal(Dimension(current=1, time=1).name, 'charge')
@@ -160,6 +161,7 @@ def test_unit_vocabulary():
                              (uV, 1e-6, 'voltage'),
                              (C, 1, 'charge'), (mC, 1e-3, 'charge'),
                              (uC, 1e-6, 'charge'), (nC, 1e-9, 'charge'),
+                             (rad, 1, 'angle'), (deg, np.pi / 180, 'angle'),
                              (dva, 1, 'visual angle'),
                              (xTh, 1, 'threshold ratio')]:
         npt.assert_almost_equal(unit.scale, scale)
@@ -378,6 +380,27 @@ def test_dva_is_not_a_length():
     # dva is still a perfectly good unit on its own:
     npt.assert_equal((5 * dva).to_value(dva), 5)
     npt.assert_equal(dva.dimension.name, 'visual angle')
+
+
+def test_deg_and_rad_are_ordinary_angles():
+    # Radians are the base scale, so the two convert by a plain factor:
+    npt.assert_almost_equal((180 * deg).to_value(rad), np.pi)
+    npt.assert_almost_equal((np.pi * rad).to_value(deg), 180)
+    npt.assert_equal(180 * deg == np.pi * rad, True)
+    npt.assert_equal(str(45 * deg), '45 deg')
+    # An ordinary angle is not a visual angle, and neither converts to the
+    # other or to anything else:
+    npt.assert_equal(deg.dimension == dva.dimension, False)
+    npt.assert_equal(45 * deg == 45 * dva, False)
+    for bad in (dva, um, ms, dimensionless):
+        with pytest.raises(DimensionMismatchError):
+            (45 * deg).to_value(bad)
+        with pytest.raises(DimensionMismatchError):
+            (1 * rad).to_value(bad)
+        with pytest.raises(DimensionMismatchError):
+            as_value(1 * bad, deg)
+    with pytest.raises(DimensionMismatchError):
+        (45 * deg) + (45 * dva)
 
 
 def test_xTh_is_not_dimensionless():

--- a/pulse2percept/units/tests/test_units.py
+++ b/pulse2percept/units/tests/test_units.py
@@ -1,3 +1,4 @@
+import copyreg
 import pickle
 from copy import copy, deepcopy
 
@@ -503,3 +504,39 @@ def test_units_copy_and_pickle():
     npt.assert_almost_equal((1 * restored).to_value(uA), 1000)
     npt.assert_equal(restored * s, mC)
     npt.assert_equal(restored * ms, uC)
+
+
+class StaleDimension(object):
+    """Pickles as a Dimension whose exponent tuple has the wrong length
+
+    That is what a pickle from p2p 0.10 holds: six base dimensions, no
+    ``angle``.
+    """
+
+    def __reduce__(self):
+        return (copyreg._reconstructor, (Dimension, object, None),
+                {'_exponents': (0, 0, 1, 0, 0, 0)})
+
+
+def test_Dimension_rejects_stale_pickle():
+    # An exponent tuple written against a different set of base dimensions
+    # would restore into the wrong dimensions, so it fails loudly instead:
+    with pytest.raises(ValueError):
+        pickle.loads(pickle.dumps(StaleDimension()))
+
+    # A Unit is protected through the Dimension it carries, and so is a
+    # Quantity through its Unit:
+    class StaleUnit(object):
+        def __reduce__(self):
+            return (copyreg._reconstructor, (Unit, object, None),
+                    {'_dimension': StaleDimension(), '_scale': 1e-6,
+                     '_symbol': 'uA'})
+
+    class StaleQuantity(object):
+        def __reduce__(self):
+            return (copyreg._reconstructor, (Quantity, object, None),
+                    {'_magnitude': 5, '_unit': StaleUnit()})
+
+    for stale in (StaleUnit(), StaleQuantity()):
+        with pytest.raises(ValueError):
+            pickle.loads(pickle.dumps(stale))

--- a/pulse2percept/utils/tests/test_three_dim.py
+++ b/pulse2percept/utils/tests/test_three_dim.py
@@ -1,5 +1,8 @@
 import numpy.testing as npt
 import numpy as np
+import pytest
+
+from pulse2percept.units import DimensionMismatchError, deg, dva, rad
 from pulse2percept.utils import parse_3d_orient
 
 
@@ -114,4 +117,16 @@ def test_parse_3d_orient():
     npt.assert_almost_equal(direction, [1/np.sqrt(2), 1 / np.sqrt(2), 0])
 
 
-
+def test_parse_3d_orient_angle_units():
+    """'angle' mode takes ordinary angles; the other two modes take vectors"""
+    bare = parse_3d_orient([0, 90, 45], orient_mode='angle')
+    for orient in ([0, 90, 45] * deg, (0 * deg, 90 * deg, 45 * deg),
+                   np.array([0, np.pi / 2, np.pi / 4]) * rad):
+        for got, want in zip(parse_3d_orient(orient, orient_mode='angle'),
+                             bare):
+            npt.assert_allclose(got, want, atol=1e-12)
+    with pytest.raises(DimensionMismatchError):
+        parse_3d_orient([0, 90, 45] * dva, orient_mode='angle')
+    # A direction vector is dimensionless, so it is left alone:
+    npt.assert_almost_equal(
+        parse_3d_orient([0, 0, 1], orient_mode='direction')[1], [0, 0, 0])

--- a/pulse2percept/utils/three_dim.py
+++ b/pulse2percept/utils/three_dim.py
@@ -2,6 +2,9 @@
 
 import numpy as np
 
+from ..units import as_value, deg
+
+
 def parse_3d_orient(orient, orient_mode='direction'):
     """Parse the orient parameter
     Given either a 3D rotation matrix, vector of angles of rotation,
@@ -16,8 +19,8 @@ def parse_3d_orient(orient, orient_mode='direction'):
             - A length 3 vector specifying the direction that the 
               thread should extend in (if orient_mode == 'direction')
             - A list of 3 angles, (r_x, r_y, r_z), specifying the rotation 
-              in degrees about each axis (x rotation performed first). 
-              (If orient_mode == 'angle')
+              in degrees (or as angle quantities) about each axis
+              (x rotation performed first). (If orient_mode == 'angle')
             - 3D rotation matrix, specifying the direction that the thread 
               should extend in (i.e. a unit vector in the z direction will
               point in the direction after being rotated by this matrix)
@@ -68,6 +71,11 @@ def parse_3d_orient(orient, orient_mode='direction'):
         angles = np.array([rot_x, rot_y, rot_z])
         return angles
 
+    if orient_mode == 'angle':
+        # Only 'angle' takes an angle; a direction vector and a rotation matrix
+        # are dimensionless. Normalized before the array conversion below, so
+        # that a list of quantities is handled elementwise:
+        orient = as_value(orient, deg, 'orient')
     if isinstance(orient, list) or isinstance(orient, tuple):
         orient = np.array(orient)
     if not isinstance(orient, np.ndarray) or orient.shape not in [(3,), (3, 3)]:


### PR DESCRIPTION
Physical rotation angle is now its own dimension. So far, specifying angles has been ambiguous - most objects expect `deg` (like `ArgusII(rot=45)` but internally operate with `rad`. Now these are both proper `units` and either one is accepted (with auto-conversion).