### PR TITLE
[ENH] Add GridImplant in favor of RectangleImplant

### DIFF
--- a/doc/topics/implants.rst
+++ b/doc/topics/implants.rst
@@ -95,18 +95,41 @@ the visual field.
 Custom implants
 ---------------
 
-A custom array usually does not need a new implant class. Wrap an
-:py:class:`~pulse2percept.implants.ElectrodeGrid` in a
-:py:class:`~pulse2percept.implants.ProsthesisSystem`:
+A custom array usually does not need a new implant class. For a regular grid,
+use :py:class:`~pulse2percept.implants.GridImplant`:
 
 .. code-block:: python
 
-    from pulse2percept.implants import ElectrodeGrid, ProsthesisSystem
+    import pulse2percept as p2p
 
-    earray = ElectrodeGrid(shape=(10, 10), spacing=500)
-    implant = ProsthesisSystem(earray=earray)
+    implant = p2p.implants.GridImplant(shape=(10, 10), spacing=500)
 
-For irregular arrays, build an
-:py:class:`~pulse2percept.implants.ElectrodeArray` from individual electrodes.
+Grids can also be hexagonal:
+
+.. code-block:: python
+
+    implant = p2p.implants.GridImplant(shape=(20, 20), spacing=400, type='hex')
+
+By default the electrodes are point sources. Pass an ``etype`` and its
+arguments for electrodes with a physical extent:
+
+.. code-block:: python
+
+    implant = p2p.implants.GridImplant(shape=(20, 20), spacing=400, type='hex',
+                                       etype=p2p.implants.DiskElectrode, r=75)
+
+:py:class:`~pulse2percept.implants.GridImplant` is a convenience only:
+:py:class:`~pulse2percept.implants.ElectrodeGrid` describes the geometry,
+:py:class:`~pulse2percept.implants.ProsthesisSystem` describes the device, and
+the two can still be combined by hand. Do that for an irregular array, built
+from individual electrodes:
+
+.. code-block:: python
+
+    from pulse2percept.implants import ElectrodeArray, ProsthesisSystem
+
+    earray = ElectrodeArray(...)
+    implant = ProsthesisSystem(earray)
+
 :py:class:`~pulse2percept.implants.EnsembleImplant` combines multiple implants
 into one system.

--- a/doc/users/release_notes.rst
+++ b/doc/users/release_notes.rst
@@ -24,6 +24,11 @@ API changes:
 
 Bug fixes:
 
+* A hexagonal :py:class:`~pulse2percept.implants.ElectrodeGrid` with a single
+  row (or, in vertical orientation, a single column) is now centered on
+  ``(x, y)`` rather than offset by a quarter of the electrode spacing
+  (:pull:`859`)
+
 v0.10.0 Encoders (2026-08-23)
 -----------------------------
 

--- a/doc/users/release_notes.rst
+++ b/doc/users/release_notes.rst
@@ -16,6 +16,9 @@ Highlights:
 
 API changes:
 
+* :py:class:`~pulse2percept.implants.RectangleImplant` is deprecated in favor
+  of :py:class:`~pulse2percept.implants.GridImplant` (:pull:`859`)
+
 * New ``deg`` and ``rad`` units for ordinary geometric angle, accepted
   wherever p2p already took an angle in degrees.
 

--- a/examples/implants/plot_electrode_grid.py
+++ b/examples/implants/plot_electrode_grid.py
@@ -127,3 +127,19 @@ offset_grid = ElectrodeGrid((11, 13), 500, type='hex', x=-600, y=200, z=150,
 
 AxonMapModel().plot()
 offset_grid.plot()
+
+##############################################################################
+# From a grid to an implant
+# -------------------------
+#
+# An :py:class:`~pulse2percept.implants.ElectrodeGrid` is geometry only: it
+# cannot hold a stimulus. To turn one into a device that a model can predict
+# from, use :py:class:`~pulse2percept.implants.GridImplant`, which takes the
+# same grid arguments and adds the ones a
+# :py:class:`~pulse2percept.implants.ProsthesisSystem` understands:
+
+from pulse2percept.implants import GridImplant
+
+implant = GridImplant((11, 13), 500, type='hex', etype=DiskElectrode, r=100,
+                      stim={'A1': 20})
+implant.plot()

--- a/pulse2percept/implants/__init__.py
+++ b/pulse2percept/implants/__init__.py
@@ -24,7 +24,7 @@ Different prosthetic implants, such as Argus II, Alpha-IMS, BVT-24, PRIMA, Corti
 
     *  :ref:`Basic Concepts > Visual Prostheses <topics-implants>`
 """
-from .base import ProsthesisSystem, RectangleImplant
+from .base import GridImplant, ProsthesisSystem, RectangleImplant
 from .electrodes import (Electrode, PointSource, DiskElectrode,
                          SquareElectrode, HexElectrode)
 from .electrode_arrays import ElectrodeArray, ElectrodeGrid
@@ -53,6 +53,7 @@ __all__ = [
     'ElectrodeArray',
     'ElectrodeGrid',
     'EnsembleImplant',
+    'GridImplant',
     'HexElectrode',
     'PhotovoltaicPixel',
     'PointSource',

--- a/pulse2percept/implants/base.py
+++ b/pulse2percept/implants/base.py
@@ -827,13 +827,22 @@ class GridImplant(ProsthesisSystem):
 
 
 @deprecated(alt_func='GridImplant', deprecated_version='0.11.0',
-            removed_version='0.12.0')
+            removed_version='0.12.0',
+            extra_msg='Not a drop-in replacement: pass '
+                      '``etype=DiskElectrode, r=75, preprocess=True`` to keep '
+                      'these defaults, and note that a left-eye grid keeps '
+                      'the column names of a right-eye one.')
 class RectangleImplant(ProsthesisSystem):
     """ A generic rectangular implant
 
     .. deprecated:: 0.11.0
 
-        Use :py:class:`~pulse2percept.implants.GridImplant` instead.
+        Use :py:class:`~pulse2percept.implants.GridImplant` instead, although
+        that is not a drop-in replacement. Pass
+        ``etype=DiskElectrode, r=75`` to keep the old geometry and
+        ``preprocess=True`` to keep preprocessing.
+        Also note that left and right eyes have the same column names (no
+        automatic flipping).
 
     Parameters
     ----------
@@ -855,12 +864,6 @@ class RectangleImplant(ProsthesisSystem):
         Whether to preprocess the stimulus
     safe_mode : bool, optional
         Whether to enforce charge balance
-
-    Notes
-    -----
-    *  Lengths may be given as plain numbers of microns or as unitful
-       quantities (e.g. ``spacing=0.4 * mm``). See
-       :py:mod:`pulse2percept.units`.
 
     """
     def __init__(self, x=0, y=0, z=0, rot=0, shape=(15, 15), r=150./2, spacing=400., eye='RE', stim=None,

--- a/pulse2percept/implants/base.py
+++ b/pulse2percept/implants/base.py
@@ -1,11 +1,12 @@
 """:py:class:`~pulse2percept.implants.ProsthesisSystem`,
+   :py:class:`~pulse2percept.implants.GridImplant`,
    :py:class:`~pulse2percept.implants.RectangleImplant`"""
 import numpy as np
 from copy import deepcopy
 from collections import OrderedDict
 from scipy.interpolate import RegularGridInterpolator
 
-from .electrodes import Electrode, DiskElectrode
+from .electrodes import Electrode, DiskElectrode, PointSource
 from .electrode_arrays import ElectrodeArray, ElectrodeGrid
 from .rasters import Raster
 from ..stimuli import (BiphasicPulseTrain, Stimulus, ImageStimulus,
@@ -724,6 +725,105 @@ class ProsthesisSystem(PrettyPrint):
         """Return a list of all electrode objects in the array"""
         return self.earray.electrode_objects
 
+
+
+class GridImplant(ProsthesisSystem):
+    """A prosthesis system whose electrodes form a regular grid
+
+    Convenience composition of an
+    :py:class:`~pulse2percept.implants.ElectrodeGrid` and a
+    :py:class:`~pulse2percept.implants.ProsthesisSystem`, for the common case
+    where a custom implant is just a grid of electrodes:
+
+    .. code-block:: python
+
+        implant = GridImplant(shape=(10, 10), spacing=500)
+
+    is the same thing as:
+
+    .. code-block:: python
+
+        implant = ProsthesisSystem(ElectrodeGrid(shape=(10, 10), spacing=500))
+
+    .. versionadded:: 0.11.0
+
+    Parameters
+    ----------
+    shape : (rows, cols)
+        The number of rows x columns in the grid.
+    spacing : double or (x_spacing, y_spacing)
+        Electrode-to-electrode spacing (um).
+    x/y/z : double, optional
+        3D location (um) of the center of the grid.
+    rot : double, optional
+        Rotation of the grid in degrees (positive angle: counter-clockwise).
+    names : (name_rows, name_cols), optional
+        Naming convention for rows and columns; see
+        :py:class:`~pulse2percept.implants.ElectrodeGrid`.
+    type : {'rect', 'hex'}, optional
+        Grid type ('rect': rectangular, 'hex': hexagonal).
+    orientation : {'horizontal', 'vertical'}, optional
+        Which way a hex grid staggers; see
+        :py:class:`~pulse2percept.implants.ElectrodeGrid`.
+    etype : :py:class:`~pulse2percept.implants.Electrode`, optional
+        A valid Electrode class.
+    stim : :py:class:`~pulse2percept.stimuli.Stimulus` source type
+        A valid source type for a stimulus.
+    eye : 'LE' or 'RE', optional
+        The eye in which the implant is implanted. Device metadata: unlike
+        :py:class:`~pulse2percept.implants.RectangleImplant`, the geometry and
+        the electrode names are the same in either eye.
+    preprocess : bool or callable, optional
+        Whether to preprocess the stimulus whenever a new one is assigned.
+    safe_mode : bool, optional
+        Whether to enforce charge balance.
+    encoder : :py:class:`~pulse2percept.stimuli.StimulusEncoder`, optional
+        How the device turns a picture into stimulation.
+    raster : :py:class:`~pulse2percept.implants.Raster`, optional
+        How the stimulator takes turns between electrodes.
+    max_current : float, optional
+        The total current (uA) the stimulator can source at any one instant.
+    **electrode_kwargs :
+        Any additional arguments passed to the ``etype`` constructor, such as
+        radius ``r`` for
+        :py:class:`~pulse2percept.implants.DiskElectrode`.
+
+    Examples
+    --------
+    A 10x10 grid of point sources, 500um apart:
+
+    >>> from pulse2percept.implants import GridImplant
+    >>> from pulse2percept.units import um
+    >>> implant = GridImplant(shape=(10, 10), spacing=500 * um)
+    >>> implant.n_electrodes
+    100
+
+    A hex grid of 75um disk electrodes:
+
+    >>> from pulse2percept.implants import DiskElectrode, GridImplant
+    >>> from pulse2percept.units import um
+    >>> implant = GridImplant(shape=(20, 20), spacing=400 * um, type='hex',
+    ...                       etype=DiskElectrode, r=75 * um)
+    >>> implant['A1']  # doctest: +NORMALIZE_WHITESPACE +ELLIPSIS
+    DiskElectrode(activated=True, name='A1', r=75.0, x=-3700.0,
+                  y=-3290.89..., z=0...)
+
+    """
+    # Frozen class: geometry lives on `earray`, not duplicated here
+    __slots__ = ()
+
+    def __init__(self, shape, spacing, x=0, y=0, z=0, rot=0, names=('A', '1'),
+                 type='rect', orientation='horizontal', etype=PointSource,
+                 stim=None, eye='RE', preprocess=False, safe_mode=False,
+                 encoder=None, raster=None, max_current=None,
+                 **electrode_kwargs):
+        earray = ElectrodeGrid(shape, spacing, x=x, y=y, z=z, rot=rot,
+                               names=names, type=type,
+                               orientation=orientation, etype=etype,
+                               **electrode_kwargs)
+        super().__init__(earray, stim=stim, eye=eye, preprocess=preprocess,
+                         safe_mode=safe_mode, encoder=encoder, raster=raster,
+                         max_current=max_current)
 
 
 class RectangleImplant(ProsthesisSystem):

--- a/pulse2percept/implants/base.py
+++ b/pulse2percept/implants/base.py
@@ -14,7 +14,7 @@ from ..stimuli import (BiphasicPulseTrain, Stimulus, ImageStimulus,
 from ..stimuli.base import _describe_unit
 from ..stimuli.pulse_trains import _as_threshold_amp
 from ..units import DimensionMismatchError, as_value, uA, um, xTh
-from ..utils import PrettyPrint
+from ..utils import PrettyPrint, deprecated
 
 
 class ProsthesisSystem(PrettyPrint):
@@ -826,6 +826,8 @@ class GridImplant(ProsthesisSystem):
                          max_current=max_current)
 
 
+@deprecated(alt_func='GridImplant', deprecated_version='0.11.0',
+            removed_version='0.12.0')
 class RectangleImplant(ProsthesisSystem):
     """ A generic rectangular implant
 

--- a/pulse2percept/implants/base.py
+++ b/pulse2percept/implants/base.py
@@ -831,6 +831,10 @@ class GridImplant(ProsthesisSystem):
 class RectangleImplant(ProsthesisSystem):
     """ A generic rectangular implant
 
+    .. deprecated:: 0.11.0
+
+        Use :py:class:`~pulse2percept.implants.GridImplant` instead.
+
     Parameters
     ----------
     x, y, z : float, optional

--- a/pulse2percept/implants/electrode_arrays.py
+++ b/pulse2percept/implants/electrode_arrays.py
@@ -2,7 +2,7 @@
    :py:class:`~pulse2percept.implants.ElectrodeGrid`"""
 from matplotlib.colors import Normalize
 import numpy as np
-from collections import OrderedDict
+from collections import Counter, OrderedDict
 from collections.abc import Iterable
 from matplotlib.collections import PatchCollection
 import matplotlib.pyplot as plt
@@ -191,7 +191,7 @@ class ElectrodeArray(PrettyPrint):
         if not isinstance(electrode, Electrode):
             raise TypeError(f"Electrode {name} must be an Electrode object, not "
                             f"{type(electrode)}.")
-        if name in self.electrode_names:
+        if name in self._electrodes:
             raise ValueError(f"Cannot add electrode: key '{name}' already "
                              f"exists.")
         self._electrodes.update({name: electrode})
@@ -204,7 +204,7 @@ class ElectrodeArray(PrettyPrint):
         name: int|str|...
             Electrode name or index
         """
-        if name not in self.electrode_names:
+        if name not in self._electrodes:
             raise ValueError(f"Cannot remove electrode: key '{name}' does not "
                              f"exist")
         del self.electrodes[name]
@@ -753,9 +753,18 @@ class ElectrodeGrid(ElectrodeArray):
                 # If `r` is a scalar, choose same radius for all electrodes:
                 r_arr = np.ones(n_elecs, dtype=float) * kwargs['r']
             # Create a grid of DiskElectrode objects:
-            for x, y, z, r, name in zip(x_arr, y_arr, z_arr, r_arr, names):
-                self.add_electrode(name, DiskElectrode(x, y, z, r, name=name))
+            elecs = [DiskElectrode(ex, ey, ez, er, name=nm)
+                     for ex, ey, ez, er, nm in zip(x_arr, y_arr, z_arr, r_arr,
+                                                   names)]
         else:
             # Pass keyword arguments to the electrode constructor:
-            for x, y, z, name in zip(x_arr, y_arr, z_arr, names):
-                self.add_electrode(name, etype(x, y, z, name=name, **kwargs))
+            elecs = [etype(ex, ey, ez, name=nm, **kwargs)
+                     for ex, ey, ez, nm in zip(x_arr, y_arr, z_arr, names)]
+        # Populated in one shot rather than through ``add_electrode``: on a
+        # grid every name is known up front, so a duplicate shows up as a
+        # short dict instead of costing a lookup per electrode.
+        self._electrodes = OrderedDict(zip(names, elecs))
+        if len(self._electrodes) != n_elecs:
+            dupe = next(nm for nm, n in Counter(names).items() if n > 1)
+            raise ValueError(f"Cannot add electrode: key '{dupe}' already "
+                             f"exists.")

--- a/pulse2percept/implants/electrode_arrays.py
+++ b/pulse2percept/implants/electrode_arrays.py
@@ -718,25 +718,24 @@ class ElectrodeGrid(ElectrodeArray):
                 else:
                     x_spc = y_spc * np.sqrt(3) / 2
 
-        # Start with a rectangular grid:
-        x_arr = (np.arange(cols) * x_spc - 0.5 * (cols - 1) * x_spc)
-        y_arr = (np.arange(rows) * y_spc - 0.5 * (rows - 1) * y_spc)
+        # Start with a rectangular grid, laid out from the origin:
+        x_arr = np.arange(cols, dtype=float) * x_spc
+        y_arr = np.arange(rows, dtype=float) * y_spc
         x_arr, y_arr = np.meshgrid(x_arr, y_arr, sparse=False)
         if self.type.lower() == 'hex':
             if orientation.lower() == 'horizontal':
                 # Shift every other row:
-                x_arr_shift = np.zeros_like(x_arr)
-                x_arr_shift[::2] = 0.5 * x_spc
-                x_arr += x_arr_shift
-                # Make sure the center is at (0, 0)
-                x_arr -= 0.25 * x_spc
-            elif orientation.lower() == 'vertical':
+                x_arr[::2] += 0.5 * x_spc
+            else:
                 # Shift every other column:
-                y_arr_shift = np.zeros_like(y_arr)
-                y_arr_shift[:, ::2] = 0.5 * y_spc
-                y_arr += y_arr_shift
-                # Make sure the center is at (0, 0)
-                y_arr -= 0.25 * y_spc
+                y_arr[:, ::2] += 0.5 * y_spc
+        # Center the lattice on (0, 0) once it is built, rather than assuming
+        # what the stagger did to its extent. (x, y) is the middle of that
+        # extent, not the centroid of the electrode centers: a hex grid with
+        # an odd number of rows has one stagger more often than the other, and
+        # its centroid sits a fraction of a pitch off center.
+        x_arr -= 0.5 * (x_arr.min() + x_arr.max())
+        y_arr -= 0.5 * (y_arr.min() + y_arr.max())
 
         # Rotate the grid and center at (x,y):
         tf = SimilarityTransform(rotation=np.deg2rad(rot), translation=[x, y])

--- a/pulse2percept/implants/electrodes.py
+++ b/pulse2percept/implants/electrodes.py
@@ -19,6 +19,22 @@ from ..utils import PrettyPrint
 from ..utils.constants import ZORDER
 
 
+#: Orientation of a flat-side-up hexagon, in radians.
+_HEX_ORIENTATION = np.radians(30)
+
+
+def _is_nonscalar(value):
+    """Whether ``value`` is a sequence where a single number is expected
+
+    The ``float`` shortcut keeps grid building off the ABC
+    ``__instancecheck__`` path: a float is never a sequence, and every
+    coordinate an :py:class:`~pulse2percept.implants.ElectrodeGrid` lays out
+    is a ``np.float64``, which is a float.
+    """
+    return (not isinstance(value, float) and
+            isinstance(value, (Sequence, np.ndarray)))
+
+
 class Electrode(PrettyPrint, metaclass=ABCMeta):
     """Electrode
 
@@ -62,11 +78,11 @@ class Electrode(PrettyPrint, metaclass=ABCMeta):
         x = as_value(x, um, 'x')
         y = as_value(y, um, 'y')
         z = as_value(z, um, 'z')
-        if isinstance(x, (Sequence, np.ndarray)):
+        if _is_nonscalar(x):
             raise TypeError(f"x must be a scalar, not {type(x)}.")
-        if isinstance(y, (Sequence, np.ndarray)):
+        if _is_nonscalar(y):
             raise TypeError(f"y must be a scalar, not {type(y)}.")
-        if isinstance(z, (Sequence, np.ndarray)):
+        if _is_nonscalar(z):
             raise TypeError(f"z must be a scalar, not {type(z)}.")
         self.x = x
         self.y = y
@@ -269,7 +285,7 @@ class DiskElectrode(Electrode):
     def __init__(self, x, y, z, r, name=None, activated=True):
         super(DiskElectrode, self).__init__(x, y, z, name, activated=activated)
         r = as_value(r, um, 'r')
-        if isinstance(r, (Sequence, np.ndarray)):
+        if _is_nonscalar(r):
             raise TypeError("Electrode radius must be a scalar.")
         if r <= 0:
             raise ValueError(f"Electrode radius must be > 0, not {r}.")
@@ -377,7 +393,7 @@ class SquareElectrode(Electrode):
         super(SquareElectrode, self).__init__(x, y, z, name=name,
                                               activated=activated)
         a = as_value(a, um, 'a')
-        if isinstance(a, (Sequence, np.ndarray)):
+        if _is_nonscalar(a):
             raise TypeError("Side length must be a scalar.")
         if a <= 0:
             raise ValueError(f"Side length must be > 0, not {a}.")
@@ -438,7 +454,7 @@ class HexElectrode(Electrode):
         super(HexElectrode, self).__init__(x, y, z, name=name,
                                            activated=activated)
         a = as_value(a, um, 'a')
-        if isinstance(a, (Sequence, np.ndarray)):
+        if _is_nonscalar(a):
             raise TypeError("Apothem of the hexagon must be a scalar.")
         if a <= 0:
             raise ValueError(f"Apothem of the hexagon must be > 0, not "
@@ -446,12 +462,12 @@ class HexElectrode(Electrode):
         self.a = a
         self.plot_patch = RegularPolygon
         self.plot_kwargs = {'numVertices': 6, 'radius': a, 'alpha': 0.2,
-                            'orientation': np.radians(30),
+                            'orientation': _HEX_ORIENTATION,
                             'ec': (0.3, 0.3, 0.3, 1),
                             'fc': (1, 1, 1, 0.8)}
         self.plot_deactivated_kwargs = {'numVertices': 6, 'radius': a,
                                         'alpha': 0.2,
-                                        'orientation': np.radians(30),
+                                        'orientation': _HEX_ORIENTATION,
                                         'ec': (0.6, 0.6, 0.6, 1),
                                         'fc': (1, 1, 1, 0.6)}
 

--- a/pulse2percept/implants/prima.py
+++ b/pulse2percept/implants/prima.py
@@ -7,9 +7,10 @@
 from matplotlib.patches import Circle, RegularPolygon
 
 import numpy as np
+from collections.abc import Sequence
 
 from .base import ProsthesisSystem
-from .electrodes import HexElectrode, _HEX_ORIENTATION, _is_nonscalar
+from .electrodes import HexElectrode, _HEX_ORIENTATION
 from .electrode_arrays import ElectrodeGrid
 from ..units import as_value, um
 
@@ -50,7 +51,7 @@ class PhotovoltaicPixel(HexElectrode):
         super(PhotovoltaicPixel, self).__init__(x, y, z, a, name=name,
                                                 activated=activated)
         r = as_value(r, um, 'r')
-        if _is_nonscalar(r):
+        if isinstance(r, (Sequence, np.ndarray)):
             raise TypeError("Radius of the active electrode must be a scalar.")
         if r <= 0:
             raise ValueError("Radius of the active electrode must be > 0, not "

--- a/pulse2percept/implants/prima.py
+++ b/pulse2percept/implants/prima.py
@@ -7,12 +7,9 @@
 from matplotlib.patches import Circle, RegularPolygon
 
 import numpy as np
-# Using or importing the ABCs from 'collections' instead of from
-# 'collections.abc' is deprecated, and in 3.8 it will stop working:
-from collections.abc import Sequence
 
 from .base import ProsthesisSystem
-from .electrodes import HexElectrode
+from .electrodes import HexElectrode, _HEX_ORIENTATION, _is_nonscalar
 from .electrode_arrays import ElectrodeGrid
 from ..units import as_value, um
 
@@ -53,7 +50,7 @@ class PhotovoltaicPixel(HexElectrode):
         super(PhotovoltaicPixel, self).__init__(x, y, z, a, name=name,
                                                 activated=activated)
         r = as_value(r, um, 'r')
-        if isinstance(r, (Sequence, np.ndarray)):
+        if _is_nonscalar(r):
             raise TypeError("Radius of the active electrode must be a scalar.")
         if r <= 0:
             raise ValueError("Radius of the active electrode must be > 0, not "
@@ -62,12 +59,12 @@ class PhotovoltaicPixel(HexElectrode):
         # Plot two objects: hex honeycomb and circular active electrode
         self.plot_patch = [RegularPolygon, Circle]
         self.plot_kwargs = [{'radius': a, 'numVertices': 6, 'alpha': 0.2,
-                             'orientation': np.radians(30),
+                             'orientation': _HEX_ORIENTATION,
                              'fc': 'k', 'ec': 'k'},
                             {'radius': r, 'linewidth': 0, 'color': 'k',
                              'alpha': 0.5}]
         self.plot_deactivated_kwargs = [{'radius': a, 'numVertices': 6,
-                                         'orientation': np.radians(30),
+                                         'orientation': _HEX_ORIENTATION,
                                          'fc': 'k', 'ec': 'k', 'alpha': 0.1},
                                         {'radius': r, 'linewidth': 0,
                                          'color': 'k', 'alpha': 0.2}]

--- a/pulse2percept/implants/tests/test_base.py
+++ b/pulse2percept/implants/tests/test_base.py
@@ -282,7 +282,7 @@ def test_rectangle_implant(ztype, x, y, rot):
 
 def test_RectangleImplant_is_deprecated():
     """Deprecated in favor of GridImplant, but otherwise unchanged"""
-    with pytest.deprecated_call(match='Use ``GridImplant`` instead'):
+    with pytest.deprecated_call(match='not a drop-in replacement'):
         implant = RectangleImplant(shape=(3, 4), spacing=100)
     # The legacy defaults and geometry survive the deprecation:
     npt.assert_equal(implant.preprocess, True)
@@ -362,27 +362,24 @@ def test_GridImplant_geometry_passthrough():
 
 
 def test_GridImplant_device_arguments_reach_ProsthesisSystem():
-    implant = GridImplant((2, 3), 100, eye='LE', stim={'A1': 5},
-                          safe_mode=False, max_current=100)
+    """Everything that is not geometry is handed to ProsthesisSystem as given
+
+    What those arguments then do is ProsthesisSystem's business and is tested
+    there; all a GridImplant owes them is not to drop or reinterpret one.
+    """
+    encoder = AmplitudeEncoder(amp_range=(0, 20))
+    raster = implants.SequentialRaster(2)
+    implant = GridImplant((2, 3), 100, eye='LE',
+                          stim={'A1': BiphasicPulse(10, 1)},
+                          preprocess=True, safe_mode=True, encoder=encoder,
+                          raster=raster, max_current=100)
     npt.assert_equal(implant.eye, 'LE')
     npt.assert_equal(implant.stim.electrodes, ['A1'])
-    npt.assert_almost_equal(implant.max_current, 100)
-    with pytest.raises(ValueError):
-        GridImplant((2, 3), 100, max_current=1, stim={'A1': 5})
-    # An encoder is what makes an image assignable at all:
-    encoder = AmplitudeEncoder(amp_range=(0, 20))
-    implant = GridImplant((2, 3), 100, encoder=encoder)
+    npt.assert_equal(implant.preprocess, True)
+    npt.assert_equal(implant.safe_mode, True)
     npt.assert_equal(implant.encoder, encoder)
-    implant.stim = ImageStimulus(np.ones((2, 3)))
-    npt.assert_equal(len(implant.stim.electrodes), implant.n_electrodes)
-    # Without an encoder, a picture is refused rather than silently read as
-    # microamps:
-    with pytest.raises(DimensionMismatchError):
-        GridImplant((2, 3), 100, stim=ImageStimulus(np.ones((2, 3))))
-    # Safe mode rejects a stimulus that is not charge-balanced:
-    with pytest.raises(ValueError):
-        GridImplant((2, 3), 100, safe_mode=True,
-                    stim=MonophasicPulse(10, 1))
+    npt.assert_equal(implant.raster, raster)
+    npt.assert_almost_equal(implant.max_current, 100)
 
 
 def test_GridImplant_does_not_relabel_the_left_eye():

--- a/pulse2percept/implants/tests/test_base.py
+++ b/pulse2percept/implants/tests/test_base.py
@@ -280,6 +280,23 @@ def test_rectangle_implant(ztype, x, y, rot):
         npt.assert_equal(implant.earray.shape, shape)
 
 
+def test_RectangleImplant_is_deprecated():
+    """Deprecated in favor of GridImplant, but otherwise unchanged"""
+    with pytest.deprecated_call(match='Use ``GridImplant`` instead'):
+        implant = RectangleImplant(shape=(3, 4), spacing=100)
+    # The legacy defaults and geometry survive the deprecation:
+    npt.assert_equal(implant.preprocess, True)
+    npt.assert_equal(implant.earray.shape, (3, 4))
+    npt.assert_equal(isinstance(implant['A1'], DiskElectrode), True)
+    npt.assert_almost_equal(implant['A1'].r, 75.)
+    # Including the left-eye column reversal that GridImplant does not do
+    # (see test_GridImplant_does_not_relabel_the_left_eye):
+    with pytest.deprecated_call():
+        le = RectangleImplant(shape=(3, 4), spacing=100, eye='LE')
+    npt.assert_equal(le['A1'].x > le['A4'].x, True)
+    npt.assert_almost_equal(le['A1'].x, implant['A4'].x)
+
+
 def test_GridImplant_is_a_grid_in_a_prosthesis_system():
     implant = GridImplant((3, 4), 100)
     npt.assert_equal(isinstance(implant, ProsthesisSystem), True)

--- a/pulse2percept/implants/tests/test_base.py
+++ b/pulse2percept/implants/tests/test_base.py
@@ -282,7 +282,7 @@ def test_rectangle_implant(ztype, x, y, rot):
 
 def test_RectangleImplant_is_deprecated():
     """Deprecated in favor of GridImplant, but otherwise unchanged"""
-    with pytest.deprecated_call(match='not a drop-in replacement'):
+    with pytest.deprecated_call(match='drop-in replacement'):
         implant = RectangleImplant(shape=(3, 4), spacing=100)
     # The legacy defaults and geometry survive the deprecation:
     npt.assert_equal(implant.preprocess, True)

--- a/pulse2percept/implants/tests/test_base.py
+++ b/pulse2percept/implants/tests/test_base.py
@@ -12,8 +12,8 @@ import matplotlib.pyplot as plt
 from skimage.measure import label, regionprops
 
 from pulse2percept.implants import (PointSource, ElectrodeArray, ElectrodeGrid,
-                                    ProsthesisSystem, RectangleImplant,
-                                    PhotovoltaicPixel)
+                                    GridImplant, ProsthesisSystem,
+                                    RectangleImplant, PhotovoltaicPixel)
 from pulse2percept.stimuli import (Stimulus, ImageStimulus, VideoStimulus,
                                    BostonTrain, LogoBVL)
 from pulse2percept.stimuli import (AmplitudeEncoder, BiphasicPulse,
@@ -278,6 +278,95 @@ def test_rectangle_implant(ztype, x, y, rot):
     for shape in [(6, 10), (5, 12), (15, 15)]:
         implant = RectangleImplant(shape=shape)
         npt.assert_equal(implant.earray.shape, shape)
+
+
+def test_GridImplant_is_a_grid_in_a_prosthesis_system():
+    implant = GridImplant((3, 4), 100)
+    npt.assert_equal(isinstance(implant, ProsthesisSystem), True)
+    npt.assert_equal(isinstance(implant.earray, ElectrodeGrid), True)
+    npt.assert_equal(implant.n_electrodes, 12)
+    npt.assert_equal(implant.earray.shape, (3, 4))
+    npt.assert_equal(implant.electrode_names,
+                     ['A1', 'A2', 'A3', 'A4', 'B1', 'B2', 'B3', 'B4',
+                      'C1', 'C2', 'C3', 'C4'])
+    npt.assert_equal(isinstance(implant['A1'], PointSource), True)
+    # Centered on the origin, 100 um apart:
+    npt.assert_almost_equal(implant['A1'].x, -150)
+    npt.assert_almost_equal(implant['A1'].y, -100)
+    npt.assert_almost_equal(implant['C4'].x, 150)
+    npt.assert_almost_equal(implant['C4'].y, 100)
+    # `shape`/`spacing` are required; there is no default geometry:
+    with pytest.raises(TypeError):
+        GridImplant()
+    with pytest.raises(TypeError):
+        GridImplant((3, 4))
+
+
+def test_GridImplant_hex():
+    implant = GridImplant((3, 4), 100, type='hex')
+    npt.assert_equal(implant.earray.type, 'hex')
+    npt.assert_equal(implant.n_electrodes, 12)
+    # Horizontal hex staggers every other row; a rect grid does not:
+    rect = GridImplant((3, 4), 100)
+    npt.assert_equal(implant['B1'].x != rect['B1'].x, True)
+
+
+def test_GridImplant_electrode_kwargs():
+    implant = GridImplant((2, 3), 100, etype=DiskElectrode, r=20)
+    npt.assert_equal(implant.n_electrodes, 6)
+    for e in implant.electrode_objects:
+        npt.assert_equal(isinstance(e, DiskElectrode), True)
+        npt.assert_almost_equal(e.r, 20)
+
+
+def test_GridImplant_geometry_passthrough():
+    implant = GridImplant((2, 3), 100, x=200, y=-300, z=50, rot=90)
+    npt.assert_almost_equal(implant.earray.coordinates().mean(axis=0),
+                            [200, -300, 50])
+    # 90 deg CCW about the grid center: (dx, dy) -> (-dy, dx)
+    unrot = GridImplant((2, 3), 100, x=200, y=-300, z=50)
+    dx, dy = unrot['A1'].x - 200, unrot['A1'].y + 300
+    npt.assert_almost_equal(implant['A1'].x, 200 - dy)
+    npt.assert_almost_equal(implant['A1'].y, -300 + dx)
+    # Unitful geometry normalizes to plain microns, as everywhere else:
+    unitful = GridImplant((2, 3), 0.1 * mm, x=0.2 * mm, y=-300 * um,
+                          z=50 * um, rot=90 * deg)
+    npt.assert_allclose(unitful.earray.coordinates(),
+                        implant.earray.coordinates(), rtol=1e-12)
+    with pytest.raises(DimensionMismatchError):
+        GridImplant((2, 3), 2 * dva)
+
+
+def test_GridImplant_device_arguments_reach_ProsthesisSystem():
+    implant = GridImplant((2, 3), 100, eye='LE', stim={'A1': 5},
+                          safe_mode=False, max_current=100)
+    npt.assert_equal(implant.eye, 'LE')
+    npt.assert_equal(implant.stim.electrodes, ['A1'])
+    npt.assert_almost_equal(implant.max_current, 100)
+    with pytest.raises(ValueError):
+        GridImplant((2, 3), 100, max_current=1, stim={'A1': 5})
+    # An encoder is what makes an image assignable at all:
+    encoder = AmplitudeEncoder(amp_range=(0, 20))
+    implant = GridImplant((2, 3), 100, encoder=encoder)
+    npt.assert_equal(implant.encoder, encoder)
+    implant.stim = ImageStimulus(np.ones((2, 3)))
+    npt.assert_equal(len(implant.stim.electrodes), implant.n_electrodes)
+    # Without an encoder, a picture is refused rather than silently read as
+    # microamps:
+    with pytest.raises(DimensionMismatchError):
+        GridImplant((2, 3), 100, stim=ImageStimulus(np.ones((2, 3))))
+    # Safe mode rejects a stimulus that is not charge-balanced:
+    with pytest.raises(ValueError):
+        GridImplant((2, 3), 100, safe_mode=True,
+                    stim=MonophasicPulse(10, 1))
+
+
+def test_GridImplant_does_not_relabel_the_left_eye():
+    """Unlike RectangleImplant, a generic grid is the same in either eye"""
+    re = GridImplant((3, 4), 100, eye='RE')
+    le = GridImplant((3, 4), 100, eye='LE')
+    npt.assert_equal(le.electrode_names, re.electrode_names)
+    npt.assert_almost_equal(le.earray.coordinates(), re.earray.coordinates())
 
 
 def test_ProsthesisSystem_reshape_stim_frames_independent():

--- a/pulse2percept/implants/tests/test_base.py
+++ b/pulse2percept/implants/tests/test_base.py
@@ -323,9 +323,16 @@ def test_GridImplant_hex():
     implant = GridImplant((3, 4), 100, type='hex')
     npt.assert_equal(implant.earray.type, 'hex')
     npt.assert_equal(implant.n_electrodes, 12)
-    # Horizontal hex staggers every other row; a rect grid does not:
-    rect = GridImplant((3, 4), 100)
-    npt.assert_equal(implant['B1'].x != rect['B1'].x, True)
+    # `type` really produces a triangular lattice, not just some other set of
+    # coordinates: every nearest neighbor is exactly one spacing away, which
+    # on a rect grid is only true of the orthogonal ones.
+    xy = implant.earray.coordinates()[:, :2]
+    dist = np.linalg.norm(xy[:, None, :] - xy[None, :, :], axis=-1)
+    np.fill_diagonal(dist, np.inf)
+    npt.assert_almost_equal(dist.min(axis=1), 100)
+    # The array is still centered on (x, y), odd row count and all:
+    npt.assert_almost_equal((xy[:, 0].min() + xy[:, 0].max()) / 2, 0)
+    npt.assert_almost_equal((xy[:, 1].min() + xy[:, 1].max()) / 2, 0)
 
 
 def test_GridImplant_electrode_kwargs():

--- a/pulse2percept/implants/tests/test_electrode_arrays.py
+++ b/pulse2percept/implants/tests/test_electrode_arrays.py
@@ -381,6 +381,61 @@ def test_ElectrodeGrid__make_grid(gtype, orientation):
 
 
 @pytest.mark.parametrize('gtype', ('rect', 'hex'))
+@pytest.mark.parametrize('orientation', ('horizontal', 'vertical'))
+@pytest.mark.parametrize('shape', [(1, 1), (1, 5), (5, 1), (1, 2), (2, 1),
+                                   (2, 2), (3, 3), (3, 4), (4, 3), (4, 4),
+                                   (5, 7), (7, 5)])
+def test_ElectrodeGrid_is_centered(gtype, orientation, shape):
+    """(x, y) is the middle of the electrode extent, whatever the shape.
+
+    A hex grid staggers every other row, which widens its extent by half a
+    pitch -- but only once both staggers are present. A single-row (or, for a
+    vertical grid, single-column) hex grid used to come out a quarter pitch
+    off, because the correction was applied unconditionally.
+    """
+    x, y = 200, -300
+    coords = ElectrodeGrid(shape, 100, x=x, y=y, type=gtype,
+                           orientation=orientation).coordinates()
+    npt.assert_almost_equal((coords[:, 0].min() + coords[:, 0].max()) / 2, x)
+    npt.assert_almost_equal((coords[:, 1].min() + coords[:, 1].max()) / 2, y)
+
+
+def test_ElectrodeGrid_centers_the_extent_not_the_centroid():
+    """The centroid is deliberately not the thing being centered.
+
+    An odd number of rows carries one stagger more often than the other, so
+    the mean of the electrode centers sits a fraction of a pitch off. `x`/`y`
+    describe where the physical array sits, so the extent is what must land
+    on them.
+    """
+    coords = ElectrodeGrid((3, 4), 100, type='hex').coordinates()
+    npt.assert_almost_equal((coords[:, 0].min() + coords[:, 0].max()) / 2, 0)
+    npt.assert_almost_equal(coords[:, 0].mean(), 100 / 12)
+
+
+@pytest.mark.parametrize('orientation', ('horizontal', 'vertical'))
+@pytest.mark.parametrize('shape', [(2, 2), (3, 4), (4, 3), (5, 5)])
+def test_ElectrodeGrid_hex_is_a_triangular_lattice(orientation, shape):
+    """Scalar `spacing` is the nearest-neighbor distance, in every direction
+
+    This is what makes a hex grid hexagonal: on a rectangular grid the
+    diagonal neighbor is further away than the orthogonal one.
+    """
+    spacing = 100
+    coords = ElectrodeGrid(shape, spacing, type='hex',
+                           orientation=orientation).coordinates()[:, :2]
+    dist = np.linalg.norm(coords[:, None, :] - coords[None, :, :], axis=-1)
+    np.fill_diagonal(dist, np.inf)
+    # Every electrode has at least one neighbor exactly `spacing` away, and
+    # none any closer:
+    npt.assert_almost_equal(dist.min(axis=1), spacing)
+    # An interior electrode has all six:
+    if min(shape) >= 3:
+        n_neighbors = np.isclose(dist, spacing).sum(axis=1)
+        npt.assert_equal(n_neighbors.max(), 6)
+
+
+@pytest.mark.parametrize('gtype', ('rect', 'hex'))
 def test_ElectrodeGrid_get_params(gtype):
     # When the electrode_type is 'DiskElectrode'
     # test the default value

--- a/pulse2percept/implants/tests/test_prima.py
+++ b/pulse2percept/implants/tests/test_prima.py
@@ -240,3 +240,33 @@ def test_PRIMA40_reshape_stim():
     # reaches it:
     PRIMA40().reshape_stim(LogoBVL())
     
+
+@pytest.mark.parametrize('implant_type, offset', [
+    (PRIMA, (0, 0)),
+    (PRIMA75, (0, 0)),
+    # PRIMA55 and PRIMA40 approximate a circular substrate by deleting
+    # electrodes from a rectangular grid, and those deletions are not quite
+    # symmetric, so the surviving footprint sits half a column pitch and/or a
+    # quarter of a row pitch off (x, y). Pinned as-is: the deletion lists are
+    # the device geometry, and this is what they currently describe.
+    (PRIMA55, (0.25 * np.sqrt(3) * 55, 0.25 * 55)),
+    (PRIMA40, (0, 0.25 * 40)),
+])
+def test_PRIMA_device_center(implant_type, offset):
+    """Where the trimmed device sits relative to the requested (x, y)
+
+    Each PRIMA is a regular hex grid with edge electrodes removed afterwards,
+    so the finished device is centered only if those removals are symmetric --
+    the grid's own centering says nothing about it. The per-electrode
+    coordinate tests would all still pass if a device drifted sideways.
+    """
+    x, y, rot = -100, 400, 37
+    xy = implant_type(x=x, y=y).earray.coordinates()[:, :2]
+    center = 0.5 * (xy.min(axis=0) + xy.max(axis=0))
+    npt.assert_almost_equal(center, np.add([x, y], offset))
+    # `rot` turns the whole footprint about (x, y), so the offset above is a
+    # property of the device rather than of the coordinate axes:
+    th = np.deg2rad(rot)
+    R = np.array([[np.cos(th), -np.sin(th)], [np.sin(th), np.cos(th)]])
+    rotated = implant_type(x=x, y=y, rot=rot).earray.coordinates()[:, :2]
+    npt.assert_almost_equal(rotated, (R @ (xy - [x, y]).T).T + [x, y])

--- a/pulse2percept/stimuli/tests/test_encoders.py
+++ b/pulse2percept/stimuli/tests/test_encoders.py
@@ -6,8 +6,8 @@ import numpy.testing as npt
 import pytest
 from scipy.integrate import trapezoid
 
-from pulse2percept.implants import (ArgusII, CustomRaster, RectangleImplant,
-                                     SequentialRaster)
+from pulse2percept.implants import (ArgusII, CustomRaster, DiskElectrode,
+                                    GridImplant, SequentialRaster)
 from pulse2percept.stimuli import (AmplitudeEncoder, BiphasicPulse,
                                    BiphasicPulseTrain, BostonTrain,
                                    FrequencyEncoder, ImageStimulus,
@@ -40,7 +40,7 @@ def pixel_implant(shape, raster=None):
     implant's electrodes sit exactly on the pixels of a ``shape`` image, so
     sampling one at the other changes nothing about what gets encoded.
     """
-    implant = RectangleImplant(shape=shape, spacing=200, r=50)
+    implant = GridImplant(shape, 200, etype=DiskElectrode, r=50)
     implant.raster = raster
     return implant
 

--- a/pulse2percept/units/base.py
+++ b/pulse2percept/units/base.py
@@ -703,6 +703,11 @@ def as_value(value, unit, name=None):
     # particular caller happened to pass a plain number.
     if not isinstance(unit, Unit):
         raise TypeError(f"'unit' must be a Unit object, not {type(unit)}.")
+    # A plain number is already what the caller wants and cannot match any of
+    # the cases below. Worth its own line: this is the boundary every
+    # coordinate of every electrode crosses, and `np.float64` is a `float`.
+    if isinstance(value, (int, float)):
+        return value
     if isinstance(value, Unit):
         # A bare unit is the quantity 1 of that unit, e.g. ``as_value(ms, ms)``:
         value = Quantity(1, value)

--- a/pulse2percept/utils/deprecation.py
+++ b/pulse2percept/utils/deprecation.py
@@ -83,13 +83,21 @@ class deprecated:
     removed_version : float or str
         The package version in which the deprecated function/class will be
         removed.
+    extra_msg : str, optional
+        Appended to the warning and to the docstring. Say here what a caller
+        has to change beyond the name when ``alt_func`` is not a drop-in
+        replacement -- different defaults, dropped behavior -- so that
+        swapping one for the other cannot silently change results.
+
+        .. versionadded:: 0.11.0
     """
 
     def __init__(self, alt_func=None, deprecated_version=None,
-                 removed_version=None):
+                 removed_version=None, extra_msg=None):
         self.alt_func = alt_func
         self.deprecated_version = deprecated_version
         self.removed_version = removed_version
+        self.extra_msg = extra_msg
 
     def __call__(self, obj):
         if isinstance(obj, type):
@@ -113,7 +121,8 @@ class deprecated:
         if self.alt_func is not None:
             alt_msg = f"Use ``{self.alt_func}`` instead."
         clause = _version_clause(self.deprecated_version, self.removed_version)
-        return msg + clause + ". " + alt_msg
+        parts = [msg + clause + ".", alt_msg, self.extra_msg or ""]
+        return " ".join(p for p in parts if p)
 
     def _update_doc(self, old_doc, msg=None):
         """Updates the docstring"""

--- a/pulse2percept/utils/tests/test_deprecation.py
+++ b/pulse2percept/utils/tests/test_deprecation.py
@@ -37,12 +37,23 @@ def mock_function():
     return 10
 
 
+@deprecated(alt_func='qwerty', extra_msg='Pass ``asdf=True`` to keep it.')
+class MockClass5:
+    pass
+
+
 def test_deprecated():
     assert_warns_msg(DeprecationWarning, MockClass1, 'Use ``qwerty`` instead')
     assert_warns_msg(DeprecationWarning, MockClass2().mymethod,
                      'since version 0.1, and will be removed in version 0.2')
     assert_warns_msg(DeprecationWarning, MockClass3, 'deprecated')
     assert_warns_msg(DeprecationWarning, mock_function, 'since version 0.4')
+
+
+def test_deprecated_extra_msg():
+    """A replacement that is not drop-in says so, where the caller sees it"""
+    assert_warns_msg(DeprecationWarning, MockClass5,
+                     'Use ``qwerty`` instead. Pass ``asdf=True`` to keep it.')
 
 
 def test_is_deprecated():


### PR DESCRIPTION
Adds a shorthand for creating an implant with an electrode array on a regular (rect/hex) grid:
```
from pulse2percept.implants import GridImplant

implant = GridImplant((11, 13), 500, type='hex', etype=DiskElectrode, r=100,
                      stim={'A1': 20})
implant.plot()
```

Existing API required you to manually wrap an `ElectrodeGrid` inside a `ProsthesisSystem` object. `GridImplant` is easier and also absorbs `RectangleImplant` (now deprecated).

The PR also significantly speeds up `_make_grid`, especially for larger and next-gen arrays.