### PR TITLE
[ENH] [API] Simplify/modernize the model/implant API

### DIFF
--- a/.github/scripts/check_install.py
+++ b/.github/scripts/check_install.py
@@ -171,11 +171,9 @@ def check_model_builds() -> list[str]:
         # grid spacing parameter `xystep` -> `step`. Ask the installed model
         # which spelling it takes rather than assuming the current one.
         spacing = "step" if hasattr(ScoreboardModel(), "step") else "xystep"
-        model = ScoreboardModel(xrange=(-4, 4), yrange=(-4, 4),
-                                **{spacing: 1}).build()
-        implant = ArgusII()
-        implant.stim = {e: 1 for e in ("A1", "F10")}
-        percept = model.predict_percept(implant)
+        model = ScoreboardModel(implant=ArgusII(), xrange=(-4, 4),
+                                yrange=(-4, 4), **{spacing: 1})
+        percept = model.predict_percept({e: 1 for e in ("A1", "F10")})
         if percept is None or percept.data.size == 0:
             return ["ScoreboardModel produced an empty percept"]
         print(f"  ScoreboardModel -> percept {percept.data.shape}, ok")

--- a/benchmarks/README.rst
+++ b/benchmarks/README.rst
@@ -135,7 +135,7 @@ computation.
    * - ``stimulus``
      - Building the stimulus, before any implant exists.
    * - ``implant``
-     - Assigning the stimulus to the implant, including the downsampling of an
+     - ``implant.prepare_stim(source)``, including the downsampling of an
        image or video onto the electrode grid.
    * - ``build``
      - ``model.build()``, both warm (``test_build``, what a user hits on every
@@ -143,7 +143,8 @@ computation.
        axon cache -- the actual computation, and the thing worth optimizing).
        Same group, so the two sit side by side in the report.
    * - ``predict_percept``
-     - The headline number.
+     - The headline number. Includes the preparation timed on its own by
+       ``implant``, because that is what a prediction does.
    * - ``end_to_end``
      - The whole one-liner.
    * - ``plot``
@@ -194,7 +195,7 @@ automatically and no other file changes. For example, a temporal model:
     Scenario(
         id='argus2_axonmap_fading',
         stimulus=lambda: array_ptrain(p2p.implants.ArgusII),
-        implant=lambda stim: p2p.implants.ArgusII(stim=stim),
+        implant=p2p.implants.ArgusII,
         model=lambda **kwargs: p2p.models.Model(
             spatial=p2p.models.AxonMapSpatial(xrange=(-12, 12),
                                               yrange=(-8, 8)),
@@ -210,10 +211,11 @@ problem: it is a kernel this check cannot see regress at all.
 Four things to know.
 
 **Stimulate the whole array.** Handing a bare ``BiphasicPulseTrain`` to an
-implant assigns it to one electrode, not all of them -- ``ArgusII(stim=...)``
-then has a stimulus of shape ``(1, 29)`` rather than ``(60, 29)``. A benchmark
-built that way exercises a sixtieth of the per-electrode work and barely moves
-when that work regresses. Use the ``array_ptrain`` helper, as above.
+implant drives one electrode, not all of them --
+``ArgusII().prepare_stim(...)`` then has shape ``(1, 29)`` rather than
+``(60, 29)``. A benchmark built that way exercises a sixtieth of the
+per-electrode work and barely moves when that work regresses. Use the
+``array_ptrain`` helper, as above.
 
 **Match the stimulus to the model.** ``BiphasicAxonMapModel`` reads pulse
 parameters off each electrode and rejects an image, and its amplitude is a
@@ -222,7 +224,7 @@ than a current; a temporal model given a single-frame stimulus measures
 nothing temporal.
 
 **An image is not a stimulus.** Gray levels are dimensionless, and both
-``implant.stim`` and ``predict_percept`` refuse them; user code turns an image
+``prepare_stim`` and ``predict_percept`` refuse them; user code turns an image
 into current with a ``StimulusEncoder``. A benchmark that did the same would
 measure a pulse train per electrode rather than the single static frame the
 image scenarios exist for, so they call the ``as_current`` helper instead,
@@ -234,9 +236,9 @@ handed to ``Model(...)`` itself reach *both* sub-models, and ``Parametrized``
 freezes attributes, so anything the temporal model does not recognize raises
 rather than being quietly ignored.
 
-**Set the capability flags.** A temporal-only model's percept has no spatial
-grid, and ``Percept.plot`` raises on one, so such a scenario needs
-``plottable=False``. And if the scenario takes more than a few seconds per
+**Set the capability flags.** A temporal-only model takes no ``implant``, so
+such a scenario needs ``binds_implant=False``; its percept also has no spatial
+grid, and ``Percept.plot`` raises on one, so it needs ``plottable=False`` too. And if the scenario takes more than a few seconds per
 ``predict_percept`` call, mark it ``slow=True`` so it stays out of the default
 run:
 

--- a/benchmarks/README.rst
+++ b/benchmarks/README.rst
@@ -135,8 +135,8 @@ computation.
    * - ``stimulus``
      - Building the stimulus, before any implant exists.
    * - ``implant``
-     - ``implant.prepare_stim(source)``, including the downsampling of an
-       image or video onto the electrode grid.
+     - Source to device-ready stimulation: the downsampling of an image or
+       video onto the electrode grid, then ``implant.prepare_stim``.
    * - ``build``
      - ``model.build()``, both warm (``test_build``, what a user hits on every
        run after the first) and cold (``test_build_cold``, ignoring the on-disk

--- a/benchmarks/conftest.py
+++ b/benchmarks/conftest.py
@@ -104,8 +104,10 @@ def make_model(scenario, n_threads, axon_pickle):
     Benchmarks that measure ``build`` need a new model for every round, and
     they need it built outside the timed section.
     """
-    def _make(ignore_pickle=False):
+    def _make(implant, ignore_pickle=False):
         kwargs = {'verbose': False, 'n_threads': n_threads}
+        if scenario.binds_implant:
+            kwargs['implant'] = implant
         if scenario.caches_axons:
             kwargs['axon_pickle'] = axon_pickle
             kwargs['ignore_pickle'] = ignore_pickle
@@ -115,21 +117,27 @@ def make_model(scenario, n_threads, axon_pickle):
 
 @pytest.fixture(scope='module')
 def implant(scenario):
-    """An implant with the scenario's stimulus already assigned."""
-    return scenario.implant(scenario.stimulus())
+    """The scenario's device."""
+    return scenario.implant()
 
 
 @pytest.fixture(scope='module')
-def built_model(make_model):
+def source(scenario, implant):
+    """What ``predict_percept`` is handed."""
+    return scenario.source(implant, scenario.stimulus())
+
+
+@pytest.fixture(scope='module')
+def built_model(make_model, implant):
     """A model that has been built once, shared by the benchmarks that need
     one. ``predict_percept`` does not mutate the model, so reuse is safe."""
-    return make_model().build()
+    return make_model(implant).build()
 
 
 @pytest.fixture(scope='module')
-def percept(built_model, implant):
+def percept(built_model, source):
     """A predicted percept, for the benchmarks that consume one."""
-    return built_model.predict_percept(implant)
+    return built_model.predict_percept(source)
 
 
 @pytest.fixture

--- a/benchmarks/scenarios.py
+++ b/benchmarks/scenarios.py
@@ -1,22 +1,25 @@
 """Pipelines exercised by the benchmark suite.
 
 A :class:`Scenario` is one end-to-end path through the library: build a
-stimulus, hand it to an implant, build a model, predict a percept. The
-benchmark functions in ``test_predict.py`` are written once and parametrized
-over :data:`SCENARIOS`, so adding a case means adding an entry here and
-nothing else.
+stimulus, bind a model to an implant, predict a percept. The benchmark
+functions in ``test_predict.py`` are written once and parametrized over
+:data:`SCENARIOS`, so adding a case means adding an entry here and nothing
+else.
 
 The scenarios below are the reference workloads for the library's main purpose
 -- predicting a percept from a stimulus, an implant and a phosphene model. The
 first two correspond to these one-liners::
 
-    p2p.models.AxonMapModel(yrange=(-8, 8), xrange=(-12, 12)).build(
-        ).predict_percept(as_current(p2p.implants.ArgusII(),
-                                     p2p.stimuli.LogoBVL()))
+    implant = p2p.implants.ArgusII()
+    p2p.models.AxonMapModel(implant=implant, yrange=(-8, 8),
+                            xrange=(-12, 12)).predict_percept(
+        as_current(implant, p2p.stimuli.LogoBVL()))
 
-    p2p.models.ScoreboardModel(yrange=(-4, 4), xrange=(-4, 4), rho=50,
-                               step=0.1).build().predict_percept(as_current(
-        p2p.implants.PRIMA(), p2p.stimuli.LogoBVL().invert()))
+    implant = p2p.implants.PRIMA()
+    p2p.models.ScoreboardModel(implant=implant, yrange=(-4, 4),
+                               xrange=(-4, 4), rho=50,
+                               step=0.1).predict_percept(
+        as_current(implant, p2p.stimuli.LogoBVL().invert()))
 
 The :func:`as_current` wrapper is a benchmark-only detail; see its docstring
 for why these workloads do not go through an encoder the way user code should.
@@ -38,8 +41,8 @@ import pulse2percept as p2p
 def array_ptrain(implant_cls, amp=20):
     """A ``BiphasicPulseTrain`` on *every* electrode of ``implant_cls``.
 
-    Handing a bare ``BiphasicPulseTrain`` to an implant assigns it to a single
-    electrode -- ``ArgusII(stim=BiphasicPulseTrain(...)).stim.shape`` is
+    Handing a bare ``BiphasicPulseTrain`` to an implant drives a single
+    electrode -- ``ArgusII().prepare_stim(BiphasicPulseTrain(...)).shape`` is
     ``(1, 29)``, not ``(60, 29)``. A benchmark built that way would exercise
     one sixtieth of the per-electrode work the kernels actually do, and would
     barely move if that work regressed. Every pulse-train scenario below goes
@@ -62,7 +65,7 @@ def array_ptrain(implant_cls, amp=20):
 
 #: Microamps that a gray level of 1.0 stands for in :func:`as_current`.
 #:
-#: One, so that the amplitudes are numerically what an image assigned straight
+#: One, so that the amplitudes are numerically what an image handed straight
 #: to an implant used to produce, and these benchmarks stay comparable across
 #: the release that made the reinterpretation explicit. Nothing here depends on
 #: the value -- the kernels below do the same arithmetic on any amplitude --
@@ -87,22 +90,23 @@ def as_current(implant, picture, amp_max=GRAY_LEVEL_UA):
     instead, on the amplitudes ``reshape_stim`` has resampled onto the
     implant's electrodes. What the kernels see does not change: the same
     electrodes, the same number of columns, the same numbers in them.
+
+    Returns the source a model is handed, not a prepared stimulus: the implant
+    prepares it inside ``predict_percept``, and ``prepare_stim`` is measured
+    on its own by the ``implant`` benchmark.
     """
     stim = implant.reshape_stim(picture)
     data = stim.data * amp_max
     if stim.time is None:
         # A *flat* sequence means N electrodes stimulated once each with no
-        # time component, which is what an image assigned to an implant
+        # time component, which is what an image handed to an implant
         # produces. Handing over the (N, 1) array instead would give it a time
         # axis of [0], and a spatial model takes a different path through
         # `predict_percept` for a stimulus that has one -- so the benchmark
         # would quietly start measuring something else.
-        data = data.ravel()
-        implant.stim = p2p.stimuli.Stimulus(data, electrodes=stim.electrodes)
-    else:
-        implant.stim = p2p.stimuli.Stimulus(data, electrodes=stim.electrodes,
-                                            time=stim.time)
-    return implant
+        return p2p.stimuli.Stimulus(data.ravel(), electrodes=stim.electrodes)
+    return p2p.stimuli.Stimulus(data, electrodes=stim.electrodes,
+                                time=stim.time)
 
 
 @dataclass(frozen=True)
@@ -116,11 +120,20 @@ class Scenario:
     stimulus : callable
         Takes no arguments, returns a stimulus.
     implant : callable
-        Takes a stimulus, returns a ``ProsthesisSystem``.
+        Takes no arguments, returns a ``ProsthesisSystem``.
+    source : callable, optional
+        Takes the implant and the stimulus, returns what ``predict_percept``
+        is given. Defaults to the stimulus unchanged; the image scenarios use
+        :func:`as_current`.
     model : callable
         Takes keyword arguments, returns an *unbuilt* model. Always receives
-        ``verbose`` and ``n_threads``; also receives ``axon_pickle`` and
-        ``ignore_pickle`` when ``caches_axons`` is True.
+        ``verbose`` and ``n_threads``; also receives ``implant`` unless
+        ``binds_implant`` is False, and ``axon_pickle``/``ignore_pickle``
+        when ``caches_axons`` is True.
+    binds_implant : bool
+        Whether the model takes an ``implant``. False for a temporal-only
+        model, which never sees an electrode and is handed the stimulus
+        directly.
     caches_axons : bool
         Whether the model caches its axon map to disk. ``AxonMapSpatial``
         pickles the grown axon bundles to ``axons.pickle`` in the working
@@ -148,6 +161,8 @@ class Scenario:
     stimulus: Callable
     implant: Callable
     model: Callable
+    source: Callable = lambda implant, stim: stim
+    binds_implant: bool = True
     caches_axons: bool = False
     slow: bool = False
     plottable: bool = True
@@ -157,7 +172,8 @@ SCENARIOS = [
     Scenario(
         id='argus2_axonmap_logobvl',
         stimulus=lambda: p2p.stimuli.LogoBVL(),
-        implant=lambda stim: as_current(p2p.implants.ArgusII(), stim),
+        implant=p2p.implants.ArgusII,
+        source=as_current,
         model=lambda **kwargs: p2p.models.AxonMapModel(xrange=(-12, 12),
                                                        yrange=(-8, 8),
                                                        **kwargs),
@@ -166,7 +182,8 @@ SCENARIOS = [
     Scenario(
         id='prima_scoreboard_logobvl',
         stimulus=lambda: p2p.stimuli.LogoBVL().invert(),
-        implant=lambda stim: as_current(p2p.implants.PRIMA(), stim),
+        implant=p2p.implants.PRIMA,
+        source=as_current,
         model=lambda **kwargs: p2p.models.ScoreboardModel(xrange=(-4, 4),
                                                           yrange=(-4, 4),
                                                           rho=50, step=0.1,
@@ -180,7 +197,7 @@ SCENARIOS = [
         id='argus2_biphasic_ptrain',
         stimulus=lambda: array_ptrain(p2p.implants.ArgusII,
                                       amp=20 * p2p.units.xTh),
-        implant=lambda stim: p2p.implants.ArgusII(stim=stim),
+        implant=p2p.implants.ArgusII,
         model=lambda **kwargs: p2p.models.BiphasicAxonMapModel(
             xrange=(-12, 12), yrange=(-8, 8), **kwargs),
         caches_axons=True,
@@ -192,7 +209,7 @@ SCENARIOS = [
     Scenario(
         id='argus2_nanduri2012_ptrain',
         stimulus=lambda: array_ptrain(p2p.implants.ArgusII),
-        implant=lambda stim: p2p.implants.ArgusII(stim=stim),
+        implant=p2p.implants.ArgusII,
         model=lambda **kwargs: p2p.models.Nanduri2012Model(
             xrange=(-4, 4), yrange=(-4, 4), step=0.5, **kwargs),
     ),
@@ -202,8 +219,9 @@ SCENARIOS = [
     Scenario(
         id='argus2_horsager2009_ptrain',
         stimulus=lambda: array_ptrain(p2p.implants.ArgusII),
-        implant=lambda stim: p2p.implants.ArgusII(stim=stim),
+        implant=p2p.implants.ArgusII,
         model=lambda **kwargs: p2p.models.Horsager2009Model(**kwargs),
+        binds_implant=False,
         plottable=False,
     ),
     # Thompson 2003: a spatial-only model taking an image, and the only
@@ -211,7 +229,8 @@ SCENARIOS = [
     Scenario(
         id='argus2_thompson2003_logobvl',
         stimulus=lambda: p2p.stimuli.LogoBVL(),
-        implant=lambda stim: as_current(p2p.implants.ArgusII(), stim),
+        implant=p2p.implants.ArgusII,
+        source=as_current,
         model=lambda **kwargs: p2p.models.Thompson2003Model(
             xrange=(-12, 12), yrange=(-8, 8), **kwargs),
     ),
@@ -221,7 +240,7 @@ SCENARIOS = [
     Scenario(
         id='argus2_scoreboard_fading_ptrain',
         stimulus=lambda: array_ptrain(p2p.implants.ArgusII),
-        implant=lambda stim: p2p.implants.ArgusII(stim=stim),
+        implant=p2p.implants.ArgusII,
         model=lambda **kwargs: p2p.models.Model(
             spatial=p2p.models.ScoreboardSpatial(xrange=(-4, 4),
                                                  yrange=(-4, 4), step=0.5),
@@ -233,7 +252,8 @@ SCENARIOS = [
     Scenario(
         id='argus2_axonmap_bostontrain',
         stimulus=lambda: p2p.stimuli.BostonTrain().rgb2gray(),
-        implant=lambda stim: as_current(p2p.implants.ArgusII(), stim),
+        implant=p2p.implants.ArgusII,
+        source=as_current,
         model=lambda **kwargs: p2p.models.AxonMapModel(xrange=(-12, 12),
                                                        yrange=(-8, 8),
                                                        **kwargs),

--- a/benchmarks/test_predict.py
+++ b/benchmarks/test_predict.py
@@ -23,25 +23,22 @@ def test_stimulus(benchmark, scenario, peak_memory):
 
 
 @pytest.mark.benchmark(group='implant')
-def test_implant(benchmark, scenario, peak_memory):
-    """Assigning the stimulus to the implant.
+def test_implant(benchmark, scenario, implant, source, peak_memory):
+    """Preparing the stimulus the device delivers.
 
     This is not just bookkeeping: an image stimulus has far more pixels than
-    the array has electrodes, so the setter downsamples it onto the electrode
-    grid. Building the stimulus happens in ``setup`` and is not timed.
+    the array has electrodes, so preparation downsamples it onto the electrode
+    grid. Building the stimulus happens in the fixtures and is not timed.
     """
-    def setup():
-        return (scenario.stimulus(),), {}
-
-    implant = benchmark.pedantic(scenario.implant, setup=setup, rounds=20,
-                                 iterations=1, warmup_rounds=1)
-    stim = scenario.stimulus()
-    benchmark.extra_info['peak_mem_mb'] = peak_memory(scenario.implant, stim)
+    benchmark(implant.prepare_stim, source)
+    benchmark.extra_info['peak_mem_mb'] = peak_memory(implant.prepare_stim,
+                                                      source)
     benchmark.extra_info['n_electrodes'] = implant.n_electrodes
 
 
 @pytest.mark.benchmark(group='build')
-def test_build(benchmark, scenario, make_model, peak_memory, n_threads):
+def test_build(benchmark, scenario, implant, make_model, peak_memory,
+               n_threads):
     """Building the model, with any on-disk cache already warm.
 
     This is the path a user hits on every run after the first, so it is the
@@ -52,20 +49,21 @@ def test_build(benchmark, scenario, make_model, peak_memory, n_threads):
     if scenario.caches_axons:
         # Populate the cache first so this benchmark measures the warm path
         # no matter which order the tests run in.
-        make_model(ignore_pickle=False).build()
+        make_model(implant, ignore_pickle=False).build()
 
     def setup():
-        return (make_model(ignore_pickle=False),), {}
+        return (make_model(implant, ignore_pickle=False),), {}
 
     benchmark.pedantic(lambda model: model.build(), setup=setup, rounds=5,
                        iterations=1, warmup_rounds=1)
     benchmark.extra_info['peak_mem_mb'] = peak_memory(
-        lambda: make_model(ignore_pickle=False).build())
+        lambda: make_model(implant, ignore_pickle=False).build())
     benchmark.extra_info['n_threads'] = n_threads
 
 
 @pytest.mark.benchmark(group='build')
-def test_build_cold(benchmark, scenario, make_model, peak_memory, n_threads):
+def test_build_cold(benchmark, scenario, implant, make_model, peak_memory,
+                    n_threads):
     """Building the model from scratch, ignoring the on-disk cache.
 
     This is the actual Jansonius-model computation -- the part worth
@@ -76,22 +74,27 @@ def test_build_cold(benchmark, scenario, make_model, peak_memory, n_threads):
                     f'the same as a warm one (see test_build)')
 
     def setup():
-        return (make_model(ignore_pickle=True),), {}
+        return (make_model(implant, ignore_pickle=True),), {}
 
     benchmark.pedantic(lambda model: model.build(), setup=setup, rounds=5,
                        iterations=1, warmup_rounds=1)
     benchmark.extra_info['peak_mem_mb'] = peak_memory(
-        lambda: make_model(ignore_pickle=True).build())
+        lambda: make_model(implant, ignore_pickle=True).build())
     benchmark.extra_info['n_threads'] = n_threads
 
 
 @pytest.mark.benchmark(group='predict_percept')
-def test_predict_percept(benchmark, built_model, implant, peak_memory,
+def test_predict_percept(benchmark, built_model, source, peak_memory,
                          n_threads):
-    """Predicting the percept: the headline number for this library."""
-    percept = benchmark(built_model.predict_percept, implant)
+    """Predicting the percept: the headline number for this library.
+
+    Includes the bound implant's own preparation of the source, which
+    ``predict_percept`` performs and which the ``implant`` group above times
+    separately.
+    """
+    percept = benchmark(built_model.predict_percept, source)
     benchmark.extra_info['peak_mem_mb'] = peak_memory(
-        built_model.predict_percept, implant)
+        built_model.predict_percept, source)
     benchmark.extra_info['n_threads'] = n_threads
     benchmark.extra_info['percept_shape'] = str(percept.shape)
 
@@ -105,8 +108,9 @@ def test_end_to_end(benchmark, scenario, make_model, peak_memory, n_threads):
     cache to a temporary directory instead of the current one.
     """
     def run():
-        implant = scenario.implant(scenario.stimulus())
-        return make_model().build().predict_percept(implant)
+        implant = scenario.implant()
+        source = scenario.source(implant, scenario.stimulus())
+        return make_model(implant).predict_percept(source)
 
     percept = benchmark(run)
     benchmark.extra_info['peak_mem_mb'] = peak_memory(run)

--- a/benchmarks/test_predict.py
+++ b/benchmarks/test_predict.py
@@ -23,16 +23,25 @@ def test_stimulus(benchmark, scenario, peak_memory):
 
 
 @pytest.mark.benchmark(group='implant')
-def test_implant(benchmark, scenario, implant, source, peak_memory):
-    """Preparing the stimulus the device delivers.
+def test_implant(benchmark, scenario, implant, peak_memory):
+    """Turning a source into the stimulation the device delivers.
 
     This is not just bookkeeping: an image stimulus has far more pixels than
-    the array has electrodes, so preparation downsamples it onto the electrode
-    grid. Building the stimulus happens in the fixtures and is not timed.
+    the array has electrodes, so it has to be resampled onto the electrode
+    grid first. That resampling is ``scenario.source``, so it is timed here
+    rather than done once in a fixture. Constructing the stimulus itself
+    happens in ``setup`` and is not timed.
     """
-    benchmark(implant.prepare_stim, source)
-    benchmark.extra_info['peak_mem_mb'] = peak_memory(implant.prepare_stim,
-                                                      source)
+    def prepare(stim):
+        return implant.prepare_stim(scenario.source(implant, stim))
+
+    def setup():
+        return (scenario.stimulus(),), {}
+
+    benchmark.pedantic(prepare, setup=setup, rounds=20, iterations=1,
+                       warmup_rounds=1)
+    benchmark.extra_info['peak_mem_mb'] = peak_memory(prepare,
+                                                      scenario.stimulus())
     benchmark.extra_info['n_electrodes'] = implant.n_electrodes
 
 
@@ -89,8 +98,8 @@ def test_predict_percept(benchmark, built_model, source, peak_memory,
     """Predicting the percept: the headline number for this library.
 
     Includes the bound implant's own preparation of the source, which
-    ``predict_percept`` performs and which the ``implant`` group above times
-    separately.
+    ``predict_percept`` performs. The ``implant`` group above times that same
+    work separately, so the two groups overlap rather than add up.
     """
     percept = benchmark(built_model.predict_percept, source)
     benchmark.extra_info['peak_mem_mb'] = peak_memory(

--- a/doc/getting_started.rst
+++ b/doc/getting_started.rst
@@ -10,8 +10,8 @@ Hello world
 A pulse2percept simulation usually has three parts:
 
 1. Choose a visual prosthesis.
-2. Assign it a stimulus.
-3. Use a model to predict the resulting percept.
+2. Bind a model to it.
+3. Predict the percept a stimulus produces.
 
 For example:
 
@@ -20,21 +20,31 @@ For example:
     import pulse2percept as p2p
     from pulse2percept.units import Hz, ms, uA
 
-    implant = p2p.implants.ArgusII(
-        stim={'A5': p2p.stimuli.BiphasicPulseTrain(
-            freq=20 * Hz,
-            amp=50 * uA,
-            phase_dur=0.45 * ms,
-        )}
-    )
+    implant = p2p.implants.ArgusII()
+    model = p2p.models.AxonMapModel(implant=implant)
 
-    model = p2p.models.AxonMapModel().build()
-    percept = model.predict_percept(implant)
+    stim = {'A5': p2p.stimuli.BiphasicPulseTrain(
+        freq=20 * Hz,
+        amp=50 * uA,
+        phase_dur=0.45 * ms,
+    )}
+    percept = model.predict_percept(stim)
 
     percept.plot()
 
 The implant describes where stimulation is delivered, the stimulus describes
-what is delivered, and the model predicts the resulting response.
+what is presented, and the model predicts the resulting response. In short::
+
+    source → implant → delivered stimulation → model → percept
+
+The middle step is the implant's: it samples, encodes, schedules and calibrates
+whatever it is given into the current its electrodes actually deliver. A model
+does that for you, but you can ask for it directly:
+
+.. code-block:: python
+
+    delivered = implant.prepare_stim(stim)
+    delivered.plot()
 
 Physical quantities can be written explicitly with :mod:pulse2percept.units; 
 bare numbers are also accepted in the documented canonical units.
@@ -53,10 +63,33 @@ easiest way is to give the implant an encoder:
             freq=20 * Hz,
         )
     )
-    implant.stim = p2p.stimuli.BostonTrain()
+    model = p2p.models.AxonMapModel(implant=implant)
 
-    percept = model.predict_percept(implant)
+    percept = model.predict_percept(p2p.stimuli.BostonTrain())
     percept.play()
+
+Building
+--------
+
+Models perform expensive one-time setup before they can predict anything.
+That happens by itself:
+
+.. code-block:: python
+
+    model = p2p.models.AxonMapModel(implant=implant)
+
+    # Builds automatically:
+    percept = model.predict_percept(stim)
+
+    # Changing a model parameter invalidates the existing build:
+    model.rho = 250
+
+    # Rebuilds automatically:
+    percept = model.predict_percept(stim)
+
+Call ``model.build()`` yourself when you would rather pay that cost at a moment
+of your choosing -- before a timed loop, say -- or want to inspect the built
+grid or axon map.
 
 From here, the :ref:`basic concepts <topics-index>` explain each part of the
 pipeline in more detail, and the :ref:`examples <sphx_glr_examples>` show

--- a/doc/getting_started.rst
+++ b/doc/getting_started.rst
@@ -32,14 +32,14 @@ For example:
 
     percept.plot()
 
-The implant describes where stimulation is delivered, the stimulus describes
-what is presented, and the model predicts the resulting response. In short::
+The implant describes the device, the stimulus describes the input, and the
+model predicts the resulting percept::
 
     source → implant → delivered stimulation → model → percept
 
-The middle step is the implant's: it samples, encodes, schedules and calibrates
-whatever it is given into the current its electrodes actually deliver. A model
-does that for you, but you can ask for it directly:
+The implant converts a source into delivered stimulation by preprocessing,
+encoding, scheduling, and threshold calibration. Models call this step
+internally; use ``prepare_stim`` directly to inspect the delivered stimulus:
 
 .. code-block:: python
 
@@ -71,8 +71,8 @@ easiest way is to give the implant an encoder:
 Building
 --------
 
-Models perform expensive one-time setup before they can predict anything.
-That happens by itself:
+Models build automatically on first prediction. Changing a parameter
+invalidates the affected build state, which is rebuilt on the next prediction:
 
 .. code-block:: python
 
@@ -81,15 +81,12 @@ That happens by itself:
     # Builds automatically:
     percept = model.predict_percept(stim)
 
-    # Changing a model parameter invalidates the existing build:
+    # Rebuilds automatically after a parameter change:
     model.rho = 250
-
-    # Rebuilds automatically:
     percept = model.predict_percept(stim)
 
-Call ``model.build()`` yourself when you would rather pay that cost at a moment
-of your choosing -- before a timed loop, say -- or want to inspect the built
-grid or axon map.
+Call ``model.build()`` explicitly to build ahead of a timed loop or inspect
+derived state such as the grid or axon map.
 
 From here, the :ref:`basic concepts <topics-index>` explain each part of the
 pipeline in more detail, and the :ref:`examples <sphx_glr_examples>` show

--- a/doc/getting_started.rst
+++ b/doc/getting_started.rst
@@ -46,7 +46,7 @@ does that for you, but you can ask for it directly:
     delivered = implant.prepare_stim(stim)
     delivered.plot()
 
-Physical quantities can be written explicitly with :mod:pulse2percept.units; 
+Physical quantities can be written explicitly with :mod:`pulse2percept.units`; 
 bare numbers are also accepted in the documented canonical units.
 
 Images and Videos

--- a/doc/topics/encoders.rst
+++ b/doc/topics/encoders.rst
@@ -13,7 +13,7 @@ the two.
 Basic usage
 -----------
 
-Attach an encoder to an implant, then assign an image or video:
+Attach an encoder to an implant, then hand it an image or video:
 
 .. code-block:: python
 
@@ -24,10 +24,16 @@ Attach an encoder to an implant, then assign an image or video:
         amp_range=(0, 50),
         freq=20,
     )
-    implant.stim = p2p.stimuli.BostonTrain()
 
-Dimensionless input is encoded on assignment. Electrical stimuli bypass the
-encoder.
+    model = p2p.models.ScoreboardModel(implant=implant)
+    percept = model.predict_percept(p2p.stimuli.BostonTrain())
+
+Dimensionless input is encoded when the implant prepares it. Electrical stimuli
+bypass the encoder. To see the pulses themselves:
+
+.. code-block:: python
+
+    delivered = implant.prepare_stim(p2p.stimuli.BostonTrain())
 
 Encoding can also be explicit:
 
@@ -35,7 +41,6 @@ Encoding can also be explicit:
 
     source = p2p.stimuli.BostonTrain()
     stim = implant.encoder.encode(source, implant=implant)
-    implant.stim = stim
 
 Passing the implant samples the source at its electrode locations before pulse
 trains are constructed, so the resulting Stimulus has one row per implant
@@ -78,7 +83,7 @@ What an encoded stimulus contains
 An encoded Stimulus retains both the requested frame-level modulation and the
 delivered pulse schedule. Spatial-only models use the frame-level modulation;
 temporal models use the delivered electrical pulses. The result is the same
-whether encoding happened explicitly or during assignment to the implant.
+whether encoding happened explicitly or inside ``prepare_stim``.
 
 Waveform samples are generated lazily, so encoding a large image or video does
 not allocate the full electrical waveform until something needs it.

--- a/doc/topics/implants.rst
+++ b/doc/topics/implants.rst
@@ -4,9 +4,9 @@
 Visual Prostheses
 =================
 
-An implant describes where stimulation is delivered: its electrodes, their
-geometry and location, and the stimulus assigned to them. The implant does not
-predict vision; that is the model's job.
+An implant describes the device: its electrodes, their geometry and location,
+and how a source stimulus becomes the current those electrodes deliver. The
+implant does not predict vision; that is the model's job.
 
 All implants derive from
 :py:class:`~pulse2percept.implants.ProsthesisSystem`. The attributes used most
@@ -15,16 +15,21 @@ often are:
 ``earray``
     The :py:class:`~pulse2percept.implants.ElectrodeArray`.
 
-``stim``
-    The :py:class:`~pulse2percept.stimuli.Stimulus` assigned to the implant.
-
 ``eye``
     The implanted eye for retinal systems.
+
+``placement``
+    Where the device sits relative to the tissue it stimulates
+    (``'epiretinal'``, ``'subretinal'``, ``'suprachoroidal'``,
+    ``'epicortical'``, ``'intracortical'``), or ``None`` for a generic array.
 
 ``encoder`` and ``raster``
     Optional device behavior used when visual input is converted to electrical
     stimulation. These are covered later in :ref:`topics-encoders` and
     :ref:`topics-rasters`.
+
+An implant holds no stimulus. What it delivers is derived from a source, on
+demand, by :py:meth:`~pulse2percept.implants.ProsthesisSystem.prepare_stim`.
 
 Basic use
 ---------
@@ -43,6 +48,33 @@ directly:
     implant.electrode_names
     implant.earray.coordinates()
     implant.plot()
+
+Preparing a stimulus
+--------------------
+
+:py:meth:`~pulse2percept.implants.ProsthesisSystem.prepare_stim` is the step
+between a *source* -- what you present to the device -- and the *delivered
+stimulation* its electrodes produce:
+
+.. code-block:: python
+
+    delivered = implant.prepare_stim({'A8': 30})
+    delivered = implant.prepare_stim(p2p.stimuli.BostonTrain())
+
+Along the way it preprocesses the source, encodes an image or video into
+current, resamples it onto the electrodes, applies the device's raster
+schedule, calibrates threshold-relative amplitudes, and runs the safety
+checks. Nothing is stored: the same implant can prepare any number of stimuli,
+and each call returns a fresh
+:py:class:`~pulse2percept.stimuli.Stimulus`.
+
+A model bound to the implant does this for you, so ``prepare_stim`` is what you
+call when you want to *look* at the stimulation itself:
+
+.. code-block:: python
+
+    implant.prepare_stim(source).plot()
+    implant.plot(stim=source, stim_cmap=True)
 
 Available implants
 ------------------

--- a/doc/topics/implants.rst
+++ b/doc/topics/implants.rst
@@ -52,24 +52,21 @@ directly:
 Preparing a stimulus
 --------------------
 
-:py:meth:`~pulse2percept.implants.ProsthesisSystem.prepare_stim` is the step
-between a *source* -- what you present to the device -- and the *delivered
-stimulation* its electrodes produce:
+:py:meth:`~pulse2percept.implants.ProsthesisSystem.prepare_stim` converts a
+source into stimulation the device can deliver:
 
 .. code-block:: python
 
     delivered = implant.prepare_stim({'A8': 30})
     delivered = implant.prepare_stim(p2p.stimuli.BostonTrain())
 
-Along the way it preprocesses the source, encodes an image or video into
-current, resamples it onto the electrodes, applies the device's raster
-schedule, calibrates threshold-relative amplitudes, and runs the safety
-checks. Nothing is stored: the same implant can prepare any number of stimuli,
-and each call returns a fresh
-:py:class:`~pulse2percept.stimuli.Stimulus`.
+Preparation includes preprocessing, image/video encoding, resampling onto the
+electrode array, raster scheduling, threshold calibration, and safety checks.
+The result is returned as a :py:class:`~pulse2percept.stimuli.Stimulus` and is
+not stored on the implant.
 
-A model bound to the implant does this for you, so ``prepare_stim`` is what you
-call when you want to *look* at the stimulation itself:
+Models call ``prepare_stim`` internally. Call it directly when the delivered
+stimulation itself is of interest:
 
 .. code-block:: python
 

--- a/doc/topics/models.rst
+++ b/doc/topics/models.rst
@@ -4,8 +4,10 @@
 Computational Models
 ====================
 
-A model predicts the response to stimulation *by a particular device*, so it
-is bound to an implant and handed the stimulus. Most users work with
+A model with a spatial component predicts the response to stimulation *by a
+particular device*, so it is bound to an implant and handed the stimulus.
+A temporal-only model describes one location's response over time and needs
+no implant. Most users work with
 :py:class:`~pulse2percept.models.Model`, which can contain a spatial component,
 a temporal component, or both:
 
@@ -131,18 +133,20 @@ grid or axon map, or want to pass build-time parameters
 Electrode-retina distance
 -------------------------
 
-:py:class:`~pulse2percept.models.ScoreboardModel` and
-:py:class:`~pulse2percept.models.AxonMapModel` read electrode ``x`` and ``y``
-only. Nonzero ``z`` has no effect on threshold or on how far current spreads,
-and building against such an array warns as much.
+:py:class:`~pulse2percept.models.ScoreboardModel`,
+:py:class:`~pulse2percept.models.AxonMapModel` and
+:py:class:`~pulse2percept.models.Thompson2003Model` read electrode ``x`` and
+``y`` only. Nonzero ``z`` does not change their response at all, and building
+against such an array warns as much.
 
 This is a limitation of the models, not a claim about the biology: a larger
-electrode-target distance is expected to raise threshold and broaden spatial
-recruitment. pulse2percept does not have the psychophysical evidence to
-parameterize that relationship, so it does not invent one. ``rho`` remains an
-effective *perceptual* spread parameter, fitted to what an individual reports
-seeing, and it is the right place to express that a particular subject's
-phosphenes are large -- whatever the reason.
+electrode-target distance is expected to raise stimulation threshold and
+broaden spatial recruitment. pulse2percept does not have the psychophysical
+evidence to parameterize that relationship, so it does not invent one. For the
+first two models, ``rho`` remains an effective *perceptual* spread parameter,
+fitted to what an individual reports seeing, and it is the right place to
+express that a particular subject's phosphenes are large -- whatever the
+reason.
 
 .. _topics-models-scene:
 

--- a/doc/topics/models.rst
+++ b/doc/topics/models.rst
@@ -83,33 +83,32 @@ The result of ``predict_percept`` is a
 Source, delivered stimulation, percept
 --------------------------------------
 
-Three different objects appear in that one line, and it is worth keeping them
-apart::
+The prediction pipeline distinguishes the source, delivered stimulation, and
+percept::
 
     source → implant → delivered stimulation → model → percept
 
 **Source**
-    What is presented to the device: a
-    :py:class:`~pulse2percept.stimuli.Stimulus` (or a dict or array that
-    becomes one), an :py:class:`~pulse2percept.stimuli.ImageStimulus`, a
-    :py:class:`~pulse2percept.stimuli.VideoStimulus`, or a
+    Input presented to the device: a
+    :py:class:`~pulse2percept.stimuli.Stimulus` (or compatible scalar, array,
+    or dict), :py:class:`~pulse2percept.stimuli.ImageStimulus`,
+    :py:class:`~pulse2percept.stimuli.VideoStimulus`, or
     :py:class:`~pulse2percept.vision.Scene`.
 
 **Delivered stimulation**
-    The current the electrodes actually produce, which the implant derives from
-    the source: ``implant.prepare_stim(source)``. This is where encoding,
-    raster scheduling, threshold calibration and the safety checks happen. A
-    model does it for you; call it yourself when you want to see it.
+    Electrical stimulation after implant preprocessing, encoding, raster
+    scheduling, threshold calibration, and safety checks. Models call
+    ``implant.prepare_stim(source)`` internally; call it directly to inspect
+    the delivered stimulus.
 
 **Percept**
-    What the bound model predicts: ``model.predict_percept(source)``.
+    Model output from ``model.predict_percept(source)``.
 
 Building
 --------
 
-Models perform expensive one-time setup -- constructing a simulation grid,
-growing an axon map -- before they can predict anything. That happens by
-itself:
+Models build automatically on first prediction. Changing a model parameter
+invalidates the affected component, which is rebuilt when needed:
 
 .. code-block:: python
 
@@ -118,35 +117,29 @@ itself:
     # Builds automatically:
     percept = model.predict_percept(stim)
 
-    # Changing a model parameter invalidates the existing build:
+    # Rebuilds the spatial component:
     model.rho = 250
-
-    # Rebuilds automatically:
     percept = model.predict_percept(stim)
 
-Rebinding the implant invalidates the build the same way, since a build
-describes one device's geometry. Call ``model.build()`` yourself when you would
-rather pay the cost at a moment of your choosing, want to inspect the built
-grid or axon map, or want to pass build-time parameters
-(``model.build(rho=250)``).
+Rebinding the implant also invalidates the spatial build because it depends on
+device geometry. ``model.build()`` forces a full rebuild and can be used to
+build eagerly or pass build-time parameters (``model.build(rho=250)``).
 
 Electrode-retina distance
 -------------------------
 
 :py:class:`~pulse2percept.models.ScoreboardModel`,
 :py:class:`~pulse2percept.models.AxonMapModel` and
-:py:class:`~pulse2percept.models.Thompson2003Model` read electrode ``x`` and
-``y`` only. Nonzero ``z`` does not change their response at all, and
-predicting against such an array warns as much.
+:py:class:`~pulse2percept.models.Thompson2003Model` use electrode ``x`` and
+``y`` coordinates only. Nonzero ``z`` values therefore do not affect their
+output and produce a warning.
 
-This is a limitation of the models, not a claim about the biology: a larger
-electrode-target distance is expected to raise stimulation threshold and
-broaden spatial recruitment. pulse2percept does not have the psychophysical
-evidence to parameterize that relationship, so it does not invent one. For the
-first two models, ``rho`` remains an effective *perceptual* spread parameter,
-fitted to what an individual reports seeing, and it is the right place to
-express that a particular subject's phosphenes are large -- whatever the
-reason.
+This is a model limitation. Electrode-target distance is expected to affect
+stimulation threshold and spatial recruitment, but pulse2percept does not
+currently parameterize that relationship because the required psychophysical
+evidence is insufficient. In the Scoreboard and AxonMap models, ``rho`` remains
+an effective perceptual spread parameter fitted to subject reports rather than
+inferred from electrode-retina distance.
 
 .. _topics-models-scene:
 
@@ -171,7 +164,7 @@ what someone is *looking at* instead, give the model a
     model = p2p.models.ScoreboardModel(implant=implant, rho=200)
     percept = model.predict_percept(scene, gaze=(0, 0) * dva)
 
-Four objects divide the problem between them:
+Scene prediction separates four responsibilities:
 
 =========  ==================================================================
 Scene      What is visually present, and where native vision is lost.
@@ -180,8 +173,8 @@ Model      Knows the retinotopy, and so connects Scene to Implant.
 Percept    What the simulated observer sees.
 =========  ==================================================================
 
-The model is the glue because it is the only object that holds a retinotopy
-*and* is handed an implant. Each electrode is followed out along this chain::
+The model maps implant coordinates into the visual field through its
+retinotopic map. Each electrode follows this chain::
 
     retinal coordinate (um)
       -> vfmap.ret_to_dva -> eye-centered visual field (dva)
@@ -194,10 +187,9 @@ neither does an eye-centered
 :py:class:`~pulse2percept.vision.Scotoma`: the scene moves past them. Pass one
 ``(x, y)`` to fixate, or one per video frame to move the eye between frames.
 
-The sampled values go to ``implant.encoder``, so the implant still decides how
-a gray level becomes current and which electrodes may pulse when. A scene is
-trial input like any other source: the model holds none of it, and asking what
-someone sees changes nothing about their device.
+The sampled values are passed to ``implant.encoder``, which maps gray levels
+to current and applies device timing constraints. A scene is per-prediction
+input and is not stored on the model or implant.
 
 An implant's ``preprocess`` -- an edge filter, an inversion, a contrast
 stretch -- is applied to the **prosthetic input branch only**, before the
@@ -211,18 +203,15 @@ operates at the scene source's pixel resolution.
 
     implant.preprocess = lambda stim: stim.filter('sobel')
 
-For a scene, ``preprocess`` must return an
+For scene input, ``preprocess`` must return an
 :py:class:`~pulse2percept.stimuli.ImageStimulus` or
-:py:class:`~pulse2percept.stimuli.VideoStimulus`; a callable that produces
-current directly has nothing left to place in the visual field, and that is
-the encoder's job in any case. Pixel values and channels are free to change --
-RGB to grayscale is fine -- but the spatial shape and the frame clock are not,
-because ``fov`` describes the geometry of the source it was given, and a
-resize or a re-timing would quietly reinterpret it.
+:py:class:`~pulse2percept.stimuli.VideoStimulus`; conversion to electrical
+stimulation belongs to the encoder. Pixel values and channels may change, but
+spatial shape and frame timing must remain unchanged because ``fov`` and the
+frame clock refer to the original scene.
 
-Scene registration is retinal. A model whose ``vfmap`` is a cortical map
-raises rather than pretending cortical registration is solved, and so does an
-implant with no ``encoder``.
+Scene registration currently requires a retinal ``vfmap`` and an implant
+``encoder``. A cortical ``vfmap`` or missing encoder raises ``ValueError``.
 
 Residual vision
 ~~~~~~~~~~~~~~~
@@ -245,9 +234,8 @@ arbitrary units, so which brightness counts as white is a claim about the
 display, not about the model. Holding it fixed across calls is what keeps two
 gazes comparable.
 
-The scotoma describes *native* vision only. What the implant is given to
-encode is sampled from the scene itself, inside the lost region as well as
-outside it: a camera does not go blind where its wearer has.
+The scotoma affects *native* vision only. Prosthetic encoding samples the
+unmasked scene, including locations inside the scotoma.
 
 Percept data layouts
 --------------------

--- a/doc/topics/models.rst
+++ b/doc/topics/models.rst
@@ -179,12 +179,6 @@ The scotoma describes *native* vision only. What the implant is given to
 encode is sampled from the scene itself, inside the lost region as well as
 outside it: a camera does not go blind where its wearer has.
 
-.. note::
-
-    ``find_threshold`` rescales an implant's own stimulus, which a
-    scene-driven model does not take from the caller. It raises rather than
-    silently ignoring the scene.
-
 Percept data layouts
 --------------------
 

--- a/doc/topics/models.rst
+++ b/doc/topics/models.rst
@@ -4,7 +4,8 @@
 Computational Models
 ====================
 
-A model predicts the response to stimulation. Most users work with
+A model predicts the response to stimulation *by a particular device*, so it
+is bound to an implant and handed the stimulus. Most users work with
 :py:class:`~pulse2percept.models.Model`, which can contain a spatial component,
 a temporal component, or both:
 
@@ -63,20 +64,85 @@ assumptions are relevant.
 Basic usage
 -----------
 
-Models follow the same workflow: initialize, build, then predict a percept from
-an implant containing a stimulus.
+Models follow the same workflow: choose an implant, bind a model to it, then
+predict a percept from a stimulus.
 
 .. code-block:: python
 
     import pulse2percept as p2p
 
-    implant = p2p.implants.ArgusII(stim={'A8': 30})
-    model = p2p.models.ScoreboardModel(rho=200).build()
-    percept = model.predict_percept(implant)
+    implant = p2p.implants.ArgusII()
+    model = p2p.models.ScoreboardModel(implant=implant, rho=200)
+    percept = model.predict_percept({'A8': 30})
 
-``build()`` performs one-time setup such as constructing an axon map. The result
-of ``predict_percept`` is a
+The result of ``predict_percept`` is a
 :py:class:`~pulse2percept.percepts.Percept`.
+
+Source, delivered stimulation, percept
+--------------------------------------
+
+Three different objects appear in that one line, and it is worth keeping them
+apart::
+
+    source → implant → delivered stimulation → model → percept
+
+**Source**
+    What is presented to the device: a
+    :py:class:`~pulse2percept.stimuli.Stimulus` (or a dict or array that
+    becomes one), an :py:class:`~pulse2percept.stimuli.ImageStimulus`, a
+    :py:class:`~pulse2percept.stimuli.VideoStimulus`, or a
+    :py:class:`~pulse2percept.vision.Scene`.
+
+**Delivered stimulation**
+    The current the electrodes actually produce, which the implant derives from
+    the source: ``implant.prepare_stim(source)``. This is where encoding,
+    raster scheduling, threshold calibration and the safety checks happen. A
+    model does it for you; call it yourself when you want to see it.
+
+**Percept**
+    What the bound model predicts: ``model.predict_percept(source)``.
+
+Building
+--------
+
+Models perform expensive one-time setup -- constructing a simulation grid,
+growing an axon map -- before they can predict anything. That happens by
+itself:
+
+.. code-block:: python
+
+    model = p2p.models.AxonMapModel(implant=implant)
+
+    # Builds automatically:
+    percept = model.predict_percept(stim)
+
+    # Changing a model parameter invalidates the existing build:
+    model.rho = 250
+
+    # Rebuilds automatically:
+    percept = model.predict_percept(stim)
+
+Rebinding the implant invalidates the build the same way, since a build
+describes one device's geometry. Call ``model.build()`` yourself when you would
+rather pay the cost at a moment of your choosing, want to inspect the built
+grid or axon map, or want to pass build-time parameters
+(``model.build(rho=250)``).
+
+Electrode-retina distance
+-------------------------
+
+:py:class:`~pulse2percept.models.ScoreboardModel` and
+:py:class:`~pulse2percept.models.AxonMapModel` read electrode ``x`` and ``y``
+only. Nonzero ``z`` has no effect on threshold or on how far current spreads,
+and building against such an array warns as much.
+
+This is a limitation of the models, not a claim about the biology: a larger
+electrode-target distance is expected to raise threshold and broaden spatial
+recruitment. pulse2percept does not have the psychophysical evidence to
+parameterize that relationship, so it does not invent one. ``rho`` remains an
+effective *perceptual* spread parameter, fitted to what an individual reports
+seeing, and it is the right place to express that a particular subject's
+phosphenes are large -- whatever the reason.
 
 .. _topics-models-scene:
 
@@ -98,8 +164,8 @@ what someone is *looking at* instead, give the model a
     implant = p2p.implants.ArgusII()
     implant.encoder = p2p.stimuli.AmplitudeEncoder(amp_range=(0, 50))
 
-    model = p2p.models.ScoreboardModel(scene=scene, rho=200).build()
-    percept = model.predict_percept(implant, gaze=(0, 0) * dva)
+    model = p2p.models.ScoreboardModel(implant=implant, rho=200)
+    percept = model.predict_percept(scene, gaze=(0, 0) * dva)
 
 Four objects divide the problem between them:
 
@@ -125,9 +191,9 @@ neither does an eye-centered
 ``(x, y)`` to fixate, or one per video frame to move the eye between frames.
 
 The sampled values go to ``implant.encoder``, so the implant still decides how
-a gray level becomes current and which electrodes may pulse when. Prediction
-does not touch ``implant.stim``: it runs against a stand-in copy, so asking
-what someone sees never rewrites their device.
+a gray level becomes current and which electrodes may pulse when. A scene is
+trial input like any other source: the model holds none of it, and asking what
+someone sees changes nothing about their device.
 
 An implant's ``preprocess`` -- an edge filter, an inversion, a contrast
 stretch -- is applied to the **prosthetic input branch only**, before the
@@ -166,9 +232,9 @@ lost region, and the prosthetic percept inside it -- as a single RGB
 
     scene = p2p.vision.Scene(p2p.stimuli.LogoBVL(), fov=40 * dva,
                              scotoma=p2p.vision.Scotoma.circle(8 * dva))
-    model = p2p.models.ScoreboardModel(scene=scene, rho=200).build()
+    model = p2p.models.ScoreboardModel(implant=implant, rho=200)
 
-    percept = model.predict_percept(implant, gaze=(0, 0) * dva, vmax=50)
+    percept = model.predict_percept(scene, gaze=(0, 0) * dva, vmax=50)
 
 ``vmax`` is required here and is not inferred: model brightness is in
 arbitrary units, so which brightness counts as white is a claim about the
@@ -223,9 +289,14 @@ Classes ending in ``Model`` are complete model objects. Classes ending in
 .. code-block:: python
 
     model = p2p.models.Model(
+        implant=implant,
         spatial=p2p.models.ScoreboardSpatial(),
         temporal=p2p.models.Nanduri2012Temporal(),
-    ).build()
+    )
+
+The implant belongs to the spatial component -- a temporal model never sees an
+electrode -- and naming it on the parent is shorthand for that. Naming a
+*different* one on both raises rather than silently picking a winner.
 
 This is useful when the spatial and temporal assumptions come from different
 models. The combined model handles the intermediate representation and returns

--- a/doc/topics/models.rst
+++ b/doc/topics/models.rst
@@ -136,8 +136,8 @@ Electrode-retina distance
 :py:class:`~pulse2percept.models.ScoreboardModel`,
 :py:class:`~pulse2percept.models.AxonMapModel` and
 :py:class:`~pulse2percept.models.Thompson2003Model` read electrode ``x`` and
-``y`` only. Nonzero ``z`` does not change their response at all, and building
-against such an array warns as much.
+``y`` only. Nonzero ``z`` does not change their response at all, and
+predicting against such an array warns as much.
 
 This is a limitation of the models, not a claim about the biology: a larger
 electrode-target distance is expected to raise stimulation threshold and

--- a/doc/topics/rasters.rst
+++ b/doc/topics/rasters.rst
@@ -26,7 +26,8 @@ Rasters are attached to an implant:
         amp_range=(0, 50),
         freq=20,
     )
-    implant.stim = p2p.stimuli.BostonTrain()
+
+    delivered = implant.prepare_stim(p2p.stimuli.BostonTrain())
 
 Electrodes in one group may pulse together; different groups occupy different
 time slots.

--- a/doc/topics/stimuli.rst
+++ b/doc/topics/stimuli.rst
@@ -25,10 +25,15 @@ For most electrical stimulation, start with a
         stim_dur=500,
     )
 
-    implant = p2p.implants.ArgusII(stim={'A5': pulse_train})
+    implant = p2p.implants.ArgusII()
+    model = p2p.models.ScoreboardModel(implant=implant)
+
+    percept = model.predict_percept({'A5': pulse_train})
 
 The dictionary key selects the electrode; unlisted electrodes receive no
-stimulation.
+stimulation. A stimulus is trial input, not implant state: the implant turns it
+into the current its electrodes deliver
+(``implant.prepare_stim({'A5': pulse_train})``) and keeps nothing.
 
 Common waveform classes include:
 

--- a/doc/topics/units.rst
+++ b/doc/topics/units.rst
@@ -129,7 +129,7 @@ pulses expressed in ``xTh`` will be automatically converted to microamps:
     train = BiphasicPulseTrain(20, 2 * xTh, 0.45)
 
     implant.thresholds = {'A4': 80 * uA}
-    implant.stim = {'A4': train}  # calibrated to 160 uA
+    implant.prepare_stim({'A4': train})  # calibrated to 160 uA
 
 Without a threshold, the train remains in ``xTh``. Current-based safety checks
 and models require calibration to a physical current.

--- a/doc/users/faq.rst
+++ b/doc/users/faq.rst
@@ -414,8 +414,8 @@ calls for a combination that is not already provided as a stand-alone model.
 See :ref:`Computational Models <topics-models>` for details.
 
 
-Why do I have to call ``build()``?
-----------------------------------
+What does ``build()`` do?
+-------------------------
 
 Some models need to perform expensive calculations that depend on their
 parameters but do not need to be repeated for every stimulus.
@@ -424,20 +424,20 @@ Calling ``build()`` performs these calculations once. For example, the Axon Map
 model can precompute retinal nerve fiber trajectories and their relationship
 to the simulation grid.
 
-The usual workflow is therefore:
+You rarely have to call it yourself: ``predict_percept`` builds a model that
+is not built yet, and giving a parameter a new value un-builds the model, so
+the next prediction picks the change up.
 
 .. code-block:: python
 
-    model = SomeModel(...)
-    model.build()
+    model = SomeModel(implant=implant, ...)
 
-    percept1 = model.predict_percept(implant1)
-    percept2 = model.predict_percept(implant2)
+    percept1 = model.predict_percept(stim1)
+    model.rho = 200          # un-builds the model
+    percept2 = model.predict_percept(stim2)   # builds it again
 
-.. note::
-
-    If you later change a parameter that affects a precomputed model quantity
-    or the simulation grid, call ``build()`` again before making predictions.
+Call ``build()`` explicitly when you want to pay that cost at a moment of your
+choosing, or to pass build-time parameters: ``model.build(rho=200)``.
 
 
 Implants and stimulation

--- a/doc/users/faq.rst
+++ b/doc/users/faq.rst
@@ -72,12 +72,9 @@ and predict the resulting percept:
     from pulse2percept.implants import ArgusII
     from pulse2percept.models import ScoreboardModel
 
-    implant = ArgusII(stim={'A8': 30})
+    model = ScoreboardModel(implant=ArgusII())
 
-    model = ScoreboardModel()
-    model.build()
-
-    percept = model.predict_percept(implant)
+    percept = model.predict_percept({'A8': 30})
     percept.plot()
 
 Here, ``30`` means 30 microamps because that is the documented unit for
@@ -87,13 +84,13 @@ electrical stimulation. You can also write the unit explicitly:
 
     from pulse2percept.units import uA
 
-    implant = ArgusII(stim={'A8': 30 * uA})
+    percept = model.predict_percept({'A8': 30 * uA})
 
 Or, as a one-liner:
 
 .. code-block:: python
 
-    ScoreboardModel().build().predict_percept(ArgusII(stim={'A8': 30})).plot()
+    ScoreboardModel(implant=ArgusII()).predict_percept({'A8': 30}).plot()
 
 .. important::
 
@@ -367,14 +364,14 @@ pulse amplitude, whereas
 frequency.
 
 Devices whose video processing is known carry an encoder of their own, in
-which case ``implant.stim = image`` encodes for you.
+which case handing the model an image encodes it for you.
 :py:class:`~pulse2percept.implants.ArgusII` is one of them. Assign a different
 encoder to ``implant.encoder`` to say how the encoding should be done, or
 ``None`` to switch it off.
 
 If you already know the electrical stimulation you want to simulate, construct
-a :py:class:`~pulse2percept.stimuli.Stimulus` directly or assign stimulation
-to the implant. An electrical stimulus never goes through the encoder.
+a :py:class:`~pulse2percept.stimuli.Stimulus` directly. An electrical stimulus
+never goes through the encoder.
 
 .. important::
 
@@ -463,14 +460,14 @@ See :ref:`Basic Concepts: Implants <topics-implants>` for details.
 How do I control which electrodes are stimulated?
 -------------------------------------------------
 
-For simple static stimulation, you can assign values by electrode name:
+For simple static stimulation, name the electrodes and their amplitudes:
 
 .. code-block:: python
 
-    implant.stim = {
+    percept = model.predict_percept({
         'A8': 30,
         'A9': 20,
-    }
+    })
 
 Only the listed electrodes are active.
 
@@ -499,13 +496,14 @@ For example:
 .. code-block:: python
 
     from pulse2percept.implants import ArgusII
+    from pulse2percept.models import ScoreboardModel
     from pulse2percept.stimuli import BostonTrain
 
-    implant = ArgusII(stim=BostonTrain())
+    model = ScoreboardModel(implant=ArgusII())
+    percept = model.predict_percept(BostonTrain())
 
 :py:class:`~pulse2percept.implants.ArgusII` comes with an encoder of its own,
-so the video is encoded on assignment. To say how, give the implant a
-different one:
+so the video is encoded for you. To say how, give the implant a different one:
 
 .. code-block:: python
 
@@ -514,10 +512,10 @@ different one:
 
     implant = ArgusII(encoder=AmplitudeEncoder(amp_range=(0, 50 * uA),
                                                freq=20 * Hz))
-    implant.stim = BostonTrain()
 
-Either way the resulting ``implant.stim`` is electrical stimulation and can be
-passed to a computational model in the usual way.
+Either way ``implant.prepare_stim(BostonTrain())`` is the electrical
+stimulation the device would deliver, which is also what the bound model
+reads.
 
 .. note::
 

--- a/doc/users/release_notes.rst
+++ b/doc/users/release_notes.rst
@@ -14,7 +14,42 @@ Highlights:
   :py:class:`~pulse2percept.vision.Scotoma` for gaze-aware simulation of
   residual vision and retinal prostheses (:pull:`854`).
 
+Model/implant API
+~~~~~~~~~~~~~~~~~
+
+Models are now bound to the implant they describe, and ``predict_percept``
+takes the stimulus source directly:
+
+.. code-block:: python
+
+    implant = p2p.implants.ArgusII()
+    model = p2p.models.AxonMapModel(implant=implant)
+    percept = model.predict_percept(stim)
+
+* Implants no longer store mutable stimulus state. Use
+  ``implant.prepare_stim(source)`` to inspect the stimulation delivered by the
+  device.
+
+* A :py:class:`~pulse2percept.vision.Scene` is prediction input like any other
+  source: ``model.predict_percept(scene, gaze=...)``.
+
+* Models now build automatically on first prediction and rebuild automatically
+  after model parameters change. ``NotBuiltError`` is gone.
+
+* :py:class:`~pulse2percept.models.AxonMapModel` no longer takes ``eye``; it
+  reads ``implant.eye``. It warns when built against a non-epiretinal implant,
+  and both retinal Beyeler models warn when ``rho`` is wider than the electrode
+  pitch.
+
+* ``find_threshold`` has been removed. Threshold searches are
+  experiment-specific optimizations over stimulus parameters and should be
+  implemented at that level.
+
 API changes:
+
+* :py:class:`~pulse2percept.implants.ProsthesisSystem` gains ``placement``,
+  naming where a device sits relative to the tissue it stimulates for the
+  device families where the literature is unambiguous.
 
 * :py:class:`~pulse2percept.implants.RectangleImplant` is deprecated in favor
   of :py:class:`~pulse2percept.implants.GridImplant` (:pull:`859`)

--- a/doc/users/release_notes.rst
+++ b/doc/users/release_notes.rst
@@ -33,8 +33,10 @@ takes the stimulus source directly:
 * A :py:class:`~pulse2percept.vision.Scene` is prediction input like any other
   source: ``model.predict_percept(scene, gaze=...)``.
 
-* Models now build automatically on first prediction and rebuild automatically
-  after model parameters change. ``NotBuiltError`` is gone.
+* Models now build automatically on first prediction, and a parameter change
+  rebuilds only the component it belongs to, so a sweep over a temporal
+  parameter no longer regrows the spatial model. ``model.build()`` still
+  forces a full rebuild. ``NotBuiltError`` is gone.
 
 * :py:class:`~pulse2percept.models.AxonMapModel` no longer takes ``eye``; it
   reads ``implant.eye``. It warns when built against a non-epiretinal implant,
@@ -56,6 +58,10 @@ API changes:
 
 * New ``deg`` and ``rad`` units for ordinary geometric angle, accepted
   wherever p2p already took an angle in degrees.
+
+* :py:class:`~pulse2percept.models.BiphasicAxonMapModel` no longer overrides
+  ``predict_percept``, so it takes ``gaze``, ``vmax`` and ``vmin`` like every
+  other model.
 
 Bug fixes:
 

--- a/examples/datasets/plot_data_beyeler2019.py
+++ b/examples/datasets/plot_data_beyeler2019.py
@@ -140,10 +140,9 @@ plot_argus_phosphenes(data, argus, axon_map=model)
 # in [Beyeler2019]_, we can tailor the axon map parameters to Subject 2:
 
 import numpy as np
-model = AxonMapModel(rho=315, lam=500, loc_od=(16.2, 1.38),
+model = AxonMapModel(implant=argus, rho=315, lam=500, loc_od=(16.2, 1.38),
                      xrange=(-30, 30), yrange=(-22.5, 22.5),
                      thresh_percept=1 / np.sqrt(np.e))
-model.build()
 
 ###############################################################################
 # Now we need to activate one electrode at a time, and predict the resulting
@@ -159,7 +158,7 @@ electrodes = data.electrode.unique()
 # Activate one electrode at a time:
 import numpy as np
 from pulse2percept.stimuli import Stimulus
-argus.stim = Stimulus(np.eye(len(electrodes)), electrodes=electrodes)
+stim = Stimulus(np.eye(len(electrodes)), electrodes=electrodes)
 
 ###############################################################################
 # Using the model's
@@ -167,7 +166,7 @@ argus.stim = Stimulus(np.eye(len(electrodes)), electrodes=electrodes)
 # a Percept object where each frame is the percept generated from activating
 # a single electrode:
 
-percepts = model.predict_percept(argus)
+percepts = model.predict_percept(stim)
 percepts.play()
 
 ###############################################################################

--- a/examples/datasets/plot_data_beyeler2019.py
+++ b/examples/datasets/plot_data_beyeler2019.py
@@ -128,7 +128,7 @@ plot_argus_phosphenes(data, argus)
 # from the fovea:
 
 from pulse2percept.models import AxonMapModel
-model = AxonMapModel(loc_od=(16.2, 1.38))
+model = AxonMapModel(implant=argus, loc_od=(16.2, 1.38))
 plot_argus_phosphenes(data, argus, axon_map=model)
 
 ###############################################################################

--- a/examples/datasets/plot_data_beyeler2019.py
+++ b/examples/datasets/plot_data_beyeler2019.py
@@ -128,7 +128,7 @@ plot_argus_phosphenes(data, argus)
 # from the fovea:
 
 from pulse2percept.models import AxonMapModel
-model = AxonMapModel(implant=argus, loc_od=(16.2, 1.38))
+model = AxonMapModel(loc_od=(16.2, 1.38))
 plot_argus_phosphenes(data, argus, axon_map=model)
 
 ###############################################################################

--- a/examples/implants/plot_argus.py
+++ b/examples/implants/plot_argus.py
@@ -61,7 +61,8 @@ fig.tight_layout()
 # (``lam``) as well as the visual field we would like to simulate (given
 # in degrees of visual angle):
 
-model = p2p.models.AxonMapModel(rho=400, lam=200,
+implant = p2p.implants.ArgusII()
+model = p2p.models.AxonMapModel(implant=implant, rho=400, lam=200,
                                 xrange=(-12, 12), yrange=(-8, 8))
 model.build()
 
@@ -69,7 +70,7 @@ model.build()
 # We can visualize where the implant sits on the axon map as follows:
 
 model.plot()
-p2p.implants.ArgusII().plot()
+implant.plot()
 
 ###############################################################################
 # We then need to choose a stimulus to run through the model:
@@ -85,17 +86,17 @@ p2p.stimuli.BostonTrain().play()
 # pretty good idea of what this video would look like to an Argus II patient:
 
 # Argus II knows how it encodes video -- gray level onto pulse amplitude at
-# 6 Hz, six rows of electrodes taking turns -- so assigning the video is all it
-# takes. What ends up in ``implant.stim`` is current, which is what a model
-# reads, and the percept comes back at one frame per video frame.
+# 6 Hz, six rows of electrodes taking turns -- so handing the model the video
+# is all it takes. The bound implant turns it into current, which is what a
+# model reads, and the percept comes back at one frame per video frame. Use
+# ``implant.prepare_stim(video)`` to look at the current itself.
 #
 # The encoder warns that most frames of this 30 fps clip carry no pulse of
 # their own: 6 Hz is the rate the real device runs at, and it is slower than
 # the video. Pass ``encoder=p2p.stimuli.AmplitudeEncoder(freq=30)`` to deliver
 # every frame instead.
 video = p2p.stimuli.BostonTrain()
-implant = p2p.implants.ArgusII(stim=video)
-model.predict_percept(implant).play()
+model.predict_percept(video).play()
 
 ###############################################################################
 # The above simulation is basically equivalent to the scoreboard model, because
@@ -109,8 +110,7 @@ model.predict_percept(implant).play()
 # ``lam`` value:
 
 model.lam = 600
-model.build()
-model.predict_percept(implant).play()
+model.predict_percept(video).play()
 
 ###############################################################################
 # On the other hand, some retinal implant recipients (e.g., 51-009) report
@@ -119,8 +119,7 @@ model.predict_percept(implant).play()
 
 model.rho = 100
 model.lam = 1000
-model.build()
-model.predict_percept(implant).play()
+model.predict_percept(video).play()
 
 
 ###############################################################################
@@ -136,26 +135,22 @@ p2p.stimuli.GirlPool().play()
 # then feed it through the axon map model:
 
 video = p2p.stimuli.GirlPool()
-implant = p2p.implants.ArgusII(stim=video)
 model.rho = 400
 model.lam = 200
-model.build()
-model.predict_percept(implant).play()
+model.predict_percept(video).play()
 
 ###############################################################################
 # Here is the same video with longer phosphenes:
 
 model.lam = 600
-model.build()
-model.predict_percept(implant).play()
+model.predict_percept(video).play()
 
 ###############################################################################
 # Here is the same video with thin and long phosphenes:
 
 model.rho = 100
 model.lam = 1000
-model.build()
-model.predict_percept(implant).play()
+model.predict_percept(video).play()
 
 ###############################################################################
 # In reality, the vision provided by Argus II may be even worse for several

--- a/examples/implants/plot_electrode_grid.py
+++ b/examples/implants/plot_electrode_grid.py
@@ -125,7 +125,11 @@ offset_grid = ElectrodeGrid((11, 13), 500, type='hex', x=-600, y=200, z=150,
 # We can also plot the grid on top of a map of retinal nerve fiber bundles:
 
 
-AxonMapModel().plot()
+# An axon map is grown for a particular eye, so the model needs the implant
+# the grid belongs to:
+from pulse2percept.implants import ProsthesisSystem
+
+AxonMapModel(implant=ProsthesisSystem(offset_grid)).plot()
 offset_grid.plot()
 
 ##############################################################################
@@ -140,6 +144,11 @@ offset_grid.plot()
 
 from pulse2percept.implants import GridImplant
 
-implant = GridImplant((11, 13), 500, type='hex', etype=DiskElectrode, r=100,
-                      stim={'A1': 20})
+implant = GridImplant((11, 13), 500, type='hex', etype=DiskElectrode, r=100)
 implant.plot()
+
+##############################################################################
+# The implant is what a model is bound to, and what turns a source stimulus
+# into the current its electrodes deliver:
+
+implant.prepare_stim({'A1': 20})

--- a/examples/implants/plot_implants.py
+++ b/examples/implants/plot_implants.py
@@ -33,18 +33,14 @@ from pulse2percept.models import AxonMapModel
 
 fig, ax = plt.subplots(ncols=2, figsize=(10, 6))
 
-# For illustrative purpose, also show the map of fiber
-# bundles in the optic fiber layer:
-model = AxonMapModel()
-model.plot(ax=ax[0])
-# Argus I is typically implanted at a 30-45deg angle:
-ArgusI(rot=-30).plot(ax=ax[0], annotate=True)
-ax[0].set_title('Argus I')
-
-model.plot(ax=ax[1])
-# Argus II is typically implanted at a 30-45deg angle:
-ArgusII(rot=-30).plot(ax=ax[1], annotate=False)
-ax[1].set_title('Argus II')
+# Argus I and II are typically implanted at a 30-45deg angle. For illustrative
+# purpose, also show the map of fiber bundles in the optic fiber layer -- an
+# axon map is grown for a particular eye, so each model names its implant:
+for axis, implant, title in [(ax[0], ArgusI(rot=-30), 'Argus I'),
+                             (ax[1], ArgusII(rot=-30), 'Argus II')]:
+    AxonMapModel(implant=implant).plot(ax=axis)
+    implant.plot(ax=axis, annotate=title == 'Argus I')
+    axis.set_title(title)
 
 ###############################################################################
 # PRIMA Bionic Vision System (Pixium Vision SA)

--- a/examples/models/plot_beyeler2019_axonmap.py
+++ b/examples/models/plot_beyeler2019_axonmap.py
@@ -80,8 +80,7 @@ print(model)
 # * ``step``: The resolution (in dva) at which to sample the visual field.
 #   For example, we are currently sampling at 0.25 dva in both x and y
 #   direction.
-# * ``loc_od_x``, ``loc_od_y``: the location of the center of the optic disc
-#   (in dva)
+# * ``loc_od``: the location of the center of the optic disc (in dva)
 # * ``thresh_percept``: You can also define a brightness threshold, below which
 #   the predicted output brightness will be zero. It is currently set to
 #   ``1/sqrt(e)``, because that will make the radius of the predicted percept
@@ -94,9 +93,9 @@ print(model)
 # * ``axons_range``: the range of angles (in degrees) to use at which axon
 #   trajectories emanate from the center of the optic disc
 # * ``n_ax_segments``: the number of segments each generated axon should have
-# * ``n_ax_segments_range``: the range of distances (in dva) to use, measured
+# * ``ax_segments_range``: the range of distances (in dva) to use, measured
 #   from the center of the optic disc, at which axon segments should be placed
-# * ``axons_pickle``: path to a pickle file where previously generated axon
+# * ``axon_pickle``: path to a pickle file where previously generated axon
 #   maps are stored
 #
 # To change parameter values, either pass them directly to the constructor

--- a/examples/models/plot_beyeler2019_axonmap.py
+++ b/examples/models/plot_beyeler2019_axonmap.py
@@ -32,15 +32,16 @@ exponentially:
 
 The axon map model can be instantiated and run in three steps.
 
-Creating the model
-------------------
+Choosing an implant
+-------------------
 
-The first step is to instantiate the
-:py:class:`~pulse2percept.models.AxonMapModel` class by calling its
-constructor method.
-The two most important parameters to set are ``rho`` and ``lam`` from
-the equation above (here set to 150 micrometers and 500 micrometers,
-respectively):
+A model predicts what a *particular* device produces, so the first step is to
+specify a visual prosthesis from the :py:mod:`~pulse2percept.implants` module.
+
+In the following, we will use an
+:py:class:`~pulse2percept.implants.ArgusII` implant. By default, the implant
+will be centered over the fovea (at x=0, y=0) and aligned with the horizontal
+meridian (rot=0):
 
 """
 # sphinx_gallery_thumbnail_number = 2
@@ -48,7 +49,20 @@ respectively):
 import numpy as np
 from pulse2percept.implants import ArgusII
 from pulse2percept.models import AxonMapModel
-model = AxonMapModel(rho=150, lam=500)
+
+implant = ArgusII()
+
+##############################################################################
+# Creating the model
+# ------------------
+#
+# The second step is to instantiate the
+# :py:class:`~pulse2percept.models.AxonMapModel` class, bound to that implant.
+# The two most important parameters to set are ``rho`` and ``lam`` from
+# the equation above (here set to 150 micrometers and 500 micrometers,
+# respectively):
+
+model = AxonMapModel(implant=implant, rho=150, lam=500)
 
 ##############################################################################
 # Parameters you don't specify will take on default values. You can inspect
@@ -88,36 +102,13 @@ print(model)
 # To change parameter values, either pass them directly to the constructor
 # above or set them by hand.
 #
-# Then build the model. This is a necessary step before you can actually use
-# the model to predict a percept, as it performs a number of expensive setup
-# computations (e.g., building the axon map, calculating electric potentials):
-
-model.build()
-
-##############################################################################
-# .. important ::
+# Before it can predict anything, the model performs a number of expensive
+# setup computations (building the axon map, laying out the simulation grid).
+# That happens automatically the first time you ask for a percept, and again
+# whenever you change a model parameter. You can also trigger it yourself with
+# ``model.build()`` -- useful when you would rather pay the cost at a moment of
+# your choosing, or want to inspect the built axon map first.
 #
-#     You need to build a model only once. After that, you can apply any number
-#     of stimuli -- or even apply the model to different implants -- without
-#     having to rebuild (which takes time).
-#
-#     However, if you change important model parameters outside the constructor
-#     (e.g., by directly setting ``model.lam = 100``), you will have to
-#     call ``model.build()`` again for your changes to take effect.
-#
-# Assigning a stimulus
-# --------------------
-# The second step is to specify a visual prosthesis from the
-# :py:mod:`~pulse2percept.implants` module.
-#
-# In the following, we will create an
-# :py:class:`~pulse2percept.implants.ArgusII` implant. By default, the implant
-# will be centered over the fovea (at x=0, y=0) and aligned with the horizontal
-# meridian (rot=0):
-
-implant = ArgusII()
-
-##############################################################################
 # You can inspect the location of the implant with respect to the underlying
 # nerve fiber bundles using the built-in plot methods:
 
@@ -129,22 +120,16 @@ implant.plot()
 # By default, the plots will be added to the current Axes object.
 # Alternatively, you can pass ``ax=`` to specify in which Axes to plot.
 #
-# The easiest way to assign a stimulus to the implant is to pass a NumPy array
-# that specifies the current amplitude to be applied to every electrode in the
-# implant.
-#
-# For example, the following sends 1 microamp to all 60 electrodes of the
-# implant:
-
-implant.stim = np.ones(60)
-
-##############################################################################
 # Predicting the percept
 # ----------------------
-# The third step is to apply the model to predict the percept resulting from
-# the specified stimulus. Note that this may take some time on your machine:
+# The third step is to hand the model a stimulus. The easiest kind is a NumPy
+# array that specifies the current amplitude to be applied to every electrode
+# in the implant.
+#
+# For example, the following sends 1 microamp to all 60 electrodes and predicts
+# the resulting percept. Note that this may take some time on your machine:
 
-percept = model.predict_percept(implant)
+percept = model.predict_percept(np.ones(60))
 
 ##############################################################################
 # The resulting percept is stored in a
@@ -163,15 +148,16 @@ ax.set_title('Predicted percept')
 # depending on the location of the implant. You can convince yourself of that
 # by re-running the model on an implant shifted and rotated across the retina:
 
-implant = ArgusII(x=-50, y=50, rot=-45)
+model.implant = ArgusII(x=-50, y=50, rot=-45)
 model.plot()
-implant.plot()
+model.implant.plot()
 
 ##############################################################################
-# The resulting percepts should look very different from the previous example:
+# The resulting percepts should look very different from the previous example.
+# Rebinding the implant invalidated the build, so the model rebuilds itself
+# here:
 
-implant.stim = np.ones(60)
-percept = model.predict_percept(implant)
+percept = model.predict_percept(np.ones(60))
 ax = percept.plot()
 ax.set_title('Predicted percept')
 
@@ -193,9 +179,9 @@ ax.set_title('Predicted percept')
 # However, you may have to increase the number of axons and number of segments
 # per axon to get a smooth percept out:
 
-model = AxonMapModel(rho=200, lam=10, n_axons=3000, n_ax_segments=3000)
-model.build()
-percept = model.predict_percept(implant)
+model = AxonMapModel(implant=model.implant, rho=200, lam=10, n_axons=3000,
+                     n_ax_segments=3000)
+percept = model.predict_percept(np.ones(60))
 ax = percept.plot()
 ax.set_title('Predicted percept')
 

--- a/examples/models/plot_beyeler2019_scoreboard.py
+++ b/examples/models/plot_beyeler2019_scoreboard.py
@@ -32,12 +32,23 @@ where :math:`\\rho` is the spatial decay constant.
 
 The scoreboard model can be instantiated and run in three simple steps.
 
+Choosing an implant
+-------------------
+
+A model predicts what a *particular* device produces, so the first step is to
+specify a visual prosthesis from the :py:mod:`~pulse2percept.implants` module.
+
+In the following, we will use a
+:py:class:`~pulse2percept.implants.PRIMA75` implant. By default, the implant
+will be centered over the fovea (at x=0, y=0) and aligned with the horizontal
+meridian (rot=0).
+
 Creating the model
 ------------------
 
-The first step is to instantiate the
-:py:class:`~pulse2percept.models.ScoreboardModel` class by calling its
-constructor method.
+The second step is to instantiate the
+:py:class:`~pulse2percept.models.ScoreboardModel` class, bound to that
+implant.
 
 The model simulates a patch of the visual field specified by ``xrange`` and
 ``yrange`` (in degrees of visual angle), sampled at a step size of ``step``.
@@ -55,8 +66,12 @@ and sample it at 0.05deg resolution:
 """
 # sphinx_gallery_thumbnail_number = 2
 
+from pulse2percept.implants import PRIMA75
 from pulse2percept.models import ScoreboardModel
-model = ScoreboardModel(xrange=(-3, 3), yrange=(-3, 3), step=0.05)
+
+implant = PRIMA75()
+model = ScoreboardModel(implant=implant, xrange=(-3, 3), yrange=(-3, 3),
+                        step=0.05)
 
 ##############################################################################
 # Parameters you don't specify will take on default values. You can inspect
@@ -85,32 +100,14 @@ print(model)
 model.rho = 20
 
 ##############################################################################
-# Then build the model. This is a necessary step before you can actually use
-# the model to predict a percept, as it performs a number of expensive setup
-# computations (e.g., building the spatial reference frame, calculating
-# electric potentials):
+# Before it can predict anything, the model performs a number of expensive
+# setup computations (building the spatial reference frame). That happens
+# automatically the first time you ask for a percept, and again whenever you
+# change a model parameter -- as the ``model.rho`` assignment above just did.
+# You can also trigger it yourself with ``model.build()``, which is what the
+# next line does so that the grid exists to be plotted:
 
 model.build()
-
-##############################################################################
-# .. note::
-#
-#     You need to build a model only once. After that, you can apply any number
-#     of stimuli -- or even apply the model to different implants -- without
-#     having to rebuild (which takes time).
-#
-# Assigning a stimulus
-# --------------------
-# The second step is to specify a visual prosthesis from the
-# :py:mod:`~pulse2percept.implants` module.
-#
-# In the following, we will create an
-# :py:class:`~pulse2percept.implants.PRIMA75` implant. By default, the implant
-# will be centered over the fovea (at x=0, y=0) and aligned with the horizontal
-# meridian (rot=0):
-
-from pulse2percept.implants import PRIMA75
-implant = PRIMA75()
 
 ##############################################################################
 # We can visualize the implant and verify that we are simulating the correct
@@ -120,34 +117,29 @@ model.plot()
 implant.plot()
 
 ##############################################################################
-# The gray window indicates the extent of the grid that was created during
-# ``model.build()`` using the values specified by ``xrange``, ``yrange``, and
-# ``step``. As we can see, the window well-covers the implant that we want
-# to simulate.
+# The gray window indicates the extent of the grid, built from the values
+# specified by ``xrange``, ``yrange``, and ``step``. As we can see, the window
+# well-covers the implant that we want to simulate.
 #
-# The easiest way to assign a stimulus to the implant is to pass a NumPy array
-# that specifies the current amplitude to be applied to every electrode in the
-# implant.
+# Predicting the percept
+# ----------------------
 #
-# For example, the following sends 10 microamps to all 142 electrodes of the
-# implant:
+# The third step is to hand the model a stimulus. The easiest kind is a NumPy
+# array that specifies the current amplitude to be applied to every electrode
+# in the implant.
+#
+# For example, the following sends 10 microamps to all 142 electrodes and
+# predicts the resulting percept. Note that this may take some time on your
+# machine:
 
 import numpy as np
-implant.stim = 10 * np.ones(142)
+percept = model.predict_percept(10 * np.ones(142))
 
 ##############################################################################
 # .. note::
 #
 #     Some models can handle stimuli that have both a spatial and a temporal
 #     component. The scoreboard model cannot.
-#
-# Predicting the percept
-# ----------------------
-#
-# The third step is to apply the model to predict the percept resulting from
-# the specified stimulus. Note that this may take some time on your machine:
-
-percept = model.predict_percept(implant)
 
 ##############################################################################
 # The resulting percept is stored in a
@@ -176,7 +168,7 @@ ax.set_title('Predicted percept')
 # ``hexbin`` function). Additional parameters can be passed to ``hexbin`` as
 # keyword arguments of :py:meth:`~pulse2percept.percepts.Percept.plot`:
 
-percept = model.predict_percept(implant)
+percept = model.predict_percept(10 * np.ones(142))
 percept.plot(kind='hex', cmap='inferno')
 
 
@@ -192,8 +184,6 @@ implant.plot(annotate=True)
 ##############################################################################
 # This makes it easier to pick an electrode; e.g., F7:
 
-implant.stim = {'F7': 10}
-
-percept = model.predict_percept(implant)
+percept = model.predict_percept({'F7': 10})
 
 percept.plot()

--- a/examples/models/plot_dynaphos.py
+++ b/examples/models/plot_dynaphos.py
@@ -18,9 +18,11 @@ The model can be instantiated and run in three steps.
 Creating the model
 ------------------
 
-The first step is to instantiate the
-:py:class:`~pulse2percept.models.cortex.DynaphosModel` class by calling its
-constructor method.
+The first step is to choose the device: a model predicts what a *particular*
+implant produces, so it is bound to one. Here we use an
+:py:class:`~pulse2percept.implants.cortex.Orion` implant at the default
+location, and instantiate the
+:py:class:`~pulse2percept.models.cortex.DynaphosModel` class against it.
 """
 # sphinx_gallery_thumbnail_number = 4
 
@@ -30,7 +32,9 @@ import matplotlib.pyplot as plt
 from pulse2percept.stimuli import BiphasicPulseTrain
 from pulse2percept.implants.cortex import Orion
 from pulse2percept.models.cortex import DynaphosModel
-model = DynaphosModel()
+
+implant = Orion()
+model = DynaphosModel(implant=implant)
 
 ##############################################################################
 # Parameters you don't specify will take on default values. You can inspect
@@ -74,33 +78,14 @@ print(model)
 model.step = 0.05
 
 ##############################################################################
-# Then build the model. This is a necessary step before you can actually use
-# the model to predict a percept, as it performs a number of expensive setup
-# computations (e.g., building the grid):
+# Before it can predict anything, the model performs a number of expensive
+# setup computations (building the grid). That happens automatically the first
+# time you ask for a percept, and again whenever you change a model parameter
+# -- as the ``model.step`` assignment above just did. You can also trigger it
+# yourself with ``model.build()``, which is what the next line does so that
+# the grid exists to be plotted:
 
 model.build()
-
-##############################################################################
-# .. important ::
-#
-#     You need to build a model only once. After that, you can apply any number
-#     of stimuli -- or even apply the model to different implants -- without
-#     having to rebuild (which takes time).
-#
-#     However, if you change important model parameters outside the constructor
-#     (e.g., by directly setting ``model.step = 0.25``), you will have to
-#     call ``model.build()`` again for your changes to take effect.
-#
-# Assigning a stimulus
-# --------------------
-# The second step is to specify a visual prosthesis from the
-# :py:mod:`~pulse2percept.implants` module.
-#
-# In the following, we will create an 
-# :py:class:`~pulse2percept.implants.cortex.Orion` implant 
-# at the default location.
-
-implant = Orion()
 
 ##############################################################################
 # You can inspect the location of the implant with respect to the visual
@@ -113,9 +98,11 @@ implant.plot()
 # By default, the plots will be added to the current Axes object.
 # Alternatively, you can pass ``ax=`` to specify in which Axes to plot.
 #
-# The easiest way to assign a stimulus to the implant is to pass a NumPy array
-# that specifies the current amplitude to be applied to every electrode in the
-# implant.
+# Predicting the percept
+# ----------------------
+# The second step is to describe the stimulus. The easiest kind is a NumPy
+# array that specifies the current amplitude to be applied to every electrode
+# in the implant.
 #
 # Note that all stimuli passed to Dynaphos must have a time component.
 #
@@ -126,17 +113,15 @@ stim_freq = 300  # stimulus frequency (Hz)
 phase_dur = 0.17  # duration of the cathodic/anodic phase (ms)
 stim_dur = 2000  # stimulus duration (ms)
 stim_amp = 100  # stimulus current (uA)
-implant.stim = {e: BiphasicPulseTrain(amp=stim_amp, freq=stim_freq, 
-                                      phase_dur=phase_dur, stim_dur=stim_dur) 
-                for e in implant.electrode_names}
+stim = {e: BiphasicPulseTrain(amp=stim_amp, freq=stim_freq,
+                              phase_dur=phase_dur, stim_dur=stim_dur)
+        for e in implant.electrode_names}
 
 ##############################################################################
-# Predicting the percept
-# ----------------------
 # The third step is to apply the model to predict the percept resulting from
-# the specified stimulus. Note that this may take some time on your machine:
+# that stimulus. Note that this may take some time on your machine:
 
-percept = model.predict_percept(implant)
+percept = model.predict_percept(stim)
 
 ###############################################################################
 # The output of the model is a :py:class:`~pulse2percept.percepts.Percept`
@@ -152,9 +137,12 @@ plt.imshow(brightest_frame, cmap='gray')
 # that the model predicts the perceived brightness to increase rapidly and
 # then drop off slowly (over the time course of seconds).
 
+# What the device actually delivers, rather than the description above:
+delivered = implant.prepare_stim(stim)
+
 fig, ax = plt.subplots(figsize=(10, 5))
-ax.plot(implant.stim.time,
-        -0.02 + 0.01 * implant.stim.data[0, :] / implant.stim.data.max(),
+ax.plot(delivered.time,
+        -0.02 + 0.01 * delivered.data[0, :] / delivered.data.max(),
         linewidth=3, label='pulse')
 ax.plot(percept.time, np.max(np.max(percept.data, axis=1), axis=0), linewidth=3, label='percept')
 ax.plot([0, stim_dur], [percept.max(), percept.max()], 'k--', label='max brightness')
@@ -188,11 +176,11 @@ for amp in amps:
     # For each value in the `amps` vector, now stored as `amp`, do:
     # 1. Generate a pulse train with amplitude `amp`, frequency 300Hz,
     #    166ms duration, and pulse duration 0.17ms
-    implant.stim = { e: BiphasicPulseTrain(freq=300, amp=amp, phase_dur=0.17,
-                                      stim_dur=166)
-                    for e in implant.electrode_names }
+    stim = {e: BiphasicPulseTrain(freq=300, amp=amp, phase_dur=0.17,
+                                  stim_dur=166)
+            for e in implant.electrode_names}
     # 2. Run the model:
-    percept = model.predict_percept(implant, t_percept=t_percept)
+    percept = model.predict_percept(stim, t_percept=t_percept)
     # 3. Save the brightness over time
     bright_over_time.append(np.max(np.max(percept.data, axis=1), axis=0))
 

--- a/examples/models/plot_granley2021_biphasic.py
+++ b/examples/models/plot_granley2021_biphasic.py
@@ -49,7 +49,12 @@ from pulse2percept.implants import ArgusII
 from pulse2percept.models import BiphasicAxonMapModel
 from pulse2percept.stimuli import BiphasicPulseTrain
 from pulse2percept.units import uA, xTh
-model = BiphasicAxonMapModel(rho=200, lam=800)
+
+# Models with an axon map are well suited for epiretinal implants, such as
+# Argus II. A model predicts what a particular device produces, so it is bound
+# to one:
+implant = ArgusII()
+model = BiphasicAxonMapModel(implant=implant, rho=200, lam=800)
 
 ##############################################################################
 # Parameters you don't specify will take on default values. You can inspect
@@ -68,25 +73,16 @@ print(model)
 # parameters, see the Axon Map Tutorial
 #
 #
-# Next, build the model to perform expensive, one time calculations,
-# and specify a visual prosthesis from the
-# :py:mod:`~pulse2percept.implants` module. Models with an axon map are well 
-# suited for epiretinal implants, such as Argus II.
+# Before it can predict anything, the model performs expensive, one-time
+# calculations (growing the axon map). That happens automatically the first
+# time you ask for a percept, and again whenever you change a model parameter
+# such as ``model.a5``. You can also trigger it yourself with
+# ``model.build()``, which is what the next line does so that the axon map
+# exists to be plotted:
+
 model.build()
-implant = ArgusII()
 
 ##############################################################################
-# .. important ::
-#
-#     You need to build a model only once. After that, you can apply any number
-#     of stimuli -- or even apply the model to different implants -- without
-#     having to rebuild (which takes time).
-#
-#     However, if you change model parameters
-#     (e.g., by directly setting ``model.a5 = 2``), you will have to
-#     call ``model.build()`` again for your changes to take effect.
-#
-#
 # You can visualize the location of the implant and the axon map
 
 model.plot()
@@ -107,8 +103,10 @@ plt.show()
 # The following creates a train with 20Hz frequency, 1xTh amplitude, and
 # 0.45ms phase duration.
 
-implant.stim = {'A4' : BiphasicPulseTrain(20, 1 * xTh, 0.45)}
-implant.stim.plot()
+stim = {'A4': BiphasicPulseTrain(20, 1 * xTh, 0.45)}
+
+# What the device would deliver, which is also what the model reads:
+implant.prepare_stim(stim).plot()
 
 ##############################################################################
 # The plot is in ``xTh``, not microamps: how much current 1xTh is depends on
@@ -117,15 +115,15 @@ implant.stim.plot()
 ##############################################################################
 # Finally, you can predict the percept resulting from stimulation
 
-percept = model.predict_percept(implant)
+percept = model.predict_percept(stim)
 ax = percept.plot()
 ax.set_title('Predicted percept')
 plt.show()
 ##############################################################################
 # Increasing the frequency will make phosphenes brighter
 fig, axes = plt.subplots(1, 2, sharex=True, sharey=True)
-implant.stim = {'A4' : BiphasicPulseTrain(50, 1 * xTh, 0.45)}
-new_percept = model.predict_percept(implant)
+new_percept = model.predict_percept(
+    {'A4': BiphasicPulseTrain(50, 1 * xTh, 0.45)})
 new_percept.plot(ax=axes[1])
 percept.plot(ax=axes[0], vmax=new_percept.max())
 axes[0].set_title("20 Hz")
@@ -138,8 +136,8 @@ plt.show()
 ##############################################################################
 # Increasing amplitude increases both size and brightness
 fig, axes = plt.subplots(1, 2, sharex=True, sharey=True)
-implant.stim = {'A4' : BiphasicPulseTrain(20, 3 * xTh, 0.45)}
-new_percept = model.predict_percept(implant)
+new_percept = model.predict_percept(
+    {'A4': BiphasicPulseTrain(20, 3 * xTh, 0.45)})
 new_percept.plot(ax=axes[1])
 percept.plot(ax=axes[0], vmax=new_percept.max())
 axes[0].set_title("1xTh")
@@ -150,8 +148,8 @@ plt.show()
 # Increasing phase duration lowers threshold in the Granley model, so a fixed
 # ``xTh`` amplitude produces a larger and brighter percept
 fig, axes = plt.subplots(1, 2, sharex=True, sharey=True)
-implant.stim = {'A4' : BiphasicPulseTrain(20, 1 * xTh, 4)}
-new_percept = model.predict_percept(implant)
+new_percept = model.predict_percept(
+    {'A4': BiphasicPulseTrain(20, 1 * xTh, 4)})
 new_percept.plot(ax=axes[1])
 percept.plot(ax=axes[0], vmax=new_percept.max())
 axes[0].set_title("0.45ms")
@@ -162,8 +160,8 @@ plt.show()
 # If you compensate for this threshold change by decreasing amplitude, the
 # remaining effect of increasing phase duration is a shorter streak
 fig, axes = plt.subplots(1, 2, sharex=True, sharey=True)
-implant.stim = {'A4' : BiphasicPulseTrain(20, 0.023835 * xTh, 20)}
-new_percept = model.predict_percept(implant)
+new_percept = model.predict_percept(
+    {'A4': BiphasicPulseTrain(20, 0.023835 * xTh, 20)})
 new_percept.plot(ax=axes[1])
 percept.plot(ax=axes[0], vmax=new_percept.max())
 axes[0].set_title("0.45ms")
@@ -186,8 +184,9 @@ plt.show()
 
 calibrated = ArgusII()
 calibrated.thresholds = {'A4': 80 * uA}
-calibrated.stim = {'A4': BiphasicPulseTrain(20, 2 * xTh, 0.45)}
-print(f"{calibrated.stim.data.max():.0f} uA")
+delivered = calibrated.prepare_stim({'A4': BiphasicPulseTrain(20, 2 * xTh,
+                                                              0.45)})
+print(f"{delivered.data.max():.0f} uA")
 
 #################################################################################
 # ``threshold_amp=80 * uA`` instead calibrates a single train. Calibration
@@ -224,15 +223,13 @@ print(model.size_model.a5)
 # scaling can easily be disabled by setting ``a0`` to 0 and ``a1`` to 1. If we increase 
 # pulse duration like we did previously, we will now see that only streak length decreases, 
 # and we no longer have to change amplitude to account for change in threshold
-model = BiphasicAxonMapModel(rho=200, lam=800)
+model = BiphasicAxonMapModel(implant=implant, rho=200, lam=800)
 model.a0 = 0
 model.a1 = 1
-model.build()
 fig, axes = plt.subplots(1, 2, sharex=True, sharey=True)
-implant.stim = {'A4' : BiphasicPulseTrain(20, 1 * xTh, 0.45)}
-percept = model.predict_percept(implant)
-implant.stim = {'A4' : BiphasicPulseTrain(20, 1 * xTh, 20)}
-new_percept = model.predict_percept(implant)
+percept = model.predict_percept({'A4': BiphasicPulseTrain(20, 1 * xTh, 0.45)})
+new_percept = model.predict_percept(
+    {'A4': BiphasicPulseTrain(20, 1 * xTh, 20)})
 new_percept.plot(ax=axes[1])
 percept.plot(ax=axes[0], vmax=new_percept.max())
 axes[0].set_title("0.45ms")
@@ -253,17 +250,15 @@ plt.show()
 # will probably be enough. However, the effect models are completely modular, and 
 # can be replaced by any python callable with the parameters frequency, amplitude, 
 # and pulse duration. For example, we can easily change the model to no longer scale size
-model = BiphasicAxonMapModel(rho=200, lam=800)
+model = BiphasicAxonMapModel(implant=implant, rho=200, lam=800)
 def size_modulation(freq, amp, pdur):
     return 1
 model.size_model = size_modulation
-model.build()
 
 fig, axes = plt.subplots(1, 2, sharex=True, sharey=True)
-implant.stim = {'A4' : BiphasicPulseTrain(20, 1 * xTh, 0.45)}
-percept = model.predict_percept(implant)
-implant.stim = {'A4' : BiphasicPulseTrain(20, 3 * xTh, 0.45)}
-new_percept = model.predict_percept(implant)
+percept = model.predict_percept({'A4': BiphasicPulseTrain(20, 1 * xTh, 0.45)})
+new_percept = model.predict_percept(
+    {'A4': BiphasicPulseTrain(20, 3 * xTh, 0.45)})
 new_percept.plot(ax=axes[1])
 percept.plot(ax=axes[0], vmax=new_percept.max())
 axes[0].set_title("1xTh")

--- a/examples/models/plot_horsager2009.py
+++ b/examples/models/plot_horsager2009.py
@@ -99,9 +99,10 @@ fig.tight_layout()
 # Instead, the model was assumed to reach threshold if the model response
 # exceeded some constant :math:`\\theta` over time.
 #
-# A threshold is a property of the stimulus, not of the model, so we build the
-# stimulus at each candidate amplitude and solve for the one whose predicted
-# brightness is :math:`\\theta`:
+# Threshold finding is an optimization over a stimulus parameter, not a
+# generic model operation, so we build the stimulus at each candidate
+# amplitude and solve for the one whose predicted brightness is
+# :math:`\\theta`:
 
 from scipy.optimize import brentq
 

--- a/examples/models/plot_horsager2009.py
+++ b/examples/models/plot_horsager2009.py
@@ -99,27 +99,35 @@ fig.tight_layout()
 # Instead, the model was assumed to reach threshold if the model response
 # exceeded some constant :math:`\\theta` over time.
 #
-# The process of finding the stimulus amplitude needed to achieve model output
-# :math:`\\theta` can be automated with the help of the
-# :py:meth:`~pulse2percept.models.Horsager2009Temporal.find_threshold` method.
-#
-# We will run this method on every data point from the ones selected above:
+# A threshold is a property of the stimulus, not of the model, so we build the
+# stimulus at each candidate amplitude and solve for the one whose predicted
+# brightness is :math:`\\theta`:
+
+from scipy.optimize import brentq
+
+
+def threshold_amp(make_stim, theta, amp_range=(0, 300)):
+    """Amplitude (uA) whose predicted max brightness matches ``theta``"""
+    def objective(amp):
+        stim = make_stim(amp)
+        percept = model.predict_percept(stim,
+                                        t_percept=np.arange(stim.duration))
+        return percept.data.max() - theta
+    return brentq(objective, *amp_range)
+
+
+###############################################################################
+# We run this on every data point from the ones selected above:
 
 amp_th = []
 for _, row in single_pulse.iterrows():
-        # Set up a biphasic pulse with amplitude 1uA - the amplitude will be
-        # up-and-down regulated by find_threshold until the output matches
-        # theta:
-    stim = BiphasicPulse(1, row['pulse_dur'],
-                         interphase_dur=row['interphase_dur'],
-                         stim_dur=row['stim_dur'],
-                         cathodic_first=True)
-    # Find the current that gives model output theta. Search amplitudes in the
-    # range [0, 300] uA. Stop the search once the candidate amplitudes are
-    # within 1 uA, or the model output is within 0.1 of theta:
-    amp_th.append(model.find_threshold(stim, row['theta'],
-                                       amp_range=(0, 300), amp_tol=1,
-                                       bright_tol=0.1))
+    def pulse_at(amp):
+        return BiphasicPulse(amp, row['pulse_dur'],
+                             interphase_dur=row['interphase_dur'],
+                             stim_dur=row['stim_dur'],
+                             cathodic_first=True)
+
+    amp_th.append(threshold_amp(pulse_at, row['theta']))
 
 plt.semilogx(single_pulse.pulse_dur, single_pulse.stim_amp, 's', label='data')
 plt.semilogx(single_pulse.pulse_dur, amp_th, 'k-', linewidth=3, label='model')
@@ -148,12 +156,13 @@ fixed_dur = data[(data.stim_type == 'fixed_duration') &
 # Find the threshold:
 amp_th = []
 for _, row in fixed_dur.iterrows():
-    stim = BiphasicPulseTrain(row['stim_freq'], 1, row['pulse_dur'],
-                              interphase_dur=row['interphase_dur'],
-                              stim_dur=row['stim_dur'], cathodic_first=True)
-    amp_th.append(model.find_threshold(stim, row['theta'],
-                                       amp_range=(0, 300), amp_tol=1,
-                                       bright_tol=0.1))
+    def train_at(amp):
+        return BiphasicPulseTrain(row['stim_freq'], amp, row['pulse_dur'],
+                                  interphase_dur=row['interphase_dur'],
+                                  stim_dur=row['stim_dur'],
+                                  cathodic_first=True)
+
+    amp_th.append(threshold_amp(train_at, row['theta']))
 
 plt.semilogx(fixed_dur.stim_freq, fixed_dur.stim_amp, 's', label='data')
 plt.semilogx(fixed_dur.stim_freq, amp_th, 'k-', linewidth=3, label='model')
@@ -182,8 +191,6 @@ plt.title('Fig. 4B: S05 (C3), 0.075 ms pulse width')
 # N pulses.
 #
 # For example, the following recreates a pulse train used in Fig. 5B:
-
-from pulse2percept.stimuli import BiphasicPulseTrain
 
 n_pulses = 2
 freq = 3

--- a/examples/models/plot_nanduri2012.py
+++ b/examples/models/plot_nanduri2012.py
@@ -61,27 +61,25 @@ earray = ElectrodeArray(DiskElectrode(0, 0, 0, 260))
 # :py:class:`~pulse2percept.implants.AlphaIMS`. Alternatively, we can wrap the
 # electrode array created above with a
 # :py:class:`~pulse2percept.implants.ProsthesisSystem` to create our own
-# retinal implant. We will also assign the above created stimulus to it:
+# retinal implant:
 
 from pulse2percept.implants import ProsthesisSystem
-implant = ProsthesisSystem(earray, stim=stim)
+implant = ProsthesisSystem(earray)
 
 ###############################################################################
 # Running the model
 # -----------------
 #
-# Interacting with a model always involves three steps:
+# Interacting with a model always involves two steps:
 #
-# 1.  **Initalize** the model by passing the desired parameters.
-# 2.  **Build** the model to perform (sometimes expensive) one-time setup
-#     computations.
-# 3.  **Predict** the percept for a given stimulus.
+# 1.  **Initalize** the model, bound to the implant it describes, by passing
+#     the desired parameters.
+# 2.  **Predict** the percept for a given stimulus.
 #
 # In the following, we will run the Nanduri model on a single pixel, (0, 0):
 
 from pulse2percept.models import Nanduri2012Model
-model = Nanduri2012Model(xrange=(0, 0), yrange=(0, 0))
-model.build()
+model = Nanduri2012Model(implant=implant, xrange=(0, 0), yrange=(0, 0))
 
 ###############################################################################
 # .. note::
@@ -92,13 +90,12 @@ model.build()
 #     :py:class:`~pulse2percept.models.Nanduri2012Model` will pass the stimulus
 #     through the spatial model first.
 #
-# After building the model, we are ready to predict the percept.
-#
-# The input to the model is an implant containing a stimulus (usually a pulse
-# train), which is processed in time by a number of linear filtering steps as
-# well as a stationary nonlinearity (a sigmoid).
+# The input to the model is the stimulus (usually a pulse train), which the
+# implant delivers and which is then processed in time by a number of linear
+# filtering steps as well as a stationary nonlinearity (a sigmoid). The model
+# performs its one-time setup computations on this first call:
 import numpy as np
-percept = model.predict_percept(implant, t_percept=np.arange(1000))
+percept = model.predict_percept(stim, t_percept=np.arange(1000))
 
 ###############################################################################
 # The output of the model is a :py:class:`~pulse2percept.percepts.Percept`
@@ -117,9 +114,12 @@ bright_th
 # then drop off slowly (over the time course of seconds).
 # This is consistent with behavioral reports from Argus II users.
 
+# What the device actually delivers, rather than the description above:
+delivered = implant.prepare_stim(stim)
+
 fig, ax = plt.subplots(figsize=(12, 5))
-ax.plot(implant.stim.time,
-        -0.02 + 0.01 * implant.stim.data[0, :] / implant.stim.data.max(),
+ax.plot(delivered.time,
+        -0.02 + 0.01 * delivered.data[0, :] / delivered.data.max(),
         linewidth=3, label='pulse')
 ax.plot(percept.time, percept.data[0, 0, :], linewidth=3, label='percept')
 ax.plot([0, stim_dur], [bright_th, bright_th], 'k--', label='max brightness')
@@ -159,10 +159,10 @@ for amp in amps:
     # following:
     # 1. Generate a pulse train with amplitude `amp`, 20 Hz frequency, 0.5 s
     #    duration, pulse duration `pdur`, and interphase gap `pdur`:
-    implant.stim = BiphasicPulseTrain(20, amp, pdur, interphase_dur=pdur,
-                                      stim_dur=stim_dur)
+    trial = BiphasicPulseTrain(20, amp, pdur, interphase_dur=pdur,
+                               stim_dur=stim_dur)
     # 2. Run the temporal model:
-    percept = model.predict_percept(implant)
+    percept = model.predict_percept(trial)
     # 3. Find the largest value in percept, this will be the predicted
     # brightness:
     bright_pred = percept.data.max()
@@ -182,10 +182,10 @@ for freq in freqs:
     # following:
     # 1. Generate a pulse train with amplitude `amp`, 20 Hz frequency, 0.5 s
     #    duration, pulse duration `pdur`, and interphase gap `pdur`:
-    implant.stim = BiphasicPulseTrain(freq, 20, pdur, interphase_dur=pdur,
-                                      stim_dur=stim_dur)
+    trial = BiphasicPulseTrain(freq, 20, pdur, interphase_dur=pdur,
+                               stim_dur=stim_dur)
     # 2. Run the temporal model
-    percept = model.predict_percept(implant)
+    percept = model.predict_percept(trial)
     # 3. Find the largest value in percept, this will be the predicted
     # brightness:
     bright_pred = percept.data.max()
@@ -220,8 +220,8 @@ fig.tight_layout()
 # specified in degrees of visual angle (dva). They are sampled at ``xydva``
 # dva:
 
-model = Nanduri2012Model(step=0.5, xrange=(-4, 4), yrange=(-4, 4))
-model.build()
+model = Nanduri2012Model(implant=implant, step=0.5, xrange=(-4, 4),
+                         yrange=(-4, 4))
 
 ###############################################################################
 # We will again apply the model to a whole range of amplitude and frequency
@@ -240,10 +240,10 @@ for amp_f in amp_factors:
     # For each value in the `amp_factors` vector, now stored as `amp_f`, do:
     # 1. Generate a pulse train with amplitude `amp_f` * `amp_th`, frequency
     #    20Hz, 0.5s duration, pulse duration `pdur`, and interphase gap `pdur`:
-    implant.stim = BiphasicPulseTrain(20, amp_f * amp_th, pdur,
-                                      interphase_dur=pdur, stim_dur=stim_dur)
+    trial = BiphasicPulseTrain(20, amp_f * amp_th, pdur,
+                               interphase_dur=pdur, stim_dur=stim_dur)
     # 2. Run the temporal model:
-    percept = model.predict_percept(implant, t_percept=t_percept)
+    percept = model.predict_percept(trial, t_percept=t_percept)
     # 3. Save the brightest frame:
     frames_amp.append(percept.max(axis='frames'))
 
@@ -258,10 +258,10 @@ for freq in freqs:
     # 1. Generate a pulse train with amplitude 1.25 * `amp_th`, frequency
     #    `freq`, 0.5s duration, pulse duration `pdur`, and interphase gap
     #    `pdur`:
-    implant.stim = BiphasicPulseTrain(freq, 1.25 * amp_th, pdur,
-                                      interphase_dur=pdur, stim_dur=stim_dur)
+    trial = BiphasicPulseTrain(freq, 1.25 * amp_th, pdur,
+                               interphase_dur=pdur, stim_dur=stim_dur)
     # 2. Run the temporal model:
-    percept = model.predict_percept(implant, t_percept=t_percept)
+    percept = model.predict_percept(trial, t_percept=t_percept)
     # 3. Save the brightest frame:
     frames_freq.append(percept.max(axis='frames'))
 

--- a/examples/models/plot_neuropythy.py
+++ b/examples/models/plot_neuropythy.py
@@ -58,7 +58,8 @@ Lets use our map in a model and visualize the transform
 
 .. code-block:: python
 
-    model = p2p.models.cortex.ScoreboardModel(vfmap=nmap, regions=['v1'])
+    model = p2p.models.cortex.ScoreboardModel(
+        implant=p2p.implants.cortex.Cortivis(), vfmap=nmap, regions=['v1'])
     model.build()
     fig, axes = plt.subplots(ncols=2, figsize=(10, 4))
     model.plot(style='cell', ax=axes[0])
@@ -119,10 +120,12 @@ Lets place a Neuralink implant across the right hemisphere of the cortex:
 .. code-block:: python
 
     nmap = p2p.topography.NeuropythyMap(subject='fsaverage', regions=['v1'])
-    model = p2p.models.cortex.ScoreboardModel(vfmap=nmap, xrange=(-4, 0), yrange=(-4, 4), step=.25).build()
+    model = p2p.models.cortex.ScoreboardModel(vfmap=nmap, xrange=(-4, 0), yrange=(-4, 4), step=.25)
     nlink = p2p.implants.cortex.Neuralink.from_neuropythy(
         nmap, xrange=model.xrange, yrange=model.yrange, step=1, rand_insertion_angle=0
     )
+    model.implant = nlink
+    model.build()
     print(len(nlink.implants), " total threads")
 
     fig = plt.figure(figsize=(10, 4))
@@ -140,12 +143,13 @@ electrode on each thread, using the scoreboard model:
 
     nmap = p2p.topography.NeuropythyMap(subject='fsaverage', regions=['v1'], jitter_boundary=True)
     model = p2p.models.cortex.ScoreboardModel(rho=800, xrange=(-15, 15), yrange=(-15, 15),
-                                              step=.25, vfmap=nmap).build()
+                                              step=.25, vfmap=nmap)
     nlink = p2p.implants.cortex.Neuralink.from_neuropythy(
         nmap, xrange=model.xrange, yrange=model.yrange, step=3, rand_insertion_angle=0
     )
-    nlink.stim = {e: 1 for e in [i for i in nlink.electrode_names if i[-1] == '1']}
-    percept = model.predict_percept(nlink)
+    model.implant = nlink
+    stim = {e: 1 for e in [i for i in nlink.electrode_names if i[-1] == '1']}
+    percept = model.predict_percept(stim)
     percept.plot()
 
 """

--- a/examples/models/plot_thompson2003.py
+++ b/examples/models/plot_thompson2003.py
@@ -19,21 +19,23 @@ The model can be loaded as follows (using 10% dropout rate):
 import matplotlib.pyplot as plt
 import numpy as np
 import pulse2percept as p2p
-model = p2p.models.Thompson2003Model(step=0.2, dropout=0.1)
-model.build()
+
+# A model predicts what a particular device produces, so it is bound to one.
+# Here we will use an :py:class:`~pulse2percept.implants.ArgusII` implant:
+implant = p2p.implants.ArgusII()
+model = p2p.models.Thompson2003Model(implant=implant, step=0.2, dropout=0.1)
 
 ###############################################################################
-# After building the model, we are ready to predict percepts.
-# Here we will use an :py:class:`~pulse2percept.implants.ArgusII` implant.
+# We are ready to predict percepts; the model builds itself on the first call.
 #
-# One way to assign a stimulus is to pass a NumPy array with the same number of
+# One way to describe a stimulus is a NumPy array with the same number of
 # elements as there are electrodes in the array (i.e., 60).
 # Choosing values from ``np.arange(60)`` will assign a different number to
 # every electrode. We should thus expect to see 60 circular phosphenes that get
 # gradually brighter from one electrode to the next:
 
-implant = p2p.implants.ArgusII(stim=np.arange(60))
-percept = model.predict_percept(implant)
+stim = np.arange(60)
+percept = model.predict_percept(stim)
 percept.plot()
 
 ###############################################################################
@@ -43,7 +45,7 @@ percept.plot()
 fig, axes = plt.subplots(ncols=4, figsize=(15, 6))
 for ax, drop in zip(axes, [0, 0.25, 0.5, 0.75]):
     model.build(dropout=drop)
-    model.predict_percept(implant).plot(ax=ax)
+    model.predict_percept(stim).plot(ax=ax)
     ax.set_title(f"{100*drop}% dropout")
 fig.tight_layout()
 
@@ -65,6 +67,6 @@ fig.tight_layout()
 # percept frame per video frame:
 
 video = p2p.stimuli.BostonTrain()
-implant.stim = video.encode(implant=implant, freq=30)
+encoded = video.encode(implant=implant, freq=30)
 model.build(dropout=0.2)
-model.predict_percept(implant, t_percept=video.time).play()
+model.predict_percept(encoded, t_percept=video.time).play()

--- a/examples/models/plot_visual_field_maps.py
+++ b/examples/models/plot_visual_field_maps.py
@@ -98,8 +98,8 @@ for ax, transform in zip(axes, transforms):
 # levels are not microamps, and `encode` is the step that says how much
 # current each one stands for.
 implant = p2p.implants.AlphaAMS()
-implant.stim = p2p.stimuli.LogoUCSB().encode(implant=implant)
-implant.stim
+stim = p2p.stimuli.LogoUCSB().encode(implant=implant)
+stim
 
 ###############################################################################
 # We can easily switch out the visual field maps by passing a ``vfmap``
@@ -108,10 +108,9 @@ implant.stim
 
 fig, axes = plt.subplots(ncols=3, sharey=True, figsize=(13, 4))
 for ax, transform in zip(axes, transforms):
-    model = p2p.models.ScoreboardModel(xrange=(-6, 6), yrange=(-6, 6),
-                                       vfmap=transform)
-    model.build()
-    model.predict_percept(implant).plot(ax=ax)
+    model = p2p.models.ScoreboardModel(implant=implant, xrange=(-6, 6),
+                                       yrange=(-6, 6), vfmap=transform)
+    model.predict_percept(stim).plot(ax=ax)
     ax.set_title(transform.__class__.__name__)
 
 ###############################################################################
@@ -137,7 +136,8 @@ for ax, transform in zip(axes, transforms):
 # coordinates in V1, V2, and V3. 
 fig, ax = plt.subplots(ncols=2, figsize=(9, 4))
 vfmap = p2p.topography.Polimeni2006Map(regions=['v1', 'v2', 'v3']) # simulate all 3 regions
-model = p2p.models.cortex.ScoreboardModel(vfmap=vfmap)
+model = p2p.models.cortex.ScoreboardModel(implant=p2p.implants.cortex.Orion(),
+                                          vfmap=vfmap)
 model.build()
 vfmap.plot(ax=ax[0])
 ax[0].set_title('Polimeni Mapping')

--- a/examples/stimuli/plot_image_stim.py
+++ b/examples/stimuli/plot_image_stim.py
@@ -168,15 +168,16 @@ logo_dilate.save('dilated_logo.png')
 # We just have to resize the image first so that the number of pixels in the
 # image matches the number of electrodes in the implant.
 #
-# But let's start from the top. The first two steps are to create a model and
-# choose an implant:
-
-# Simulate only what we need (14x14 deg sampled at 0.1 deg):
-model = p2p.models.ScoreboardModel(xrange=(-7, 7), yrange=(-7, 7), step=0.1)
-model.build()
+# But let's start from the top. The first two steps are to choose an implant
+# and create a model bound to it:
 
 from pulse2percept.implants import AlphaAMS
 implant = AlphaAMS()
+
+# Simulate only what we need (14x14 deg sampled at 0.1 deg):
+model = p2p.models.ScoreboardModel(implant=implant, xrange=(-7, 7),
+                                   yrange=(-7, 7), step=0.1)
+model.build()
 
 # Show the visual field we're simulating (dashed lines) atop the implant:
 model.plot()
@@ -187,7 +188,7 @@ implant.plot()
 # all we need to do is downscale the image to the size of the grid, and then
 # *encode* it:
 
-implant.stim = logo_gray.resize(implant.shape).encode()
+stim_gray = logo_gray.resize(implant.shape).encode()
 
 ##############################################################################
 # The downscaling assigns the pixels of the image to the electrodes in
@@ -211,10 +212,10 @@ implant.stim = logo_gray.resize(implant.shape).encode()
 #    In the near future, this will be done automatically using an implant's
 #    ``preprocess`` method.
 #
-# Then the implant can be passed to the model's
+# Then the stimulus can be passed to the model's
 # :py:meth:`~pulse2percept.models.ScoreboardModel.predict_percept` method:
 
-percept_gray = model.predict_percept(implant)
+percept_gray = model.predict_percept(stim_gray)
 
 ##############################################################################
 # .. note ::
@@ -228,8 +229,8 @@ percept_gray = model.predict_percept(implant)
 # resulting percept, we can re-run the model on ``logo_dilate`` and plot the
 # two percepts side-by-side:
 
-implant.stim = logo_dilate.trim().resize(implant.shape).encode()
-percept_dilate = model.predict_percept(implant)
+stim_dilate = logo_dilate.trim().resize(implant.shape).encode()
+percept_dilate = model.predict_percept(stim_dilate)
 
 fig, (ax1, ax2) = plt.subplots(ncols=2, figsize=(10, 4))
 percept_gray.plot(ax=ax1)
@@ -248,7 +249,7 @@ percept_dilate.plot(ax=ax2)
 # (0.46 ms phase duration), lasting 500 ms overall. Gray levels in the range
 # [0, 1] are mapped onto currents in the range [0, 50] uA:
 
-implant.stim = logo_dilate.trim().resize(implant.shape).encode()
+stim_dilate = logo_dilate.trim().resize(implant.shape).encode()
 
 ##############################################################################
 # We can customize the range of amplitudes to be used by passing a keyword
@@ -262,17 +263,18 @@ implant.stim = logo_dilate.trim().resize(implant.shape).encode()
 # ``encode`` is a shorthand for
 # :py:class:`~pulse2percept.stimuli.AmplitudeEncoder`, which offers the full
 # set of options. Give one to an implant and the implant encodes whatever
-# picture is assigned to it -- sampling it at the electrode locations *before*
+# picture it is handed -- sampling it at the electrode locations *before*
 # building the pulse trains, which for a video is the difference between a
 # stimulus of a few hundred kilobytes and one of a few hundred megabytes:
 #
 # .. code-block:: python
 #
 #     implant.encoder = p2p.stimuli.AmplitudeEncoder(amp_range=(0, 50))
-#     implant.stim = p2p.stimuli.BostonTrain()
+#     delivered = implant.prepare_stim(p2p.stimuli.BostonTrain())
 #
 # :py:class:`~pulse2percept.implants.ArgusII` brings one along already, so
-# ``p2p.implants.ArgusII(stim=p2p.stimuli.BostonTrain())`` is the whole setup.
+# ``model.predict_percept(p2p.stimuli.BostonTrain())`` on a model bound to one
+# is the whole setup.
 #
 # The other way to encode a gray level is as a pulse *rate* at fixed amplitude,
 # which is what :py:class:`~pulse2percept.stimuli.FrequencyEncoder` does. It is
@@ -284,7 +286,7 @@ implant.stim = logo_dilate.trim().resize(implant.shape).encode()
 #
 #     implant.encoder = p2p.stimuli.FrequencyEncoder(freq_range=(0, 300),
 #                                                    amp=50, clock=1)
-#     implant.stim = p2p.stimuli.BostonTrain()
+#     delivered = implant.prepare_stim(p2p.stimuli.BostonTrain())
 #
 # A real stimulator usually cannot drive every electrode at once, because the
 # current it can source at any instant is limited. Give the implant a
@@ -298,7 +300,7 @@ implant.stim = logo_dilate.trim().resize(implant.shape).encode()
 #
 #     implant.max_current = 1000  # uA, summed over electrodes
 #     implant.raster = p2p.implants.SequentialRaster(6)  # one row at a time
-#     implant.stim = video
+#     delivered = implant.prepare_stim(video)
 #
 # The raster belongs to the implant, and is the only place the schedule is
 # described: assigning one binds it to that implant, so
@@ -322,7 +324,8 @@ implant.stim = logo_dilate.trim().resize(implant.shape).encode()
 # with a proper temporal model, such as
 # :py:class:`~pulse2percept.models.Horsager2009Temporal`:
 
-model = p2p.models.Model(spatial=p2p.models.ScoreboardSpatial,
+model = p2p.models.Model(implant=implant,
+                         spatial=p2p.models.ScoreboardSpatial,
                          temporal=p2p.models.Horsager2009Temporal)
 
 ##############################################################################
@@ -352,7 +355,7 @@ model.build(xrange=(-7, 7), yrange=(-7, 7), step=0.1, rho=50)
 # time points to :py:meth:`~pulse2percept.Model.predict_percept` (e.g.,
 # ``t_percept=np.arange(500)`` to get an output every millisecond):
 
-percept = model.predict_percept(implant)
+percept = model.predict_percept(stim_dilate)
 
 ##############################################################################
 # The output of the model is a :py:class:`~pulse2percept.percepts.Percept`

--- a/examples/stimuli/plot_psychophysics.py
+++ b/examples/stimuli/plot_psychophysics.py
@@ -98,27 +98,21 @@ stim.play()
 # To demonstrate, we will pass a ``GratingStimululus`` to an
 # :py:class:`~pulse2percept.implants.ArgusII` implant and use the
 # :py:class:`~pulse2percept.models.AxonMapModel` [Beyeler2019]_ to interpret it:
-#
-# .. important ::
-#   
-#   Don't forget to build the model before using ``predict_percept``
-#
 
 from pulse2percept.implants import ArgusII
 from pulse2percept.models import AxonMapModel
 
-model = AxonMapModel()
-model.build()
-
 implant = ArgusII()
+model = AxonMapModel(implant=implant)
+
 grating = GratingStimulus((25,25), temporal_freq=0.1)
 # A model reads current, so the video is encoded first. Its frames are 20 ms
 # apart, so the pulse rate has to be at least 50 Hz for every frame to get a
 # pulse; asking for a percept at the video's own frame times then gives one
 # percept frame per video frame:
-implant.stim = grating.encode(implant=implant, freq=50)
+stim = grating.encode(implant=implant, freq=50)
 
-percept = model.predict_percept(implant, t_percept=grating.time)
+percept = model.predict_percept(stim, t_percept=grating.time)
 percept.play()
 
 #####################################################################################
@@ -139,16 +133,12 @@ percept.play()
 # In the following example, we will invert the stimulus before passing it to the
 # implant:
 
-model = AxonMapModel()
-model.build()
-
-implant = ArgusII()
 grating = GratingStimulus((25,25), temporal_freq=0.1).invert()
 # A model reads current, so the video is encoded first. Its frames are 20 ms
 # apart, so the pulse rate has to be at least 50 Hz for every frame to get a
 # pulse; asking for a percept at the video's own frame times then gives one
 # percept frame per video frame:
-implant.stim = grating.encode(implant=implant, freq=50)
+stim = grating.encode(implant=implant, freq=50)
 
-percept = model.predict_percept(implant, t_percept=grating.time)
+percept = model.predict_percept(stim, t_percept=grating.time)
 percept.play()

--- a/examples/stimuli/plot_pulses.py
+++ b/examples/stimuli/plot_pulses.py
@@ -142,9 +142,9 @@ from pulse2percept.stimuli import AmplitudeEncoder, SnellenChart
 
 implant = ArgusII()
 encoder = AmplitudeEncoder(amp_range=(0, 50), freq=20)
-implant.stim = encoder.encode(SnellenChart().invert(), implant=implant)
+stim = encoder.encode(SnellenChart().invert(), implant=implant)
 
-implant.stim.plot(time=(0, 100))
+stim.plot(time=(0, 100))
 
 ##############################################################################
 # Color is current, centered on zero, so the cathodic and anodic phase of each
@@ -155,4 +155,4 @@ implant.stim.plot(time=(0, 100))
 # Zoom in time with ``time=``, and drill down into individual waveforms by
 # naming electrodes:
 
-implant.stim.plot(electrodes=['A1', 'C7', 'F10'])
+stim.plot(electrodes=['A1', 'C7', 'F10'])

--- a/examples/stimuli/plot_video_stim.py
+++ b/examples/stimuli/plot_video_stim.py
@@ -105,23 +105,24 @@ video.resize((40, 40)).rotate(10).invert().filter('median').play()
 #
 # An implant that knows how its device does this carries a
 # :py:class:`~pulse2percept.stimuli.StimulusEncoder` of its own, and encodes
-# whatever video is assigned to it. Here we replace Argus II's own 6 Hz encoder
+# whatever video it is handed. Here we replace Argus II's own 6 Hz encoder
 # with a 30 Hz one, so that every frame of this 30 fps video gets a pulse:
 
 implant = p2p.implants.ArgusII(
     encoder=p2p.stimuli.AmplitudeEncoder(amp_range=(0, 50), freq=30))
-implant.stim = video
+
+# ``implant.prepare_stim(video)`` is the current the device would deliver, if
+# you want to look at it.
 
 ##############################################################################
 # Then you can feed the video directly into any of the available models
 # described by a :py:class:`~pulse2percept.models.Model` object, such as the
 # axon map model:
 
-model = p2p.models.AxonMapModel()
-model.build()
+model = p2p.models.AxonMapModel(implant=implant)
 # One percept frame per video frame: a spatial model reads the modulation the
 # encoder asked for, not the pulse train realizing it.
-percept = model.predict_percept(implant)
+percept = model.predict_percept(video)
 percept.play()
 
 ##############################################################################

--- a/examples/vision/plot_amd_prima.py
+++ b/examples/vision/plot_amd_prima.py
@@ -48,19 +48,20 @@ implant.encoder = AmplitudeEncoder(amp_range=(0, 40), freq=20)
 
 ###############################################################################
 
-model = ScoreboardModel(scene=scene, rho=50, xrange=(-6, 6), yrange=(-6, 6),
-                        step=0.05).build()
+model = ScoreboardModel(implant=implant, rho=50, xrange=(-6, 6),
+                        yrange=(-6, 6), step=0.05)
 
 ###############################################################################
+# The scene is trial input, like any other stimulus:
 
-percept = model.predict_percept(implant, gaze=(0, 0) * dva, vmax=40)
+percept = model.predict_percept(scene, gaze=(0, 0) * dva, vmax=40)
 
 percept.plot()
 plt.title('Native vision with a PRIMA percept in the scotoma')
 
 ###############################################################################
 
-percept = model.predict_percept(implant, gaze=(8, -4) * dva, vmax=40)
+percept = model.predict_percept(scene, gaze=(8, -4) * dva, vmax=40)
 
 percept.plot()
 plt.title('Looking 8 degrees right and 4 degrees down')
@@ -69,7 +70,7 @@ plt.title('Looking 8 degrees right and 4 degrees down')
 
 implant.preprocess = lambda stim: stim.filter('sobel')
 
-percept = model.predict_percept(implant, gaze=(0, 0) * dva, vmax=40)
+percept = model.predict_percept(scene, gaze=(0, 0) * dva, vmax=40)
 
 percept.plot()
 plt.title('Edge-filtered device input, intact vision around it')

--- a/pulse2percept/implants/alpha.py
+++ b/pulse2percept/implants/alpha.py
@@ -83,6 +83,8 @@ class AlphaIMS(ProsthesisSystem):
     # Frozen class: User cannot add more class attributes
     __slots__ = ('shape',)
 
+    placement = 'subretinal'
+
     def __init__(self, x=0, y=0, z=-100, rot=0, eye='RE', preprocess=True, safe_mode=False):
         self.eye = eye
         self.preprocess = preprocess
@@ -222,6 +224,8 @@ class AlphaAMS(ProsthesisSystem):
     """
     # Frozen class: User cannot add more class attributes
     __slots__ = ('shape',)
+
+    placement = 'subretinal'
 
     def __init__(self, x=0, y=0, z=0, rot=0, eye='RE', preprocess=True, safe_mode=False):
         self.eye = eye

--- a/pulse2percept/implants/alpha.py
+++ b/pulse2percept/implants/alpha.py
@@ -53,7 +53,7 @@ class AlphaIMS(ProsthesisSystem):
         Eye in which array is implanted.
     preprocess : bool or callable, optional
         Either True/False to indicate whether to execute the implant's default
-        preprocessing method whenever a new stimulus is assigned, or a custom
+        preprocessing method whenever a stimulus is prepared, or a custom
         function (callable).
     safe_mode : bool, optional
         If safe mode is enabled, only charge-balanced stimuli are allowed.
@@ -66,7 +66,7 @@ class AlphaIMS(ProsthesisSystem):
     >>> from pulse2percept.implants import AlphaIMS
     >>> AlphaIMS(x=0, y=0, z=100, rot=5)  # doctest: +NORMALIZE_WHITESPACE
     AlphaIMS(earray=ElectrodeGrid, eye='RE', preprocess=True,
-             safe_mode=False, shape=(39, 39), stim=None)
+             safe_mode=False, shape=(39, 39))
 
     Get access to the third electrode in the top row (by name or by row/column
     index):
@@ -83,8 +83,7 @@ class AlphaIMS(ProsthesisSystem):
     # Frozen class: User cannot add more class attributes
     __slots__ = ('shape',)
 
-    def __init__(self, x=0, y=0, z=-100, rot=0, eye='RE', stim=None,
-                 preprocess=True, safe_mode=False):
+    def __init__(self, x=0, y=0, z=-100, rot=0, eye='RE', preprocess=True, safe_mode=False):
         self.eye = eye
         self.preprocess = preprocess
         self.safe_mode = safe_mode
@@ -143,10 +142,6 @@ class AlphaIMS(ProsthesisSystem):
             for elec, z_elec in zip(self.earray.electrode_objects, z):
                 elec.z = z_elec
 
-        # Beware of race condition: Stim must be set last, because it requires
-        # indexing into self.electrodes:
-        self.stim = stim
-
     def _pprint_params(self):
         """Return dict of class attributes to pretty-print"""
         params = super()._pprint_params()
@@ -198,7 +193,7 @@ class AlphaAMS(ProsthesisSystem):
         Eye in which array is implanted.
     preprocess : bool or callable, optional
         Either True/False to indicate whether to execute the implant's default
-        preprocessing method whenever a new stimulus is assigned, or a custom
+        preprocessing method whenever a stimulus is prepared, or a custom
         function (callable).
     safe_mode : bool, optional
         If safe mode is enabled, only charge-balanced stimuli are allowed.
@@ -211,7 +206,7 @@ class AlphaAMS(ProsthesisSystem):
     >>> from pulse2percept.implants import AlphaAMS
     >>> AlphaAMS(x=0, y=0, z=100, rot=5)  # doctest: +NORMALIZE_WHITESPACE
     AlphaAMS(earray=ElectrodeGrid, eye='RE', preprocess=True,
-             safe_mode=False, shape=(40, 40), stim=None)
+             safe_mode=False, shape=(40, 40))
 
     Get access to the third electrode in the top row (by name or by row/column
     index):
@@ -228,8 +223,7 @@ class AlphaAMS(ProsthesisSystem):
     # Frozen class: User cannot add more class attributes
     __slots__ = ('shape',)
 
-    def __init__(self, x=0, y=0, z=0, rot=0, eye='RE', stim=None,
-                 preprocess=True, safe_mode=False):
+    def __init__(self, x=0, y=0, z=0, rot=0, eye='RE', preprocess=True, safe_mode=False):
         self.eye = eye
         self.preprocess = preprocess
         self.safe_mode = safe_mode
@@ -240,10 +234,6 @@ class AlphaAMS(ProsthesisSystem):
         self.earray = ElectrodeGrid(self.shape, e_spacing, x=x, y=y, z=z,
                                     rot=rot, etype=DiskElectrode,
                                     r=elec_radius)
-
-        # Beware of race condition: Stim must be set last, because it requires
-        # indexing into self.electrodes:
-        self.stim = stim
 
         # Set left/right eye:
         # Unfortunately, in the left eye the labeling of columns is reversed...

--- a/pulse2percept/implants/argus.py
+++ b/pulse2percept/implants/argus.py
@@ -72,7 +72,7 @@ class ArgusI(ProsthesisSystem):
         Eye in which array is implanted.
     preprocess : bool or callable, optional
         Either True/False to indicate whether to execute the implant's default
-        preprocessing method whenever a new stimulus is assigned, or a custom
+        preprocessing method whenever a stimulus is prepared, or a custom
         function (callable).
     safe_mode : bool, optional
         If safe mode is enabled, only charge-balanced stimuli are allowed.
@@ -88,7 +88,7 @@ class ArgusI(ProsthesisSystem):
     >>> from pulse2percept.implants import ArgusI
     >>> ArgusI(x=0, y=0, z=100, rot=5)  # doctest: +NORMALIZE_WHITESPACE
     ArgusI(earray=ElectrodeGrid, eye='RE', preprocess=True,
-           safe_mode=False, shape=(4, 4), stim=None)
+           safe_mode=False, shape=(4, 4))
 
     Get access to electrode 'B1', either by name or by row/column index:
 
@@ -104,8 +104,8 @@ class ArgusI(ProsthesisSystem):
     # Frozen class: User cannot add more class attributes
     __slots__ = ('shape',)
 
-    def __init__(self, x=0, y=0, z=0, rot=0, eye='RE', stim=None,
-                 preprocess=True, safe_mode=False, use_legacy_names=False):
+    def __init__(self, x=0, y=0, z=0, rot=0, eye='RE', preprocess=True,
+                 safe_mode=False, use_legacy_names=False):
         self.eye = eye
         self.preprocess = preprocess
         self.safe_mode = safe_mode
@@ -124,10 +124,6 @@ class ArgusI(ProsthesisSystem):
         self.earray = ElectrodeGrid(self.shape, spacing, x=x, y=y, z=z,
                                     rot=rot, etype=DiskElectrode, r=r_arr,
                                     names=names)
-
-        # Beware of race condition: Stim must be set last, because it requires
-        # indexing into self.electrodes:
-        self.stim = stim
 
         # Set left/right eye:
         if not isinstance(eye, str):
@@ -213,7 +209,7 @@ class ArgusII(ProsthesisSystem):
         Eye in which array is implanted.
     preprocess : bool or callable, optional
         Either True/False to indicate whether to execute the implant's default
-        preprocessing method whenever a new stimulus is assigned, or a custom
+        preprocessing method whenever a stimulus is prepared, or a custom
         function (callable).
     safe_mode : bool, optional
         If safe mode is enabled, only charge-balanced stimuli are allowed.
@@ -222,7 +218,7 @@ class ArgusII(ProsthesisSystem):
         :py:class:`~pulse2percept.stimuli.AmplitudeEncoder` at 6 Hz, which is
         the rate Argus II runs its video at. Pass ``encoder=None`` to switch
         automatic encoding off, so that an image or a video assigned to
-        ``stim`` is refused rather than encoded.
+        an image or a video is refused rather than encoded.
 
         .. versionadded:: 0.10.0
     raster : :py:class:`~pulse2percept.implants.Raster`, optional
@@ -242,7 +238,7 @@ class ArgusII(ProsthesisSystem):
     >>> ArgusII(x=0, y=0, z=100, rot=5)  # doctest: +NORMALIZE_WHITESPACE
     ArgusII(earray=ElectrodeGrid, encoder=AmplitudeEncoder, eye='RE',
             preprocess=True, raster=SequentialRaster, safe_mode=False,
-            shape=(6, 10), stim=None)
+            shape=(6, 10))
 
     Get access to electrode 'E7', either by name or by row/column index:
 
@@ -254,19 +250,19 @@ class ArgusII(ProsthesisSystem):
     DiskElectrode(activated=True, name='E7', r=112.5, x=862.5,
                   y=862.5, z=100.0)
 
-    Because the device brings its own encoder, a picture can be assigned
-    straight to ``stim`` and comes back as current:
+    Because the device brings its own encoder, a picture can be presented
+    directly and comes back as current:
 
     >>> from pulse2percept.stimuli import LogoBVL
-    >>> ArgusII(stim=LogoBVL()).stim.unit
+    >>> ArgusII().prepare_stim(LogoBVL()).unit
     uA
 
     """
     # Frozen class: User cannot add more class attributes
     __slots__ = ('shape',)
 
-    def __init__(self, x=0, y=0, z=0, rot=0, eye='RE', stim=None,
-                 preprocess=True, safe_mode=False, encoder=_DEVICE_DEFAULT,
+    def __init__(self, x=0, y=0, z=0, rot=0, eye='RE', preprocess=True,
+                 safe_mode=False, encoder=_DEVICE_DEFAULT,
                  raster=_DEVICE_DEFAULT):
         self.safe_mode = safe_mode
         self.preprocess = preprocess
@@ -288,7 +284,6 @@ class ArgusII(ProsthesisSystem):
         # Beware of race condition: Stim must be set last, because it requires
         # indexing into self.electrodes -- and, for a picture, the encoder and
         # raster set just above:
-        self.stim = stim
 
         # Set left/right eye:
         if not isinstance(eye, str):

--- a/pulse2percept/implants/argus.py
+++ b/pulse2percept/implants/argus.py
@@ -219,8 +219,8 @@ class ArgusII(ProsthesisSystem):
         How the device turns a picture into stimulation. Defaults to a fresh
         :py:class:`~pulse2percept.stimuli.AmplitudeEncoder` at 6 Hz, which is
         the rate Argus II runs its video at. Pass ``encoder=None`` to switch
-        automatic encoding off, so that an image or a video assigned to
-        an image or a video is refused rather than encoded.
+        automatic encoding off, so that an image or video input is refused
+        rather than encoded.
 
         .. versionadded:: 0.10.0
     raster : :py:class:`~pulse2percept.implants.Raster`, optional
@@ -284,10 +284,6 @@ class ArgusII(ProsthesisSystem):
                         if encoder is _DEVICE_DEFAULT else encoder)
         self.raster = (SequentialRaster(6, group_dur=2 * ms)
                        if raster is _DEVICE_DEFAULT else raster)
-
-        # Beware of race condition: Stim must be set last, because it requires
-        # indexing into self.electrodes -- and, for a picture, the encoder and
-        # raster set just above:
 
         # Set left/right eye:
         if not isinstance(eye, str):

--- a/pulse2percept/implants/argus.py
+++ b/pulse2percept/implants/argus.py
@@ -104,6 +104,8 @@ class ArgusI(ProsthesisSystem):
     # Frozen class: User cannot add more class attributes
     __slots__ = ('shape',)
 
+    placement = 'epiretinal'
+
     def __init__(self, x=0, y=0, z=0, rot=0, eye='RE', preprocess=True,
                  safe_mode=False, use_legacy_names=False):
         self.eye = eye
@@ -260,6 +262,8 @@ class ArgusII(ProsthesisSystem):
     """
     # Frozen class: User cannot add more class attributes
     __slots__ = ('shape',)
+
+    placement = 'epiretinal'
 
     def __init__(self, x=0, y=0, z=0, rot=0, eye='RE', preprocess=True,
                  safe_mode=False, encoder=_DEVICE_DEFAULT,

--- a/pulse2percept/implants/base.py
+++ b/pulse2percept/implants/base.py
@@ -510,55 +510,35 @@ class ProsthesisSystem(PrettyPrint):
         self._earray = earray
 
     def prepare_stim(self, source):
-        """Turn what is presented to the device into what it delivers
+        """Turn a source into stimulation the implant can deliver.
 
-        A stimulus can be created from many source types, such as scalars,
-        NumPy arrays, and dictionaries (see
-        :py:class:`~pulse2percept.stimuli.Stimulus` for a complete list).
+        Preparation applies preprocessing, converts the source to a
+        :py:class:`~pulse2percept.stimuli.Stimulus`, encodes dimensionless visual
+        input when an encoder is present, reshapes it to the electrode array, removes
+        deactivated electrodes, applies threshold calibration, and runs safety checks.
+        The input is not modified and the result is not stored.
 
-        .. note::
-           Unless when using dictionary notation, the number of stimuli must
-           equal the number of electrodes in ``earray``.
-
-        What comes back is always something the implant can deliver; for an
-        electrical prosthesis that means a current (see
-        :py:attr:`~pulse2percept.implants.ProsthesisSystem.stimulus_unit`).
-        An image or a video is not that, so it is run through the implant's
-        :py:attr:`~pulse2percept.implants.ProsthesisSystem.encoder` on the way
-        through. Without an encoder there is no principled default mapping from
-        a gray level to an amplitude or a frequency, so one raises a
-        :py:class:`~pulse2percept.units.DimensionMismatchError`: say which you
-        want with an
-        :py:class:`~pulse2percept.stimuli.AmplitudeEncoder` or a
-        :py:class:`~pulse2percept.stimuli.FrequencyEncoder`.
-
-        The implant keeps no trial state: ``source`` is not modified, the
-        result is not stored, and every call reads the implant as it stands.
-        Changing
-        :py:attr:`~pulse2percept.implants.ProsthesisSystem.thresholds` or
-        deactivating an electrode therefore affects the *next* call.
+        Images and videos require an encoder unless preprocessing already converts
+        them to the implant's
+        :py:attr:`~pulse2percept.implants.ProsthesisSystem.stimulus_unit`.
 
         .. versionadded:: 0.11.0
-            Replaces the ``stim`` property, which stored the result on the
-            implant.
+            Replaces the stateful ``stim`` property.
 
         Parameters
         ----------
         source : :py:class:`~pulse2percept.stimuli.Stimulus` source type
-            What is presented to the device: an electrical stimulus, or an
-            image or video for the implant's ``encoder`` to turn into one.
+            Any source accepted by :py:class:`~pulse2percept.stimuli.Stimulus`,
+            including electrical stimulation and image or video input for the
+            implant encoder.
 
         Returns
         -------
         stim : :py:class:`~pulse2percept.stimuli.Stimulus` or None
-            The stimulation this implant's electrodes would deliver. None if
-            ``source`` is None or empty.
+            Stimulation delivered by the implant, or None for an empty source.
 
         Examples
         --------
-        Send a biphasic pulse (30uA, 0.45ms phase duration) to an implant made
-        from a single :py:class:`~pulse2percept.implants.DiskElectrode`:
-
         >>> from pulse2percept.implants import DiskElectrode, ProsthesisSystem
         >>> from pulse2percept.stimuli import BiphasicPulse
         >>> implant = ProsthesisSystem(DiskElectrode(0, 0, 0, 100))
@@ -569,14 +549,13 @@ class ProsthesisSystem(PrettyPrint):
         >>> from pulse2percept.implants import ArgusII
         >>> stim = ArgusII().prepare_stim({'B7': 13})
 
-        Argus II comes with an encoder, so an image can be presented directly:
+        Argus II includes an encoder, so it can prepare an image directly:
 
         >>> from pulse2percept.stimuli import LogoBVL
         >>> ArgusII().prepare_stim(LogoBVL()).unit
         uA
-
         """
-        # An empty source is not stimulation, and there is nothing to prepare:
+        # Empty input produces no stimulation:
         if source is None:
             return None
         if isinstance(source, (list, tuple, dict)) and not source:
@@ -596,13 +575,9 @@ class ProsthesisSystem(PrettyPrint):
             # Use electrode names as stimulus coordinates:
             stim = Stimulus(data, electrodes=self.electrode_names)
 
-        # A picture is not something an implant can deliver, so this is
-        # where it becomes stimulation. Preprocessing goes first and may
-        # have done the job already (a `preprocess` that encodes is exactly
-        # as valid as an `encoder`), in which case there is nothing
-        # dimensionless left to encode. What comes back knows both what
-        # the device delivers and what it was asked for, so there is one
-        # stimulus here and not two (see `Stimulus._spatial_view`).
+        # Encode dimensionless visual input after preprocessing. Preprocessing
+        # may already have converted the source to electrical stimulation.
+        # Encoded stimuli retain frame-level modulation via `_spatial_view`.
         if (self.encoder is not None and
                 stim.unit.dimension.is_dimensionless and
                 stim.unit.dimension != self.stimulus_unit.dimension):
@@ -614,10 +589,7 @@ class ProsthesisSystem(PrettyPrint):
         if len(stim.electrodes) > self.n_electrodes:
             stim = self.reshape_stim(stim)
 
-        # Whatever came in is now a Stimulus laid out on this implant's
-        # electrodes. Whether it is a stimulus the implant can *deliver*
-        # is the next question, and it is asked before anything else looks
-        # at the numbers:
+        # Validate the physical quantity before inspecting stimulus values:
         self._require_deliverable_stim(stim)
 
         # Make sure all electrode names are valid:
@@ -626,19 +598,15 @@ class ProsthesisSystem(PrettyPrint):
             if not self.earray[electrode]:
                 raise ValueError(f'Electrode "{electrode}" not found in '
                                  f'implant.')
-        # Remove deactivated electrodes from the stimulus. Removal
-        # rewrites the stimulus, so it happens on a copy: the caller's
-        # object is theirs, and a stimulus defined by more than its
-        # samples keeps that description only if it says how to drop an
-        # electrode (see `Stimulus._without_electrodes`).
+        # Remove deactivated electrodes without modifying the caller's source.
+        # `_without_electrodes` preserves structured stimulus information.
         off = [name for (name, e) in self.electrodes.items()
                if not e.activated and name in stim.electrodes]
         if off:
             stim = stim._without_electrodes(off)
         # Calibrate a copy; do not mutate the caller's stimulus.
         stim = self._calibrated(deepcopy(stim))
-        # Perform safety checks, etc. These are all questions about what
-        # gets delivered, so they are asked of the calibrated pulse train:
+        # Run safety checks on the calibrated delivered stimulus:
         self.check_stim(stim)
         return stim
 

--- a/pulse2percept/implants/base.py
+++ b/pulse2percept/implants/base.py
@@ -265,8 +265,8 @@ class ProsthesisSystem(PrettyPrint):
             f"{_describe_unit(self.stimulus_unit)}, but this stimulus is "
             f"measured in {_describe_unit(stim.unit)}. Give the implant an "
             f"'encoder' (pulse2percept.stimuli.AmplitudeEncoder or "
-            f"FrequencyEncoder) so that image or video input is encoded on "
-            f"assignment, encode it yourself first, or give the implant a "
+            f"FrequencyEncoder) so that image or video input is encoded during "
+            f"'prepare_stim', encode it yourself first, or give the implant a "
             f"'preprocess' function that does.")
 
     @staticmethod

--- a/pulse2percept/implants/base.py
+++ b/pulse2percept/implants/base.py
@@ -20,47 +20,44 @@ from ..utils import PrettyPrint, deprecated
 class ProsthesisSystem(PrettyPrint):
     """Visual prosthesis system
 
-    A visual prosthesis combines an electrode array and (optionally) a
-    stimulus. This is the base class for prosthesis systems such as
+    A visual prosthesis describes an electrode array together with the input
+    pipeline that turns what is presented to the device into the stimulation
+    its electrodes deliver (see
+    :py:meth:`~pulse2percept.implants.ProsthesisSystem.prepare_stim`). This is
+    the base class for prosthesis systems such as
     :py:class:`~pulse2percept.implants.ArgusII` and
     :py:class:`~pulse2percept.implants.AlphaIMS`.
 
     .. versionadded:: 0.6
+
+    .. versionchanged:: 0.11.0
+        An implant no longer stores a stimulus. ``implant.stim = source``
+        became ``delivered = implant.prepare_stim(source)``, and a model is
+        given the source rather than the implant (see
+        :py:meth:`~pulse2percept.models.Model.predict_percept`).
 
     Parameters
     ----------
     earray : :py:class:`~pulse2percept.implants.ElectrodeArray` or
              :py:class:`~pulse2percept.implants.Electrode`
         The electrode array used to deliver electrical stimuli to the retina.
-    stim : :py:class:`~pulse2percept.stimuli.Stimulus` source type
-        A valid source type for the :py:class:`~pulse2percept.stimuli.Stimulus`
-        object (e.g., scalar, NumPy array, pulse train). It must be electrical
-        (see
-        :py:attr:`~pulse2percept.implants.ProsthesisSystem.stimulus_unit`), or
-        an image or a video that the implant's ``encoder`` turns into one.
-
-        .. versionchanged:: 0.10.0
-            A stimulus that is neither a current nor something the implant's
-            ``encoder`` can turn into one is refused here, instead of at the
-            point where a model tries to read it.
     eye : 'LE' or 'RE'
         A string indicating whether the system is implanted in the left ('LE')
         or right eye ('RE')
     preprocess : bool or callable, optional
         Either True/False to indicate whether to execute the implant's default
-        preprocessing method whenever a new stimulus is assigned, or a custom
+        preprocessing method whenever a stimulus is prepared, or a custom
         function (callable).
     safe_mode : bool, optional
         If safe mode is enabled, only charge-balanced stimuli are allowed.
         Safety is an electrical property, so this also requires the stimulus
         to be measured in units of current.
     encoder : :py:class:`~pulse2percept.stimuli.StimulusEncoder`, optional
-        How the device turns a picture into stimulation. If given, assigning an
-        image or a video to
-        :py:attr:`~pulse2percept.implants.ProsthesisSystem.stim` encodes it
-        first, so that ``implant.stim`` always ends up electrical. If None,
-        such a stimulus is refused, since there is no principled default
-        mapping from a gray level to an amplitude or a frequency.
+        How the device turns a picture into stimulation. If given, preparing an
+        image or a video encodes it first, so that what comes back is always
+        electrical. If None, such a stimulus is refused, since there is no
+        principled default mapping from a gray level to an amplitude or a
+        frequency.
 
         .. versionadded:: 0.10.0
     raster : :py:class:`~pulse2percept.implants.Raster`, optional
@@ -73,7 +70,7 @@ class ProsthesisSystem(PrettyPrint):
         .. versionadded:: 0.10.0
     max_current : float, optional
         The total current (uA) the stimulator can source at any one instant,
-        summed over all electrodes. If given, assigning a stimulus that exceeds
+        summed over all electrodes. If given, preparing a stimulus that exceeds
         it raises. If None, no such check is performed.
 
         May be given as a plain number of microamps or as a unitful quantity
@@ -90,20 +87,20 @@ class ProsthesisSystem(PrettyPrint):
     >>> from pulse2percept.implants import DiskElectrode, ProsthesisSystem
     >>> implant = ProsthesisSystem(DiskElectrode(200, -50, 10, 100), eye='LE')
 
-    .. note::
-
-        A stimulus can also be assigned later (see
-        :py:attr:`~pulse2percept.implants.ProsthesisSystem.stim`).
-
     """
     # Frozen class: User cannot add more class attributes
-    __slots__ = ('_earray', '_stim', '_eye', 'safe_mode', 'preprocess',
+    __slots__ = ('_earray', '_eye', 'safe_mode', 'preprocess',
                  '_encoder', '_raster', '_max_current', '_thresholds')
 
     #: Physical quantity delivered by the implant. Subclasses may override.
     stimulus_unit = uA
 
-    def __init__(self, earray, stim=None, eye='RE', preprocess=False,
+    #: Where the device sits relative to the tissue it stimulates, where the
+    #: literature is unambiguous about it; None where it is not, or where the
+    #: class describes a family rather than a device.
+    placement = None
+
+    def __init__(self, earray, eye='RE', preprocess=False,
                  safe_mode=False, encoder=None, raster=None, max_current=None):
         self.earray = earray
         self.eye = eye
@@ -112,14 +109,11 @@ class ProsthesisSystem(PrettyPrint):
         self.encoder = encoder
         self.raster = raster
         self.max_current = max_current
-        # Assign stimulus last because encoding depends on the initialized
-        # encoder, raster, and electrode array.
-        self.stim = stim
 
     def _pprint_params(self):
         """Return dict of class attributes to pretty-print"""
         params = {
-            'earray': self.earray, 'stim': self.stim, 'safe_mode': self.safe_mode,
+            'earray': self.earray, 'safe_mode': self.safe_mode,
             'preprocess': self.preprocess
         }
         if hasattr(self, "eye"):
@@ -189,24 +183,22 @@ class ProsthesisSystem(PrettyPrint):
         """Perceptual threshold current (uA) for each electrode.
 
         Assign a single current for the whole array, a per-electrode dict,
-        or None to clear the calibration. Threshold-relative pulse trains
-        are recalibrated when this property changes.
+        or None to clear the calibration. Threshold-relative pulse trains are
+        calibrated against whatever is in force at the moment
+        :py:meth:`~pulse2percept.implants.ProsthesisSystem.prepare_stim` runs.
 
         .. versionadded:: 0.10.0
+
+        .. versionchanged:: 0.11.0
+            Changing thresholds affects the next stimulus prepared, rather
+            than rewriting one the implant was holding.
         """
         return dict(getattr(self, '_thresholds', None) or {})
 
     @thresholds.setter
     def thresholds(self, thresholds):
         """Threshold setter (called upon ``self.thresholds = ...``)"""
-        previous = getattr(self, '_thresholds', {})
         self._thresholds = self._normalize_thresholds(thresholds)
-        try:
-            self._recalibrate_stim()
-        except Exception:
-            # Thresholds and stimulus move together or not at all:
-            self._thresholds = previous
-            raise
 
     def _normalize_thresholds(self, thresholds):
         """Return thresholds as a mapping of electrode names to uA."""
@@ -225,19 +217,6 @@ class ProsthesisSystem(PrettyPrint):
             if threshold is not None:
                 normalized[name] = threshold
         return normalized
-
-    def _recalibrate_stim(self):
-        """Recalibrate the stored stimulus for the thresholds now in force"""
-        stim = getattr(self, '_stim', None)
-        if stim is None:
-            return
-        calibrated = self._calibrated(stim)
-        if calibrated is stim:
-            return
-        # Checked before it is stored, so a rejected stimulus is not the one
-        # left behind:
-        self.check_stim(calibrated)
-        self._stim = calibrated
 
     def _calibrated(self, stim):
         """Apply implant thresholds to retained ``BiphasicPulseTrain`` sources.
@@ -340,7 +319,8 @@ class ProsthesisSystem(PrettyPrint):
     def check_stim(self, stim):
         """Quality-check the stimulus
 
-        This method is executed every time a new value is assigned to ``stim``.
+        This method is executed every time a stimulus is prepared (see
+        :py:meth:`~pulse2percept.implants.ProsthesisSystem.prepare_stim`).
 
         If ``safe_mode`` is set to True, this function will only allow stimuli
         that are charge-balanced. If ``max_current`` is set, it will only allow
@@ -349,9 +329,9 @@ class ProsthesisSystem(PrettyPrint):
         Both are questions about electricity, and neither can be answered about
         a stimulus that is not a current, so each raises a
         :py:class:`~pulse2percept.units.DimensionMismatchError` on one. In the
-        ordinary flow this cannot happen: assigning to
-        :py:attr:`~pulse2percept.implants.ProsthesisSystem.stim` has already
-        checked the stimulus against
+        ordinary flow this cannot happen:
+        :py:meth:`~pulse2percept.implants.ProsthesisSystem.prepare_stim` has
+        already checked the stimulus against
         :py:attr:`~pulse2percept.implants.ProsthesisSystem.stimulus_unit`.
         ``check_stim`` is public, though, and may be handed anything.
 
@@ -393,7 +373,7 @@ class ProsthesisSystem(PrettyPrint):
     def preprocess_stim(self, stim):
         """Preprocess the stimulus
 
-        This methods is executed every time a new value is assigned to ``stim``.
+        This method is executed every time a stimulus is prepared.
 
         No preprocessing is performed by default, but the user can define their
         own method in implants that inherit from
@@ -463,7 +443,8 @@ class ProsthesisSystem(PrettyPrint):
                 f"does not match the number of electrodes in the implant ({self.n_electrodes})."
             )
 
-    def plot(self, annotate=False, autoscale=True, ax=None, stim_cmap=False):
+    def plot(self, annotate=False, autoscale=True, ax=None, stim=None,
+             stim_cmap=False):
         """Plot
 
         Parameters
@@ -475,6 +456,13 @@ class ProsthesisSystem(PrettyPrint):
         ax : matplotlib.axes._subplots.AxesSubplot, optional
             A Matplotlib axes object. If None, will either use the current axes
             (if exists) or create a new Axes object.
+        stim : :py:class:`~pulse2percept.stimuli.Stimulus` source type, optional
+            What is presented to the device. Prepared through
+            :py:meth:`~pulse2percept.implants.ProsthesisSystem.prepare_stim`,
+            so the colors show what the electrodes actually deliver. Required
+            by ``stim_cmap``.
+
+            .. versionadded:: 0.11.0
         stim_cmap : bool, str, or matplotlib colormap, optional
             If not false, the fill color of the plotted electrodes will vary based
             on maximum stimulus amplitude on each electrode. The chosen colormap
@@ -485,27 +473,22 @@ class ProsthesisSystem(PrettyPrint):
         ax : ``matplotlib.axes.Axes``
             Returns the axis object of the plot
         """
-        stim = None
+        color_stim = None
         if stim_cmap:
-            if self.stim is None:
-                raise ValueError("Must assign a stimulus in order to enable stimulus coloring")
-            stim = self.stim
+            color_stim = self.prepare_stim(stim)
+            if color_stim is None:
+                raise ValueError("Must pass a stimulus ('stim') in order to "
+                                 "enable stimulus coloring.")
             if stim_cmap == True:
                 stim_cmap = 'YlOrRd'
-        return self.earray.plot(annotate=annotate, autoscale=autoscale, ax=ax, color_stim=stim, cmap=stim_cmap)
+        return self.earray.plot(annotate=annotate, autoscale=autoscale, ax=ax,
+                                color_stim=color_stim, cmap=stim_cmap)
 
     def activate(self, electrodes):
         self.earray.activate(electrodes)
 
     def deactivate(self, electrodes):
         self.earray.deactivate(electrodes)
-        # Switching an electrode off rewrites the stimulus, so it is replaced
-        # rather than modified in place: it may be an object the caller still
-        # holds, and one defined by more than its samples cannot lose an
-        # electrode and remain one unless it says how (see
-        # `Stimulus._without_electrodes`).
-        if self.stim is not None:
-            self._stim = self.stim._without_electrodes(electrodes)
 
     @property
     def earray(self):
@@ -526,37 +509,50 @@ class ProsthesisSystem(PrettyPrint):
                             f"{type(earray)}.")
         self._earray = earray
 
-    @property
-    def stim(self):
-        """Stimulus
+    def prepare_stim(self, source):
+        """Turn what is presented to the device into what it delivers
 
         A stimulus can be created from many source types, such as scalars,
         NumPy arrays, and dictionaries (see
         :py:class:`~pulse2percept.stimuli.Stimulus` for a complete list).
 
-        A stimulus can be assigned either in the
-        :py:class:`~pulse2percept.implants.ProsthesisSystem` constructor
-        or later by assigning a value to `stim`.
-
         .. note::
            Unless when using dictionary notation, the number of stimuli must
            equal the number of electrodes in ``earray``.
 
-        What is stored is always something the implant can deliver; for an
+        What comes back is always something the implant can deliver; for an
         electrical prosthesis that means a current (see
         :py:attr:`~pulse2percept.implants.ProsthesisSystem.stimulus_unit`).
         An image or a video is not that, so it is run through the implant's
         :py:attr:`~pulse2percept.implants.ProsthesisSystem.encoder` on the way
-        in. Without an encoder there is no principled default mapping from a
-        gray level to an amplitude or a frequency, so assigning one raises a
+        through. Without an encoder there is no principled default mapping from
+        a gray level to an amplitude or a frequency, so one raises a
         :py:class:`~pulse2percept.units.DimensionMismatchError`: say which you
         want with an
         :py:class:`~pulse2percept.stimuli.AmplitudeEncoder` or a
         :py:class:`~pulse2percept.stimuli.FrequencyEncoder`.
 
-        .. versionchanged:: 0.10.0
-            A non-electrical stimulus is encoded on assignment if the implant
-            has an encoder, and refused otherwise.
+        The implant keeps no trial state: ``source`` is not modified, the
+        result is not stored, and every call reads the implant as it stands.
+        Changing
+        :py:attr:`~pulse2percept.implants.ProsthesisSystem.thresholds` or
+        deactivating an electrode therefore affects the *next* call.
+
+        .. versionadded:: 0.11.0
+            Replaces the ``stim`` property, which stored the result on the
+            implant.
+
+        Parameters
+        ----------
+        source : :py:class:`~pulse2percept.stimuli.Stimulus` source type
+            What is presented to the device: an electrical stimulus, or an
+            image or video for the implant's ``encoder`` to turn into one.
+
+        Returns
+        -------
+        stim : :py:class:`~pulse2percept.stimuli.Stimulus` or None
+            The stimulation this implant's electrodes would deliver. None if
+            ``source`` is None or empty.
 
         Examples
         --------
@@ -566,92 +562,85 @@ class ProsthesisSystem(PrettyPrint):
         >>> from pulse2percept.implants import DiskElectrode, ProsthesisSystem
         >>> from pulse2percept.stimuli import BiphasicPulse
         >>> implant = ProsthesisSystem(DiskElectrode(0, 0, 0, 100))
-        >>> implant.stim = BiphasicPulse(30, 0.45)
+        >>> stim = implant.prepare_stim(BiphasicPulse(30, 0.45))
 
         Stimulate Electrode B7 in Argus II with 13 uA:
 
         >>> from pulse2percept.implants import ArgusII
-        >>> implant = ArgusII(stim={'B7': 13})
+        >>> stim = ArgusII().prepare_stim({'B7': 13})
 
-        Argus II comes with an encoder, so an image can be assigned directly:
+        Argus II comes with an encoder, so an image can be presented directly:
 
         >>> from pulse2percept.stimuli import LogoBVL
-        >>> implant = ArgusII(stim=LogoBVL())
-        >>> implant.stim.unit
+        >>> ArgusII().prepare_stim(LogoBVL()).unit
         uA
 
         """
-        return self._stim
+        # An empty source is not stimulation, and there is nothing to prepare:
+        if source is None:
+            return None
+        if isinstance(source, (list, tuple, dict)) and not source:
+            return None
+        if isinstance(source, np.ndarray) and source.size == 0:
+            return None
 
-    @stim.setter
-    def stim(self, data):
-        """Stimulus setter (called upon ``self.stim = data``)"""
-        # if stim is empty or None
-        if data is None:
-            self._stim = None
-        elif isinstance(data, (list, tuple, dict)) and not data:
-            self._stim = None
-        elif isinstance(data, np.ndarray) and data.size == 0:
-            self._stim = None
+        data = self._preprocess(source)
+        # Convert to stimulus object:
+        if isinstance(data, Stimulus):
+            # Already a stimulus object:
+            stim = data
+        elif isinstance(data, dict):
+            # Electrode names already provided by keys:
+            stim = Stimulus(data)
         else:
-            data = self._preprocess(data)
-            # Convert to stimulus object:
-            if isinstance(data, Stimulus):
-                # Already a stimulus object:
-                stim = data
-            elif isinstance(data, dict):
-                # Electrode names already provided by keys:
-                stim = Stimulus(data)
-            else:
-                # Use electrode names as stimulus coordinates:
-                stim = Stimulus(data, electrodes=self.electrode_names)
+            # Use electrode names as stimulus coordinates:
+            stim = Stimulus(data, electrodes=self.electrode_names)
 
-            # A picture is not something an implant can deliver, so this is
-            # where it becomes stimulation. Preprocessing goes first and may
-            # have done the job already (a `preprocess` that encodes is exactly
-            # as valid as an `encoder`), in which case there is nothing
-            # dimensionless left to encode. What comes back knows both what
-            # the device delivers and what it was asked for, so there is one
-            # stimulus here and not two (see `Stimulus._spatial_view`).
-            if (self.encoder is not None and
-                    stim.unit.dimension.is_dimensionless and
-                    stim.unit.dimension != self.stimulus_unit.dimension):
-                stim = self.encoder.encode(stim, implant=self)
+        # A picture is not something an implant can deliver, so this is
+        # where it becomes stimulation. Preprocessing goes first and may
+        # have done the job already (a `preprocess` that encodes is exactly
+        # as valid as an `encoder`), in which case there is nothing
+        # dimensionless left to encode. What comes back knows both what
+        # the device delivers and what it was asked for, so there is one
+        # stimulus here and not two (see `Stimulus._spatial_view`).
+        if (self.encoder is not None and
+                stim.unit.dimension.is_dimensionless and
+                stim.unit.dimension != self.stimulus_unit.dimension):
+            stim = self.encoder.encode(stim, implant=self)
 
-            # If the stim is larger than the number of electrodes, most commonly
-            # we're dealing with an image or video stim. In this case, we might
-            # want to try and reshape the stimulus to fit the array:
-            if len(stim.electrodes) > self.n_electrodes:
-                stim = self.reshape_stim(stim)
+        # If the stim is larger than the number of electrodes, most commonly
+        # we're dealing with an image or video stim. In this case, we might
+        # want to try and reshape the stimulus to fit the array:
+        if len(stim.electrodes) > self.n_electrodes:
+            stim = self.reshape_stim(stim)
 
-            # Whatever came in is now a Stimulus laid out on this implant's
-            # electrodes. Whether it is a stimulus the implant can *deliver*
-            # is the next question, and it is asked before anything else looks
-            # at the numbers:
-            self._require_deliverable_stim(stim)
+        # Whatever came in is now a Stimulus laid out on this implant's
+        # electrodes. Whether it is a stimulus the implant can *deliver*
+        # is the next question, and it is asked before anything else looks
+        # at the numbers:
+        self._require_deliverable_stim(stim)
 
-            # Make sure all electrode names are valid:
-            for electrode in stim.electrodes:
-                # Invalid index will return None:
-                if not self.earray[electrode]:
-                    raise ValueError(f'Electrode "{electrode}" not found in '
-                                     f'implant.')
-            # Remove deactivated electrodes from the stimulus. Removal
-            # rewrites the stimulus, so it happens on a copy: the caller's
-            # object is theirs, and a stimulus defined by more than its
-            # samples keeps that description only if it says how to drop an
-            # electrode (see `Stimulus._without_electrodes`).
-            off = [name for (name, e) in self.electrodes.items()
-                   if not e.activated and name in stim.electrodes]
-            if off:
-                stim = stim._without_electrodes(off)
-            # Calibrate a copy; do not mutate the caller's stimulus.
-            stim = self._calibrated(deepcopy(stim))
-            # Perform safety checks, etc. These are all questions about what
-            # gets delivered, so they are asked of the calibrated pulse train:
-            self.check_stim(stim)
-            # Store stimulus:
-            self._stim = stim
+        # Make sure all electrode names are valid:
+        for electrode in stim.electrodes:
+            # Invalid index will return None:
+            if not self.earray[electrode]:
+                raise ValueError(f'Electrode "{electrode}" not found in '
+                                 f'implant.')
+        # Remove deactivated electrodes from the stimulus. Removal
+        # rewrites the stimulus, so it happens on a copy: the caller's
+        # object is theirs, and a stimulus defined by more than its
+        # samples keeps that description only if it says how to drop an
+        # electrode (see `Stimulus._without_electrodes`).
+        off = [name for (name, e) in self.electrodes.items()
+               if not e.activated and name in stim.electrodes]
+        if off:
+            stim = stim._without_electrodes(off)
+        # Calibrate a copy; do not mutate the caller's stimulus.
+        stim = self._calibrated(deepcopy(stim))
+        # Perform safety checks, etc. These are all questions about what
+        # gets delivered, so they are asked of the calibrated pulse train:
+        self.check_stim(stim)
+        return stim
 
     @property
     def eye(self):
@@ -767,14 +756,12 @@ class GridImplant(ProsthesisSystem):
         :py:class:`~pulse2percept.implants.ElectrodeGrid`.
     etype : :py:class:`~pulse2percept.implants.Electrode`, optional
         A valid Electrode class.
-    stim : :py:class:`~pulse2percept.stimuli.Stimulus` source type
-        A valid source type for a stimulus.
     eye : 'LE' or 'RE', optional
         The eye in which the implant is implanted. Device metadata: unlike
         :py:class:`~pulse2percept.implants.RectangleImplant`, the geometry and
         the electrode names are the same in either eye.
     preprocess : bool or callable, optional
-        Whether to preprocess the stimulus whenever a new one is assigned.
+        Whether to preprocess a stimulus whenever one is prepared.
     safe_mode : bool, optional
         Whether to enforce charge balance.
     encoder : :py:class:`~pulse2percept.stimuli.StimulusEncoder`, optional
@@ -814,14 +801,14 @@ class GridImplant(ProsthesisSystem):
 
     def __init__(self, shape, spacing, x=0, y=0, z=0, rot=0, names=('A', '1'),
                  type='rect', orientation='horizontal', etype=PointSource,
-                 stim=None, eye='RE', preprocess=False, safe_mode=False,
+                 eye='RE', preprocess=False, safe_mode=False,
                  encoder=None, raster=None, max_current=None,
                  **electrode_kwargs):
         earray = ElectrodeGrid(shape, spacing, x=x, y=y, z=z, rot=rot,
                                names=names, type=type,
                                orientation=orientation, etype=etype,
                                **electrode_kwargs)
-        super().__init__(earray, stim=stim, eye=eye, preprocess=preprocess,
+        super().__init__(earray, eye=eye, preprocess=preprocess,
                          safe_mode=safe_mode, encoder=encoder, raster=raster,
                          max_current=max_current)
 
@@ -858,15 +845,13 @@ class RectangleImplant(ProsthesisSystem):
         The distance (um) between electrodes in the implant
     eye : str, optional
         The eye in which the implant is implanted
-    stim : :py:class:`~pulse2percept.stimuli.Stimulus` source type
-        A valid source type for a stimulus
     preprocess : bool, optional
         Whether to preprocess the stimulus
     safe_mode : bool, optional
         Whether to enforce charge balance
 
     """
-    def __init__(self, x=0, y=0, z=0, rot=0, shape=(15, 15), r=150./2, spacing=400., eye='RE', stim=None,
+    def __init__(self, x=0, y=0, z=0, rot=0, shape=(15, 15), r=150./2, spacing=400., eye='RE',
                  preprocess=True, safe_mode=False):
         self.safe_mode = safe_mode
         self.preprocess = preprocess
@@ -874,7 +859,6 @@ class RectangleImplant(ProsthesisSystem):
         names = ('A', '1')
         self.earray = ElectrodeGrid(self.shape, spacing, x=x, y=y, z=z, r=r,
                                     rot=rot, names=names, etype=DiskElectrode)
-        self.stim = stim
 
         # Set left/right eye:
         if not isinstance(eye, str):

--- a/pulse2percept/implants/bvt.py
+++ b/pulse2percept/implants/bvt.py
@@ -71,6 +71,8 @@ class BVT24(ProsthesisSystem):
     # Frozen class: User cannot add more class attributes
     __slots__ = ()
 
+    placement = 'suprachoroidal'
+
     def __init__(self, x=0, y=0, z=0, rot=0, eye='RE', preprocess=False, safe_mode=False):
         self.eye = eye
         self.preprocess = preprocess
@@ -189,6 +191,8 @@ class BVT44(ProsthesisSystem):
     """
     # Frozen class: User cannot add more class attributes
     __slots__ = ()
+
+    placement = 'suprachoroidal'
 
     def __init__(self, x=0, y=0, z=0, rot=0, eye='LE', preprocess=False, safe_mode=False):
         self.eye = eye

--- a/pulse2percept/implants/bvt.py
+++ b/pulse2percept/implants/bvt.py
@@ -62,7 +62,7 @@ class BVT24(ProsthesisSystem):
         Eye in which array is implanted.
     preprocess : bool or callable, optional
         Either True/False to indicate whether to execute the implant's default
-        preprocessing method whenever a new stimulus is assigned, or a custom
+        preprocessing method whenever a stimulus is prepared, or a custom
         function (callable).
     safe_mode : bool, optional
         If safe mode is enabled, only charge-balanced stimuli are allowed.
@@ -71,8 +71,7 @@ class BVT24(ProsthesisSystem):
     # Frozen class: User cannot add more class attributes
     __slots__ = ()
 
-    def __init__(self, x=0, y=0, z=0, rot=0, eye='RE', stim=None,
-                 preprocess=False, safe_mode=False):
+    def __init__(self, x=0, y=0, z=0, rot=0, eye='RE', preprocess=False, safe_mode=False):
         self.eye = eye
         self.preprocess = preprocess
         self.safe_mode = safe_mode
@@ -134,9 +133,6 @@ class BVT24(ProsthesisSystem):
         for x, y, z, r, name in zip(x_arr, y_arr, z_arr, r_arr, names):
             self.earray.add_electrode(name, DiskElectrode(x, y, z, r))
 
-        # Beware of race condition: Stim must be set last, because it requires
-        # indexing into self.electrodes:
-        self.stim = stim
 
 
 class BVT44(ProsthesisSystem):
@@ -186,7 +182,7 @@ class BVT44(ProsthesisSystem):
         Eye in which array is implanted.
     preprocess : bool or callable, optional
         Either True/False to indicate whether to execute the implant's default
-        preprocessing method whenever a new stimulus is assigned, or a custom
+        preprocessing method whenever a stimulus is prepared, or a custom
         function (callable).
     safe_mode : bool, optional
         If safe mode is enabled, only charge-balanced stimuli are allowed.
@@ -194,8 +190,7 @@ class BVT44(ProsthesisSystem):
     # Frozen class: User cannot add more class attributes
     __slots__ = ()
 
-    def __init__(self, x=0, y=0, z=0, rot=0, eye='LE', stim=None,
-                 preprocess=False, safe_mode=False):
+    def __init__(self, x=0, y=0, z=0, rot=0, eye='LE', preprocess=False, safe_mode=False):
         self.eye = eye
         self.preprocess = preprocess
         self.safe_mode = safe_mode
@@ -238,6 +233,3 @@ class BVT44(ProsthesisSystem):
         for x, y, z, r, name in zip(x_arr, y_arr, z_arr, r_arr, names):
             self.earray.add_electrode(name, DiskElectrode(x, y, z, r))
 
-        # Beware of race condition: Stim must be set last, because it requires
-        # indexing into self.electrodes:
-        self.stim = stim

--- a/pulse2percept/implants/cortex/cortivis.py
+++ b/pulse2percept/implants/cortex/cortivis.py
@@ -33,12 +33,9 @@ class Cortivis(ProsthesisSystem):
         Rotation angle of the array (deg). Positive values denote
         counter-clock-wise (CCW) rotations in the retinal coordinate
         system.
-    stim : :py:class:`~pulse2percept.stimuli.Stimulus` source type
-        A valid source type for the :py:class:`~pulse2percept.stimuli.Stimulus`
-        object (e.g., scalar, NumPy array, pulse train).
     preprocess : bool or callable, optional
         Either True/False to indicate whether to execute the implant's default
-        preprocessing method whenever a new stimulus is assigned, or a custom
+        preprocessing method whenever a stimulus is prepared, or a custom
         function (callable).
     safe_mode : bool, optional
         If safe mode is enabled, only charge-balanced stimuli are allowed.
@@ -50,7 +47,7 @@ class Cortivis(ProsthesisSystem):
     >>> from pulse2percept.implants.cortex import Cortivis
     >>> Cortivis() # doctest: +NORMALIZE_WHITESPACE
     Cortivis(earray=ElectrodeGrid, preprocess=False, 
-         safe_mode=False, shape=(10, 10), stim=None)
+         safe_mode=False, shape=(10, 10))
 
     Get access to electrode '11':
 
@@ -64,8 +61,7 @@ class Cortivis(ProsthesisSystem):
 
     # 400um spacing, 80um diameter at base, 10x10
     # depth of shanks: 1.5mm
-    def __init__(self, x=20000, y=-5000, z=0, rot=0, stim=None,
-                 preprocess=False, safe_mode=False):
+    def __init__(self, x=20000, y=-5000, z=0, rot=0, preprocess=False, safe_mode=False):
         # Inspected and offset here, before the grid ever sees it:
         z = as_value(z, um, 'z')
         if not np.isclose(z, 0):
@@ -88,10 +84,6 @@ class Cortivis(ProsthesisSystem):
                                     etype=DiskElectrode)
         for e in ['01', '02', '03', '04']:
             self.earray.remove_electrode(e)
-
-        # Beware of race condition: Stim must be set last, because it requires
-        # indexing into self.electrodes:
-        self.stim = stim
 
     def _pprint_params(self):
         """Return dict of class attributes to pretty-print"""

--- a/pulse2percept/implants/cortex/cortivis.py
+++ b/pulse2percept/implants/cortex/cortivis.py
@@ -61,6 +61,8 @@ class Cortivis(ProsthesisSystem):
 
     # 400um spacing, 80um diameter at base, 10x10
     # depth of shanks: 1.5mm
+    placement = 'intracortical'
+
     def __init__(self, x=20000, y=-5000, z=0, rot=0, preprocess=False, safe_mode=False):
         # Inspected and offset here, before the grid ever sees it:
         z = as_value(z, um, 'z')

--- a/pulse2percept/implants/cortex/icvp.py
+++ b/pulse2percept/implants/cortex/icvp.py
@@ -36,12 +36,9 @@ class ICVP(ProsthesisSystem):
         Rotation angle of the array (deg). Positive values denote
         counter-clock-wise (CCW) rotations in the retinal coordinate
         system.
-    stim : :py:class:`~pulse2percept.stimuli.Stimulus` source type
-        A valid source type for the :py:class:`~pulse2percept.stimuli.Stimulus`
-        object (e.g., scalar, NumPy array, pulse train).
     preprocess : bool or callable, optional
         Either True/False to indicate whether to execute the implant's default
-        preprocessing method whenever a new stimulus is assigned, or a custom
+        preprocessing method whenever a stimulus is prepared, or a custom
         function (callable).
     safe_mode : bool, optional
         If safe mode is enabled, only charge-balanced stimuli are allowed.
@@ -53,7 +50,7 @@ class ICVP(ProsthesisSystem):
     >>> from pulse2percept.implants.cortex import Orion
     >>> ICVP() # doctest: +NORMALIZE_WHITESPACE
     ICVP(earray=ElectrodeGrid, preprocess=False, 
-         safe_mode=False, shape=(5, 4), stim=None)
+         safe_mode=False, shape=(5, 4))
 
     Get access to electrode '11':
 
@@ -74,8 +71,7 @@ class ICVP(ProsthesisSystem):
     # depth of shanks: 650 or 850 um
     # (https://ieeexplore.ieee.org/stamp/stamp.jsp?arnumber=9175335)
 
-    def __init__(self, x=15000, y=0, z=0, rot=0, stim=None,
-                 preprocess=False, safe_mode=False):
+    def __init__(self, x=15000, y=0, z=0, rot=0, preprocess=False, safe_mode=False):
         # Inspected, broadcast and offset here, before the grid ever sees it:
         z = as_value(z, um, 'z')
         if not np.isclose(z, 0):
@@ -112,10 +108,6 @@ class ICVP(ProsthesisSystem):
             self.earray.remove_electrode(e)
 
         self.earray.deactivate(['R', 'C'])
-
-        # Beware of race condition: Stim must be set last, because it requires
-        # indexing into self.electrodes:
-        self.stim = stim
 
     def _pprint_params(self):
         """Return dict of class attributes to pretty-print"""

--- a/pulse2percept/implants/cortex/icvp.py
+++ b/pulse2percept/implants/cortex/icvp.py
@@ -71,6 +71,8 @@ class ICVP(ProsthesisSystem):
     # depth of shanks: 650 or 850 um
     # (https://ieeexplore.ieee.org/stamp/stamp.jsp?arnumber=9175335)
 
+    placement = 'intracortical'
+
     def __init__(self, x=15000, y=0, z=0, rot=0, preprocess=False, safe_mode=False):
         # Inspected, broadcast and offset here, before the grid ever sees it:
         z = as_value(z, um, 'z')

--- a/pulse2percept/implants/cortex/neuralink.py
+++ b/pulse2percept/implants/cortex/neuralink.py
@@ -116,7 +116,8 @@ class EllipsoidElectrode(Electrode):
 
 class NeuralinkThread(ProsthesisSystem, metaclass=ABCMeta):
     """Base class for Neuralink threads"""
-    pass
+
+    placement = 'intracortical'
 
 
 class LinearEdgeThread(NeuralinkThread):
@@ -256,6 +257,8 @@ class LinearEdgeThread(NeuralinkThread):
 
 
 class Neuralink(EnsembleImplant):
+
+    placement = 'intracortical'
 
     @classmethod
     @rename_parameter('xystep', 'step', deprecated_version='0.10.0',

--- a/pulse2percept/implants/cortex/neuralink.py
+++ b/pulse2percept/implants/cortex/neuralink.py
@@ -68,13 +68,11 @@ class EllipsoidElectrode(Electrode):
         
         self.rot, self.angles, self.direction = parse_3d_orient(orient, orient_mode)
 
-
     def _pprint_params(self):
         """Return dict of class attributes to pretty-print"""
         params = super()._pprint_params()
         params.update({'rx': self.rx, 'ry': self.ry, 'rz': self.rz, 'angles': self.angles})
         return params
-
 
     def electric_potential(self, x, y, z, v0):
         raise NotImplementedError
@@ -128,7 +126,7 @@ class LinearEdgeThread(NeuralinkThread):
     def __init__(self, x=0, y=0, z=0, orient=np.array([0,0,1]), orient_mode='direction', 
                  r=5, n_elecs=32, spacing=50, insertion_depth=0, 
                  electrode=EllipsoidElectrode,
-                 stim=None, preprocess=False, safe_mode=False):
+                 preprocess=False, safe_mode=False):
         """
         Neuralink thread
         
@@ -209,8 +207,6 @@ class LinearEdgeThread(NeuralinkThread):
         self.earray = ElectrodeArray(electrodes)
         self.safe_mode = safe_mode
         self.preprocess = preprocess
-        self.stim = stim
-
 
     def _pprint_params(self):
         """Return dict of class attributes to pretty-print"""
@@ -374,7 +370,6 @@ class Neuralink(EnsembleImplant):
             else:
                 direction = rot_direction
 
-
             location = surface_points[:, i]
             name = ''
             j = i
@@ -435,7 +430,7 @@ class Neuralink(EnsembleImplant):
 
     
 
-    def __init__(self, threads, stim=None, preprocess=False, safe_mode=False):
+    def __init__(self, threads, preprocess=False, safe_mode=False):
         """
         Neuralink implant, consisting of one or more 
         :py:class:`~pulse2percept.implants.cortex.NeuralinkThread`s.
@@ -449,12 +444,9 @@ class Neuralink(EnsembleImplant):
         threads : collection of NeuralinkThread
             Collection (list) of NeuralinkThread objects to combine into an \
             implant.
-        stim : :py:class:`~pulse2percept.stimuli.Stimulus` source type
-            A valid source type for the :py:class:`~pulse2percept.stimuli.Stimulus`
-            object (e.g., scalar, NumPy array, pulse train).
         preprocess : bool or callable, optional
             Either True/False to indicate whether to execute the implant's default
-            preprocessing method whenever a new stimulus is assigned, or a custom
+            preprocessing method whenever a stimulus is prepared, or a custom
             function (callable).
         safe_mode : bool, optional
             If safe mode is enabled, only charge-balanced stimuli are allowed.
@@ -467,7 +459,7 @@ class Neuralink(EnsembleImplant):
             for thread in threads:
                 if not isinstance(thread, NeuralinkThread):
                     raise TypeError("threads must be a collection of NeuralinkThread objects")
-        super().__init__(threads, stim=stim, preprocess=preprocess, safe_mode=safe_mode)
+        super().__init__(threads, preprocess=preprocess, safe_mode=safe_mode)
     
     def plot3D(self, ax=None, **kwargs):
         """Plot the implant in 3D space

--- a/pulse2percept/implants/cortex/orion.py
+++ b/pulse2percept/implants/cortex/orion.py
@@ -34,12 +34,9 @@ class Orion(ProsthesisSystem):
         Rotation angle of the array (deg). Positive values denote
         counter-clock-wise (CCW) rotations in the retinal coordinate
         system.
-    stim : :py:class:`~pulse2percept.stimuli.Stimulus` source type
-        A valid source type for the :py:class:`~pulse2percept.stimuli.Stimulus`
-        object (e.g., scalar, NumPy array, pulse train).
     preprocess : bool or callable, optional
         Either True/False to indicate whether to execute the implant's default
-        preprocessing method whenever a new stimulus is assigned, or a custom
+        preprocessing method whenever a stimulus is prepared, or a custom
         function (callable).
     safe_mode : bool, optional
         If safe mode is enabled, only charge-balanced stimuli are allowed.
@@ -51,7 +48,7 @@ class Orion(ProsthesisSystem):
     >>> from pulse2percept.implants.cortex import Orion
     >>> Orion() # doctest: +NORMALIZE_WHITESPACE
     Orion(earray=ElectrodeGrid, preprocess=False, 
-          safe_mode=False, shape=(10, 7), stim=None)
+          safe_mode=False, shape=(10, 7))
 
     Get access to electrode '96':
 
@@ -62,8 +59,7 @@ class Orion(ProsthesisSystem):
     """
     # Frozen class: User cannot add more class attributes
     __slots__ = ('shape',)
-    def __init__(self, x=15000, y=0, z=0, rot=0, stim=None,
-                 preprocess=False, safe_mode=False):
+    def __init__(self, x=15000, y=0, z=0, rot=0, preprocess=False, safe_mode=False):
 
         # This one inspects `z` itself before handing the geometry to
         # ElectrodeGrid, so it cannot rely on the grid to normalize for it:
@@ -87,10 +83,6 @@ class Orion(ProsthesisSystem):
             eobject.name = ename
             electrodes.update({ename: eobject})
         self._earray._electrodes = electrodes
-
-        # Beware of race condition: Stim must be set last, because it requires
-        # indexing into self.electrodes:
-        self.stim = stim
 
     def _pprint_params(self):
         """Return dict of class attributes to pretty-print"""

--- a/pulse2percept/implants/cortex/orion.py
+++ b/pulse2percept/implants/cortex/orion.py
@@ -59,6 +59,8 @@ class Orion(ProsthesisSystem):
     """
     # Frozen class: User cannot add more class attributes
     __slots__ = ('shape',)
+    placement = 'epicortical'
+
     def __init__(self, x=15000, y=0, z=0, rot=0, preprocess=False, safe_mode=False):
 
         # This one inspects `z` itself before handing the geometry to

--- a/pulse2percept/implants/cortex/tests/test_neuralink.py
+++ b/pulse2percept/implants/cortex/tests/test_neuralink.py
@@ -234,7 +234,6 @@ def test_LinearEdgeThread_defaults():
     npt.assert_almost_equal(thread.spacing, 50)
     npt.assert_almost_equal(thread.insertion_depth, 0)
     npt.assert_equal(thread.electrode, EllipsoidElectrode)
-    npt.assert_equal(thread.stim, None)
     npt.assert_equal(thread.safe_mode, False)
     npt.assert_equal(thread.preprocess, False)
     # The thread also sticks out of the cortex, for visualization:
@@ -277,12 +276,12 @@ def test_LinearEdgeThread_custom_electrode():
 
 
 def test_LinearEdgeThread_stim():
-    thread = LinearEdgeThread(n_elecs=3, stim={'0': 1, '2': 3})
-    npt.assert_equal(thread.stim.electrodes, ['0', '2'])
-    npt.assert_almost_equal(thread.stim.data.ravel(), [1, 3])
+    stim = LinearEdgeThread(n_elecs=3).prepare_stim({'0': 1, '2': 3})
+    npt.assert_equal(stim.electrodes, ['0', '2'])
+    npt.assert_almost_equal(stim.data.ravel(), [1, 3])
     # safe_mode rejects stimuli that are not charge-balanced:
     with pytest.raises(ValueError):
-        LinearEdgeThread(n_elecs=3, safe_mode=True, stim={'0': 1})
+        LinearEdgeThread(n_elecs=3, safe_mode=True).prepare_stim({'0': 1})
 
 
 def test_LinearEdgeThread_pprint():
@@ -294,7 +293,7 @@ def test_LinearEdgeThread_pprint():
     npt.assert_equal(params['n_elecs'], 4)
     npt.assert_equal(params['spacing'], 25)
     # Inherited from ProsthesisSystem:
-    npt.assert_equal(params['stim'], None)
+    npt.assert_equal(params['safe_mode'], False)
     npt.assert_equal('LinearEdgeThread' in str(thread), True)
 
 
@@ -334,13 +333,13 @@ def test_Neuralink_requires_threads():
 
 def test_Neuralink_stim():
     nlink = Neuralink({'A': LinearEdgeThread(n_elecs=2),
-                       'B': LinearEdgeThread(500, 500, n_elecs=2)},
-                      stim={'A-0': 1, 'B-1': 2})
-    npt.assert_equal(nlink.stim.electrodes, ['A-0', 'B-1'])
-    npt.assert_almost_equal(nlink.stim.data.ravel(), [1, 2])
+                       'B': LinearEdgeThread(500, 500, n_elecs=2)})
+    stim = nlink.prepare_stim({'A-0': 1, 'B-1': 2})
+    npt.assert_equal(stim.electrodes, ['A-0', 'B-1'])
+    npt.assert_almost_equal(stim.data.ravel(), [1, 2])
     with pytest.raises(ValueError):
-        Neuralink([LinearEdgeThread(n_elecs=2)], safe_mode=True,
-                  stim={'0-0': 1})
+        Neuralink([LinearEdgeThread(n_elecs=2)],
+                  safe_mode=True).prepare_stim({'0-0': 1})
 
 
 def _ax3d():

--- a/pulse2percept/implants/ensemble.py
+++ b/pulse2percept/implants/ensemble.py
@@ -11,7 +11,7 @@ from ..utils import rename_parameter
 class EnsembleImplant(ProsthesisSystem):
     
     # Frozen class: User cannot add more class attributes
-    __slots__ = ('_implants', '_earray', '_stim', 'safe_mode', 'preprocess')
+    __slots__ = ('_implants', '_earray', 'safe_mode', 'preprocess')
 
     @classmethod
     @rename_parameter('xystep', 'step', deprecated_version='0.10.0',
@@ -181,22 +181,19 @@ class EnsembleImplant(ProsthesisSystem):
         
         return cls(implant_list)
 
-    def __init__(self, implants, stim=None, preprocess=False,safe_mode=False):
+    def __init__(self, implants, preprocess=False, safe_mode=False):
         """Ensemble implant
 
         An ensemble implant combines multiple implants into one larger electrode array
         for the purpose of modeling tandem implants, e.g. ICVP, Neuralink
-        
+
         Parameters
         ----------
         implants : list or dict
             A list or dict of implants to be combined.
-        stim : :py:class:`~pulse2percept.stimuli.Stimulus` source type
-            A valid source type for the :py:class:`~pulse2percept.stimuli.Stimulus`
-            object (e.g., scalar, NumPy array, pulse train).
         preprocess : bool or callable, optional
             Either True/False to indicate whether to execute the implant's default
-            preprocessing method whenever a new stimulus is assigned, or a custom
+            preprocessing method whenever a stimulus is prepared, or a custom
             function (callable).
         safe_mode : bool, optional
             If safe mode is enabled, only charge-balanced stimuli are allowed.
@@ -204,14 +201,10 @@ class EnsembleImplant(ProsthesisSystem):
         self.preprocess = preprocess
         self.safe_mode = safe_mode
         self.implants = implants
-        # self.stim might be set in self.implants = implants, so don't override it 
-        # unless the user actually passes a stimulus
-        if stim is not None or not hasattr(self, 'stim'):
-            self.stim = stim
 
     def _pprint_params(self):
         """Return dict of class attributes to pretty-print"""
-        return {'implants': self.implants, 'earray': self.earray, 'stim': self.stim,
+        return {'implants': self.implants, 'earray': self.earray,
                 'safe_mode': self.safe_mode, 'preprocess': self.preprocess}
 
     @property
@@ -243,15 +236,58 @@ class EnsembleImplant(ProsthesisSystem):
                 electrodes[str(i) + "-" + str(name)] = electrode
             
         self._earray = ElectrodeArray(electrodes)
-        self.merge_stimuli()
-        
-    def _structured_children(self):
+
+    def prepare_stim(self, source):
+        """Turn what is presented to the ensemble into what it delivers
+
+        Accepts everything
+        :py:meth:`~pulse2percept.implants.ProsthesisSystem.prepare_stim`
+        does, laid out on the ensemble's combined electrode array, plus one
+        form of its own: a dict keyed by the ensemble's own implant keys, which
+        gives each constituent implant a source of its own. Each is prepared by
+        the implant it belongs to -- with that implant's encoder, raster,
+        thresholds and safety limits -- and the results are merged onto the
+        combined array.
+
+        .. versionchanged:: 0.11.0
+            Replaces ``merge_stimuli``, which read a stimulus stored on each
+            constituent implant. Per-implant input is now named at the call.
+
+        Parameters
+        ----------
+        source : dict or :py:class:`~pulse2percept.stimuli.Stimulus` source type
+            Either one source for the whole ensemble, or ``{implant_key:
+            source}``. A key that is missing contributes zeros.
+
+        Returns
+        -------
+        stim : :py:class:`~pulse2percept.stimuli.Stimulus` or None
+
+        Examples
+        --------
+        >>> import numpy as np
+        >>> from pulse2percept.implants import EnsembleImplant
+        >>> from pulse2percept.implants.cortex import Orion
+        >>> ensemble = EnsembleImplant([Orion(), Orion(x=-35000)])
+        >>> ensemble.prepare_stim({0: np.ones(60),
+        ...                        1: 2 * np.ones(60)}).data.shape
+        (120, 1)
+
+        """
+        if isinstance(source, dict) and source and \
+                all(key in self._implants for key in source):
+            return self._merged({key: implant.prepare_stim(source.get(key))
+                                 for key, implant in self._implants.items()})
+        return super().prepare_stim(source)
+
+    def _structured_children(self, prepared):
         """One source per ensemble electrode, or ``None``"""
         sources = {}
         for i, implant in self._implants.items():
-            if implant.stim is None:
+            stim = prepared.get(i)
+            if stim is None:
                 return None
-            child = implant.stim._structured_sources()
+            child = stim._structured_sources()
             if child is None:
                 return None
             child = {str(e): src for e, src in child}
@@ -265,98 +301,98 @@ class EnsembleImplant(ProsthesisSystem):
         # Ensemble order, not the order the children happened to be built in:
         return {name: sources[name] for name in self.electrode_names}
 
-    def merge_stimuli(self):
-        """Constructs the combined stimulus for all implants in self._implants"""
-        if any([i.stim for i in self._implants.values()]):
-            # An implant with no stimulus contributes zeros and no
-            # interpretation of them, so only the ones that have a stimulus
-            # decide what the merged numbers mean:
-            present = [i.stim for i in self._implants.values()
-                       if i.stim is not None]
-            if len({(s.unit, s.time_unit) for s in present}) > 1:
-                names = ', '.join(sorted({_describe_unit(s.unit)
-                                          for s in present}))
-                raise DimensionMismatchError(
-                    f"Cannot merge stimuli measured in different units "
-                    f"({names}). Convert them to a common unit first.")
+    def _merged(self, prepared):
+        """Combine one prepared stimulus per constituent implant into one"""
+        if not any(stim is not None for stim in prepared.values()):
+            return None
+        # An implant with no stimulus contributes zeros and no
+        # interpretation of them, so only the ones that have a stimulus
+        # decide what the merged numbers mean:
+        present = [stim for stim in prepared.values() if stim is not None]
+        if len({(s.unit, s.time_unit) for s in present}) > 1:
+            names = ', '.join(sorted({_describe_unit(s.unit)
+                                      for s in present}))
+            raise DimensionMismatchError(
+                f"Cannot merge stimuli measured in different units "
+                f"({names}). Convert them to a common unit first.")
 
-            # The metadata of each implant is stored under 'user'; concatenate
-            # those, keyed by which implant they came from:
-            user_metadata = {str(i): implant.stim.metadata['user']
-                             for i, implant in self._implants.items()
-                             if implant.stim is not None}
+        # The metadata of each implant is stored under 'user'; concatenate
+        # those, keyed by which implant they came from:
+        user_metadata = {str(i): stim.metadata['user']
+                         for i, stim in prepared.items()
+                         if stim is not None}
 
-            # runtime import to avoid circular import
-            from ..stimuli import Stimulus
+        # runtime import to avoid circular import
+        from ..stimuli import Stimulus
 
-            sources = self._structured_children()
-            if sources is not None:
-                # Every electrode has a source of its own, so the ensemble is
-                # that collection
-                merged = Stimulus(sources, electrodes=self.electrode_names,
-                                  metadata=user_metadata)
-                self.stim = merged._inherit_units(present[0])
-                return
-
-            # Need to combine all stimuli
-            # The ith stim is a np array of shape (implant[i].n_electrodes, len(times[i]))
-            # i.e. the amplitude of each electrode at each time point in times[i]
-            # HOWEVER, the times are not necessarily the same across implants
-            # So we need to create a new times array that is the union of all times
-            # and then interpolate the stimuli for each implant to this new time array
-            # Also, times[i] can be None if the stim is not temporal; in this case, we
-            # just line it up with the first time point. Finally, if the
-            # stim is none, then we just set it to all 0's, for all the time points
-            stims = []
-            times = []
-            for i, implant in self._implants.items():
-                if implant.stim is not None:
-                    stims.append(implant.stim)
-                    times.append(implant.stim.time)
-                else:
-                    stims.append(None)
-                    times.append(None)
-
-            # Collect all time points, ignoring None
-            valid_times = [t for t in times if t is not None]
-            
-            if valid_times:
-                # Get the union of all time points. Two implants that pulse at
-                # the same instant get there by accumulating their own way, so
-                # an exact `np.unique` would keep both copies and leave the
-                # merged axis with points closer together than DT:
-                t_sorted, starts_group, _ = unique_time_points(valid_times)
-                new_times = t_sorted[starts_group]
-            else:
-                new_times = None  # No time-dependent stimulation
-            
-            # Create a new list to hold interpolated stimuli
-            new_stims = []
-            num_timepoints = len(new_times) if new_times is not None else 1
-            for i, (stim, t) in enumerate(zip(stims, times)):
-                n_electrodes = len(self._implants[list(self._implants.keys())[i]].electrode_names)
-                if stim is None:
-                    # If stim is None, create a zero array of shape (n_electrodes, len(new_times))
-                    new_stim = np.zeros((n_electrodes, num_timepoints))
-                elif t is None:
-                    # If stim exists but has no time information, assume all values correspond to first time point
-                    # fill the rest with 0s
-                    new_stim = np.zeros((n_electrodes, num_timepoints))
-                    new_stim[:, 0] = stim.data[:, 0]
-                else:
-                    # Interpolate the stim data to new_times
-                    new_stim = np.zeros((n_electrodes, len(new_times)))
-                    for j in range(stim.data.shape[0]):  # Interpolate each electrode separately
-                        # if the stim ends, make it 0 instead of repeating the last value. Only interpolate
-                        # for the times that are in the original stim
-                        new_stim[j] = np.interp(new_times, t, stim.data[j], left=0, right=0)
-                
-                new_stims.append(new_stim)
-            
-            # Combine all new_stims into a final array (stack along a new axis if needed)
-            merged = Stimulus(np.concatenate(new_stims), time=new_times,
-                              electrodes=self.electrode_names,
+        sources = self._structured_children(prepared)
+        if sources is not None:
+            # Every electrode has a source of its own, so the ensemble is
+            # that collection
+            merged = Stimulus(sources, electrodes=self.electrode_names,
                               metadata=user_metadata)
-            # The merge concatenates raw data arrays, so the result would
-            # otherwise fall back to the default (current) reading of them:
-            self.stim = merged._inherit_units(present[0])
+            return merged._inherit_units(present[0])
+
+        # Need to combine all stimuli
+        # The ith stim is a np array of shape (implant[i].n_electrodes, len(times[i]))
+        # i.e. the amplitude of each electrode at each time point in times[i]
+        # HOWEVER, the times are not necessarily the same across implants
+        # So we need to create a new times array that is the union of all times
+        # and then interpolate the stimuli for each implant to this new time array
+        # Also, times[i] can be None if the stim is not temporal; in this case, we
+        # just line it up with the first time point. Finally, if the
+        # stim is none, then we just set it to all 0's, for all the time points
+        stims = []
+        times = []
+        for i in self._implants:
+            stim = prepared.get(i)
+            if stim is not None:
+                stims.append(stim)
+                times.append(stim.time)
+            else:
+                stims.append(None)
+                times.append(None)
+
+        # Collect all time points, ignoring None
+        valid_times = [t for t in times if t is not None]
+        
+        if valid_times:
+            # Get the union of all time points. Two implants that pulse at
+            # the same instant get there by accumulating their own way, so
+            # an exact `np.unique` would keep both copies and leave the
+            # merged axis with points closer together than DT:
+            t_sorted, starts_group, _ = unique_time_points(valid_times)
+            new_times = t_sorted[starts_group]
+        else:
+            new_times = None  # No time-dependent stimulation
+        
+        # Create a new list to hold interpolated stimuli
+        new_stims = []
+        num_timepoints = len(new_times) if new_times is not None else 1
+        for i, (stim, t) in enumerate(zip(stims, times)):
+            n_electrodes = len(self._implants[list(self._implants.keys())[i]].electrode_names)
+            if stim is None:
+                # If stim is None, create a zero array of shape (n_electrodes, len(new_times))
+                new_stim = np.zeros((n_electrodes, num_timepoints))
+            elif t is None:
+                # If stim exists but has no time information, assume all values correspond to first time point
+                # fill the rest with 0s
+                new_stim = np.zeros((n_electrodes, num_timepoints))
+                new_stim[:, 0] = stim.data[:, 0]
+            else:
+                # Interpolate the stim data to new_times
+                new_stim = np.zeros((n_electrodes, len(new_times)))
+                for j in range(stim.data.shape[0]):  # Interpolate each electrode separately
+                    # if the stim ends, make it 0 instead of repeating the last value. Only interpolate
+                    # for the times that are in the original stim
+                    new_stim[j] = np.interp(new_times, t, stim.data[j], left=0, right=0)
+            
+            new_stims.append(new_stim)
+        
+        # Combine all new_stims into a final array (stack along a new axis if needed)
+        merged = Stimulus(np.concatenate(new_stims), time=new_times,
+                          electrodes=self.electrode_names,
+                          metadata=user_metadata)
+        # The merge concatenates raw data arrays, so the result would
+        # otherwise fall back to the default (current) reading of them:
+        return merged._inherit_units(present[0])

--- a/pulse2percept/implants/ensemble.py
+++ b/pulse2percept/implants/ensemble.py
@@ -246,8 +246,9 @@ class EnsembleImplant(ProsthesisSystem):
         form of its own: a dict keyed by the ensemble's own implant keys, which
         gives each constituent implant a source of its own. Each is prepared by
         the implant it belongs to -- with that implant's encoder, raster,
-        thresholds and safety limits -- and the results are merged onto the
-        combined array.
+        thresholds and safety limits -- and the merged result then goes through
+        the ensemble's own pipeline, so an ensemble-level ``preprocess`` or
+        ``safe_mode`` still has the last word.
 
         .. versionchanged:: 0.11.0
             Replaces ``merge_stimuli``, which read a stimulus stored on each
@@ -276,8 +277,12 @@ class EnsembleImplant(ProsthesisSystem):
         """
         if isinstance(source, dict) and source and \
                 all(key in self._implants for key in source):
-            return self._merged({key: implant.prepare_stim(source.get(key))
-                                 for key, implant in self._implants.items()})
+            prepared = {key: implant.prepare_stim(source.get(key))
+                        for key, implant in self._implants.items()}
+            # Through the ensemble's own pipeline, not around it: merging is
+            # how the per-implant input becomes one stimulus, not a second way
+            # of preparing one. `None` falls through unchanged.
+            source = self._merged(prepared)
         return super().prepare_stim(source)
 
     def _structured_children(self, prepared):

--- a/pulse2percept/implants/ensemble.py
+++ b/pulse2percept/implants/ensemble.py
@@ -238,31 +238,26 @@ class EnsembleImplant(ProsthesisSystem):
         self._earray = ElectrodeArray(electrodes)
 
     def prepare_stim(self, source):
-        """Turn what is presented to the ensemble into what it delivers
+        """Prepare stimulation for an ensemble implant.
 
-        Accepts everything
-        :py:meth:`~pulse2percept.implants.ProsthesisSystem.prepare_stim`
-        does, laid out on the ensemble's combined electrode array, plus one
-        form of its own: a dict keyed by the ensemble's own implant keys, which
-        gives each constituent implant a source of its own. Each is prepared by
-        the implant it belongs to -- with that implant's encoder, raster,
-        thresholds and safety limits -- and the merged result then goes through
-        the ensemble's own pipeline, so an ensemble-level ``preprocess`` or
-        ``safe_mode`` still has the last word.
+        ``source`` may address the combined electrode array directly, or be a dict
+        keyed by constituent implant keys. Per-implant sources are prepared by each
+        constituent implant, merged, then passed through ensemble-level preprocessing
+        and safety checks. Missing implant keys contribute zeros.
 
         .. versionchanged:: 0.11.0
-            Replaces ``merge_stimuli``, which read a stimulus stored on each
-            constituent implant. Per-implant input is now named at the call.
+            Replaces ``merge_stimuli`` and the stimuli previously stored on
+            constituent implants.
 
         Parameters
         ----------
         source : dict or :py:class:`~pulse2percept.stimuli.Stimulus` source type
-            Either one source for the whole ensemble, or ``{implant_key:
-            source}``. A key that is missing contributes zeros.
+            One source for the whole ensemble, or ``{implant_key: source}``.
 
         Returns
         -------
         stim : :py:class:`~pulse2percept.stimuli.Stimulus` or None
+            Merged stimulation for the ensemble.
 
         Examples
         --------
@@ -273,15 +268,13 @@ class EnsembleImplant(ProsthesisSystem):
         >>> ensemble.prepare_stim({0: np.ones(60),
         ...                        1: 2 * np.ones(60)}).data.shape
         (120, 1)
-
         """
         if isinstance(source, dict) and source and \
                 all(key in self._implants for key in source):
             prepared = {key: implant.prepare_stim(source.get(key))
                         for key, implant in self._implants.items()}
-            # Through the ensemble's own pipeline, not around it: merging is
-            # how the per-implant input becomes one stimulus, not a second way
-            # of preparing one. `None` falls through unchanged.
+            # Merge per-implant results before applying ensemble-level
+            # preprocessing and safety checks.
             source = self._merged(prepared)
         return super().prepare_stim(source)
 

--- a/pulse2percept/implants/imie.py
+++ b/pulse2percept/implants/imie.py
@@ -42,7 +42,7 @@ class IMIE(ProsthesisSystem):
         Eye in which array is implanted.
     preprocess : bool or callable, optional
         Either True/False to indicate whether to execute the implant's default
-        preprocessing method whenever a new stimulus is assigned, or a custom
+        preprocessing method whenever a stimulus is prepared, or a custom
         function (callable).
     safe_mode : bool, optional
         If safe mode is enabled, only charge-balanced stimuli are allowed.
@@ -51,8 +51,7 @@ class IMIE(ProsthesisSystem):
     # Frozen class: User cannot add more class attributes
     __slots__ = ('shape',)
 
-    def __init__(self, x=0, y=0, z=0, rot=0, eye='RE', stim=None,
-                 preprocess=True, safe_mode=False):
+    def __init__(self, x=0, y=0, z=0, rot=0, eye='RE', preprocess=True, safe_mode=False):
         self.eye = eye
         self.preprocess = preprocess
         self.safe_mode = safe_mode
@@ -118,7 +117,6 @@ class IMIE(ProsthesisSystem):
 
         # Beware of race condition: Stim must be set last, because it requires
         # indexing into self.electrodes:   
-        self.stim = stim
 
     def _pprint_params(self):
         """Return dict of class attributes to pretty-print"""

--- a/pulse2percept/implants/imie.py
+++ b/pulse2percept/implants/imie.py
@@ -117,9 +117,6 @@ class IMIE(ProsthesisSystem):
             new_e = DiskElectrode(newx, newy, newz, small_radius, name=elec)
             self.earray.add_electrode(elec, new_e)
 
-        # Beware of race condition: Stim must be set last, because it requires
-        # indexing into self.electrodes:   
-
     def _pprint_params(self):
         """Return dict of class attributes to pretty-print"""
         params = super()._pprint_params()

--- a/pulse2percept/implants/imie.py
+++ b/pulse2percept/implants/imie.py
@@ -51,6 +51,8 @@ class IMIE(ProsthesisSystem):
     # Frozen class: User cannot add more class attributes
     __slots__ = ('shape',)
 
+    placement = 'epiretinal'
+
     def __init__(self, x=0, y=0, z=0, rot=0, eye='RE', preprocess=True, safe_mode=False):
         self.eye = eye
         self.preprocess = preprocess

--- a/pulse2percept/implants/prima.py
+++ b/pulse2percept/implants/prima.py
@@ -132,6 +132,8 @@ class PRIMA(ProsthesisSystem):
     # Frozen class: User cannot add more class attributes
     __slots__ = ('shape', 'spacing', 'trench')
 
+    placement = 'subretinal'
+
     def __init__(self, x=0, y=0, z=-100, rot=0, eye='RE', preprocess=False, safe_mode=False):
         # 85 um pixels with 15 um trenches, 28 um active electrode:
         self.trench = 15  # um
@@ -228,6 +230,8 @@ class PRIMA75(ProsthesisSystem):
     """
     # Frozen class: User cannot add more class attributes
     __slots__ = ('shape', 'spacing', 'trench')
+
+    placement = 'subretinal'
 
     def __init__(self, x=0, y=0, z=-100, rot=0, eye='RE', preprocess=False, safe_mode=False):
         # 70 um pixels with 5 um trenches, 20 um active electrode:
@@ -333,6 +337,8 @@ class PRIMA55(ProsthesisSystem):
     """
     # Frozen class: User cannot add more class attributes
     __slots__ = ('shape', 'spacing', 'trench')
+
+    placement = 'subretinal'
 
     def __init__(self, x=0, y=0, z=-100, rot=0, eye='RE', preprocess=False, safe_mode=False):
         # 50 um pixels with 5 um trenches, 16 um active electrode:
@@ -443,6 +449,8 @@ class PRIMA40(ProsthesisSystem):
     """
     # Frozen class: User cannot add more class attributes
     __slots__ = ('shape', 'spacing', 'trench')
+
+    placement = 'subretinal'
 
     def __init__(self, x=0, y=0, z=-100, rot=0, eye='RE', preprocess=False, safe_mode=False):
         # 35 um pixels with 5 um trenches, 16 um active electrode:

--- a/pulse2percept/implants/prima.py
+++ b/pulse2percept/implants/prima.py
@@ -118,7 +118,7 @@ class PRIMA(ProsthesisSystem):
         Eye in which array is implanted.
     preprocess : bool or callable, optional
         Either True/False to indicate whether to execute the implant's default
-        preprocessing method whenever a new stimulus is assigned, or a custom
+        preprocessing method whenever a stimulus is prepared, or a custom
         function (callable).
     safe_mode : bool, optional
         If safe mode is enabled, only charge-balanced stimuli are allowed.
@@ -132,8 +132,7 @@ class PRIMA(ProsthesisSystem):
     # Frozen class: User cannot add more class attributes
     __slots__ = ('shape', 'spacing', 'trench')
 
-    def __init__(self, x=0, y=0, z=-100, rot=0, eye='RE', stim=None,
-                 preprocess=False, safe_mode=False):
+    def __init__(self, x=0, y=0, z=-100, rot=0, eye='RE', preprocess=False, safe_mode=False):
         # 85 um pixels with 15 um trenches, 28 um active electrode:
         self.trench = 15  # um
         self.spacing = 100  # um
@@ -181,9 +180,6 @@ class PRIMA(ProsthesisSystem):
             for elec, z_elec in zip(self.earray.electrode_objects, z):
                 elec.z = z_elec
 
-        # Beware of race condition: Stim must be set last, because it requires
-        # indexing into self.electrodes:
-        self.stim = stim
 
 
 class PRIMA75(ProsthesisSystem):
@@ -224,7 +220,7 @@ class PRIMA75(ProsthesisSystem):
         Eye in which array is implanted.
     preprocess : bool or callable, optional
         Either True/False to indicate whether to execute the implant's default
-        preprocessing method whenever a new stimulus is assigned, or a custom
+        preprocessing method whenever a stimulus is prepared, or a custom
         function (callable).
     safe_mode : bool, optional
         If safe mode is enabled, only charge-balanced stimuli are allowed.
@@ -233,8 +229,7 @@ class PRIMA75(ProsthesisSystem):
     # Frozen class: User cannot add more class attributes
     __slots__ = ('shape', 'spacing', 'trench')
 
-    def __init__(self, x=0, y=0, z=-100, rot=0, eye='RE', stim=None,
-                 preprocess=False, safe_mode=False):
+    def __init__(self, x=0, y=0, z=-100, rot=0, eye='RE', preprocess=False, safe_mode=False):
         # 70 um pixels with 5 um trenches, 20 um active electrode:
         self.spacing = 75  # um
         self.trench = 5  # um
@@ -285,9 +280,6 @@ class PRIMA75(ProsthesisSystem):
             for elec, z_elec in zip(self.earray.electrode_objects, z):
                 elec.z = z_elec
 
-        # Beware of race condition: Stim must be set last, because it requires
-        # indexing into self.electrodes:
-        self.stim = stim
 
 
 class PRIMA55(ProsthesisSystem):
@@ -333,7 +325,7 @@ class PRIMA55(ProsthesisSystem):
         Eye in which array is implanted.
     preprocess : bool or callable, optional
         Either True/False to indicate whether to execute the implant's default
-        preprocessing method whenever a new stimulus is assigned, or a custom
+        preprocessing method whenever a stimulus is prepared, or a custom
         function (callable).
     safe_mode : bool, optional
         If safe mode is enabled, only charge-balanced stimuli are allowed.
@@ -342,8 +334,7 @@ class PRIMA55(ProsthesisSystem):
     # Frozen class: User cannot add more class attributes
     __slots__ = ('shape', 'spacing', 'trench')
 
-    def __init__(self, x=0, y=0, z=-100, rot=0, eye='RE', stim=None,
-                 preprocess=False, safe_mode=False):
+    def __init__(self, x=0, y=0, z=-100, rot=0, eye='RE', preprocess=False, safe_mode=False):
         # 50 um pixels with 5 um trenches, 16 um active electrode:
         self.spacing = 55  # um
         self.trench = 5
@@ -399,9 +390,6 @@ class PRIMA55(ProsthesisSystem):
             for elec, z_elec in zip(self.earray.electrode_objects, z):
                 elec.z = z_elec
 
-        # Beware of race condition: Stim must be set last, because it requires
-        # indexing into self.electrodes:
-        self.stim = stim
 
 
 class PRIMA40(ProsthesisSystem):
@@ -447,7 +435,7 @@ class PRIMA40(ProsthesisSystem):
         Eye in which array is implanted.
     preprocess : bool or callable, optional
         Either True/False to indicate whether to execute the implant's default
-        preprocessing method whenever a new stimulus is assigned, or a custom
+        preprocessing method whenever a stimulus is prepared, or a custom
         function (callable).
     safe_mode : bool, optional
         If safe mode is enabled, only charge-balanced stimuli are allowed.
@@ -456,8 +444,7 @@ class PRIMA40(ProsthesisSystem):
     # Frozen class: User cannot add more class attributes
     __slots__ = ('shape', 'spacing', 'trench')
 
-    def __init__(self, x=0, y=0, z=-100, rot=0, eye='RE', stim=None,
-                 preprocess=False, safe_mode=False):
+    def __init__(self, x=0, y=0, z=-100, rot=0, eye='RE', preprocess=False, safe_mode=False):
         # 35 um pixels with 5 um trenches, 16 um active electrode:
         self.spacing = 40  # um
         self.trench = 5  # um
@@ -520,6 +507,3 @@ class PRIMA40(ProsthesisSystem):
             for elec, z_elec in zip(self.earray.electrode_objects, z):
                 elec.z = z_elec
 
-        # Beware of race condition: Stim must be set last, because it requires
-        # indexing into self.electrodes:
-        self.stim = stim

--- a/pulse2percept/implants/tests/test_argus.py
+++ b/pulse2percept/implants/tests/test_argus.py
@@ -97,15 +97,15 @@ def test_ArgusI(ztype, x, y, rot):
     npt.assert_equal(argus.electrode_names[15], 'M1')
     npt.assert_equal(argus.electrode_names[0], 'L6')
 
-    # Set a stimulus via dict:
-    argus = implants.ArgusI(stim={'B3': 13})
-    npt.assert_equal(argus.stim.shape, (1, 1))
-    npt.assert_equal(argus.stim.electrodes, ['B3'])
+    # Prepare a stimulus via dict:
+    stim = implants.ArgusI().prepare_stim({'B3': 13})
+    npt.assert_equal(stim.shape, (1, 1))
+    npt.assert_equal(stim.electrodes, ['B3'])
 
-    # Set a stimulus via array:
-    argus = implants.ArgusI(stim=np.ones(16))
-    npt.assert_equal(argus.stim.shape, (16, 1))
-    npt.assert_almost_equal(argus.stim.data, 1)
+    # Prepare a stimulus via array:
+    stim = implants.ArgusI().prepare_stim(np.ones(16))
+    npt.assert_equal(stim.shape, (16, 1))
+    npt.assert_almost_equal(stim.data, 1)
 
 
 @pytest.mark.parametrize('ztype', ('float', 'list'))
@@ -181,15 +181,15 @@ def test_ArgusII(ztype, x, y, rot):
         npt.assert_equal(after[el].x < before[el].x, True)
         npt.assert_equal(after[el].y > before[el].y, True)
 
-    # Set a stimulus via dict:
-    argus = implants.ArgusII(stim={'B7': 13})
-    npt.assert_equal(argus.stim.shape, (1, 1))
-    npt.assert_equal(argus.stim.electrodes, ['B7'])
+    # Prepare a stimulus via dict:
+    stim = implants.ArgusII().prepare_stim({'B7': 13})
+    npt.assert_equal(stim.shape, (1, 1))
+    npt.assert_equal(stim.electrodes, ['B7'])
 
-    # Set a stimulus via array:
-    argus = implants.ArgusII(stim=np.ones(60))
-    npt.assert_equal(argus.stim.shape, (60, 1))
-    npt.assert_almost_equal(argus.stim.data, 1)
+    # Prepare a stimulus via array:
+    stim = implants.ArgusII().prepare_stim(np.ones(60))
+    npt.assert_equal(stim.shape, (60, 1))
+    npt.assert_almost_equal(stim.data, 1)
 
 
 def test_ArgusII_defaults():
@@ -223,16 +223,16 @@ def test_ArgusII_defaults():
     npt.assert_equal(implants.ArgusII(raster=None).encoder is None, False)
     # ... and switching the raster off really does stop the multiplexing: every
     # electrode then fires on the same schedule, at the same instant.
-    unrastered = implants.ArgusII(raster=None, stim=LogoBVL())
-    npt.assert_equal(unrastered.stim.metadata['encoder']['cycle'], None)
+    unrastered = implants.ArgusII(raster=None).prepare_stim(LogoBVL())
+    npt.assert_equal(unrastered.metadata['encoder']['cycle'], None)
     # There is an instant at which every electrode is at its own peak, so the
     # stimulator has to source the whole array at once:
-    npt.assert_almost_equal(np.abs(unrastered.stim.data).sum(axis=0).max(),
-                            np.abs(unrastered.stim.data).max(axis=1).sum(),
+    npt.assert_almost_equal(np.abs(unrastered.data).sum(axis=0).max(),
+                            np.abs(unrastered.data).max(axis=1).sum(),
                             decimal=3)
-    rastered = implants.ArgusII(stim=LogoBVL())
-    npt.assert_array_less(np.abs(rastered.stim.data).sum(axis=0).max(),
-                          np.abs(unrastered.stim.data).sum(axis=0).max())
+    rastered = implants.ArgusII().prepare_stim(LogoBVL())
+    npt.assert_array_less(np.abs(rastered.data).sum(axis=0).max(),
+                          np.abs(unrastered.data).sum(axis=0).max())
     # ... and either can be replaced outright:
     custom = implants.ArgusII(encoder=AmplitudeEncoder(freq=20),
                               raster=SequentialRaster(3))
@@ -244,41 +244,42 @@ def test_ArgusII_defaults():
         implants.ArgusII(raster='line')
 
 
-def test_ArgusII_encodes_pictures_on_assignment():
-    """The device's own defaults are what make `ArgusII(stim=picture)` work"""
-    argus = implants.ArgusII(stim=LogoBVL())
-    npt.assert_equal(argus.stim.unit, uA)
-    npt.assert_equal(argus.stim.shape[0], argus.n_electrodes)
-    npt.assert_equal(list(argus.stim.electrodes), list(argus.electrode_names))
+def test_ArgusII_encodes_pictures_on_preparation():
+    """The device's own defaults are what make `prepare_stim(picture)` work"""
+    argus = implants.ArgusII()
+    stim = argus.prepare_stim(LogoBVL())
+    npt.assert_equal(stim.unit, uA)
+    npt.assert_equal(stim.shape[0], argus.n_electrodes)
+    npt.assert_equal(list(stim.electrodes), list(argus.electrode_names))
     # 6 Hz over the 500 ms an image is treated as lasting is three pulses:
-    npt.assert_almost_equal(argus.stim.time[-1], 500)
-    npt.assert_almost_equal(np.abs(argus.stim.data).max(), 50, decimal=4)
+    npt.assert_almost_equal(stim.time[-1], 500)
+    npt.assert_almost_equal(np.abs(stim.data).max(), 50, decimal=4)
     # The raster is in there too: six groups, each 2 ms behind the one before:
-    npt.assert_almost_equal(argus.stim.metadata['encoder']['cycle'], 12)
+    npt.assert_almost_equal(stim.metadata['encoder']['cycle'], 12)
     # ... which is what a raster is for: at no instant is more than one group
     # of electrodes drawing current.
-    groups = argus.raster.groups(argus.stim.electrodes)
-    for column in argus.stim.data.T:
+    groups = argus.raster.groups(stim.electrodes)
+    for column in stim.data.T:
         npt.assert_equal(np.unique(groups[column != 0]).size <= 1, True)
 
     # A video keeps its own frame clock, which is what a model reports at:
     with pytest.warns(UserWarning, match='deliver no pulse'):
         # 6 Hz against 29.97 fps: most frames carry no pulse of their own
-        argus = implants.ArgusII(stim=BostonTrain())
-    npt.assert_equal(argus.stim.unit, uA)
-    meta = argus.stim.metadata['encoder']
+        stim = argus.prepare_stim(BostonTrain())
+    npt.assert_equal(stim.unit, uA)
+    meta = stim.metadata['encoder']
     npt.assert_equal(meta['frame_time'].size, 94)
     npt.assert_almost_equal(meta['frame_dur'], 1000 / 29.97, decimal=3)
 
     # Without an encoder the very same picture is refused, since there is no
     # default mapping from a gray level onto an amplitude:
     with pytest.raises(DimensionMismatchError):
-        implants.ArgusII(encoder=None, stim=LogoBVL())
+        implants.ArgusII(encoder=None).prepare_stim(LogoBVL())
 
     # And the whole point of it: a picture goes straight into a model, with no
     # encoding step for the caller to spell out.
-    model = AxonMapModel(xrange=(-4, 4), yrange=(-3, 3), step=1, rho=200,
-                         lam=100).build()
-    percept = model.predict_percept(implants.ArgusII(stim=LogoBVL()))
+    model = AxonMapModel(implant=argus, xrange=(-4, 4), yrange=(-3, 3), step=1,
+                         rho=200, lam=100).build()
+    percept = model.predict_percept(LogoBVL())
     npt.assert_equal(percept.data.shape[:2], model.grid.x.shape)
     npt.assert_equal(np.any(percept.data > 0), True)

--- a/pulse2percept/implants/tests/test_base.py
+++ b/pulse2percept/implants/tests/test_base.py
@@ -1063,3 +1063,28 @@ def test_ProsthesisSystem_partial_calibration_of_xTh_is_refused():
     stim = implant.prepare_stim(uA_source)
     factors = [src.amp_factor for _, src in stim._structured_sources()]
     npt.assert_equal(factors, [2, None])
+
+
+@pytest.mark.parametrize('cls,expected', [
+    (implants.ArgusII, 'epiretinal'),
+    (implants.IMIE, 'epiretinal'),
+    (implants.AlphaAMS, 'subretinal'),
+    (implants.PRIMA75, 'subretinal'),
+    (implants.BVT24, 'suprachoroidal'),
+    (cortex.Orion, 'epicortical'),
+    (cortex.Cortivis, 'intracortical'),
+    (cortex.ICVP, 'intracortical'),
+])
+def test_named_devices_say_where_they_sit(cls, expected):
+    npt.assert_equal(cls.placement, expected)
+    npt.assert_equal(cls().placement, expected)
+
+
+def test_a_generic_array_says_nothing_about_placement():
+    # `placement` records what the literature is unambiguous about; a bare
+    # grid of electrodes is a shape, not a device, and models read `None` as
+    # "no claim" rather than as a placement of its own.
+    npt.assert_equal(implants.GridImplant(shape=(2, 2), spacing=500).placement, None)
+    npt.assert_equal(
+        implants.ProsthesisSystem(implants.PointSource(0, 0, 0)).placement,
+        None)

--- a/pulse2percept/implants/tests/test_base.py
+++ b/pulse2percept/implants/tests/test_base.py
@@ -25,7 +25,7 @@ from pulse2percept.models import ScoreboardModel
 
 class PhotovoltaicArray(ProsthesisSystem):
     def __init__(self, x=0, y=0, z=-100, r=5, spacing=40, rot=0,
-                 stim=None, preprocess=False, safe_mode=False):
+                 preprocess=False, safe_mode=False):
         # 35 um pixels with 5 um trenches, 16 um active electrode:
         self.spacing = spacing  # um
         self.trench = 5  # um
@@ -49,10 +49,6 @@ class PhotovoltaicArray(ProsthesisSystem):
         for e in rm_names:
             self.earray.remove_electrode(e)
 
-        # Beware of race condition: Stim must be set last, because it requires
-        # indexing into self.electrodes:
-        self.stim = stim
-
 
 def test_ProsthesisSystem():
     # Invalid instantiations:
@@ -70,13 +66,12 @@ def test_ProsthesisSystem():
     for i, e in zip(implant, implant.earray):
         npt.assert_equal(i, e)
 
-    # Set a stimulus after the constructor:
-    npt.assert_equal(implant.stim, None)
-    implant.stim = 3
-    npt.assert_equal(isinstance(implant.stim, Stimulus), True)
-    npt.assert_equal(implant.stim.shape, (1, 1))
-    npt.assert_equal(implant.stim.time, None)
-    npt.assert_equal(implant.stim.electrodes, [0])
+    # Prepare a stimulus:
+    stim = implant.prepare_stim(3)
+    npt.assert_equal(isinstance(stim, Stimulus), True)
+    npt.assert_equal(stim.shape, (1, 1))
+    npt.assert_equal(stim.time, None)
+    npt.assert_equal(stim.electrodes, [0])
 
     plt.cla()
     ax = implant.plot()
@@ -85,51 +80,50 @@ def test_ProsthesisSystem():
 
     with pytest.raises(ValueError):
         # Wrong number of stimuli
-        implant.stim = [1, 2]
+        implant.prepare_stim([1, 2])
     with pytest.raises(TypeError):
         # Invalid stim type:
-        implant.stim = "stim"
+        implant.prepare_stim("stim")
     # Invalid electrode names:
     with pytest.raises(ValueError):
-        implant.stim = {'A1': 1}
+        implant.prepare_stim({'A1': 1})
     with pytest.raises(ValueError):
-        implant.stim = Stimulus({'A1': 1})
+        implant.prepare_stim(Stimulus({'A1': 1}))
     # Safe mode requires charge-balanced pulses:
     with pytest.raises(ValueError):
         implant = ProsthesisSystem(PointSource(0, 0, 0), safe_mode=True)
-        implant.stim = 1
+        implant.prepare_stim(1)
 
     # Slots:
     npt.assert_equal(hasattr(implant, '__slots__'), True)
     npt.assert_equal(hasattr(implant, '__dict__'), False)
 
 
-def test_ProsthesisSystem_stim():
+def test_ProsthesisSystem_prepare_stim():
     implant = ProsthesisSystem(ElectrodeGrid((13, 13), 20))
-    stim = Stimulus(np.ones((13 * 13 + 1, 5)))
     with pytest.raises(ValueError):
-        implant.stim = stim
+        implant.prepare_stim(Stimulus(np.ones((13 * 13 + 1, 5))))
 
-    # make sure empty stimulus causes None stim
-    implant.stim = []
-    npt.assert_equal(implant.stim, None)
-    implant.stim = {}
-    npt.assert_equal(implant.stim, None)
-    implant.stim = np.array([])
-    npt.assert_equal(implant.stim, None)
+    # make sure an empty source prepares to None
+    npt.assert_equal(implant.prepare_stim(None), None)
+    npt.assert_equal(implant.prepare_stim([]), None)
+    npt.assert_equal(implant.prepare_stim({}), None)
+    npt.assert_equal(implant.prepare_stim(np.array([])), None)
 
     # color mapping
-    stim = np.zeros((13*13, 5))
-    stim[84, 0] = 1
-    stim[98, 2] = 2
-    implant.stim = stim
+    source = np.zeros((13*13, 5))
+    source[84, 0] = 1
+    source[98, 2] = 2
     plt.cla()
-    ax = implant.plot(stim_cmap='hsv')
+    ax = implant.plot(stim=source, stim_cmap='hsv')
     plt.colorbar()
     npt.assert_equal(len(ax.collections), 1)
     npt.assert_equal(ax.collections[0].colorbar.vmax, 2)
     npt.assert_equal(ax.collections[0].cmap(ax.collections[0].norm(1)),
                      (0.0, 1.0, 0.9647031631761764, 1))
+    # `stim_cmap` has nothing to color without a stimulus to prepare:
+    with pytest.raises(ValueError):
+        implant.plot(stim_cmap='hsv')
     # make sure default behaviour unchanged
     plt.cla()
     ax = implant.plot()
@@ -137,19 +131,38 @@ def test_ProsthesisSystem_stim():
     npt.assert_equal(len(ax.collections), 1)
     npt.assert_equal(ax.collections[0].colorbar.vmax, 1)
     npt.assert_equal(ax.collections[0].cmap(ax.collections[0].norm(1)),
-                     (0.993248, 0.906157, 0.143936, 1))  
+                     (0.993248, 0.906157, 0.143936, 1))
 
     # Deactivated electrodes cannot receive stimuli:
     implant.deactivate('H4')
     npt.assert_equal(implant['H4'].activated, False)
-    implant.stim = {'H4': 1}
-    npt.assert_equal('H4' in implant.stim.electrodes, False)
+    npt.assert_equal('H4' in implant.prepare_stim({'H4': 1}).electrodes, False)
 
     implant.deactivate('all')
-    npt.assert_equal(implant.stim.data.size == 0, True)
+    npt.assert_equal(implant.prepare_stim(source).data.size == 0, True)
     implant.activate('all')
-    implant.stim = {'H4': 1}
-    npt.assert_equal('H4' in implant.stim.electrodes, True)
+    npt.assert_equal('H4' in implant.prepare_stim({'H4': 1}).electrodes, True)
+
+
+def test_ProsthesisSystem_prepare_stim_is_stateless():
+    """Preparing leaves neither the implant nor the caller's source changed"""
+    implant = ArgusII(preprocess=False)
+    source = Stimulus({'A1': 10, 'B2': 20})
+    first = implant.prepare_stim(source)
+    # The result is a copy, so the caller can keep using their own object:
+    npt.assert_equal(first is source, False)
+    npt.assert_almost_equal(first.data, source.data)
+
+    # Two calls with different input do not leak into one another:
+    second = implant.prepare_stim({'C3': 30})
+    npt.assert_equal(sorted(str(e) for e in first.electrodes), ['A1', 'B2'])
+    npt.assert_equal([str(e) for e in second.electrodes], ['C3'])
+    npt.assert_equal(hasattr(implant, 'stim'), False)
+    npt.assert_equal(hasattr(implant, '_stim'), False)
+
+    # And the same source prepares to the same thing every time:
+    again = implant.prepare_stim(source)
+    npt.assert_almost_equal(again.data, first.data)
 
 
 @pytest.mark.parametrize('rot', (0, 30, 92))
@@ -157,7 +170,7 @@ def test_ProsthesisSystem_stim():
 @pytest.mark.parametrize('n_frames', (1, 3, 4))
 def test_ProsthesisSystem_reshape_stim(rot, gtype, n_frames):
     implant = ProsthesisSystem(ElectrodeGrid((10, 10), 30, rot=rot, type=gtype))
-    # Smoke test the reshaping. It is called on the way to `implant.stim`, but
+    # Smoke test the reshaping. It runs inside `prepare_stim`, but
     # a picture is not a stimulus an implant can deliver, so it is exercised
     # directly here (which is also how an encoder reaches it):
     n_px = 21
@@ -180,10 +193,11 @@ def test_ProsthesisSystem_reshape_stim(rot, gtype, n_frames):
     data = np.zeros((50, 50))
     data[20:-20, 10:-10] = 1
     sampled = implant.reshape_stim(ImageStimulus(data))
-    implant.stim = Stimulus(sampled.data, electrodes=sampled.electrodes)
-    model = ScoreboardModel(xrange=(-1, 1), yrange=(-1, 1), rho=30, step=0.02)
+    stim = Stimulus(sampled.data, electrodes=sampled.electrodes)
+    model = ScoreboardModel(implant=implant, xrange=(-1, 1), yrange=(-1, 1),
+                            rho=30, step=0.02)
     model.build()
-    percept = label(model.predict_percept(implant).data.squeeze().T > 0.2)
+    percept = label(model.predict_percept(stim).data.squeeze().T > 0.2)
     npt.assert_almost_equal(regionprops(percept)[0].orientation, 0, decimal=1)
 
     # Smoke test a large hex grid (old code results in MemoryError):
@@ -193,12 +207,14 @@ def test_ProsthesisSystem_reshape_stim(rot, gtype, n_frames):
 
 def test_ProsthesisSystem_deactivate():
     implant = ProsthesisSystem(ElectrodeGrid((10, 10), 30))
-    implant.stim = np.ones(implant.n_electrodes)
+    source = np.ones(implant.n_electrodes)
     electrode = 'A3'
-    npt.assert_equal(electrode in implant.stim.electrodes, True)
+    npt.assert_equal(electrode in implant.prepare_stim(source).electrodes, True)
     implant.deactivate(electrode)
     npt.assert_equal(implant[electrode].activated, False)
-    npt.assert_equal(electrode in implant.stim.electrodes, False)
+    # Deactivating affects the next preparation, not one already handed out:
+    npt.assert_equal(electrode in implant.prepare_stim(source).electrodes,
+                     False)
 
 @pytest.mark.parametrize('ztype', ('float', 'list'))
 @pytest.mark.parametrize('x', (-100, 200))
@@ -264,15 +280,15 @@ def test_rectangle_implant(ztype, x, y, rot):
         npt.assert_equal(after[el].x < before[el].x, True)
         npt.assert_equal(after[el].y > before[el].y, True)
 
-    # Set a stimulus via dict:
-    implant = RectangleImplant(stim={'B7': 13})
-    npt.assert_equal(implant.stim.shape, (1, 1))
-    npt.assert_equal(implant.stim.electrodes, ['B7'])
+    # Prepare a stimulus via dict:
+    stim = RectangleImplant().prepare_stim({'B7': 13})
+    npt.assert_equal(stim.shape, (1, 1))
+    npt.assert_equal(stim.electrodes, ['B7'])
 
-    # Set a stimulus via array:
-    implant = RectangleImplant(stim=np.ones(225))
-    npt.assert_equal(implant.stim.shape, (225, 1))
-    npt.assert_almost_equal(implant.stim.data, 1)
+    # Prepare a stimulus via array:
+    stim = RectangleImplant().prepare_stim(np.ones(225))
+    npt.assert_equal(stim.shape, (225, 1))
+    npt.assert_almost_equal(stim.data, 1)
 
     # test different shapes
     for shape in [(6, 10), (5, 12), (15, 15)]:
@@ -370,11 +386,11 @@ def test_GridImplant_device_arguments_reach_ProsthesisSystem():
     encoder = AmplitudeEncoder(amp_range=(0, 20))
     raster = implants.SequentialRaster(2)
     implant = GridImplant((2, 3), 100, eye='LE',
-                          stim={'A1': BiphasicPulse(10, 1)},
                           preprocess=True, safe_mode=True, encoder=encoder,
                           raster=raster, max_current=100)
     npt.assert_equal(implant.eye, 'LE')
-    npt.assert_equal(implant.stim.electrodes, ['A1'])
+    npt.assert_equal(
+        implant.prepare_stim({'A1': BiphasicPulse(10, 1)}).electrodes, ['A1'])
     npt.assert_equal(implant.preprocess, True)
     npt.assert_equal(implant.safe_mode, True)
     npt.assert_equal(implant.encoder, encoder)
@@ -420,14 +436,14 @@ def test_ProsthesisSystem_reshape_stim_frames_independent():
 
 
 def test_ProsthesisSystem_rgb_video_stim():
-    """An RGB video can be assigned to an implant directly (Issue #802)"""
+    """An RGB video can be presented to an implant directly (Issue #802)"""
     n_frames = 4
     vid = VideoStimulus(np.random.default_rng(0).random((6, 10, 3, n_frames)),
                         metadata={'fps': 20})
     implant = ArgusII(encoder=AmplitudeEncoder(amp_range=(0, 20)))
-    implant.stim = vid
-    npt.assert_equal(len(implant.stim.electrodes), implant.n_electrodes)
-    npt.assert_equal(implant.stim._spatial_view().shape,
+    stim = implant.prepare_stim(vid)
+    npt.assert_equal(len(stim.electrodes), implant.n_electrodes)
+    npt.assert_equal(stim._spatial_view().shape,
                      (implant.n_electrodes, n_frames))
 
 
@@ -544,9 +560,9 @@ def test_ProsthesisSystem_max_current_units():
 def test_ProsthesisSystem_safety_checks_are_electrical():
     """Electrical safety may only be asked about an electrical stimulus
 
-    In the ordinary flow the setter has already refused anything that is not a
-    current (see ``test_ProsthesisSystem_requires_an_electrical_stimulus``), so
-    these guards are reached by calling ``check_stim`` directly -- which is
+    In the ordinary flow ``prepare_stim`` has already refused anything that is
+    not a current (see ``test_ProsthesisSystem_requires_an_electrical_stimulus``),
+    so these guards are reached by calling ``check_stim`` directly -- which is
     public, and which a subclass may call on a stimulus of its own making.
     """
     img = ImageStimulus(np.linspace(0, 1, 16).reshape((4, 4)))
@@ -580,7 +596,7 @@ def test_ProsthesisSystem_safety_checks_are_electrical():
 def test_ProsthesisSystem_requires_an_electrical_stimulus():
     """An implant delivers current, so a picture it cannot encode is refused
 
-    Not when a model eventually reads it: the assignment is the line that was
+    Not when a model eventually reads it: the preparation is the line that was
     wrong, and without an encoder there is no principled default mapping from a
     gray level onto an amplitude or a frequency for the implant to apply on the
     user's behalf.
@@ -590,44 +606,39 @@ def test_ProsthesisSystem_requires_an_electrical_stimulus():
 
     for source in (img, VideoStimulus(np.ones((6, 10, 3)) * 0.5,
                                       time=[0, 20, 40]), BostonTrain()):
+        implant = ArgusII(encoder=None)
         with pytest.raises(DimensionMismatchError) as excinfo:
-            ArgusII(encoder=None, stim=source)
+            implant.prepare_stim(source)
         npt.assert_equal('encoder' in str(excinfo.value), True)
         npt.assert_equal('dimensionless' in str(excinfo.value), True)
-        implant = ArgusII(encoder=None)
-        with pytest.raises(DimensionMismatchError):
-            implant.stim = source
-        # Nothing was stored, so the implant is left as it was:
-        npt.assert_equal(implant.stim, None)
         # A generic system has no encoder either:
         with pytest.raises(DimensionMismatchError):
-            ProsthesisSystem(ArgusII().earray, stim=source)
+            ProsthesisSystem(ArgusII().earray).prepare_stim(source)
 
     # Encoded, the very same picture goes through:
     implant = ArgusII(encoder=None)
-    implant.stim = AmplitudeEncoder(amp_range=(0, 50)).encode(img,
-                                                              implant=implant)
-    npt.assert_equal(implant.stim.unit, uA)
+    encoded = AmplitudeEncoder(amp_range=(0, 50)).encode(img, implant=implant)
+    npt.assert_equal(implant.prepare_stim(encoded).unit, uA)
 
     # ... and so does everything that was electrical all along:
     for source in ({'A1': 20}, np.ones(60),
                    {'A1': BiphasicPulse(0.02 * mA, 0.45, stim_dur=50)}):
-        implant = ArgusII(stim=source)
-        npt.assert_equal(implant.stim.unit, uA)
+        npt.assert_equal(ArgusII().prepare_stim(source).unit, uA)
     for source in (20, BiphasicPulse(20, 0.45, stim_dur=50)):
-        single = ProsthesisSystem(DiskElectrode(0, 0, 0, 100), stim=source)
-        npt.assert_equal(single.stim.unit, uA)
+        single = ProsthesisSystem(DiskElectrode(0, 0, 0, 100))
+        npt.assert_equal(single.prepare_stim(source).unit, uA)
 
     # A subclass may declare that it delivers something else, in which case a
     # picture is already what it delivers and the encoder stays out of it:
     class Projector(ArgusII):
         stimulus_unit = dimensionless
 
-    npt.assert_equal(Projector(stim=img).stim.unit, dimensionless)
+    npt.assert_equal(Projector().prepare_stim(img).unit, dimensionless)
 
 
 def test_ProsthesisSystem_encoder():
-    """A picture assigned to an implant with an encoder is encoded on the way in
+    """A picture prepared by an implant with an encoder is encoded on the way
+    through
     """
     img = ImageStimulus(np.linspace(0, 1, 16).reshape((4, 4)))
     implant = ProsthesisSystem(ArgusII().earray)
@@ -640,34 +651,33 @@ def test_ProsthesisSystem_encoder():
     # Giving it one is all it takes:
     implant.encoder = AmplitudeEncoder(amp_range=(0, 50), freq=20)
     npt.assert_equal('encoder' in str(implant), True)
-    implant.stim = img
-    npt.assert_equal(implant.stim.unit, uA)
-    npt.assert_equal(implant.stim.shape[0], implant.n_electrodes)
-    npt.assert_almost_equal(np.abs(implant.stim.data).max(), 50)
-    # What it stored is exactly what encoding it by hand gives:
+    stim = implant.prepare_stim(img)
+    npt.assert_equal(stim.unit, uA)
+    npt.assert_equal(stim.shape[0], implant.n_electrodes)
+    npt.assert_almost_equal(np.abs(stim.data).max(), 50)
+    # What comes back is exactly what encoding it by hand gives:
     by_hand = implant.encoder.encode(img, implant=implant)
-    npt.assert_almost_equal(implant.stim.data, by_hand.data)
-    npt.assert_almost_equal(implant.stim.time, by_hand.time)
+    npt.assert_almost_equal(stim.data, by_hand.data)
+    npt.assert_almost_equal(stim.time, by_hand.time)
 
     # A custom encoder is honored, and its parameters reach the stimulus:
     implant.encoder = AmplitudeEncoder(amp_range=(10, 30), freq=50,
                                        frame_dur=100)
-    implant.stim = img
-    npt.assert_almost_equal(np.abs(implant.stim.data).max(), 30)
-    npt.assert_almost_equal(implant.stim.time[-1], 100)
+    stim = implant.prepare_stim(img)
+    npt.assert_almost_equal(np.abs(stim.data).max(), 30)
+    npt.assert_almost_equal(stim.time[-1], 100)
     implant.encoder = FrequencyEncoder(freq_range=(0, 100), amp=42,
                                        frame_dur=100)
-    implant.stim = img
-    npt.assert_almost_equal(np.abs(implant.stim.data).max(), 42)
+    npt.assert_almost_equal(np.abs(implant.prepare_stim(img).data).max(), 42)
 
     # An electrical stimulus bypasses the encoder entirely, whatever is
     # installed -- there is nothing left to encode:
     implant.encoder = AmplitudeEncoder(amp_range=(0, 50))
     for source in ({'A1': 20}, np.ones(60),
                    BiphasicPulse(20, 0.45, stim_dur=50)):
-        implant.stim = source
-        npt.assert_equal(implant.stim.unit, uA)
-        npt.assert_equal('encoder' in implant.stim.metadata, False)
+        stim = implant.prepare_stim(source)
+        npt.assert_equal(stim.unit, uA)
+        npt.assert_equal('encoder' in stim.metadata, False)
 
     # The encoder sees the implant it is installed on, so it samples at that
     # implant's electrodes and schedules against that implant's raster. An
@@ -675,30 +685,30 @@ def test_ProsthesisSystem_encoder():
     # the schedules are the raster groups and nothing else:
     implant.encoder = AmplitudeEncoder(amp_range=(10, 50))
     implant.raster = implants.SequentialRaster(6)
-    implant.stim = img
-    delays = [implant.stim.time[np.argmax(implant.stim.data[e] < 0)]
+    stim = implant.prepare_stim(img)
+    delays = [stim.time[np.argmax(stim.data[e] < 0)]
               for e in (0, 10, 20, 30, 40, 50)]
     npt.assert_almost_equal(delays, np.arange(6) * 50 / 6, decimal=2)
-    npt.assert_equal(len(np.unique(np.abs(implant.stim.data) > 0, axis=0)), 6)
+    npt.assert_equal(len(np.unique(np.abs(stim.data) > 0, axis=0)), 6)
 
 
 def test_ProsthesisSystem_encoded_stim_is_one_object():
     """An encoded stimulus knows both what it delivers and what it was asked
-    for, so the implant stores one of it
+    for, so preparation returns one of it
     """
     img = ImageStimulus(np.linspace(0, 1, 16).reshape((4, 4)))
-    implant = ArgusII(stim=img)
-    npt.assert_equal(hasattr(implant, '_spatial_stim'), False)
-    # `stim` is still the delivered pulse train -- that invariant is what makes
-    # the safety checks and the temporal models meaningful:
-    npt.assert_equal(implant.stim.time.size > 1, True)
+    implant = ArgusII()
+    stim = implant.prepare_stim(img)
+    # What comes back is the delivered pulse train -- that invariant is what
+    # makes the safety checks and the temporal models meaningful:
+    npt.assert_equal(stim.time.size > 1, True)
     # ... and the same object says what the encoder asked each electrode for:
     # one column, no waveform, no raster.
-    spatial = implant.stim._spatial_view()
+    spatial = stim._spatial_view()
     npt.assert_equal(spatial.shape, (60, 1))
     npt.assert_equal(spatial.time, None)
     npt.assert_equal(spatial.unit, uA)
-    npt.assert_almost_equal(np.abs(implant.stim.data).max(axis=1),
+    npt.assert_almost_equal(np.abs(stim.data).max(axis=1),
                             spatial.data.ravel(), decimal=4)
 
     # A video keeps one column per video frame:
@@ -707,34 +717,33 @@ def test_ProsthesisSystem_encoded_stim_is_one_object():
     with pytest.warns(UserWarning, match='deliver no pulse'):
         # 6 Hz against 20 fps; irrelevant here, but it is not the modulation
         # that goes short of frames, only the train delivering it:
-        implant.stim = vid
-    npt.assert_equal(implant.stim._spatial_view().shape, (60, 4))
-    npt.assert_almost_equal(implant.stim._spatial_view().time,
-                            np.arange(4) * 50.0)
+        stim = implant.prepare_stim(vid)
+    npt.assert_equal(stim._spatial_view().shape, (60, 4))
+    npt.assert_almost_equal(stim._spatial_view().time, np.arange(4) * 50.0)
 
     # An encoded stimulus carries that description wherever it came from, so
-    # encoding by hand and assigning the result is the same thing as letting
+    # encoding by hand and preparing the result is the same thing as letting
     # the implant do it:
-    by_hand = ArgusII(encoder=None,
-                      stim=AmplitudeEncoder(amp_range=(0, 50)).encode(
-                          img, implant=ArgusII()))
-    npt.assert_almost_equal(by_hand.stim._spatial_view().data,
-                            ArgusII(stim=img).stim._spatial_view().data)
-    # A stimulus assigned as current has only the one description of itself:
+    by_hand = ArgusII(encoder=None).prepare_stim(
+        AmplitudeEncoder(amp_range=(0, 50)).encode(img, implant=ArgusII()))
+    npt.assert_almost_equal(by_hand._spatial_view().data,
+                            ArgusII().prepare_stim(img)._spatial_view().data)
+    # A stimulus given as current has only the one description of itself:
     for source in ({'A1': 20}, np.ones(60)):
-        implant.stim = source
-        npt.assert_equal(implant.stim._spatial_view() is implant.stim, True)
-        npt.assert_equal(implant.stim._has_spatial_view, False)
+        stim = implant.prepare_stim(source)
+        npt.assert_equal(stim._spatial_view() is stim, True)
+        npt.assert_equal(stim._has_spatial_view, False)
 
     # Switching an electrode off reaches both descriptions, or a model reading
     # one of them would go on stimulating through a dead electrode -- and it
     # does not cost the schedule:
-    implant = ArgusII(stim=img)
+    implant = ArgusII()
     implant.deactivate(['A1', 'B2'])
-    npt.assert_equal(implant.stim._has_spatial_view, True)
-    npt.assert_equal(implant.stim.shape[0], 58)
-    npt.assert_equal(implant.stim._spatial_view().shape[0], 58)
-    npt.assert_equal('A1' in implant.stim._spatial_view().electrodes, False)
+    stim = implant.prepare_stim(img)
+    npt.assert_equal(stim._has_spatial_view, True)
+    npt.assert_equal(stim.shape[0], 58)
+    npt.assert_equal(stim._spatial_view().shape[0], 58)
+    npt.assert_equal('A1' in stim._spatial_view().electrodes, False)
 
 
 def test_ProsthesisSystem_preprocess_crosses_the_boundary():
@@ -746,90 +755,84 @@ def test_ProsthesisSystem_preprocess_crosses_the_boundary():
     implant = ArgusII(safe_mode=True, encoder=None, raster=None,
                       preprocess=lambda x: encoder.encode(x, implant=bare))
     implant.max_current = 100 * mA
-    implant.stim = img
-    npt.assert_equal(implant.stim.unit, uA)
-    npt.assert_equal(implant.stim.is_charge_balanced, True)
+    stim = implant.prepare_stim(img)
+    npt.assert_equal(stim.unit, uA)
+    npt.assert_equal(stim.is_charge_balanced, True)
     # Preprocessing that already crossed the boundary leaves the encoder with
     # nothing to do, so an installed one does not encode twice:
     encoded = encoder.encode(img, implant=bare)
     twice = ArgusII(raster=None,
                     preprocess=lambda x: encoder.encode(x, implant=bare))
-    twice.stim = img
-    npt.assert_almost_equal(twice.stim.data, encoded.data)
-    # The same chain, assigned already-encoded, and this time with a limit
+    npt.assert_almost_equal(twice.prepare_stim(img).data, encoded.data)
+    # The same chain, presented already-encoded, and this time with a limit
     # tight enough to matter:
     implant = ArgusII(preprocess=False, safe_mode=True)
     implant.max_current = 100 * uA
     with pytest.raises(ValueError) as excinfo:
-        implant.stim = encoded
+        implant.prepare_stim(encoded)
     npt.assert_equal('exceeds max_current' in str(excinfo.value), True)
     implant.max_current = 2 * mA
-    implant.stim = encoded
-    npt.assert_equal(implant.stim.unit, uA)
+    npt.assert_equal(implant.prepare_stim(encoded).unit, uA)
 
 
 def test_ProsthesisSystem_historical_stimuli_unchanged():
     """A bare stimulus is electrical by contract, and is checked as before"""
     implant = ArgusII(preprocess=False, safe_mode=True)
-    implant.stim = {'A1': BiphasicPulse(50, 0.45)}
-    npt.assert_equal(implant.stim.unit, uA)
+    npt.assert_equal(implant.prepare_stim({'A1': BiphasicPulse(50, 0.45)}).unit,
+                     uA)
     with pytest.raises(ValueError) as excinfo:
-        implant.stim = {'A1': MonophasicPulse(50, 0.45)}
+        implant.prepare_stim({'A1': MonophasicPulse(50, 0.45)})
     npt.assert_equal('charge-balanced' in str(excinfo.value), True)
     # A plain number is microamps, and the limit is read the same way:
     implant = ArgusII(preprocess=False)
     implant.max_current = 60
+    source = {name: 2 for name in ArgusII().electrode_names}
     with pytest.raises(ValueError) as excinfo:
-        implant.stim = {name: 2 for name in ArgusII().electrode_names}
+        implant.prepare_stim(source)
     npt.assert_equal('draws 120.0 uA at once' in str(excinfo.value), True)
     implant.max_current = 0.2 * mA
-    implant.stim = {name: 2 for name in ArgusII().electrode_names}
-    npt.assert_equal(implant.stim.unit, uA)
+    npt.assert_equal(implant.prepare_stim(source).unit, uA)
 
 
 def test_ProsthesisSystem_deactivated_electrodes_do_not_mutate_the_source():
     # Filtering out deactivated electrodes rewrites the stimulus, so it
     # happens on a copy. A stimulus defined by its pulse parameters cannot
-    # lose an electrode and remain one, so what the implant stores for it is
-    # an ordinary Stimulus -- assigning a perfectly good pulse must not fail
+    # lose an electrode and remain one, so what comes back for it is an
+    # ordinary Stimulus -- presenting a perfectly good pulse must not fail
     # merely because the electrode it names happens to be switched off.
     pulse = BiphasicPulse(20, 0.45, electrode='A1')
     implant = ArgusII()
     implant.deactivate('A1')
-    implant.stim = pulse
-    npt.assert_equal(type(implant.stim), Stimulus)
-    npt.assert_equal(implant.stim.shape[0], 0)
+    stim = implant.prepare_stim(pulse)
+    npt.assert_equal(type(stim), Stimulus)
+    npt.assert_equal(stim.shape[0], 0)
     # The caller still holds their pulse, unchanged:
     npt.assert_equal(type(pulse), BiphasicPulse)
     npt.assert_equal(pulse.shape[0], 1)
     npt.assert_almost_equal(pulse.amp, 20)
 
-    # Same for an electrode switched off after the fact:
-    implant = ArgusII(stim=BiphasicPulse(20, 0.45, electrode='A1'))
-    npt.assert_equal(type(implant.stim), BiphasicPulse)
-    implant.deactivate('A1')
-    npt.assert_equal(type(implant.stim), Stimulus)
-    npt.assert_equal(implant.stim.shape[0], 0)
+    # With every electrode on, the pulse keeps its own kind:
+    npt.assert_equal(type(ArgusII().prepare_stim(pulse)), BiphasicPulse)
 
     # An ordinary stimulus is not mutated by either path, which it used to be:
     for deactivate_first in (True, False):
-        stim = Stimulus({'A1': 10, 'B2': 20})
+        source = Stimulus({'A1': 10, 'B2': 20})
         implant = ArgusII()
         if deactivate_first:
             implant.deactivate('A1')
-            implant.stim = stim
+            stim = implant.prepare_stim(source)
         else:
-            implant.stim = stim
+            implant.prepare_stim(source)
             implant.deactivate('A1')
-        npt.assert_equal(sorted(str(e) for e in stim.electrodes),
+            stim = implant.prepare_stim(source)
+        npt.assert_equal(sorted(str(e) for e in source.electrodes),
                          ['A1', 'B2'])
-        npt.assert_equal([str(e) for e in implant.stim.electrodes], ['B2'])
+        npt.assert_equal([str(e) for e in stim.electrodes], ['B2'])
 
     # Nothing deactivated means nothing is copied or removed:
-    stim = Stimulus({'A1': 10, 'B2': 20})
-    implant = ArgusII(stim=stim)
-    npt.assert_equal(sorted(str(e) for e in implant.stim.electrodes),
-                     ['A1', 'B2'])
+    source = Stimulus({'A1': 10, 'B2': 20})
+    stim = ArgusII().prepare_stim(source)
+    npt.assert_equal(sorted(str(e) for e in stim.electrodes), ['A1', 'B2'])
 
 
 def test_ProsthesisSystem_deactivated_electrode_does_not_render_the_others():
@@ -843,23 +846,15 @@ def test_ProsthesisSystem_deactivated_electrode_does_not_render_the_others():
     trains = {name: BiphasicPulseTrain(20 + i, 10, 0.45, stim_dur=200)
               for i, name in enumerate(['A1', 'A2', 'A3'])}
     implant = ArgusII()
+    npt.assert_equal(unrendered(implant.prepare_stim(trains)), 3)
     implant.deactivate('A2')
-    implant.stim = trains
-    npt.assert_equal([str(e) for e in implant.stim.electrodes], ['A1', 'A3'])
-    npt.assert_equal(implant.stim._components is None, False)
-    npt.assert_equal(unrendered(implant.stim), 2)
-
-    # ...and deactivating one after the fact is the same story:
-    implant = ArgusII(stim={name: BiphasicPulseTrain(20 + i, 10, 0.45,
-                                                     stim_dur=200)
-                            for i, name in enumerate(['A1', 'A2', 'A3'])})
-    npt.assert_equal(unrendered(implant.stim), 3)
-    implant.deactivate('A2')
-    npt.assert_equal([str(e) for e in implant.stim.electrodes], ['A1', 'A3'])
-    npt.assert_equal(unrendered(implant.stim), 2)
+    stim = implant.prepare_stim(trains)
+    npt.assert_equal([str(e) for e in stim.electrodes], ['A1', 'A3'])
+    npt.assert_equal(stim._components is None, False)
+    npt.assert_equal(unrendered(stim), 2)
     # The waveform is still the one the trains describe:
-    npt.assert_equal(implant.stim.data.shape[0], 2)
-    npt.assert_almost_equal(implant.stim.time[-1], 200)
+    npt.assert_equal(stim.data.shape[0], 2)
+    npt.assert_almost_equal(stim.time[-1], 200)
 
 
 def test_ProsthesisSystem_thresholds():
@@ -901,26 +896,27 @@ def test_ProsthesisSystem_thresholds_are_validated():
 
 def test_ProsthesisSystem_thresholds_calibrate_pulse_trains():
     implant = ArgusII()
-    implant.stim = {'A1': BiphasicPulseTrain(20, 2 * xTh, 0.45),
-                    'A2': BiphasicPulseTrain(20, 2 * xTh, 0.45)}
+    source = {'A1': BiphasicPulseTrain(20, 2 * xTh, 0.45),
+              'A2': BiphasicPulseTrain(20, 2 * xTh, 0.45)}
     # Uncalibrated, the stimulus is not a current at all:
-    npt.assert_equal(implant.stim.unit, xTh)
+    npt.assert_equal(implant.prepare_stim(source).unit, xTh)
     implant.thresholds = {'A1': 80 * uA, 'A2': 120 * uA}
-    npt.assert_equal(implant.stim.unit, uA)
-    for _, src in implant.stim._structured_sources():
+    stim = implant.prepare_stim(source)
+    npt.assert_equal(stim.unit, uA)
+    for _, src in stim._structured_sources():
         npt.assert_almost_equal(src.amp_factor, 2)
-    npt.assert_almost_equal([src.amp for _, src
-                             in implant.stim._structured_sources()],
+    npt.assert_almost_equal([src.amp for _, src in stim._structured_sources()],
                             [160, 240])
-    npt.assert_almost_equal(np.abs(implant.stim['A1']).max(), 160, decimal=3)
+    npt.assert_almost_equal(np.abs(stim['A1']).max(), 160, decimal=3)
 
 
 def test_ProsthesisSystem_thresholds_hold_current_stimuli_fixed():
-    implant = ArgusII(stim={'A1': BiphasicPulseTrain(20, 160 * uA, 0.45)})
-    source = implant.stim._structured_sources()[0][1]
+    implant = ArgusII()
+    train = {'A1': BiphasicPulseTrain(20, 160 * uA, 0.45)}
+    source = implant.prepare_stim(train)._structured_sources()[0][1]
     npt.assert_equal(source.amp_factor, None)
     implant.thresholds = 80 * uA
-    source = implant.stim._structured_sources()[0][1]
+    source = implant.prepare_stim(train)._structured_sources()[0][1]
     npt.assert_almost_equal(source.amp, 160)
     npt.assert_almost_equal(source.amp_factor, 2)
 
@@ -929,116 +925,141 @@ def test_ProsthesisSystem_thresholds_hold_current_stimuli_fixed():
                          [(2 * xTh, 2), (160 * uA, 160)])
 def test_ProsthesisSystem_clearing_thresholds_restores_the_train(amp,
                                                                  cleared_amp):
-    implant = ArgusII(stim={'A1': BiphasicPulseTrain(20, amp, 0.45)})
+    implant = ArgusII()
+    train = {'A1': BiphasicPulseTrain(20, amp, 0.45)}
     implant.thresholds = 40 * uA
+    implant.prepare_stim(train)
     implant.thresholds = None
-    source = implant.stim._structured_sources()[0][1]
+    source = implant.prepare_stim(train)._structured_sources()[0][1]
     npt.assert_almost_equal(source.amp, cleared_amp)
     npt.assert_equal(source.amp_factor, None if cleared_amp == 160 else 2)
 
 
 def test_ProsthesisSystem_thresholds_beat_the_pulse_trains_own():
     implant = ArgusII()
+    train = {'A1': BiphasicPulseTrain(20, 2 * xTh, 0.45,
+                                      threshold_amp=50 * uA)}
     implant.thresholds = 100 * uA
-    implant.stim = {'A1': BiphasicPulseTrain(20, 2 * xTh, 0.45,
-                                             threshold_amp=50 * uA)}
-    npt.assert_almost_equal(implant.stim._structured_sources()[0][1].amp, 200)
+    stim = implant.prepare_stim(train)
+    npt.assert_almost_equal(stim._structured_sources()[0][1].amp, 200)
     # Clearing falls back to the train's own threshold, not the reference:
     implant.thresholds = None
-    source = implant.stim._structured_sources()[0][1]
+    source = implant.prepare_stim(train)._structured_sources()[0][1]
     npt.assert_almost_equal(source.amp, 100)
     npt.assert_almost_equal(source.threshold_amp, 50)
 
 
 def test_ProsthesisSystem_thresholds_leave_raw_waveforms_alone():
-    implant = ArgusII(stim={'A1': 30})
-    before = implant.stim.data.copy()
+    implant = ArgusII()
+    before = implant.prepare_stim({'A1': 30}).data.copy()
     implant.thresholds = 80 * uA
-    npt.assert_array_equal(implant.stim.data, before)
-    npt.assert_equal(implant.stim._structured_sources(), None)
+    stim = implant.prepare_stim({'A1': 30})
+    npt.assert_array_equal(stim.data, before)
+    npt.assert_equal(stim._structured_sources(), None)
 
 
-def test_ProsthesisSystem_thresholds_are_atomic():
-    implant = ArgusII(stim={'A1': BiphasicPulseTrain(20, 2 * xTh, 0.45)})
+def test_ProsthesisSystem_thresholds_are_checked_when_the_stimulus_is():
+    """A threshold that puts a stimulus over the limit is caught on preparation
+
+    The implant holds no stimulus to recheck, so the pairing of thresholds and
+    delivery limits is decided the next time one is prepared.
+    """
+    implant = ArgusII()
+    train = {'A1': BiphasicPulseTrain(20, 2 * xTh, 0.45)}
     implant.max_current = 250
     implant.thresholds = {'A1': 90 * uA}
-    npt.assert_almost_equal(implant.stim._structured_sources()[0][1].amp, 180)
-    # 2 * 200 uA is over the limit, so neither half of the change is kept:
+    stim = implant.prepare_stim(train)
+    npt.assert_almost_equal(stim._structured_sources()[0][1].amp, 180)
+    # 2 * 200 uA is over the limit, so preparing against it raises:
+    implant.thresholds = {'A1': 200 * uA}
     with pytest.raises(ValueError):
-        implant.thresholds = {'A1': 200 * uA}
-    npt.assert_almost_equal(implant.thresholds['A1'], 90)
-    npt.assert_almost_equal(implant.stim._structured_sources()[0][1].amp, 180)
+        implant.prepare_stim(train)
+    # The stimulus already handed out is the caller's, and is untouched:
+    npt.assert_almost_equal(stim._structured_sources()[0][1].amp, 180)
 
 
 def test_ProsthesisSystem_thresholds_do_not_render_the_stimulus():
-    implant = ArgusII(stim={'A1': BiphasicPulseTrain(20, 2 * xTh, 0.45)})
+    implant = ArgusII()
     implant.thresholds = 80 * uA
-    source = implant.stim._structured_sources()[0][1]
+    stim = implant.prepare_stim({'A1': BiphasicPulseTrain(20, 2 * xTh, 0.45)})
+    source = stim._structured_sources()[0][1]
     # `data is None` is what says no waveform has been generated:
     npt.assert_equal(source._Stimulus__stim['data'], None)
 
 
 def test_ProsthesisSystem_thresholds_do_not_revive_deactivated_electrodes():
     implant = ArgusII()
-    implant.stim = {'A1': BiphasicPulseTrain(20, 2 * xTh, 0.45),
-                    'A2': BiphasicPulseTrain(20, 2 * xTh, 0.45)}
+    source = {'A1': BiphasicPulseTrain(20, 2 * xTh, 0.45),
+              'A2': BiphasicPulseTrain(20, 2 * xTh, 0.45)}
     implant.deactivate('A1')
-    npt.assert_equal(list(implant.stim.electrodes), ['A2'])
+    npt.assert_equal(list(implant.prepare_stim(source).electrodes), ['A2'])
     implant.thresholds = 80 * uA
-    npt.assert_equal(list(implant.stim.electrodes), ['A2'])
-    npt.assert_almost_equal(implant.stim._structured_sources()[0][1].amp, 160)
+    stim = implant.prepare_stim(source)
+    npt.assert_equal(list(stim.electrodes), ['A2'])
+    npt.assert_almost_equal(stim._structured_sources()[0][1].amp, 160)
     implant.thresholds = None
-    npt.assert_equal(list(implant.stim.electrodes), ['A2'])
+    npt.assert_equal(list(implant.prepare_stim(source).electrodes), ['A2'])
 
 
 def test_ProsthesisSystem_thresholds_preserve_metadata():
     implant = ArgusII()
-    implant.stim = {'A1': BiphasicPulseTrain(20, 2 * xTh, 0.45,
-                                             metadata='train'),
-                    'A2': BiphasicPulseTrain(20, 2 * xTh, 0.45)}
-    implant.stim.metadata['user'] = 'collection'
+    source = Stimulus({'A1': BiphasicPulseTrain(20, 2 * xTh, 0.45,
+                                                metadata='train'),
+                       'A2': BiphasicPulseTrain(20, 2 * xTh, 0.45)})
+    source.metadata['user'] = 'collection'
     implant.thresholds = 80 * uA
-    npt.assert_equal(implant.stim.metadata['user'], 'collection')
-    npt.assert_equal(implant.stim._structured_sources()[0][1].metadata['user'],
+    stim = implant.prepare_stim(source)
+    npt.assert_equal(stim.metadata['user'], 'collection')
+    npt.assert_equal(stim._structured_sources()[0][1].metadata['user'],
                      'train')
 
 
-def test_ProsthesisSystem_thresholds_recalibrate_from_the_current_stimulus():
-    # Recalibration preserves the original 2xTh basis.
-    implant = ArgusII(stim={'A1': BiphasicPulseTrain(20, 2 * xTh, 0.45)})
+def test_ProsthesisSystem_thresholds_calibrate_from_the_original_source():
+    """Each preparation starts from the caller's source, not the last result
+
+    Calibrating twice would compound the factors; calibrating from the source
+    every time preserves the original 2xTh basis.
+    """
+    implant = ArgusII()
+    train = {'A1': BiphasicPulseTrain(20, 2 * xTh, 0.45)}
     implant.thresholds = 80 * uA
+    npt.assert_almost_equal(
+        implant.prepare_stim(train)._structured_sources()[0][1].amp, 160)
     implant.thresholds = 50 * uA
-    source = implant.stim._structured_sources()[0][1]
+    source = implant.prepare_stim(train)._structured_sources()[0][1]
     npt.assert_almost_equal(source.amp, 100)
     npt.assert_almost_equal(source.amp_factor, 2)
 
 
 def test_ProsthesisSystem_uncalibrated_xTh_is_not_yet_a_current():
-    implant = ArgusII(stim={'A1': BiphasicPulseTrain(20, 2 * xTh, 0.45)})
-    npt.assert_equal(implant.stim.unit, xTh)
-    npt.assert_almost_equal(np.abs(implant.stim.data).max(), 2, decimal=3)
+    implant = ArgusII()
+    train = {'A1': BiphasicPulseTrain(20, 2 * xTh, 0.45)}
+    stim = implant.prepare_stim(train)
+    npt.assert_equal(stim.unit, xTh)
+    npt.assert_almost_equal(np.abs(stim.data).max(), 2, decimal=3)
     implant.max_current = 250
     with pytest.raises(DimensionMismatchError):
-        implant.check_stim(implant.stim)
+        implant.check_stim(stim)
     implant.safe_mode = True
     with pytest.raises(DimensionMismatchError):
-        implant.check_stim(implant.stim)
+        implant.check_stim(stim)
     implant.thresholds = 80 * uA
-    implant.check_stim(implant.stim)
-    npt.assert_almost_equal(np.abs(implant.stim.data).max(), 160, decimal=3)
+    stim = implant.prepare_stim(train)
+    implant.check_stim(stim)
+    npt.assert_almost_equal(np.abs(stim.data).max(), 160, decimal=3)
 
 
 def test_ProsthesisSystem_partial_calibration_of_xTh_is_refused():
-    implant = ArgusII(stim={'A1': BiphasicPulseTrain(20, 2 * xTh, 0.45),
-                            'A2': BiphasicPulseTrain(20, 2 * xTh, 0.45)})
-    with pytest.raises(DimensionMismatchError) as err:
-        implant.thresholds = {'A1': 80 * uA}
-    npt.assert_equal('A2' in str(err.value), True)
-    npt.assert_equal(implant.thresholds, {})
-    npt.assert_equal(implant.stim.unit, xTh)
-    # A current-valued train is already a current, threshold or no threshold:
-    implant.stim = {'A1': BiphasicPulseTrain(20, 160 * uA, 0.45),
-                    'A2': BiphasicPulseTrain(20, 160 * uA, 0.45)}
+    implant = ArgusII()
+    xth_source = {'A1': BiphasicPulseTrain(20, 2 * xTh, 0.45),
+                  'A2': BiphasicPulseTrain(20, 2 * xTh, 0.45)}
     implant.thresholds = {'A1': 80 * uA}
-    factors = [src.amp_factor for _, src in implant.stim._structured_sources()]
+    with pytest.raises(DimensionMismatchError) as err:
+        implant.prepare_stim(xth_source)
+    npt.assert_equal('A2' in str(err.value), True)
+    # A current-valued train is already a current, threshold or no threshold:
+    uA_source = {'A1': BiphasicPulseTrain(20, 160 * uA, 0.45),
+                 'A2': BiphasicPulseTrain(20, 160 * uA, 0.45)}
+    stim = implant.prepare_stim(uA_source)
+    factors = [src.amp_factor for _, src in stim._structured_sources()]
     npt.assert_equal(factors, [2, None])

--- a/pulse2percept/implants/tests/test_bvt.py
+++ b/pulse2percept/implants/tests/test_bvt.py
@@ -62,23 +62,17 @@ def test_BVT24(x, y, rot, eye):
 
 
 def test_BVT24_stim():
-    # Assign a stimulus:
+    # Prepare a stimulus via dict:
     implant = BVT24()
-    implant.stim = {'C1': 1}
-    npt.assert_equal(implant.stim.electrodes, ['C1'])
-    npt.assert_equal(implant.stim.time, None)
-    npt.assert_equal(implant.stim.data, [[1]])
+    stim = implant.prepare_stim({'C1': 1})
+    npt.assert_equal(stim.electrodes, ['C1'])
+    npt.assert_equal(stim.time, None)
+    npt.assert_equal(stim.data, [[1]])
 
-    # You can also assign the stimulus in the constructor:
-    BVT24(stim={'C1': 1})
-    npt.assert_equal(implant.stim.electrodes, ['C1'])
-    npt.assert_equal(implant.stim.time, None)
-    npt.assert_equal(implant.stim.data, [[1]])
-
-    # Set a stimulus via array:
-    implant = BVT24(stim=np.ones(35))
-    npt.assert_equal(implant.stim.shape, (35, 1))
-    npt.assert_almost_equal(implant.stim.data, 1)
+    # Prepare a stimulus via array:
+    stim = implant.prepare_stim(np.ones(35))
+    npt.assert_equal(stim.shape, (35, 1))
+    npt.assert_almost_equal(stim.data, 1)
 
 
 @pytest.mark.parametrize('x', (-100, 200))
@@ -133,23 +127,17 @@ def test_BVT44(x, y, rot, eye):
 
 
 def test_BVT44_stim():
-    # Assign a stimulus:
+    # Prepare a stimulus via dict:
     implant = BVT44()
-    implant.stim = {'A1': 1}
-    npt.assert_equal(implant.stim.electrodes, ['A1'])
-    npt.assert_equal(implant.stim.time, None)
-    npt.assert_equal(implant.stim.data, [[1]])
+    stim = implant.prepare_stim({'A1': 1})
+    npt.assert_equal(stim.electrodes, ['A1'])
+    npt.assert_equal(stim.time, None)
+    npt.assert_equal(stim.data, [[1]])
 
-    # You can also assign the stimulus in the constructor:
-    BVT44(stim={'A1': 1})
-    npt.assert_equal(implant.stim.electrodes, ['A1'])
-    npt.assert_equal(implant.stim.time, None)
-    npt.assert_equal(implant.stim.data, [[1]])
-
-    # Set a stimulus via array:
-    implant = BVT44(stim=np.ones(46))
-    npt.assert_equal(implant.stim.shape, (46, 1))
-    npt.assert_almost_equal(implant.stim.data, 1)
+    # Prepare a stimulus via array:
+    stim = implant.prepare_stim(np.ones(46))
+    npt.assert_equal(stim.shape, (46, 1))
+    npt.assert_almost_equal(stim.data, 1)
 
 
 @pytest.mark.parametrize('cls', (BVT24, BVT44))

--- a/pulse2percept/implants/tests/test_ensemble.py
+++ b/pulse2percept/implants/tests/test_ensemble.py
@@ -39,9 +39,8 @@ def test_EnsembleImplant():
     npt.assert_equal(ensemble.electrode_names, ['A-0','B-0'])
 
     # predict_percept smoke test
-    ensemble.stim = [1,1]
-    model = ScoreboardModel().build()
-    model.predict_percept(ensemble)
+    model = ScoreboardModel(implant=ensemble).build()
+    model.predict_percept([1, 1])
 
 # we essentially just need to make sure that electrode names are
 # set properly, the rest of the EnsembleImplant functionality 
@@ -116,62 +115,61 @@ def test_from_cortical_map():
     npt.assert_approx_equal(ensemble['2-1'].z, c2['1'].z, 5)
 
 
-def test_merge_stimuli():
-    implant = EnsembleImplant([Orion(),
-                               Orion(x=-35000)])
-    npt.assert_equal(implant.stim is None, True)
-    implant = EnsembleImplant([Orion(stim=np.ones(60)),
-                               Orion(x=-35000)])
-    npt.assert_equal(implant.stim.data.shape, (120, 1))
-    npt.assert_equal(implant.stim.electrodes, implant.electrode_names)
-    implant = EnsembleImplant([Orion(stim=np.ones(60)),
-                               Orion(x=-35000, stim=np.ones(60)*2)])
-    npt.assert_equal(implant.stim.data.shape, (120, 1))
-    npt.assert_equal(implant.stim.electrodes, implant.electrode_names)
-    npt.assert_equal(implant.stim.data[:60], 1)
-    npt.assert_equal(implant.stim.data[60:], 2)
+def test_prepare_stim_merges_per_implant_input():
+    """A dict keyed by implant gives each constituent its own source"""
+    ensemble = EnsembleImplant([Orion(), Orion(x=-35000)])
+    npt.assert_equal(ensemble.prepare_stim(None), None)
+    npt.assert_equal(ensemble.prepare_stim({}), None)
+    # A key left out contributes zeros, but the rest still merge:
+    stim = ensemble.prepare_stim({0: np.ones(60)})
+    npt.assert_equal(stim.data.shape, (120, 1))
+    npt.assert_equal(stim.electrodes, ensemble.electrode_names)
+    stim = ensemble.prepare_stim({0: np.ones(60), 1: np.ones(60) * 2})
+    npt.assert_equal(stim.data.shape, (120, 1))
+    npt.assert_equal(stim.electrodes, ensemble.electrode_names)
+    npt.assert_equal(stim.data[:60], 1)
+    npt.assert_equal(stim.data[60:], 2)
 
     # with time
-    implant = EnsembleImplant([Orion(stim=np.ones((60, 5))),
-                               Orion(x=-35000, stim=np.ones((60, 2))*2)])
-    npt.assert_equal(implant.stim.data.shape, (120, 5))
-    npt.assert_equal(implant.stim.data[:60], 1)
-    npt.assert_equal(implant.stim.data[60:, :2], 2)
-    npt.assert_equal(implant.stim.data[60:, 2:], 0)
+    stim = ensemble.prepare_stim({0: np.ones((60, 5)),
+                                  1: np.ones((60, 2)) * 2})
+    npt.assert_equal(stim.data.shape, (120, 5))
+    npt.assert_equal(stim.data[:60], 1)
+    npt.assert_equal(stim.data[60:, :2], 2)
+    npt.assert_equal(stim.data[60:, 2:], 0)
     # A merge of sampled waveforms has no structure to keep:
-    npt.assert_equal(implant.stim._structured_sources(), None)
+    npt.assert_equal(stim._structured_sources(), None)
 
     # biphasic pulse trains
-    implant1 = Orion()
-    implant1.stim = {e : BiphasicPulseTrain(50, 1, .45) for e in implant1.electrode_names}
-    implant2 = Orion(x=-35000)
-    implant2.stim = {e : BiphasicPulseTrain(20, 2, .85) for e in implant2.electrode_names}
-    implant = EnsembleImplant([implant1, implant2])
+    names = Orion().electrode_names
+    stim = ensemble.prepare_stim(
+        {0: {e: BiphasicPulseTrain(50, 1, .45) for e in names},
+         1: {e: BiphasicPulseTrain(20, 2, .85) for e in names}})
     # Asked before `.data`: reading the waveform must not be what builds it.
     # Each child electrode keeps the train that drives it, under the name the
     # ensemble gives it, so a model still sees two clocks and not one array:
-    sources = implant.stim._structured_sources()
-    npt.assert_equal([e for e, _ in sources], implant.electrode_names)
+    sources = stim._structured_sources()
+    npt.assert_equal([e for e, _ in sources], ensemble.electrode_names)
     sources = dict(sources)
     npt.assert_equal((sources['0-96'].freq, sources['0-96'].phase_dur),
                      (50, .45))
     npt.assert_equal((sources['1-96'].freq, sources['1-96'].phase_dur),
                      (20, .85))
-    npt.assert_equal(implant.stim.data.shape, (120, 471))
+    npt.assert_equal(stim.data.shape, (120, 471))
     # Two implants that pulse at the same instant get there by accumulating
     # their own way, so merging their time axes needs a tolerance:
-    npt.assert_equal(np.all(np.diff(implant.stim.time) > 0.95 * DT), True)
+    npt.assert_equal(np.all(np.diff(stim.time) > 0.95 * DT), True)
 
     # with cortivis and orion
-    implant = EnsembleImplant([Orion(stim=np.ones(60)),
-                                 Cortivis(x=10000, stim=np.ones(96)*2)])
-    npt.assert_equal(implant.stim.data.shape, (156, 1))
+    mixed = EnsembleImplant([Orion(), Cortivis(x=10000)])
+    npt.assert_equal(
+        mixed.prepare_stim({0: np.ones(60), 1: np.ones(96) * 2}).data.shape,
+        (156, 1))
 
-    # make sure supplying stim still overrides individual implants
-    implant = EnsembleImplant([Orion(stim=np.ones(60)*2),
-                               Orion(x=-35000, stim=np.ones(60)*2)], stim=np.ones(120)*3)
-    npt.assert_equal(implant.stim.data.shape, (120, 1))
-    npt.assert_equal(implant.stim.data, 3)
+    # A source that is not keyed by implant is laid out on the whole array:
+    stim = ensemble.prepare_stim(np.ones(120) * 3)
+    npt.assert_equal(stim.data.shape, (120, 1))
+    npt.assert_equal(stim.data, 3)
 
 
 def test_EnsembleImplant_from_coords_units():

--- a/pulse2percept/implants/tests/test_ensemble.py
+++ b/pulse2percept/implants/tests/test_ensemble.py
@@ -9,7 +9,7 @@ from pulse2percept.implants import (EnsembleImplant, PointSource, ProsthesisSyst
 from pulse2percept.implants.cortex import Cortivis, Orion
 from pulse2percept.topography import Polimeni2006Map
 from pulse2percept.models.cortex.base import ScoreboardModel
-from pulse2percept.stimuli import BiphasicPulseTrain
+from pulse2percept.stimuli import BiphasicPulseTrain, MonophasicPulse
 from pulse2percept.utils.constants import DT
 from pulse2percept.utils.testing import assert_warns_msg
 
@@ -170,6 +170,25 @@ def test_prepare_stim_merges_per_implant_input():
     stim = ensemble.prepare_stim(np.ones(120) * 3)
     npt.assert_equal(stim.data.shape, (120, 1))
     npt.assert_equal(stim.data, 3)
+
+
+def test_prepare_stim_merged_goes_through_the_ensemble_pipeline():
+    """Merging is how per-implant input becomes one stimulus, not a way around
+
+    The children prepare their own halves, but what the ensemble delivers is
+    still the ensemble's to preprocess and to check.
+    """
+    ensemble = EnsembleImplant([Orion(), Orion(x=-35000)],
+                               preprocess=lambda s: s * -2)
+    stim = ensemble.prepare_stim({0: np.ones(60), 1: np.ones(60) * 2})
+    npt.assert_almost_equal(stim.data[:60], -2)
+    npt.assert_almost_equal(stim.data[60:], -4)
+
+    # ... and an ensemble-level safety check still refuses what it should,
+    # even though neither child enforces charge balance of its own:
+    unsafe = EnsembleImplant([Orion(), Orion(x=-35000)], safe_mode=True)
+    with pytest.raises(ValueError, match='charge-balanced'):
+        unsafe.prepare_stim({0: {'96': MonophasicPulse(20, 0.45)}})
 
 
 def test_EnsembleImplant_from_coords_units():

--- a/pulse2percept/implants/tests/test_imie.py
+++ b/pulse2percept/implants/tests/test_imie.py
@@ -81,20 +81,14 @@ def test_IMIE(x, y, rot, eye):
         npt.assert_equal(after[el].y > before[el].y, True)
 
 def test_IMIE_stim():
-    # Assign a stimulus:
+    # Prepare a stimulus via dict:
     implant = implants.IMIE()
-    implant.stim = {'A3': 1}
-    npt.assert_equal(implant.stim.electrodes, ['A3'])
-    npt.assert_equal(implant.stim.time, None)
-    npt.assert_equal(implant.stim.data, [[1]])
+    stim = implant.prepare_stim({'A3': 1})
+    npt.assert_equal(stim.electrodes, ['A3'])
+    npt.assert_equal(stim.time, None)
+    npt.assert_equal(stim.data, [[1]])
 
-    # You can also assign the stimulus in the constructor:
-    implants.IMIE(stim={'A3': 1})
-    npt.assert_equal(implant.stim.electrodes, ['A3'])
-    npt.assert_equal(implant.stim.time, None)
-    npt.assert_equal(implant.stim.data, [[1]])
-
-    # Set a stimulus via array:
-    implant = implants.IMIE(stim=np.ones(256))
-    npt.assert_equal(implant.stim.shape, (256, 1))
-    npt.assert_almost_equal(implant.stim.data, 1)
+    # Prepare a stimulus via array:
+    stim = implant.prepare_stim(np.ones(256))
+    npt.assert_equal(stim.shape, (256, 1))
+    npt.assert_almost_equal(stim.data, 1)

--- a/pulse2percept/implants/tests/test_rasters.py
+++ b/pulse2percept/implants/tests/test_rasters.py
@@ -483,21 +483,18 @@ def test_ProsthesisSystem_max_current():
         implant.max_current = 0
     # 60 electrodes at 20 uA each is 1200 uA at once:
     implant.max_current = 1500
-    implant.stim = np.full(60, 20)
-    npt.assert_equal(implant.stim.shape, (60, 1))
+    npt.assert_equal(implant.prepare_stim(np.full(60, 20)).shape, (60, 1))
     implant.max_current = 1000
     with pytest.raises(ValueError):
-        implant.stim = np.full(60, 20)
+        implant.prepare_stim(np.full(60, 20))
     # The sign does not matter: what the stimulator sources is the sum of the
     # magnitudes:
     with pytest.raises(ValueError):
-        implant.stim = np.full(60, -20)
+        implant.prepare_stim(np.full(60, -20))
     # A single electrode is well within the limit:
-    implant.stim = {'A1': 900}
-    npt.assert_almost_equal(implant.stim.data.max(), 900)
+    npt.assert_almost_equal(implant.prepare_stim({'A1': 900}).data.max(), 900)
     # An empty stimulus has nothing to check:
-    implant.stim = None
-    npt.assert_equal(implant.stim, None)
+    npt.assert_equal(implant.prepare_stim(None), None)
 
 
 def test_Raster_units():

--- a/pulse2percept/models/__init__.py
+++ b/pulse2percept/models/__init__.py
@@ -19,8 +19,7 @@ Computational models of the prosthetic vision, such as phosphene and neural resp
     *  :ref:`Basic Concepts > Computational Models <topics-models>`
 
 """
-from .base import (BaseModel, Model, NotBuiltError, SpatialModel,
-                   TemporalModel)
+from .base import BaseModel, Model, SpatialModel, TemporalModel
 from .temporal import AlphaTemporal, FadingTemporal
 from .beyeler2019 import (ScoreboardModel, ScoreboardSpatial, AxonMapSpatial,
                           AxonMapModel)
@@ -46,7 +45,6 @@ __all__ = [
     'Nanduri2012Spatial',
     'Nanduri2012Temporal',
     'BiphasicAxonMapModel',
-    'NotBuiltError',
     'ScoreboardModel',
     'ScoreboardSpatial',
     'SpatialModel',

--- a/pulse2percept/models/base.py
+++ b/pulse2percept/models/base.py
@@ -1869,6 +1869,9 @@ class Model(Frozen, PrettyPrint):
         Performs expensive one-time calculations, such as building the spatial
         grid used to predict a percept.
 
+        Rebuilds every component, built or not. ``predict_percept`` builds
+        only the components that need it; call this to force the rest.
+
         Parameters
         ----------
         build_params: additional parameters to set
@@ -1889,11 +1892,24 @@ class Model(Frozen, PrettyPrint):
             self.temporal.build()
         return self
 
+    def _build_stale(self):
+        """Build the components that are not built, and only those
+
+        A component un-builds itself when one of its own parameters changes,
+        so a sweep over ``model.temporal.tau`` leaves the spatial component
+        built and its axon map intact. Rebuilding both here would grow that
+        map again on every iteration.
+        """
+        if self.has_space and not self.spatial.is_built:
+            self.spatial.build()
+        if self.has_time and not self.temporal.is_built:
+            self.temporal.build()
+
     def predict_percept(self, source, t_percept=None, gaze=None, vmax=None,
                         vmin=0):
         """Predict a percept
 
-        Builds the model first if it is not built.
+        Builds whichever components are not built yet.
 
         Given an ordinary stimulus source, this predicts what the bound
         implant delivers for it (see
@@ -1965,8 +1981,7 @@ class Model(Frozen, PrettyPrint):
         """
         # Before the scene is sampled and a whole stimulus encoded from it,
         # so that a build the caller never asked for does not happen twice:
-        if not self.is_built:
-            self.build()
+        self._build_stale()
         if not isinstance(source, Scene):
             for name, value in (('gaze', gaze), ('vmax', vmax)):
                 if value is not None:
@@ -1999,8 +2014,7 @@ class Model(Frozen, PrettyPrint):
 
     def _predict_percept(self, stim, t_percept=None):
         """Predict the percept a prepared stimulus produces"""
-        if not self.is_built:
-            self.build()
+        self._build_stale()
         # The sub-models normalize too; doing it here as well keeps the error
         # message below reading in plain milliseconds:
         t_percept = as_value(t_percept, self.time_unit, 't_percept')

--- a/pulse2percept/models/base.py
+++ b/pulse2percept/models/base.py
@@ -190,10 +190,10 @@ def _spatial_input(stim):
 
 
 def _delivered(stim):
-    """Return the stimulus as the pulse train the electrodes deliver.
+    """Return the delivered pulse train for a prepared stimulus.
 
-    Strips an encoded stimulus of its frame-level modulation view, so that
-    the spatial stage reads the waveform a temporal stage then integrates.
+    Encoded stimuli carry a frame-level view for spatial-only models. Remove that
+    view before a temporal stage integrates the waveform.
     """
     if stim is None or not stim._has_spatial_view:
         return stim
@@ -241,7 +241,7 @@ def _device_scene(scene, implant):
 
 
 def _scene_stim(model, scene, gaze):
-    """What the scene delivers to the bound implant's electrodes"""
+    """Prepare electrode stimulation sampled from a scene."""
     if not model.has_space:
         raise ValueError("A scene is registered against the retina, which "
                          "needs a spatial model. This model has only a "
@@ -272,10 +272,8 @@ def _scene_stim(model, scene, gaze):
     seen = Stimulus(gray, electrodes=implant.electrode_names,
                     time=device_scene.time,
                     metadata=device_scene.source.metadata)
-    # Preprocessing already ran, on the picture rather than on the values it
-    # samples to; everything else `prepare_stim` does is still wanted, so a
-    # stand-in with that one setting off runs it. A shallow copy, because the
-    # caller's implant is not this prediction's to change:
+    # Preprocessing already ran on the scene source. Use a shallow copy with
+    # preprocessing disabled for the remaining preparation steps:
     device = copy(implant)
     device.preprocess = False
     return device.prepare_stim(seen._inherit_units(device_scene.source))
@@ -321,13 +319,12 @@ def _blend_meridian(resp, grid, meridian, width):
     return blurred.reshape(resp.shape).astype(resp.dtype, copy=False)
 
 
-#: Declared parameter names per model class, so that ``__setattr__`` below
-#: does not rebuild the default dict on every assignment.
+#: Parameter names declared by each model class, cached for ``__setattr__``.
 _declared = {}
 
 
 def _declared_params(model):
-    """The names ``get_default_params`` declares, cached per class"""
+    """Return cached parameter names declared by ``get_default_params``."""
     cls = type(model)
     names = _declared.get(cls)
     if names is None:
@@ -336,10 +333,9 @@ def _declared_params(model):
 
 
 def _unchanged(before, after):
-    """Whether re-assigning a parameter left it at the same value
+    """Return whether an assignment preserves the current value.
 
-    Falls back to "changed" for anything that cannot be compared, which costs
-    at most one rebuild.
+    Values that cannot be compared are treated as changed.
     """
     if before is after:
         return True
@@ -350,14 +346,11 @@ def _unchanged(before, after):
 
 
 def _electrode_pitch(model):
-    """The implant's typical nearest-neighbour spacing, in ``space_unit``
+    """Return median nearest-neighbor electrode spacing in ``space_unit``.
 
-    Measured in the dimensions the model actually reads: a model whose visual
-    field map is two-dimensional drops ``z`` when it predicts, so it must drop
-    ``z`` here too, or electrodes it sees as neighbours look far apart.
-
-    Returns None when there is nothing to compare: fewer than two electrodes,
-    or an array whose electrodes coincide in those dimensions.
+    Distances use the dimensions represented by ``vfmap`` so that pitch matches
+    the coordinates used for prediction. Returns ``None`` for fewer than two
+    electrodes or zero spacing.
     """
     coords = model.implant.earray.coordinates(model.space_unit)
     coords = coords[:, :model.vfmap.ndim]
@@ -370,11 +363,7 @@ def _electrode_pitch(model):
 
 
 def _warn_rho_vs_pitch(model):
-    """Warn when current spread is wide compared to electrode spacing
-
-    Describes what the numbers mean and leaves them alone: ``rho`` is a fitted
-    perceptual parameter, and the fit is the user's to defend.
-    """
+    """Warn when ``rho`` exceeds the implant's median electrode spacing."""
     pitch = _electrode_pitch(model)
     if pitch is None or model.rho <= pitch:
         return
@@ -389,11 +378,7 @@ def _warn_rho_vs_pitch(model):
 
 
 def _warn_ignores_z(model, earray):
-    """Warn that this model's kernel reads x and y only
-
-    Not a claim that electrode-retina distance does not matter -- it is
-    expected to -- only that this model does not represent it.
-    """
+    """Warn when a model ignores nonzero electrode ``z`` coordinates."""
     if np.allclose([e.z for e in earray.electrode_objects], 0):
         return
     warnings.warn(
@@ -415,9 +400,8 @@ class BaseModel(Parametrized, metaclass=ABCMeta):
 
     .. versionchanged:: 0.11.0
 
-        Building is automatic. ``predict_percept`` builds a model that is not
-        built yet, and giving any parameter a new value un-builds it, so
-        ``model.rho = 200`` takes effect on the next prediction.
+        ``predict_percept`` builds automatically. Changing a model parameter
+        invalidates the build, so the new value is used on the next prediction.
 
     .. versionchanged:: 0.10.0
 
@@ -427,13 +411,9 @@ class BaseModel(Parametrized, metaclass=ABCMeta):
     """
 
     def __setattr__(self, name, value):
-        """Giving a declared parameter a new value un-builds the model
+        """Invalidate the build when a declared parameter changes.
 
-        Which parameters a build depends on is not worth enumerating: the
-        expensive ones are the point of building, and re-deriving a grid
-        because ``thresh_percept`` moved is cheaper than being wrong.
-        Assignments that change nothing keep the build, so
-        ``model.rho = model.rho`` is free.
+        Assignments that preserve the current value leave the build intact.
         """
         if _is_constructing(self) or name not in _declared_params(self):
             super().__setattr__(name, value)
@@ -561,10 +541,9 @@ class BaseModel(Parametrized, metaclass=ABCMeta):
     def build(self, **build_params):
         """Build the model
 
-        Every model must have a ```build`` method, which is meant to perform
-        all expensive one-time calculations. ``predict_percept`` calls it for
-        you when the model is not built; call it yourself to pay the cost at a
-        moment of your choosing, or to pass build-time parameters.
+        Every model must have a ```build`` method for expensive one-time
+        calculations. ``predict_percept`` calls it automatically when needed;
+        call it explicitly to build eagerly or pass build-time parameters.
 
         .. important::
 
@@ -721,13 +700,12 @@ class SpatialModel(BaseModel, metaclass=ABCMeta):
             raise TypeError(f"'implant' must be a ProsthesisSystem object, "
                             f"not {type(implant)}.")
         if implant is not getattr(self, '_implant', None):
-            # A build describes one device's geometry, so it does not survive
-            # being pointed at another:
+            # Spatial build state depends on implant geometry:
             self._is_built = False
         self._implant = implant
 
     def _require_implant(self):
-        """Require the implant a spatial prediction is about"""
+        """Raise if no implant is bound to the spatial model."""
         if not isinstance(self.implant, ProsthesisSystem):
             raise ValueError(
                 f"{type(self).__name__} predicts what a particular implant "
@@ -831,8 +809,7 @@ class SpatialModel(BaseModel, metaclass=ABCMeta):
     def get_default_params(self):
         """Return a dictionary of default values for all model parameters"""
         params = {
-            # The device whose electrodes this model places in the visual
-            # field. Required before building or predicting:
+            # Implant geometry used by the spatial model:
             'implant': None,
             # We will be simulating a patch of the visual field (xrange/yrange
             # in degrees of visual angle), at a given spatial resolution (step
@@ -1039,13 +1016,10 @@ class SpatialModel(BaseModel, metaclass=ABCMeta):
                                       t_percept=t_percept)
 
     def _predict_prepared(self, stim, t_percept=None):
-        """Predict the spatial response to an already-prepared stimulus
+        """Predict the spatial response to an already prepared stimulus.
 
-        The half of :py:meth:`predict_percept` that runs after the implant's
-        input pipeline, so that a composite model can prepare once and hand
-        the same stimulus to both stages. Models that replace the whole
-        spatial prediction rather than customizing ``_predict_spatial``
-        override this.
+        Composite models use this path to prepare stimulation once before running
+        spatial and temporal stages.
         """
         if not self.is_built:
             self.build()
@@ -1056,9 +1030,8 @@ class SpatialModel(BaseModel, metaclass=ABCMeta):
         source = _spatial_input(stim)
         _require_stim_dimension(self, source)
         if source.time is None and t_percept is not None:
-            # A single-frame source (an image) modulates the electrodes to one
-            # steady thing, so there are no times to ask about even though the
-            # pulse train delivering it does have a time axis:
+            # Static modulation has no time axis even if its encoded pulse
+            # train does:
             what = ("the modulation behind this stimulus"
                     if source is not stim else "stimulus")
             raise ValueError(f"Cannot calculate spatial response at times "
@@ -1617,9 +1590,8 @@ class Model(Frozen, PrettyPrint):
         return BaseModel.time_unit
 
     def __init__(self, spatial=None, temporal=None, **params):
-        # The implant belongs to the spatial model, which is the only stage
-        # that knows what an electrode is. Held back from `params` so that it
-        # is not offered to a temporal model that has no such parameter:
+        # Only the spatial component depends on implant geometry, so do not
+        # forward `implant` to the temporal component:
         implant = params.pop('implant', None)
         # A sub-model passed as a *class* is constructed from `params` below,
         # and `set_params` then hands the same dict to the resulting instance.
@@ -1869,8 +1841,7 @@ class Model(Frozen, PrettyPrint):
         Performs expensive one-time calculations, such as building the spatial
         grid used to predict a percept.
 
-        Rebuilds every component, built or not. ``predict_percept`` builds
-        only the components that need it; call this to force the rest.
+        Unlike prediction-time auto-building, this rebuilds every component.
 
         Parameters
         ----------
@@ -1893,12 +1864,10 @@ class Model(Frozen, PrettyPrint):
         return self
 
     def _build_stale(self):
-        """Build the components that are not built, and only those
+        """Build only components whose cached state is invalid.
 
-        A component un-builds itself when one of its own parameters changes,
-        so a sweep over ``model.temporal.tau`` leaves the spatial component
-        built and its axon map intact. Rebuilding both here would grow that
-        map again on every iteration.
+        This avoids rebuilding an unchanged spatial stage during temporal parameter
+        sweeps, and vice versa.
         """
         if self.has_space and not self.spatial.is_built:
             self.spatial.build()
@@ -1911,13 +1880,11 @@ class Model(Frozen, PrettyPrint):
 
         Builds whichever components are not built yet.
 
-        Given an ordinary stimulus source, this predicts what the bound
-        implant delivers for it (see
-        :py:meth:`~pulse2percept.implants.ProsthesisSystem.prepare_stim`).
-        Given a :py:class:`~pulse2percept.vision.Scene`, the model is the
-        glue: it follows each electrode out through its own ``vfmap`` to the
-        place in the scene that electrode sees, hands those values to the
-        implant's ``encoder``, and predicts the percept that results.
+        For an ordinary source, the bound implant prepares the delivered
+        stimulation before prediction. For a
+        :py:class:`~pulse2percept.vision.Scene`, electrode locations are mapped
+        through ``vfmap`` to sample the scene, then encoded by the implant
+        before prediction.
 
         If the scene also has a
         :py:class:`~pulse2percept.vision.Scotoma`, the result is what the
@@ -1979,8 +1946,7 @@ class Model(Frozen, PrettyPrint):
             RGB percept of dimensions Y x X x 3 x T on the scene's pixel grid.
 
         """
-        # Before the scene is sampled and a whole stimulus encoded from it,
-        # so that a build the caller never asked for does not happen twice:
+        # Scene sampling depends on the current spatial build:
         self._build_stale()
         if not isinstance(source, Scene):
             for name, value in (('gaze', gaze), ('vmax', vmax)):
@@ -2002,10 +1968,9 @@ class Model(Frozen, PrettyPrint):
         return source._compose(resp, vmax, vmin=vmin, gaze=gaze)
 
     def _prepared(self, source):
-        """Run a source through the bound implant's input pipeline
+        """Prepare a source for the bound implant.
 
-        A temporal-only model has no implant and no electrodes, so what it is
-        given is already the stimulus it integrates.
+        Temporal-only models have no implant and return the source unchanged.
         """
         if not self.has_space:
             return source
@@ -2032,17 +1997,15 @@ class Model(Frozen, PrettyPrint):
                              f"have a time component.")
 
         if self.has_space and self.has_time:
-            # Need to calculate the spatial response at all stimulus points
-            # (i.e., whenever the stimulus changes). The delivered pulse train
-            # rather than the modulation behind it: integrating those pulses is
-            # what the temporal stage is for.
+            # Run the spatial stage on the delivered pulse train; the temporal
+            # stage integrates those pulses.
             resp = self.spatial._predict_prepared(_delivered(stim),
                                                   t_percept=None)
             if has_time_axis:
                 combine = getattr(self.spatial, '_combine_temporal', None)
                 if resp.time is None and combine is not None:
-                    # A spatial model hands over a percept with no time axis,
-                    # so the spatial model decides what to do with it:
+                    # Allow a spatial model to define custom temporal
+                    # combination for a timeless intermediate percept:
                     resp = combine(resp, self.temporal, stim, t_percept)
                 else:
                     # Then pass that to the temporal model, which will output

--- a/pulse2percept/models/base.py
+++ b/pulse2percept/models/base.py
@@ -388,6 +388,21 @@ def _warn_rho_vs_pitch(model):
         f"driven.")
 
 
+def _warn_ignores_z(model, earray):
+    """Warn that this model's kernel reads x and y only
+
+    Not a claim that electrode-retina distance does not matter -- it is
+    expected to -- only that this model does not represent it.
+    """
+    if np.allclose([e.z for e in earray.electrode_objects], 0):
+        return
+    warnings.warn(
+        f"{type(model).__name__} does not model electrode-retina distance: "
+        f"nonzero z values have no effect on threshold or current spread. In "
+        f"a real implant, distance is expected to affect both, but that "
+        f"relationship is not parameterized by this model.")
+
+
 class BaseModel(Parametrized, metaclass=ABCMeta):
     """Abstract base class for all models
 
@@ -546,8 +561,9 @@ class BaseModel(Parametrized, metaclass=ABCMeta):
         """Build the model
 
         Every model must have a ```build`` method, which is meant to perform
-        all expensive one-time calculations. You must call ``build`` before
-        calling ``predict_percept``.
+        all expensive one-time calculations. ``predict_percept`` calls it for
+        you when the model is not built; call it yourself to pay the cost at a
+        moment of your choosing, or to pass build-time parameters.
 
         .. important::
 
@@ -605,10 +621,10 @@ class SpatialModel(BaseModel, metaclass=ABCMeta):
     *  ``build``: builds the spatial grid used to calculate the percept.
        You can add your own ``_build`` method (note the underscore) that
        performs additional expensive one-time calculations.
-    *  ``predict_percept``: predicts the percepts based on an implant/stimulus.
-       Don't customize this method - implement your own ``_predict_spatial``
-       instead (see below).
-       A user must call ``build`` before calling ``predict_percept``.
+    *  ``predict_percept``: predicts the percept a stimulus produces on the
+       bound implant. Don't customize this method - implement your own
+       ``_predict_spatial`` instead (see below). It builds the model first if
+       it is not built.
 
     To create your own spatial model, you must subclass ``SpatialModel`` and
     provide an implementation for:
@@ -906,8 +922,8 @@ class SpatialModel(BaseModel, metaclass=ABCMeta):
         """Build the model
 
         Performs expensive one-time calculations, such as building the spatial
-        grid used to predict a percept. You must call ``build`` before
-        calling ``predict_percept``.
+        grid used to predict a percept. ``predict_percept`` calls it for you
+        when the model is not built.
 
         .. important::
 
@@ -1168,9 +1184,9 @@ class TemporalModel(BaseModel, metaclass=ABCMeta):
     *  ``build``: builds the model in order to calculate the percept.
        You can add your own ``_build`` method (note the underscore) that
        performs additional expensive one-time calculations.
-    *  ``predict_percept``: predicts the percepts based on an implant/stimulus.
-       You can add your own ``_predict_temporal`` method to customize this
-       step. A user must call ``build`` before calling ``predict_percept``.
+    *  ``predict_percept``: predicts the percept a stimulus produces. You can
+       add your own ``_predict_temporal`` method to customize this step. It
+       builds the model first if it is not built.
 
     To create your own temporal model, you must subclass ``SpatialModel`` and
     provide an implementation for:
@@ -1876,9 +1892,7 @@ class Model(Frozen, PrettyPrint):
                         vmin=0):
         """Predict a percept
 
-        .. important ::
-
-            You must call ``build`` before calling ``predict_percept``.
+        Builds the model first if it is not built.
 
         Given an ordinary stimulus source, this predicts what the bound
         implant delivers for it (see

--- a/pulse2percept/models/base.py
+++ b/pulse2percept/models/base.py
@@ -1,6 +1,5 @@
 """:py:class:`~pulse2percept.models.BaseModel`,
    :py:class:`~pulse2percept.models.Model`,
-   :py:class:`~pulse2percept.models.NotBuiltError`,
    :py:class:`~pulse2percept.models.SpatialModel`,
    :py:class:`~pulse2percept.models.TemporalModel`"""
 import warnings
@@ -9,6 +8,7 @@ from copy import deepcopy, copy
 import numpy as np
 import multiprocessing
 from scipy.ndimage import gaussian_filter1d
+from scipy.spatial import cKDTree
 
 from ..implants import ProsthesisSystem
 from ..stimuli import ImageStimulus, Stimulus, VideoStimulus
@@ -321,14 +321,6 @@ def _blend_meridian(resp, grid, meridian, width):
     return blurred.reshape(resp.shape).astype(resp.dtype, copy=False)
 
 
-class NotBuiltError(ValueError, AttributeError):
-    """Exception class used to raise if model is used before building
-
-    This class inherits from both ValueError and AttributeError to help with
-    exception handling and backward compatibility.
-    """
-
-
 #: Declared parameter names per model class, so that ``__setattr__`` below
 #: does not rebuild the default dict on every assignment.
 _declared = {}
@@ -357,25 +349,43 @@ def _unchanged(before, after):
         return False
 
 
-def _invalidating(set_attr):
-    """Wrap ``__setattr__`` so a new parameter value un-builds the model.
+def _electrode_pitch(model):
+    """The implant's typical nearest-neighbour spacing, in ``space_unit``
 
-    Which parameters a build depends on is not worth enumerating: the
-    expensive ones are the point of building, and re-deriving a grid because
-    ``thresh_percept`` moved is cheaper than being wrong. Assignments that
-    change nothing keep the build, so ``model.rho = model.rho`` is free.
+    Measured in the dimensions the model actually reads: a model whose visual
+    field map is two-dimensional drops ``z`` when it predicts, so it must drop
+    ``z`` here too, or electrodes it sees as neighbours look far apart.
+
+    Returns None when there is nothing to compare: fewer than two electrodes,
+    or an array whose electrodes coincide in those dimensions.
     """
+    coords = model.implant.earray.coordinates(model.space_unit)
+    coords = coords[:, :model.vfmap.ndim]
+    if len(coords) < 2:
+        return None
+    # The nearest *other* electrode, so the query asks for two:
+    distances, _ = cKDTree(coords).query(coords, k=2)
+    pitch = float(np.median(distances[:, 1]))
+    return pitch if pitch > 0 else None
 
-    def __setattr__(self, name, value):
-        if _is_constructing(self) or name not in _declared_params(self):
-            set_attr(self, name, value)
-            return
-        before = getattr(self, name, None)
-        set_attr(self, name, value)
-        if not _unchanged(before, getattr(self, name, None)):
-            object.__setattr__(self, '_is_built', False)
 
-    return __setattr__
+def _warn_rho_vs_pitch(model):
+    """Warn when current spread is wide compared to electrode spacing
+
+    Describes what the numbers mean and leaves them alone: ``rho`` is a fitted
+    perceptual parameter, and the fit is the user's to defend.
+    """
+    pitch = _electrode_pitch(model)
+    if pitch is None or model.rho <= pitch:
+        return
+    overlap = np.exp(-pitch ** 2 / (2 * model.rho ** 2))
+    warnings.warn(
+        f"rho={model.rho:.0f} um is wider than this implant's electrode "
+        f"pitch ({pitch:.0f} um), a ratio of {model.rho / pitch:.2f}. A point "
+        f"one pitch away from an electrode still sees {overlap:.0%} of its "
+        f"peak, so neighbouring electrodes blur into each other and the "
+        f"percept says more about rho than about which electrodes were "
+        f"driven.")
 
 
 class BaseModel(Parametrized, metaclass=ABCMeta):
@@ -400,8 +410,22 @@ class BaseModel(Parametrized, metaclass=ABCMeta):
 
     """
 
-    #: A new parameter value invalidates the build; see ``_invalidating``.
-    __setattr__ = _invalidating(Parametrized.__setattr__)
+    def __setattr__(self, name, value):
+        """Giving a declared parameter a new value un-builds the model
+
+        Which parameters a build depends on is not worth enumerating: the
+        expensive ones are the point of building, and re-deriving a grid
+        because ``thresh_percept`` moved is cheaper than being wrong.
+        Assignments that change nothing keep the build, so
+        ``model.rho = model.rho`` is free.
+        """
+        if _is_constructing(self) or name not in _declared_params(self):
+            super().__setattr__(name, value)
+            return
+        before = getattr(self, name, None)
+        super().__setattr__(name, value)
+        if not _unchanged(before, getattr(self, name, None)):
+            object.__setattr__(self, '_is_built', False)
 
     # The units a model's numerical implementation works in. p2p converts a
     # unitful argument to these at the API boundary and hands the kernels

--- a/pulse2percept/models/base.py
+++ b/pulse2percept/models/base.py
@@ -329,6 +329,55 @@ class NotBuiltError(ValueError, AttributeError):
     """
 
 
+#: Declared parameter names per model class, so that ``__setattr__`` below
+#: does not rebuild the default dict on every assignment.
+_declared = {}
+
+
+def _declared_params(model):
+    """The names ``get_default_params`` declares, cached per class"""
+    cls = type(model)
+    names = _declared.get(cls)
+    if names is None:
+        names = _declared[cls] = frozenset(model.get_default_params())
+    return names
+
+
+def _unchanged(before, after):
+    """Whether re-assigning a parameter left it at the same value
+
+    Falls back to "changed" for anything that cannot be compared, which costs
+    at most one rebuild.
+    """
+    if before is after:
+        return True
+    try:
+        return bool(np.all(before == after))
+    except Exception:
+        return False
+
+
+def _invalidating(set_attr):
+    """Wrap ``__setattr__`` so a new parameter value un-builds the model.
+
+    Which parameters a build depends on is not worth enumerating: the
+    expensive ones are the point of building, and re-deriving a grid because
+    ``thresh_percept`` moved is cheaper than being wrong. Assignments that
+    change nothing keep the build, so ``model.rho = model.rho`` is free.
+    """
+
+    def __setattr__(self, name, value):
+        if _is_constructing(self) or name not in _declared_params(self):
+            set_attr(self, name, value)
+            return
+        before = getattr(self, name, None)
+        set_attr(self, name, value)
+        if not _unchanged(before, getattr(self, name, None)):
+            object.__setattr__(self, '_is_built', False)
+
+    return __setattr__
+
+
 class BaseModel(Parametrized, metaclass=ABCMeta):
     """Abstract base class for all models
 
@@ -338,12 +387,21 @@ class BaseModel(Parametrized, metaclass=ABCMeta):
 
     *  Build a model (via ``build``) and flip the ``is_built`` switch
 
+    .. versionchanged:: 0.11.0
+
+        Building is automatic. ``predict_percept`` builds a model that is not
+        built yet, and giving any parameter a new value un-builds it, so
+        ``model.rho = 200`` takes effect on the next prediction.
+
     .. versionchanged:: 0.10.0
 
         Everything other than the build workflow moved to
         :py:class:`~pulse2percept.utils.Parametrized`.
 
     """
+
+    #: A new parameter value invalidates the build; see ``_invalidating``.
+    __setattr__ = _invalidating(Parametrized.__setattr__)
 
     # The units a model's numerical implementation works in. p2p converts a
     # unitful argument to these at the API boundary and hands the kernels
@@ -935,7 +993,7 @@ class SpatialModel(BaseModel, metaclass=ABCMeta):
 
         """
         if not self.is_built:
-            raise NotBuiltError("You must call ``build`` first.")
+            self.build()
         return self._predict_prepared(self.implant.prepare_stim(source),
                                       t_percept=t_percept)
 
@@ -949,7 +1007,7 @@ class SpatialModel(BaseModel, metaclass=ABCMeta):
         override this.
         """
         if not self.is_built:
-            raise NotBuiltError("You must call ``build`` first.")
+            self.build()
         t_percept = as_value(t_percept, self.time_unit, 't_percept')
         if stim is None:
             # Nothing to see here:
@@ -1285,7 +1343,7 @@ class TemporalModel(BaseModel, metaclass=ABCMeta):
 
         """
         if not self.is_built:
-            raise NotBuiltError("You must call ``build`` first.")
+            self.build()
         if stim is None:
             # Nothing to see here:
             return None
@@ -1866,11 +1924,10 @@ class Model(Frozen, PrettyPrint):
             RGB percept of dimensions Y x X x 3 x T on the scene's pixel grid.
 
         """
-        # Before the scene is sampled and a whole stimulus encoded from it:
-        # not being built is the caller's oldest mistake, and it should not be
-        # reported after two newer ones.
+        # Before the scene is sampled and a whole stimulus encoded from it,
+        # so that a build the caller never asked for does not happen twice:
         if not self.is_built:
-            raise NotBuiltError("You must call ``build`` first.")
+            self.build()
         if not isinstance(source, Scene):
             for name, value in (('gaze', gaze), ('vmax', vmax)):
                 if value is not None:
@@ -1904,7 +1961,7 @@ class Model(Frozen, PrettyPrint):
     def _predict_percept(self, stim, t_percept=None):
         """Predict the percept a prepared stimulus produces"""
         if not self.is_built:
-            raise NotBuiltError("You must call ``build`` first.")
+            self.build()
         # The sub-models normalize too; doing it here as well keeps the error
         # message below reading in plain milliseconds:
         t_percept = as_value(t_percept, self.time_unit, 't_percept')

--- a/pulse2percept/models/base.py
+++ b/pulse2percept/models/base.py
@@ -398,9 +398,10 @@ def _warn_ignores_z(model, earray):
         return
     warnings.warn(
         f"{type(model).__name__} does not model electrode-retina distance: "
-        f"nonzero z values have no effect on threshold or current spread. In "
-        f"a real implant, distance is expected to affect both, but that "
-        f"relationship is not parameterized by this model.")
+        f"nonzero z values do not change its response. In a real implant, "
+        f"distance is expected to affect stimulation threshold and spatial "
+        f"recruitment, but that relationship is not parameterized by this "
+        f"model.")
 
 
 class BaseModel(Parametrized, metaclass=ABCMeta):

--- a/pulse2percept/models/base.py
+++ b/pulse2percept/models/base.py
@@ -180,13 +180,13 @@ def _require_stim_dimension(model, stim):
         f"{_describe_unit(stim.unit)}.")
 
 
-def _spatial_input(implant):
-    """Return the spatial view of an implant stimulus.
+def _spatial_input(stim):
+    """Return the spatial view of a prepared stimulus.
 
     Encoded stimuli expose frame-level modulation to spatial-only
     models instead of the time-resolved pulse schedule.
     """
-    return implant.stim._spatial_view()
+    return stim._spatial_view()
 
 
 def _rescale(stim, scale):
@@ -199,20 +199,15 @@ def _rescale(stim, scale):
                     metadata=deepcopy(stim.metadata))._inherit_units(stim)
 
 
-def _rescaled_implant(implant, amp):
-    """Return a copy of ``implant`` with its stimulus scaled to peak at ``amp``."""
-    trial = deepcopy(implant)
-    trial.stim = implant.stim * (amp / implant.stim.data.max())
-    return trial
+def _delivered(stim):
+    """Return the stimulus as the pulse train the electrodes deliver.
 
-
-def _delivered(implant):
-    """Return an implant whose spatial input is the delivered pulse train."""
-    if implant.stim is None or not implant.stim._has_spatial_view:
-        return implant
-    stand_in = copy(implant)
-    stand_in._stim = Stimulus(implant.stim)
-    return stand_in
+    Strips an encoded stimulus of its frame-level modulation view, so that
+    the spatial stage reads the waveform a temporal stage then integrates.
+    """
+    if stim is None or not stim._has_spatial_view:
+        return stim
+    return Stimulus(stim)
 
 
 def _device_scene(scene, implant):
@@ -255,13 +250,14 @@ def _device_scene(scene, implant):
     return device
 
 
-def _scene_driven_implant(model, implant, gaze):
-    """A stand-in implant carrying what the scene delivers to its electrodes"""
-    scene = model.scene
+def _scene_stim(model, scene, gaze):
+    """What the scene delivers to the bound implant's electrodes"""
     if not model.has_space:
         raise ValueError("A scene is registered against the retina, which "
                          "needs a spatial model. This model has only a "
                          "temporal one.")
+    model.spatial._require_implant()
+    implant = model.implant
     vfmap = getattr(model.spatial, 'vfmap', None)
     if not isinstance(vfmap, RetinalMap):
         raise ValueError(
@@ -286,14 +282,13 @@ def _scene_driven_implant(model, implant, gaze):
     seen = Stimulus(gray, electrodes=implant.electrode_names,
                     time=device_scene.time,
                     metadata=device_scene.source.metadata)
-    trial = copy(implant)
     # Preprocessing already ran, on the picture rather than on the values it
-    # samples to; everything else the setter does is still wanted:
-    trial.preprocess = False
-    # Through the setter, so the encoder, the safety checks and whatever else
-    # the device does to a stimulus all still happen:
-    trial.stim = seen._inherit_units(device_scene.source)
-    return trial
+    # samples to; everything else `prepare_stim` does is still wanted, so a
+    # stand-in with that one setting off runs it. A shallow copy, because the
+    # caller's implant is not this prediction's to change:
+    device = copy(implant)
+    device.preprocess = False
+    return device.prepare_stim(seen._inherit_units(device_scene.source))
 
 
 def _blend_meridian(resp, grid, meridian, width):
@@ -516,6 +511,14 @@ class BaseModel(Parametrized, metaclass=ABCMeta):
         # already-copied model would be rebuilt on every revisit.
         if id(self) in memodict:
             return memodict[id(self)]
+        implant = getattr(self, '_implant', None)
+        if implant is not None:
+            # The implant is the device a model is pointed at, not part of the
+            # model's own state, so a copy describes the same physical
+            # implant. Seeding the memo is what shares it: it also keeps
+            # `copy.implant is model.implant`, and stops the rebuild below
+            # from being invalidated by a freshly copied device.
+            memodict.setdefault(id(implant), implant)
         copied = super().__deepcopy__(memodict)
         if self.is_built:
             copied.build()
@@ -607,6 +610,41 @@ class SpatialModel(BaseModel, metaclass=ABCMeta):
         # `_vfmap_first`.
         super().__init__(**_vfmap_first(params))
         self.grid = None
+
+    @property
+    def implant(self):
+        """The prosthesis system this model predicts percepts for
+
+        A spatial model says where in the visual field the electrodes of a
+        particular device are seen, so the device is model context rather than
+        trial input: it is named once, and
+        :py:meth:`~pulse2percept.models.SpatialModel.predict_percept` is then
+        given the stimulus. Rebinding invalidates the build.
+
+        .. versionadded:: 0.11.0
+        """
+        return getattr(self, '_implant', None)
+
+    @implant.setter
+    def implant(self, implant):
+        """Implant setter (called upon ``self.implant = implant``)"""
+        if implant is not None and not isinstance(implant, ProsthesisSystem):
+            raise TypeError(f"'implant' must be a ProsthesisSystem object, "
+                            f"not {type(implant)}.")
+        if implant is not getattr(self, '_implant', None):
+            # A build describes one device's geometry, so it does not survive
+            # being pointed at another:
+            self._is_built = False
+        self._implant = implant
+
+    def _require_implant(self):
+        """Require the implant a spatial prediction is about"""
+        if not isinstance(self.implant, ProsthesisSystem):
+            raise ValueError(
+                f"{type(self).__name__} predicts what a particular implant "
+                f"produces, so it needs one: "
+                f"{type(self).__name__}(implant=ArgusII()). The stimulus is "
+                f"what 'predict_percept' takes.")
 
     def set_params(self, **params):
         """Set the parameters of this model
@@ -704,6 +742,9 @@ class SpatialModel(BaseModel, metaclass=ABCMeta):
     def get_default_params(self):
         """Return a dictionary of default values for all model parameters"""
         params = {
+            # The device whose electrodes this model places in the visual
+            # field. Required before building or predicting:
+            'implant': None,
             # We will be simulating a patch of the visual field (xrange/yrange
             # in degrees of visual angle), at a given spatial resolution (step
             # size):
@@ -812,6 +853,7 @@ class SpatialModel(BaseModel, metaclass=ABCMeta):
         """
         # See `BaseModel.build`:
         self.set_params(**build_params)
+        self._require_implant()
         if self.vfmap.ndim not in self.ndim:
             raise ValueError(f"Model expects one of {self.ndim} dimensions, but "
                              f"visual field map has {self.vfmap.ndim} dimensions.")
@@ -847,7 +889,7 @@ class SpatialModel(BaseModel, metaclass=ABCMeta):
         """Hook for spatial-model postprocessing."""
         return resp
 
-    def predict_percept(self, implant, t_percept=None):
+    def predict_percept(self, source, t_percept=None):
         """Predict the spatial response
 
         .. important::
@@ -857,8 +899,8 @@ class SpatialModel(BaseModel, metaclass=ABCMeta):
 
         .. note::
 
-            **This method reads modulation frames, not pulses.** Where
-            ``implant.stim`` was produced by the implant's own
+            **This method reads modulation frames, not pulses.** Where the
+            prepared stimulus was produced by the implant's own
             :py:class:`~pulse2percept.stimuli.StimulusEncoder`, what is read
             is one amplitude per electrode per frame of the source video,
             rather than the pulse train delivering it.
@@ -874,17 +916,17 @@ class SpatialModel(BaseModel, metaclass=ABCMeta):
             :py:class:`~pulse2percept.models.Model` hands its spatial stage
             the delivered pulse train instead whenever it also has a temporal
             stage, since integrating those pulses is what that stage is for.
-            Models that replace ``predict_percept`` outright rather than
-            customizing ``_predict_spatial`` --
-            :py:class:`~pulse2percept.models.BiphasicAxonMapSpatial` and
-            :py:class:`~pulse2percept.models.cortex.DynaphosModel` -- read
-            ``implant.stim`` directly and are unaffected by any of this.
+
+        .. versionchanged:: 0.11.0
+            Takes the stimulus source rather than an implant; the implant is
+            the one this model is bound to.
 
         Parameters
         ----------
-        implant: :py:class:`~pulse2percept.implants.ProsthesisSystem`
-            A valid prosthesis system. A stimulus can be passed via
-            :py:meth:`~pulse2percept.implants.ProsthesisSystem.stim`.
+        source : :py:class:`~pulse2percept.stimuli.Stimulus` source type
+            What is presented to the device. Anything
+            :py:meth:`~pulse2percept.implants.ProsthesisSystem.prepare_stim`
+            accepts, including an image or a video for the implant's encoder.
         t_percept: float or list of floats, optional
             The time points at which to output a percept, counted in this
             model's :py:attr:`~pulse2percept.models.BaseModel.time_unit`
@@ -899,26 +941,37 @@ class SpatialModel(BaseModel, metaclass=ABCMeta):
         percept: :py:class:`~pulse2percept.models.Percept`
             A Percept object whose ``data`` container has dimensions Y x X x T,
             and whose time axis is labelled in ``time_unit``.
-            Will return None if ``implant.stim`` is None.
+            Will return None if ``source`` is None or empty.
 
         """
         if not self.is_built:
             raise NotBuiltError("You must call ``build`` first.")
-        if not isinstance(implant, ProsthesisSystem):
-            raise TypeError(f"'implant' must be a ProsthesisSystem object, "
-                            f"not {type(implant)}.")
+        return self._predict_prepared(self.implant.prepare_stim(source),
+                                      t_percept=t_percept)
+
+    def _predict_prepared(self, stim, t_percept=None):
+        """Predict the spatial response to an already-prepared stimulus
+
+        The half of :py:meth:`predict_percept` that runs after the implant's
+        input pipeline, so that a composite model can prepare once and hand
+        the same stimulus to both stages. Models that replace the whole
+        spatial prediction rather than customizing ``_predict_spatial``
+        override this.
+        """
+        if not self.is_built:
+            raise NotBuiltError("You must call ``build`` first.")
         t_percept = as_value(t_percept, self.time_unit, 't_percept')
-        if implant.stim is None:
+        if stim is None:
             # Nothing to see here:
             return None
-        source = _spatial_input(implant)
+        source = _spatial_input(stim)
         _require_stim_dimension(self, source)
         if source.time is None and t_percept is not None:
             # A single-frame source (an image) modulates the electrodes to one
             # steady thing, so there are no times to ask about even though the
             # pulse train delivering it does have a time axis:
             what = ("the modulation behind this stimulus"
-                    if source is not implant.stim else "stimulus")
+                    if source is not stim else "stimulus")
             raise ValueError(f"Cannot calculate spatial response at times "
                              f"t_percept={t_percept} because {what} does not "
                              f"have a time component.")
@@ -976,29 +1029,34 @@ class SpatialModel(BaseModel, metaclass=ABCMeta):
                     stim[:, stim.time[t_unique]], electrodes=stim.electrodes,
                     time=uniq_time
                 )._inherit_units(stim)._inherit_metadata(stim)
-                resp_unique = self._predict_spatial(implant.earray, stim_unique)
+                resp_unique = self._predict_spatial(self.implant.earray,
+                                                    stim_unique)
                 # reconstruct original time points, making sure to preserve C ordering
                 resp = resp_unique[..., inverse].copy(order='C')
             else:
-                resp = self._predict_spatial(implant.earray, stim)
+                resp = self._predict_spatial(self.implant.earray, stim)
         resp = self._postprocess_spatial(resp)
         return Percept(resp.reshape(list(self.grid.x.shape) + [-1]),
                        space=self.grid, time=t_percept,
                        time_unit=self.time_unit,
                        metadata={'stim': stim}, n_gray=self.n_gray, noise=self.noise)
 
-    def find_threshold(self, implant, bright_th, amp_range=(0, 999), amp_tol=1,
+    def find_threshold(self, stim, bright_th, amp_range=(0, 999), amp_tol=1,
                        bright_tol=0.1, max_iter=100):
         """Find the threshold current for a certain stimulus
 
         Estimates ``amp_th`` such that the output of
         ``model.predict_percept(stim(amp_th))`` is approximately ``bright_th``.
 
+        .. versionchanged:: 0.11.0
+            Takes the stimulus rather than an implant carrying one, and scales
+            that stimulus rather than a copy of the implant.
+
         Parameters
         ----------
-        implant : :py:class:`~pulse2percept.implants.ProsthesisSystem`
-            The implant and its stimulus to use. Stimulus amplitude will be
-            up and down regulated until ``amp_th`` is found.
+        stim : :py:class:`~pulse2percept.stimuli.Stimulus`
+            The stimulus to use. Stimulus amplitude will be up and down
+            regulated until ``amp_th`` is found.
         bright_th : float
             Model output (brightness) that's considered "at threshold".
         amp_range : (amp_lo, amp_hi), optional
@@ -1030,17 +1088,17 @@ class SpatialModel(BaseModel, metaclass=ABCMeta):
            :py:mod:`pulse2percept.units`.
 
         """
-        if not isinstance(implant, ProsthesisSystem):
-            raise TypeError(f"'implant' must be a ProsthesisSystem, not "
-                            f"{type(implant)}.")
+        if not isinstance(stim, Stimulus):
+            raise TypeError(f"'stim' must be a Stimulus, not {type(stim)}.")
         amp_range = as_value(amp_range, self.stimulus_unit, 'amp_range')
         amp_tol = as_value(amp_tol, self.stimulus_unit, 'amp_tol')
 
-        def inner_predict(amp, fnc_predict, implant):
-            return fnc_predict(_rescaled_implant(implant, amp)).data.max()
+        def inner_predict(amp, fnc_predict, stim):
+            return fnc_predict(_rescale(stim,
+                                        amp / stim.data.max())).data.max()
 
         return bisect(bright_th, inner_predict,
-                      args=[self.predict_percept, implant],
+                      args=[self.predict_percept, stim],
                       x_lo=amp_range[0], x_hi=amp_range[1], x_tol=amp_tol,
                       y_tol=bright_tol, max_iter=max_iter)
 
@@ -1410,9 +1468,8 @@ class TemporalModel(BaseModel, metaclass=ABCMeta):
         A stimulus of the wrong sign is not an error -- the model integrates it
         and rectifies the result away -- so it otherwise looks exactly like a
         stimulus that was simply too weak to see. Assigning a grayscale image
-        or video straight to ``implant.stim`` lands here, because gray levels
-        are nonnegative and most temporal models are driven by cathodic
-        current.
+        or video that was never encoded lands here, because gray levels are
+        nonnegative and most temporal models are driven by cathodic current.
         """
         if np.any(resp) or not np.any(stim.data):
             return
@@ -1458,7 +1515,7 @@ class TemporalModel(BaseModel, metaclass=ABCMeta):
             The time points at which to output a percept, counted in this
             model's :py:attr:`~pulse2percept.models.BaseModel.time_unit`
             (milliseconds, for every model p2p ships).
-            If None, ``implant.stim.time`` is used.
+            If None, the stimulus' own time points are used.
             May be given as a unitful quantity (e.g. ``[0, 20] * ms``); see
             :py:mod:`pulse2percept.units`.
 
@@ -1526,14 +1583,11 @@ class Model(Frozen, PrettyPrint):
     temporal: :py:class:`~pulse2percept.models.TemporalModel` or None
         The temporal model, which decides how the response evolves over time.
         May be given as a class, which is then constructed from ``params``.
-    scene: :py:class:`~pulse2percept.vision.Scene` or None
-        What the eye is looking at. With a scene,
-        :py:meth:`~pulse2percept.models.Model.predict_percept` registers it
-        against the implant through this model's own ``vfmap`` rather than
-        taking a stimulus from the caller. Belongs to the composite rather
-        than to either component, and is not forwarded to them: it is what
-        connects the retinotopy one of them holds to the implant the other
-        never sees.
+    implant: :py:class:`~pulse2percept.implants.ProsthesisSystem`, optional
+        The device this model predicts percepts for. Stored on the spatial
+        model, which is what needs it, and read back through ``model.implant``;
+        there is one implant, not a copy per component. A temporal-only model
+        never sees an electrode, and so does not take one.
 
         .. versionadded:: 0.11.0
 
@@ -1600,7 +1654,11 @@ class Model(Frozen, PrettyPrint):
             return self.spatial.time_unit
         return BaseModel.time_unit
 
-    def __init__(self, spatial=None, temporal=None, scene=None, **params):
+    def __init__(self, spatial=None, temporal=None, **params):
+        # The implant belongs to the spatial model, which is the only stage
+        # that knows what an electrode is. Held back from `params` so that it
+        # is not offered to a temporal model that has no such parameter:
+        implant = params.pop('implant', None)
         # A sub-model passed as a *class* is constructed from `params` below,
         # and `set_params` then hands the same dict to the resulting instance.
         # Both paths rewrite renamed parameters, so an old name reaching this
@@ -1629,15 +1687,15 @@ class Model(Frozen, PrettyPrint):
                 raise TypeError(f"'temporal' must be a TemporalModel instance, "
                                 f"not {type(temporal)}.")
         self.temporal = temporal
-        # The scene belongs to the composite, not to either component: it is
-        # what connects the retinotopy one of them holds to the implant the
-        # other never sees. Deliberately not forwarded to `set_params`.
-        if scene is not None and not isinstance(scene, Scene):
-            raise TypeError(f"'scene' must be a Scene object, not "
-                            f"{type(scene)}.")
-        self.scene = scene
         # Use user-specified parameter values instead of defaults:
         self.set_params(params)
+        if implant is not None:
+            if not self.has_space:
+                raise ValueError(
+                    "An implant is where a spatial model puts its electrodes, "
+                    "and this model has only a temporal component. A temporal "
+                    "model is given the stimulus and nothing else.")
+            self.spatial.implant = implant
 
     def __getattr__(self, attr):
         """Called when the default attr access fails with an AttributeError
@@ -1744,12 +1802,7 @@ class Model(Frozen, PrettyPrint):
         # the constructor, so those cannot be passed in as parameters:
         spatial = attributes.pop('spatial', None)
         temporal = attributes.pop('temporal', None)
-        # Same reason: a subclass constructor may splat its keyword arguments
-        # into the sub-models, which do not accept a scene.
-        scene = attributes.pop('scene', None)
         result = self.__class__(**attributes)
-        if scene is not None:
-            object.__setattr__(result, 'scene', scene)
         # Whatever the constructor made, replace it with our copies. Model
         # parameters (e.g. `rho`) are forwarded to the sub-models by
         # `__setattr__`, so they live in `spatial`/`temporal`, not in
@@ -1793,8 +1846,6 @@ class Model(Frozen, PrettyPrint):
     def _pprint_params(self):
         """Return a dictionary of parameters to pretty - print"""
         params = {'spatial': self.spatial, 'temporal': self.temporal}
-        if self.scene is not None:
-            params['scene'] = self.scene
         # Also display the parameters from the spatial/temporal model:
         if self.has_space:
             params.update(self.spatial._pprint_params())
@@ -1868,7 +1919,7 @@ class Model(Frozen, PrettyPrint):
             self.temporal.build()
         return self
 
-    def predict_percept(self, implant, t_percept=None, gaze=None, vmax=None,
+    def predict_percept(self, source, t_percept=None, gaze=None, vmax=None,
                         vmin=0):
         """Predict a percept
 
@@ -1876,12 +1927,13 @@ class Model(Frozen, PrettyPrint):
 
             You must call ``build`` before calling ``predict_percept``.
 
-        Without a :py:class:`~pulse2percept.vision.Scene`, this predicts what
-        ``implant.stim`` produces, as it always has. With one, the model is
-        the glue: it follows each electrode out through its own ``vfmap`` to
-        the place in the scene that electrode sees, hands those values to the
-        implant's ``encoder``, and predicts the percept that results. The
-        caller's ``implant.stim`` is not touched.
+        Given an ordinary stimulus source, this predicts what the bound
+        implant delivers for it (see
+        :py:meth:`~pulse2percept.implants.ProsthesisSystem.prepare_stim`).
+        Given a :py:class:`~pulse2percept.vision.Scene`, the model is the
+        glue: it follows each electrode out through its own ``vfmap`` to the
+        place in the scene that electrode sees, hands those values to the
+        implant's ``encoder``, and predicts the percept that results.
 
         If the scene also has a
         :py:class:`~pulse2percept.vision.Scotoma`, the result is what the
@@ -1891,22 +1943,23 @@ class Model(Frozen, PrettyPrint):
 
         .. versionchanged:: 0.11.0
 
-            Added ``gaze``, ``vmax`` and ``vmin``, which are what a scene
-            needs and are rejected without one.
+            Takes what is presented to the device -- a stimulus source or a
+            scene -- rather than an implant carrying a stimulus. ``gaze``,
+            ``vmax`` and ``vmin`` are what a scene needs, and are rejected
+            without one.
 
         Parameters
         ----------
-        implant: :py:class:`~pulse2percept.implants.ProsthesisSystem`
-            A valid prosthesis system. A stimulus can be passed via
-            :py:meth:`~pulse2percept.implants.ProsthesisSystem.stim`. With a
-            scene the stimulus comes from the scene instead, and the implant
-            supplies its electrode locations, its ``encoder`` and its device
-            scheduling.
+        source : :py:class:`~pulse2percept.stimuli.Stimulus` source type or
+                 :py:class:`~pulse2percept.vision.Scene`
+            What is presented to the device: anything
+            :py:meth:`~pulse2percept.implants.ProsthesisSystem.prepare_stim`
+            accepts, or a scene the implanted eye is looking at.
         t_percept: float or list of floats, optional
             The time points at which to output a percept, counted in this
             model's :py:attr:`~pulse2percept.models.BaseModel.time_unit`
             (milliseconds, for every model p2p ships).
-            If None, ``implant.stim.time`` is used.
+            If None, the time points of the prepared stimulus are used.
             May be given as a unitful quantity (e.g. ``[0, 20] * ms``); see
             :py:mod:`pulse2percept.units`.
         gaze : (x, y) or (n_frames, 2), optional
@@ -1938,8 +1991,8 @@ class Model(Frozen, PrettyPrint):
         percept: :py:class:`~pulse2percept.models.Percept`
             Without a scene, or with one that has no scotoma: a brightness
             percept whose ``data`` has dimensions Y x X x T, and None if
-            ``implant.stim`` is None. With a scene that has a scotoma: an RGB
-            percept of dimensions Y x X x 3 x T on the scene's pixel grid.
+            ``source`` is None or empty. With a scene that has a scotoma: an
+            RGB percept of dimensions Y x X x 3 x T on the scene's pixel grid.
 
         """
         # Before the scene is sampled and a whole stimulus encoded from it:
@@ -1947,46 +2000,51 @@ class Model(Frozen, PrettyPrint):
         # reported after two newer ones.
         if not self.is_built:
             raise NotBuiltError("You must call ``build`` first.")
-        if self.scene is None:
+        if not isinstance(source, Scene):
             for name, value in (('gaze', gaze), ('vmax', vmax)):
                 if value is not None:
                     raise ValueError(
                         f"'{name}' says where an implanted eye is looking in "
-                        f"a scene, and this model has none. Build it with "
-                        f"'scene' to place one.")
+                        f"a scene, and this prediction is not about one. Pass "
+                        f"a Scene to place one.")
             if vmin != 0:
                 raise ValueError("'vmin' maps a percept onto a display, which "
                                  "only happens for a scene with a scotoma.")
-            return self._predict_percept(implant, t_percept)
-        if not isinstance(implant, ProsthesisSystem):
-            raise TypeError(f"'implant' must be a ProsthesisSystem object, "
-                            f"not {type(implant)}.")
-        trial = _scene_driven_implant(self, implant, gaze)
-        resp = self._predict_percept(trial, t_percept)
-        if self.scene.scotoma is None or resp is None:
+            return self._predict_percept(self._prepared(source), t_percept)
+        resp = self._predict_percept(_scene_stim(self, source, gaze),
+                                     t_percept)
+        if source.scotoma is None or resp is None:
             # Nothing is lost, so there is nothing to compose the percept
             # into: what the implant produces is the whole answer.
             return resp
-        return self.scene._compose(resp, vmax, vmin=vmin, gaze=gaze)
+        return source._compose(resp, vmax, vmin=vmin, gaze=gaze)
 
-    def _predict_percept(self, implant, t_percept=None):
-        """Predict the percept an implant's own stimulus produces"""
+    def _prepared(self, source):
+        """Run a source through the bound implant's input pipeline
+
+        A temporal-only model has no implant and no electrodes, so what it is
+        given is already the stimulus it integrates.
+        """
+        if not self.has_space:
+            return source
+        self.spatial._require_implant()
+        return self.implant.prepare_stim(source)
+
+    def _predict_percept(self, stim, t_percept=None):
+        """Predict the percept a prepared stimulus produces"""
         if not self.is_built:
             raise NotBuiltError("You must call ``build`` first.")
-        if not isinstance(implant, ProsthesisSystem):
-            raise TypeError(f"'implant' must be a ProsthesisSystem object, not "
-                            f"{type(implant)}.")
         # The sub-models normalize too; doing it here as well keeps the error
         # message below reading in plain milliseconds:
         t_percept = as_value(t_percept, self.time_unit, 't_percept')
-        if implant.stim is None or (not self.has_space and not self.has_time):
+        if stim is None or (not self.has_space and not self.has_time):
             # Nothing to see here:
             return None
-        _require_stim_dimension(self, implant.stim)
+        _require_stim_dimension(self, stim)
         # `_has_time_axis`, not `stim.time`: whether there is a time axis is a
         # question a stimulus can answer from its structure, and asking it for
         # the axis itself would generate the waveform behind it.
-        has_time_axis = _has_time_axis(implant.stim)
+        has_time_axis = _has_time_axis(stim)
         if not has_time_axis and t_percept is not None:
             raise ValueError(f"Cannot calculate temporal response at times "
                              f"t_percept={t_percept}, because stimulus/percept does not "
@@ -1994,40 +2052,44 @@ class Model(Frozen, PrettyPrint):
 
         if self.has_space and self.has_time:
             # Need to calculate the spatial response at all stimulus points
-            # (i.e., whenever the stimulus changes)
-            resp = self.spatial.predict_percept(_delivered(implant),
-                                                t_percept=None)
+            # (i.e., whenever the stimulus changes). The delivered pulse train
+            # rather than the modulation behind it: integrating those pulses is
+            # what the temporal stage is for.
+            resp = self.spatial._predict_prepared(_delivered(stim),
+                                                  t_percept=None)
             if has_time_axis:
                 combine = getattr(self.spatial, '_combine_temporal', None)
                 if resp.time is None and combine is not None:
                     # A spatial model hands over a percept with no time axis,
                     # so the spatial model decides what to do with it:
-                    resp = combine(resp, self.temporal, implant.stim,
-                                   t_percept)
+                    resp = combine(resp, self.temporal, stim, t_percept)
                 else:
                     # Then pass that to the temporal model, which will output
                     # at all `t_percept` time steps:
                     resp = self.temporal.predict_percept(resp,
                                                          t_percept=t_percept)
         elif self.has_space:
-            resp = self.spatial.predict_percept(implant, t_percept=t_percept)
+            resp = self.spatial._predict_prepared(stim, t_percept=t_percept)
         elif self.has_time:
-            resp = self.temporal.predict_percept(implant.stim,
-                                                 t_percept=t_percept)
+            resp = self.temporal.predict_percept(stim, t_percept=t_percept)
         return resp
 
-    def find_threshold(self, implant, bright_th, amp_range=(0, 999), amp_tol=1,
+    def find_threshold(self, stim, bright_th, amp_range=(0, 999), amp_tol=1,
                        bright_tol=0.1, max_iter=100, t_percept=None):
         """Find the threshold current for a certain stimulus
 
         Estimates ``amp_th`` such that the output of
         ``model.predict_percept(stim(amp_th))`` is approximately ``bright_th``.
 
+        .. versionchanged:: 0.11.0
+            Takes the stimulus rather than an implant carrying one, and scales
+            that stimulus rather than a copy of the implant.
+
         Parameters
         ----------
-        implant : :py:class:`~pulse2percept.implants.ProsthesisSystem`
-            The implant and its stimulus to use. Stimulus amplitude will be
-            up and down regulated until ``amp_th`` is found.
+        stim : :py:class:`~pulse2percept.stimuli.Stimulus`
+            The stimulus to use. Stimulus amplitude will be up and down
+            regulated until ``amp_th`` is found.
         bright_th : float
             Model output (brightness) that's considered "at threshold".
         amp_range : (amp_lo, amp_hi), optional
@@ -2046,7 +2108,7 @@ class Model(Frozen, PrettyPrint):
             The time points at which to output a percept, counted in this
             model's :py:attr:`~pulse2percept.models.BaseModel.time_unit`
             (milliseconds, for every model p2p ships).
-            If None, ``implant.stim.time`` is used.
+            If None, the stimulus' own time points are used.
             May be given as a unitful quantity (e.g. ``[0, 20] * ms``); see
             :py:mod:`pulse2percept.units`.
 
@@ -2066,25 +2128,18 @@ class Model(Frozen, PrettyPrint):
            :py:mod:`pulse2percept.units`.
 
         """
-        if not isinstance(implant, ProsthesisSystem):
-            raise TypeError(f"'implant' must be a ProsthesisSystem, not "
-                            f"{type(implant)}.")
-        if self.scene is not None:
-            # Thresholding rescales `implant.stim`, and with a scene that
-            raise NotImplementedError(
-                "find_threshold scales an implant's own stimulus, but this "
-                "model builds one from its scene instead. Drop the scene "
-                "(or use a second model without one) to find a threshold.")
+        if not isinstance(stim, Stimulus):
+            raise TypeError(f"'stim' must be a Stimulus, not {type(stim)}.")
         amp_range = as_value(amp_range, self.stimulus_unit, 'amp_range')
         amp_tol = as_value(amp_tol, self.stimulus_unit, 'amp_tol')
         t_percept = as_value(t_percept, self.time_unit, 't_percept')
 
-        def inner_predict(amp, fnc_predict, implant, **kwargs):
-            return fnc_predict(_rescaled_implant(implant, amp),
+        def inner_predict(amp, fnc_predict, stim, **kwargs):
+            return fnc_predict(_rescale(stim, amp / stim.data.max()),
                                **kwargs).data.max()
 
         return bisect(bright_th, inner_predict,
-                      args=[self.predict_percept, implant],
+                      args=[self.predict_percept, stim],
                       kwargs={'t_percept': t_percept},
                       x_lo=amp_range[0], x_hi=amp_range[1], x_tol=amp_tol,
                       y_tol=bright_tol, max_iter=max_iter)

--- a/pulse2percept/models/base.py
+++ b/pulse2percept/models/base.py
@@ -18,7 +18,7 @@ from ..topography import Curcio1990Map, Grid2D, RetinalMap
 from ..units import (DimensionMismatchError, Quantity, Unit, as_value, dva, ms,
                      um, uA)
 from ..vision import Scene
-from ..utils import (PrettyPrint, FreezeError, Frozen, Parametrized, bisect,
+from ..utils import (PrettyPrint, FreezeError, Frozen, Parametrized,
                      deprecated_alias, warn_deprecated_params,
                      rename_deprecated_params)
 from ..utils.base import _is_constructing
@@ -187,16 +187,6 @@ def _spatial_input(stim):
     models instead of the time-resolved pulse schedule.
     """
     return stim._spatial_view()
-
-
-def _rescale(stim, scale):
-    """Return a sampled copy of ``stim`` scaled by ``scale``.
-
-    Metadata and units are preserved.
-    """
-    return Stimulus(scale * stim.data, electrodes=stim.electrodes,
-                    time=stim.time,
-                    metadata=deepcopy(stim.metadata))._inherit_units(stim)
 
 
 def _delivered(stim):
@@ -1041,67 +1031,6 @@ class SpatialModel(BaseModel, metaclass=ABCMeta):
                        time_unit=self.time_unit,
                        metadata={'stim': stim}, n_gray=self.n_gray, noise=self.noise)
 
-    def find_threshold(self, stim, bright_th, amp_range=(0, 999), amp_tol=1,
-                       bright_tol=0.1, max_iter=100):
-        """Find the threshold current for a certain stimulus
-
-        Estimates ``amp_th`` such that the output of
-        ``model.predict_percept(stim(amp_th))`` is approximately ``bright_th``.
-
-        .. versionchanged:: 0.11.0
-            Takes the stimulus rather than an implant carrying one, and scales
-            that stimulus rather than a copy of the implant.
-
-        Parameters
-        ----------
-        stim : :py:class:`~pulse2percept.stimuli.Stimulus`
-            The stimulus to use. Stimulus amplitude will be up and down
-            regulated until ``amp_th`` is found.
-        bright_th : float
-            Model output (brightness) that's considered "at threshold".
-        amp_range : (amp_lo, amp_hi), optional
-            Range of amplitudes to search, counted in this model's
-            :py:attr:`~pulse2percept.models.BaseModel.stimulus_unit`
-            (microamps, for every model p2p ships).
-        amp_tol : float, optional
-            Search will stop if candidate range of amplitudes is within
-            ``amp_tol``, in ``stimulus_unit``
-        bright_tol : float, optional
-            Search will stop if model brightness is within ``bright_tol`` of
-            ``bright_th``
-        max_iter : int, optional
-            Search will stop after ``max_iter`` iterations
-
-        Returns
-        -------
-        amp_th : float
-            Threshold current, in ``stimulus_unit``, estimated so that the
-            output of ``model.predict_percept(stim(amp_th))`` is within
-            ``bright_tol`` of ``bright_th``.
-
-        Notes
-        -----
-        *  ``amp_range`` and ``amp_tol`` may be given as unitful quantities
-           (e.g. ``amp_range=(0, 1 * mA)``); the answer comes back as a plain
-           number of microamps. ``bright_th`` and ``bright_tol`` are model
-           output, which is not a physical quantity and carries no unit. See
-           :py:mod:`pulse2percept.units`.
-
-        """
-        if not isinstance(stim, Stimulus):
-            raise TypeError(f"'stim' must be a Stimulus, not {type(stim)}.")
-        amp_range = as_value(amp_range, self.stimulus_unit, 'amp_range')
-        amp_tol = as_value(amp_tol, self.stimulus_unit, 'amp_tol')
-
-        def inner_predict(amp, fnc_predict, stim):
-            return fnc_predict(_rescale(stim,
-                                        amp / stim.data.max())).data.max()
-
-        return bisect(bright_th, inner_predict,
-                      args=[self.predict_percept, stim],
-                      x_lo=amp_range[0], x_hi=amp_range[1], x_tol=amp_tol,
-                      y_tol=bright_tol, max_iter=max_iter)
-
     def plot(self, use_dva=False, style='hull', autoscale=True, ax=None,
              figsize=None):
         """Plot the model
@@ -1485,72 +1414,6 @@ class TemporalModel(BaseModel, metaclass=ABCMeta):
             f"pulse2percept.stimuli.AmplitudeEncoder gives it the right "
             f"polarity; otherwise negate it.")
 
-    def find_threshold(self, stim, bright_th, amp_range=(0, 999), amp_tol=1,
-                       bright_tol=0.1, max_iter=100, t_percept=None):
-        """Find the threshold current for a certain stimulus
-
-        Estimates ``amp_th`` such that the output of
-        ``model.predict_percept(stim(amp_th))`` is approximately ``bright_th``.
-
-        Parameters
-        ----------
-        stim : :py:class:`~pulse2percept.stimuli.Stimulus`
-            The stimulus to use. Stimulus amplitude will be up and down
-            regulated until ``amp_th`` is found.
-        bright_th : float
-            Model output (brightness) that's considered "at threshold".
-        amp_range : (amp_lo, amp_hi), optional
-            Range of amplitudes to search, counted in this model's
-            :py:attr:`~pulse2percept.models.BaseModel.stimulus_unit`
-            (microamps, for every model p2p ships).
-        amp_tol : float, optional
-            Search will stop if candidate range of amplitudes is within
-            ``amp_tol``, in ``stimulus_unit``
-        bright_tol : float, optional
-            Search will stop if model brightness is within ``bright_tol`` of
-            ``bright_th``
-        max_iter : int, optional
-            Search will stop after ``max_iter`` iterations
-        t_percept: float or list of floats, optional
-            The time points at which to output a percept, counted in this
-            model's :py:attr:`~pulse2percept.models.BaseModel.time_unit`
-            (milliseconds, for every model p2p ships).
-            If None, the stimulus' own time points are used.
-            May be given as a unitful quantity (e.g. ``[0, 20] * ms``); see
-            :py:mod:`pulse2percept.units`.
-
-        Returns
-        -------
-        amp_th : float
-            Threshold current, in ``stimulus_unit``, estimated so that the
-            output of ``model.predict_percept(stim(amp_th))`` is within
-            ``bright_tol`` of ``bright_th``.
-
-        Notes
-        -----
-        *  ``amp_range``, ``amp_tol`` and ``t_percept`` may be given as unitful
-           quantities; the answer comes back as a plain number of microamps.
-           ``bright_th`` and ``bright_tol`` are model output, which is not a
-           physical quantity and carries no unit. See
-           :py:mod:`pulse2percept.units`.
-
-        """
-        if not isinstance(stim, Stimulus):
-            raise TypeError(f"'stim' must be a Stimulus, not {type(stim)}.")
-        amp_range = as_value(amp_range, self.stimulus_unit, 'amp_range')
-        amp_tol = as_value(amp_tol, self.stimulus_unit, 'amp_tol')
-        t_percept = as_value(t_percept, self.time_unit, 't_percept')
-
-        def inner_predict(amp, fnc_predict, stim, **kwargs):
-            _stim = _rescale(stim, amp / stim.data.max())
-            return fnc_predict(_stim, **kwargs).data.max()
-
-        return bisect(bright_th, inner_predict,
-                      args=[self.predict_percept, stim],
-                      kwargs={'t_percept': t_percept},
-                      x_lo=amp_range[0], x_hi=amp_range[1], x_tol=amp_tol,
-                      y_tol=bright_tol, max_iter=max_iter)
-
 
 class Model(Frozen, PrettyPrint):
     """Computational model
@@ -1695,6 +1558,14 @@ class Model(Frozen, PrettyPrint):
                     "An implant is where a spatial model puts its electrodes, "
                     "and this model has only a temporal component. A temporal "
                     "model is given the stimulus and nothing else.")
+            bound = self.spatial.implant
+            if bound is not None and bound is not implant:
+                raise ValueError(
+                    f"This model was given two different implants: "
+                    f"'implant' is {type(implant).__name__} and the spatial "
+                    f"model is already bound to "
+                    f"{type(bound).__name__}. A model describes one device, "
+                    f"so name it once - either here or on the spatial model.")
             self.spatial.implant = implant
 
     def __getattr__(self, attr):
@@ -2073,76 +1944,6 @@ class Model(Frozen, PrettyPrint):
         elif self.has_time:
             resp = self.temporal.predict_percept(stim, t_percept=t_percept)
         return resp
-
-    def find_threshold(self, stim, bright_th, amp_range=(0, 999), amp_tol=1,
-                       bright_tol=0.1, max_iter=100, t_percept=None):
-        """Find the threshold current for a certain stimulus
-
-        Estimates ``amp_th`` such that the output of
-        ``model.predict_percept(stim(amp_th))`` is approximately ``bright_th``.
-
-        .. versionchanged:: 0.11.0
-            Takes the stimulus rather than an implant carrying one, and scales
-            that stimulus rather than a copy of the implant.
-
-        Parameters
-        ----------
-        stim : :py:class:`~pulse2percept.stimuli.Stimulus`
-            The stimulus to use. Stimulus amplitude will be up and down
-            regulated until ``amp_th`` is found.
-        bright_th : float
-            Model output (brightness) that's considered "at threshold".
-        amp_range : (amp_lo, amp_hi), optional
-            Range of amplitudes to search, counted in this model's
-            :py:attr:`~pulse2percept.models.BaseModel.stimulus_unit`
-            (microamps, for every model p2p ships).
-        amp_tol : float, optional
-            Search will stop if candidate range of amplitudes is within
-            ``amp_tol``
-        bright_tol : float, optional
-            Search will stop if model brightness is within ``bright_tol`` of
-            ``bright_th``
-        max_iter : int, optional
-            Search will stop after ``max_iter`` iterations
-        t_percept: float or list of floats, optional
-            The time points at which to output a percept, counted in this
-            model's :py:attr:`~pulse2percept.models.BaseModel.time_unit`
-            (milliseconds, for every model p2p ships).
-            If None, the stimulus' own time points are used.
-            May be given as a unitful quantity (e.g. ``[0, 20] * ms``); see
-            :py:mod:`pulse2percept.units`.
-
-        Returns
-        -------
-        amp_th : float
-            Threshold current, in ``stimulus_unit``, estimated so that the
-            output of ``model.predict_percept(stim(amp_th))`` is within
-            ``bright_tol`` of ``bright_th``.
-
-        Notes
-        -----
-        *  ``amp_range``, ``amp_tol`` and ``t_percept`` may be given as unitful
-           quantities; the answer comes back as a plain number of microamps.
-           ``bright_th`` and ``bright_tol`` are model output, which is not a
-           physical quantity and carries no unit. See
-           :py:mod:`pulse2percept.units`.
-
-        """
-        if not isinstance(stim, Stimulus):
-            raise TypeError(f"'stim' must be a Stimulus, not {type(stim)}.")
-        amp_range = as_value(amp_range, self.stimulus_unit, 'amp_range')
-        amp_tol = as_value(amp_tol, self.stimulus_unit, 'amp_tol')
-        t_percept = as_value(t_percept, self.time_unit, 't_percept')
-
-        def inner_predict(amp, fnc_predict, stim, **kwargs):
-            return fnc_predict(_rescale(stim, amp / stim.data.max()),
-                               **kwargs).data.max()
-
-        return bisect(bright_th, inner_predict,
-                      args=[self.predict_percept, stim],
-                      kwargs={'t_percept': t_percept},
-                      x_lo=amp_range[0], x_hi=amp_range[1], x_tol=amp_tol,
-                      y_tol=bright_tol, max_iter=max_iter)
 
     @property
     def has_space(self):

--- a/pulse2percept/models/beyeler2019.py
+++ b/pulse2percept/models/beyeler2019.py
@@ -13,7 +13,7 @@ from ..units import deg, dva, um
 from ..utils import deprecated_alias
 from ..utils.constants import UM_PER_MM, ZORDER
 from ..topography import Watson2014Map
-from ..implants import ProsthesisSystem, ElectrodeArray
+from ..implants import ElectrodeArray
 from ..stimuli import Stimulus
 from ..models import Model, SpatialModel
 from .base import _blend_meridian
@@ -904,6 +904,9 @@ class AxonMapSpatial(SpatialModel):
         if self.lam < 10:
             raise ValueError('"lam" < 10 is not supported by this model. '
                              'Consider using ScoreboardModel instead.')
+        if self.implant.eye != self.eye:
+            raise ValueError(f"The implant is in {self.implant.eye} but the "
+                             f"model is set up for {self.eye}.")
         # In a left eye, the OD must have a negative x coordinate:
         self._correct_loc_od()
         # Check whether pickle file needs to be rebuilt:
@@ -1236,11 +1239,3 @@ class AxonMapModel(Model):
                                            temporal=None,
                                            **params)
 
-    def predict_percept(self, implant, t_percept=None):
-        # Need to add an additional check before running the base method:
-        if isinstance(implant, ProsthesisSystem):
-            if implant.eye != self.spatial.eye:
-                raise ValueError(f"The implant is in {implant.eye} but the model was "
-                                 f"built for {self.spatial.eye}.")
-        return super(AxonMapModel, self).predict_percept(implant,
-                                                         t_percept=t_percept)

--- a/pulse2percept/models/beyeler2019.py
+++ b/pulse2percept/models/beyeler2019.py
@@ -81,6 +81,40 @@ def _flatten_bundles(bundles):
     return flat, np.concatenate(([0], np.cumsum(lens))), bundle_id
 
 
+def _electrode_pitch(model):
+    """The implant's typical nearest-neighbour spacing, in ``space_unit``
+
+    Returns None when there is nothing to compare: fewer than two electrodes,
+    or an array whose electrodes sit on top of each other.
+    """
+    xyz = model.implant.earray.coordinates(model.space_unit)
+    if len(xyz) < 2:
+        return None
+    # The nearest *other* electrode, so the query asks for two:
+    distances, _ = cKDTree(xyz).query(xyz, k=2)
+    pitch = float(np.median(distances[:, 1]))
+    return pitch if pitch > 0 else None
+
+
+def _warn_rho_vs_pitch(model):
+    """Warn when current spread is wide compared to electrode spacing
+
+    Describes what the numbers mean and leaves them alone: ``rho`` is a fitted
+    perceptual parameter, and the fit is the user's to defend.
+    """
+    pitch = _electrode_pitch(model)
+    if pitch is None or model.rho <= pitch:
+        return
+    overlap = np.exp(-pitch ** 2 / (2 * model.rho ** 2))
+    warnings.warn(
+        f"rho={model.rho:.0f} um is wider than this implant's electrode "
+        f"pitch ({pitch:.0f} um), a ratio of {model.rho / pitch:.2f}. A point "
+        f"one pitch away from an electrode still sees {overlap:.0%} of its "
+        f"peak, so neighbouring electrodes blur into each other and the "
+        f"percept says more about rho than about which electrodes were "
+        f"driven.")
+
+
 class ScoreboardSpatial(SpatialModel):
     """Scoreboard model of [Beyeler2019]_ (spatial module only)
 
@@ -149,9 +183,9 @@ class ScoreboardSpatial(SpatialModel):
         Alias for ``n_threads``; ``None`` or ``-1`` uses every core.
 
     .. important ::
-        If you change important model parameters outside the constructor (e.g.,
-        by directly setting ``model.xrange = (-10, 10)``), you will have to call
-        ``model.build()`` again for your changes to take effect.
+        Changing a model parameter outside the constructor (e.g., by directly
+        setting ``model.xrange = (-10, 10)``) un-builds the model, and the next
+        ``predict_percept`` builds it again.
     """
 
     def get_default_params(self):
@@ -163,6 +197,9 @@ class ScoreboardSpatial(SpatialModel):
     def get_param_units(self):
         """Return a dict of the units that parameters are stored in"""
         return {**super().get_param_units(), 'rho': um}
+
+    def _build(self):
+        _warn_rho_vs_pitch(self)
 
     def _predict_spatial(self, earray, stim):
         """Predicts the brightness at spatial locations"""
@@ -249,9 +286,9 @@ class ScoreboardModel(Model):
         Alias for ``n_threads``; ``None`` or ``-1`` uses every core.
 
     .. important ::
-        If you change important model parameters outside the constructor (e.g.,
-        by directly setting ``model.xrange = (-10, 10)``), you will have to call
-        ``model.build()`` again for your changes to take effect.
+        Changing a model parameter outside the constructor (e.g., by directly
+        setting ``model.xrange = (-10, 10)``) un-builds the model, and the next
+        ``predict_percept`` builds it again.
 
     """
 
@@ -293,8 +330,6 @@ class AxonMapSpatial(SpatialModel):
         amplitude, summed over the skipped electrodes, so the error at a point
         is bounded by ``min_current_spread`` times the summed amplitude across
         electrodes.
-    eye : {'RE', LE'}, optional
-        Eye for which to generate the axon map.
     xrange : (x_min, x_max), optional
         A tuple indicating the range of x values to simulate (in degrees of
         visual angle). In a right eye, negative x values correspond to the
@@ -367,9 +402,9 @@ class AxonMapSpatial(SpatialModel):
         Alias for ``n_threads``; ``None`` or ``-1`` uses every core.
 
     .. important ::
-        If you change important model parameters outside the constructor (e.g.,
-        by directly setting ``model.lam = 100``), you will have to call
-        ``model.build()`` again for your changes to take effect.
+        Changing a model parameter outside the constructor (e.g., by directly
+        setting ``model.lam = 100``) un-builds the model, and the next
+        ``predict_percept`` builds it again.
 
     Notes
     -----
@@ -387,12 +422,34 @@ class AxonMapSpatial(SpatialModel):
         self.axon_contrib = None
         self.axon_idx_start = None
         self.axon_idx_end = None
+        self._built_eye = None
+
+    @property
+    def eye(self):
+        """The eye the axon map is grown for, which is the implanted one
+
+        .. versionchanged:: 0.11.0
+
+            No longer a parameter of its own. An axon map describes the retina
+            a particular device sits on, so the bound implant is what says
+            which eye, and the two can no longer disagree.
+        """
+        self._require_implant()
+        return self.implant.eye
+
+    @property
+    def is_built(self):
+        """False again once the bound implant has changed eyes
+
+        The one build-invalidating change the parameter machinery cannot see:
+        ``eye`` is not a parameter, and the implant is the same object it was
+        built with.
+        """
+        return super().is_built and self._built_eye == self.implant.eye
 
     def get_default_params(self):
         base_params = super(AxonMapSpatial, self).get_default_params()
         params = {
-            # Left or right eye:
-            'eye': 'RE',
             'rho': 300,
             'lam': 500,
             # Set the (x,y) location of the optic disc:
@@ -889,24 +946,31 @@ class AxonMapSpatial(SpatialModel):
         return tangent.reshape(xc.shape)
 
 
+    def _warn_placement(self):
+        """Warn when the implant is not where nerve fiber bundles run"""
+        placement = self.implant.placement
+        if placement is None or placement == 'epiretinal':
+            return
+        warnings.warn(
+            f"{type(self).__name__} predicts elongated percepts because an "
+            f"epiretinal array stimulates passing nerve fiber bundles. This "
+            f"implant is {placement}, where that mechanism does not apply, so "
+            f"the streaks below are an artifact of the model rather than a "
+            f"prediction about the device. ScoreboardModel is the usual "
+            f"phenomenological starting point for other placements.")
+
     def _correct_loc_od(self):
-        if self.eye.upper() == 'LE':
-            # In a left eye, the optic disc must have a negative x coordinate:
-            self.loc_od = (-np.abs(self.loc_od[0]), self.loc_od[1])
-        elif self.eye.upper() == 'RE':
-            # In a right eye, the optic disc must have a positive x coordinate:
-            self.loc_od = (np.abs(self.loc_od[0]), self.loc_od[1])
-        else:
-            err_str = (f"Eye should be either 'LE' or 'RE', not {self.eye}.")
-            raise ValueError(err_str)
+        """Put the optic disc on the nasal side of whichever eye this is"""
+        sign = -1 if self.eye == 'LE' else 1
+        self.loc_od = (sign * np.abs(self.loc_od[0]), self.loc_od[1])
 
     def _build(self):
         if self.lam < 10:
             raise ValueError('"lam" < 10 is not supported by this model. '
                              'Consider using ScoreboardModel instead.')
-        if self.implant.eye != self.eye:
-            raise ValueError(f"The implant is in {self.implant.eye} but the "
-                             f"model is set up for {self.eye}.")
+        self._warn_placement()
+        _warn_rho_vs_pitch(self)
+        self._built_eye = self.implant.eye
         # In a left eye, the OD must have a negative x coordinate:
         self._correct_loc_od()
         # Check whether pickle file needs to be rebuilt:
@@ -1150,8 +1214,6 @@ class AxonMapModel(Model):
         stimulus amplitude, summed over the skipped electrodes, so the error
         at a point is bounded by ``min_current_spread`` times the summed
         amplitude across electrodes.
-    eye : {'RE', LE'}, optional
-        Eye for which to generate the axon map.
     xrange : (x_min, x_max), optional
         A tuple indicating the range of x values to simulate (in degrees of
         visual angle). In a right eye, negative x values correspond to the
@@ -1224,9 +1286,9 @@ class AxonMapModel(Model):
         Alias for ``n_threads``; ``None`` or ``-1`` uses every core.
 
     .. important ::
-        If you change important model parameters outside the constructor (e.g.,
-        by directly setting ``model.lam = 100``), you will have to call
-        ``model.build()`` again for your changes to take effect.
+        Changing a model parameter outside the constructor (e.g., by directly
+        setting ``model.lam = 100``) un-builds the model, and the next
+        ``predict_percept`` builds it again.
 
     Notes
     -----

--- a/pulse2percept/models/beyeler2019.py
+++ b/pulse2percept/models/beyeler2019.py
@@ -16,7 +16,7 @@ from ..topography import Watson2014Map
 from ..implants import ElectrodeArray
 from ..stimuli import Stimulus
 from ..models import Model, SpatialModel
-from .base import _blend_meridian, _warn_rho_vs_pitch
+from .base import _blend_meridian, _warn_ignores_z, _warn_rho_vs_pitch
 from ._beyeler2019 import (fast_scoreboard, fast_axon_map, fast_jansonius,
                            fast_find_closest_axon)        
 
@@ -169,10 +169,7 @@ class ScoreboardSpatial(SpatialModel):
 
     def _predict_spatial(self, earray, stim):
         """Predicts the brightness at spatial locations"""
-        if not np.allclose([e.z for e in earray.electrode_objects], 0):
-            msg = ("Nonzero electrode-retina distances do not have any effect "
-                   "on the model output.")
-            warnings.warn(msg)
+        _warn_ignores_z(self, earray)
         # This does the expansion of a compact stimulus and a list of
         # electrodes to activation values at X,Y grid locations:
         x_el, y_el, _ = self._electrode_coords(earray, stim)
@@ -1005,10 +1002,7 @@ class AxonMapSpatial(SpatialModel):
 
     def _predict_spatial(self, earray, stim):
         """Predicts the brightness at specific times ``t``"""
-        if not np.allclose([e.z for e in earray.electrode_objects], 0):
-            msg = ("Nonzero electrode-retina distances do not have any effect "
-                   "on the model output.")
-            warnings.warn(msg)
+        _warn_ignores_z(self, earray)
         # This does the expansion of a compact stimulus and a list of
         # electrodes to activation values at X,Y grid locations:
         x_el, y_el, _ = self._electrode_coords(earray, stim)

--- a/pulse2percept/models/beyeler2019.py
+++ b/pulse2percept/models/beyeler2019.py
@@ -16,7 +16,7 @@ from ..topography import Watson2014Map
 from ..implants import ElectrodeArray
 from ..stimuli import Stimulus
 from ..models import Model, SpatialModel
-from .base import _blend_meridian
+from .base import _blend_meridian, _warn_rho_vs_pitch
 from ._beyeler2019 import (fast_scoreboard, fast_axon_map, fast_jansonius,
                            fast_find_closest_axon)        
 
@@ -79,40 +79,6 @@ def _flatten_bundles(bundles):
         raise ValueError("Every bundle must have at least one segment.")
     flat = np.ascontiguousarray(np.concatenate(distinct))
     return flat, np.concatenate(([0], np.cumsum(lens))), bundle_id
-
-
-def _electrode_pitch(model):
-    """The implant's typical nearest-neighbour spacing, in ``space_unit``
-
-    Returns None when there is nothing to compare: fewer than two electrodes,
-    or an array whose electrodes sit on top of each other.
-    """
-    xyz = model.implant.earray.coordinates(model.space_unit)
-    if len(xyz) < 2:
-        return None
-    # The nearest *other* electrode, so the query asks for two:
-    distances, _ = cKDTree(xyz).query(xyz, k=2)
-    pitch = float(np.median(distances[:, 1]))
-    return pitch if pitch > 0 else None
-
-
-def _warn_rho_vs_pitch(model):
-    """Warn when current spread is wide compared to electrode spacing
-
-    Describes what the numbers mean and leaves them alone: ``rho`` is a fitted
-    perceptual parameter, and the fit is the user's to defend.
-    """
-    pitch = _electrode_pitch(model)
-    if pitch is None or model.rho <= pitch:
-        return
-    overlap = np.exp(-pitch ** 2 / (2 * model.rho ** 2))
-    warnings.warn(
-        f"rho={model.rho:.0f} um is wider than this implant's electrode "
-        f"pitch ({pitch:.0f} um), a ratio of {model.rho / pitch:.2f}. A point "
-        f"one pitch away from an electrode still sees {overlap:.0%} of its "
-        f"peak, so neighbouring electrodes blur into each other and the "
-        f"percept says more about rho than about which electrodes were "
-        f"driven.")
 
 
 class ScoreboardSpatial(SpatialModel):
@@ -956,8 +922,9 @@ class AxonMapSpatial(SpatialModel):
             f"epiretinal array stimulates passing nerve fiber bundles. This "
             f"implant is {placement}, where that mechanism does not apply, so "
             f"the streaks below are an artifact of the model rather than a "
-            f"prediction about the device. ScoreboardModel is the usual "
-            f"phenomenological starting point for other placements.")
+            f"prediction about the device. A placement-appropriate "
+            f"local-response scoreboard model is a safer phenomenological "
+            f"starting point.")
 
     def _correct_loc_od(self):
         """Put the optic disc on the nasal side of whichever eye this is"""

--- a/pulse2percept/models/beyeler2019.py
+++ b/pulse2percept/models/beyeler2019.py
@@ -97,9 +97,8 @@ class ScoreboardSpatial(SpatialModel):
     Parameters
     ----------
     implant : :py:class:`~pulse2percept.implants.ProsthesisSystem`
-        The device this model predicts percepts for. Required: a percept is
-        what a particular implant produces, and ``predict_percept`` takes what
-        is presented to that device.
+        The implant whose stimulation this model predicts. Required before
+        building or predicting.
 
         .. versionadded:: 0.11.0
 
@@ -157,7 +156,7 @@ class ScoreboardSpatial(SpatialModel):
 
     .. important ::
         Changing a model parameter outside the constructor (e.g., by directly
-        setting ``model.xrange = (-10, 10)``) un-builds the model, and the next
+        setting ``model.xrange = (-10, 10)``) invalidates the build, and the next
         ``predict_percept`` builds it again.
     """
 
@@ -205,9 +204,8 @@ class ScoreboardModel(Model):
     Parameters
     ----------
     implant : :py:class:`~pulse2percept.implants.ProsthesisSystem`
-        The device this model predicts percepts for. Required: a percept is
-        what a particular implant produces, and ``predict_percept`` takes what
-        is presented to that device.
+        The implant whose stimulation this model predicts. Required before
+        building or predicting.
 
         .. versionadded:: 0.11.0
 
@@ -264,7 +262,7 @@ class ScoreboardModel(Model):
 
     .. important ::
         Changing a model parameter outside the constructor (e.g., by directly
-        setting ``model.xrange = (-10, 10)``) un-builds the model, and the next
+        setting ``model.xrange = (-10, 10)``) invalidates the build, and the next
         ``predict_percept`` builds it again.
 
     """
@@ -291,9 +289,8 @@ class AxonMapSpatial(SpatialModel):
     Parameters
     ----------
     implant : :py:class:`~pulse2percept.implants.ProsthesisSystem`
-        The device this model predicts percepts for. Required: a percept is
-        what a particular implant produces, and ``predict_percept`` takes what
-        is presented to that device.
+        The implant whose stimulation this model predicts. Required before
+        building or predicting.
 
         .. versionadded:: 0.11.0
 
@@ -387,7 +384,7 @@ class AxonMapSpatial(SpatialModel):
 
     .. important ::
         Changing a model parameter outside the constructor (e.g., by directly
-        setting ``model.lam = 100``) un-builds the model, and the next
+        setting ``model.lam = 100``) invalidates the build, and the next
         ``predict_percept`` builds it again.
 
     Notes
@@ -410,25 +407,19 @@ class AxonMapSpatial(SpatialModel):
 
     @property
     def eye(self):
-        """The eye the axon map is grown for, which is the implanted one
+        """Eye used to build the axon map.
+
+        The eye is taken from the bound implant.
 
         .. versionchanged:: 0.11.0
-
-            No longer a parameter of its own. An axon map describes the retina
-            a particular device sits on, so the bound implant is what says
-            which eye, and the two can no longer disagree.
+            ``eye`` is no longer a separate model parameter.
         """
         self._require_implant()
         return self.implant.eye
 
     @property
     def is_built(self):
-        """False again once the bound implant has changed eyes
-
-        The one build-invalidating change the parameter machinery cannot see:
-        ``eye`` is not a parameter, and the implant is the same object it was
-        built with.
-        """
+        """Return whether the axon map is built for the implant's current eye."""
         return super().is_built and self._built_eye == self.implant.eye
 
     def get_default_params(self):
@@ -931,7 +922,7 @@ class AxonMapSpatial(SpatialModel):
 
 
     def _warn_placement(self):
-        """Warn when the implant is not where nerve fiber bundles run"""
+        """Warn when an epiretinal axon-map model is used with another placement."""
         placement = self.implant.placement
         if placement is None or placement == 'epiretinal':
             return
@@ -945,7 +936,7 @@ class AxonMapSpatial(SpatialModel):
             f"starting point.")
 
     def _correct_loc_od(self):
-        """Put the optic disc on the nasal side of whichever eye this is"""
+        """Place the optic disc on the nasal side of the implanted eye."""
         sign = -1 if self.eye == 'LE' else 1
         self.loc_od = (sign * np.abs(self.loc_od[0]), self.loc_od[1])
 
@@ -1180,9 +1171,8 @@ class AxonMapModel(Model):
     Parameters
     ----------
     implant : :py:class:`~pulse2percept.implants.ProsthesisSystem`
-        The device this model predicts percepts for. Required: a percept is
-        what a particular implant produces, and ``predict_percept`` takes what
-        is presented to that device.
+        The implant whose stimulation this model predicts. Required before
+        building or predicting.
 
         .. versionadded:: 0.11.0
 
@@ -1276,7 +1266,7 @@ class AxonMapModel(Model):
 
     .. important ::
         Changing a model parameter outside the constructor (e.g., by directly
-        setting ``model.lam = 100``) un-builds the model, and the next
+        setting ``model.lam = 100``) invalidates the build, and the next
         ``predict_percept`` builds it again.
 
     Notes

--- a/pulse2percept/models/beyeler2019.py
+++ b/pulse2percept/models/beyeler2019.py
@@ -96,6 +96,13 @@ class ScoreboardSpatial(SpatialModel):
 
     Parameters
     ----------
+    implant : :py:class:`~pulse2percept.implants.ProsthesisSystem`
+        The device this model predicts percepts for. Required: a percept is
+        what a particular implant produces, and ``predict_percept`` takes what
+        is presented to that device.
+
+        .. versionadded:: 0.11.0
+
     rho : double, optional
         Exponential decay constant describing phosphene size (microns).
     min_current_spread : float, optional
@@ -197,6 +204,13 @@ class ScoreboardModel(Model):
 
     Parameters
     ----------
+    implant : :py:class:`~pulse2percept.implants.ProsthesisSystem`
+        The device this model predicts percepts for. Required: a percept is
+        what a particular implant produces, and ``predict_percept`` takes what
+        is presented to that device.
+
+        .. versionadded:: 0.11.0
+
     rho : double, optional
         Exponential decay constant describing phosphene size (microns).
     min_current_spread : float, optional
@@ -276,6 +290,13 @@ class AxonMapSpatial(SpatialModel):
 
     Parameters
     ----------
+    implant : :py:class:`~pulse2percept.implants.ProsthesisSystem`
+        The device this model predicts percepts for. Required: a percept is
+        what a particular implant produces, and ``predict_percept`` takes what
+        is presented to that device.
+
+        .. versionadded:: 0.11.0
+
     lam : double, optional
         Exponential decay constant along the axon(microns).
 
@@ -1158,6 +1179,13 @@ class AxonMapModel(Model):
 
     Parameters
     ----------
+    implant : :py:class:`~pulse2percept.implants.ProsthesisSystem`
+        The device this model predicts percepts for. Required: a percept is
+        what a particular implant produces, and ``predict_percept`` takes what
+        is presented to that device.
+
+        .. versionadded:: 0.11.0
+
     lam : double, optional
         Exponential decay constant along the axon(microns).
 

--- a/pulse2percept/models/cortex/base.py
+++ b/pulse2percept/models/cortex/base.py
@@ -79,7 +79,7 @@ class CortexSpatial(SpatialModel):
     .. important::
 
         Changing a model parameter outside the constructor (e.g., by directly
-        setting ``model.xrange = (-10, 10)``) un-builds the model, and the
+        setting ``model.xrange = (-10, 10)``) invalidates the build, and the
         next ``predict_percept`` builds it again.
     """
     @property
@@ -227,9 +227,8 @@ class ScoreboardSpatial(CortexSpatial):
     Parameters
     ----------
     implant : :py:class:`~pulse2percept.implants.ProsthesisSystem`
-        The device this model predicts percepts for. Required: a percept is
-        what a particular implant produces, and ``predict_percept`` takes what
-        is presented to that device.
+        The implant whose stimulation this model predicts. Required before
+        building or predicting.
 
         .. versionadded:: 0.11.0
 
@@ -295,7 +294,7 @@ class ScoreboardSpatial(CortexSpatial):
     .. important ::
     
         Changing a model parameter outside the constructor (e.g., by directly
-        setting ``model.xrange = (-10, 10)``) un-builds the model, and the
+        setting ``model.xrange = (-10, 10)``) invalidates the build, and the
         next ``predict_percept`` builds it again.
 
     """
@@ -391,9 +390,8 @@ class ScoreboardModel(Model):
     Parameters
     ----------
     implant : :py:class:`~pulse2percept.implants.ProsthesisSystem`
-        The device this model predicts percepts for. Required: a percept is
-        what a particular implant produces, and ``predict_percept`` takes what
-        is presented to that device.
+        The implant whose stimulation this model predicts. Required before
+        building or predicting.
 
         .. versionadded:: 0.11.0
 
@@ -458,7 +456,7 @@ class ScoreboardModel(Model):
 
     .. important ::
         Changing a model parameter outside the constructor (e.g., by directly
-        setting ``model.xrange = (-10, 10)``) un-builds the model, and the next
+        setting ``model.xrange = (-10, 10)``) invalidates the build, and the next
         ``predict_percept`` builds it again.
 
     """

--- a/pulse2percept/models/cortex/base.py
+++ b/pulse2percept/models/cortex/base.py
@@ -78,9 +78,9 @@ class CortexSpatial(SpatialModel):
 
     .. important::
 
-        If you change important model parameters outside the constructor (e.g.,
-        by directly setting ``model.xrange = (-10, 10)``), you will have to call
-        ``model.build()`` again for your changes to take effect.
+        Changing a model parameter outside the constructor (e.g., by directly
+        setting ``model.xrange = (-10, 10)``) un-builds the model, and the
+        next ``predict_percept`` builds it again.
     """
     @property
     def regions(self):
@@ -287,9 +287,9 @@ class ScoreboardSpatial(CortexSpatial):
 
     .. important ::
     
-        If you change important model parameters outside the constructor (e.g.,
-        by directly setting ``model.xrange = (-10, 10)``), you will have to call
-        ``model.build()`` again for your changes to take effect.
+        Changing a model parameter outside the constructor (e.g., by directly
+        setting ``model.xrange = (-10, 10)``) un-builds the model, and the
+        next ``predict_percept`` builds it again.
 
     """
     def __init__(self, **params):
@@ -440,9 +440,9 @@ class ScoreboardModel(Model):
         Alias for ``n_threads``; ``None`` or ``-1`` uses every core.
 
     .. important ::
-        If you change important model parameters outside the constructor (e.g.,
-        by directly setting ``model.xrange = (-10, 10)``), you will have to call
-        ``model.build()`` again for your changes to take effect.
+        Changing a model parameter outside the constructor (e.g., by directly
+        setting ``model.xrange = (-10, 10)``) un-builds the model, and the next
+        ``predict_percept`` builds it again.
 
     """
 

--- a/pulse2percept/models/cortex/base.py
+++ b/pulse2percept/models/cortex/base.py
@@ -226,6 +226,13 @@ class ScoreboardSpatial(CortexSpatial):
 
     Parameters
     ----------
+    implant : :py:class:`~pulse2percept.implants.ProsthesisSystem`
+        The device this model predicts percepts for. Required: a percept is
+        what a particular implant produces, and ``predict_percept`` takes what
+        is presented to that device.
+
+        .. versionadded:: 0.11.0
+
     rho : double, optional
         Exponential decay constant describing phosphene size (microns).
     min_current_spread : float, optional
@@ -383,6 +390,13 @@ class ScoreboardModel(Model):
 
     Parameters
     ----------
+    implant : :py:class:`~pulse2percept.implants.ProsthesisSystem`
+        The device this model predicts percepts for. Required: a percept is
+        what a particular implant produces, and ``predict_percept`` takes what
+        is presented to that device.
+
+        .. versionadded:: 0.11.0
+
     rho : double, optional
         Exponential decay constant describing phosphene size (microns).
     min_current_spread : float, optional

--- a/pulse2percept/models/cortex/base.py
+++ b/pulse2percept/models/cortex/base.py
@@ -446,10 +446,6 @@ class ScoreboardModel(Model):
 
     """
 
-    def __init__(self, scene=None, **params):
-        # `scene` is composite state and this is the one standalone model that
-        # forwards its keyword arguments to the spatial model, which does not
-        # take one. Named here so it goes only to `Model.__init__`.
-        super(ScoreboardModel, self).__init__(spatial=ScoreboardSpatial(**params),
-                                              temporal=None, scene=scene,
-                                              **params)
+    def __init__(self, **params):
+        super(ScoreboardModel, self).__init__(
+            spatial=ScoreboardSpatial(**params), temporal=None, **params)

--- a/pulse2percept/models/cortex/base.py
+++ b/pulse2percept/models/cortex/base.py
@@ -2,7 +2,7 @@
    :py:class:`~pulse2percept.models.cortex.ScoreboardSpatial`, 
    :py:class:`~pulse2percept.models.cortex.ScoreboardModel`"""
 
-from ..base import Model, SpatialModel, _blend_meridian
+from ..base import Model, SpatialModel, _blend_meridian, _warn_rho_vs_pitch
 from ...topography import Polimeni2006Map
 from .._beyeler2019 import fast_scoreboard, fast_scoreboard_3d
 from ...units import DimensionMismatchError, dva, um
@@ -311,6 +311,9 @@ class ScoreboardSpatial(CortexSpatial):
         # Cortical coordinates are stored in microns (see `CorticalMap`), and
         # the current spread is compared against them:
         return {**super().get_param_units(), 'rho': um, 'meridian_blend': dva}
+
+    def _build(self):
+        _warn_rho_vs_pitch(self)
 
     def _postprocess_spatial(self, resp):
         """Blend the percept across the vertical meridian

--- a/pulse2percept/models/cortex/dynaphos.py
+++ b/pulse2percept/models/cortex/dynaphos.py
@@ -246,8 +246,8 @@ class DynaphosModel(BaseModel):
         """Build the model
 
         Performs expensive one-time calculations, such as building the spatial
-        grid used to predict a percept. You must call ``build`` before
-        calling ``predict_percept``.
+        grid used to predict a percept. ``predict_percept`` calls it for you
+        when the model is not built.
 
         Parameters
         ----------

--- a/pulse2percept/models/cortex/dynaphos.py
+++ b/pulse2percept/models/cortex/dynaphos.py
@@ -3,7 +3,7 @@ import numpy as np
 import warnings
 from copy import deepcopy, copy
 
-from ..base import BaseModel, NotBuiltError, _require_stim_dimension
+from ..base import BaseModel, _require_stim_dimension
 from ...percepts import Percept
 from ...implants import ProsthesisSystem
 from ...stimuli import BiphasicPulseTrain
@@ -114,9 +114,9 @@ class DynaphosModel(BaseModel):
         
     .. important::
     
-        If you change important model parameters outside the constructor (e.g.,
-        by directly setting ``model.xrange = (-10, 10)``), you will have to call
-        ``model.build()`` again for your changes to take effect.
+        Changing a model parameter outside the constructor (e.g., by directly
+        setting ``model.xrange = (-10, 10)``) un-builds the model, and the
+        next ``predict_percept`` builds it again.
     """
     #: ``step`` used to be called ``xystep``. The old name still reads and
     #: writes ``step``, with a ``DeprecationWarning``. Declared here rather
@@ -443,7 +443,7 @@ class DynaphosModel(BaseModel):
 
         """
         if not self.is_built:
-            raise NotBuiltError("You must call ``build`` first.")
+            self.build()
         t_percept = as_value(t_percept, self.time_unit, 't_percept')
         prepared = self.implant.prepare_stim(source)
         if prepared is None:

--- a/pulse2percept/models/cortex/dynaphos.py
+++ b/pulse2percept/models/cortex/dynaphos.py
@@ -52,9 +52,8 @@ class DynaphosModel(BaseModel):
     Parameters
     ----------
     implant : :py:class:`~pulse2percept.implants.ProsthesisSystem`
-        The device this model predicts percepts for. Required: a percept is
-        what a particular implant produces, and ``predict_percept`` takes what
-        is presented to that device.
+        The implant whose stimulation this model predicts. Required before
+        building or predicting.
 
         .. versionadded:: 0.11.0
 
@@ -122,7 +121,7 @@ class DynaphosModel(BaseModel):
     .. important::
     
         Changing a model parameter outside the constructor (e.g., by directly
-        setting ``model.xrange = (-10, 10)``) un-builds the model, and the
+        setting ``model.xrange = (-10, 10)``) invalidates the build, and the
         next ``predict_percept`` builds it again.
     """
     #: ``step`` used to be called ``xystep``. The old name still reads and

--- a/pulse2percept/models/cortex/dynaphos.py
+++ b/pulse2percept/models/cortex/dynaphos.py
@@ -51,6 +51,13 @@ class DynaphosModel(BaseModel):
     
     Parameters
     ----------
+    implant : :py:class:`~pulse2percept.implants.ProsthesisSystem`
+        The device this model predicts percepts for. Required: a percept is
+        what a particular implant produces, and ``predict_percept`` takes what
+        is presented to that device.
+
+        .. versionadded:: 0.11.0
+
     dt : float, optional
         Sampling time step of the simulation (ms)
     regions : list of str, optional

--- a/pulse2percept/models/cortex/dynaphos.py
+++ b/pulse2percept/models/cortex/dynaphos.py
@@ -142,10 +142,36 @@ class DynaphosModel(BaseModel):
 
             self.vfmap.regions = self.regions
             self.grid = None
+
+    @property
+    def implant(self):
+        """The prosthesis system this model predicts percepts for
+
+        Model context rather than trial input: named once, and
+        :py:meth:`predict_percept` is then given the stimulus. Rebinding
+        invalidates the build.
+
+        .. versionadded:: 0.11.0
+        """
+        return getattr(self, '_implant', None)
+
+    @implant.setter
+    def implant(self, implant):
+        """Implant setter (called upon ``self.implant = implant``)"""
+        if implant is not None and not isinstance(implant, ProsthesisSystem):
+            raise TypeError(f"'implant' must be a ProsthesisSystem object, "
+                            f"not {type(implant)}.")
+        if implant is not getattr(self, '_implant', None):
+            self._is_built = False
+        self._implant = implant
+
     
     def get_default_params(self):
             """Returns all settable parameters of the Dynaphos model"""
             params = {
+                # The device whose electrodes this model places in the visual
+                # field. Required before building or predicting:
+                'implant': None,
                 'xrange': (-5, 5),  # dva
                 'yrange': (-5, 5),  # dva
                 'step': 0.25,  # dva
@@ -236,6 +262,12 @@ class DynaphosModel(BaseModel):
         from ...topography import Grid2D
         # See `BaseModel.build`:
         self.set_params(**build_params)
+        if not isinstance(self.implant, ProsthesisSystem):
+            raise ValueError(
+                f"{type(self).__name__} predicts what a particular implant "
+                f"produces, so it needs one: "
+                f"{type(self).__name__}(implant=Cortivis()). The stimulus is "
+                f"what 'predict_percept' takes.")
         # check that freq/pdur fit. `freq` counts cycles per second, and every
         # duration in this model is in milliseconds:
         window_dur = MS_PER_S / self.freq
@@ -384,18 +416,22 @@ class DynaphosModel(BaseModel):
                 frame_idx = frame_idx + 1
         return np.asarray(bright)
     
-    def predict_percept(self, implant, t_percept=None):
+    def predict_percept(self, source, t_percept=None):
         """Predict the spatiotemporal response
+
+        .. versionchanged:: 0.11.0
+            Takes the stimulus source rather than an implant; the implant is
+            the one this model is bound to.
 
         Parameters
         ----------
-        implant: :py:class:`~pulse2percept.implants.ProsthesisSystem`
-            A valid prosthesis system. A stimulus can be passed via
-            :py:meth:`~pulse2percept.implants.ProsthesisSystem.stim`.
+        source : :py:class:`~pulse2percept.stimuli.Stimulus` source type
+            What is presented to the device; see
+            :py:meth:`~pulse2percept.implants.ProsthesisSystem.prepare_stim`.
         t_percept: float or list of floats, optional
             The time points at which to output a percept (ms). This
             model's numerical contract is fixed to milliseconds.
-            If None, ``implant.stim.time`` is used.
+            If None, the prepared stimulus' own time points are used.
             May be given as a unitful quantity (e.g. ``[0, 20] * ms``);
             see :py:mod:`pulse2percept.units`.
 
@@ -403,28 +439,26 @@ class DynaphosModel(BaseModel):
         -------
         percept: :py:class:`~pulse2percept.models.Percept`
             A Percept object whose ``data`` container has dimensions Y x X x T.
-            Will return None if ``implant.stim`` is None.
+            Will return None if ``source`` is None or empty.
 
         """
         if not self.is_built:
             raise NotBuiltError("You must call ``build`` first.")
-        if not isinstance(implant, ProsthesisSystem):
-            raise TypeError(f"'implant' must be a ProsthesisSystem object, "
-                            f"not {type(implant)}.")
         t_percept = as_value(t_percept, self.time_unit, 't_percept')
-        if implant.stim is None:
+        prepared = self.implant.prepare_stim(source)
+        if prepared is None:
             # Nothing to see here:
             return None
-        _require_stim_dimension(self, implant.stim)
-        if implant.stim.time is None and t_percept is not None:
+        _require_stim_dimension(self, prepared)
+        if prepared.time is None and t_percept is not None:
             raise ValueError(f"Cannot calculate spatial response at times "
                              f"t_percept={t_percept} because stimulus does not "
                              f"have a time component.")
-        if implant.stim.time is None:
+        if prepared.time is None:
             raise ValueError(f"Cannot calculate response because stimulus does not "
                              f"have a time component.")
         # Make sure we don't change the user's Stimulus object:
-        stim = deepcopy(implant.stim)
+        stim = deepcopy(prepared)
         # The pulse clock is a question about what the stimulus is made of,
         # and compressing it answers "samples, and nothing else". So ask
         # first; the waveform below is what the time evolution runs on:
@@ -458,8 +492,8 @@ class DynaphosModel(BaseModel):
             # Stimulus was compressed to zero:
             resp = np.zeros((self.grid.x.size, n_time), dtype=np.float32)
         else:
-            resp = self._predict_percept(implant.earray, stim, t_percept,
-                                         clocks)
+            resp = self._predict_percept(self.implant.earray, stim,
+                                         t_percept, clocks)
         return Percept(resp.reshape(list(self.grid.x.shape) + [t_percept.size]),
                        space=self.grid, time=t_percept,
                        time_unit=self.time_unit,

--- a/pulse2percept/models/cortex/tests/test_base.py
+++ b/pulse2percept/models/cortex/tests/test_base.py
@@ -20,7 +20,7 @@ from pulse2percept.topography import Watson2014Map
 def test_ScoreboardSpatial(ModelClass, jitter_boundary, regions):
     # ScoreboardSpatial automatically sets `regions`
     vfmap = Polimeni2006Map(k=15, a=.5, b=90, jitter_boundary=jitter_boundary, regions=regions)
-    model = ModelClass(xrange=(-3, 3), yrange=(-3, 3), step=0.1, vfmap=vfmap).build()
+    model = ModelClass(implant=Cortivis(), xrange=(-3, 3), yrange=(-3, 3), step=0.1, vfmap=vfmap).build()
     npt.assert_equal(model.regions, regions)
     npt.assert_equal(model.vfmap.regions, regions)
 
@@ -31,11 +31,11 @@ def test_ScoreboardSpatial(ModelClass, jitter_boundary, regions):
     npt.assert_equal(model.rho, 987)
 
     # Nothing in, None out:
-    npt.assert_equal(model.predict_percept(Cortivis()), None)
+    npt.assert_equal(model.predict_percept(None), None)
 
     # Converting ret <=> dva
     vfmap = Polimeni2006Map(k=15, a=0.5, b=90, jitter_boundary=jitter_boundary, regions=regions)
-    model = ModelClass(xrange=(-3, 3), yrange=(-3, 3), step=1, vfmap=vfmap).build()
+    model = ModelClass(implant=Cortivis(), xrange=(-3, 3), yrange=(-3, 3), step=1, vfmap=vfmap).build()
     npt.assert_equal(isinstance(model.vfmap, Polimeni2006Map), True)
     if jitter_boundary:
         npt.assert_equal(np.isnan(model.vfmap.dva_to_v1([0], [0])), False)
@@ -54,9 +54,8 @@ def test_ScoreboardSpatial(ModelClass, jitter_boundary, regions):
         if 'v3' in regions:
             npt.assert_equal(model.grid.v3.x[~np.isnan(model.grid.v3.x)].size, 36)
 
-    implant = Cortivis(x=1000, stim=np.zeros(96))
     # Zero in = zero out:
-    percept = model.predict_percept(implant)
+    percept = model.predict_percept(np.zeros(96))
     npt.assert_equal(isinstance(percept, Percept), True)
     npt.assert_equal(percept.shape, list(model.grid.x.shape) + [1])
     npt.assert_almost_equal(percept.data, 0)
@@ -67,20 +66,20 @@ def test_ScoreboardSpatial(ModelClass, jitter_boundary, regions):
     [['v1'], ['v2'], ['v3'], ['v1', 'v2'], ['v2', 'v3'], ['v1', 'v3'], ['v1', 'v2', 'v3']])
 def test_predict_spatial(ModelClass, regions):
     # test that no current can spread between hemispheres
-    model = ModelClass(xrange=(-3, 3), yrange=(-3, 3), step=0.5, rho=100000, regions=regions).build()
-    implant = Orion(x = 15000)
-    implant.stim = {e:5 for e in implant.electrode_names}
-    percept = model.predict_percept(implant)
+    implant = Orion(x=15000)
+    model = ModelClass(implant=implant, xrange=(-3, 3), yrange=(-3, 3),
+                       step=0.5, rho=100000, regions=regions).build()
+    percept = model.predict_percept({e: 5 for e in implant.electrode_names})
     half = percept.shape[1] // 2
     npt.assert_equal(np.all(percept.data[:, half+1:] == 0), True)
     npt.assert_equal(np.all(percept.data[:, :half] != 0), True)
 
     # implant only in v1, shouldnt change with v2/v3
     vfmap = Polimeni2006Map(k=15, a=0.5, b=90)
-    model = ModelClass(xrange=(-5, 0), yrange=(-3, 3), step=0.1, rho=400, vfmap=vfmap).build()
+    model = ModelClass(implant=Cortivis(x=30000, y=0, rot=0), xrange=(-5, 0),
+                       yrange=(-3, 3), step=0.1, rho=400, vfmap=vfmap).build()
     elecs = [79, 49, 19, 80, 50, 20, 90, 61, 31, 2, 72, 42, 12, 83, 53, 23, 93, 64, 34, 5, 75, 45, 15, 86, 56, 26, 96, 67, 37, 8, 68, 38]
-    implant = Cortivis(x=30000, y=0, rot=0, stim={str(i) : [1, 0] for i in elecs})
-    percept = model.predict_percept(implant)
+    percept = model.predict_percept({str(i): [1, 0] for i in elecs})
     npt.assert_equal(percept.shape, list(model.grid.x.shape) + [2])
     npt.assert_equal(np.all(percept.data[:, :, 1] == 0), True)
     pmax = percept.data.max()
@@ -94,9 +93,10 @@ def test_predict_spatial(ModelClass, regions):
     if 'v1' in regions:
         # make sure cortical representation is flipped
         vfmap = Polimeni2006Map(k=15, a=0.5, b=90)
-        model = ModelClass(xrange=(-5, 0), yrange=(-3, 3), step=0.1, rho=400, vfmap=vfmap).build()
-        implant = Orion(x=30000, y=0, rot=0, stim={'40' : 1,  '94' :5})
-        percept = model.predict_percept(implant)
+        model = ModelClass(implant=Orion(x=30000, y=0, rot=0),
+                           xrange=(-5, 0), yrange=(-3, 3), step=0.1, rho=400,
+                           vfmap=vfmap).build()
+        percept = model.predict_percept({'40': 1, '94': 5})
         half = model.grid.shape[0] // 2
         npt.assert_equal(np.sum(percept.data[:half, :, :]) >  np.sum(percept.data[half:, :, :]), True)
 
@@ -105,16 +105,18 @@ def test_predict_spatial(ModelClass, regions):
 @pytest.mark.parametrize('regions', [['v1', 'v2'], ['v1', 'v3'], ['v2', 'v3']])
 def test_predict_spatial_regionsum(ModelClass,regions):
     print(regions)
-    model1 = ModelClass(xrange=(-3, 3), yrange=(-3, 3), step=0.1, rho=10000, regions=regions[0]).build()
-    model2 = ModelClass(xrange=(-3, 3), yrange=(-3, 3), step=0.1, rho=10000, regions=regions[1]).build()
-    model_both = ModelClass(xrange=(-3, 3), yrange=(-3, 3), step=0.1, rho=10000, regions=regions).build()
+    implant = Orion(x=10000, y=10000)
+    grid = dict(implant=implant, xrange=(-3, 3), yrange=(-3, 3), step=0.1,
+                rho=10000)
+    model1 = ModelClass(regions=regions[0], **grid).build()
+    model2 = ModelClass(regions=regions[1], **grid).build()
+    model_both = ModelClass(regions=regions, **grid).build()
 
-    implant = Orion(x = 10000, y=10000)
-    implant.stim = {e : 1 for e in implant.electrode_names}
+    source = {e: 1 for e in implant.electrode_names}
 
-    percept1 = model1.predict_percept(implant)
-    percept2 = model2.predict_percept(implant)
-    percept_both = model_both.predict_percept(implant)
+    percept1 = model1.predict_percept(source)
+    percept2 = model2.predict_percept(source)
+    percept_both = model_both.predict_percept(source)
 
     # Separate filtering introduces float32 round-off.
     npt.assert_almost_equal(percept1.data + percept2.data, percept_both.data,
@@ -127,16 +129,18 @@ def test_eq_beyeler(ModelClass, stimval):
     
 
     vfmap = Watson2014Map()
-    cortex = ModelClass(xrange=(-3, 3), yrange=(-3, 3), step=0.1,
-                        rho=200 * stimval, regions=['ret'],
-                        vfmap=vfmap, meridian_blend=0).build()
-    retina = BeyelerScoreboard(xrange=(-3, 3), yrange=(-3, 3), step=0.1, rho=200 * stimval).build()
-
     implant = ArgusII()
-    implant.stim = {e : 3 for e in implant.electrode_names[::stimval+1]}
+    cortex = ModelClass(implant=implant, xrange=(-3, 3), yrange=(-3, 3),
+                        step=0.1, rho=200 * stimval, regions=['ret'],
+                        vfmap=vfmap, meridian_blend=0).build()
+    retina = BeyelerScoreboard(implant=implant, xrange=(-3, 3),
+                               yrange=(-3, 3), step=0.1,
+                               rho=200 * stimval).build()
 
-    p1 = cortex.predict_percept(implant)
-    p2 = retina.predict_percept(implant)
+    source = {e: 3 for e in implant.electrode_names[::stimval + 1]}
+
+    p1 = cortex.predict_percept(source)
+    p2 = retina.predict_percept(source)
 
     npt.assert_equal(p1.data, p2.data)
 
@@ -144,7 +148,7 @@ def test_eq_beyeler(ModelClass, stimval):
 
 @pytest.mark.parametrize('ModelClass', [ScoreboardModel, ScoreboardSpatial])
 def test_deepcopy_Scoreboard(ModelClass):
-    original = ModelClass()
+    original = ModelClass(implant=Cortivis())
     copied = copy.deepcopy(original)
 
     # Assert these are two different objects
@@ -167,7 +171,7 @@ def test_deepcopy_Scoreboard(ModelClass):
 @pytest.mark.parametrize('ModelClass', [ScoreboardModel, ScoreboardSpatial])
 def test_plot(ModelClass):
     # make sure that plotting works before and after building
-    m = ModelClass()
+    m = ModelClass(implant=Cortivis())
     m.plot()
     plt.close()
     m.build()
@@ -178,12 +182,11 @@ def test_plot(ModelClass):
 def test_poli_nlink():
     # make sure that the polimeni map and neuralink work togther with scoreboard
     # since this is an odd combo of 2d map and 3d implant
-    model = ScoreboardModel(rho=800, step=.5).build()
+    implant = LinearEdgeThread(x=20000)
+    model = ScoreboardModel(implant=implant, rho=800, step=.5).build()
     npt.assert_equal(model.grid.v1.z is None, True)
     npt.assert_equal(model.grid.v1.x is None, False)
-    implant = LinearEdgeThread(x=20000,)
-    implant.stim = {e : 1 for e in implant.electrode_names}
-    percept = model.predict_percept(implant)
+    percept = model.predict_percept({e: 1 for e in implant.electrode_names})
     npt.assert_almost_equal(np.sum(percept.data), 32.494125, decimal=3)
     npt.assert_equal(np.sum(percept.data > .05), 4)
 
@@ -205,18 +208,19 @@ def test_CortexSpatial_meridian_blend(ModelClass):
 
     # Close to the midline, so the phosphenes land on the vertical meridian
     implant = Cortivis(x=5000)
-    implant.stim = {e: 1 for e in implant.electrode_names}
-    plain = make(meridian_blend=0)
-    unblended = plain.predict_percept(implant).data
+    source = {e: 1 for e in implant.electrode_names}
+    plain = make(implant=implant, meridian_blend=0)
+    unblended = plain.predict_percept(source).data
     npt.assert_array_less(0, unblended.max())
 
-    default_model = make()
+    default_model = make(implant=implant)
     npt.assert_equal(default_model.meridian_blend, 0.1)
-    default_data = default_model.predict_percept(implant).data
+    default_data = default_model.predict_percept(source).data
     npt.assert_equal(np.array_equal(default_data, unblended), False)
 
     width = 0.5
-    blended = make(meridian_blend=width).predict_percept(implant).data
+    blended = make(implant=implant,
+                   meridian_blend=width).predict_percept(source).data
     npt.assert_equal(blended.shape, unblended.shape)
     npt.assert_equal(blended.dtype, unblended.dtype)
 
@@ -247,10 +251,11 @@ def test_CortexSpatial_meridian_blend_reapplies_threshold():
     # Blending pulls brightness across the meridian, which could otherwise
     # lift a point that `thresh_percept` had zeroed back off zero.
     implant = Cortivis(x=5000)
-    implant.stim = {e: 1 for e in implant.electrode_names}
-    model = ScoreboardModel(xrange=(-5, 5), yrange=(-5, 5), step=0.2, rho=800,
-                            meridian_blend=0.5, thresh_percept=0.1).build()
-    data = model.predict_percept(implant).data
+    model = ScoreboardModel(implant=implant, xrange=(-5, 5), yrange=(-5, 5),
+                            step=0.2, rho=800, meridian_blend=0.5,
+                            thresh_percept=0.1).build()
+    data = model.predict_percept(
+        {e: 1 for e in implant.electrode_names}).data
     npt.assert_equal(np.any(data > 0), True)
     # Nothing survives strictly between zero and the threshold:
     npt.assert_equal(np.any((np.abs(data) > 0) & (np.abs(data) < 0.1)), False)

--- a/pulse2percept/models/cortex/tests/test_base.py
+++ b/pulse2percept/models/cortex/tests/test_base.py
@@ -259,3 +259,49 @@ def test_CortexSpatial_meridian_blend_reapplies_threshold():
     npt.assert_equal(np.any(data > 0), True)
     # Nothing survives strictly between zero and the threshold:
     npt.assert_equal(np.any((np.abs(data) > 0) & (np.abs(data) < 0.1)), False)
+
+
+def _user_warnings(build):
+    """The UserWarning messages a build emits, and nothing else"""
+    import warnings
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter('always')
+        build()
+    return [str(w.message) for w in caught
+            if issubclass(w.category, UserWarning)]
+
+
+def _cortex_grid(ndim):
+    return dict(xrange=(-3, 3), yrange=(-3, 3), step=1,
+                vfmap=Polimeni2006Map(regions=['v1'], jitter_boundary=True,
+                                      ndim=ndim))
+
+
+@pytest.mark.parametrize('ndim', [2, 3])
+def test_cortical_scoreboard_warns_when_rho_is_wider_than_the_pitch(ndim):
+    """The same Gaussian spread as the retinal model, so the same warning"""
+    grid = _cortex_grid(ndim)
+    # Cortivis' 400 um pitch, against a current spread three times as wide:
+    said = _user_warnings(
+        ScoreboardModel(implant=Cortivis(), rho=1200, **grid).build)
+    npt.assert_equal(any('pitch (400 um)' in w for w in said), True)
+    npt.assert_equal(any('ratio of 3.00' in w for w in said), True)
+    npt.assert_equal(
+        _user_warnings(ScoreboardModel(implant=Cortivis(), rho=400,
+                                       **grid).build), [])
+
+
+def test_a_three_dimensional_map_counts_depth_as_spacing():
+    """Pitch is measured in whichever dimensions the model reads
+
+    A Neuralink thread stacks its electrodes along z at one (x, y). A 3-D map
+    reads that depth and sees 50 um neighbours; a 2-D one projects them onto
+    the same point, where there is no spacing left to compare rho against.
+    """
+    thread = LinearEdgeThread()
+    said = _user_warnings(
+        ScoreboardModel(implant=thread, rho=200, **_cortex_grid(3)).build)
+    npt.assert_equal(any('pitch (50 um)' in w for w in said), True)
+    npt.assert_equal(
+        _user_warnings(ScoreboardModel(implant=thread, rho=200,
+                                       **_cortex_grid(2)).build), [])

--- a/pulse2percept/models/cortex/tests/test_dynaphos.py
+++ b/pulse2percept/models/cortex/tests/test_dynaphos.py
@@ -26,9 +26,11 @@ def test_DynaphosModel():
     npt.assert_equal(model.regions, ['v1'])
     npt.assert_equal(model.vfmap.regions, ['v1'])
 
-    # can't set frequency/pulse dur that don't match up
+    # can't set frequency/pulse dur that don't match up. A failed build
+    # leaves the parameters the caller asked for in place, so put them back:
     with pytest.raises(ValueError):
         model.build(freq=300,p_dur=10)
+    model.build(freq=300, p_dur=1)
 
     # Nothing in, None out:
     npt.assert_equal(model.predict_percept(None), None)

--- a/pulse2percept/models/cortex/tests/test_dynaphos.py
+++ b/pulse2percept/models/cortex/tests/test_dynaphos.py
@@ -21,7 +21,7 @@ from pulse2percept.units import (DimensionMismatchError, Quantity, mA,
 from pulse2percept.utils.testing import assert_warns_msg
 
 def test_DynaphosModel():
-    model = DynaphosModel(xrange=(-3, 3), yrange=(-3, 3), step=0.1).build()
+    model = DynaphosModel(implant=Cortivis(), xrange=(-3, 3), yrange=(-3, 3), step=0.1).build()
 
     npt.assert_equal(model.regions, ['v1'])
     npt.assert_equal(model.vfmap.regions, ['v1'])
@@ -31,44 +31,44 @@ def test_DynaphosModel():
         model.build(freq=300,p_dur=10)
 
     # Nothing in, None out:
-    npt.assert_equal(model.predict_percept(Cortivis()), None)
+    npt.assert_equal(model.predict_percept(None), None)
 
-    implant = Cortivis(x=1000, stim={e:BiphasicPulseTrain(freq=300,amp=0,phase_dur=1) for e in Cortivis().electrode_names})
+    source = {e:BiphasicPulseTrain(freq=300,amp=0,phase_dur=1) for e in Cortivis().electrode_names}
     # Zero in = zero out:
-    percept = model.predict_percept(implant)
+    percept = model.predict_percept(source)
     npt.assert_equal(isinstance(percept, Percept), True)
     npt.assert_equal(percept.shape, list(model.grid.x.shape)+[51]) # 51 time points
     npt.assert_almost_equal(percept.data, 0)
 
     # Can't pass stimulus with no time component
     with pytest.raises(ValueError):
-        model.predict_percept(Cortivis(stim=[300 for e in Cortivis().electrode_names]))
+        model.predict_percept([300 for e in Cortivis().electrode_names])
 
 def test_predict_spatial():
     # test that no current can spread between hemispheres
-    model = DynaphosModel(xrange=(-3, 3), yrange=(-3, 3), step=0.5).build()
-    implant = Orion(x = 15000)
-    implant.stim = {e:BiphasicPulseTrain(freq=300,amp=2000,phase_dur=0.17) for e in implant.electrode_names}
+    implant = Orion(x=15000)
+    model = DynaphosModel(implant=implant, xrange=(-3, 3), yrange=(-3, 3),
+                          step=0.5).build()
+    source = {e: BiphasicPulseTrain(freq=300, amp=2000, phase_dur=0.17)
+              for e in implant.electrode_names}
     # Check brightest frame of percept
-    percept = model.predict_percept(implant).max(axis='frames')
+    percept = model.predict_percept(source).max(axis='frames')
     half = percept.shape[1] // 2
     npt.assert_equal(np.all(percept[:, half+1:] == 0), True)
     npt.assert_equal(np.all(percept[:, :half] != 0), True)
 
 def test_temporal_predict():
-    model = DynaphosModel(step=0.1).build()
+    model = DynaphosModel(implant=Cortivis(), step=0.1).build()
     # User can set params
     model.dt = 40
     npt.assert_equal(model.dt, 40)
-
-    implant = Cortivis(stim=np.zeros((96, 100)))
 
     # Can't request the same time more than once (this would break the Cython
     # loop, because `idx_frame` is incremented after a write; also doesn't
     # make much sense):
     with pytest.raises(ValueError):
-        implant.stim = np.ones((96, 100))
-        model.predict_percept(implant, t_percept=[0.2, 0.2])
+        source = np.ones((96, 100))
+        model.predict_percept(source, t_percept=[0.2, 0.2])
 
     # Brightness scales with amplitude. The train is built on the model's own
     # clock, so that the duty cycle driving the activation is the one that
@@ -80,20 +80,23 @@ def test_temporal_predict():
     sdur = 1000.0  # stimulus duration (ms)
     pdur = model.p_dur  # (ms)
     t_percept = np.arange(0, sdur, 20)
-    implant = ProsthesisSystem(ElectrodeArray(DiskElectrode(0, 0, 0, 260)))
+    single = DynaphosModel(
+        implant=ProsthesisSystem(ElectrodeArray(DiskElectrode(0, 0, 0, 260))),
+        step=0.1, dt=20).build()
     bright_amp = []
     for amp in np.linspace(20, 70, 5):
-        implant.stim = BiphasicPulseTrain(model.freq, amp, pdur,
+        source = BiphasicPulseTrain(model.freq, amp, pdur,
                                           interphase_dur=pdur, stim_dur=sdur)
-        percept = model.predict_percept(implant, t_percept=t_percept)
+        percept = single.predict_percept(source, t_percept=t_percept)
         bright_amp.append(percept.data.max())
     bright_amp_ref = np.array([0.0, 0.0, 0.4636, 0.7247, 0.8891])
     npt.assert_almost_equal(bright_amp, bright_amp_ref, decimal=3)
     npt.assert_equal(np.all(np.diff(bright_amp) >= 0), True)
 
     # Test that default models give expected values
-    implant = Orion(x=15000, stim={'55': BiphasicPulseTrain(freq=300, amp=100, phase_dur=0.17)})
-    percept = model.predict_percept(implant)
+    orion = DynaphosModel(implant=Orion(x=15000), step=0.1, dt=20).build()
+    percept = orion.predict_percept(
+        {'55': BiphasicPulseTrain(freq=300, amp=100, phase_dur=0.17)})
     npt.assert_equal(np.sum(percept.data > 0.0122), 147)
     npt.assert_equal(np.sum(percept.data > 0.0375), 96)
     npt.assert_equal(np.sum(percept.data > 0.3305), 49)
@@ -101,7 +104,7 @@ def test_temporal_predict():
     npt.assert_equal(np.sum(percept.data > 0.8883), 9)
 
 def test_deepcopy_Dynaphos():
-    original = DynaphosModel()
+    original = DynaphosModel(implant=Cortivis())
     copied = copy.deepcopy(original)
 
     # Assert these are two different objects
@@ -124,7 +127,7 @@ def test_deepcopy_Dynaphos():
 
 def test_dynaphos_plot():
     # make sure that plotting works before and after building
-    m = DynaphosModel()
+    m = DynaphosModel(implant=Cortivis())
     m.plot()
     plt.close()
     m.build()
@@ -140,33 +143,31 @@ def test_DynaphosModel_units():
     with a tolerance rather than for equality.
     """
     kwargs = dict(xrange=(-3, 3), yrange=(-3, 3), step=0.5)
-    bare = DynaphosModel(rheobase=23.9, **kwargs).build()
-    unitful = DynaphosModel(rheobase=0.0239 * mA, **kwargs).build()
+    bare = DynaphosModel(implant=Cortivis(), rheobase=23.9, **kwargs).build()
+    unitful = DynaphosModel(implant=Cortivis(), rheobase=0.0239 * mA, **kwargs).build()
     npt.assert_allclose(unitful.rheobase, 23.9, rtol=1e-12)
     npt.assert_equal(isinstance(unitful.rheobase, Quantity), False)
-    implant = Cortivis(stim={'11': BiphasicPulseTrain(20, 50, 0.45,
-                                                      stim_dur=100)})
-    npt.assert_allclose(unitful.predict_percept(implant).data,
-                        bare.predict_percept(implant).data, rtol=1e-6)
+    source = {'11': BiphasicPulseTrain(20, 50, 0.45, stim_dur=100)}
+    npt.assert_allclose(unitful.predict_percept(source).data,
+                        bare.predict_percept(source).data, rtol=1e-6)
     # The model states what its numbers mean:
     npt.assert_equal((bare.stimulus_unit, bare.space_unit, bare.time_unit),
                      (uA, um, ms))
     with pytest.raises(DimensionMismatchError):
-        DynaphosModel(rheobase=5 * ms)
+        DynaphosModel(implant=Cortivis(), rheobase=5 * ms)
 
 
 def test_DynaphosModel_t_percept_units():
     """This model overrides `predict_percept`, so it normalizes for itself"""
-    model = DynaphosModel(xrange=(-3, 3), yrange=(-3, 3), step=1).build()
-    implant = Cortivis(stim={'11': BiphasicPulseTrain(20, 50, 0.45,
-                                                      stim_dur=100)})
-    bare = model.predict_percept(implant, t_percept=[0, 20, 40])
+    model = DynaphosModel(implant=Cortivis(), xrange=(-3, 3), yrange=(-3, 3), step=1).build()
+    source = {'11': BiphasicPulseTrain(20, 50, 0.45, stim_dur=100)}
+    bare = model.predict_percept(source, t_percept=[0, 20, 40])
     for spelling in ([0, 20, 40] * ms, np.array([0, .02, .04]) * s):
-        unitful = model.predict_percept(implant, t_percept=spelling)
+        unitful = model.predict_percept(source, t_percept=spelling)
         npt.assert_allclose(unitful.data, bare.data, rtol=1e-12)
         npt.assert_allclose(unitful.time, [0, 20, 40], rtol=1e-12)
     with pytest.raises(DimensionMismatchError):
-        model.predict_percept(implant, t_percept=[0, 20] * uA)
+        model.predict_percept(source, t_percept=[0, 20] * uA)
 
 
 def test_DynaphosModel_default_frame_clock_stops_at_the_stimulus():
@@ -177,23 +178,23 @@ def test_DynaphosModel_default_frame_clock_stops_at_the_stimulus():
     stimulus was over, and for a model counting in anything but milliseconds
     it would have been meaningless.
     """
-    stim = BiphasicPulseTrain(20, 50, 0.1, stim_dur=10)
-    implant = Cortivis(stim={'11': stim})
-    kwargs = dict(xrange=(-2, 2), yrange=(-2, 2), step=1)
+    source = {'11': BiphasicPulseTrain(20, 50, 0.1, stim_dur=10)}
+    delivered = Cortivis().prepare_stim(source)
+    kwargs = dict(implant=Cortivis(), xrange=(-2, 2), yrange=(-2, 2), step=1)
 
     # Coarser than a millisecond, which is the case the literal was written
     # for, and still the same clock it always produced:
     model = DynaphosModel(dt=2, **kwargs).build()
-    npt.assert_allclose(model.predict_percept(implant).time,
+    npt.assert_allclose(model.predict_percept(source).time,
                         np.arange(0, 11, 2), rtol=1e-12)
 
     # Finer than a millisecond, which is where it overshot:
     model = DynaphosModel(dt=0.5, **kwargs).build()
-    percept = model.predict_percept(implant)
+    percept = model.predict_percept(source)
     npt.assert_allclose(percept.time, np.arange(0, 10.25, 0.5), rtol=1e-12)
-    npt.assert_equal(percept.time[-1] <= implant.stim.time[-1], True)
+    npt.assert_equal(percept.time[-1] <= delivered.time[-1], True)
     # The endpoint is included, not dropped:
-    npt.assert_allclose(percept.time[-1], implant.stim.time[-1], rtol=1e-12)
+    npt.assert_allclose(percept.time[-1], delivered.time[-1], rtol=1e-12)
 
 
 def test_DynaphosModel_deprecated_xystep():
@@ -203,7 +204,7 @@ def test_DynaphosModel_deprecated_xystep():
     msg = "The 'xystep' parameter of DynaphosModel is deprecated"
     assert_warns_msg(DeprecationWarning, DynaphosModel, msg, xystep=1)
     with pytest.warns(DeprecationWarning):
-        model = DynaphosModel(xrange=(-2, 2), yrange=(-2, 2), xystep=1)
+        model = DynaphosModel(implant=Cortivis(), xrange=(-2, 2), yrange=(-2, 2), xystep=1)
     npt.assert_almost_equal(model.step, 1)
 
     assert_warns_msg(DeprecationWarning, setattr, msg, model, 'xystep', 2)
@@ -220,12 +221,12 @@ def test_DynaphosModel_deprecated_xystep():
     # Both names are the same parameter, so supplying both must raise:
     for params in ({'xystep': 1, 'step': 2}, {'step': 2, 'xystep': 1}):
         with pytest.raises(TypeError, match="same parameter"):
-            DynaphosModel(**params)
+            DynaphosModel(implant=Cortivis(), **params)
 
     # The new name stays silent:
     with warnings.catch_warnings():
         warnings.simplefilter("error", DeprecationWarning)
-        model = DynaphosModel(step=1)
+        model = DynaphosModel(implant=Cortivis(), step=1)
         model.step = 2
         npt.assert_almost_equal(model.step, 2)
 
@@ -234,14 +235,14 @@ def test_dynaphos_reads_the_pulse_train_itself():
     # The same train has to predict the same percept however it is assigned.
     # That used to be false: a bare train carried no per-electrode metadata
     # and was simulated on the model's default clock instead of its own.
-    model = DynaphosModel(step=0.5, xrange=(-2, 2), yrange=(-2, 2)).build()
+    model = DynaphosModel(
+        implant=ProsthesisSystem(ElectrodeArray(DiskElectrode(0, 0, 0, 260))),
+        step=0.5, xrange=(-2, 2), yrange=(-2, 2)).build()
     model.dt = 20
     t_percept = np.arange(0, 200, 20)
 
     def predict(stim):
-        implant = ProsthesisSystem(ElectrodeArray(DiskElectrode(0, 0, 0, 260)))
-        implant.stim = stim
-        return model.predict_percept(implant, t_percept=t_percept).data
+        return model.predict_percept(stim, t_percept=t_percept).data
 
     def train():
         return BiphasicPulseTrain(300, 100, 0.17, interphase_dur=0.17,
@@ -259,16 +260,17 @@ def test_dynaphos_reads_the_pulse_train_itself():
 def test_dynaphos_uses_its_defaults_for_an_arbitrary_waveform():
     # No pulse train behind the samples, so there is no clock to read and the
     # model simulates on its own -- which is what it has always done:
-    model = DynaphosModel(step=0.5, xrange=(-2, 2), yrange=(-2, 2)).build()
+    model = DynaphosModel(
+        implant=ProsthesisSystem(ElectrodeArray(DiskElectrode(0, 0, 0, 260))),
+        step=0.5, xrange=(-2, 2), yrange=(-2, 2)).build()
     model.dt = 20
-    implant = ProsthesisSystem(ElectrodeArray(DiskElectrode(0, 0, 0, 260)))
-    implant.stim = Stimulus([[0, 100, 100, 0]], time=[0, 1, 199, 200])
-    percept = model.predict_percept(implant, t_percept=np.arange(0, 200, 20))
+    source = Stimulus([[0, 100, 100, 0]], time=[0, 1, 199, 200])
+    percept = model.predict_percept(source, t_percept=np.arange(0, 200, 20))
     npt.assert_equal(np.any(percept.data), True)
     # A train whose own clock happens to be the model's gives the same answer
     # as the defaults do, which is what says the defaults were used:
     model.freq, model.p_dur = 111, 0.29
-    other = model.predict_percept(implant,
+    other = model.predict_percept(source,
                                   t_percept=np.arange(0, 200, 20)).data
     npt.assert_equal(np.allclose(percept.data, other), False)
 
@@ -278,38 +280,43 @@ def test_dynaphos_reads_the_clock_before_compression():
     # it no longer describe it. The parameters have to be taken first -- and
     # compression drops the electrodes driven at zero, so what is left has to
     # still line up with the right train.
-    model = DynaphosModel(step=0.5, xrange=(-2, 2), yrange=(-2, 2)).build()
-    model.dt = 20
     implant = ProsthesisSystem(ElectrodeArray([
         DiskElectrode(0, 0, 0, 260), DiskElectrode(1000, 0, 0, 260)]))
-    implant.stim = {0: BiphasicPulseTrain(300, 0, 0.17, stim_dur=200),
-                    1: BiphasicPulseTrain(300, 100, 0.17, stim_dur=200)}
-    both = model.predict_percept(implant, t_percept=np.arange(0, 200, 20))
+    model = DynaphosModel(implant=implant, step=0.5, xrange=(-2, 2),
+                          yrange=(-2, 2)).build()
+    model.dt = 20
+    both = model.predict_percept(
+        {0: BiphasicPulseTrain(300, 0, 0.17, stim_dur=200),
+         1: BiphasicPulseTrain(300, 100, 0.17, stim_dur=200)},
+        t_percept=np.arange(0, 200, 20))
     # Only the second electrode survives compression, and it is the second
     # train's clock that has to reach the simulation:
-    implant.stim = {1: BiphasicPulseTrain(300, 100, 0.17, stim_dur=200)}
     npt.assert_allclose(both.data,
                         model.predict_percept(
-                            implant, t_percept=np.arange(0, 200, 20)).data)
+                            {1: BiphasicPulseTrain(300, 100, 0.17,
+                                                   stim_dur=200)},
+                            t_percept=np.arange(0, 200, 20)).data)
 
 
 def _ensemble_of_two_clocks():
-    """Two implants driven at different frequencies, merged into one"""
-    fast = Orion(stim={e: BiphasicPulseTrain(50, 300, 0.45, stim_dur=100)
-                       for e in Orion().electrode_names})
-    slow = Orion(x=-35000,
-                 stim={e: BiphasicPulseTrain(20, 300, 0.85, stim_dur=100)
-                       for e in Orion().electrode_names})
-    return EnsembleImplant([fast, slow])
+    """Two implants driven at different frequencies, and their merged input"""
+    ensemble = EnsembleImplant([Orion(), Orion(x=-35000)])
+    names = Orion().electrode_names
+    source = {0: {e: BiphasicPulseTrain(50, 300, 0.45, stim_dur=100)
+                  for e in names},
+              1: {e: BiphasicPulseTrain(20, 300, 0.85, stim_dur=100)
+                  for e in names}}
+    return ensemble, source
 
 
 def test_dynaphos_reads_ensemble_clocks():
     # An ensemble keeps its members' trains rather than sampling them away,
     # so every member is simulated at the clock it was built with instead of
     # the model's own default.
-    ensemble = _ensemble_of_two_clocks()
-    clocks = _pulse_train_clocks(ensemble.stim)
-    npt.assert_equal(len(clocks), len(ensemble.stim.electrodes))
+    ensemble, source = _ensemble_of_two_clocks()
+    stim = ensemble.prepare_stim(source)
+    clocks = _pulse_train_clocks(stim)
+    npt.assert_equal(len(clocks), len(stim.electrodes))
     npt.assert_equal(sorted(set(clocks.values())), [(20, 0.85), (50, 0.45)])
     # ...and the members keep their own, rather than sharing one:
     npt.assert_equal(clocks['0-96'], (50, 0.45))
@@ -317,17 +324,17 @@ def test_dynaphos_reads_ensemble_clocks():
 
 
 def test_dynaphos_ensemble_prediction_uses_those_clocks():
-    model = DynaphosModel(xrange=(-3, 3), yrange=(-3, 3), step=1).build()
-    ensemble = _ensemble_of_two_clocks()
-    with_clocks = model.predict_percept(ensemble).data
+    ensemble, source = _ensemble_of_two_clocks()
+    model = DynaphosModel(implant=ensemble, xrange=(-3, 3), yrange=(-3, 3),
+                          step=1).build()
+    with_clocks = model.predict_percept(source).data
     npt.assert_equal(np.any(with_clocks), True)
     # The same waveform with the trains behind it taken away is back on the
     # model's default clock
-    waveform_only = _ensemble_of_two_clocks()
-    waveform_only.stim = Stimulus(ensemble.stim.data,
-                                  electrodes=ensemble.stim.electrodes,
-                                  time=ensemble.stim.time)
-    npt.assert_equal(_pulse_train_clocks(waveform_only.stim), None)
+    stim = ensemble.prepare_stim(source)
+    waveform_only = Stimulus(stim.data, electrodes=stim.electrodes,
+                             time=stim.time)
+    npt.assert_equal(_pulse_train_clocks(waveform_only), None)
     npt.assert_equal(
         np.allclose(with_clocks,
                     model.predict_percept(waveform_only).data), False)

--- a/pulse2percept/models/granley2021.py
+++ b/pulse2percept/models/granley2021.py
@@ -16,15 +16,6 @@ from ._granley2021 import fast_biphasic_axon_map
 # Safety limit for locating delayed temporal peaks.
 _PEAK_SEARCH_DOUBLINGS = 4
 
-# `find_threshold` bisects on a scaled copy of the stimulus *data*, which this
-# model does not read, so the search cannot converge:
-_FIND_THRESHOLD_MSG = (
-    "{cls} does not support find_threshold. It takes amplitude as a multiple "
-    "of threshold and reads it from the pulse train the stimulus is made of, "
-    "not from the stimulus data, so scaling the data leaves the percept "
-    "unchanged. Vary `amp` when building the BiphasicPulseTrain instead."
-)
-
 
 class DefaultBrightModel(BaseModel):
     """
@@ -670,12 +661,6 @@ class BiphasicAxonMapSpatial(AxonMapSpatial):
             return float(max(src.stim_dur for _, src in sources))
         return float(stim.time[-1])
 
-    def find_threshold(self, stim, bright_th, amp_range=(0, 999), amp_tol=1,
-                       bright_tol=0.1, max_iter=100):
-        """Not supported by this model"""
-        raise NotImplementedError(_FIND_THRESHOLD_MSG.format(
-            cls=type(self).__name__))
-
 
 class BiphasicAxonMapModel(Model):
     """ BiphasicAxonMapModel of [Granley2021]_ (standalone model)
@@ -890,14 +875,3 @@ class BiphasicAxonMapModel(Model):
             return None
         _require_stim_dimension(self, stim)
         return self.spatial._predict_prepared(stim, t_percept=t_percept)
-
-    def find_threshold(self, stim, bright_th, amp_range=(0, 999), amp_tol=1,
-                       bright_tol=0.1, max_iter=100, t_percept=None):
-        """Not supported by this model
-
-        Raises
-        ------
-        NotImplementedError
-        """
-        raise NotImplementedError(_FIND_THRESHOLD_MSG.format(
-            cls=type(self).__name__))

--- a/pulse2percept/models/granley2021.py
+++ b/pulse2percept/models/granley2021.py
@@ -288,6 +288,13 @@ class BiphasicAxonMapSpatial(AxonMapSpatial):
 
     Parameters
     ----------
+    implant : :py:class:`~pulse2percept.implants.ProsthesisSystem`
+        The device this model predicts percepts for. Required: a percept is
+        what a particular implant produces, and ``predict_percept`` takes what
+        is presented to that device.
+
+        .. versionadded:: 0.11.0
+
     bright_model: callable, optional
         Model used to modulate percept brightness with amplitude, frequency,
         and pulse duration
@@ -707,6 +714,13 @@ class BiphasicAxonMapModel(Model):
 
     Parameters
     ----------
+    implant : :py:class:`~pulse2percept.implants.ProsthesisSystem`
+        The device this model predicts percepts for. Required: a percept is
+        what a particular implant produces, and ``predict_percept`` takes what
+        is presented to that device.
+
+        .. versionadded:: 0.11.0
+
     bright_model: callable, optional
         Model used to modulate percept brightness with amplitude, frequency,
         and pulse duration
@@ -823,52 +837,3 @@ class BiphasicAxonMapModel(Model):
     def __init__(self, **params):
         super(BiphasicAxonMapModel, self).__init__(
             spatial=BiphasicAxonMapSpatial(), temporal=None, **params)
-
-    def predict_percept(self, source, t_percept=None):
-        """Predict a percept.
-
-        Overrides base predict percept to keep desired time axes.
-        Builds the model first if it is not built.
-
-        .. important::
-
-            This model works in multiples of perceptual threshold, so give
-            amplitude in :py:data:`~pulse2percept.units.xTh` (``2 * xTh``),
-            or calibrate the electrode with ``threshold_amp`` or
-            :py:attr:`~pulse2percept.implants.ProsthesisSystem.thresholds`
-            and give it in microamps. See
-            :py:class:`~pulse2percept.models.BiphasicAxonMapSpatial` for what
-            counts as threshold here.
-
-            The model reads the intended amplitude, frequency and pulse
-            duration off the
-            :py:class:`~pulse2percept.stimuli.BiphasicPulseTrain` objects the
-            stimulus is made of, not off its samples. Editing the data array
-            in place will not change the predicted percept.
-
-        Parameters
-        ----------
-        source : :py:class:`~pulse2percept.stimuli.Stimulus` source type
-            What is presented to the device; see
-            :py:meth:`~pulse2percept.implants.ProsthesisSystem.prepare_stim`.
-        t_percept: float or list of floats, optional
-            The time points at which to output a percept (ms). This
-            model's numerical contract is fixed to milliseconds.
-            If None, the prepared stimulus' own time points are used.
-            May be given as a unitful quantity (e.g. ``[0, 20] * ms``);
-            see :py:mod:`pulse2percept.units`.
-
-        Returns
-        -------
-        percept: :py:class:`~pulse2percept.models.Percept`
-            A Percept object whose ``data`` container has dimensions Y x X x T.
-            Will return None if ``source`` is None or empty.
-        """
-        if not self.is_built:
-            self.build()
-        stim = self._prepared(source)
-        if stim is None or (not self.has_space and not self.has_time):
-            # Nothing to see here:
-            return None
-        _require_stim_dimension(self, stim)
-        return self.spatial._predict_prepared(stim, t_percept=t_percept)

--- a/pulse2percept/models/granley2021.py
+++ b/pulse2percept/models/granley2021.py
@@ -4,7 +4,7 @@ import numpy as np
 from copy import deepcopy
 
 from . import AxonMapSpatial, Model
-from ..implants import ProsthesisSystem, ElectrodeArray
+from ..implants import ElectrodeArray
 from ..stimuli import BiphasicPulseTrain, Stimulus
 from ..percepts import Percept
 from ..units import as_value, um, xTh
@@ -559,20 +559,19 @@ class BiphasicAxonMapSpatial(AxonMapSpatial):
             self._cutoff_r2(self.rho),
             self.n_threads)
 
-    def predict_percept(self, implant, t_percept=None):
+    def _predict_prepared(self, stim, t_percept=None):
         """ Predicts the spatial response
-        Override base predict percept to have desired timesteps and
+        Override the base spatial prediction to have desired timesteps and
         remove unneccesary computation
 
         Parameters
         ----------
-        implant: :py:class:`~pulse2percept.implants.ProsthesisSystem`
-            A valid prosthesis system. A stimulus can be passed via
-            :py:meth:`~pulse2percept.implants.ProsthesisSystem.stim`.
+        stim : :py:class:`~pulse2percept.stimuli.Stimulus`
+            The stimulus the bound implant delivers.
         t_percept: float or list of floats, optional
             The time points at which to output a percept (ms). This
             model's numerical contract is fixed to milliseconds.
-            If None, ``implant.stim.time`` is used.
+            If None, the stimulus' own time points are used.
             May be given as a unitful quantity (e.g. ``[0, 20] * ms``);
             see :py:mod:`pulse2percept.units`.
 
@@ -580,24 +579,17 @@ class BiphasicAxonMapSpatial(AxonMapSpatial):
         -------
         percept: :py:class:`~pulse2percept.models.Percept`
             A Percept object whose ``data`` container has dimensions Y x X x 1.
-            Will return None if ``implant.stim`` is None.
+            Will return None if ``stim`` is None.
         """
         if not self.is_built:
             raise NotBuiltError("You must call ``build`` first.")
-        if not isinstance(implant, ProsthesisSystem):
-            raise TypeError(f"'implant' must be a ProsthesisSystem object, "
-                            f"not {type(implant)}.")
-        if implant.eye != self.eye:
-            raise ValueError(f"The implant is in {implant.eye} but the model "
-                             f"was built for {self.eye}.")
-        if implant.stim is None:
+        if stim is None:
             return None
         # Determine what physical quantity the stimulus is:
-        _require_stim_dimension(self, implant.stim)
+        _require_stim_dimension(self, stim)
         # Determine which pulse trains the stimulus is made of:
-        params = _pulse_train_params(implant.stim)
+        params = _pulse_train_params(stim)
         t_percept = as_value(t_percept, self.time_unit, 't_percept')
-        stim = implant.stim
         n_time = 1 if t_percept is None else np.array([t_percept]).size
         if not params:
             # Nothing is driven above zero amplitude:
@@ -607,8 +599,8 @@ class BiphasicAxonMapSpatial(AxonMapSpatial):
             resp = np.zeros(list(self.grid.x.shape) + [n_time])
             # Response goes in first frame
             resp[:, :, 0] = self._predict_spatial(
-                implant.earray, stim).reshape(self.grid.x.shape)
-        # This override bypasses SpatialModel.predict_percept:
+                self.implant.earray, stim).reshape(self.grid.x.shape)
+        # This override bypasses SpatialModel._predict_prepared:
         resp = self._postprocess_spatial(resp)
         return Percept(resp, space=self.grid, time=t_percept,
                        time_unit=self.time_unit,
@@ -678,7 +670,7 @@ class BiphasicAxonMapSpatial(AxonMapSpatial):
             return float(max(src.stim_dur for _, src in sources))
         return float(stim.time[-1])
 
-    def find_threshold(self, implant, bright_th, amp_range=(0, 999), amp_tol=1,
+    def find_threshold(self, stim, bright_th, amp_range=(0, 999), amp_tol=1,
                        bright_tol=0.1, max_iter=100):
         """Not supported by this model"""
         raise NotImplementedError(_FIND_THRESHOLD_MSG.format(
@@ -721,7 +713,7 @@ class BiphasicAxonMapModel(Model):
         :py:class:`~pulse2percept.stimuli.BiphasicPulseTrain` objects the
         stimulus is made of, not off its samples. Scaling a pulse train
         (``pt * 2``) or the stimulus assembled from one
-        (``implant.stim * 2``) gives a train at the new amplitude and does
+        (``stim * 2``) gives a train at the new amplitude and does
         change the percept, while editing the data array in place does not.
         A stimulus that is only samples -- a raw waveform, an appended
         sequence of two trains, anything whose amplitudes were rewritten --
@@ -847,7 +839,7 @@ class BiphasicAxonMapModel(Model):
         super(BiphasicAxonMapModel, self).__init__(
             spatial=BiphasicAxonMapSpatial(), temporal=None, **params)
 
-    def predict_percept(self, implant, t_percept=None):
+    def predict_percept(self, source, t_percept=None):
         """Predict a percept.
 
         Overrides base predict percept to keep desired time axes
@@ -874,13 +866,13 @@ class BiphasicAxonMapModel(Model):
 
         Parameters
         ----------
-        implant: :py:class:`~pulse2percept.implants.ProsthesisSystem`
-            A valid prosthesis system. A stimulus can be passed via
-            :py:meth:`~pulse2percept.implants.ProsthesisSystem.stim`.
+        source : :py:class:`~pulse2percept.stimuli.Stimulus` source type
+            What is presented to the device; see
+            :py:meth:`~pulse2percept.implants.ProsthesisSystem.prepare_stim`.
         t_percept: float or list of floats, optional
             The time points at which to output a percept (ms). This
             model's numerical contract is fixed to milliseconds.
-            If None, ``implant.stim.time`` is used.
+            If None, the prepared stimulus' own time points are used.
             May be given as a unitful quantity (e.g. ``[0, 20] * ms``);
             see :py:mod:`pulse2percept.units`.
 
@@ -888,21 +880,18 @@ class BiphasicAxonMapModel(Model):
         -------
         percept: :py:class:`~pulse2percept.models.Percept`
             A Percept object whose ``data`` container has dimensions Y x X x T.
-            Will return None if ``implant.stim`` is None.
+            Will return None if ``source`` is None or empty.
         """
         if not self.is_built:
             raise NotBuiltError("You must call ``build`` first.")
-        if not isinstance(implant, ProsthesisSystem):
-            raise TypeError(f"'implant' must be a ProsthesisSystem object, not "
-                            f"{type(implant)}.")
-        if implant.stim is None or (not self.has_space and not self.has_time):
+        stim = self._prepared(source)
+        if stim is None or (not self.has_space and not self.has_time):
             # Nothing to see here:
             return None
-        _require_stim_dimension(self, implant.stim)
-        resp = self.spatial.predict_percept(implant, t_percept=t_percept)
-        return resp
+        _require_stim_dimension(self, stim)
+        return self.spatial._predict_prepared(stim, t_percept=t_percept)
 
-    def find_threshold(self, implant, bright_th, amp_range=(0, 999), amp_tol=1,
+    def find_threshold(self, stim, bright_th, amp_range=(0, 999), amp_tol=1,
                        bright_tol=0.1, max_iter=100, t_percept=None):
         """Not supported by this model
 

--- a/pulse2percept/models/granley2021.py
+++ b/pulse2percept/models/granley2021.py
@@ -827,11 +827,8 @@ class BiphasicAxonMapModel(Model):
     def predict_percept(self, source, t_percept=None):
         """Predict a percept.
 
-        Overrides base predict percept to keep desired time axes
-
-        .. note::
-
-            You must call ``build`` before calling ``predict_percept``.
+        Overrides base predict percept to keep desired time axes.
+        Builds the model first if it is not built.
 
         .. important::
 

--- a/pulse2percept/models/granley2021.py
+++ b/pulse2percept/models/granley2021.py
@@ -289,9 +289,8 @@ class BiphasicAxonMapSpatial(AxonMapSpatial):
     Parameters
     ----------
     implant : :py:class:`~pulse2percept.implants.ProsthesisSystem`
-        The device this model predicts percepts for. Required: a percept is
-        what a particular implant produces, and ``predict_percept`` takes what
-        is presented to that device.
+        The implant whose stimulation this model predicts. Required before
+        building or predicting.
 
         .. versionadded:: 0.11.0
 
@@ -558,9 +557,9 @@ class BiphasicAxonMapSpatial(AxonMapSpatial):
             self.n_threads)
 
     def _predict_prepared(self, stim, t_percept=None):
-        """ Predicts the spatial response
-        Override the base spatial prediction to have desired timesteps and
-        remove unneccesary computation
+        """Predict the spatial response with model-specific time handling.
+
+        Avoids intermediate computation used by the generic spatial path.
 
         Parameters
         ----------
@@ -715,9 +714,8 @@ class BiphasicAxonMapModel(Model):
     Parameters
     ----------
     implant : :py:class:`~pulse2percept.implants.ProsthesisSystem`
-        The device this model predicts percepts for. Required: a percept is
-        what a particular implant produces, and ``predict_percept`` takes what
-        is presented to that device.
+        The implant whose stimulation this model predicts. Required before
+        building or predicting.
 
         .. versionadded:: 0.11.0
 

--- a/pulse2percept/models/granley2021.py
+++ b/pulse2percept/models/granley2021.py
@@ -10,7 +10,7 @@ from ..percepts import Percept
 from ..units import as_value, um, xTh
 from ..utils import FreezeError, rename_parameter
 from ..utils.base import has_own_attr
-from .base import NotBuiltError, BaseModel, _require_stim_dimension
+from .base import BaseModel, _require_stim_dimension
 from ._granley2021 import fast_biphasic_axon_map
 
 # Safety limit for locating delayed temporal peaks.
@@ -573,7 +573,7 @@ class BiphasicAxonMapSpatial(AxonMapSpatial):
             Will return None if ``stim`` is None.
         """
         if not self.is_built:
-            raise NotBuiltError("You must call ``build`` first.")
+            self.build()
         if stim is None:
             return None
         # Determine what physical quantity the stimulus is:
@@ -868,7 +868,7 @@ class BiphasicAxonMapModel(Model):
             Will return None if ``source`` is None or empty.
         """
         if not self.is_built:
-            raise NotBuiltError("You must call ``build`` first.")
+            self.build()
         stim = self._prepared(source)
         if stim is None or (not self.has_space and not self.has_time):
             # Nothing to see here:

--- a/pulse2percept/models/nanduri2012.py
+++ b/pulse2percept/models/nanduri2012.py
@@ -86,14 +86,11 @@ class Nanduri2012Spatial(SpatialModel):
                             self.thresh_percept,
                             self.n_threads)
 
-    def predict_percept(self, implant, t_percept=None):
+    def _build(self):
         if not np.all([isinstance(e, DiskElectrode)
-                       for e in implant.electrode_objects]):
+                       for e in self.implant.electrode_objects]):
             raise TypeError("The Nanduri2012 spatial model only supports "
                             "DiskElectrode arrays.")
-        return super(Nanduri2012Spatial, self).predict_percept(
-            implant, t_percept=t_percept
-        )
 
 
 class Nanduri2012Temporal(TemporalModel):

--- a/pulse2percept/models/nanduri2012.py
+++ b/pulse2percept/models/nanduri2012.py
@@ -74,7 +74,7 @@ class Nanduri2012Spatial(SpatialModel):
         # electrodes to activation values at X,Y grid locations:
         x_el, y_el, z_el = self._electrode_coords(earray, stim)
         # The disk radius is a size rather than a coordinate, so it is read
-        # directly. `predict_percept` has already refused anything but disks:
+        # directly. `_build` has already refused anything but disks:
         r_el = np.ascontiguousarray([earray[e].r for e in stim.electrodes],
                                     dtype=np.float32)
         return spatial_fast(self._stim_values(stim), x_el, y_el, z_el,

--- a/pulse2percept/models/nanduri2012.py
+++ b/pulse2percept/models/nanduri2012.py
@@ -9,6 +9,13 @@ from ..stimuli import Stimulus
 from ..units import ms
 
 
+def _require_disk_electrodes(electrodes):
+    """The Nanduri model reads a disk radius off every electrode it sees"""
+    if not all(isinstance(e, DiskElectrode) for e in electrodes):
+        raise TypeError("The Nanduri2012 spatial model only supports "
+                        "DiskElectrode arrays.")
+
+
 class Nanduri2012Spatial(SpatialModel):
     """Spatial response model of [Nanduri2012]_
 
@@ -36,6 +43,13 @@ class Nanduri2012Spatial(SpatialModel):
 
     Parameters
     ----------
+    implant : :py:class:`~pulse2percept.implants.ProsthesisSystem`
+        The device this model predicts percepts for. Required: a percept is
+        what a particular implant produces, and ``predict_percept`` takes what
+        is presented to that device.
+
+        .. versionadded:: 0.11.0
+
     atten_a : float, optional
         Nominator of the attentuation function
     atten_n : float32, optional
@@ -70,11 +84,15 @@ class Nanduri2012Spatial(SpatialModel):
 
     def _predict_spatial(self, earray, stim):
         """Predicts the brightness at spatial locations"""
+        # Re-checked here and not only at build time: the bound implant stays
+        # the caller's, and swapping its `earray` afterwards would otherwise
+        # reach the kernel below as a missing `.r`.
+        _require_disk_electrodes(earray.electrode_objects)
         # This does the expansion of a compact stimulus and a list of
         # electrodes to activation values at X,Y grid locations:
         x_el, y_el, z_el = self._electrode_coords(earray, stim)
         # The disk radius is a size rather than a coordinate, so it is read
-        # directly. `_build` has already refused anything but disks:
+        # directly:
         r_el = np.ascontiguousarray([earray[e].r for e in stim.electrodes],
                                     dtype=np.float32)
         return spatial_fast(self._stim_values(stim), x_el, y_el, z_el,
@@ -87,10 +105,7 @@ class Nanduri2012Spatial(SpatialModel):
                             self.n_threads)
 
     def _build(self):
-        if not np.all([isinstance(e, DiskElectrode)
-                       for e in self.implant.electrode_objects]):
-            raise TypeError("The Nanduri2012 spatial model only supports "
-                            "DiskElectrode arrays.")
+        _require_disk_electrodes(self.implant.electrode_objects)
 
 
 class Nanduri2012Temporal(TemporalModel):
@@ -211,6 +226,13 @@ class Nanduri2012Model(Model):
 
     Parameters
     ----------
+    implant : :py:class:`~pulse2percept.implants.ProsthesisSystem`
+        The device this model predicts percepts for. Required: a percept is
+        what a particular implant produces, and ``predict_percept`` takes what
+        is presented to that device.
+
+        .. versionadded:: 0.11.0
+
     atten_a : float, optional
         Nominator of the attentuation function (Eq.2 in the paper)
     atten_n : float32, optional

--- a/pulse2percept/models/nanduri2012.py
+++ b/pulse2percept/models/nanduri2012.py
@@ -10,7 +10,7 @@ from ..units import ms
 
 
 def _require_disk_electrodes(electrodes):
-    """The Nanduri model reads a disk radius off every electrode it sees"""
+    """Require disk electrodes, whose radius is used by the Nanduri model."""
     if not all(isinstance(e, DiskElectrode) for e in electrodes):
         raise TypeError("The Nanduri2012 spatial model only supports "
                         "DiskElectrode arrays.")
@@ -44,9 +44,8 @@ class Nanduri2012Spatial(SpatialModel):
     Parameters
     ----------
     implant : :py:class:`~pulse2percept.implants.ProsthesisSystem`
-        The device this model predicts percepts for. Required: a percept is
-        what a particular implant produces, and ``predict_percept`` takes what
-        is presented to that device.
+        The implant whose stimulation this model predicts. Required before
+        building or predicting.
 
         .. versionadded:: 0.11.0
 
@@ -84,9 +83,8 @@ class Nanduri2012Spatial(SpatialModel):
 
     def _predict_spatial(self, earray, stim):
         """Predicts the brightness at spatial locations"""
-        # Re-checked here and not only at build time: the bound implant stays
-        # the caller's, and swapping its `earray` afterwards would otherwise
-        # reach the kernel below as a missing `.r`.
+        # Re-check because the bound implant's electrode array may change
+        # after the model was built.
         _require_disk_electrodes(earray.electrode_objects)
         # This does the expansion of a compact stimulus and a list of
         # electrodes to activation values at X,Y grid locations:
@@ -227,9 +225,8 @@ class Nanduri2012Model(Model):
     Parameters
     ----------
     implant : :py:class:`~pulse2percept.implants.ProsthesisSystem`
-        The device this model predicts percepts for. Required: a percept is
-        what a particular implant produces, and ``predict_percept`` takes what
-        is presented to that device.
+        The implant whose stimulation this model predicts. Required before
+        building or predicting.
 
         .. versionadded:: 0.11.0
 

--- a/pulse2percept/models/tests/test_api_equivalence.py
+++ b/pulse2percept/models/tests/test_api_equivalence.py
@@ -1,9 +1,9 @@
-"""The new prediction API predicts exactly what the old one did (#XXX)
+"""The new prediction API predicts exactly what the old one did
 
 Every reference below was produced by the pre-refactor pipeline --
 ``implant.stim = source`` followed by ``model.predict_percept(implant)`` -- at
 commit 62d5b4e, and is compared against the same setup written the new way:
-``model = Model(implant=implant)`` followed by
+``model = SomeModel(implant=implant)`` followed by
 ``model.predict_percept(source)``. The API changed; the numbers did not.
 
 Percepts are compared by shape, time axis and three whole-array reductions

--- a/pulse2percept/models/tests/test_api_equivalence.py
+++ b/pulse2percept/models/tests/test_api_equivalence.py
@@ -6,15 +6,18 @@ commit 62d5b4e, and is compared against the same setup written the new way:
 ``model = SomeModel(implant=implant)`` followed by
 ``model.predict_percept(source)``. The API changed; the numbers did not.
 
-Percepts are compared by shape, time axis and three whole-array reductions
-rather than element by element: a change in what any electrode contributes
-moves at least one of them, and pinning three numbers per case keeps the
-references readable.
+Percepts are compared by shape, time axis and a handful of whole-array
+reductions rather than element by element, which keeps the references
+readable. Sum, peak and sum of squares say how much brightness there is;
+they are blind to where it sits, so a permuted electrode map or a shifted
+retinotopy could preserve all three. The brightness moments say where it
+sits: mean and mean-square pixel index along the percept's Y and X axes,
+which no translation or reshuffling of the grid leaves alone.
 
-``percept.data`` is float32, so the reductions carry a few ulps of slack that
-varies with the platform's ``exp`` and the compiler's floating-point
-contraction. ``RTOL`` is loose enough to absorb that and still orders of
-magnitude tighter than any change in the pipeline would be.
+``percept.data`` is float32, so the reductions carry slack that varies with
+the platform's ``exp`` and the compiler's floating-point contraction.
+``RTOL`` is loose enough to absorb that and still orders of magnitude tighter
+than any change in the pipeline would be.
 """
 import warnings
 
@@ -37,43 +40,80 @@ GRID = dict(xrange=(-8, 8), yrange=(-6, 6), step=1)
 AXON = dict(n_axons=200, n_ax_segments=100, ignore_pickle=True)
 
 #: What the pre-refactor pipeline predicted: shape, (t_first, t_last), sum,
-#: max, sum of squares.
+#: max, sum of squares, and the brightness moments (mean_y, mean_sq_y,
+#: mean_x, mean_sq_x) that `moments` below computes.
 REFERENCE = {
     'scoreboard': ((13, 17, 1), None,
-                   106.27331389391497, 29.729562759399414, 1590.841862258684),
+                   106.27331389391497, 29.729562759399414, 1590.841862258684,
+                   (4.855147072796709, 24.43435468223049,
+                    6.805482721437667, 47.70945073251632)),
     'axonmap': ((13, 17, 1), None,
-                111.66620632618813, 23.478652954101562, 1327.6353996210921),
+                111.66620632618813, 23.478652954101562, 1327.6353996210921,
+                (5.185161927644366, 27.987468482922242,
+                 6.827698436941981, 47.849236089244805)),
     'spatiotemporal': ((13, 17, 4), (0.0, 60.0),
                        2.282379476566313, 0.32124122977256775,
-                       0.28389843167895795),
+                       0.28389843167895795,
+                       (4.931046339872862, 24.86797727082938,
+                        6.931046450353491, 48.59216420177322)),
     'encoded_image': ((13, 17, 1), None,
                       4068.7693935632706, 46.307098388671875,
-                      105311.18907585883),
+                      105311.18907585883,
+                      (8.147908231279617, 75.03071679781367,
+                       8.276378690968135, 92.40379187416536)),
     'encoded_video': ((13, 17, 3), (0.0, 100.0),
                       13472.329383134842, 51.660400390625,
-                      337278.64476578706),
+                      337278.64476578706,
+                      (6.0661377111050685, 49.745639543040014,
+                       7.921347896154394, 86.90694497105545)),
     'encoded_video_temporal': ((13, 17, 3), (50.0, 150.0),
                                39.186431967886165, 0.21076203882694244,
-                               3.328352739130871),
+                               3.328352739130871,
+                               (6.528613866884478, 56.270883389329825,
+                                7.894180997742635, 86.76219135133657)),
     'biphasic': ((13, 17, 1), None,
-                 3.807037961360792, 0.5194367010755934, 1.0132546632537747),
+                 3.807037961360792, 0.5194367010755934, 1.0132546632537747,
+                 (5.0853018679140565, 27.047305434768763,
+                  6.941999430159145, 49.25247073610444)),
     'dynaphos': ((7, 7, 6), (0.0, 100.0),
                  3.864256768792984e-06, 1.0946714610327035e-06,
-                 3.800738015684018e-12),
+                 3.800738015684018e-12,
+                 (2.0, 4.0, 1.0, 1.0)),
     'scene_gaze': ((13, 17, 1), None,
-                   1663.1452019751928, 36.72337341308594, 43973.7099062507),
+                   1663.1452019751928, 36.72337341308594, 43973.7099062507,
+                   (6.000000013081055, 40.855445551864825,
+                    8.174004836496247, 71.63952372279992)),
     'scene_scotoma': ((41, 41, 3, 1), None,
-                      2435.118678161456, 1.0, 1652.0926838311032),
+                      2435.118678161456, 1.0, 1652.0926838311032,
+                      (19.9999999996621, 544.5046493203229,
+                       27.224079296239694, 833.4678215082496)),
 }
 
 
-#: Ten times float32 epsilon: the reductions are computed in float64, but from
-#: float32 inputs.
-RTOL = 1e-6
+#: Sized from the spread actually observed across the platforms CI runs on,
+#: not from float32 epsilon: the AxonMap sum differs by 3e-6 between macOS and
+#: Linux for percepts that are otherwise bit-identical within a platform.
+RTOL = 1e-5
+
+
+def moments(data):
+    """Mean and mean-square pixel index of brightness along Y and X
+
+    Raw moments rather than centered ones: a percept driven by a single
+    electrode has essentially no spread, and a variance computed from it is
+    cancellation noise that no tolerance can pin.
+    """
+    total = data.sum()
+    out = []
+    for axis in (0, 1):
+        shape = [-1 if k == axis else 1 for k in range(data.ndim)]
+        idx = np.arange(data.shape[axis], dtype=np.float64).reshape(shape)
+        out += [(data * idx).sum() / total, (data * idx ** 2).sum() / total]
+    return out
 
 
 def assert_matches_reference(name, percept):
-    shape, time, total, peak, sumsq = REFERENCE[name]
+    shape, time, total, peak, sumsq, spatial = REFERENCE[name]
     data = np.asarray(percept.data, dtype=np.float64)
     npt.assert_equal(percept.data.shape, shape)
     if time is None:
@@ -84,6 +124,7 @@ def assert_matches_reference(name, percept):
     npt.assert_allclose(data.sum(), total, rtol=RTOL)
     npt.assert_allclose(data.max(), peak, rtol=RTOL)
     npt.assert_allclose((data ** 2).sum(), sumsq, rtol=RTOL)
+    npt.assert_allclose(moments(data), spatial, rtol=RTOL)
 
 
 def picture():

--- a/pulse2percept/models/tests/test_api_equivalence.py
+++ b/pulse2percept/models/tests/test_api_equivalence.py
@@ -1,23 +1,13 @@
-"""The new prediction API predicts exactly what the old one did
+"""Regression tests for numerical equivalence across the prediction API refactor.
 
-Every reference below was produced by the pre-refactor pipeline --
-``implant.stim = source`` followed by ``model.predict_percept(implant)`` -- at
-commit 62d5b4e, and is compared against the same setup written the new way:
-``model = SomeModel(implant=implant)`` followed by
-``model.predict_percept(source)``. The API changed; the numbers did not.
+Reference values were generated at commit ``62d5b4e`` with the old
+``implant.stim = source; model.predict_percept(implant)`` pipeline. Each case
+compares the new API against those references using shape, time, global
+intensity reductions, and raw spatial moments.
 
-Percepts are compared by shape, time axis and a handful of whole-array
-reductions rather than element by element, which keeps the references
-readable. Sum, peak and sum of squares say how much brightness there is;
-they are blind to where it sits, so a permuted electrode map or a shifted
-retinotopy could preserve all three. The brightness moments say where it
-sits: mean and mean-square pixel index along the percept's Y and X axes,
-which no translation or reshuffling of the grid leaves alone.
-
-``percept.data`` is float32, so the reductions carry slack that varies with
-the platform's ``exp`` and the compiler's floating-point contraction.
-``RTOL`` is loose enough to absorb that and still orders of magnitude tighter
-than any change in the pipeline would be.
+The spatial moments catch translations or permutations that sum, maximum, and
+sum of squares cannot detect. ``RTOL = 1e-5`` covers the measured
+cross-platform floating-point spread (about 3e-6 for the AxonMap sum).
 """
 import warnings
 
@@ -97,11 +87,9 @@ RTOL = 1e-5
 
 
 def moments(data):
-    """Mean and mean-square pixel index of brightness along Y and X
+    """Return raw first and second brightness moments along Y and X.
 
-    Raw moments rather than centered ones: a percept driven by a single
-    electrode has essentially no spread, and a variance computed from it is
-    cancellation noise that no tolerance can pin.
+    Raw moments avoid cancellation in nearly point-like percepts.
     """
     total = data.sum()
     out = []
@@ -187,8 +175,8 @@ def test_encoded_video_prediction_is_unchanged():
 
 
 def test_encoded_video_with_a_temporal_stage_is_unchanged():
-    # The other half of the modulation/pulses distinction: with a temporal
-    # stage the spatial one reads the delivered train instead.
+    # With a temporal stage, the spatial model reads the delivered pulse
+    # train rather than frame-level modulation.
     model = Model(implant=ArgusII(),
                   spatial=ScoreboardSpatial(rho=200, **GRID),
                   temporal=FadingTemporal(tau=100)).build()
@@ -231,19 +219,19 @@ def test_scene_with_scotoma_prediction_is_unchanged():
 
 @pytest.mark.parametrize('ModelClass', [ScoreboardModel, AxonMapModel])
 def test_one_bound_model_predicts_many_stimuli(ModelClass):
-    """A bound model is asked repeatedly, and keeps nothing between calls"""
+    """Check repeated predictions do not store per-trial stimulus state."""
     extra = AXON if ModelClass is AxonMapModel else {}
     model = ModelClass(implant=ArgusII(), rho=200, **GRID, **extra).build()
     sources = [{'C5': 30, 'A1': 10}, {'A1': 20}, picture(),
                {'C5': 30, 'A1': 10}]
     percepts = [model.predict_percept(s) for s in sources]
 
-    # The first and last are the same stimulus, so they are the same percept:
+    # Repeated input must reproduce the same percept:
     npt.assert_array_equal(percepts[0].data, percepts[-1].data)
-    # ... and the ones in between really were different predictions:
+    # Intermediate inputs must produce different percepts:
     npt.assert_equal(np.allclose(percepts[0].data, percepts[1].data), False)
     npt.assert_equal(np.allclose(percepts[0].data, percepts[2].data), False)
-    # Nothing was built a second time, and nothing was stored on the implant:
+    # Repeated predictions neither rebuild nor store stimulus state:
     npt.assert_equal(model.is_built, True)
     npt.assert_equal(hasattr(model.implant, 'stim'), False)
 
@@ -257,7 +245,6 @@ def test_rebinding_the_implant_invalidates_the_build():
     npt.assert_equal(model.is_built, False)
     model.build()
     there = model.predict_percept({'C5': 30})
-    # The same stimulus on a shifted array lands somewhere else, which is what
-    # says the rebind reached the prediction rather than being ignored:
+    # Rebinding the implant must change spatial registration:
     npt.assert_equal(np.allclose(here.data, there.data), False)
     npt.assert_equal(np.argmax(here.data) != np.argmax(there.data), True)

--- a/pulse2percept/models/tests/test_api_equivalence.py
+++ b/pulse2percept/models/tests/test_api_equivalence.py
@@ -10,6 +10,11 @@ Percepts are compared by shape, time axis and three whole-array reductions
 rather than element by element: a change in what any electrode contributes
 moves at least one of them, and pinning three numbers per case keeps the
 references readable.
+
+``percept.data`` is float32, so the reductions carry a few ulps of slack that
+varies with the platform's ``exp`` and the compiler's floating-point
+contraction. ``RTOL`` is loose enough to absorb that and still orders of
+magnitude tighter than any change in the pipeline would be.
 """
 import warnings
 
@@ -62,6 +67,11 @@ REFERENCE = {
 }
 
 
+#: Ten times float32 epsilon: the reductions are computed in float64, but from
+#: float32 inputs.
+RTOL = 1e-6
+
+
 def assert_matches_reference(name, percept):
     shape, time, total, peak, sumsq = REFERENCE[name]
     data = np.asarray(percept.data, dtype=np.float64)
@@ -71,9 +81,9 @@ def assert_matches_reference(name, percept):
     else:
         npt.assert_allclose([percept.time[0], percept.time[-1]], time,
                             rtol=1e-12)
-    npt.assert_allclose(data.sum(), total, rtol=1e-9)
-    npt.assert_allclose(data.max(), peak, rtol=1e-9)
-    npt.assert_allclose((data ** 2).sum(), sumsq, rtol=1e-9)
+    npt.assert_allclose(data.sum(), total, rtol=RTOL)
+    npt.assert_allclose(data.max(), peak, rtol=RTOL)
+    npt.assert_allclose((data ** 2).sum(), sumsq, rtol=RTOL)
 
 
 def picture():

--- a/pulse2percept/models/tests/test_api_equivalence.py
+++ b/pulse2percept/models/tests/test_api_equivalence.py
@@ -1,0 +1,212 @@
+"""The new prediction API predicts exactly what the old one did (#XXX)
+
+Every reference below was produced by the pre-refactor pipeline --
+``implant.stim = source`` followed by ``model.predict_percept(implant)`` -- at
+commit 62d5b4e, and is compared against the same setup written the new way:
+``model = Model(implant=implant)`` followed by
+``model.predict_percept(source)``. The API changed; the numbers did not.
+
+Percepts are compared by shape, time axis and three whole-array reductions
+rather than element by element: a change in what any electrode contributes
+moves at least one of them, and pinning three numbers per case keeps the
+references readable.
+"""
+import warnings
+
+import numpy as np
+import numpy.testing as npt
+import pytest
+
+from pulse2percept.implants import ArgusII, GridImplant
+from pulse2percept.implants.cortex import Cortivis
+from pulse2percept.models import (AxonMapModel, BiphasicAxonMapModel,
+                                  FadingTemporal, Model, ScoreboardModel,
+                                  ScoreboardSpatial)
+from pulse2percept.models.cortex import DynaphosModel
+from pulse2percept.stimuli import (AmplitudeEncoder, BiphasicPulseTrain,
+                                   ImageStimulus, VideoStimulus)
+from pulse2percept.units import dva, xTh
+from pulse2percept.vision import Scene, Scotoma
+
+GRID = dict(xrange=(-8, 8), yrange=(-6, 6), step=1)
+AXON = dict(n_axons=200, n_ax_segments=100, ignore_pickle=True)
+
+#: What the pre-refactor pipeline predicted: shape, (t_first, t_last), sum,
+#: max, sum of squares.
+REFERENCE = {
+    'scoreboard': ((13, 17, 1), None,
+                   106.27331389391497, 29.729562759399414, 1590.841862258684),
+    'axonmap': ((13, 17, 1), None,
+                111.66620632618813, 23.478652954101562, 1327.6353996210921),
+    'spatiotemporal': ((13, 17, 4), (0.0, 60.0),
+                       2.282379476566313, 0.32124122977256775,
+                       0.28389843167895795),
+    'encoded_image': ((13, 17, 1), None,
+                      4068.7693935632706, 46.307098388671875,
+                      105311.18907585883),
+    'encoded_video': ((13, 17, 3), (0.0, 100.0),
+                      13472.329383134842, 51.660400390625,
+                      337278.64476578706),
+    'encoded_video_temporal': ((13, 17, 3), (50.0, 150.0),
+                               39.186431967886165, 0.21076203882694244,
+                               3.328352739130871),
+    'biphasic': ((13, 17, 1), None,
+                 3.807037961360792, 0.5194367010755934, 1.0132546632537747),
+    'dynaphos': ((7, 7, 6), (0.0, 100.0),
+                 3.864256768792984e-06, 1.0946714610327035e-06,
+                 3.800738015684018e-12),
+    'scene_gaze': ((13, 17, 1), None,
+                   1663.1452019751928, 36.72337341308594, 43973.7099062507),
+    'scene_scotoma': ((41, 41, 3, 1), None,
+                      2435.118678161456, 1.0, 1652.0926838311032),
+}
+
+
+def assert_matches_reference(name, percept):
+    shape, time, total, peak, sumsq = REFERENCE[name]
+    data = np.asarray(percept.data, dtype=np.float64)
+    npt.assert_equal(percept.data.shape, shape)
+    if time is None:
+        npt.assert_equal(percept.time, None)
+    else:
+        npt.assert_allclose([percept.time[0], percept.time[-1]], time,
+                            rtol=1e-12)
+    npt.assert_allclose(data.sum(), total, rtol=1e-9)
+    npt.assert_allclose(data.max(), peak, rtol=1e-9)
+    npt.assert_allclose((data ** 2).sum(), sumsq, rtol=1e-9)
+
+
+def picture():
+    return ImageStimulus(np.linspace(0, 1, 64).reshape((8, 8)))
+
+
+def movie():
+    rng = np.random.default_rng(0)
+    return VideoStimulus(rng.random((6, 10, 3)), metadata={'fps': 20})
+
+
+def scene_of(**kwargs):
+    px = 41
+    ramp = ImageStimulus(np.tile(np.linspace(0, 1, px), (px, 1)))
+    return Scene(ramp, fov=(px, px), **kwargs)
+
+
+def encoding_grid():
+    return GridImplant(shape=(4, 4), spacing=500,
+                       encoder=AmplitudeEncoder(amp_range=(0, 50)))
+
+
+def test_scoreboard_prediction_is_unchanged():
+    model = ScoreboardModel(implant=ArgusII(), rho=200, **GRID).build()
+    assert_matches_reference('scoreboard',
+                             model.predict_percept({'C5': 30, 'A1': 10}))
+
+
+def test_axonmap_prediction_is_unchanged():
+    model = AxonMapModel(implant=ArgusII(), rho=200, lam=500, **GRID,
+                         **AXON).build()
+    assert_matches_reference('axonmap',
+                             model.predict_percept({'C5': 30, 'A1': 10}))
+
+
+def test_spatiotemporal_prediction_is_unchanged():
+    model = Model(implant=ArgusII(),
+                  spatial=ScoreboardSpatial(rho=200, **GRID),
+                  temporal=FadingTemporal(tau=100)).build()
+    percept = model.predict_percept(
+        {'C5': BiphasicPulseTrain(20, 50, 0.45, stim_dur=100)},
+        t_percept=[0, 20, 40, 60])
+    assert_matches_reference('spatiotemporal', percept)
+
+
+def test_encoded_image_prediction_is_unchanged():
+    model = ScoreboardModel(implant=ArgusII(), rho=200, **GRID).build()
+    assert_matches_reference('encoded_image',
+                             model.predict_percept(picture()))
+
+
+def test_encoded_video_prediction_is_unchanged():
+    # Argus II's own 6 Hz encoder and six-group raster, so this covers the
+    # schedule as well as the encoding.
+    model = ScoreboardModel(implant=ArgusII(), rho=200, **GRID).build()
+    with warnings.catch_warnings():
+        warnings.simplefilter('ignore')
+        percept = model.predict_percept(movie())
+    assert_matches_reference('encoded_video', percept)
+
+
+def test_encoded_video_with_a_temporal_stage_is_unchanged():
+    # The other half of the modulation/pulses distinction: with a temporal
+    # stage the spatial one reads the delivered train instead.
+    model = Model(implant=ArgusII(),
+                  spatial=ScoreboardSpatial(rho=200, **GRID),
+                  temporal=FadingTemporal(tau=100)).build()
+    with warnings.catch_warnings():
+        warnings.simplefilter('ignore')
+        percept = model.predict_percept(movie())
+    assert_matches_reference('encoded_video_temporal', percept)
+
+
+def test_biphasic_axon_map_prediction_is_unchanged():
+    implant = ArgusII()
+    implant.thresholds = 80
+    model = BiphasicAxonMapModel(implant=implant, rho=200, lam=500, **GRID,
+                                 **AXON).build()
+    percept = model.predict_percept(
+        {'C5': BiphasicPulseTrain(20, 2 * xTh, 0.45, stim_dur=100)})
+    assert_matches_reference('biphasic', percept)
+
+
+def test_dynaphos_prediction_is_unchanged():
+    model = DynaphosModel(implant=Cortivis(), xrange=(-3, 3), yrange=(-3, 3),
+                          step=1, dt=20).build()
+    percept = model.predict_percept(
+        {'11': BiphasicPulseTrain(300, 100, 0.17, stim_dur=100)})
+    assert_matches_reference('dynaphos', percept)
+
+
+def test_scene_with_gaze_prediction_is_unchanged():
+    model = ScoreboardModel(implant=encoding_grid(), rho=200, **GRID).build()
+    percept = model.predict_percept(scene_of(), gaze=(4, 0) * dva)
+    assert_matches_reference('scene_gaze', percept)
+
+
+def test_scene_with_scotoma_prediction_is_unchanged():
+    model = ScoreboardModel(implant=encoding_grid(), rho=200, **GRID).build()
+    scene = scene_of(scotoma=Scotoma.circle(6), scotoma_fill=0.0)
+    assert_matches_reference('scene_scotoma',
+                             model.predict_percept(scene, vmax=50))
+
+
+@pytest.mark.parametrize('ModelClass', [ScoreboardModel, AxonMapModel])
+def test_one_bound_model_predicts_many_stimuli(ModelClass):
+    """A bound model is asked repeatedly, and keeps nothing between calls"""
+    extra = AXON if ModelClass is AxonMapModel else {}
+    model = ModelClass(implant=ArgusII(), rho=200, **GRID, **extra).build()
+    sources = [{'C5': 30, 'A1': 10}, {'A1': 20}, picture(),
+               {'C5': 30, 'A1': 10}]
+    percepts = [model.predict_percept(s) for s in sources]
+
+    # The first and last are the same stimulus, so they are the same percept:
+    npt.assert_array_equal(percepts[0].data, percepts[-1].data)
+    # ... and the ones in between really were different predictions:
+    npt.assert_equal(np.allclose(percepts[0].data, percepts[1].data), False)
+    npt.assert_equal(np.allclose(percepts[0].data, percepts[2].data), False)
+    # Nothing was built a second time, and nothing was stored on the implant:
+    npt.assert_equal(model.is_built, True)
+    npt.assert_equal(hasattr(model.implant, 'stim'), False)
+
+
+def test_rebinding_the_implant_invalidates_the_build():
+    model = ScoreboardModel(implant=ArgusII(), rho=200, **GRID).build()
+    npt.assert_equal(model.is_built, True)
+    here = model.predict_percept({'C5': 30})
+
+    model.implant = ArgusII(x=2000)
+    npt.assert_equal(model.is_built, False)
+    model.build()
+    there = model.predict_percept({'C5': 30})
+    # The same stimulus on a shifted array lands somewhere else, which is what
+    # says the rebind reached the prediction rather than being ignored:
+    npt.assert_equal(np.allclose(here.data, there.data), False)
+    npt.assert_equal(np.argmax(here.data) != np.argmax(there.data), True)

--- a/pulse2percept/models/tests/test_base.py
+++ b/pulse2percept/models/tests/test_base.py
@@ -18,7 +18,7 @@ from pulse2percept.models import (AxonMapModel, AxonMapSpatial, BaseModel,
                                   FadingTemporal, Model, NotBuiltError,
                                   ScoreboardModel, ScoreboardSpatial,
                                   SpatialModel, TemporalModel)
-from pulse2percept.models.base import _blend_meridian, _rescale
+from pulse2percept.models.base import _blend_meridian
 from pulse2percept.models.cortex import (ScoreboardSpatial as
                                          CortexScoreboardSpatial)
 from pulse2percept.units import (DimensionMismatchError, Quantity,
@@ -947,6 +947,17 @@ def test_Model_build():
     npt.assert_equal(model.is_built, True)
 
 
+def test_Model_names_one_implant():
+    """Two implants is contradictory model context, not a precedence question"""
+    implant = ArgusI()
+    # The same object twice says nothing new:
+    model = Model(implant=implant, spatial=ValidSpatialModel(implant=implant))
+    npt.assert_equal(model.implant is implant, True)
+    # Two different ones would have to silently pick a winner:
+    with pytest.raises(ValueError, match='two different implants'):
+        Model(implant=implant, spatial=ValidSpatialModel(implant=ArgusII()))
+
+
 def test_Model_predict_percept():
     # A None Model has nothing to build, nothing to perceive:
     model = Model()
@@ -1007,7 +1018,7 @@ def test_Model_predict_percept_frame_clock(fps):
     # real models: `ValidTemporalModel` returns one row per electrode, not one
     # per grid point, so it cannot consume a spatial percept.
     both = Model(implant=implant,
-                 spatial=ScoreboardSpatial(implant=ArgusII(), xrange=(-2, 2), yrange=(-2, 2),
+                 spatial=ScoreboardSpatial(xrange=(-2, 2), yrange=(-2, 2),
                                            step=1),
                  temporal=FadingTemporal()).build()
     npt.assert_equal(both.predict_percept(stim).data.shape[-1], 6)
@@ -1091,106 +1102,6 @@ def test_Model_predict_percept_correctly_parallelizes():
 
     # we expect roughly a linear decrease in time as thread count increases
     npt.assert_almost_equal(actual=two_thread_temporal_predict_time, desired=one_thread_temporal_predict_time / 2, decimal=1e-5)
-
-
-class ScalingSpatialModel(ValidSpatialModel):
-    """Spatial model whose brightness equals the stimulus amplitude.
-
-    `find_threshold` bisects on amplitude, so a model with a known,
-    monotonic amplitude-to-brightness mapping gives a predictable threshold.
-    """
-
-    def _predict_spatial(self, earray, stim):
-        if not self.is_built:
-            raise NotBuiltError
-        n_time = 1 if stim.time is None else stim.time.size
-        out = np.zeros((self.grid.x.size, n_time), dtype=np.float32)
-        out[:] = np.abs(stim.data).max()
-        return out
-
-
-class ScalingTemporalModel(ValidTemporalModel):
-    """Temporal model whose brightness equals the stimulus amplitude."""
-
-    def _predict_temporal(self, stim, t_percept):
-        if not self.is_built:
-            raise NotBuiltError
-        out = np.zeros((stim.data.shape[0], len(t_percept)), dtype=np.float32)
-        out[:] = np.abs(stim.data).max()
-        return out
-
-
-def test_SpatialModel_find_threshold():
-    model = ScalingSpatialModel(step=5).build()
-    stim = Stimulus({'A1': 1})
-
-    # Brightness equals amplitude, so the threshold is the target brightness:
-    npt.assert_almost_equal(model.find_threshold(stim, 20), 20, decimal=0)
-    npt.assert_almost_equal(model.find_threshold(stim, 55), 55, decimal=0)
-
-    # `stim` must be a Stimulus:
-    with pytest.raises(TypeError):
-        model.find_threshold(ArgusI(), 20)
-
-
-def test_TemporalModel_find_threshold():
-    model = ScalingTemporalModel().build()
-    stim = Stimulus({'A1': 1})
-
-    npt.assert_almost_equal(model.find_threshold(stim, 20), 20, decimal=0)
-
-    # `stim` must be a Stimulus:
-    with pytest.raises(TypeError):
-        model.find_threshold(ArgusI(), 20)
-
-
-def test_Model_find_threshold():
-    model = Model(spatial=ScalingSpatialModel(step=5)).build()
-    stim = Stimulus({'A1': 1})
-
-    npt.assert_almost_equal(model.find_threshold(stim, 20), 20, decimal=0)
-
-    # `stim` must be a Stimulus:
-    with pytest.raises(TypeError):
-        model.find_threshold(ArgusI(), 20)
-
-
-def test_find_threshold_keeps_encoder_metadata():
-    # `find_threshold` rebuilds the stimulus at each trial amplitude. The
-    # encoder records the video's frame clock in the stimulus metadata, and
-    # that is what decides when `predict_percept` reports a percept -- so a
-    # rebuild that drops it silently evaluates every trial on the 50 Hz
-    # fallback instead of the time base the caller's own `predict_percept`
-    # will use.
-    implant = ArgusI()
-    rng = np.random.default_rng(0)
-    vid = VideoStimulus(rng.random((4, 4, 6)), metadata={'fps': 29.97})
-    with warnings.catch_warnings():
-        warnings.simplefilter('ignore')
-        stim = AmplitudeEncoder(amp_range=(0, 50), freq=60).encode(
-            vid, implant=implant)
-    n_frames = stim.metadata['encoder']['frame_time'].size
-
-    seen = []
-    model = FadingTemporal(tau=100).build()
-    unwrapped = FadingTemporal.predict_percept
-
-    def spy(self, stim, t_percept=None):
-        percept = unwrapped(self, stim, t_percept=t_percept)
-        seen.append(percept.time.size)
-        return percept
-
-    FadingTemporal.predict_percept = spy
-    try:
-        model.find_threshold(stim, 0.2, max_iter=5)
-        npt.assert_equal(set(seen), {n_frames})
-        seen.clear()
-        # ... and the same through the combined model:
-        Model(temporal=FadingTemporal(tau=100)).build().find_threshold(
-            stim, 0.2, max_iter=5)
-        npt.assert_equal(set(seen), {n_frames})
-    finally:
-        FadingTemporal.predict_percept = unwrapped
 
 
 def test_Model_deepcopy_memo():
@@ -1327,7 +1238,7 @@ def test_model_t_percept_units():
                                 yrange=(-2, 2), step=1).build()
     temporal = FadingTemporal().build()
     composite = Model(implant=implant,
-                      spatial=ScoreboardSpatial(implant=ArgusII(), xrange=(-2, 2), yrange=(-2, 2),
+                      spatial=ScoreboardSpatial(xrange=(-2, 2), yrange=(-2, 2),
                                                 step=1),
                       temporal=FadingTemporal()).build()
     for model, stim in [(spatial, source),
@@ -1344,37 +1255,6 @@ def test_model_t_percept_units():
     # A single unitful time point, not just a list:
     single = spatial.predict_percept(source, t_percept=0.02 * s)
     npt.assert_allclose(single.time, [20], rtol=1e-12)
-
-
-def test_model_find_threshold_units():
-    """Amplitudes are currents; brightness is not a physical quantity"""
-    implant = ArgusII()
-    trial = implant.prepare_stim(
-        {'A1': BiphasicPulseTrain(20, 20, 0.45, stim_dur=100)})
-    spatial = ScoreboardSpatial(implant=implant, xrange=(-2, 2),
-                                yrange=(-2, 2), step=1).build()
-    composite = Model(implant=implant,
-                      spatial=ScoreboardSpatial(implant=ArgusII(), xrange=(-2, 2), yrange=(-2, 2),
-                                                step=1)).build()
-    for model in (spatial, composite):
-        bare = model.find_threshold(trial, 0.1, amp_range=(0, 200), amp_tol=1)
-        unitful = model.find_threshold(trial, 0.1,
-                                       amp_range=(0, 0.2 * mA), amp_tol=1 * uA)
-        npt.assert_allclose(unitful, bare, rtol=1e-12)
-        # The answer is a plain number of microamps:
-        npt.assert_equal(isinstance(unitful, Quantity), False)
-        with pytest.raises(DimensionMismatchError):
-            model.find_threshold(trial, 0.1, amp_range=(0, 5 * ms))
-        with pytest.raises(DimensionMismatchError):
-            model.find_threshold(trial, 0.1, amp_tol=1 * dva)
-    # ... and on a temporal model, where `t_percept` joins them:
-    temporal = FadingTemporal().build()
-    stim = BiphasicPulseTrain(20, 20, 0.45, stim_dur=100)
-    npt.assert_allclose(
-        temporal.find_threshold(stim, 0.01, amp_range=(0, 0.2 * mA),
-                                amp_tol=1 * uA, t_percept=[0, 50] * ms),
-        temporal.find_threshold(stim, 0.01, amp_range=(0, 200), amp_tol=1,
-                                t_percept=[0, 50]), rtol=1e-12)
 
 
 def test_model_requires_a_current_stimulus():
@@ -1400,7 +1280,7 @@ def test_model_requires_a_current_stimulus():
                                 yrange=(-2, 2), step=1).build()
     temporal = FadingTemporal().build()
     composite = Model(implant=implant,
-                      spatial=ScoreboardSpatial(implant=ArgusII(), xrange=(-2, 2), yrange=(-2, 2),
+                      spatial=ScoreboardSpatial(xrange=(-2, 2), yrange=(-2, 2),
                                                 step=1),
                       temporal=FadingTemporal()).build()
     with pytest.raises(DimensionMismatchError):
@@ -1777,28 +1657,6 @@ def test_spatial_model_reads_modulation_not_pulses():
                      plain.time.size)
 
 
-def test_find_threshold_scales_both_representations():
-    # `find_threshold` varies the amplitude between trials. A spatial model
-    # reads the modulation, so a search that scaled only the pulse train would
-    # evaluate every trial on the unscaled picture and never move.
-    implant = ArgusII()
-    delivered = implant.prepare_stim(LogoBVL())
-    model = ScoreboardModel(implant=implant, xrange=(-12, 12), yrange=(-8, 8),
-                            step=1).build()
-    amp_th = model.find_threshold(delivered, 50, amp_range=(0, 500),
-                                  amp_tol=0.5)
-    npt.assert_equal(0 < amp_th < 500, True)
-    # The answer is a threshold of what `predict_percept` reports, which is
-    # only true if both descriptions were scaled together:
-    modulation = delivered._spatial_view()
-    bare = ScoreboardModel(implant=ArgusII(encoder=None), xrange=(-12, 12),
-                           yrange=(-8, 8), step=1).build()
-    scaled = Stimulus(modulation.data * amp_th / delivered.data.max(),
-                      electrodes=modulation.electrodes)
-    npt.assert_allclose(bare.predict_percept(scaled).data.max(), 50,
-                        rtol=0.05)
-
-
 def _blend_grid(step=0.5, extent=6):
     """A plain dva grid to hand `_blend_meridian`"""
     grid = Grid2D((-extent, extent), (-extent, extent), step=step)
@@ -2089,25 +1947,6 @@ def test_combined_model_still_integrates_the_delivered_pulses():
     # Stripping the modulation view happens on a stand-in, so the prepared
     # stimulus the caller holds keeps its schedule:
     npt.assert_equal(delivered._has_spatial_view, True)
-
-
-def test_find_threshold_scales_an_encoded_stimulus_structurally():
-    # Every trial scales the one schedule, so the modulation a spatial model
-    # reads and the waveform a temporal one would read move together -- and
-    # the search never has to expand either.
-    implant = ArgusII()
-    delivered = implant.prepare_stim(LogoBVL())
-    model = ScoreboardModel(implant=implant, xrange=(-12, 12), yrange=(-8, 8),
-                            step=1).build()
-    # The search reads the delivered peak once, to know what it is scaling
-    # to. From there on nothing needs the pulses:
-    peak = delivered.data.max()
-    with _no_schedule_expansion():
-        trial = delivered * 2
-        npt.assert_equal(type(trial), type(delivered))
-        npt.assert_allclose(trial._spatial_view().data,
-                            2 * delivered._spatial_view().data, rtol=1e-6)
-        npt.assert_equal(np.any(model.predict_percept(trial).data), True)
 
 
 def test_deactivating_an_encoded_electrode_keeps_the_schedule():

--- a/pulse2percept/models/tests/test_base.py
+++ b/pulse2percept/models/tests/test_base.py
@@ -126,9 +126,10 @@ def test_SpatialModel():
     with pytest.raises(ValueError):
         # stim.time==None but requesting t_percept != None
         model.predict_percept(np.ones(16), t_percept=[0, 1, 2])
-    with pytest.raises(NotBuiltError):
-        # must call build first
-        ValidSpatialModel(implant=implant).predict_percept(np.ones(16))
+    # An unbuilt model builds itself rather than refusing:
+    fresh = ValidSpatialModel(implant=implant)
+    npt.assert_equal(fresh.predict_percept(np.ones(16)) is not None, True)
+    npt.assert_equal(fresh.is_built, True)
     with pytest.raises(TypeError):
         # the implant must be a ProsthesisSystem
         ValidSpatialModel(implant=Stimulus(3))
@@ -673,9 +674,12 @@ def test_TemporalModel():
     with pytest.raises(ValueError):
         # stim.time==None but requesting t_percept != None
         ValidTemporalModel().predict_percept(Stimulus(3), t_percept=[0, 1, 2])
-    with pytest.raises(NotBuiltError):
-        # Must call build first:
-        ValidTemporalModel().predict_percept(Stimulus(3))
+    # An unbuilt model builds itself rather than refusing:
+    fresh = ValidTemporalModel()
+    npt.assert_equal(
+        fresh.predict_percept(Stimulus({'A1': [[1, 1]]}, time=[0, 1]))
+        is not None, True)
+    npt.assert_equal(fresh.is_built, True)
     with pytest.raises(TypeError):
         # Must pass a stimulus:
         ValidTemporalModel().build().predict_percept(ArgusI())
@@ -947,6 +951,47 @@ def test_Model_build():
     npt.assert_equal(model.is_built, True)
 
 
+def test_a_new_parameter_value_un_builds_the_model():
+    """Which parameters a build depends on is not enumerated anywhere"""
+    model = ValidSpatialModel(step=1).build()
+    # Assigning the value it already has changes nothing, so the build stands:
+    model.step = model.step
+    model.thresh_percept = 0
+    npt.assert_equal(model.is_built, True)
+    # A different value un-builds it, whether or not the grid depends on it:
+    model.step = 2
+    npt.assert_equal(model.is_built, False)
+    model.build()
+    model.thresh_percept = 0.5
+    npt.assert_equal(model.is_built, False)
+    # Attributes that are not parameters are not the build's business:
+    model.build()
+    model.grid = model.grid
+    npt.assert_equal(model.is_built, True)
+
+
+def test_a_composite_un_builds_the_stage_the_parameter_belongs_to():
+    model = Model(spatial=ValidSpatialModel(step=1),
+                  temporal=ValidTemporalModel()).build()
+    model.step = 2
+    npt.assert_equal(model.spatial.is_built, False)
+    npt.assert_equal(model.temporal.is_built, True)
+    npt.assert_equal(model.is_built, False)
+
+
+@pytest.mark.parametrize('make_model', [
+    lambda: ValidSpatialModel(),
+    lambda: Model(spatial=ValidSpatialModel()),
+    lambda: Model(spatial=ValidSpatialModel(), temporal=FadingTemporal()),
+])
+def test_predict_percept_builds_what_it_needs(make_model):
+    model = make_model()
+    npt.assert_equal(model.is_built, False)
+    npt.assert_equal(model.predict_percept({'A1': np.ones(10)}) is not None,
+                     True)
+    npt.assert_equal(model.is_built, True)
+
+
 def test_Model_names_one_implant():
     """Two implants is contradictory model context, not a precedence question"""
     implant = ArgusI()
@@ -975,9 +1020,6 @@ def test_Model_predict_percept():
 
     # Invalid calls:
     model = Model(spatial=ValidSpatialModel(), temporal=ValidTemporalModel())
-    with pytest.raises(NotBuiltError):
-        # Must call build first:
-        model.predict_percept({'A1': 1})
     model.build()
     with pytest.raises(ValueError):
         # Cannot request t_percepts that are not multiples of dt:

--- a/pulse2percept/models/tests/test_base.py
+++ b/pulse2percept/models/tests/test_base.py
@@ -975,6 +975,45 @@ def test_a_composite_un_builds_the_stage_the_parameter_belongs_to():
     npt.assert_equal(model.is_built, False)
 
 
+def test_predict_percept_rebuilds_only_the_stale_stage():
+    """A sweep over one stage's parameter must not rebuild the other
+
+    The spatial build is the expensive one -- growing an axon map, loading a
+    pickle -- so a loop over a temporal parameter that quietly regrew it would
+    cost far more than the sweep itself.
+    """
+    builds = {'spatial': 0, 'temporal': 0}
+
+    class CountingSpatial(ValidSpatialModel):
+        def _build(self):
+            builds['spatial'] += 1
+
+    class CountingTemporal(FadingTemporal):
+        def _build(self):
+            super()._build()
+            builds['temporal'] += 1
+
+    model = Model(spatial=CountingSpatial(),
+                  temporal=CountingTemporal()).build()
+    npt.assert_equal(builds, {'spatial': 1, 'temporal': 1})
+
+    model.temporal.tau = 50
+    model.predict_percept({'A1': np.ones(10)})
+    npt.assert_equal(builds, {'spatial': 1, 'temporal': 2})
+
+    model.spatial.step = 2
+    model.predict_percept({'A1': np.ones(10)})
+    npt.assert_equal(builds, {'spatial': 2, 'temporal': 2})
+
+    # Nothing is stale, so predicting again builds nothing:
+    model.predict_percept({'A1': np.ones(10)})
+    npt.assert_equal(builds, {'spatial': 2, 'temporal': 2})
+
+    # `build` stays the way to force a full rebuild:
+    model.build()
+    npt.assert_equal(builds, {'spatial': 3, 'temporal': 3})
+
+
 @pytest.mark.parametrize('make_model', [
     lambda: ValidSpatialModel(),
     lambda: Model(spatial=ValidSpatialModel()),

--- a/pulse2percept/models/tests/test_base.py
+++ b/pulse2percept/models/tests/test_base.py
@@ -18,7 +18,7 @@ from pulse2percept.models import (AxonMapModel, AxonMapSpatial, BaseModel,
                                   FadingTemporal, Model, NotBuiltError,
                                   ScoreboardModel, ScoreboardSpatial,
                                   SpatialModel, TemporalModel)
-from pulse2percept.models.base import _blend_meridian, _rescaled_implant
+from pulse2percept.models.base import _blend_meridian, _rescale
 from pulse2percept.models.cortex import (ScoreboardSpatial as
                                          CortexScoreboardSpatial)
 from pulse2percept.units import (DimensionMismatchError, Quantity,
@@ -69,10 +69,15 @@ def test_BaseModel():
 
 
 class ValidSpatialModel(SpatialModel):
+    """A spatial model that predicts nothing, bound to a fresh ArgusI
+
+    A spatial model needs an implant before it can build, and which one is
+    beside the point for most of the tests below, so the double supplies one.
+    """
 
     def get_default_params(self):
         params = super(ValidSpatialModel, self).get_default_params()
-        params.update({'vfmap': Watson2014Map()})
+        params.update({'vfmap': Watson2014Map(), 'implant': ArgusI()})
         return params
 
     def _predict_spatial(self, earray, stim):
@@ -83,8 +88,9 @@ class ValidSpatialModel(SpatialModel):
 
 
 def test_SpatialModel():
+    implant = ArgusI()
     # Build grid:
-    model = ValidSpatialModel()
+    model = ValidSpatialModel(implant=implant)
     npt.assert_equal(model.grid, None)
     npt.assert_equal(model.is_built, False)
     model.build()
@@ -93,7 +99,7 @@ def test_SpatialModel():
     npt.assert_equal(isinstance(model.grid.ret.x, np.ndarray), True)
 
     # Can overwrite default values:
-    model = ValidSpatialModel(step=1.234)
+    model = ValidSpatialModel(implant=implant, step=1.234)
     npt.assert_almost_equal(model.step, 1.234)
     model.build(step=2.345)
     npt.assert_almost_equal(model.step, 2.345)
@@ -105,12 +111,12 @@ def test_SpatialModel():
         model.newparam = 1
 
     # Returns Percept object of proper size:
-    npt.assert_equal(model.predict_percept(ArgusI()), None)
-    for stim in [np.ones(16), np.zeros(16), {'A1': 2}, np.ones((16, 2))]:
-        implant = ArgusI(stim=stim)
-        percept = model.predict_percept(implant)
+    npt.assert_equal(model.predict_percept(None), None)
+    for source in [np.ones(16), np.zeros(16), {'A1': 2}, np.ones((16, 2))]:
+        percept = model.predict_percept(source)
         npt.assert_equal(isinstance(percept, Percept), True)
-        n_time = 1 if implant.stim.time is None else len(implant.stim.time)
+        stim = implant.prepare_stim(source)
+        n_time = 1 if stim.time is None else len(stim.time)
         npt.assert_equal(percept.shape, (model.grid.x.shape[0],
                                          model.grid.x.shape[1],
                                          n_time))
@@ -119,15 +125,16 @@ def test_SpatialModel():
     # Invalid calls:
     with pytest.raises(ValueError):
         # stim.time==None but requesting t_percept != None
-        implant.stim = np.ones(16)
-        model.predict_percept(implant, t_percept=[0, 1, 2])
+        model.predict_percept(np.ones(16), t_percept=[0, 1, 2])
     with pytest.raises(NotBuiltError):
         # must call build first
-        model = ValidSpatialModel()
-        model.predict_percept(ArgusI())
+        ValidSpatialModel(implant=implant).predict_percept(np.ones(16))
     with pytest.raises(TypeError):
-        # must pass an implant
-        ValidSpatialModel().build().predict_percept(Stimulus(3))
+        # the implant must be a ProsthesisSystem
+        ValidSpatialModel(implant=Stimulus(3))
+    with pytest.raises(ValueError):
+        # ... and there must be one at all
+        ValidSpatialModel(implant=None).build()
 
 
 def test_SpatialModel_predict_percept_time_order():
@@ -145,14 +152,13 @@ def test_SpatialModel_predict_percept_time_order():
             # so the caller can tell which frame ended up where:
             return np.tile(stim.data[0], (self.grid.x.size, 1))
 
-    model = RecordingSpatialModel(step=2).build()
+    model = RecordingSpatialModel(implant=ArgusI(), step=2).build()
     # Amplitudes chosen so that sorting the frames by value shuffles them with
     # respect to time (sorted: 1, 2, 3 -> frames 1, 2, 0):
-    implant = ArgusI(stim={'A1': [3, 1, 2]})
     with warnings.catch_warnings():
         # A shuffled time axis makes Stimulus warn:
         warnings.simplefilter('error', UserWarning)
-        percept = model.predict_percept(implant)
+        percept = model.predict_percept({'A1': [3, 1, 2]})
 
     # The model saw time running forwards:
     npt.assert_equal(len(seen_time), 1)
@@ -174,10 +180,9 @@ def test_SpatialModel_predict_percept_deduplicates_frames():
             n_calls.append(stim.data.shape[1])
             return np.tile(stim.data[0], (self.grid.x.size, 1))
 
-    model = CountingSpatialModel(step=2).build()
+    model = CountingSpatialModel(implant=ArgusI(), step=2).build()
     # Four time points, but only two distinct frames:
-    implant = ArgusI(stim={'A1': [2, 5, 2, 5]})
-    percept = model.predict_percept(implant)
+    percept = model.predict_percept({'A1': [2, 5, 2, 5]})
     # _predict_spatial was called once, on the two unique frames only:
     npt.assert_equal(n_calls, [2])
     npt.assert_almost_equal(percept.time, [0, 1, 2, 3])
@@ -197,16 +202,15 @@ def test_SpatialModel_predict_percept_keeps_metadata():
             return np.zeros((self.grid.x.size, stim.data.shape[1]),
                             dtype=np.float32)
 
-    model = RecordingSpatialModel(step=2).build()
-    implant = ArgusI(stim=Stimulus({'A1': BiphasicPulseTrain(20, 10, 0.45,
-                                                             stim_dur=20)},
-                                   metadata='mine'))
-    model.predict_percept(implant)
+    model = RecordingSpatialModel(implant=ArgusI(), step=2).build()
+    source = Stimulus({'A1': BiphasicPulseTrain(20, 10, 0.45, stim_dur=20)},
+                      metadata='mine')
+    model.predict_percept(source)
     npt.assert_equal(len(seen_metadata), 1)
     npt.assert_equal(seen_metadata[0]['user'], 'mine')
     # ...also when the caller asks for time points of their own:
     seen_metadata.clear()
-    model.predict_percept(implant, t_percept=[0, 5, 10])
+    model.predict_percept(source, t_percept=[0, 5, 10])
     npt.assert_equal(seen_metadata[0]['user'], 'mine')
 
 
@@ -470,7 +474,7 @@ def test_Model_units():
     with pytest.raises(DimensionMismatchError):
         Model(temporal=FadingTemporal()).build(dt=5 * um)
     # Both halves of a spatial+temporal model normalize independently:
-    model = Model(spatial=ScoreboardSpatial(), temporal=FadingTemporal())
+    model = Model(spatial=ScoreboardSpatial(implant=ArgusII()), temporal=FadingTemporal())
     model.set_params({'rho': 0.3 * mm, 'tau': 0.15 * s, 'dt': 0.01 * ms})
     npt.assert_almost_equal(model.spatial.rho, 300)
     npt.assert_almost_equal(model.temporal.tau, 150)
@@ -479,19 +483,19 @@ def test_Model_units():
 
 def test_SpatialModel_units():
     # A range can be given as a quantity wrapping a pair...
-    model = ScoreboardSpatial(xrange=(-5, 5) * dva, yrange=(-4, 4) * dva,
+    model = ScoreboardSpatial(implant=ArgusII(), xrange=(-5, 5) * dva, yrange=(-4, 4) * dva,
                               step=1 * dva)
     npt.assert_almost_equal(model.xrange, [-5, 5])
     npt.assert_almost_equal(model.yrange, [-4, 4])
     npt.assert_almost_equal(model.step, 1)
     # ... or as a pair of quantities, which keeps the tuple it was given:
-    model = ScoreboardSpatial(xrange=(-5 * dva, 5 * dva))
+    model = ScoreboardSpatial(implant=ArgusII(), xrange=(-5 * dva, 5 * dva))
     npt.assert_equal(model.xrange, (-5, 5))
     # Either way it grids identically to the bare-number spelling:
-    bare = ScoreboardSpatial(xrange=(-5, 5), yrange=(-5, 5), step=1).build()
-    for unitful in (ScoreboardSpatial(xrange=(-5, 5) * dva,
+    bare = ScoreboardSpatial(implant=ArgusII(), xrange=(-5, 5), yrange=(-5, 5), step=1).build()
+    for unitful in (ScoreboardSpatial(implant=ArgusII(), xrange=(-5, 5) * dva,
                                       yrange=(-5, 5) * dva, step=1 * dva),
-                    ScoreboardSpatial(xrange=(-5 * dva, 5 * dva),
+                    ScoreboardSpatial(implant=ArgusII(), xrange=(-5 * dva, 5 * dva),
                                       yrange=(-5 * dva, 5 * dva),
                                       step=1 * dva)):
         unitful.build()
@@ -501,21 +505,21 @@ def test_SpatialModel_units():
     # the one exception, and means something specific; see
     # `test_SpatialModel_retinal_range`:
     with pytest.raises(DimensionMismatchError):
-        ScoreboardSpatial(xrange=(-5 * ms, 5 * ms))
+        ScoreboardSpatial(implant=ArgusII(), xrange=(-5 * ms, 5 * ms))
     with pytest.raises(DimensionMismatchError):
-        ScoreboardSpatial(xrange=(-5, 5) * uA)
+        ScoreboardSpatial(implant=ArgusII(), xrange=(-5, 5) * uA)
     # The grid spacing takes dva and nothing else: a grid spaced evenly on the
     # retina is a different grid, not a different spelling of this one.
     with pytest.raises(DimensionMismatchError):
-        ScoreboardSpatial(step=100 * um)
+        ScoreboardSpatial(implant=ArgusII(), step=100 * um)
     with pytest.raises(DimensionMismatchError):
-        ScoreboardSpatial(xystep=100 * um)
+        ScoreboardSpatial(implant=ArgusII(), xystep=100 * um)
 
 
 def test_SpatialModel_retinal_range():
     """A retinal extent is shorthand for the visual field range it covers"""
     # Curcio1990Map puts 280 um to the degree, so 2.8 mm is 10 dva:
-    model = ScoreboardSpatial(xrange=(-2.8 * mm, 2.8 * mm),
+    model = ScoreboardSpatial(implant=ArgusII(), xrange=(-2.8 * mm, 2.8 * mm),
                               yrange=(-1.4 * mm, 1.4 * mm),
                               vfmap=Curcio1990Map(), step=1)
     npt.assert_allclose(model.xrange, (-10, 10), rtol=1e-12)
@@ -524,7 +528,7 @@ def test_SpatialModel_retinal_range():
     # the dva spelling does:
     for value in (model.xrange, model.yrange):
         npt.assert_equal(isinstance(value, Quantity), False)
-    bare = ScoreboardSpatial(xrange=(-10, 10), yrange=(-5, 5),
+    bare = ScoreboardSpatial(implant=ArgusII(), xrange=(-10, 10), yrange=(-5, 5),
                              vfmap=Curcio1990Map(), step=1).build()
     npt.assert_almost_equal(bare.grid.x, model.build().grid.x)
     npt.assert_almost_equal(bare.grid.y, model.grid.y)
@@ -532,38 +536,38 @@ def test_SpatialModel_retinal_range():
     # applied first however the parameters were ordered:
     for order in ({'xrange': (-2.8 * mm, 2.8 * mm), 'vfmap': Curcio1990Map()},
                   {'vfmap': Curcio1990Map(), 'xrange': (-2.8 * mm, 2.8 * mm)}):
-        npt.assert_allclose(ScoreboardSpatial(step=1, **order).xrange,
+        npt.assert_allclose(ScoreboardSpatial(implant=ArgusII(), step=1, **order).xrange,
                             (-10, 10), rtol=1e-12)
-        npt.assert_allclose(ScoreboardModel(step=1, **order).xrange,
+        npt.assert_allclose(ScoreboardModel(implant=ArgusII(), step=1, **order).xrange,
                             (-10, 10), rtol=1e-12)
         npt.assert_allclose(
-            ScoreboardSpatial(step=1).build(**order).xrange, (-10, 10),
+            ScoreboardSpatial(implant=ArgusII(), step=1).build(**order).xrange, (-10, 10),
             rtol=1e-12)
         npt.assert_allclose(
-            ScoreboardModel(step=1).build(**order).xrange, (-10, 10),
+            ScoreboardModel(implant=ArgusII(), step=1).build(**order).xrange, (-10, 10),
             rtol=1e-12)
     # A quantity wrapping a pair says the same thing:
     npt.assert_allclose(
-        ScoreboardSpatial(xrange=(-2.8, 2.8) * mm, vfmap=Curcio1990Map(),
+        ScoreboardSpatial(implant=ArgusII(), xrange=(-2.8, 2.8) * mm, vfmap=Curcio1990Map(),
                           step=1).xrange, (-10, 10), rtol=1e-12)
     # The retinal y axis points the other way, so the pair comes back sorted
     # rather than reversed:
-    yrange = ScoreboardSpatial(yrange=(1.4 * mm, -1.4 * mm),
+    yrange = ScoreboardSpatial(implant=ArgusII(), yrange=(1.4 * mm, -1.4 * mm),
                                vfmap=Curcio1990Map(), step=1).yrange
     npt.assert_allclose(yrange, (-5, 5), rtol=1e-12)
     # Resolved once, at assignment: a later map does not reinterpret it.
-    model = ScoreboardSpatial(xrange=(-2.8 * mm, 2.8 * mm),
+    model = ScoreboardSpatial(implant=ArgusII(), xrange=(-2.8 * mm, 2.8 * mm),
                               vfmap=Curcio1990Map(), step=1)
     model.vfmap = Watson2014Map()
     npt.assert_allclose(model.xrange, (-10, 10), rtol=1e-12)
     # Direct assignment is sequential, and uses the map in place at the time:
-    model = ScoreboardSpatial(step=1)
+    model = ScoreboardSpatial(implant=ArgusII(), step=1)
     model.vfmap = Curcio1990Map()
     model.xrange = (-2.8 * mm, 2.8 * mm)
     npt.assert_allclose(model.xrange, (-10, 10), rtol=1e-12)
     # It must be a pair, whatever the units:
     with pytest.raises(ValueError):
-        ScoreboardSpatial(xrange=2.8 * mm, vfmap=Curcio1990Map())
+        ScoreboardSpatial(implant=ArgusII(), xrange=2.8 * mm, vfmap=Curcio1990Map())
 
 
 def test_SpatialModel_retinal_range_nonlinear_map():
@@ -576,7 +580,7 @@ def test_SpatialModel_retinal_range_nonlinear_map():
     than to a scale factor. No ``build``: growing axon bundles is expensive
     and has nothing to do with what the range came out as.
     """
-    model = AxonMapModel(xrange=(-4 * mm, 4 * mm), yrange=(-2 * mm, 2 * mm))
+    model = AxonMapModel(implant=ArgusII(), xrange=(-4 * mm, 4 * mm), yrange=(-2 * mm, 2 * mm))
     npt.assert_equal(isinstance(model.vfmap, Watson2014Map), True)
     # Each range is resolved along its own meridian, which is what makes the
     # two answers independent of one another:
@@ -594,7 +598,7 @@ def test_SpatialModel_retinal_range_nonlinear_map():
     npt.assert_equal(abs(model.xrange[1] - 4000 / 280.0) > 0.4, True)
     # The spatial model alone answers identically, and is what the composite
     # forwarded to:
-    npt.assert_allclose(AxonMapSpatial(xrange=(-4 * mm, 4 * mm)).xrange,
+    npt.assert_allclose(AxonMapSpatial(implant=ArgusII(), xrange=(-4 * mm, 4 * mm)).xrange,
                         model.xrange, rtol=1e-12)
 
 
@@ -602,7 +606,7 @@ def test_SpatialModel_retinal_range_needs_a_retinal_map():
     """Only a retinal map can say what visual field an extent covers"""
     # A cortical map is not one, whether it was passed explicitly ...
     with pytest.raises(DimensionMismatchError) as excinfo:
-        ScoreboardSpatial(xrange=(-2 * mm, 2 * mm), vfmap=Polimeni2006Map())
+        ScoreboardSpatial(implant=ArgusII(), xrange=(-2 * mm, 2 * mm), vfmap=Polimeni2006Map())
     npt.assert_equal('in dva instead' in str(excinfo.value), True)
     # ... or is the model's own default, which a cortical model installs only
     # after its parameters have been applied:
@@ -615,7 +619,7 @@ def test_SpatialModel_retinal_range_needs_a_retinal_map():
             return 280.0 * xdva, -280.0 * ydva
 
     with pytest.raises(NotImplementedError) as excinfo:
-        ScoreboardSpatial(xrange=(-2 * mm, 2 * mm), vfmap=NoInverse())
+        ScoreboardSpatial(implant=ArgusII(), xrange=(-2 * mm, 2 * mm), vfmap=NoInverse())
     npt.assert_equal('in dva instead' in str(excinfo.value), True)
 
 
@@ -639,17 +643,18 @@ def test_TemporalModel():
         model.newparam = 1
 
     # Returns Percept object of proper size:
-    npt.assert_equal(model.predict_percept(ArgusI().stim), None)
+    implant = ArgusI()
+    npt.assert_equal(model.predict_percept(implant.prepare_stim(None)), None)
     model.dt = 1
-    for stim in [np.ones((16, 3)), np.zeros((16, 3)),
-                 {'A1': [1, 2]}, np.ones((16, 2))]:
-        implant = ArgusI(stim=stim)
-        percept = model.predict_percept(implant.stim)
+    for source in [np.ones((16, 3)), np.zeros((16, 3)),
+                   {'A1': [1, 2]}, np.ones((16, 2))]:
+        stim = implant.prepare_stim(source)
+        percept = model.predict_percept(stim)
         # By default, percept is output every 20ms. If stimulus is too short,
         # output at t=[0, 20]. This is mentioned in the docs - for really short
         # stimuli, users should specify the desired time points manually.
-        n_time = 1 if implant.stim.time is None else 2
-        npt.assert_equal(percept.shape, (implant.stim.shape[0], 1, n_time))
+        n_time = 1 if stim.time is None else 2
+        npt.assert_equal(percept.shape, (stim.shape[0], 1, n_time))
         npt.assert_almost_equal(percept.data, 0)
 
     # t_percept is automatically sorted:
@@ -674,6 +679,7 @@ def test_TemporalModel():
     with pytest.raises(TypeError):
         # Must pass a stimulus:
         ValidTemporalModel().build().predict_percept(ArgusI())
+
 
 def test_eq_TemporalModel():
     valid = ValidTemporalModel()
@@ -787,6 +793,10 @@ def test_Model():
 
     # SpatialModel, but no TemporalModel:
     model = Model(spatial=ValidSpatialModel())
+    # An implant is what a spatial model needs; a temporal one never sees an
+    # electrode, so offering it one is a mistake worth naming:
+    with pytest.raises(ValueError, match='only a temporal'):
+        Model(temporal=ValidTemporalModel(), implant=ArgusI())
     npt.assert_equal(model.has_space, True)
     npt.assert_equal(model.has_time, False)
     npt.assert_almost_equal(model.step, 0.25)
@@ -846,6 +856,10 @@ def test_Model():
 def test_Model_set_params():
     # SpatialModel, but no TemporalModel:
     model = Model(spatial=ValidSpatialModel())
+    # An implant is what a spatial model needs; a temporal one never sees an
+    # electrode, so offering it one is a mistake worth naming:
+    with pytest.raises(ValueError, match='only a temporal'):
+        Model(temporal=ValidTemporalModel(), implant=ArgusI())
     model.set_params({'step': 2.33})
     npt.assert_almost_equal(model.step, 2.33)
     npt.assert_almost_equal(model.spatial.step, 2.33)
@@ -912,6 +926,10 @@ def test_Model_build():
 
     # SpatialModel, but no TemporalModel:
     model = Model(spatial=ValidSpatialModel())
+    # An implant is what a spatial model needs; a temporal one never sees an
+    # electrode, so offering it one is a mistake worth naming:
+    with pytest.raises(ValueError, match='only a temporal'):
+        Model(temporal=ValidTemporalModel(), implant=ArgusI())
     npt.assert_equal(model.is_built, False)
     model.build()
     npt.assert_equal(model.is_built, True)
@@ -932,39 +950,33 @@ def test_Model_build():
 def test_Model_predict_percept():
     # A None Model has nothing to build, nothing to perceive:
     model = Model()
-    npt.assert_equal(model.predict_percept(ArgusI()), None)
-    npt.assert_equal(model.predict_percept(ArgusI(stim={'A1': 1})), None)
-    npt.assert_equal(model.predict_percept(ArgusI(stim={'A1': 1}),
-                                           t_percept=[0, 1]), None)
+    npt.assert_equal(model.predict_percept(None), None)
+    npt.assert_equal(model.predict_percept({'A1': 1}), None)
+    npt.assert_equal(model.predict_percept({'A1': 1}, t_percept=[0, 1]), None)
 
     # Just the spatial model:
     model = Model(spatial=ValidSpatialModel()).build()
-    npt.assert_equal(model.predict_percept(ArgusI()), None)
+    npt.assert_equal(model.predict_percept(None), None)
     # Just the temporal model:
     model = Model(temporal=ValidTemporalModel()).build()
-    npt.assert_equal(model.predict_percept(ArgusI()), None)
+    npt.assert_equal(model.predict_percept(None), None)
     # Both spatial and temporal:
 
     # Invalid calls:
     model = Model(spatial=ValidSpatialModel(), temporal=ValidTemporalModel())
     with pytest.raises(NotBuiltError):
         # Must call build first:
-        model.predict_percept(ArgusI())
+        model.predict_percept({'A1': 1})
     model.build()
     with pytest.raises(ValueError):
         # Cannot request t_percepts that are not multiples of dt:
-        model.predict_percept(ArgusI(stim={'A1': np.ones(16)}),
-                              t_percept=[0.1, 0.11])
+        model.predict_percept({'A1': np.ones(16)}, t_percept=[0.1, 0.11])
     with pytest.raises(ValueError):
         # Has temporal model but stim.time is None:
         ValidTemporalModel().predict_percept(Stimulus(3))
     with pytest.raises(ValueError):
         # stim.time==None but requesting t_percept != None
-        model.predict_percept(ArgusI(stim=np.ones(16)),
-                              t_percept=[0, 1, 2])
-    with pytest.raises(TypeError):
-        # Must pass an implant:
-        model.predict_percept(Stimulus(3))
+        model.predict_percept(np.ones(16), t_percept=[0, 1, 2])
 
 
 @pytest.mark.parametrize('fps', [29.97, 30, 24])
@@ -976,10 +988,10 @@ def test_Model_predict_percept_frame_clock(fps):
     # to do with the source.
     implant = ArgusI()
     vid = VideoStimulus(np.random.rand(4, 4, 6), metadata={'fps': fps})
-    implant.stim = AmplitudeEncoder(amp_range=(0, 50), freq=60).encode(
+    stim = AmplitudeEncoder(amp_range=(0, 50), freq=60).encode(
         vid, implant=implant)
     model = Model(temporal=ValidTemporalModel()).build()
-    percept = model.predict_percept(implant)
+    percept = model.predict_percept(stim)
     npt.assert_equal(percept.data.shape[-1], 6)
     # Evenly spaced, and on the model's dt grid -- 1000/29.97 ms is neither a
     # whole number of dt nor, if rounded point by point, evenly spaced:
@@ -994,17 +1006,18 @@ def test_Model_predict_percept_frame_clock(fps):
     # Stimulus, so the frame clock has to survive that hop too. This leg needs
     # real models: `ValidTemporalModel` returns one row per electrode, not one
     # per grid point, so it cannot consume a spatial percept.
-    both = Model(spatial=ScoreboardSpatial(xrange=(-2, 2), yrange=(-2, 2),
+    both = Model(implant=implant,
+                 spatial=ScoreboardSpatial(implant=ArgusII(), xrange=(-2, 2), yrange=(-2, 2),
                                            step=1),
                  temporal=FadingTemporal()).build()
-    npt.assert_equal(both.predict_percept(implant).data.shape[-1], 6)
+    npt.assert_equal(both.predict_percept(stim).data.shape[-1], 6)
     # An explicit `t_percept` still wins:
     npt.assert_equal(
-        model.predict_percept(implant, t_percept=[0, 1, 2]).data.shape[-1], 3)
+        model.predict_percept(stim, t_percept=[0, 1, 2]).data.shape[-1], 3)
     # ... and a stimulus that did not come from an encoder keeps the 20 ms
     # default it always had:
-    implant.stim = Stimulus(np.ones((16, 2)), time=[0, 100])
-    npt.assert_almost_equal(model.predict_percept(implant).time,
+    plain = Stimulus(np.ones((16, 2)), time=[0, 100])
+    npt.assert_almost_equal(model.predict_percept(plain).time,
                             np.arange(0, 101, 20))
 
 
@@ -1018,12 +1031,12 @@ def test_Model_predict_percept_frame_peak():
     implant = ArgusI()
     rng = np.random.default_rng(0)
     vid = VideoStimulus(rng.random((4, 4, 16)), metadata={'fps': 29.97})
-    implant.stim = AmplitudeEncoder(amp_range=(0, 50), freq=20).encode(
+    stim = AmplitudeEncoder(amp_range=(0, 50), freq=20).encode(
         vid, implant=implant)
     model = Model(temporal=FadingTemporal(tau=100)).build()
-    peak = model.predict_percept(implant)
+    peak = model.predict_percept(stim)
     # Same frames, but sampled only at the instant each one ends:
-    at_end = model.predict_percept(implant, t_percept=peak.time)
+    at_end = model.predict_percept(stim, t_percept=peak.time)
     npt.assert_equal(peak.data.shape, at_end.data.shape)
     npt.assert_almost_equal(peak.time, at_end.time)
 
@@ -1043,20 +1056,20 @@ def test_Model_predict_percept_frame_peak():
     # `reduce='last'` asks for the closing instant instead, which is what every
     # version before 0.10.0 reported:
     last = Model(temporal=FadingTemporal(tau=100, reduce='last')).build()
-    npt.assert_array_equal(last.predict_percept(implant).data, at_end.data)
+    npt.assert_array_equal(last.predict_percept(stim).data, at_end.data)
 
 
 def test_Model_predict_percept_correctly_parallelizes():
     # setup and time spatial model with 1 thread
     one_thread_spatial = Model(spatial=ValidSpatialModel(n_threads=1)).build()
     start_time_one_thread_spatial = time.perf_counter()
-    one_thread_spatial.predict_percept(ArgusI())
+    one_thread_spatial.predict_percept(np.ones(16))
     one_thread_spatial_predict_time = time.perf_counter() - start_time_one_thread_spatial
 
     # setup and time spatial model with 2 threads
     two_thread_spatial = Model(spatial=ValidSpatialModel(n_threads=2)).build()
     start_time_two_thread_spatial = time.perf_counter()
-    two_thread_spatial.predict_percept(ArgusI())
+    two_thread_spatial.predict_percept(np.ones(16))
     two_threaded_spatial_predict_time = time.perf_counter() - start_time_two_thread_spatial
 
     # we expect roughly a linear decrease in time as thread count increases
@@ -1065,13 +1078,15 @@ def test_Model_predict_percept_correctly_parallelizes():
     # setup and time temporal model with 1 thread
     one_thread_temporal = Model(temporal=ValidTemporalModel(n_threads=1)).build()
     start_time_one_thread_temporal = time.perf_counter()
-    one_thread_temporal.predict_percept(ArgusI())
+    one_thread_temporal.predict_percept(Stimulus(np.ones((16, 2)),
+                                                  time=[0, 100]))
     one_thread_temporal_predict_time = time.perf_counter() - start_time_one_thread_temporal
 
     # setup and time temporal model with 2 threads
     two_thread_temporal = Model(temporal=ValidTemporalModel(n_threads=2)).build()
     start_time_two_thread_temporal = time.perf_counter()
-    two_thread_temporal.predict_percept(ArgusI())
+    two_thread_temporal.predict_percept(Stimulus(np.ones((16, 2)),
+                                                  time=[0, 100]))
     two_thread_temporal_predict_time = time.perf_counter() - start_time_two_thread_temporal
 
     # we expect roughly a linear decrease in time as thread count increases
@@ -1107,15 +1122,15 @@ class ScalingTemporalModel(ValidTemporalModel):
 
 def test_SpatialModel_find_threshold():
     model = ScalingSpatialModel(step=5).build()
-    implant = ArgusI(stim={'A1': 1})
+    stim = Stimulus({'A1': 1})
 
     # Brightness equals amplitude, so the threshold is the target brightness:
-    npt.assert_almost_equal(model.find_threshold(implant, 20), 20, decimal=0)
-    npt.assert_almost_equal(model.find_threshold(implant, 55), 55, decimal=0)
+    npt.assert_almost_equal(model.find_threshold(stim, 20), 20, decimal=0)
+    npt.assert_almost_equal(model.find_threshold(stim, 55), 55, decimal=0)
 
-    # `implant` must be a ProsthesisSystem:
+    # `stim` must be a Stimulus:
     with pytest.raises(TypeError):
-        model.find_threshold(Stimulus({'A1': 1}), 20)
+        model.find_threshold(ArgusI(), 20)
 
 
 def test_TemporalModel_find_threshold():
@@ -1126,18 +1141,18 @@ def test_TemporalModel_find_threshold():
 
     # `stim` must be a Stimulus:
     with pytest.raises(TypeError):
-        model.find_threshold(ArgusI(stim={'A1': 1}), 20)
+        model.find_threshold(ArgusI(), 20)
 
 
 def test_Model_find_threshold():
     model = Model(spatial=ScalingSpatialModel(step=5)).build()
-    implant = ArgusI(stim={'A1': 1})
+    stim = Stimulus({'A1': 1})
 
-    npt.assert_almost_equal(model.find_threshold(implant, 20), 20, decimal=0)
+    npt.assert_almost_equal(model.find_threshold(stim, 20), 20, decimal=0)
 
-    # `implant` must be a ProsthesisSystem:
+    # `stim` must be a Stimulus:
     with pytest.raises(TypeError):
-        model.find_threshold(Stimulus({'A1': 1}), 20)
+        model.find_threshold(ArgusI(), 20)
 
 
 def test_find_threshold_keeps_encoder_metadata():
@@ -1152,9 +1167,9 @@ def test_find_threshold_keeps_encoder_metadata():
     vid = VideoStimulus(rng.random((4, 4, 6)), metadata={'fps': 29.97})
     with warnings.catch_warnings():
         warnings.simplefilter('ignore')
-        implant.stim = AmplitudeEncoder(amp_range=(0, 50), freq=60).encode(
+        stim = AmplitudeEncoder(amp_range=(0, 50), freq=60).encode(
             vid, implant=implant)
-    n_frames = implant.stim.metadata['encoder']['frame_time'].size
+    n_frames = stim.metadata['encoder']['frame_time'].size
 
     seen = []
     model = FadingTemporal(tau=100).build()
@@ -1167,12 +1182,12 @@ def test_find_threshold_keeps_encoder_metadata():
 
     FadingTemporal.predict_percept = spy
     try:
-        model.find_threshold(implant.stim, 0.2, max_iter=5)
+        model.find_threshold(stim, 0.2, max_iter=5)
         npt.assert_equal(set(seen), {n_frames})
         seen.clear()
         # ... and the same through the combined model:
         Model(temporal=FadingTemporal(tau=100)).build().find_threshold(
-            implant, 0.2, max_iter=5)
+            stim, 0.2, max_iter=5)
         npt.assert_equal(set(seen), {n_frames})
     finally:
         FadingTemporal.predict_percept = unwrapped
@@ -1261,7 +1276,7 @@ def test_Model_deepcopy_preserves_submodels_and_params():
 
 def test_model_unit_contract():
     """Every model states the units its numerical implementation works in"""
-    spatial = ScoreboardSpatial(xrange=(-2, 2), yrange=(-2, 2), step=1)
+    spatial = ScoreboardSpatial(implant=ArgusII(), xrange=(-2, 2), yrange=(-2, 2), step=1)
     temporal = FadingTemporal()
     for model in (spatial, temporal, Model(spatial=spatial),
                   Model(spatial=spatial, temporal=temporal)):
@@ -1283,7 +1298,8 @@ def test_model_electrode_coords_follow_the_stimulus():
     coordinates up by name rather than taking the array as it stands.
     """
     implant = ArgusII()
-    model = ScoreboardSpatial(xrange=(-2, 2), yrange=(-2, 2), step=1)
+    model = ScoreboardSpatial(implant=implant, xrange=(-2, 2), yrange=(-2, 2),
+                              step=1)
     # A subset, in an order that is not the array's:
     stim = Stimulus({'F10': 1, 'A1': 2, 'C5': 3})
     x, y, z = model._electrode_coords(implant.earray, stim)
@@ -1298,22 +1314,25 @@ def test_model_electrode_coords_follow_the_stimulus():
     # End to end: a one-electrode stimulus lights up the same place whether it
     # is the only row or one of several.
     model.build()
-    only = model.predict_percept(ArgusII(stim={'F10': 3}))
-    among = model.predict_percept(ArgusII(stim={'F10': 3, 'A1': 0, 'C5': 0}))
+    only = model.predict_percept({'F10': 3})
+    among = model.predict_percept({'F10': 3, 'A1': 0, 'C5': 0})
     npt.assert_almost_equal(only.data, among.data)
 
 
 def test_model_t_percept_units():
     """`t_percept` is a time, spelled however the caller likes"""
-    implant = ArgusII(stim=BiphasicPulseTrain(20, 50, 0.45, stim_dur=100))
-    spatial = ScoreboardSpatial(xrange=(-2, 2), yrange=(-2, 2),
-                                step=1).build()
+    implant = ArgusII()
+    source = BiphasicPulseTrain(20, 50, 0.45, stim_dur=100)
+    spatial = ScoreboardSpatial(implant=implant, xrange=(-2, 2),
+                                yrange=(-2, 2), step=1).build()
     temporal = FadingTemporal().build()
-    composite = Model(spatial=ScoreboardSpatial(xrange=(-2, 2), yrange=(-2, 2),
+    composite = Model(implant=implant,
+                      spatial=ScoreboardSpatial(implant=ArgusII(), xrange=(-2, 2), yrange=(-2, 2),
                                                 step=1),
                       temporal=FadingTemporal()).build()
-    for model, stim in [(spatial, implant), (temporal, implant.stim),
-                        (composite, implant)]:
+    for model, stim in [(spatial, source),
+                        (temporal, implant.prepare_stim(source)),
+                        (composite, source)]:
         bare = model.predict_percept(stim, t_percept=[0, 20, 40])
         for spelling in ([0, 20, 40] * ms, np.array([0, .02, .04]) * s,
                          [0 * ms, 20000 * us, 0.04 * s]):
@@ -1323,30 +1342,31 @@ def test_model_t_percept_units():
         with pytest.raises(DimensionMismatchError):
             model.predict_percept(stim, t_percept=[0, 20] * uA)
     # A single unitful time point, not just a list:
-    single = spatial.predict_percept(implant, t_percept=0.02 * s)
+    single = spatial.predict_percept(source, t_percept=0.02 * s)
     npt.assert_allclose(single.time, [20], rtol=1e-12)
 
 
 def test_model_find_threshold_units():
     """Amplitudes are currents; brightness is not a physical quantity"""
-    implant = ArgusII(stim={'A1': BiphasicPulseTrain(20, 20, 0.45,
-                                                     stim_dur=100)})
-    spatial = ScoreboardSpatial(xrange=(-2, 2), yrange=(-2, 2),
-                                step=1).build()
-    composite = Model(spatial=ScoreboardSpatial(xrange=(-2, 2), yrange=(-2, 2),
+    implant = ArgusII()
+    trial = implant.prepare_stim(
+        {'A1': BiphasicPulseTrain(20, 20, 0.45, stim_dur=100)})
+    spatial = ScoreboardSpatial(implant=implant, xrange=(-2, 2),
+                                yrange=(-2, 2), step=1).build()
+    composite = Model(implant=implant,
+                      spatial=ScoreboardSpatial(implant=ArgusII(), xrange=(-2, 2), yrange=(-2, 2),
                                                 step=1)).build()
     for model in (spatial, composite):
-        bare = model.find_threshold(implant, 0.1, amp_range=(0, 200),
-                                    amp_tol=1)
-        unitful = model.find_threshold(implant, 0.1,
+        bare = model.find_threshold(trial, 0.1, amp_range=(0, 200), amp_tol=1)
+        unitful = model.find_threshold(trial, 0.1,
                                        amp_range=(0, 0.2 * mA), amp_tol=1 * uA)
         npt.assert_allclose(unitful, bare, rtol=1e-12)
         # The answer is a plain number of microamps:
         npt.assert_equal(isinstance(unitful, Quantity), False)
         with pytest.raises(DimensionMismatchError):
-            model.find_threshold(implant, 0.1, amp_range=(0, 5 * ms))
+            model.find_threshold(trial, 0.1, amp_range=(0, 5 * ms))
         with pytest.raises(DimensionMismatchError):
-            model.find_threshold(implant, 0.1, amp_tol=1 * dva)
+            model.find_threshold(trial, 0.1, amp_tol=1 * dva)
     # ... and on a temporal model, where `t_percept` joins them:
     temporal = FadingTemporal().build()
     stim = BiphasicPulseTrain(20, 20, 0.45, stim_dur=100)
@@ -1367,53 +1387,61 @@ def test_model_requires_a_current_stimulus():
     `stimulus_unit` exists to declare away.
     """
     img = ImageStimulus(np.linspace(0, 1, 16).reshape((4, 4)))
-    spatial = ScoreboardSpatial(xrange=(-2, 2), yrange=(-2, 2),
-                                step=1).build()
-    temporal = FadingTemporal().build()
-    composite = Model(spatial=ScoreboardSpatial(xrange=(-2, 2), yrange=(-2, 2),
-                                                step=1),
-                      temporal=FadingTemporal()).build()
-    # `implant.stim = img` is either encoded by the implant or refused by it
-    # (see `ProsthesisSystem.stimulus_unit`), so the model-side guard is
+    # `implant.prepare_stim(img)` is either encoded by the implant or refused
+    # by it (see `ProsthesisSystem.stimulus_unit`), so the model-side guard is
     # reached through an implant that claims to deliver something else. Both
-    # are needed: the implant one catches the assignment that was actually
-    # wrong, and this one is what no model may be talked out of.
+    # are needed: the implant one catches the call that was actually wrong,
+    # and this one is what no model may be talked out of.
     class Projector(ArgusII):
         stimulus_unit = dimensionless
 
+    implant = Projector(preprocess=False)
+    spatial = ScoreboardSpatial(implant=implant, xrange=(-2, 2),
+                                yrange=(-2, 2), step=1).build()
+    temporal = FadingTemporal().build()
+    composite = Model(implant=implant,
+                      spatial=ScoreboardSpatial(implant=ArgusII(), xrange=(-2, 2), yrange=(-2, 2),
+                                                step=1),
+                      temporal=FadingTemporal()).build()
     with pytest.raises(DimensionMismatchError):
-        ArgusII(preprocess=False, encoder=None, stim=img)
-    implant = Projector(preprocess=False, stim=img)
-    npt.assert_equal(implant.stim.unit, dimensionless)
+        ArgusII(preprocess=False, encoder=None).prepare_stim(img)
+    projected = implant.prepare_stim(img)
+    npt.assert_equal(projected.unit, dimensionless)
     for model in (spatial, composite):
         with pytest.raises(DimensionMismatchError) as excinfo:
-            model.predict_percept(implant)
+            model.predict_percept(img)
         npt.assert_equal('electric current' in str(excinfo.value), True)
         npt.assert_equal('dimensionless' in str(excinfo.value), True)
     with pytest.raises(DimensionMismatchError):
-        temporal.predict_percept(implant.stim)
+        temporal.predict_percept(projected)
 
     # Encoded, it goes through:
     encoded = AmplitudeEncoder(amp_range=(0, 50)).encode(
         img, implant=ArgusII(raster=None))
     npt.assert_equal(encoded.unit, uA)
-    for model in (spatial, composite):
-        npt.assert_equal(model.predict_percept(ArgusII(stim=encoded)) is None,
-                         False)
+    argus = ArgusII(encoder=None, raster=None)
+    for model in (ScoreboardSpatial(implant=argus, xrange=(-2, 2),
+                                    yrange=(-2, 2), step=1).build(),
+                  Model(implant=argus,
+                        spatial=ScoreboardSpatial(xrange=(-2, 2),
+                                                  yrange=(-2, 2), step=1),
+                        temporal=FadingTemporal()).build()):
+        npt.assert_equal(model.predict_percept(encoded) is None, False)
 
     # A current spelled in another unit is converted, not refused. `Stimulus`
     # has already done the converting, which is the point:
     npt.assert_equal(Stimulus([0.05 * mA]).unit, uA)
     npt.assert_allclose(Stimulus([0.05 * mA]).data, 50, rtol=1e-12)
-    bare = ArgusII(stim={'A1': BiphasicPulseTrain(20, 50, 0.45, stim_dur=100)})
-    unitful = ArgusII(stim={'A1': BiphasicPulseTrain(20, 0.05 * mA, 0.45,
-                                                     stim_dur=100)})
-    npt.assert_allclose(spatial.predict_percept(unitful).data,
-                        spatial.predict_percept(bare).data, rtol=1e-12)
+    electrical = ScoreboardSpatial(implant=ArgusII(), xrange=(-2, 2),
+                                   yrange=(-2, 2), step=1).build()
+    bare = {'A1': BiphasicPulseTrain(20, 50, 0.45, stim_dur=100)}
+    unitful = {'A1': BiphasicPulseTrain(20, 0.05 * mA, 0.45, stim_dur=100)}
+    npt.assert_allclose(electrical.predict_percept(unitful).data,
+                        electrical.predict_percept(bare).data, rtol=1e-12)
 
     # A Percept is brightness, not current, and is not checked -- it is what a
     # spatial model hands a temporal one:
-    percept = spatial.predict_percept(bare)
+    percept = electrical.predict_percept(bare)
     npt.assert_equal(temporal.predict_percept(percept) is None, False)
 
 
@@ -1452,12 +1480,13 @@ def test_model_units_are_a_numerical_contract():
     # value and neighbouring columns never coincide:
     ramp = Stimulus(np.arange(10, dtype=float).reshape((1, -1)),
                     electrodes=['A1'], time=np.arange(10, dtype=float))
-    implant = ArgusII(stim=ramp)
-    canonical = RecordingSpatial(xrange=(-2, 2), yrange=(-2, 2),
-                                 step=1).build()
-    milli = MilliSpatial(xrange=(-2, 2), yrange=(-2, 2), step=1).build()
-    canonical.predict_percept(implant)
-    milli.predict_percept(implant)
+    implant = ArgusII()
+    canonical = RecordingSpatial(implant=implant, xrange=(-2, 2),
+                                 yrange=(-2, 2), step=1).build()
+    milli = MilliSpatial(implant=implant, xrange=(-2, 2), yrange=(-2, 2),
+                         step=1).build()
+    canonical.predict_percept(ramp)
+    milli.predict_percept(ramp)
     a, m = canonical.seen, milli.seen
 
     # Stimulus values: uA in, mA out
@@ -1471,25 +1500,25 @@ def test_model_units_are_a_numerical_contract():
     npt.assert_allclose(m['x'][0], implant['A1'].x / 1000, rtol=1e-6)
     # Time: ms in, s out
     npt.assert_allclose(m['time'], a['time'] / 1000, rtol=1e-12)
-    npt.assert_allclose(a['time'], implant.stim.time, rtol=0, atol=0)
+    npt.assert_allclose(a['time'], ramp.time, rtol=0, atol=0)
     # ... and the canonical model really is the zero-conversion path:
-    npt.assert_allclose(a['amp'], implant.stim.data, rtol=0, atol=0)
+    npt.assert_allclose(a['amp'], ramp.data, rtol=0, atol=0)
 
     # `t_percept` is read in the model's own unit, and converted back to the
     # stimulus' unit to index it, so 0.005 s and 5 ms pick the same sample:
-    milli.predict_percept(implant, t_percept=[0.0, 0.005])
-    canonical.predict_percept(implant, t_percept=[0.0, 5.0])
+    milli.predict_percept(ramp, t_percept=[0.0, 0.005])
+    canonical.predict_percept(ramp, t_percept=[0.0, 5.0])
     # rtol at float32 precision: `Stimulus.data` is float32, so 0.005 mA is
     # only good to about seven digits however exact the conversion was.
     npt.assert_allclose(canonical.seen['amp'], [[0, 5]], rtol=1e-6)
     npt.assert_allclose(milli.seen['amp'], [[0, 0.005]], rtol=1e-6)
     # The percept is labelled in the model's unit, not in milliseconds:
     npt.assert_allclose(
-        milli.predict_percept(implant, t_percept=[0.0, 0.005]).time,
+        milli.predict_percept(ramp, t_percept=[0.0, 0.005]).time,
         [0.0, 0.005], rtol=1e-12)
     # A quantity is normalized into that unit too:
     npt.assert_allclose(
-        milli.predict_percept(implant, t_percept=[0 * ms, 5 * ms]).time,
+        milli.predict_percept(ramp, t_percept=[0 * ms, 5 * ms]).time,
         [0.0, 0.005], rtol=1e-12)
 
     # The dimension guard reads the declared unit: mA and uA are the same
@@ -1499,9 +1528,11 @@ def test_model_units_are_a_numerical_contract():
     class Projector(ArgusII):
         stimulus_unit = dimensionless
 
+    projected = MilliSpatial(implant=Projector(preprocess=False),
+                             xrange=(-2, 2), yrange=(-2, 2), step=1).build()
     with pytest.raises(DimensionMismatchError):
-        milli.predict_percept(Projector(preprocess=False, stim=ImageStimulus(
-            np.linspace(0, 1, 16).reshape((4, 4)))))
+        projected.predict_percept(
+            ImageStimulus(np.linspace(0, 1, 16).reshape((4, 4))))
 
 
 class SecondSpatial(RecordingSpatial):
@@ -1537,15 +1568,15 @@ def test_percept_time_crosses_model_boundary():
     """
     ramp = Stimulus(np.arange(21, dtype=float).reshape((1, -1)),
                     electrodes=['A1'], time=np.arange(21, dtype=float))
-    implant = ArgusII(stim=ramp)
-    spatial = SecondSpatial(xrange=(-2, 2), yrange=(-2, 2), step=1).build()
+    spatial = SecondSpatial(implant=ArgusII(), xrange=(-2, 2), yrange=(-2, 2),
+                            step=1).build()
     temporal = MilliTemporal().build()
     npt.assert_equal(spatial.time_unit, s)
     npt.assert_equal(temporal.time_unit, ms)
 
     # The spatial model labels its percept in its own unit, and `t_percept`
     # was read in that unit too:
-    percept = spatial.predict_percept(implant, t_percept=[0, .005, .010])
+    percept = spatial.predict_percept(ramp, t_percept=[0, .005, .010])
     npt.assert_equal(percept.time_unit, s)
     npt.assert_allclose(percept.time, [0, .005, .010], rtol=1e-12)
     npt.assert_allclose(percept.times(ms), [0, 5, 10], rtol=1e-12)
@@ -1564,28 +1595,28 @@ def test_percept_time_crosses_model_boundary():
     npt.assert_allclose(temporal.seen['values'], percept.data, rtol=0, atol=0)
 
     # The same crossing through a composite, which is where it really happens:
-    model = Model(spatial=SecondSpatial(xrange=(-2, 2), yrange=(-2, 2),
+    model = Model(implant=ArgusII(),
+                  spatial=SecondSpatial(xrange=(-2, 2), yrange=(-2, 2),
                                         step=1),
                   temporal=MilliTemporal()).build()
     # A composite reports the unit of the stage that reads `t_percept` and
     # writes the percept, which is the temporal model:
     npt.assert_equal(model.time_unit, ms)
     npt.assert_equal(model.spatial.time_unit, s)
-    out = model.predict_percept(implant, t_percept=[0, 5, 10])
+    out = model.predict_percept(ramp, t_percept=[0, 5, 10])
     npt.assert_equal(out.time_unit, ms)
     npt.assert_allclose(out.time, [0, 5, 10], rtol=1e-12)
     # The spatial model ran at every stimulus time point, in seconds, and the
     # temporal model got those same instants back in milliseconds:
-    npt.assert_allclose(model.temporal.seen['time'], implant.stim.time,
-                        rtol=1e-12)
+    npt.assert_allclose(model.temporal.seen['time'], ramp.time, rtol=1e-12)
     # Spelling `t_percept` unitfully changes nothing:
     npt.assert_allclose(
-        model.predict_percept(implant, t_percept=[0 * ms, 5 * ms,
-                                                  10 * ms]).time,
+        model.predict_percept(ramp, t_percept=[0 * ms, 5 * ms,
+                                               10 * ms]).time,
         [0, 5, 10], rtol=1e-12)
     npt.assert_allclose(
-        model.predict_percept(implant, t_percept=[0, .005 * s,
-                                                  .010 * s]).time,
+        model.predict_percept(ramp, t_percept=[0, .005 * s,
+                                               .010 * s]).time,
         [0, 5, 10], rtol=1e-12)
 
 
@@ -1681,34 +1712,36 @@ def test_spatial_model_reads_modulation_not_pulses():
     six groups by default, which is exactly the case that showed it.
     """
     logo = LogoBVL()
-    implant = ArgusII(stim=logo)
-    spatial = ScoreboardSpatial(xrange=(-12, 12), yrange=(-8, 8),
-                                step=1).build()
+    implant = ArgusII()
+    delivered = implant.prepare_stim(logo)
+    spatial = ScoreboardSpatial(implant=implant, xrange=(-12, 12),
+                                yrange=(-8, 8), step=1).build()
 
     # One frame in, one frame out -- not one per pulse edge:
-    percept = spatial.predict_percept(implant)
-    npt.assert_equal(implant.stim.time.size > 50, True)
+    percept = spatial.predict_percept(logo)
+    npt.assert_equal(delivered.time.size > 50, True)
     npt.assert_equal(percept.data.shape[-1], 1)
     # ... and every electrode the image lights is lit in it, rather than the
     # one raster group that happened to be firing at the sampled instant:
-    lit = implant.stim._spatial_view().data.ravel() > 0
+    lit = delivered._spatial_view().data.ravel() > 0
     npt.assert_equal(lit.sum() > 10, True)
     groups = implant.raster.groups(implant.electrode_names)
     # No instant of the delivered train ever holds more than one group, so
     # anything above one is more than a raster slot's worth of picture:
     npt.assert_equal(len(np.unique(groups[lit])) > 1, True)
-    for column in implant.stim.data.T:
+    for column in delivered.data.T:
         npt.assert_equal(np.unique(groups[column != 0]).size <= 1, True)
     # Which is what the percept says too: it is the same picture the
     # modulation asked for, run through the model.
-    direct = spatial.predict_percept(
-        ArgusII(encoder=None, stim=implant.stim._spatial_view()))
+    bare = ScoreboardSpatial(implant=ArgusII(encoder=None), xrange=(-12, 12),
+                             yrange=(-8, 8), step=1).build()
+    direct = bare.predict_percept(delivered._spatial_view())
     npt.assert_almost_equal(percept.data, direct.data)
 
     # A video reports one percept frame per *video* frame:
     with pytest.warns(UserWarning, match='deliver no pulse'):
-        implant = ArgusII(stim=BostonTrain())
-    npt.assert_equal(spatial.predict_percept(implant).data.shape[-1], 94)
+        n_frames = spatial.predict_percept(BostonTrain()).data.shape[-1]
+    npt.assert_equal(n_frames, 94)
 
     # A model with a temporal component is the opposite case: the pulses are
     # what it integrates, so it has to see them, and the spatial stage it is
@@ -1722,45 +1755,47 @@ def test_spatial_model_reads_modulation_not_pulses():
             seen.append(float(stim.data.min()))
             return super()._predict_spatial(earray, stim)
 
-    implant = ArgusII(stim=logo)
-    both = Model(spatial=Recording(xrange=(-12, 12), yrange=(-8, 8), step=1),
+    both = Model(implant=implant,
+                 spatial=Recording(xrange=(-12, 12), yrange=(-8, 8), step=1),
                  temporal=FadingTemporal(tau=100)).build()
-    both.predict_percept(implant)
+    both.predict_percept(logo)
     npt.assert_array_less(seen[-1], 0)
-    # ... and the implant it was handed is untouched by that:
-    npt.assert_equal(implant.stim._has_spatial_view, True)
+    # ... and the caller's own picture is untouched by that:
+    npt.assert_equal(implant.prepare_stim(logo)._has_spatial_view, True)
     # Spatial-only, the same model class reads the modulation instead:
     seen.clear()
-    Recording(xrange=(-12, 12), yrange=(-8, 8),
-              step=1).build().predict_percept(implant)
+    Recording(implant=implant, xrange=(-12, 12), yrange=(-8, 8),
+              step=1).build().predict_percept(logo)
     npt.assert_array_less(-1e-12, seen[-1])
 
-    # Nothing changes for a stimulus that was assigned as current: there is no
-    # modulation behind it, so there is nothing to prefer.
-    plain = ArgusII(stim={'A1': BiphasicPulseTrain(20, 50, 0.45,
-                                                   stim_dur=100)})
-    npt.assert_equal(plain.stim._has_spatial_view, False)
-    npt.assert_equal(
-        spatial.predict_percept(plain).data.shape[-1],
-        plain.stim.time.size)
+    # Nothing changes for a stimulus that was presented as current: there is
+    # no modulation behind it, so there is nothing to prefer.
+    plain = implant.prepare_stim(
+        {'A1': BiphasicPulseTrain(20, 50, 0.45, stim_dur=100)})
+    npt.assert_equal(plain._has_spatial_view, False)
+    npt.assert_equal(spatial.predict_percept(plain).data.shape[-1],
+                     plain.time.size)
 
 
 def test_find_threshold_scales_both_representations():
     # `find_threshold` varies the amplitude between trials. A spatial model
     # reads the modulation, so a search that scaled only the pulse train would
     # evaluate every trial on the unscaled picture and never move.
-    implant = ArgusII(stim=LogoBVL())
-    model = ScoreboardModel(xrange=(-12, 12), yrange=(-8, 8), step=1).build()
-    amp_th = model.find_threshold(implant, 50, amp_range=(0, 500),
+    implant = ArgusII()
+    delivered = implant.prepare_stim(LogoBVL())
+    model = ScoreboardModel(implant=implant, xrange=(-12, 12), yrange=(-8, 8),
+                            step=1).build()
+    amp_th = model.find_threshold(delivered, 50, amp_range=(0, 500),
                                   amp_tol=0.5)
     npt.assert_equal(0 < amp_th < 500, True)
     # The answer is a threshold of what `predict_percept` reports, which is
     # only true if both descriptions were scaled together:
-    modulation = implant.stim._spatial_view()
-    scaled = ArgusII(encoder=None, stim=Stimulus(
-        modulation.data * amp_th / implant.stim.data.max(),
-        electrodes=modulation.electrodes))
-    npt.assert_allclose(model.predict_percept(scaled).data.max(), 50,
+    modulation = delivered._spatial_view()
+    bare = ScoreboardModel(implant=ArgusII(encoder=None), xrange=(-12, 12),
+                           yrange=(-8, 8), step=1).build()
+    scaled = Stimulus(modulation.data * amp_th / delivered.data.max(),
+                      electrodes=modulation.electrodes)
+    npt.assert_allclose(bare.predict_percept(scaled).data.max(), 50,
                         rtol=0.05)
 
 
@@ -1948,7 +1983,7 @@ def test_blend_meridian_bad_input():
 def test_postprocess_spatial_hook():
     # The hook is a no-op by default, and a model that overrides it sees the
     # finished response, at every requested time point.
-    plain = ScoreboardSpatial(xrange=(-2, 2), yrange=(-2, 2), step=1).build()
+    plain = ScoreboardSpatial(implant=ArgusII(), xrange=(-2, 2), yrange=(-2, 2), step=1).build()
     resp = np.arange(12, dtype=np.float32).reshape(4, 3)
     npt.assert_equal(plain._postprocess_spatial(resp) is resp, True)
 
@@ -1959,11 +1994,11 @@ def test_postprocess_spatial_hook():
             seen.append(resp.shape)
             return 2 * resp
 
-    implant = ArgusII(encoder=None, stim=Stimulus(
-        {'A5': [1, 2, 3], 'F7': [3, 2, 1]}))
-    doubled = Doubling(xrange=(-2, 2), yrange=(-2, 2), step=1).build()
-    expected = plain.predict_percept(implant)
-    got = doubled.predict_percept(implant)
+    source = Stimulus({'A5': [1, 2, 3], 'F7': [3, 2, 1]})
+    doubled = Doubling(implant=ArgusII(), xrange=(-2, 2), yrange=(-2, 2),
+                       step=1).build()
+    expected = plain.predict_percept(source)
+    got = doubled.predict_percept(source)
     npt.assert_equal(len(seen), 1)
     npt.assert_equal(seen[0], (plain.grid.x.size, expected.data.shape[-1]))
     npt.assert_allclose(got.data, 2 * expected.data)
@@ -1975,20 +2010,22 @@ def test_models_accept_read_only_stimulus_data():
     # rejects such an array outright ("buffer source array is read-only"),
     # which is a failure no numerical test would catch on its own.
     from pulse2percept.models import Nanduri2012Spatial, Nanduri2012Temporal
-    implant = ArgusII(stim={'A1': BiphasicPulseTrain(20, 50, 0.45,
-                                                     stim_dur=20)})
-    npt.assert_equal(implant.stim.data.flags.writeable, False)
-    spatial = Nanduri2012Spatial(xrange=(-1, 1), yrange=(-1, 1),
-                                 step=1).build()
-    resp = spatial.predict_percept(implant)
+    implant = ArgusII()
+    source = {'A1': BiphasicPulseTrain(20, 50, 0.45, stim_dur=20)}
+    stim = implant.prepare_stim(source)
+    npt.assert_equal(stim.data.flags.writeable, False)
+    spatial = Nanduri2012Spatial(implant=implant, xrange=(-1, 1),
+                                 yrange=(-1, 1), step=1).build()
+    resp = spatial.predict_percept(source)
     npt.assert_equal(np.all(np.isfinite(resp.data)), True)
     temporal = Nanduri2012Temporal().build()
-    npt.assert_equal(temporal.predict_percept(implant.stim) is not None, True)
+    npt.assert_equal(temporal.predict_percept(stim) is not None, True)
     # And the same for the axon map / scoreboard kernels:
     for cls in (ScoreboardSpatial, AxonMapSpatial):
-        model = cls(xrange=(-1, 1), yrange=(-1, 1), step=1).build()
+        model = cls(implant=implant, xrange=(-1, 1), yrange=(-1, 1),
+                    step=1).build()
         npt.assert_equal(np.all(np.isfinite(
-            model.predict_percept(implant).data)), True)
+            model.predict_percept(source).data)), True)
 
 
 @contextmanager
@@ -2014,16 +2051,17 @@ def _no_schedule_expansion():
 def test_spatial_model_predicts_without_expanding_the_schedule(source):
     # A spatial model reads one amplitude per electrode per frame. Nothing
     # about that needs the pulse train the schedule would expand into.
-    spatial = ScoreboardSpatial(xrange=(-12, 12), yrange=(-8, 8),
-                                step=1).build()
+    implant = ArgusII()
+    spatial = ScoreboardSpatial(implant=implant, xrange=(-12, 12),
+                                yrange=(-8, 8), step=1).build()
     picture = (LogoBVL() if source == 'image' else
                VideoStimulus(np.random.default_rng(0).random((6, 10, 4)),
                              metadata={'fps': 20}))
     with warnings.catch_warnings():
         warnings.simplefilter('ignore')
-        implant = ArgusII(stim=picture)
+        prepared = implant.prepare_stim(picture)
     with _no_schedule_expansion():
-        percept = spatial.predict_percept(implant)
+        percept = spatial.predict_percept(prepared)
     npt.assert_equal(np.any(percept.data), True)
     npt.assert_equal(percept.data.shape[-1], 1 if source == 'image' else 4)
 
@@ -2032,7 +2070,8 @@ def test_combined_model_still_integrates_the_delivered_pulses():
     # The opposite case: a temporal stage integrates pulses, so the spatial
     # stage under it has to be handed them. That reading is unchanged, and the
     # implant it was asked of keeps its own schedule.
-    implant = ArgusII(stim=LogoBVL())
+    implant = ArgusII()
+    delivered = implant.prepare_stim(LogoBVL())
     seen = []
 
     class Recording(ScoreboardSpatial):
@@ -2042,41 +2081,47 @@ def test_combined_model_still_integrates_the_delivered_pulses():
             seen.append(float(stim.data.min()))
             return super()._predict_spatial(earray, stim)
 
-    both = Model(spatial=Recording(xrange=(-12, 12), yrange=(-8, 8), step=1),
+    both = Model(implant=implant,
+                 spatial=Recording(xrange=(-12, 12), yrange=(-8, 8), step=1),
                  temporal=FadingTemporal(tau=100)).build()
-    both.predict_percept(implant)
+    both.predict_percept(LogoBVL())
     npt.assert_array_less(seen[-1], 0)
-    # The stand-in did not take the schedule away from the implant:
-    npt.assert_equal(implant.stim._has_spatial_view, True)
+    # Stripping the modulation view happens on a stand-in, so the prepared
+    # stimulus the caller holds keeps its schedule:
+    npt.assert_equal(delivered._has_spatial_view, True)
 
 
 def test_find_threshold_scales_an_encoded_stimulus_structurally():
     # Every trial scales the one schedule, so the modulation a spatial model
     # reads and the waveform a temporal one would read move together -- and
     # the search never has to expand either.
-    implant = ArgusII(stim=LogoBVL())
-    model = ScoreboardModel(xrange=(-12, 12), yrange=(-8, 8), step=1).build()
+    implant = ArgusII()
+    delivered = implant.prepare_stim(LogoBVL())
+    model = ScoreboardModel(implant=implant, xrange=(-12, 12), yrange=(-8, 8),
+                            step=1).build()
     # The search reads the delivered peak once, to know what it is scaling
     # to. From there on nothing needs the pulses:
-    peak = implant.stim.data.max()
+    peak = delivered.data.max()
     with _no_schedule_expansion():
-        trial = _rescaled_implant(implant, 2 * peak)
-        npt.assert_equal(type(trial.stim), type(implant.stim))
-        npt.assert_allclose(trial.stim._spatial_view().data,
-                            2 * implant.stim._spatial_view().data, rtol=1e-6)
+        trial = delivered * 2
+        npt.assert_equal(type(trial), type(delivered))
+        npt.assert_allclose(trial._spatial_view().data,
+                            2 * delivered._spatial_view().data, rtol=1e-6)
         npt.assert_equal(np.any(model.predict_percept(trial).data), True)
 
 
 def test_deactivating_an_encoded_electrode_keeps_the_schedule():
-    implant = ArgusII(stim=LogoBVL())
-    before = implant.stim._spatial_view()
+    implant = ArgusII()
+    logo = LogoBVL()
+    before = implant.prepare_stim(logo)._spatial_view()
     with _no_schedule_expansion():
         implant.deactivate(['A1', 'B2'])
-        after = implant.stim._spatial_view()
-    npt.assert_equal(implant.stim._has_spatial_view, True)
-    npt.assert_equal(len(implant.stim.electrodes), 58)
+        stim = implant.prepare_stim(logo)
+        after = stim._spatial_view()
+        npt.assert_equal(stim._has_spatial_view, True)
+        npt.assert_equal(len(stim.electrodes), 58)
     keep = [i for i, e in enumerate(before.electrodes)
             if str(e) not in ('A1', 'B2')]
     npt.assert_array_equal(after.data, before.data[keep])
     # The waveform is still there to be had, and matches too:
-    npt.assert_equal(implant.stim.data.shape[0], 58)
+    npt.assert_equal(stim.data.shape[0], 58)

--- a/pulse2percept/models/tests/test_base.py
+++ b/pulse2percept/models/tests/test_base.py
@@ -15,7 +15,7 @@ from pulse2percept.stimuli import (AmplitudeEncoder, BiphasicPulseTrain,
                                    Stimulus, VideoStimulus)
 from pulse2percept.percepts import Percept
 from pulse2percept.models import (AxonMapModel, AxonMapSpatial, BaseModel,
-                                  FadingTemporal, Model, NotBuiltError,
+                                  FadingTemporal, Model,
                                   ScoreboardModel, ScoreboardSpatial,
                                   SpatialModel, TemporalModel)
 from pulse2percept.models.base import _blend_meridian
@@ -81,8 +81,6 @@ class ValidSpatialModel(SpatialModel):
         return params
 
     def _predict_spatial(self, earray, stim):
-        if not self.is_built:
-            raise NotBuiltError
         n_time = 1 if stim.time is None else stim.time.size
         return np.zeros((self.grid.x.size, n_time), dtype=np.float32)
 
@@ -448,8 +446,6 @@ def test_SpatialModel_plot():
 class ValidTemporalModel(TemporalModel):
 
     def _predict_temporal(self, stim, t_percept):
-        if not self.is_built:
-            raise NotBuiltError
         return np.zeros((stim.data.shape[0], len(t_percept)), dtype=np.float32)
 
 

--- a/pulse2percept/models/tests/test_beyeler2019.py
+++ b/pulse2percept/models/tests/test_beyeler2019.py
@@ -1086,7 +1086,7 @@ def test_axon_map_warns_when_the_implant_is_not_epiretinal():
                 n_ax_segments=30)
     said = _user_warnings(AxonMapModel(implant=PRIMA75(), **grid).build)
     npt.assert_equal(any('subretinal' in w for w in said), True)
-    npt.assert_equal(any('ScoreboardModel' in w for w in said), True)
+    npt.assert_equal(any('scoreboard model' in w for w in said), True)
     # An implant whose placement nobody wrote down says nothing either way.
     # Its pitch is wide enough not to trip the other warning:
     quiet = GridImplant(shape=(3, 3), spacing=2000)
@@ -1109,3 +1109,19 @@ def test_rho_wider_than_the_electrode_pitch_warns(ModelClass):
     matched = ModelClass(implant=GridImplant(shape=(3, 3), spacing=400),
                          rho=400, **grid)
     npt.assert_equal(_user_warnings(matched.build), [])
+
+
+@pytest.mark.parametrize('ModelClass', [ScoreboardModel, AxonMapModel])
+def test_electrode_pitch_ignores_a_dimension_the_model_drops(ModelClass):
+    """A retinal model reads x and y, so z cannot pull neighbours apart"""
+    from pulse2percept.implants import (DiskElectrode, ElectrodeArray,
+                                        ProsthesisSystem)
+    extra = {'n_axons': 50, 'n_ax_segments': 30} if ModelClass is AxonMapModel         else {}
+    # Three electrodes 100 um apart in x, but 1000 um apart in z. Reading all
+    # three coordinates would call that a ~1005 um pitch and stay quiet:
+    stacked = ProsthesisSystem(ElectrodeArray(
+        [DiskElectrode(100 * i, 0, 1000 * i, 50) for i in range(3)]))
+    model = ModelClass(implant=stacked, rho=400, step=1, xrange=(-2, 2),
+                       yrange=(-2, 2), **extra)
+    said = _user_warnings(model.build)
+    npt.assert_equal(any('pitch (100 um)' in w for w in said), True)

--- a/pulse2percept/models/tests/test_beyeler2019.py
+++ b/pulse2percept/models/tests/test_beyeler2019.py
@@ -186,9 +186,13 @@ def test_ScoreboardModel_predict_percept():
     # Warning for nonzero electrode-retina distances
     raised = ScoreboardModel(implant=ArgusII(z=10), step=0.55, rho=100)
     raised.build()
-    msg = ("Nonzero electrode-retina distances do not have any effect on the "
-           "model output.")
-    assert_warns_msg(UserWarning, raised.predict_percept, msg, np.ones(60))
+    # Framed as a limitation of the model, not as a claim that distance is
+    # irrelevant, and named so the reader knows which model is silent about it:
+    assert_warns_msg(UserWarning, raised.predict_percept,
+                     "ScoreboardSpatial does not model electrode-retina distance",
+                     np.ones(60))
+    assert_warns_msg(UserWarning, raised.predict_percept,
+                     "not parameterized by this model", np.ones(60))
 
 
 def test_AxonMapSpatial():
@@ -680,9 +684,13 @@ def test_AxonMapModel_predict_percept():
     raised = AxonMapModel(implant=ArgusII(z=10), step=1, rho=100, lam=40,
                           meridian_blend=0, n_axons=250, n_ax_segments=200,
                           ignore_pickle=True).build()
-    msg = ("Nonzero electrode-retina distances do not have any effect on the "
-           "model output.")
-    assert_warns_msg(UserWarning, raised.predict_percept, msg, np.ones(60))
+    # Framed as a limitation of the model, not as a claim that distance is
+    # irrelevant, and named so the reader knows which model is silent about it:
+    assert_warns_msg(UserWarning, raised.predict_percept,
+                     "AxonMapSpatial does not model electrode-retina distance",
+                     np.ones(60))
+    assert_warns_msg(UserWarning, raised.predict_percept,
+                     "not parameterized by this model", np.ones(60))
 
 
 @pytest.mark.parametrize('ModelClass', (ScoreboardModel, AxonMapModel))

--- a/pulse2percept/models/tests/test_beyeler2019.py
+++ b/pulse2percept/models/tests/test_beyeler2019.py
@@ -318,13 +318,10 @@ def test_AxonMapModel():
     # Zeros in, zeros out:
     npt.assert_almost_equal(model.predict_percept(np.zeros(60)).data, 0)
 
-    # Implant and model must be built for same eye:
-    with pytest.raises(ValueError):
-        AxonMapModel(implant=ArgusII(eye='LE'), step=5).build()
-    with pytest.raises(ValueError):
-        AxonMapModel(implant=ArgusII(), eye='invalid').build()
-    with pytest.raises(ValueError):
-        AxonMapModel(implant=ArgusII(), step=5).build(eye='invalid')
+    # The eye is the implanted one, and is not settable on its own:
+    npt.assert_equal(AxonMapModel(implant=ArgusII(eye='LE'), step=5).eye, 'LE')
+    with pytest.raises(AttributeError):
+        AxonMapModel(implant=ArgusII(), eye='LE')
 
     # Lambda cannot be too small:
     with pytest.raises(ValueError):
@@ -484,7 +481,7 @@ def test_AxonMapModel__jansonius2009(eye, loc_od, sign):
 
     # A single axon fiber with `phi0`=0 should return a single pixel location
     # that corresponds to the optic disc
-        model = AxonMapModel(implant=ArgusII(), loc_od=loc_od, step=2, eye=eye,
+        model = AxonMapModel(implant=ArgusII(eye=eye), loc_od=loc_od, step=2,
                              ax_segments_range=(0, 0),
                              n_ax_segments=1)
         single_fiber = model.spatial._jansonius2009(0)
@@ -1049,3 +1046,66 @@ def test_AxonMapSpatial_axons_range_units():
         axons_range, bare.axons_range, rtol=1e-12)
     with pytest.raises(DimensionMismatchError):
         AxonMapSpatial(implant=ArgusII(), axons_range=(-30 * dva, 30 * dva))
+
+
+def _user_warnings(build):
+    """The UserWarning messages a build emits, and nothing else
+
+    Building an axon map also emits ResourceWarnings from the pickle cache,
+    which have nothing to do with what these tests are about.
+    """
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter('always')
+        build()
+    return [str(w.message) for w in caught
+            if issubclass(w.category, UserWarning)]
+
+
+def test_axon_map_eye_follows_the_implant():
+    """The eye is the implanted one, and cannot drift out of step with it"""
+    implant = ArgusII(eye='RE')
+    model = AxonMapModel(implant=implant, step=2, n_axons=50,
+                         n_ax_segments=30).build()
+    npt.assert_equal(model.eye, 'RE')
+    # The optic disc is on the nasal side, which is a different side per eye:
+    npt.assert_equal(model.loc_od[0] > 0, True)
+
+    # Turning the *bound implant* around is the one build-invalidating change
+    # the parameter machinery cannot see, so the model checks it itself:
+    implant.eye = 'LE'
+    npt.assert_equal(model.eye, 'LE')
+    npt.assert_equal(model.is_built, False)
+    model.predict_percept({'A1': 20})
+    npt.assert_equal(model.is_built, True)
+    npt.assert_equal(model.loc_od[0] < 0, True)
+
+
+def test_axon_map_warns_when_the_implant_is_not_epiretinal():
+    from pulse2percept.implants import GridImplant, PRIMA75
+    grid = dict(step=1, xrange=(-2, 2), yrange=(-2, 2), n_axons=50,
+                n_ax_segments=30)
+    said = _user_warnings(AxonMapModel(implant=PRIMA75(), **grid).build)
+    npt.assert_equal(any('subretinal' in w for w in said), True)
+    npt.assert_equal(any('ScoreboardModel' in w for w in said), True)
+    # An implant whose placement nobody wrote down says nothing either way.
+    # Its pitch is wide enough not to trip the other warning:
+    quiet = GridImplant(shape=(3, 3), spacing=2000)
+    npt.assert_equal(_user_warnings(AxonMapModel(implant=quiet, **grid).build),
+                     [])
+
+
+@pytest.mark.parametrize('ModelClass', [ScoreboardModel, AxonMapModel])
+def test_rho_wider_than_the_electrode_pitch_warns(ModelClass):
+    from pulse2percept.implants import GridImplant
+    extra = {'n_axons': 50, 'n_ax_segments': 30} if ModelClass is AxonMapModel         else {}
+    grid = dict(step=1, xrange=(-2, 2), yrange=(-2, 2), **extra)
+    dense = ModelClass(implant=GridImplant(shape=(3, 3), spacing=100),
+                       rho=400, **grid)
+    said = _user_warnings(dense.build)
+    # The numbers a reader needs to judge it, not a verdict:
+    npt.assert_equal(any('pitch (100 um)' in w for w in said), True)
+    npt.assert_equal(any('ratio of 4.00' in w for w in said), True)
+    # rho at the pitch is the boundary, and is not warned about:
+    matched = ModelClass(implant=GridImplant(shape=(3, 3), spacing=400),
+                         rho=400, **grid)
+    npt.assert_equal(_user_warnings(matched.build), [])

--- a/pulse2percept/models/tests/test_beyeler2019.py
+++ b/pulse2percept/models/tests/test_beyeler2019.py
@@ -29,7 +29,7 @@ pytestmark = pytest.mark.usefixtures('axon_cache_in_tmp')
 
 def test_ScoreboardSpatial():
     # ScoreboardSpatial automatically sets `rho`:
-    model = ScoreboardSpatial(step=5)
+    model = ScoreboardSpatial(implant=ArgusII(), step=5)
 
     # User can set `rho`:
     model.rho = 123
@@ -38,28 +38,27 @@ def test_ScoreboardSpatial():
     npt.assert_equal(model.rho, 987)
 
     # Nothing in, None out:
-    npt.assert_equal(model.predict_percept(ArgusI()), None)
+    npt.assert_equal(model.predict_percept(None), None)
 
     # Converting ret <=> dva
     npt.assert_equal(isinstance(model.vfmap, Watson2014Map), True)
     npt.assert_almost_equal(model.vfmap.ret_to_dva(0, 0), (0, 0))
     npt.assert_almost_equal(model.vfmap.dva_to_ret(0, 0), (0, 0))
-    model2 = ScoreboardSpatial(vfmap=Watson2014DisplaceMap())
+    model2 = ScoreboardSpatial(implant=ArgusII(), vfmap=Watson2014DisplaceMap())
     npt.assert_equal(isinstance(model2.vfmap, Watson2014DisplaceMap),
                      True)
 
-    implant = ArgusI(stim=np.zeros(16))
     # Zero in = zero out:
-    percept = model.predict_percept(implant)
+    percept = model.predict_percept(np.zeros(60))
     npt.assert_equal(isinstance(percept, Percept), True)
     npt.assert_equal(percept.shape, list(model.grid.x.shape) + [1])
     npt.assert_almost_equal(percept.data, 0)
 
     # Multiple frames are processed independently:
-    model = ScoreboardSpatial(rho=200, step=5,
+    model = ScoreboardSpatial(implant=ArgusI(), rho=200, step=5,
                               xrange=(-20, 20), yrange=(-15, 15))
     model.build()
-    percept = model.predict_percept(ArgusI(stim={'A1': [1, 0], 'B3': [0, 2]}))
+    percept = model.predict_percept({'A1': [1, 0], 'B3': [0, 2]})
     npt.assert_equal(percept.shape, list(model.grid.x.shape) + [2])
     pmax = percept.data.max(axis=(0, 1))
     npt.assert_almost_equal(percept.data[2, 3, 0], pmax[0])
@@ -70,7 +69,7 @@ def test_ScoreboardSpatial():
 
 
 def test_deepcopy_ScoreboardSpatial():
-    original = ScoreboardSpatial()
+    original = ScoreboardSpatial(implant=ArgusII())
     copied = copy.deepcopy(original)
 
     # Assert these are two different objects
@@ -93,7 +92,7 @@ def test_deepcopy_ScoreboardSpatial():
 
 def test_ScoreboardModel():
     # ScoreboardModel automatically sets `rho`:
-    model = ScoreboardModel(step=5)
+    model = ScoreboardModel(implant=ArgusII(), step=5)
     npt.assert_equal(model.has_space, True)
     npt.assert_equal(model.has_time, False)
     npt.assert_equal(hasattr(model.spatial, 'rho'), True)
@@ -110,21 +109,20 @@ def test_ScoreboardModel():
     npt.assert_equal(isinstance(model.vfmap, Watson2014Map), True)
     npt.assert_almost_equal(model.vfmap.ret_to_dva(0, 0), (0, 0))
     npt.assert_almost_equal(model.vfmap.dva_to_ret(0, 0), (0, 0))
-    model2 = ScoreboardModel(vfmap=Watson2014DisplaceMap())
+    model2 = ScoreboardModel(implant=ArgusII(), vfmap=Watson2014DisplaceMap())
     npt.assert_equal(isinstance(model2.vfmap, Watson2014DisplaceMap),
                      True)
     # Nothing in, None out:
-    npt.assert_equal(model.predict_percept(ArgusI()), None)
+    npt.assert_equal(model.predict_percept(None), None)
 
     # Zero in = zero out:
-    implant = ArgusI(stim=np.zeros(16))
-    npt.assert_almost_equal(model.predict_percept(implant).data, 0)
+    npt.assert_almost_equal(model.predict_percept(np.zeros(60)).data, 0)
 
     # Multiple frames are processed independently:
-    model = ScoreboardModel(rho=200, step=5,
+    model = ScoreboardModel(implant=ArgusI(), rho=200, step=5,
                             xrange=(-20, 20), yrange=(-15, 15))
     model.build()
-    percept = model.predict_percept(ArgusI(stim={'A1': [1, 2]}))
+    percept = model.predict_percept({'A1': [1, 2]})
     npt.assert_equal(percept.shape, list(model.grid.x.shape) + [2])
     pmax = percept.data.max(axis=(0, 1))
     npt.assert_almost_equal(percept.data[2, 3, :], pmax)
@@ -133,7 +131,7 @@ def test_ScoreboardModel():
 
 
 def test_deepcopy_ScoreboardModel():
-    original = ScoreboardModel()
+    original = ScoreboardModel(implant=ArgusII())
     copied = copy.deepcopy(original)
 
     # Assert these are two different objects
@@ -156,13 +154,13 @@ def test_deepcopy_ScoreboardModel():
 
 
 def test_ScoreboardModel_predict_percept():
-    model = ScoreboardModel(step=0.55, rho=100, thresh_percept=0,
+    model = ScoreboardModel(implant=ArgusII(), step=0.55, rho=100, thresh_percept=0,
                             xrange=(-20, 20), yrange=(-15, 15))
     model.build()
     # Single-electrode stim:
     img_stim = np.zeros(60)
     img_stim[47] = 1
-    percept = model.predict_percept(ArgusII(stim=img_stim))
+    percept = model.predict_percept(img_stim)
     # Single bright pixel, very small Gaussian kernel:
     npt.assert_equal(np.sum(percept.data > 0.8), 1)
     npt.assert_equal(np.sum(percept.data > 0.5), 2)
@@ -172,29 +170,30 @@ def test_ScoreboardModel_predict_percept():
     npt.assert_almost_equal(percept.data[33, 46, 0], np.max(percept.data))
 
     # Full Argus II: 60 bright spots
-    model = ScoreboardModel(step=0.55, rho=100)
+    model = ScoreboardModel(implant=ArgusII(), step=0.55, rho=100)
     model.build()
-    percept = model.predict_percept(ArgusII(stim=np.ones(60)))
+    percept = model.predict_percept(np.ones(60))
     npt.assert_equal(np.sum(np.isclose(percept.data, 0.8, rtol=0.1, atol=0.1)),
                      88)
 
     # Model gives same outcome as Spatial:
-    spatial = ScoreboardSpatial(step=1, rho=100)
+    spatial = ScoreboardSpatial(implant=ArgusII(), step=1, rho=100)
     spatial.build()
-    spatial_percept = model.predict_percept(ArgusII(stim=np.ones(60)))
+    spatial_percept = model.predict_percept(np.ones(60))
     npt.assert_almost_equal(percept.data, spatial_percept.data)
     npt.assert_equal(percept.time, None)
 
     # Warning for nonzero electrode-retina distances
-    implant = ArgusI(stim=np.ones(16), z=10)
+    raised = ScoreboardModel(implant=ArgusII(z=10), step=0.55, rho=100)
+    raised.build()
     msg = ("Nonzero electrode-retina distances do not have any effect on the "
            "model output.")
-    assert_warns_msg(UserWarning, model.predict_percept, msg, implant)
+    assert_warns_msg(UserWarning, raised.predict_percept, msg, np.ones(60))
 
 
 def test_AxonMapSpatial():
     # AxonMapSpatial automatically sets `rho`, `lam`:
-    model = AxonMapSpatial(step=5)
+    model = AxonMapSpatial(implant=ArgusII(), step=5)
 
     # User can set `rho`:
     model.rho = 123
@@ -206,16 +205,15 @@ def test_AxonMapSpatial():
     npt.assert_equal(isinstance(model.vfmap, Watson2014Map), True)
     npt.assert_almost_equal(model.vfmap.ret_to_dva(0, 0), (0, 0))
     npt.assert_almost_equal(model.vfmap.dva_to_ret(0, 0), (0, 0))
-    model2 = AxonMapSpatial(vfmap=Watson2014DisplaceMap())
+    model2 = AxonMapSpatial(implant=ArgusII(), vfmap=Watson2014DisplaceMap())
     npt.assert_equal(isinstance(model2.vfmap, Watson2014DisplaceMap),
                      True)
 
     # Nothing in, None out:
-    npt.assert_equal(model.predict_percept(ArgusI()), None)
+    npt.assert_equal(model.predict_percept(None), None)
 
     # Zero in = zero out:
-    implant = ArgusI(stim=np.zeros(16))
-    percept = model.predict_percept(implant)
+    percept = model.predict_percept(np.zeros(60))
     npt.assert_equal(isinstance(percept, Percept), True)
     npt.assert_equal(percept.shape, list(model.grid.x.shape) + [1])
     npt.assert_almost_equal(percept.data, 0)
@@ -223,13 +221,13 @@ def test_AxonMapSpatial():
 
     # Lambda cannot be too small:
     with pytest.raises(ValueError):
-        AxonMapSpatial(lam=9).build()
+        AxonMapSpatial(implant=ArgusII(), lam=9).build()
 
     # Multiple frames are processed independently:
-    model = AxonMapSpatial(rho=200, lam=100, step=5,
+    model = AxonMapSpatial(implant=ArgusI(), rho=200, lam=100, step=5,
                            xrange=(-20, 20), yrange=(-15, 15))
     model.build()
-    percept = model.predict_percept(ArgusI(stim={'A1': [1, 0], 'B3': [0, 2]}))
+    percept = model.predict_percept({'A1': [1, 0], 'B3': [0, 2]})
     npt.assert_equal(percept.shape, list(model.grid.x.shape) + [2])
     pmax = percept.data.max(axis=(0, 1))
     npt.assert_almost_equal(percept.data[2, 3, 0], pmax[0])
@@ -240,7 +238,7 @@ def test_AxonMapSpatial():
 
 
 def test_deepcopy_AxonMapSpatial():
-    original = AxonMapSpatial()
+    original = AxonMapSpatial(implant=ArgusII())
     copied = copy.deepcopy(original)
 
     # Assert these are two different objects
@@ -263,13 +261,13 @@ def test_deepcopy_AxonMapSpatial():
     npt.assert_equal(copied is not None, True)
 
 def test_AxonMapSpatial_plot():
-    model = AxonMapSpatial()
+    model = AxonMapSpatial(implant=ArgusII())
     for use_dva, xlim in zip([True, False], [(-18, 18), (-5000, 5000)]):
         ax = model.plot(use_dva=use_dva)
         npt.assert_equal(isinstance(ax, Subplot), True)
         npt.assert_equal(ax.get_xlim(), xlim)
     # Simulated area might be larger than that:
-    model = AxonMapSpatial(xrange=(-20.5, 20.5), yrange=(-16.1, 16.1))
+    model = AxonMapSpatial(implant=ArgusII(), xrange=(-20.5, 20.5), yrange=(-16.1, 16.1))
     ax = model.plot(use_dva=True)
     npt.assert_almost_equal(ax.get_xlim(), (-21, 21))
     npt.assert_almost_equal(ax.get_ylim(), (-18, 18))
@@ -296,7 +294,7 @@ def test_AxonMapModel():
                   'n_axons': 9, 'n_ax_segments': 50,
                   'xrange': (-30, 30), 'yrange': (-20, 20),
                   'loc_od': (5, 6)}
-    model = AxonMapModel()
+    model = AxonMapModel(implant=ArgusII())
     for param in set_params:
         npt.assert_equal(hasattr(model.spatial, param), True)
 
@@ -304,7 +302,7 @@ def test_AxonMapModel():
     for key, value in set_params.items():
         setattr(model.spatial, key, value)
         npt.assert_equal(getattr(model.spatial, key), value)
-    model = AxonMapModel(**set_params)
+    model = AxonMapModel(implant=ArgusII(), **set_params)
     model.build(**set_params)
     for key, value in set_params.items():
         npt.assert_equal(getattr(model.spatial, key), value)
@@ -313,28 +311,24 @@ def test_AxonMapModel():
     npt.assert_equal(isinstance(model.vfmap, Watson2014Map), True)
     npt.assert_almost_equal(model.vfmap.ret_to_dva(0, 0), (0, 0))
     npt.assert_almost_equal(model.vfmap.dva_to_ret(0, 0), (0, 0))
-    model2 = AxonMapModel(vfmap=Watson2014DisplaceMap())
+    model2 = AxonMapModel(implant=ArgusII(), vfmap=Watson2014DisplaceMap())
     npt.assert_equal(isinstance(model2.vfmap, Watson2014DisplaceMap),
                      True)
 
     # Zeros in, zeros out:
-    implant = ArgusII(stim=np.zeros(60))
-    npt.assert_almost_equal(model.predict_percept(implant).data, 0)
-    implant.stim = np.zeros(60)
-    npt.assert_almost_equal(model.predict_percept(implant).data, 0)
+    npt.assert_almost_equal(model.predict_percept(np.zeros(60)).data, 0)
 
     # Implant and model must be built for same eye:
     with pytest.raises(ValueError):
-        implant = ArgusII(eye='LE', stim=np.zeros(60))
-        model.predict_percept(implant)
+        AxonMapModel(implant=ArgusII(eye='LE'), step=5).build()
     with pytest.raises(ValueError):
-        AxonMapModel(eye='invalid').build()
+        AxonMapModel(implant=ArgusII(), eye='invalid').build()
     with pytest.raises(ValueError):
-        AxonMapModel(step=5).build(eye='invalid')
+        AxonMapModel(implant=ArgusII(), step=5).build(eye='invalid')
 
     # Lambda cannot be too small:
     with pytest.raises(ValueError):
-        AxonMapModel(lam=9).build()
+        AxonMapModel(implant=ArgusII(), lam=9).build()
 
 
 @pytest.mark.parametrize('cls', [AxonMapSpatial, AxonMapModel])
@@ -342,9 +336,10 @@ def test_AxonMap_deprecated_axlambda(cls):
     # `lam` was called `axlambda` until 0.10.0. The old name still works,
     # everywhere the new one does, but warns:
     msg = "The 'axlambda' parameter of"
-    assert_warns_msg(DeprecationWarning, cls, msg, axlambda=400)
+    assert_warns_msg(DeprecationWarning, cls, msg, implant=ArgusII(),
+                     axlambda=400)
     with pytest.warns(DeprecationWarning):
-        model = cls(axlambda=400)
+        model = cls(implant=ArgusII(), axlambda=400)
     npt.assert_equal(model.lam, 400)
 
     # Setting and getting the attribute:
@@ -420,7 +415,7 @@ def test_AxonMap_axlambda_warning_blames_caller(cls):
 # deselected) and would surface any failure as a collection error.
 @pytest.mark.parametrize('build', (False, True))
 def test_deepcopy_AxonMapModel(build):
-    original = AxonMapModel()
+    original = AxonMapModel(implant=ArgusII())
     if build:
         original.build()
     copied = copy.deepcopy(original)
@@ -449,7 +444,7 @@ def test_deepcopy_AxonMapModel(build):
 def test_AxonMapModel__jansonius2009(eye, loc_od, sign):
     # With `rho` starting at 0, all axons should originate in the optic disc
     # center
-    model = AxonMapModel(loc_od=loc_od, step=2,
+    model = AxonMapModel(implant=ArgusII(), loc_od=loc_od, step=2,
                          ax_segments_range=(0, 45),
                          n_ax_segments=100)
     for phi0 in [-135.0, 66.0, 128.0]:
@@ -459,7 +454,7 @@ def test_AxonMapModel__jansonius2009(eye, loc_od, sign):
 
     # These axons should all end at the meridian
     for phi0 in [110.0, 135.0, 160.0]:
-        model = AxonMapModel(loc_od=(15, 2), step=2,
+        model = AxonMapModel(implant=ArgusII(), loc_od=(15, 2), step=2,
                              n_ax_segments=801,
                              ax_segments_range=(0, 45))
         ax_pos = model.spatial._jansonius2009(sign * phi0)
@@ -468,28 +463,28 @@ def test_AxonMapModel__jansonius2009(eye, loc_od, sign):
     # `phi0` must be within [-180, 180]
     for phi0 in [-200.0, 181.0]:
         with pytest.raises(ValueError):
-            failed = AxonMapModel(step=2)
+            failed = AxonMapModel(implant=ArgusII(), step=2)
             failed.spatial._jansonius2009(phi0)
 
     # `n_rho` must be >= 1
     for n_rho in [-1, 0]:
         with pytest.raises(ValueError):
-            model = AxonMapModel(n_ax_segments=n_rho, step=2)
+            model = AxonMapModel(implant=ArgusII(), n_ax_segments=n_rho, step=2)
             model.spatial._jansonius2009(0.0)
 
     # `ax_segments_range` must have min <= max
     for lorho in [-200.0, 90.0]:
         with pytest.raises(ValueError):
-            model = AxonMapModel(ax_segments_range=(lorho, 45), step=2)
+            model = AxonMapModel(implant=ArgusII(), ax_segments_range=(lorho, 45), step=2)
             model.spatial._jansonius2009(0)
     for hirho in [-200.0, 40.0]:
         with pytest.raises(ValueError):
-            model = AxonMapModel(ax_segments_range=(45, hirho), step=2)
+            model = AxonMapModel(implant=ArgusII(), ax_segments_range=(45, hirho), step=2)
             model.spatial._jansonius2009(0)
 
     # A single axon fiber with `phi0`=0 should return a single pixel location
     # that corresponds to the optic disc
-        model = AxonMapModel(loc_od=loc_od, step=2, eye=eye,
+        model = AxonMapModel(implant=ArgusII(), loc_od=loc_od, step=2, eye=eye,
                              ax_segments_range=(0, 0),
                              n_ax_segments=1)
         single_fiber = model.spatial._jansonius2009(0)
@@ -499,7 +494,7 @@ def test_AxonMapModel__jansonius2009(eye, loc_od, sign):
 
 def test_AxonMapModel_grow_axon_bundles():
     for n_axons in [1, 2, 3, 5, 10]:
-        model = AxonMapModel(step=2, n_axons=n_axons,
+        model = AxonMapModel(implant=ArgusII(), step=2, n_axons=n_axons,
                              axons_range=(-20, 20), xrange=(-20, 20),
                              yrange=(-15, 15))
         bundles = model.spatial.grow_axon_bundles()
@@ -507,7 +502,7 @@ def test_AxonMapModel_grow_axon_bundles():
 
 
 def test_AxonMapModel_find_closest_axon():
-    model = AxonMapModel(step=1, n_axons=5,
+    model = AxonMapModel(implant=ArgusII(), step=1, n_axons=5,
                          xrange=(-20, 20), yrange=(-15, 15),
                          axons_range=(-45, 45))
     model.build()
@@ -544,7 +539,7 @@ def test_AxonMapModel_find_closest_axon_respects_n_threads(monkeypatch,
 
     ``n_threads``/``n_jobs`` is the one knob this package gives for capping
     CPU use, and the tree query is part of ``build``. Passing ``workers=-1``
-    here would let ``AxonMapModel(n_threads=1).build()`` fan out over every
+    here would let ``AxonMapModel(implant=ArgusII(), n_threads=1).build()`` fan out over every
     core anyway.
     """
     from pulse2percept.models import beyeler2019
@@ -557,7 +552,7 @@ def test_AxonMapModel_find_closest_axon_respects_n_threads(monkeypatch,
             return super().query(*args, **kwargs)
 
     monkeypatch.setattr(beyeler2019, 'cKDTree', RecordingKDTree)
-    model = AxonMapSpatial(n_threads=n_threads)
+    model = AxonMapSpatial(implant=ArgusII(), n_threads=n_threads)
     bundles = [np.array([[0.0, 0.0], [1.0, 1.0]], dtype=np.float32),
                np.array([[10.0, 10.0], [11.0, 11.0]], dtype=np.float32)]
     closest, idx = model.find_closest_axon(bundles, xret=[0.5, 10.5],
@@ -568,7 +563,7 @@ def test_AxonMapModel_find_closest_axon_respects_n_threads(monkeypatch,
 
 
 def test_AxonMapModel_calc_axon_sensitivity():
-    model = AxonMapModel(step=2, n_axons=10,
+    model = AxonMapModel(implant=ArgusII(), step=2, n_axons=10,
                          xrange=(-20, 20), yrange=(-15, 15),
                          axons_range=(-30, 30))
     model.build()
@@ -601,7 +596,7 @@ def test_AxonMapModel_calc_axon_sensitivity():
 def test_AxonMapModel_calc_axon_sensitivity_removed_pad():
     # 'pad' used to pad all axons to the length of the longest one for the
     # (now removed) jax backend. Deprecated in 0.9.1, removed in 0.10.0:
-    model = AxonMapModel(step=2, n_axons=10, xrange=(-20, 20),
+    model = AxonMapModel(implant=ArgusII(), step=2, n_axons=10, xrange=(-20, 20),
                          yrange=(-15, 15), axons_range=(-30, 30))
     model.build()
     axons = model.spatial.find_closest_axon(model.spatial.grow_axon_bundles())
@@ -610,7 +605,7 @@ def test_AxonMapModel_calc_axon_sensitivity_removed_pad():
 
 
 def test_AxonMapModel_calc_bundle_tangent():
-    model = AxonMapModel(step=5, n_axons=500,
+    model = AxonMapModel(implant=ArgusII(), step=5, n_axons=500,
                          xrange=(-20, 20), yrange=(-15, 15),
                          n_ax_segments=500, axons_range=(-180, 180),
                          ax_segments_range=(3, 50))
@@ -625,7 +620,7 @@ def test_AxonMapModel_calc_bundle_tangent():
 
 
 def test_AxonMapModel_calc_bundle_tangent_fast():
-    model = AxonMapModel(step=5, n_axons=500,
+    model = AxonMapModel(implant=ArgusII(), step=5, n_axons=500,
                          xrange=(-20, 20), yrange=(-15, 15),
                          n_ax_segments=500, axons_range=(-180, 180),
                          ax_segments_range=(3, 50))
@@ -643,7 +638,7 @@ def test_AxonMapModel_predict_percept():
     # `meridian_blend=0` throughout: the expectations below pin the axon-map
     # computation, which the default postprocessing does not change. The blend
     # itself is covered by `test_AxonMapSpatial_meridian_blend`.
-    model = AxonMapModel(step=0.55, lam=100, rho=100,
+    model = AxonMapModel(implant=ArgusII(), step=0.55, lam=100, rho=100,
                          thresh_percept=0, meridian_blend=0,
                          xrange=(-20, 20), yrange=(-15, 15),
                          n_axons=500)
@@ -651,7 +646,7 @@ def test_AxonMapModel_predict_percept():
     # Single-electrode stim:
     img_stim = np.zeros(60)
     img_stim[47] = 1
-    percept = model.predict_percept(ArgusII(stim=img_stim))
+    percept = model.predict_percept(img_stim)
     # Single bright pixel, rest of arc is less bright:
     npt.assert_equal(np.sum(percept.data > 0.8), 1)
     npt.assert_equal(np.sum(percept.data > 0.6), 2)
@@ -667,28 +662,30 @@ def test_AxonMapModel_predict_percept():
     npt.assert_almost_equal(np.sum(percept.data[39:, :, 0]), 0)
 
     # Full Argus II with small lambda: 60 bright spots
-    model = AxonMapModel(step=1, rho=100, lam=40, meridian_blend=0,
+    model = AxonMapModel(implant=ArgusII(), step=1, rho=100, lam=40, meridian_blend=0,
                          xrange=(-20, 20), yrange=(-15, 15), n_axons=500)
     model.build()
-    percept = model.predict_percept(ArgusII(stim=np.ones(60)))
+    percept = model.predict_percept(np.ones(60))
     # Most spots are pretty bright, but there are 2 dimmer ones (due to their
     # location on the retina):
     npt.assert_equal(np.sum(percept.data > 0.5), 28)
     npt.assert_equal(np.sum(percept.data > 0.275), 56)
 
     # Model gives same outcome as Spatial:
-    spatial = AxonMapSpatial(step=1, rho=100, lam=40, meridian_blend=0,
+    spatial = AxonMapSpatial(implant=ArgusII(), step=1, rho=100, lam=40, meridian_blend=0,
                              xrange=(-20, 20), yrange=(-15, 15), n_axons=500)
     spatial.build()
-    spatial_percept = spatial.predict_percept(ArgusII(stim=np.ones(60)))
+    spatial_percept = spatial.predict_percept(np.ones(60))
     npt.assert_almost_equal(percept.data, spatial_percept.data)
     npt.assert_equal(percept.time, None)
 
     # Warning for nonzero electrode-retina distances
-    implant = ArgusI(stim=np.ones(16), z=10)
+    raised = AxonMapModel(implant=ArgusII(z=10), step=1, rho=100, lam=40,
+                          meridian_blend=0, n_axons=250, n_ax_segments=200,
+                          ignore_pickle=True).build()
     msg = ("Nonzero electrode-retina distances do not have any effect on the "
            "model output.")
-    assert_warns_msg(UserWarning, model.predict_percept, msg, implant)
+    assert_warns_msg(UserWarning, raised.predict_percept, msg, np.ones(60))
 
 
 @pytest.mark.parametrize('ModelClass', (ScoreboardModel, AxonMapModel))
@@ -703,26 +700,25 @@ def test_min_current_spread(ModelClass):
     """
     stim = np.zeros(60)
     stim[[10, 33, 47]] = [1.0, -0.5, 0.75]
-    implant = ArgusII(stim=stim)
-    kwargs = {'step': 0.75, 'xrange': (-12, 12), 'yrange': (-8, 8),
-              'rho': 200}
+    kwargs = {'implant': ArgusII(), 'step': 0.75, 'xrange': (-12, 12),
+              'yrange': (-8, 8), 'rho': 200}
 
     exact = ModelClass(min_current_spread=0,
-                       **kwargs).build().predict_percept(implant).data
-    default = ModelClass(**kwargs).build().predict_percept(implant).data
+                       **kwargs).build().predict_percept(stim).data
+    default = ModelClass(**kwargs).build().predict_percept(stim).data
     npt.assert_allclose(default, exact, rtol=1e-5,
                         atol=1e-6 * np.abs(exact).max())
 
     # A coarse cutoff *does* change the result, which is how we know the
     # parameter reaches the kernel at all:
     coarse = ModelClass(min_current_spread=0.5,
-                        **kwargs).build().predict_percept(implant).data
+                        **kwargs).build().predict_percept(stim).data
     assert np.abs(coarse - exact).max() > 1e-3
 
     # A cutoff of 1 or more would drop every electrode:
     model = ModelClass(min_current_spread=1, **kwargs).build()
     with pytest.raises(ValueError):
-        model.predict_percept(implant)
+        model.predict_percept(stim)
 
 
 @pytest.mark.parametrize('ModelClass', (ScoreboardModel, AxonMapModel))
@@ -739,14 +735,13 @@ def test_min_current_spread_error_bound(ModelClass, amp):
     """
     min_spread = 1e-8
     stim = np.full(60, amp)
-    implant = ArgusII(stim=stim)
-    kwargs = {'step': 0.75, 'xrange': (-14, 14), 'yrange': (-10, 10),
-              'rho': 200}
+    kwargs = {'implant': ArgusII(), 'step': 0.75, 'xrange': (-14, 14),
+              'yrange': (-10, 10), 'rho': 200}
 
     exact = ModelClass(min_current_spread=0,
-                       **kwargs).build().predict_percept(implant).data
+                       **kwargs).build().predict_percept(stim).data
     default = ModelClass(min_current_spread=min_spread,
-                         **kwargs).build().predict_percept(implant).data
+                         **kwargs).build().predict_percept(stim).data
     # What the docs promise: `min_current_spread` times the summed amplitude,
     # plus whatever the float32 accumulation itself costs:
     dropped = min_spread * np.abs(stim).sum()
@@ -770,15 +765,15 @@ def test_predict_percept_frames_are_independent(ModelClass):
     """
     rng = np.random.default_rng(42)
     data = rng.normal(size=(60, 4)).astype(np.float32)
-    model = ModelClass(step=1, xrange=(-10, 10), yrange=(-8, 8),
-                       rho=200).build()
+    model = ModelClass(implant=ArgusII(), step=1, xrange=(-10, 10),
+                       yrange=(-8, 8), rho=200).build()
 
     joint = model.predict_percept(
-        ArgusII(stim=Stimulus(data, time=[0, 1, 2, 3]))).data
+        Stimulus(data, time=[0, 1, 2, 3])).data
     npt.assert_equal(joint.shape[-1], 4)
     for i in range(data.shape[1]):
         frame = model.predict_percept(
-            ArgusII(stim=Stimulus(data[:, i:i + 1]))).data
+            Stimulus(data[:, i:i + 1])).data
         npt.assert_allclose(joint[..., i], frame[..., 0], rtol=1e-5,
                             atol=1e-6 * np.abs(frame).max())
 
@@ -790,8 +785,9 @@ def test_predict_percept_all_zero_stim(ModelClass):
     The kernels skip electrodes that are zero for the whole stimulus, so the
     case where *every* electrode is skipped is worth pinning down.
     """
-    model = ModelClass(step=1, xrange=(-10, 10), yrange=(-8, 8)).build()
-    percept = model.predict_percept(ArgusII(stim=np.zeros(60)))
+    model = ModelClass(implant=ArgusII(), step=1, xrange=(-10, 10),
+                       yrange=(-8, 8)).build()
+    percept = model.predict_percept(np.zeros(60))
     npt.assert_equal(np.all(percept.data == 0), True)
 
 
@@ -844,21 +840,20 @@ def test_predict_percept_thread_count_invariant(ModelClass):
     """
     stim = np.zeros(60)
     stim[[5, 22, 51]] = [1.0, 0.6, -0.3]
-    implant = ArgusII(stim=stim)
-    kwargs = {'step': 1, 'xrange': (-10, 10), 'yrange': (-8, 8),
-              'rho': 200}
+    kwargs = {'implant': ArgusII(), 'step': 1, 'xrange': (-10, 10),
+              'yrange': (-8, 8), 'rho': 200}
 
     serial = ModelClass(n_threads=1,
-                        **kwargs).build().predict_percept(implant).data
+                        **kwargs).build().predict_percept(stim).data
     for n_threads in (2, 3, 8):
         parallel = ModelClass(
-            n_threads=n_threads, **kwargs).build().predict_percept(implant)
+            n_threads=n_threads, **kwargs).build().predict_percept(stim)
         npt.assert_array_equal(parallel.data, serial)
 
 
 def test_AxonMapModel_find_closest_axon_return_segment():
     """``return_segment`` reports where in the axon the closest point is."""
-    model = AxonMapModel(step=2, n_axons=20, xrange=(-12, 12),
+    model = AxonMapModel(implant=ArgusII(), step=2, n_axons=20, xrange=(-12, 12),
                          yrange=(-12, 12), axons_range=(-45, 45))
     model.build()
     spatial = model.spatial
@@ -892,7 +887,7 @@ def test_AxonMapModel_find_closest_axon_return_segment():
 
 def test_AxonMapModel_calc_axon_sensitivity_empty_bundle():
     """A bundle with no segments is rejected rather than silently skipped."""
-    model = AxonMapModel(step=4, n_axons=5, xrange=(-8, 8), yrange=(-8, 8))
+    model = AxonMapModel(implant=ArgusII(), step=4, n_axons=5, xrange=(-8, 8), yrange=(-8, 8))
     model.build()
     n_points = model.spatial.grid.ret.x.size
     bundles = [np.zeros((0, 2), dtype=np.float32)] * n_points
@@ -905,7 +900,7 @@ def test_AxonMapModel_build_cache_roundtrip(tmp_path):
     pickle_file = str(tmp_path / 'axons.pickle')
 
     def build(ignore_pickle):
-        return AxonMapModel(step=1, xrange=(-8, 8), yrange=(-8, 8),
+        return AxonMapModel(implant=ArgusII(), step=1, xrange=(-8, 8), yrange=(-8, 8),
                             n_axons=200, axon_pickle=pickle_file,
                             ignore_pickle=ignore_pickle).build().spatial
 
@@ -941,7 +936,7 @@ def test_AxonMapModel_build_rejects_pre_step_cache(tmp_path):
     pickle_file = str(tmp_path / 'axons.pickle')
 
     def build(ignore_pickle=False):
-        return AxonMapModel(step=1, xrange=(-8, 8), yrange=(-8, 8),
+        return AxonMapModel(implant=ArgusII(), step=1, xrange=(-8, 8), yrange=(-8, 8),
                             n_axons=200, axon_pickle=pickle_file,
                             ignore_pickle=ignore_pickle).build().spatial
 
@@ -975,18 +970,19 @@ def _straddling_pair(coord):
 def test_AxonMapSpatial_meridian_blend(ModelClass):
     def make(**params):
         # Offset by half a step so the nearest rows straddle the raphe.
-        return ModelClass(xrange=(-6, 6), yrange=(-6.125, 5.875), step=0.25,
-                          rho=200, lam=400, n_axons=250, n_ax_segments=200,
-                          ignore_pickle=True, **params).build()
+        return ModelClass(implant=ArgusII(), xrange=(-6, 6),
+                          yrange=(-6.125, 5.875), step=0.25, rho=200, lam=400,
+                          n_axons=250, n_ax_segments=200, ignore_pickle=True,
+                          **params).build()
 
-    implant = ArgusII(stim={'C4': 1, 'C8': 1})
+    source = {'C4': 1, 'C8': 1}
     plain = make(meridian_blend=0)
-    unblended = plain.predict_percept(implant).data
+    unblended = plain.predict_percept(source).data
 
     width = 1
     blended_model = make()
     npt.assert_equal(blended_model.meridian_blend, width)
-    blended = blended_model.predict_percept(implant).data
+    blended = blended_model.predict_percept(source).data
     npt.assert_equal(blended.shape, unblended.shape)
     npt.assert_equal(blended.dtype, unblended.dtype)
 
@@ -1016,12 +1012,11 @@ def test_AxonMapSpatial_meridian_blend(ModelClass):
 def test_AxonMapSpatial_meridian_blend_reapplies_threshold():
     # Blending pulls brightness across the raphe, which could otherwise lift a
     # point that `thresh_percept` had zeroed back off zero.
-    implant = ArgusII(stim={'C4': 1})
-    model = AxonMapSpatial(xrange=(-6, 6), yrange=(-6, 6), step=0.25, rho=200,
-                           lam=400, n_axons=250, n_ax_segments=200,
-                           ignore_pickle=True, meridian_blend=1,
-                           thresh_percept=0.1).build()
-    data = model.predict_percept(implant).data
+    model = AxonMapSpatial(implant=ArgusII(), xrange=(-6, 6), yrange=(-6, 6),
+                           step=0.25, rho=200, lam=400, n_axons=250,
+                           n_ax_segments=200, ignore_pickle=True,
+                           meridian_blend=1, thresh_percept=0.1).build()
+    data = model.predict_percept({'C4': 1}).data
     npt.assert_equal(np.any(data > 0), True)
     # Nothing survives strictly between zero and the threshold:
     npt.assert_equal(np.any((np.abs(data) > 0) & (np.abs(data) < 0.1)), False)
@@ -1029,15 +1024,15 @@ def test_AxonMapSpatial_meridian_blend_reapplies_threshold():
 
 def test_AxonMapSpatial_meridian_blend_over_time():
     # Every frame is blended, and each one on its own.
-    implant = ArgusII(stim=Stimulus({'C4': [0, 1, 2], 'C8': [2, 1, 0]}))
-    model = AxonMapSpatial(xrange=(-6, 6), yrange=(-6, 6), step=0.5, rho=200,
-                           lam=400, n_axons=250, n_ax_segments=200,
-                           ignore_pickle=True, meridian_blend=1).build()
-    percept = model.predict_percept(implant)
+    model = AxonMapSpatial(implant=ArgusII(), xrange=(-6, 6), yrange=(-6, 6),
+                           step=0.5, rho=200, lam=400, n_axons=250,
+                           n_ax_segments=200, ignore_pickle=True,
+                           meridian_blend=1).build()
+    percept = model.predict_percept(
+        Stimulus({'C4': [0, 1, 2], 'C8': [2, 1, 0]}))
     npt.assert_equal(percept.data.shape[-1], 3)
     for t in range(3):
-        frame = ArgusII(encoder=None, stim=Stimulus(
-            {'C4': [0, 1, 2][t], 'C8': [2, 1, 0][t]}))
+        frame = Stimulus({'C4': [0, 1, 2][t], 'C8': [2, 1, 0][t]})
         npt.assert_allclose(percept.data[..., t],
                             model.predict_percept(frame).data[..., 0],
                             atol=1e-6)
@@ -1045,12 +1040,12 @@ def test_AxonMapSpatial_meridian_blend_over_time():
 
 def test_AxonMapSpatial_axons_range_units():
     """`axons_range` is a range of ordinary polar angles, stored in degrees"""
-    npt.assert_equal(AxonMapSpatial().get_param_units()['axons_range'], deg)
-    bare = AxonMapSpatial(axons_range=(-30, 30))
-    npt.assert_equal(AxonMapSpatial(axons_range=(-30 * deg, 30 * deg)).
+    npt.assert_equal(AxonMapSpatial(implant=ArgusII()).get_param_units()['axons_range'], deg)
+    bare = AxonMapSpatial(implant=ArgusII(), axons_range=(-30, 30))
+    npt.assert_equal(AxonMapSpatial(implant=ArgusII(), axons_range=(-30 * deg, 30 * deg)).
                      axons_range, bare.axons_range)
     npt.assert_allclose(
-        AxonMapSpatial(axons_range=np.array([-np.pi, np.pi]) / 6 * rad).
+        AxonMapSpatial(implant=ArgusII(), axons_range=np.array([-np.pi, np.pi]) / 6 * rad).
         axons_range, bare.axons_range, rtol=1e-12)
     with pytest.raises(DimensionMismatchError):
-        AxonMapSpatial(axons_range=(-30 * dva, 30 * dva))
+        AxonMapSpatial(implant=ArgusII(), axons_range=(-30 * dva, 30 * dva))

--- a/pulse2percept/models/tests/test_end_to_end.py
+++ b/pulse2percept/models/tests/test_end_to_end.py
@@ -73,9 +73,9 @@ def test_endtoend_amplitude_modulation():
     # Four gray levels, evenly spaced, one per electrode:
     implant = make_implant(one_per_group())
     img = ImageStimulus(np.array([[0.25, 0.50], [0.75, 1.00]]))
-    stim = AmplitudeEncoder(amp_range=(0, 50), freq=20,
-                            frame_dur=200).encode(img, implant=implant)
-    implant.stim = stim
+    stim = implant.prepare_stim(
+        AmplitudeEncoder(amp_range=(0, 50), freq=20,
+                         frame_dur=200).encode(img, implant=implant))
     npt.assert_equal(list(stim.electrodes), NAMES)
 
     # --- what the encoder produced --------------------------------------
@@ -102,11 +102,10 @@ def test_endtoend_amplitude_modulation():
     # `models.base._spatial_input`). Wrapping the schedule in an ordinary
     # `Stimulus` is what asks for the delivered pulses instead, which is what
     # makes the raster visible below:
-    npt.assert_equal(implant.stim._spatial_view().shape, (4, 1))
-    implant.stim = Stimulus(stim)
-    model = ScoreboardSpatial(xrange=(-4, 4), yrange=(-4, 4), step=0.2,
-                              rho=200).build()
-    percept = model.predict_percept(implant)
+    npt.assert_equal(stim._spatial_view().shape, (4, 1))
+    model = ScoreboardSpatial(implant=implant, xrange=(-4, 4), yrange=(-4, 4),
+                              step=0.2, rho=200).build()
+    percept = model.predict_percept(Stimulus(stim))
     here, middle = at_electrodes(model, implant)
     # Brightest over time, since no two electrodes are ever on together:
     env = percept.data.max(axis=-1)
@@ -151,9 +150,9 @@ def test_endtoend_frequency_modulation():
     # electrode sets, so nothing has to be quantized away:
     implant = make_implant(one_per_group())
     img = ImageStimulus(np.array([[0.25, 1 / 3], [0.5, 1.0]]))
-    stim = FrequencyEncoder(freq_range=(0, 200), amp=50,
-                            frame_dur=200).encode(img, implant=implant)
-    implant.stim = stim
+    stim = implant.prepare_stim(
+        FrequencyEncoder(freq_range=(0, 200), amp=50,
+                         frame_dur=200).encode(img, implant=implant))
 
     # --- what the encoder produced --------------------------------------
     # One amplitude for everyone; the gray level sets the rate instead:
@@ -180,7 +179,7 @@ def test_endtoend_frequency_modulation():
     # --- what the model made of it --------------------------------------
     # A temporal model integrates the pulses, so more pulses is brighter even
     # though every pulse carries the same current:
-    percept = FadingTemporal().build().predict_percept(implant.stim)
+    percept = FadingTemporal().build().predict_percept(stim)
     # One percept frame per video frame -- the image is a single 200 ms frame:
     npt.assert_equal(percept.data.shape, (4, 1, 1))
     bright = percept.data[:, 0, 0]
@@ -224,9 +223,9 @@ def test_endtoend_raster_order(order):
     img = ImageStimulus(np.array([[0.25, 0.50], [0.75, 1.00]]))
     implant = make_implant(CustomRaster({n: g
                                          for n, g in zip(NAMES, order)}))
-    stim = AmplitudeEncoder(amp_range=(0, 50), freq=20,
-                            frame_dur=200).encode(img, implant=implant)
-    implant.stim = stim
+    stim = implant.prepare_stim(
+        AmplitudeEncoder(amp_range=(0, 50), freq=20,
+                         frame_dur=200).encode(img, implant=implant))
 
     # Each electrode starts in the slot its group was given -- 50 ms period
     # split four ways is 12.5 ms per slot:
@@ -244,10 +243,9 @@ def test_endtoend_raster_order(order):
     # the order the raster puts them in, and each is as bright as its own gray
     # level regardless of when its turn comes. Asked of the delivered pulses,
     # because that is where a raster lives (see `_spatial_input`):
-    implant.stim = Stimulus(stim)
-    model = ScoreboardSpatial(xrange=(-4, 4), yrange=(-4, 4), step=0.2,
-                              rho=200).build()
-    percept = model.predict_percept(implant)
+    model = ScoreboardSpatial(implant=implant, xrange=(-4, 4), yrange=(-4, 4),
+                              step=0.2, rho=200).build()
+    percept = model.predict_percept(Stimulus(stim))
     here, _ = at_electrodes(model, implant)
     env = percept.data.max(axis=-1)
     bright = np.array([env[here[n]] for n in NAMES])
@@ -279,14 +277,14 @@ def test_endtoend_raster_is_what_separates_the_groups():
 
     implant.max_current = 60
     with pytest.raises(ValueError, match='raster'):
-        implant.stim = plain
+        implant.prepare_stim(plain)
     # Giving the implant the raster is enough -- the encoder picks it up, and
     # the same image now fits inside the current limit:
     implant.raster = one_per_group()
-    implant.stim = AmplitudeEncoder(amp_range=(0, 50), freq=20,
-                                    frame_dur=200).encode(img,
-                                                          implant=implant)
-    npt.assert_almost_equal(np.abs(implant.stim.data).sum(axis=0).max(), 50.0)
+    rastered = implant.prepare_stim(
+        AmplitudeEncoder(amp_range=(0, 50), freq=20,
+                         frame_dur=200).encode(img, implant=implant))
+    npt.assert_almost_equal(np.abs(rastered.data).sum(axis=0).max(), 50.0)
 
 
 def test_endtoend_slow_train_stays_lit_for_the_whole_video():
@@ -307,23 +305,26 @@ def test_endtoend_slow_train_stays_lit_for_the_whole_video():
     peak it reached is what stops the report from depending on sampling phase.
     """
     # Argus II's own defaults: an amplitude encoder at 6 Hz, and a six-group
-    # raster. So the whole setup is `ArgusII(stim=BostonTrain())`.
+    # raster. So the whole setup is `ArgusII().prepare_stim(BostonTrain())`.
+    implant = ArgusII()
     with pytest.warns(UserWarning, match='deliver no pulse'):
         # 6 Hz against 29.97 fps: most frames carry no pulse of their own, and
         # the encoder says so. That is a property of the stimulus, not a reason
         # for the percept to go dark:
-        implant = ArgusII(stim=BostonTrain())
+        delivered = implant.prepare_stim(BostonTrain())
     # The encoder schedules pulses across the whole video, not just its start.
     # The last of the six raster groups takes its turn 5 x 2 = 10 ms behind the
     # first, which is what puts the final pulse past the 3000.5 ms that an
     # unrastered Argus II would end on:
-    onset = implant.stim.time[np.any(implant.stim.data < 0, axis=0)]
+    onset = delivered.time[np.any(delivered.data < 0, axis=0)]
     npt.assert_almost_equal(onset.max(), 3010.5, decimal=1)
 
-    model = Model(spatial=ScoreboardSpatial(xrange=(-12, 12), yrange=(-8, 8),
+    model = Model(implant=implant,
+                  spatial=ScoreboardSpatial(xrange=(-12, 12), yrange=(-8, 8),
                                             step=1),
                   temporal=FadingTemporal(tau=100)).build()
-    percept = model.predict_percept(implant)
+    with pytest.warns(UserWarning, match='deliver no pulse'):
+        percept = model.predict_percept(BostonTrain())
     # One percept frame per video frame, covering the whole video:
     npt.assert_equal(percept.data.shape[-1], 94)
     npt.assert_array_less(3000, percept.time[-1])

--- a/pulse2percept/models/tests/test_granley2021.py
+++ b/pulse2percept/models/tests/test_granley2021.py
@@ -119,7 +119,7 @@ def test_eq_DefaultSizeModel():
 
 
 def test_deepcopy_BiphasicAxonMapSpatial():
-    original = BiphasicAxonMapSpatial()
+    original = BiphasicAxonMapSpatial(implant=ArgusII())
     copied = copy.deepcopy(original)
 
     # Assert these are two different objects
@@ -135,7 +135,7 @@ def test_deepcopy_BiphasicAxonMapSpatial():
 
 
 def test_deepcopy_BiphasicAxonMapModel():
-    original = BiphasicAxonMapModel()
+    original = BiphasicAxonMapModel(implant=ArgusII())
     copied = copy.deepcopy(original)
 
     # Assert these are two different objects
@@ -215,27 +215,26 @@ def test_effects_models_removed_engine(cls, arg):
 def test_biphasicAxonMapSpatial():
     # Lambda cannot be too small:
     with pytest.raises(ValueError):
-        BiphasicAxonMapSpatial(lam=9).build()
+        BiphasicAxonMapSpatial(implant=ArgusII(), lam=9).build()
 
-    model = BiphasicAxonMapModel(step=2).build()
+    model = BiphasicAxonMapModel(implant=ArgusII(), step=2).build()
     # Only accepts biphasic pulse trains with no delay dur
-    implant = ArgusI(stim=np.ones(16))
     with pytest.raises(TypeError):
-        model.predict_percept(implant)
+        model.predict_percept(np.ones(60))
 
     # Nothing in, None out:
-    npt.assert_equal(model.predict_percept(ArgusI()), None)
+    npt.assert_equal(model.predict_percept(None), None)
 
     # Zero in = zero out:
-    implant = ArgusI(stim=np.zeros(16))
-    percept = model.predict_percept(implant)
+    source = np.zeros(60)
+    percept = model.predict_percept(source)
     npt.assert_equal(isinstance(percept, Percept), True)
     npt.assert_equal(percept.shape, list(model.grid.x.shape) + [1])
     npt.assert_almost_equal(percept.data, 0)
     npt.assert_equal(percept.time, None)
 
     # Should be equal to axon map model if effects models return 1
-    model = BiphasicAxonMapSpatial(step=2)
+    model = BiphasicAxonMapSpatial(implant=ArgusII(), step=2)
     def bright_model(freq, amp, pdur): return 1
     def size_model(freq, amp, pdur): return 1
     def streak_model(freq, amp, pdur): return 1
@@ -243,44 +242,43 @@ def test_biphasicAxonMapSpatial():
     model.size_model = size_model
     model.streak_model = streak_model
     model.build()
-    axon_map = AxonMapSpatial(step=2).build()
-    implant = ArgusII()
+    axon_map = AxonMapSpatial(implant=ArgusII(), step=2).build()
     # The axon map reads current and this model reads threshold multiples, so
     # a 1 uA threshold is what makes the two numbers the same one:
-    implant.stim = Stimulus({'A5': BiphasicPulseTrain(20, 1 * xTh, 0.45,
+    source = Stimulus({'A5': BiphasicPulseTrain(20, 1 * xTh, 0.45,
                                                       threshold_amp=1 * uA)})
-    percept = model.predict_percept(implant)
-    percept_axon = axon_map.predict_percept(implant)
+    percept = model.predict_percept(source)
+    percept_axon = axon_map.predict_percept(source)
     npt.assert_almost_equal(
         percept.data[:, :, 0], percept_axon.max(axis='frames'))
 
     # Effect models must be callable
-    model = BiphasicAxonMapSpatial(step=2)
+    model = BiphasicAxonMapSpatial(implant=ArgusII(), step=2)
     model.bright_model = 1.0
     with pytest.raises(TypeError):
         model.build()
 
     # If t_percept is not specified, there should only be one frame
-    model = BiphasicAxonMapSpatial(step=2)
+    model = BiphasicAxonMapSpatial(implant=ArgusII(), step=2)
     model.build()
     implant = ArgusII()
-    implant.stim = Stimulus({'A5': BiphasicPulseTrain(20, 1 * xTh, 0.45)})
-    percept = model.predict_percept(implant)
+    source = Stimulus({'A5': BiphasicPulseTrain(20, 1 * xTh, 0.45)})
+    percept = model.predict_percept(source)
     npt.assert_equal(percept.time is None, True)
     # If t_percept is specified, only first frame should have data
     # and the rest should be empty
-    percept = model.predict_percept(implant, t_percept=[0, 1, 2, 5, 10])
+    percept = model.predict_percept(source, t_percept=[0, 1, 2, 5, 10])
     npt.assert_equal(len(percept.time), 5)
     npt.assert_equal(np.any(percept.data[:, :, 0]), True)
     npt.assert_equal(np.any(percept.data[:, :, 1:]), False)
 
     # Test that default models give expected values
-    model = BiphasicAxonMapSpatial(rho=400, lam=600,
+    model = BiphasicAxonMapSpatial(implant=ArgusII(), rho=400, lam=600,
                                    step=1, xrange=(-20, 20), yrange=(-15, 15))
     model.build()
     implant = ArgusII()
-    implant.stim = Stimulus({'A4': BiphasicPulseTrain(20, 1 * xTh, 1)})
-    percept = model.predict_percept(implant)
+    source = Stimulus({'A4': BiphasicPulseTrain(20, 1 * xTh, 1)})
+    percept = model.predict_percept(source)
     npt.assert_equal(np.sum(percept.data > 0.0813), 70)
     npt.assert_equal(np.sum(percept.data > 0.1626), 50)
     npt.assert_equal(np.sum(percept.data > 0.2439), 33)
@@ -293,7 +291,7 @@ def test_biphasicAxonMapModel():
                   'n_axons': 9, 'n_ax_segments': 50,
                   'xrange': (-30, 30), 'yrange': (-20, 20),
                   'loc_od': (5, 6)}
-    model = BiphasicAxonMapModel()
+    model = BiphasicAxonMapModel(implant=ArgusII())
     for param in set_params:
         npt.assert_equal(hasattr(model.spatial, param), True)
 
@@ -318,7 +316,7 @@ def test_biphasicAxonMapModel():
     npt.assert_equal(model.lam, 450)
 
     # Effect model parameters can be passed even in constructor
-    model = BiphasicAxonMapModel(a0=5, rho=432)
+    model = BiphasicAxonMapModel(implant=ArgusII(), a0=5, rho=432)
     npt.assert_equal(model.a0, 5)
     npt.assert_equal(model.spatial.bright_model.a0, 5)
     npt.assert_equal(model.rho, 432)
@@ -329,7 +327,7 @@ def test_biphasicAxonMapModel():
         model.invalid_param = 5
 
     # Custom parameters also propogate to effects models
-    model = BiphasicAxonMapModel()
+    model = BiphasicAxonMapModel(implant=ArgusII())
 
     class TestSizeModel():
         def __init__(self):
@@ -347,13 +345,13 @@ def test_biphasicAxonMapModel():
     # This also tests for recursion error in another classes __init__
     class TestInitClassGood():
         def __init__(self):
-            self.model = BiphasicAxonMapModel()
+            self.model = BiphasicAxonMapModel(implant=ArgusII())
             # This shouldnt raise an error
             self.model.a0
 
     class TestInitClassBad():
         def __init__(self):
-            self.model = BiphasicAxonMapModel()
+            self.model = BiphasicAxonMapModel(implant=ArgusII())
             # This should
             self.model.a10 = 999
     # If this fails, something is wrong with getattr / setattr logic
@@ -362,33 +360,32 @@ def test_biphasicAxonMapModel():
         TestInitClassBad()
 
     # User can override default values
-    model = BiphasicAxonMapModel()
+    model = BiphasicAxonMapModel(implant=ArgusII())
     for key, value in set_params.items():
         setattr(model.spatial, key, value)
         npt.assert_equal(getattr(model.spatial, key), value)
-    model = BiphasicAxonMapModel(**set_params)
+    model = BiphasicAxonMapModel(implant=ArgusII(), **set_params)
     model.build(**set_params)
     for key, value in set_params.items():
         npt.assert_equal(getattr(model.spatial, key), value)
 
     # Zeros in, zeros out:
-    implant = ArgusII(stim=np.zeros(60))
-    npt.assert_almost_equal(model.predict_percept(implant).data, 0)
-    implant.stim = np.zeros(60)
-    npt.assert_almost_equal(model.predict_percept(implant).data, 0)
+    source = np.zeros(60)
+    npt.assert_almost_equal(model.predict_percept(source).data, 0)
+    source = np.zeros(60)
+    npt.assert_almost_equal(model.predict_percept(source).data, 0)
 
     # Implant and model must be built for same eye:
     with pytest.raises(ValueError):
-        implant = ArgusII(eye='LE', stim=np.zeros(60))
-        model.predict_percept(implant)
+        BiphasicAxonMapModel(implant=ArgusII(eye='LE'), step=5).build()
     with pytest.raises(ValueError):
-        BiphasicAxonMapModel(eye='invalid').build()
+        BiphasicAxonMapModel(implant=ArgusII(), eye='invalid').build()
     with pytest.raises(ValueError):
-        BiphasicAxonMapModel(step=5).build(eye='invalid')
+        BiphasicAxonMapModel(implant=ArgusII(), step=5).build(eye='invalid')
 
     # Lambda cannot be too small:
     with pytest.raises(ValueError):
-        BiphasicAxonMapModel(lam=9).build()
+        BiphasicAxonMapModel(implant=ArgusII(), lam=9).build()
 
 
 @pytest.mark.parametrize('cls', [BiphasicAxonMapSpatial, BiphasicAxonMapModel])
@@ -400,7 +397,7 @@ def test_biphasicAxonMap_deprecated_axlambda(cls):
     msg = f"The 'axlambda' parameter of {cls.__name__} is deprecated"
     assert_warns_msg(DeprecationWarning, cls, msg, axlambda=400)
     with pytest.warns(DeprecationWarning):
-        model = cls(axlambda=400)
+        model = cls(implant=ArgusII(), axlambda=400)
     npt.assert_equal(model.lam, 400)
     npt.assert_equal(model.streak_model.lam, 400)
 
@@ -419,12 +416,12 @@ def test_biphasicAxonMap_deprecated_axlambda(cls):
     for params in ({'axlambda': 400, 'lam': 500},
                    {'lam': 500, 'axlambda': 400}):
         with pytest.raises(TypeError, match="same parameter"):
-            cls(**params)
+            cls(implant=ArgusII(), **params)
 
     # The new name stays silent:
     with warnings.catch_warnings():
         warnings.simplefilter("error", DeprecationWarning)
-        model = cls(lam=400)
+        model = cls(implant=ArgusII(), lam=400)
         model.lam = 500
         npt.assert_equal(model.lam, 500)
         npt.assert_equal(model.streak_model.lam, 500)
@@ -453,16 +450,16 @@ def test_find_threshold_not_supported(model_cls):
     # the pulse train, so the inherited `find_threshold` - which bisects on a
     # scaled copy of the stimulus data - cannot converge. It has to say so
     # rather than fail somewhere deeper with a confusing message.
-    model = model_cls(xrange=(-3, 3), yrange=(-2, 2), step=1,
+    model = model_cls(implant=ArgusII(), xrange=(-3, 3), yrange=(-2, 2), step=1,
                       n_ax_segments=30).build()
-    implant = ArgusII(stim={'A1': BiphasicPulseTrain(20, 1 * xTh, 0.45,
-                                                     stim_dur=100)})
+    source = {'A1': BiphasicPulseTrain(20, 1 * xTh, 0.45,
+                                                     stim_dur=100)}
     with pytest.raises(NotImplementedError) as excinfo:
-        model.find_threshold(implant, 0.5)
+        model.find_threshold(source, 0.5)
     npt.assert_equal(model_cls.__name__ in str(excinfo.value), True)
     npt.assert_equal('pulse train' in str(excinfo.value), True)
     # predict_percept is unaffected:
-    npt.assert_equal(model.predict_percept(implant) is not None, True)
+    npt.assert_equal(model.predict_percept(source) is not None, True)
 
 
 @pytest.mark.parametrize('model_cls', [BiphasicAxonMapModel,
@@ -473,19 +470,19 @@ def test_find_threshold_not_supported(model_cls):
 def test_scaled_pulse_train_changes_percept(model_cls, compose):
     # Scaling has to give what building the train at that amplitude in the
     # first place gives:
-    model = model_cls(xrange=(-12, 12), yrange=(-8, 8), step=1,
-                      n_ax_segments=30).build()
-    implant = ArgusII(stim={'C5': BiphasicPulseTrain(20, 1 * xTh, 0.45,
-                                                     stim_dur=100)})
-    single = model.predict_percept(implant).data
+    model = model_cls(implant=ArgusII(), xrange=(-12, 12), yrange=(-8, 8),
+                      step=1, n_ax_segments=30).build()
+    source = model.implant.prepare_stim(
+        {'C5': BiphasicPulseTrain(20, 1 * xTh, 0.45, stim_dur=100)})
+    single = model.predict_percept(source).data
     if compose:
-        implant.stim = implant.stim * 2
+        source = source * 2
     else:
-        implant.stim = {'C5': BiphasicPulseTrain(20, 1 * xTh, 0.45,
-                                                 stim_dur=100) * 2}
-    doubled = model.predict_percept(implant).data
-    direct = model.predict_percept(ArgusII(
-        stim={'C5': BiphasicPulseTrain(20, 2 * xTh, 0.45, stim_dur=100)})).data
+        source = {'C5': BiphasicPulseTrain(20, 1 * xTh, 0.45,
+                                           stim_dur=100) * 2}
+    doubled = model.predict_percept(source).data
+    direct = model.predict_percept(
+        {'C5': BiphasicPulseTrain(20, 2 * xTh, 0.45, stim_dur=100)}).data
     npt.assert_equal(np.any(single), True)
     npt.assert_array_almost_equal(doubled, direct)
     npt.assert_equal(np.allclose(doubled, single), False)
@@ -499,26 +496,27 @@ def test_modified_pulse_train_rejected(model_cls, modify):
     # A DC offset, a non-finite factor and an appended second train all leave
     # something other than a biphasic pulse train. The model must say so rather
     # than predict from pulse parameters that no longer describe the stimulus:
-    model = model_cls(xrange=(-3, 3), yrange=(-2, 2), step=1,
-                      n_ax_segments=30).build()
-    implant = ArgusII(stim={'C5': BiphasicPulseTrain(20, 1 * xTh, 0.45,
-                                                     stim_dur=100)})
+    model = model_cls(implant=ArgusII(), xrange=(-3, 3), yrange=(-2, 2),
+                      step=1, n_ax_segments=30).build()
+    source = model.implant.prepare_stim(
+        {'C5': BiphasicPulseTrain(20, 1 * xTh, 0.45, stim_dur=100)})
     with np.errstate(divide='ignore', invalid='ignore'):
-        implant.stim = modify(implant.stim)
+        source = modify(source)
     with pytest.raises(TypeError):
-        model.predict_percept(implant)
+        model.predict_percept(source)
 
 
 def test_pulse_train_amp_sign_does_not_change_percept():
     # `BiphasicPulse` takes the magnitude of `amp`, so these two trains have
     # the very same waveform, and must therefore predict the same percept:
-    model = BiphasicAxonMapModel(xrange=(-12, 12), yrange=(-8, 8), step=1,
+    model = BiphasicAxonMapModel(implant=ArgusII(), xrange=(-12, 12),
+                                 yrange=(-8, 8), step=1,
                                  n_ax_segments=30).build()
-    pos = ArgusII(stim={'C5': BiphasicPulseTrain(20, 1 * xTh, 0.45,
-                                                 stim_dur=100)})
-    neg = ArgusII(stim={'C5': BiphasicPulseTrain(20, -1 * xTh, 0.45,
-                                                 stim_dur=100)})
-    npt.assert_almost_equal(pos.stim.data, neg.stim.data)
+    pos = model.implant.prepare_stim(
+        {'C5': BiphasicPulseTrain(20, 1 * xTh, 0.45, stim_dur=100)})
+    neg = model.implant.prepare_stim(
+        {'C5': BiphasicPulseTrain(20, -1 * xTh, 0.45, stim_dur=100)})
+    npt.assert_almost_equal(pos.data, neg.data)
     npt.assert_array_almost_equal(model.predict_percept(pos).data,
                                   model.predict_percept(neg).data)
 
@@ -532,14 +530,14 @@ def test_BiphasicAxonMapModel_min_current_spread():
     """
     stim = {e: BiphasicPulseTrain(20, 30 * xTh, 0.45)
             for e in ('A2', 'C5', 'F8')}
-    implant = ArgusII(stim=stim)
+    source = stim
     kwargs = {'xrange': (-8, 8), 'yrange': (-8, 8), 'step': 0.5,
               'rho': 200, 'verbose': False}
 
-    exact = BiphasicAxonMapModel(
-        min_current_spread=0, **kwargs).build().predict_percept(implant).data
-    default = BiphasicAxonMapModel(
-        **kwargs).build().predict_percept(implant).data
+    exact = BiphasicAxonMapModel(implant=ArgusII(), 
+        min_current_spread=0, **kwargs).build().predict_percept(source).data
+    default = BiphasicAxonMapModel(implant=ArgusII(), 
+        **kwargs).build().predict_percept(source).data
     # For three electrodes the default cutoff is not worth thinking about;
     # see `test_BiphasicAxonMapModel_min_current_spread_error_bound` for the
     # case where it is:
@@ -548,8 +546,8 @@ def test_BiphasicAxonMapModel_min_current_spread():
 
     # A coarse cutoff does change the result, which is how we know it is
     # wired through rather than silently dropped:
-    coarse = BiphasicAxonMapModel(
-        min_current_spread=0.5, **kwargs).build().predict_percept(implant).data
+    coarse = BiphasicAxonMapModel(implant=ArgusII(), 
+        min_current_spread=0.5, **kwargs).build().predict_percept(source).data
     assert np.abs(coarse - exact).max() > 1e-3
 
 
@@ -565,18 +563,18 @@ def test_BiphasicAxonMapModel_min_current_spread_error_bound(amp):
     """
     min_spread = 1e-8
     freq, pdur = 20, 0.45
-    implant = ArgusII(stim={e: BiphasicPulseTrain(freq, amp * xTh, pdur)
-                            for e in ArgusII().electrode_names})
+    source = {e: BiphasicPulseTrain(freq, amp * xTh, pdur)
+                            for e in ArgusII().electrode_names}
     kwargs = {'xrange': (-14, 14), 'yrange': (-10, 10), 'step': 0.75,
               'rho': 200, 'lam': 800, 'verbose': False}
 
-    model = BiphasicAxonMapModel(min_current_spread=0, **kwargs).build()
-    exact = model.predict_percept(implant).data
-    default = BiphasicAxonMapModel(
+    model = BiphasicAxonMapModel(implant=ArgusII(), min_current_spread=0, **kwargs).build()
+    exact = model.predict_percept(source).data
+    default = BiphasicAxonMapModel(implant=ArgusII(), 
         min_current_spread=min_spread,
-        **kwargs).build().predict_percept(implant).data
+        **kwargs).build().predict_percept(source).data
 
-    n_el = len(implant.electrode_names)
+    n_el = model.implant.n_electrodes
     f_bright = np.asarray(model.spatial.bright_model(
         np.full(n_el, freq), np.full(n_el, amp), np.full(n_el, pdur)))
     dropped = min_spread * np.abs(f_bright).sum()
@@ -591,16 +589,16 @@ def test_BiphasicAxonMapModel_rejects_nonpositive_effects(attr):
     zero or negative. The default models cannot produce that, but a custom
     one could.
     """
-    model = BiphasicAxonMapModel(xrange=(-4, 4), yrange=(-4, 4), step=1,
+    model = BiphasicAxonMapModel(implant=ArgusII(), xrange=(-4, 4), yrange=(-4, 4), step=1,
                                  verbose=False).build()
     setattr(model.spatial, attr, lambda freq, amp, pdur: np.zeros_like(amp))
-    implant = ArgusII(stim={'A2': BiphasicPulseTrain(20, 30 * xTh, 0.45)})
+    source = {'A2': BiphasicPulseTrain(20, 30 * xTh, 0.45)}
     with pytest.raises(ValueError, match=attr):
-        model.predict_percept(implant)
+        model.predict_percept(source)
 
     # A positive factor is accepted:
     setattr(model.spatial, attr, lambda freq, amp, pdur: np.ones_like(amp))
-    npt.assert_equal(model.predict_percept(implant) is not None, True)
+    npt.assert_equal(model.predict_percept(source) is not None, True)
 
 
 @pytest.mark.parametrize('attr', ('bright_model', 'size_model',
@@ -618,14 +616,14 @@ def test_BiphasicAxonMapModel_rejects_nonfinite_effects(attr, bad):
     ``bright_model`` as well, which the positivity check deliberately does
     not (a zero or negative brightness factor is legitimate).
     """
-    model = BiphasicAxonMapModel(xrange=(-4, 4), yrange=(-4, 4), step=1,
+    model = BiphasicAxonMapModel(implant=ArgusII(), xrange=(-4, 4), yrange=(-4, 4), step=1,
                                  verbose=False).build()
     setattr(model.spatial, attr,
             lambda freq, amp, pdur: np.full_like(np.asarray(amp, dtype=float),
                                                  bad))
-    implant = ArgusII(stim={'A2': BiphasicPulseTrain(20, 30 * xTh, 0.45)})
+    source = {'A2': BiphasicPulseTrain(20, 30 * xTh, 0.45)}
     with pytest.raises(ValueError, match=attr):
-        model.predict_percept(implant)
+        model.predict_percept(source)
 
 
 def test_BiphasicAxonMapModel_reduces_to_AxonMapModel():
@@ -645,42 +643,41 @@ def test_BiphasicAxonMapModel_reduces_to_AxonMapModel():
               'rho': 200, 'lam': 800, 'verbose': False}
     electrodes = ('A2', 'C5', 'F8')
 
-    biphasic = BiphasicAxonMapModel(**kwargs)
+    biphasic = BiphasicAxonMapModel(implant=ArgusII(), **kwargs)
     for attr in ('bright_model', 'size_model', 'streak_model'):
         setattr(biphasic.spatial, attr,
                 lambda freq, amp, pdur: np.ones_like(np.asarray(amp,
                                                                 dtype=float)))
     biphasic.build()
-    got = biphasic.predict_percept(ArgusII(
-        stim={e: BiphasicPulseTrain(20, 30 * xTh, 0.45)
-              for e in electrodes})).data
+    got = biphasic.predict_percept({e: BiphasicPulseTrain(20, 30 * xTh, 0.45)
+              for e in electrodes}).data
 
-    plain = AxonMapModel(**kwargs).build()
+    plain = AxonMapModel(implant=ArgusII(), **kwargs).build()
     stim = np.zeros(60)
     names = list(ArgusII().electrode_names)
     for e in electrodes:
         stim[names.index(e)] = 1.0
-    want = plain.predict_percept(ArgusII(stim=stim)).data
+    want = plain.predict_percept(stim).data
 
     npt.assert_allclose(got, want, rtol=1e-5, atol=1e-6 * np.abs(want).max())
 
 
 def test_BiphasicAxonMap_t_percept_units():
     """This model overrides `predict_percept`, so it normalizes for itself"""
-    implant = ArgusII(stim={'A1': BiphasicPulseTrain(20, 1 * xTh, 0.45,
-                                                     stim_dur=100)})
-    for model in (BiphasicAxonMapSpatial(step=2).build(),
-                  BiphasicAxonMapModel(step=2).build()):
+    source = {'A1': BiphasicPulseTrain(20, 1 * xTh, 0.45,
+                                                     stim_dur=100)}
+    for model in (BiphasicAxonMapSpatial(implant=ArgusII(), step=2).build(),
+                  BiphasicAxonMapModel(implant=ArgusII(), step=2).build()):
         # A single time point is one time point, not something with a `len`:
-        npt.assert_equal(model.predict_percept(implant,
+        npt.assert_equal(model.predict_percept(source,
                                                t_percept=20).data.shape[-1], 1)
-        bare = model.predict_percept(implant, t_percept=[0, 20])
+        bare = model.predict_percept(source, t_percept=[0, 20])
         for spelling in ([0, 20] * ms, np.array([0, 0.02]) * s, 20 * ms):
-            unitful = model.predict_percept(implant, t_percept=spelling)
+            unitful = model.predict_percept(source, t_percept=spelling)
             npt.assert_allclose(unitful.data.max(), bare.data.max(),
                                 rtol=1e-12)
         with pytest.raises(DimensionMismatchError):
-            model.predict_percept(implant, t_percept=[0, 20] * uA)
+            model.predict_percept(source, t_percept=[0, 20] * uA)
 
 
 def test_BiphasicAxonMap_dimension_before_waveform():
@@ -698,11 +695,11 @@ def test_BiphasicAxonMap_dimension_before_waveform():
     class Projector(ArgusII):
         stimulus_unit = dimensionless
 
-    implant = Projector(preprocess=False, stim=img)
-    for model in (BiphasicAxonMapSpatial(step=2).build(),
-                  BiphasicAxonMapModel(step=2).build()):
+    projector = Projector(preprocess=False)
+    for model in (BiphasicAxonMapSpatial(implant=projector, step=2).build(),
+                  BiphasicAxonMapModel(implant=projector, step=2).build()):
         with pytest.raises(DimensionMismatchError) as excinfo:
-            model.predict_percept(implant)
+            model.predict_percept(img)
         # Both dimensions this model reads are named, not just the one:
         for accepted in ('electric current', 'threshold ratio'):
             npt.assert_equal(accepted in str(excinfo.value), True)
@@ -710,8 +707,8 @@ def test_BiphasicAxonMap_dimension_before_waveform():
     # A current-valued stimulus of the wrong waveform still gets the
     # model-specific message:
     with pytest.raises(TypeError) as excinfo:
-        BiphasicAxonMapSpatial(step=2).build().predict_percept(
-            ArgusII(stim={'A1': MonophasicPulse(-1, 0.45, stim_dur=100)}))
+        BiphasicAxonMapSpatial(implant=ArgusII(), step=2).build().predict_percept(
+            {'A1': MonophasicPulse(-1, 0.45, stim_dur=100)})
     npt.assert_equal('BiphasicPulseTrain' in str(excinfo.value), True)
 
 
@@ -723,21 +720,21 @@ def test_BiphasicAxonMapSpatial_meridian_blend(ModelClass):
     # otherwise `meridian_blend`, inherited from `AxonMapSpatial`, would be
     # accepted and then quietly ignored.
     def make(**params):
-        return ModelClass(xrange=(-6, 6), yrange=(-6, 6), step=0.25, rho=200,
+        return ModelClass(implant=ArgusII(), xrange=(-6, 6), yrange=(-6, 6), step=0.25, rho=200,
                           lam=400, n_axons=250, n_ax_segments=200,
                           ignore_pickle=True, **params).build()
 
-    implant = ArgusII(stim={'C4': BiphasicPulseTrain(20, 20 * xTh, 0.45),
-                            'C8': BiphasicPulseTrain(20, 20 * xTh, 0.45)})
+    source = {'C4': BiphasicPulseTrain(20, 20 * xTh, 0.45),
+                            'C8': BiphasicPulseTrain(20, 20 * xTh, 0.45)}
     plain = make(meridian_blend=0)
-    unblended = plain.predict_percept(implant).data
+    unblended = plain.predict_percept(source).data
 
     # Exercises the width inherited from `AxonMapSpatial` rather than one of
     # its own -- the point of the test is that the hook runs at all here:
     width = 1
     blended_model = make()
     npt.assert_equal(blended_model.meridian_blend, width)
-    blended = blended_model.predict_percept(implant).data
+    blended = blended_model.predict_percept(source).data
     npt.assert_equal(blended.shape, unblended.shape)
     npt.assert_equal(blended.dtype, unblended.dtype)
     npt.assert_equal(np.array_equal(blended, unblended), False)
@@ -780,11 +777,11 @@ def test_BiphasicAxonMap_predicts_without_a_waveform(model_cls, build_stim):
     # This model is a function of frequency, amplitude and phase duration, and
     # it now takes them from the pulse trains themselves. None of them needs
     # the train sampled, so predicting must not sample one.
-    model = model_cls(xrange=(-3, 3), yrange=(-2, 2), step=1,
+    model = model_cls(implant=ArgusII(), xrange=(-3, 3), yrange=(-2, 2), step=1,
                       n_ax_segments=30).build()
-    implant = ArgusII(stim=build_stim())
+    source = build_stim()
     with _no_pulse_train_rendering():
-        percept = model.predict_percept(implant)
+        percept = model.predict_percept(source)
     npt.assert_equal(np.any(percept.data), True)
 
 
@@ -792,13 +789,13 @@ def test_BiphasicAxonMap_predicts_without_a_waveform(model_cls, build_stim):
                                        BiphasicAxonMapSpatial])
 def test_BiphasicAxonMap_ignores_user_metadata(model_cls):
     # Metadata that happens to name pulse parameters is still just metadata:
-    model = model_cls(xrange=(-3, 3), yrange=(-2, 2), step=1,
-                      n_ax_segments=30).build()
-    implant = ArgusII(stim={'C5': BiphasicPulseTrain(20, 1 * xTh, 0.45,
-                                                     stim_dur=100)})
-    expected = model.predict_percept(implant).data
-    implant.stim.metadata['user'] = {'amp': 999, 'freq': 1}
-    npt.assert_array_equal(model.predict_percept(implant).data, expected)
+    model = model_cls(implant=ArgusII(), xrange=(-3, 3), yrange=(-2, 2),
+                      step=1, n_ax_segments=30).build()
+    source = model.implant.prepare_stim(
+        {'C5': BiphasicPulseTrain(20, 1 * xTh, 0.45, stim_dur=100)})
+    expected = model.predict_percept(source).data
+    source.metadata['user'] = {'amp': 999, 'freq': 1}
+    npt.assert_array_equal(model.predict_percept(source).data, expected)
 
 
 @pytest.mark.parametrize('model_cls', [BiphasicAxonMapModel,
@@ -820,11 +817,11 @@ def test_BiphasicAxonMap_rejects_what_it_cannot_read(model_cls, build_stim):
     # not this model's protocol, a delayed one is outside what it was fit on,
     # and a raw waveform has no parameters at all. Each is refused rather than
     # predicted from whatever numbers happen to be lying around:
-    model = model_cls(xrange=(-3, 3), yrange=(-2, 2), step=1,
+    model = model_cls(implant=ArgusII(), xrange=(-3, 3), yrange=(-2, 2), step=1,
                       n_ax_segments=30).build()
-    implant = ArgusII(stim=build_stim())
+    source = build_stim()
     with pytest.raises(TypeError):
-        model.predict_percept(implant)
+        model.predict_percept(source)
 
 
 @pytest.mark.parametrize('model_cls', [BiphasicAxonMapModel,
@@ -832,22 +829,21 @@ def test_BiphasicAxonMap_rejects_what_it_cannot_read(model_cls, build_stim):
 def test_BiphasicAxonMap_zero_amplitude_is_inactive(model_cls):
     # A train at zero amplitude drives nothing, which is a zero percept rather
     # than an error -- and is read off `amp`, not off the waveform:
-    model = model_cls(xrange=(-3, 3), yrange=(-2, 2), step=1,
+    model = model_cls(implant=ArgusII(), xrange=(-3, 3), yrange=(-2, 2), step=1,
                       n_ax_segments=30).build()
-    implant = ArgusII(stim={'C5': BiphasicPulseTrain(20, 0 * xTh, 0.45,
+    source = {'C5': BiphasicPulseTrain(20, 0 * xTh, 0.45,
                                                      stim_dur=100),
                             'A2': BiphasicPulseTrain(20, 0 * xTh, 0.45,
-                                                     stim_dur=100)})
+                                                     stim_dur=100)}
     with _no_pulse_train_rendering():
-        percept = model.predict_percept(implant)
+        percept = model.predict_percept(source)
     npt.assert_almost_equal(percept.data, 0)
     # One driven electrode among zeros still predicts from that one alone:
-    implant.stim = {'C5': BiphasicPulseTrain(20, 0 * xTh, 0.45, stim_dur=100),
+    source = {'C5': BiphasicPulseTrain(20, 0 * xTh, 0.45, stim_dur=100),
                     'A2': BiphasicPulseTrain(20, 1 * xTh, 0.45, stim_dur=100)}
     with _no_pulse_train_rendering():
-        mixed = model.predict_percept(implant).data
-    only = model.predict_percept(ArgusII(
-        stim={'A2': BiphasicPulseTrain(20, 1 * xTh, 0.45, stim_dur=100)})).data
+        mixed = model.predict_percept(source).data
+    only = model.predict_percept({'A2': BiphasicPulseTrain(20, 1 * xTh, 0.45, stim_dur=100)}).data
     npt.assert_array_almost_equal(mixed, only)
 
 
@@ -858,15 +854,15 @@ def test_BiphasicAxonMap_rejects_an_encoded_stimulus(model_cls):
     # frequency may differ from frame to frame, so there is no one `freq` for
     # this model to read. It stays refused, and refusing it does not expand
     # the schedule into a waveform either.
-    model = model_cls(xrange=(-3, 3), yrange=(-2, 2), step=1,
+    model = model_cls(implant=ArgusII(), xrange=(-3, 3), yrange=(-2, 2), step=1,
                       n_ax_segments=30).build()
     implant = ArgusII()
     encoded = AmplitudeEncoder().encode(
         ImageStimulus(np.linspace(0, 1, 64).reshape(8, 8)), implant=implant)
     npt.assert_equal(encoded._structured_sources(), None)
-    implant.stim = encoded
+    source = encoded
     with pytest.raises(TypeError):
-        model.predict_percept(implant)
+        model.predict_percept(source)
 
 
 # The temporal models a Granley composite is expected to work with. Their
@@ -883,14 +879,13 @@ _EPISODE = 200
 def _composite(temporal):
     """A Granley spatial model paired with ``temporal``, and Granley alone"""
     grid = dict(xrange=(-3, 3), yrange=(-2, 2), step=1, n_ax_segments=30)
-    composite = Model(spatial=BiphasicAxonMapSpatial(**grid),
+    composite = Model(spatial=BiphasicAxonMapSpatial(implant=ArgusII(), **grid),
                       temporal=temporal)
-    return composite.build(), BiphasicAxonMapModel(**grid).build()
+    return composite.build(), BiphasicAxonMapModel(implant=ArgusII(), **grid).build()
 
 
-def _composite_implant(stim_dur=_STIM_DUR):
-    return ArgusII(stim={'A5': BiphasicPulseTrain(20, 1 * xTh, 0.45,
-                                                  stim_dur=stim_dur)})
+def _composite_source(stim_dur=_STIM_DUR):
+    return {'A5': BiphasicPulseTrain(20, 1 * xTh, 0.45, stim_dur=stim_dur)}
 
 
 def _every_dt(temporal, until=_EPISODE):
@@ -909,7 +904,7 @@ def test_BiphasicAxonMapSpatial_with_temporal_model_runs(temporal_cls):
     # The drive is built from the retained pulse-train parameters, so pairing
     # the two still asks for no waveform:
     with _no_pulse_train_rendering():
-        percept = composite.predict_percept(_composite_implant())
+        percept = composite.predict_percept(_composite_source())
     npt.assert_equal(percept.data.ndim, 3)
     npt.assert_equal(percept.data.shape[-1] > 1, True)
     npt.assert_equal(np.all(np.isfinite(percept.data)), True)
@@ -920,19 +915,19 @@ def test_BiphasicAxonMapSpatial_composite_peaks_at_the_granley_percept(
         temporal_cls):
     temporal = temporal_cls()
     composite, granley = _composite(temporal)
-    implant = _composite_implant()
-    percept = composite.predict_percept(implant,
+    source = _composite_source()
+    percept = composite.predict_percept(source,
                                         t_percept=_every_dt(temporal))
     npt.assert_array_almost_equal(
         percept.max(axis='frames'),
-        granley.predict_percept(implant).data[..., 0])
+        granley.predict_percept(source).data[..., 0])
 
 
 @pytest.mark.parametrize('temporal_cls', _TEMPORALS)
 def test_BiphasicAxonMapSpatial_composite_is_space_time_separable(
         temporal_cls):
     composite, _ = _composite(temporal_cls())
-    percept = composite.predict_percept(_composite_implant(),
+    percept = composite.predict_percept(_composite_source(),
                                         t_percept=[10, 20, 40, 80, 160])
     lit = percept.data[percept.data.max(axis=-1) > 0]
     npt.assert_equal(len(lit) > 1, True)
@@ -946,14 +941,14 @@ def test_BiphasicAxonMapSpatial_composite_is_space_time_separable(
 def test_BiphasicAxonMapSpatial_composite_peak_ignores_requested_sampling(
         temporal_cls):
     composite, granley = _composite(temporal_cls())
-    implant = _composite_implant()
-    granley_max = granley.predict_percept(implant).data.max()
+    source = _composite_source()
+    granley_max = granley.predict_percept(source).data.max()
     # Asked only for instants that fall well before the peak, the percept must
     # stay below the Granley maximum rather than renormalizing onto it:
-    early = composite.predict_percept(implant, t_percept=[10, 20])
+    early = composite.predict_percept(source, t_percept=[10, 20])
     npt.assert_equal(early.data.max() < 0.9 * granley_max, True)
     # And those samples are the ones a longer run reports at the same times:
-    longer = composite.predict_percept(implant, t_percept=[10, 20, 40, 80])
+    longer = composite.predict_percept(source, t_percept=[10, 20, 40, 80])
     npt.assert_array_almost_equal(early.data, longer.data[..., :2])
 
 
@@ -961,7 +956,7 @@ def test_BiphasicAxonMapSpatial_composite_peak_ignores_requested_sampling(
 def test_BiphasicAxonMapSpatial_composite_decays_after_stimulation(
         temporal_cls):
     composite, _ = _composite(temporal_cls())
-    percept = composite.predict_percept(_composite_implant(),
+    percept = composite.predict_percept(_composite_source(),
                                         t_percept=[100, 150, 200])
     frame_max = percept.data.max(axis=(0, 1))
     npt.assert_equal(np.all(np.diff(frame_max) < 0), True)
@@ -974,16 +969,16 @@ def test_BiphasicAxonMapSpatial_composite_decays_after_stimulation(
                                                   'tau3')])
 def test_BiphasicAxonMapSpatial_composite_temporal_params_only_move_time(
         temporal_cls, param):
-    implant = _composite_implant()
+    source = _composite_source()
     traces = []
     for value in (10, 60):
         temporal = temporal_cls(**{param: value})
         composite, granley = _composite(temporal)
-        percept = composite.predict_percept(implant,
+        percept = composite.predict_percept(source,
                                             t_percept=_every_dt(temporal))
         peak_frame = percept.max(axis='frames')
         npt.assert_array_almost_equal(
-            peak_frame, granley.predict_percept(implant).data[..., 0])
+            peak_frame, granley.predict_percept(source).data[..., 0])
         brightest = np.unravel_index(np.argmax(peak_frame), peak_frame.shape)
         traces.append(percept.data[brightest])
     npt.assert_equal(np.allclose(traces[0], traces[1]), False)
@@ -998,10 +993,10 @@ def test_BiphasicAxonMapSpatial_composite_ignores_temporal_thresh_percept(
     temporal = temporal_cls(thresh_percept=0.1)
     composite, _ = _composite(temporal)
     plain, _ = _composite(temporal_cls())
-    implant = _composite_implant()
+    source = _composite_source()
     npt.assert_array_almost_equal(
-        composite.predict_percept(implant, t_percept=[10, 20, 40]).data,
-        plain.predict_percept(implant, t_percept=[10, 20, 40]).data)
+        composite.predict_percept(source, t_percept=[10, 20, 40]).data,
+        plain.predict_percept(source, t_percept=[10, 20, 40]).data)
     npt.assert_almost_equal(temporal.thresh_percept, 0.1)
 
 
@@ -1009,12 +1004,9 @@ def test_BiphasicAxonMapSpatial_composite_ignores_inactive_stim_dur():
     # A train at zero amplitude is inactive everywhere, so it must not stretch
     # the envelope the active one rides on either:
     composite, _ = _composite(FadingTemporal())
-    short = ArgusII(stim={'A5': BiphasicPulseTrain(20, 1 * xTh, 0.45,
-                                                   stim_dur=100)})
-    padded = ArgusII(stim={'A5': BiphasicPulseTrain(20, 1 * xTh, 0.45,
-                                                    stim_dur=100),
-                           'A2': BiphasicPulseTrain(20, 0 * xTh, 0.45,
-                                                    stim_dur=1000)})
+    short = {'A5': BiphasicPulseTrain(20, 1 * xTh, 0.45, stim_dur=100)}
+    padded = {'A5': BiphasicPulseTrain(20, 1 * xTh, 0.45, stim_dur=100),
+              'A2': BiphasicPulseTrain(20, 0 * xTh, 0.45, stim_dur=1000)}
     t_percept = [40, 80, 100]
     npt.assert_array_almost_equal(
         composite.predict_percept(padded, t_percept=t_percept).data,
@@ -1027,12 +1019,12 @@ def test_BiphasicAxonMapSpatial_composite_rejects_unequal_stim_dur(
     # One separable envelope cannot have one electrode's contribution stop at
     # 100 ms and another's at 1000 ms:
     composite, _ = _composite(temporal_cls())
-    implant = ArgusII(stim={'A5': BiphasicPulseTrain(20, 1 * xTh, 0.45,
+    source = {'A5': BiphasicPulseTrain(20, 1 * xTh, 0.45,
                                                      stim_dur=100),
                             'A2': BiphasicPulseTrain(20, 1 * xTh, 0.45,
-                                                     stim_dur=1000)})
+                                                     stim_dur=1000)}
     with pytest.raises(NotImplementedError):
-        composite.predict_percept(implant)
+        composite.predict_percept(source)
 
 
 def test_BiphasicAxonMapSpatial_composite_rides_an_alpha_envelope():
@@ -1043,12 +1035,12 @@ def test_BiphasicAxonMapSpatial_composite_rides_an_alpha_envelope():
     """
     temporal = AlphaTemporal(tau=20)
     composite, granley = _composite(temporal)
-    implant = _composite_implant()
+    source = _composite_source()
     t = _every_dt(temporal)
-    percept = composite.predict_percept(implant, t_percept=t)
+    percept = composite.predict_percept(source, t_percept=t)
 
     # Time-varying, and still peaking at the Granley frame:
-    granley_frame = granley.predict_percept(implant).data[..., 0]
+    granley_frame = granley.predict_percept(source).data[..., 0]
     npt.assert_equal(percept.data.shape[-1], len(t))
     npt.assert_array_almost_equal(percept.max(axis='frames'), granley_frame)
 
@@ -1064,7 +1056,7 @@ def test_BiphasicAxonMapSpatial_composite_rides_an_alpha_envelope():
     npt.assert_array_less(trace[-1], trace[peak])
 
     fading, _ = _composite(FadingTemporal(tau=20))
-    fade = fading.predict_percept(implant, t_percept=t).data[
+    fade = fading.predict_percept(source, t_percept=t).data[
         np.unravel_index(np.argmax(granley_frame), granley_frame.shape)]
     npt.assert_array_less(np.argmax(fade), peak)
 
@@ -1075,9 +1067,9 @@ def test_BiphasicAxonMapSpatial_composite_normalizes_a_delayed_peak():
     # let the percept outshine the Granley frame it is supposed to peak at:
     temporal = Horsager2009Temporal(tau3=100)
     composite, granley = _composite(temporal)
-    implant = _composite_implant()
-    granley_frame = granley.predict_percept(implant).data[..., 0]
-    percept = composite.predict_percept(implant,
+    source = _composite_source()
+    granley_frame = granley.predict_percept(source).data[..., 0]
+    percept = composite.predict_percept(source,
                                         t_percept=_every_dt(temporal, 400))
     npt.assert_equal(percept.data.max() <= granley_frame.max(), True)
     npt.assert_array_almost_equal(percept.max(axis='frames'), granley_frame)
@@ -1088,19 +1080,18 @@ def test_BiphasicAxonMapSpatial_composite_rejects_an_unlocatable_peak():
     # saying so beats normalizing by a value known not to be the peak.
     composite, _ = _composite(Horsager2009Temporal(tau3=300))
     with pytest.raises(ValueError):
-        composite.predict_percept(_composite_implant())
+        composite.predict_percept(_composite_source())
 
 
 def _threshold_model():
-    return BiphasicAxonMapModel(xrange=(-3, 3), yrange=(-2, 2), step=1,
+    return BiphasicAxonMapModel(implant=ArgusII(), xrange=(-3, 3), yrange=(-2, 2), step=1,
                                 n_ax_segments=30).build()
 
 
 def _percept_at(model, train, thresholds=None):
-    implant = ArgusII(stim={'A2': train})
     if thresholds is not None:
-        implant.thresholds = thresholds
-    return model.predict_percept(implant).data
+        model.implant.thresholds = thresholds
+    return model.predict_percept({'A2': train}).data
 
 
 def test_BiphasicAxonMap_reads_threshold_multiples_not_current():
@@ -1137,27 +1128,27 @@ def test_BiphasicAxonMap_same_current_differs_by_threshold():
 @pytest.mark.parametrize('model_cls', [BiphasicAxonMapModel,
                                        BiphasicAxonMapSpatial])
 def test_BiphasicAxonMap_uncalibrated_current_raises(model_cls):
-    model = model_cls(xrange=(-3, 3), yrange=(-2, 2), step=1,
+    model = model_cls(implant=ArgusII(), xrange=(-3, 3), yrange=(-2, 2), step=1,
                       n_ax_segments=30).build()
-    implant = ArgusII(stim={'A2': BiphasicPulseTrain(20, 160 * uA, 0.45,
-                                                     stim_dur=100)})
+    source = {'A2': BiphasicPulseTrain(20, 160 * uA, 0.45,
+                                                     stim_dur=100)}
     with pytest.raises(ValueError) as err:
-        model.predict_percept(implant)
+        model.predict_percept(source)
     for remedy in ('2 * xTh', 'threshold_amp', 'implant.thresholds'):
         npt.assert_equal(remedy in str(err.value), True)
     # Any one of the three fixes it:
-    implant.thresholds = 80 * uA
-    npt.assert_equal(np.any(model.predict_percept(implant).data), True)
+    model.implant.thresholds = 80 * uA
+    npt.assert_equal(np.any(model.predict_percept(source).data), True)
 
 
 @pytest.mark.parametrize('model_cls', [BiphasicAxonMapModel,
                                        BiphasicAxonMapSpatial])
 def test_BiphasicAxonMap_zero_current_needs_no_threshold(model_cls):
     # Zero-current electrodes need no threshold.
-    model = model_cls(xrange=(-3, 3), yrange=(-2, 2), step=1,
+    model = model_cls(implant=ArgusII(), xrange=(-3, 3), yrange=(-2, 2), step=1,
                       n_ax_segments=30).build()
-    implant = ArgusII(stim={'A2': BiphasicPulseTrain(20, 0 * uA, 0.45,
-                                                     stim_dur=100)})
+    source = {'A2': BiphasicPulseTrain(20, 0 * uA, 0.45,
+                                                     stim_dur=100)}
     with _no_pulse_train_rendering():
-        percept = model.predict_percept(implant)
+        percept = model.predict_percept(source)
     npt.assert_almost_equal(percept.data, 0)

--- a/pulse2percept/models/tests/test_granley2021.py
+++ b/pulse2percept/models/tests/test_granley2021.py
@@ -375,13 +375,11 @@ def test_biphasicAxonMapModel():
     source = np.zeros(60)
     npt.assert_almost_equal(model.predict_percept(source).data, 0)
 
-    # Implant and model must be built for same eye:
-    with pytest.raises(ValueError):
-        BiphasicAxonMapModel(implant=ArgusII(eye='LE'), step=5).build()
-    with pytest.raises(ValueError):
-        BiphasicAxonMapModel(implant=ArgusII(), eye='invalid').build()
-    with pytest.raises(ValueError):
-        BiphasicAxonMapModel(implant=ArgusII(), step=5).build(eye='invalid')
+    # The eye is the implanted one, and is not settable on its own:
+    npt.assert_equal(
+        BiphasicAxonMapModel(implant=ArgusII(eye='LE'), step=5).eye, 'LE')
+    with pytest.raises(AttributeError):
+        BiphasicAxonMapModel(implant=ArgusII(), eye='LE')
 
     # Lambda cannot be too small:
     with pytest.raises(ValueError):

--- a/pulse2percept/models/tests/test_granley2021.py
+++ b/pulse2percept/models/tests/test_granley2021.py
@@ -445,25 +445,6 @@ def test_DefaultStreakModel_deprecated_axlambda():
 
 @pytest.mark.parametrize('model_cls', [BiphasicAxonMapModel,
                                        BiphasicAxonMapSpatial])
-def test_find_threshold_not_supported(model_cls):
-    # This model takes amplitude as a multiple of threshold and reads it off
-    # the pulse train, so the inherited `find_threshold` - which bisects on a
-    # scaled copy of the stimulus data - cannot converge. It has to say so
-    # rather than fail somewhere deeper with a confusing message.
-    model = model_cls(implant=ArgusII(), xrange=(-3, 3), yrange=(-2, 2), step=1,
-                      n_ax_segments=30).build()
-    source = {'A1': BiphasicPulseTrain(20, 1 * xTh, 0.45,
-                                                     stim_dur=100)}
-    with pytest.raises(NotImplementedError) as excinfo:
-        model.find_threshold(source, 0.5)
-    npt.assert_equal(model_cls.__name__ in str(excinfo.value), True)
-    npt.assert_equal('pulse train' in str(excinfo.value), True)
-    # predict_percept is unaffected:
-    npt.assert_equal(model.predict_percept(source) is not None, True)
-
-
-@pytest.mark.parametrize('model_cls', [BiphasicAxonMapModel,
-                                       BiphasicAxonMapSpatial])
 # Scaling the train itself, and scaling the stimulus the implant made of it;
 # the second is what a user reaches for:
 @pytest.mark.parametrize('compose', [False, True])

--- a/pulse2percept/models/tests/test_horsager2009.py
+++ b/pulse2percept/models/tests/test_horsager2009.py
@@ -25,11 +25,12 @@ def test_Horsager2009Temporal():
 
     # Nothing in, None out:
     implant = ProsthesisSystem(PointSource(0, 0, 0))
-    npt.assert_equal(model.predict_percept(implant.stim), None)
+    npt.assert_equal(model.predict_percept(implant.prepare_stim(None)),
+                     None)
 
     # Zero in = zero out:
-    implant.stim = np.zeros((1, 6))
-    percept = model.predict_percept(implant.stim, t_percept=[0, 1, 2])
+    percept = model.predict_percept(implant.prepare_stim(np.zeros((1, 6))),
+                                    t_percept=[0, 1, 2])
     npt.assert_equal(isinstance(percept, Percept), True)
     npt.assert_equal(percept.shape, (1, 1, 3))
     npt.assert_almost_equal(percept.data, 0)
@@ -38,8 +39,8 @@ def test_Horsager2009Temporal():
     # loop, because `idx_frame` is incremented after a write; also doesn't
     # make much sense):
     with pytest.raises(ValueError):
-        implant.stim = np.ones((1, 100))
-        model.predict_percept(implant.stim, t_percept=[0.2, 0.2])
+        model.predict_percept(implant.prepare_stim(np.ones((1, 100))),
+                              t_percept=[0.2, 0.2])
 
     # Single-pulse brightness from Fig.3. These three (amp, phase_dur) pairs sit
     # on one threshold curve in the paper, so the model should call them equally
@@ -124,8 +125,7 @@ def test_Horsager2009Model():
                                   stim_dur=200, cathodic_first=True)
         model1 = Horsager2009Model().build()
         model2 = Horsager2009Temporal().build()
-        implant = ProsthesisSystem(PointSource(0, 0, 0), stim=stim)
-        npt.assert_almost_equal(model1.predict_percept(implant).data,
+        npt.assert_almost_equal(model1.predict_percept(stim).data,
                                 model2.predict_percept(stim).data)
 
 

--- a/pulse2percept/models/tests/test_nanduri2012.py
+++ b/pulse2percept/models/tests/test_nanduri2012.py
@@ -137,8 +137,6 @@ def test_Nanduri2012Temporal(scale_out):
     implant = ProsthesisSystem(ElectrodeArray(DiskElectrode(0, 0, 0, 260)))
     bright_amp = []
     for amp in np.linspace(0, 50, 5):
-        # implant.stim = PulseTrain(model.dt, freq=20, amp=amp, dur=sdur,
-        #                           pulse_dur=pdur, interphase_dur=pdur)
         stim = implant.prepare_stim(
             BiphasicPulseTrain(20, amp, pdur, interphase_dur=pdur,
                                stim_dur=sdur))
@@ -153,8 +151,6 @@ def test_Nanduri2012Temporal(scale_out):
 
     bright_freq = []
     for freq in np.linspace(0, 100, 5):
-        # implant.stim = PulseTrain(model.dt, freq=freq, amp=20, dur=sdur,
-        #                           pulse_dur=pdur, interphase_dur=pdur)
         stim = implant.prepare_stim(
             BiphasicPulseTrain(freq, 20, pdur, interphase_dur=pdur,
                                stim_dur=sdur))

--- a/pulse2percept/models/tests/test_nanduri2012.py
+++ b/pulse2percept/models/tests/test_nanduri2012.py
@@ -41,6 +41,14 @@ def test_Nanduri2012Spatial():
         Nanduri2012Spatial(implant=ProsthesisSystem(ElectrodeArray(
             [DiskElectrode(0, 0, 0, 100), PointSource(100, 100, 0)]))).build()
 
+    # The bound implant stays the caller's, so a build-time check alone would
+    # let a swapped array through to a kernel that reads a radius off it:
+    model = Nanduri2012Spatial(implant=ProsthesisSystem(ElectrodeArray(
+        DiskElectrode(0, 0, 0, 100))), step=5).build()
+    model.implant.earray = ElectrodeArray(PointSource(0, 0, 0))
+    with pytest.raises(TypeError):
+        model.predict_percept({0: 1})
+
     # Multiple frames are processed independently:
     model = Nanduri2012Spatial(implant=ArgusI(), atten_a=14000, step=5,
                                xrange=(-20, 20), yrange=(-15, 15))

--- a/pulse2percept/models/tests/test_nanduri2012.py
+++ b/pulse2percept/models/tests/test_nanduri2012.py
@@ -14,7 +14,7 @@ from pulse2percept.utils import FreezeError
 
 def test_Nanduri2012Spatial():
     # Nanduri2012Spatial automatically sets `atten_a`:
-    model = Nanduri2012Spatial(step=5)
+    model = Nanduri2012Spatial(implant=ArgusI(), step=5)
 
     # User can set `atten_a`:
     model.atten_a = 12345
@@ -23,31 +23,29 @@ def test_Nanduri2012Spatial():
     npt.assert_equal(model.atten_a, 987)
 
     # Nothing in, None out:
-    npt.assert_equal(model.predict_percept(ArgusI()), None)
+    npt.assert_equal(model.predict_percept(None), None)
 
     # Zero in = zero out:
-    implant = ArgusI(stim=np.zeros(16))
-    percept = model.predict_percept(implant)
+    percept = model.predict_percept(np.zeros(16))
     npt.assert_equal(isinstance(percept, Percept), True)
     npt.assert_equal(percept.shape, list(model.grid.x.shape) + [1])
     npt.assert_almost_equal(percept.data, 0)
 
-    # Only works for DiskElectrode arrays:
+    # Only works for DiskElectrode arrays, which is a fact about the implant
+    # the model is bound to, so it is caught when that model is built:
     with pytest.raises(TypeError):
-        implant = ProsthesisSystem(ElectrodeArray(PointSource(0, 0, 0)))
-        implant.stim = 1
-        model.predict_percept(implant)
+        Nanduri2012Spatial(
+            implant=ProsthesisSystem(ElectrodeArray(PointSource(0, 0, 0)))
+        ).build()
     with pytest.raises(TypeError):
-        implant = ProsthesisSystem(ElectrodeArray([DiskElectrode(0, 0, 0, 100),
-                                                   PointSource(100, 100, 0)]))
-        implant.stim = [1, 1]
-        model.predict_percept(implant)
+        Nanduri2012Spatial(implant=ProsthesisSystem(ElectrodeArray(
+            [DiskElectrode(0, 0, 0, 100), PointSource(100, 100, 0)]))).build()
 
     # Multiple frames are processed independently:
-    model = Nanduri2012Spatial(atten_a=14000, step=5,
+    model = Nanduri2012Spatial(implant=ArgusI(), atten_a=14000, step=5,
                                xrange=(-20, 20), yrange=(-15, 15))
     model.build()
-    percept = model.predict_percept(ArgusI(stim={'A1': [1, 2]}))
+    percept = model.predict_percept({'A1': [1, 2]})
     npt.assert_equal(percept.shape, list(model.grid.x.shape) + [2])
     pmax = percept.data.max(axis=(0, 1))
     npt.assert_almost_equal(percept.data[2, 3, :], pmax)
@@ -64,7 +62,7 @@ def test_Nanduri2012Spatial():
 
 
 def test_eq_Nanduri2012Spatial():
-    nanduri_spatial = Nanduri2012Spatial()
+    nanduri_spatial = Nanduri2012Spatial(implant=ArgusI())
 
     # Assert not equal for differing classes
     npt.assert_equal(nanduri_spatial == int, False)
@@ -81,13 +79,13 @@ def test_eq_Nanduri2012Spatial():
     npt.assert_equal(nanduri_spatial == copied, True)
 
     # Assert differing objects aren't equal
-    differing_model = Nanduri2012Model()
+    differing_model = Nanduri2012Model(implant=ArgusI())
     differing_model.xrange = (-10, 10)
     npt.assert_equal(nanduri_spatial == differing_model, False)
 
 
 def test_deepcopy_Nanduri2012Spatial():
-    original = Nanduri2012Spatial()
+    original = Nanduri2012Spatial(implant=ArgusI())
     copied = copy.deepcopy(original)
 
     # Assert these are two different objects
@@ -114,11 +112,11 @@ def test_Nanduri2012Temporal(scale_out):
         model.rho = 100
 
     # Nothing in, None out:
-    npt.assert_equal(model.predict_percept(ArgusI().stim), None)
+    npt.assert_equal(model.predict_percept(ArgusI().prepare_stim(None)), None)
 
     # Zero in = zero out:
-    implant = ArgusI(stim=np.zeros((16, 100)))
-    percept = model.predict_percept(implant.stim, t_percept=[0, 1, 2])
+    stim = ArgusI().prepare_stim(np.zeros((16, 100)))
+    percept = model.predict_percept(stim, t_percept=[0, 1, 2])
     npt.assert_equal(isinstance(percept, Percept), True)
     npt.assert_equal(percept.shape, (16, 1, 3))
     npt.assert_almost_equal(percept.data, 0)
@@ -127,8 +125,8 @@ def test_Nanduri2012Temporal(scale_out):
     # loop, because `idx_frame` is incremented after a write; also doesn't
     # make much sense):
     with pytest.raises(ValueError):
-        implant.stim = np.ones((16, 100))
-        model.predict_percept(implant.stim, t_percept=[0.2, 0.2])
+        model.predict_percept(ArgusI().prepare_stim(np.ones((16, 100))),
+                              t_percept=[0.2, 0.2])
 
     # Brightness scales differently with amplitude vs frequency:
     model = Nanduri2012Temporal(dt=5e-3, scale_out=scale_out)
@@ -141,9 +139,10 @@ def test_Nanduri2012Temporal(scale_out):
     for amp in np.linspace(0, 50, 5):
         # implant.stim = PulseTrain(model.dt, freq=20, amp=amp, dur=sdur,
         #                           pulse_dur=pdur, interphase_dur=pdur)
-        implant.stim = BiphasicPulseTrain(20, amp, pdur, interphase_dur=pdur,
-                                          stim_dur=sdur)
-        percept = model.predict_percept(implant.stim, t_percept=t_percept)
+        stim = implant.prepare_stim(
+            BiphasicPulseTrain(20, amp, pdur, interphase_dur=pdur,
+                               stim_dur=sdur))
+        percept = model.predict_percept(stim, t_percept=t_percept)
         bright_amp.append(percept.data.max())
     # These shifted by under 1.5% in 0.10.0, when the kernel stopped advancing
     # only one stimulus frame per simulation step: a pulse edge and the sample
@@ -156,9 +155,10 @@ def test_Nanduri2012Temporal(scale_out):
     for freq in np.linspace(0, 100, 5):
         # implant.stim = PulseTrain(model.dt, freq=freq, amp=20, dur=sdur,
         #                           pulse_dur=pdur, interphase_dur=pdur)
-        implant.stim = BiphasicPulseTrain(freq, 20, pdur, interphase_dur=pdur,
-                                          stim_dur=sdur)
-        percept = model.predict_percept(implant.stim, t_percept=t_percept)
+        stim = implant.prepare_stim(
+            BiphasicPulseTrain(freq, 20, pdur, interphase_dur=pdur,
+                               stim_dur=sdur))
+        percept = model.predict_percept(stim, t_percept=t_percept)
         bright_freq.append(percept.data.max())
     bright_freq_ref = np.array([0.0, 0.03892, 0.07297, 0.10686, 0.13841])
     npt.assert_almost_equal(bright_freq, scale_out * bright_freq_ref,
@@ -180,7 +180,7 @@ def test_deepcopy_Nanduri2012Temporal():
     npt.assert_equal(original != copied, True)
 
 def test_Nanduri2012Model():
-    model = Nanduri2012Model(step=5)
+    model = Nanduri2012Model(implant=ArgusI(), step=5)
     npt.assert_equal(hasattr(model, 'has_time'), True)
     npt.assert_equal(model.has_time, True)
 
@@ -208,7 +208,7 @@ def test_Nanduri2012Model():
 
 
 def test_deepcopy_Nanduri2012Model():
-    original = Nanduri2012Model()
+    original = Nanduri2012Model(implant=ArgusI())
     copied = copy.deepcopy(original)
 
     # Assert these are two different objects
@@ -224,68 +224,70 @@ def test_deepcopy_Nanduri2012Model():
 
 def test_Nanduri2012Model_predict_percept():
     # Nothing in = nothing out:
-    model = Nanduri2012Model(xrange=(0, 0), yrange=(0, 0))
+    model = Nanduri2012Model(implant=ArgusI(), xrange=(0, 0), yrange=(0, 0))
     model.build()
-    implant = ArgusI(stim=None)
-    npt.assert_equal(model.predict_percept(implant), None)
-    implant.stim = np.zeros(16)
-    npt.assert_almost_equal(model.predict_percept(implant).data, 0)
+    npt.assert_equal(model.predict_percept(None), None)
+    npt.assert_almost_equal(model.predict_percept(np.zeros(16)).data, 0)
 
     # Single-pixel model same as TemporalModel:
-    implant = ProsthesisSystem(DiskElectrode(0, 0, 0, 100))
-    # implant.stim = PulseTrain(5e-6)
-    implant.stim = BiphasicPulseTrain(20, 20, 0.45, interphase_dur=0.45)
+    single = ProsthesisSystem(DiskElectrode(0, 0, 0, 100))
+    model = Nanduri2012Model(implant=single, xrange=(0, 0), yrange=(0, 0))
+    model.build()
+    train = BiphasicPulseTrain(20, 20, 0.45, interphase_dur=0.45)
     t_percept = [0, 0.01, 1.0]
-    percept = model.predict_percept(implant, t_percept=t_percept)
+    percept = model.predict_percept(train, t_percept=t_percept)
     temp = Nanduri2012Temporal().build()
-    temp = temp.predict_percept(implant.stim, t_percept=t_percept)
+    temp = temp.predict_percept(single.prepare_stim(train),
+                                t_percept=t_percept)
     npt.assert_almost_equal(percept.data, temp.data, decimal=4)
 
-    # Only works for DiskElectrode arrays:
+    # Only works for DiskElectrode arrays, which the bound implant either is
+    # or is not, so it is caught when the model is built:
     with pytest.raises(TypeError):
-        implant = ProsthesisSystem(ElectrodeArray(PointSource(0, 0, 0)))
-        implant.stim = 1
-        model.predict_percept(implant)
+        Nanduri2012Model(
+            implant=ProsthesisSystem(ElectrodeArray(PointSource(0, 0, 0))),
+            xrange=(0, 0), yrange=(0, 0)).build()
     with pytest.raises(TypeError):
-        implant = ProsthesisSystem(ElectrodeArray([DiskElectrode(0, 0, 0, 100),
-                                                   PointSource(100, 100, 0)]))
-        implant.stim = [1, 1]
-        model.predict_percept(implant)
+        Nanduri2012Model(implant=ProsthesisSystem(ElectrodeArray(
+            [DiskElectrode(0, 0, 0, 100), PointSource(100, 100, 0)])),
+            xrange=(0, 0), yrange=(0, 0)).build()
 
     # Requested times must be multiples of model.dt:
     implant = ProsthesisSystem(ElectrodeArray(DiskElectrode(0, 0, 0, 260)))
-    # implant.stim = PulseTrain(tsample)
-    implant.stim = BiphasicPulseTrain(20, 20, 0.45)
+    model = Nanduri2012Model(implant=implant, xrange=(0, 0), yrange=(0, 0))
+    model.build()
+    train = BiphasicPulseTrain(20, 20, 0.45)
     model.temporal.dt = 0.1
     with pytest.raises(ValueError):
-        model.predict_percept(implant, t_percept=[0.01])
+        model.predict_percept(train, t_percept=[0.01])
     with pytest.raises(ValueError):
-        model.predict_percept(implant, t_percept=[0.01, 1.0])
+        model.predict_percept(train, t_percept=[0.01, 1.0])
     with pytest.raises(ValueError):
-        model.predict_percept(implant, t_percept=np.arange(0, 0.5, 0.101))
-    model.predict_percept(implant, t_percept=np.arange(0, 0.5, 1.0000001))
+        model.predict_percept(train, t_percept=np.arange(0, 0.5, 0.101))
+    model.predict_percept(train, t_percept=np.arange(0, 0.5, 1.0000001))
 
     # Can't request the same time more than once (this would break the Cython
     # loop, because `idx_frame` is incremented after a write; also doesn't
     # make much sense):
     with pytest.raises(ValueError):
-        model.predict_percept(implant, t_percept=[0.2, 0.2])
+        model.predict_percept(train, t_percept=[0.2, 0.2])
 
     # It's ok to extrapolate beyond `stim` if the `extrapolate` flag is set:
     model.temporal.dt = 1e-2
-    npt.assert_almost_equal(model.predict_percept(implant,
+    npt.assert_almost_equal(model.predict_percept(train,
                                                   t_percept=10000).data, 0)
 
     # Output shape must be determined by t_percept:
-    npt.assert_equal(model.predict_percept(implant, t_percept=0).shape,
+    npt.assert_equal(model.predict_percept(train, t_percept=0).shape,
                      (1, 1, 1))
-    npt.assert_equal(model.predict_percept(implant, t_percept=[0, 1]).shape,
+    npt.assert_equal(model.predict_percept(train, t_percept=[0, 1]).shape,
                      (1, 1, 2))
 
     # Brightness vs. size (use values from Nanduri paper):
-    model = Nanduri2012Model(step=0.5, xrange=(-4, 4), yrange=(-4, 4))
-    model.build()
     implant = ProsthesisSystem(ElectrodeArray(DiskElectrode(0, 0, 0, 260)))
+    model = Nanduri2012Model(implant=implant, step=0.5, xrange=(-4, 4),
+                             yrange=(-4, 4))
+    model.build()
     amp_th = 30
     bright_th = 0.107
     stim_dur = 1000.0
@@ -294,10 +296,9 @@ def test_Nanduri2012Model_predict_percept():
     amp_factors = [1, 6]
     frames_amp = []
     for amp_f in amp_factors:
-        implant.stim = BiphasicPulseTrain(20, amp_f * amp_th, pdur,
-                                          interphase_dur=pdur,
-                                          stim_dur=stim_dur)
-        percept = model.predict_percept(implant, t_percept=t_percept)
+        train = BiphasicPulseTrain(20, amp_f * amp_th, pdur,
+                                   interphase_dur=pdur, stim_dur=stim_dur)
+        percept = model.predict_percept(train, t_percept=t_percept)
         idx_frame = np.argmax(np.max(percept.data, axis=(0, 1)))
         brightest_frame = percept.data[..., idx_frame]
         frames_amp.append(brightest_frame)
@@ -305,10 +306,9 @@ def test_Nanduri2012Model_predict_percept():
     freqs = [20, 120]
     frames_freq = []
     for freq in freqs:
-        implant.stim = BiphasicPulseTrain(freq, 1.25 * amp_th, pdur,
-                                          interphase_dur=pdur,
-                                          stim_dur=stim_dur)
-        percept = model.predict_percept(implant, t_percept=t_percept)
+        train = BiphasicPulseTrain(freq, 1.25 * amp_th, pdur,
+                                   interphase_dur=pdur, stim_dur=stim_dur)
+        percept = model.predict_percept(train, t_percept=t_percept)
         idx_frame = np.argmax(np.max(percept.data, axis=(0, 1)))
         brightest_frame = percept.data[..., idx_frame]
         frames_freq.append(brightest_frame)

--- a/pulse2percept/models/tests/test_scene.py
+++ b/pulse2percept/models/tests/test_scene.py
@@ -604,15 +604,6 @@ def test_per_frame_gaze_moves_the_eye_between_video_frames():
         seen_by(model, scene_of(), gaze=gaze)
 
 
-def test_find_threshold_works_on_a_scene_capable_model():
-    """A scene is trial input, so it takes nothing away from thresholding"""
-    model = model_for(implant_at(0, 0))
-    amp_th = model.find_threshold(
-        model.implant.prepare_stim(BiphasicPulse(20, 0.45)), 0.1,
-        amp_range=(0, 200), amp_tol=1)
-    npt.assert_equal(0 < amp_th < 200, True)
-
-
 def test_a_bound_implant_survives_a_deepcopy():
     """A copied model describes the same physical implant"""
     from copy import deepcopy

--- a/pulse2percept/models/tests/test_scene.py
+++ b/pulse2percept/models/tests/test_scene.py
@@ -15,7 +15,7 @@ from pulse2percept.implants import (ElectrodeGrid, PointSource,
                                     ProsthesisSystem)
 from pulse2percept.models import (FadingTemporal, Model, NotBuiltError,
                                   ScoreboardModel, ScoreboardSpatial)
-from pulse2percept.models.base import _scene_driven_implant
+from pulse2percept.models.base import _scene_stim
 from pulse2percept.models.cortex import ScoreboardModel as CortexScoreboard
 from pulse2percept.percepts import Percept
 from pulse2percept.stimuli import (AmplitudeEncoder, BiphasicPulse,
@@ -71,38 +71,37 @@ def implant_at(x_um=0, y_um=0, encoder=True):
         encoder=AmplitudeEncoder(amp_range=(0, AMP_MAX)) if encoder else None)
 
 
-def model_for(scene, **kwargs):
+def model_for(implant, **kwargs):
     # An explicit `vfmap`: the retinotopy is what the expected values below
     # are computed through, so it cannot be left to a default.
     params = {'rho': 200, 'xrange': (-3, 3), 'yrange': (-3, 3), 'step': 1,
               'vfmap': Curcio1990Map()}
     params.update(kwargs)
-    return ScoreboardModel(scene=scene, **params).build()
+    return ScoreboardModel(implant=implant, **params).build()
 
 
-def seen_by(model, implant, gaze=None):
+def seen_by(model, scene, gaze=None):
     """The gray level each electrode was handed, in electrode order
 
     Read back off the amplitudes the encoder produced, which is the only place
     the sampled scene shows up once registration is over.
     """
-    trial = _scene_driven_implant(model, implant, gaze)
-    view = trial.stim._spatial_view()
+    view = _scene_stim(model, scene, gaze)._spatial_view()
     return np.asarray(view.data, dtype=float).reshape(
-        (len(trial.electrode_names), -1)) / AMP_MAX
+        (len(model.implant.electrode_names), -1)) / AMP_MAX
 
 
 def test_the_model_supplies_its_own_vfmap():
     """The caller never names a retinotopy; the model already has one"""
     scene = scene_of()
     implant = implant_at(*Curcio1990Map().dva_to_ret(6.0, 0.0))
-    npt.assert_almost_equal(seen_by(model_for(scene), implant),
+    npt.assert_almost_equal(seen_by(model_for(implant), scene),
                             [[ramp_at(6.0)]], decimal=4)
     # Give the model a different retinotopy and the same electrode reads a
     # different part of the scene, with nothing else changing and nothing
     # about the map appearing at the call site:
-    watson = model_for(scene, vfmap=Watson2014Map())
-    npt.assert_equal(np.allclose(seen_by(watson, implant), ramp_at(6.0)),
+    watson = model_for(implant, vfmap=Watson2014Map())
+    npt.assert_equal(np.allclose(seen_by(watson, scene), ramp_at(6.0)),
                      False)
 
 
@@ -111,27 +110,28 @@ def test_a_nonlinear_retinal_map_still_registers(x_dva):
     """Not 280 um/dva, and not linear either"""
     vfmap = SquareMap()
     implant = implant_at(*vfmap.dva_to_ret(x_dva, 0.0))
-    model = model_for(scene_of(), vfmap=vfmap)
-    npt.assert_almost_equal(seen_by(model, implant), [[ramp_at(x_dva)]],
+    model = model_for(implant, vfmap=vfmap)
+    npt.assert_almost_equal(seen_by(model, scene_of()), [[ramp_at(x_dva)]],
                             decimal=4)
 
 
 def test_gaze_moves_the_scene_past_the_implant():
     """Gaze is the scene point on the fovea, so scene = visual field + gaze"""
-    model = model_for(scene_of())
-    implant = implant_at(0, 0)
+    scene = scene_of()
+    model = model_for(implant_at(0, 0))
     for gaze_x in (-4.0, 0.0, 6.0):
-        npt.assert_almost_equal(seen_by(model, implant, gaze=(gaze_x, 0)),
+        npt.assert_almost_equal(seen_by(model, scene, gaze=(gaze_x, 0)),
                                 [[ramp_at(gaze_x)]], decimal=4)
     # Units at the boundary, and the same answer through them:
-    npt.assert_almost_equal(seen_by(model, implant, gaze=(6, 0) * dva),
-                            seen_by(model, implant, gaze=(6.0, 0.0)))
+    npt.assert_almost_equal(seen_by(model, scene, gaze=(6, 0) * dva),
+                            seen_by(model, scene, gaze=(6.0, 0.0)))
     # Several electrodes keep their separation in the visual field whatever
     # the gaze: shifting gaze shifts what all of them see by the same amount.
     grid = ProsthesisSystem(ElectrodeGrid((1, 3), 280),
                             encoder=AmplitudeEncoder(amp_range=(0, AMP_MAX)))
-    here = seen_by(model, grid).ravel()
-    there = seen_by(model, grid, gaze=(2, 0)).ravel()
+    on_grid = model_for(grid)
+    here = seen_by(on_grid, scene).ravel()
+    there = seen_by(on_grid, scene, gaze=(2, 0)).ravel()
     npt.assert_almost_equal(np.diff(here), np.diff(there), decimal=4)
     npt.assert_almost_equal(there - here, ramp_at(2) - ramp_at(0), decimal=4)
 
@@ -140,11 +140,11 @@ def test_y_orientation_survives_the_map():
     """Row 0 of the scene is +y in the visual field, both sides of the map"""
     data = np.tile(np.linspace(0, 1, SCENE_PX).reshape((-1, 1)),
                    (1, SCENE_PX))
-    model = model_for(scene_of(ImageStimulus(data)))
+    scene = scene_of(ImageStimulus(data))
     vfmap = Curcio1990Map()
     for y_dva in (5.0, -5.0):
         implant = implant_at(*vfmap.dva_to_ret(0.0, y_dva))
-        npt.assert_almost_equal(seen_by(model, implant),
+        npt.assert_almost_equal(seen_by(model_for(implant), scene),
                                 [[(HALF - y_dva) / (2 * HALF)]], decimal=4)
 
 
@@ -156,35 +156,33 @@ def test_color_becomes_luminance_only_at_the_device():
     npt.assert_almost_equal(scene._sample_at(0.0, 0.0)[0, :, 0], [1, 0, 0],
                             decimal=5)
     # ... and the luminance of pure red reaches the implant:
-    npt.assert_almost_equal(seen_by(model_for(scene), implant_at(0, 0)),
+    npt.assert_almost_equal(seen_by(model_for(implant_at(0, 0)), scene),
                             [[0.2125]], decimal=3)
 
 
 def test_scene_driven_prediction_leaves_the_implant_alone():
     """Predicting what someone sees is a question, not an assignment"""
-    model = model_for(scene_of())
     implant = implant_at(0, 0)
-    npt.assert_equal(implant.stim, None)
-    model.predict_percept(implant)
-    npt.assert_equal(implant.stim, None)
-    # ... and an implant that already had a stimulus keeps exactly that one:
-    implant.stim = BiphasicPulse(20, 0.45)
-    before = implant.stim.data.copy()
-    model.predict_percept(implant)
-    npt.assert_array_equal(implant.stim.data, before)
+    model = model_for(implant)
+    model.predict_percept(scene_of())
+    # The implant holds no trial state to be disturbed, and the settings the
+    # scene path temporarily overrides are back the way the caller left them:
+    npt.assert_equal(hasattr(implant, 'stim'), False)
+    npt.assert_equal(implant.preprocess, False)
+    npt.assert_equal(model.implant is implant, True)
 
 
 def test_a_scene_driven_stimulus_still_goes_through_the_device():
-    """The stand-in implant is assigned to, not written behind"""
+    """The sampled scene is prepared by the implant, not written behind it"""
     grid = ProsthesisSystem(ElectrodeGrid((1, 3), 280),
                             encoder=AmplitudeEncoder(amp_range=(0, AMP_MAX)))
     grid.deactivate('A2')
-    trial = _scene_driven_implant(model_for(scene_of()), grid, None)
-    npt.assert_equal('A2' in list(trial.stim.electrodes), False)
-    npt.assert_equal(len(trial.stim.electrodes), 2)
-    # It is a current by the time it is stored, which is the encoder having
-    # run inside the setter:
-    npt.assert_equal(trial.stim.unit, grid.stimulus_unit)
+    stim = _scene_stim(model_for(grid), scene_of(), None)
+    npt.assert_equal('A2' in list(stim.electrodes), False)
+    npt.assert_equal(len(stim.electrodes), 2)
+    # It is a current by the time it comes back, which is the encoder having
+    # run inside `prepare_stim`:
+    npt.assert_equal(stim.unit, grid.stimulus_unit)
 
 
 def edge_source():
@@ -200,17 +198,17 @@ def test_preprocessing_runs_on_the_picture_not_on_electrode_values():
     at_edge = implant_at(*Curcio1990Map().dva_to_ret(0.5, 0.0))
     inside = implant_at(*Curcio1990Map().dva_to_ret(10.0, 0.0))
     # Untouched, the two electrodes see the two sides of the step:
-    npt.assert_almost_equal(seen_by(model_for(scene), at_edge), [[0.5]],
+    npt.assert_almost_equal(seen_by(model_for(at_edge), scene), [[0.5]],
                             decimal=3)
-    npt.assert_almost_equal(seen_by(model_for(scene), inside), [[1.0]],
+    npt.assert_almost_equal(seen_by(model_for(inside), scene), [[1.0]],
                             decimal=3)
     for implant in (at_edge, inside):
         implant.preprocess = lambda stim: stim.filter('sobel')
-    model = model_for(scene)
     # Sobel puts everything at the edge and nothing in the flat interior,
     # which is the opposite ordering from the raw scene:
-    npt.assert_equal(seen_by(model, at_edge)[0, 0] > 0.3, True)
-    npt.assert_almost_equal(seen_by(model, inside), [[0.0]], decimal=4)
+    npt.assert_equal(seen_by(model_for(at_edge), scene)[0, 0] > 0.3, True)
+    npt.assert_almost_equal(seen_by(model_for(inside), scene), [[0.0]],
+                            decimal=4)
 
 
 def test_preprocessing_does_not_reach_native_vision():
@@ -219,12 +217,12 @@ def test_preprocessing_does_not_reach_native_vision():
     scene = scene_of(source, scotoma=Scotoma.circle(6), scotoma_fill=0.0)
     implant = implant_at(*Curcio1990Map().dva_to_ret(0.0, 0.0))
     implant.preprocess = lambda stim: stim.invert()
-    model = model_for(scene, rho=100)
+    model = model_for(implant, rho=100)
     # The electrode is at the fovea, where the ramp reads 0.5 either way, so
     # look somewhere the inversion actually shows:
-    npt.assert_almost_equal(seen_by(model, implant, gaze=(8, 0)),
+    npt.assert_almost_equal(seen_by(model, scene, gaze=(8, 0)),
                             [[1 - ramp_at(8.0)]], decimal=3)
-    percept = model.predict_percept(implant, gaze=(8, 0) * dva, vmax=100)
+    percept = model.predict_percept(scene, gaze=(8, 0) * dva, vmax=100)
     # Outside the scotoma: the original scene, bit for bit and uninverted.
     original = np.repeat(source.data.reshape((SCENE_PX, SCENE_PX, 1)), 3,
                          axis=-1)
@@ -246,11 +244,12 @@ def test_preprocessing_runs_exactly_once():
     scene = scene_of()
     implant = implant_at(0, 0)
     implant.preprocess = counted
-    model_for(scene).predict_percept(implant)
+    model = model_for(implant)
+    model.predict_percept(scene)
     npt.assert_equal(len(calls), 1)
     # Inversion is not idempotent, so a second pass would show up as the
     # original ramp coming back:
-    npt.assert_almost_equal(seen_by(model_for(scene), implant, gaze=(8, 0)),
+    npt.assert_almost_equal(seen_by(model, scene, gaze=(8, 0)),
                             [[1 - ramp_at(8.0)]], decimal=3)
     # The caller's implant still preprocesses; only the stand-in was told not
     # to, and only because it had already happened:
@@ -263,7 +262,7 @@ def test_a_video_scene_is_preprocessed_the_same_way():
     scene = scene_of(VideoStimulus(frames, time=[0, 100]))
     implant = implant_at(0, 0)
     implant.preprocess = lambda stim: stim.invert()
-    seen = seen_by(model_for(scene), implant)
+    seen = seen_by(model_for(implant), scene)
     npt.assert_equal(seen.shape, (1, 2))
     npt.assert_almost_equal(seen.ravel(), [0.8, 0.2], decimal=3)
 
@@ -276,7 +275,7 @@ def test_scene_preprocessing_must_return_a_picture(returns):
     implant = implant_at(0, 0)
     implant.preprocess = returns
     with pytest.raises(TypeError) as excinfo:
-        model_for(scene).predict_percept(implant)
+        model_for(implant).predict_percept(scene)
     npt.assert_equal('preprocess' in str(excinfo.value), True)
     npt.assert_equal('encoder' in str(excinfo.value), True)
 
@@ -287,7 +286,7 @@ def test_scene_preprocessing_must_preserve_spatial_shape():
     implant = implant_at(0, 0)
     implant.preprocess = lambda stim: stim.resize((20, 20))
     with pytest.raises(ValueError) as excinfo:
-        model_for(scene).predict_percept(implant)
+        model_for(implant).predict_percept(scene)
     npt.assert_equal('shape' in str(excinfo.value), True)
 
 
@@ -300,13 +299,13 @@ def test_scene_preprocessing_must_preserve_the_frame_clock():
     implant.preprocess = lambda stim: VideoStimulus(
         stim.data.reshape(stim.vid_shape)[..., :1], time=stim.time[:1])
     with pytest.raises(ValueError) as excinfo:
-        model_for(scene).predict_percept(implant)
+        model_for(implant).predict_percept(scene)
     npt.assert_equal('frame' in str(excinfo.value), True)
     # The same instants told in seconds rather than milliseconds are the same
     # clock, and stay allowed:
     implant.preprocess = lambda stim: VideoStimulus(
         1 - stim.data.reshape(stim.vid_shape), time=stim.time / 1000 * s)
-    npt.assert_almost_equal(seen_by(model_for(scene), implant).ravel(),
+    npt.assert_almost_equal(seen_by(model_for(implant), scene).ravel(),
                             [0.8, 0.2], decimal=3)
 
 
@@ -314,70 +313,80 @@ def test_a_scene_needs_an_encoder_and_a_retina():
     """Both failures name what is missing rather than dying downstream"""
     scene = scene_of()
     with pytest.raises(ValueError) as excinfo:
-        model_for(scene).predict_percept(implant_at(0, 0, encoder=False))
+        model_for(implant_at(0, 0, encoder=False)).predict_percept(scene)
     npt.assert_equal('encoder' in str(excinfo.value), True)
     # A cortical model has no retinotopy to follow an electrode out along:
-    cortical = CortexScoreboard(scene=scene, rho=200, xrange=(-3, 3),
-                                yrange=(-3, 3), step=1).build()
+    cortical = CortexScoreboard(implant=implant_at(0, 0), rho=200,
+                                xrange=(-3, 3), yrange=(-3, 3),
+                                step=1).build()
     with pytest.raises(ValueError) as excinfo:
-        cortical.predict_percept(implant_at(0, 0))
+        cortical.predict_percept(scene)
     npt.assert_equal('vfmap' in str(excinfo.value), True)
     # ... and neither has a temporal-only model:
     from pulse2percept.models import Nanduri2012Temporal
-    temporal = Model(temporal=Nanduri2012Temporal(), scene=scene).build()
+    temporal = Model(temporal=Nanduri2012Temporal()).build()
     with pytest.raises(ValueError):
-        temporal.predict_percept(implant_at(0, 0))
+        temporal.predict_percept(scene)
 
 
 def test_an_unbuilt_model_says_so_before_it_samples_anything():
     """The oldest mistake is reported first, not after two newer ones"""
-    unbuilt = ScoreboardModel(scene=scene_of(), rho=200, xrange=(-3, 3),
-                              yrange=(-3, 3), step=1)
+    unbuilt = ScoreboardModel(implant=implant_at(0, 0), rho=200,
+                              xrange=(-3, 3), yrange=(-3, 3), step=1)
     with pytest.raises(NotBuiltError):
-        unbuilt.predict_percept(implant_at(0, 0))
+        unbuilt.predict_percept(scene_of())
     # ... including when there is a newer mistake waiting behind it:
+    unbuilt = ScoreboardModel(implant=implant_at(0, 0, encoder=False),
+                              rho=200, xrange=(-3, 3), yrange=(-3, 3), step=1)
     with pytest.raises(NotBuiltError):
-        unbuilt.predict_percept(implant_at(0, 0, encoder=False))
+        unbuilt.predict_percept(scene_of())
 
 
-def test_a_scene_must_be_a_scene():
-    with pytest.raises(TypeError):
-        ScoreboardModel(scene=ramp_source())
+def test_an_ordinary_source_is_not_registered_as_a_scene():
+    """Only a Scene takes the registration path; a picture is stimulation"""
+    grid = ProsthesisSystem(ElectrodeGrid((3, 3), 280),
+                            encoder=AmplitudeEncoder(amp_range=(0, AMP_MAX)))
+    model = model_for(grid)
+    # The same pixels, not wrapped in a Scene, are sampled onto the electrodes
+    # and encoded rather than registered through the retinotopy, so `gaze` is
+    # not a thing that can be asked of them:
+    percept = model.predict_percept(ramp_source())
+    npt.assert_equal(percept.is_rgb, False)
+    npt.assert_equal(percept.data.ndim, 3)
+    with pytest.raises(ValueError):
+        model.predict_percept(ramp_source(), gaze=(1, 0))
 
 
 def test_without_a_scene_nothing_changes():
-    """The legacy path is untouched, and scene arguments are refused"""
-    implant = implant_at(0, 0)
-    implant.stim = BiphasicPulse(20, 0.45)
-    plain = ScoreboardModel(rho=200, xrange=(-3, 3), yrange=(-3, 3),
-                            step=1).build()
-    npt.assert_equal(plain.scene, None)
-    percept = plain.predict_percept(implant)
+    """The ordinary path is untouched, and scene arguments are refused"""
+    plain = ScoreboardModel(implant=implant_at(0, 0), rho=200,
+                            xrange=(-3, 3), yrange=(-3, 3), step=1).build()
+    percept = plain.predict_percept(BiphasicPulse(20, 0.45))
     npt.assert_equal(percept.is_rgb, False)
     npt.assert_equal(percept.data.ndim, 3)
     for kwargs in ({'gaze': (1, 0)}, {'vmax': 20}, {'vmin': 3}):
         with pytest.raises(ValueError):
-            plain.predict_percept(implant, **kwargs)
-    # A model with no stimulus at all still says nothing rather than raising:
-    npt.assert_equal(plain.predict_percept(implant_at(0, 0)), None)
+            plain.predict_percept(BiphasicPulse(20, 0.45), **kwargs)
+    # No stimulus at all still says nothing rather than raising:
+    npt.assert_equal(plain.predict_percept(None), None)
 
 
 def test_a_scene_without_a_scotoma_returns_the_prosthetic_percept():
     """Nothing is lost, so there is nothing to compose into"""
-    model = model_for(scene_of())
-    percept = model.predict_percept(implant_at(0, 0))
+    model = model_for(implant_at(0, 0))
+    percept = model.predict_percept(scene_of())
     npt.assert_equal(percept.is_rgb, False)
     npt.assert_equal(percept.data.ndim, 3)
     # On the model's grid, not the scene's:
     npt.assert_equal(percept.shape[:2], model.spatial.grid.shape)
     # `vmax` is meaningless here and is simply unused:
     npt.assert_array_equal(
-        model.predict_percept(implant_at(0, 0), vmax=20).data, percept.data)
+        model.predict_percept(scene_of(), vmax=20).data, percept.data)
 
 
 def test_a_scene_with_a_scotoma_returns_a_composed_rgb_percept():
     scene = scene_of(scotoma=Scotoma.circle(6), scotoma_fill=0.0)
-    percept = model_for(scene).predict_percept(implant_at(0, 0), vmax=20)
+    percept = model_for(implant_at(0, 0)).predict_percept(scene, vmax=20)
     npt.assert_equal(percept.is_rgb, True)
     npt.assert_equal(percept.shape, (SCENE_PX, SCENE_PX, 3, 1))
     npt.assert_equal(percept.data.min() >= 0, True)
@@ -389,9 +398,9 @@ def test_a_scene_with_a_scotoma_returns_a_composed_rgb_percept():
 
 def test_vmax_is_required_for_a_composed_percept():
     scene = scene_of(scotoma=Scotoma.circle(6))
-    model = model_for(scene)
+    model = model_for(implant_at(0, 0))
     with pytest.raises(ValueError) as excinfo:
-        model.predict_percept(implant_at(0, 0))
+        model.predict_percept(scene)
     npt.assert_equal('vmax' in str(excinfo.value), True)
 
 
@@ -400,7 +409,7 @@ def test_the_intact_periphery_is_the_scene_exactly():
     rng = np.random.default_rng(0)
     rgb = ImageStimulus(rng.random((SCENE_PX, SCENE_PX, 3)))
     scene = scene_of(rgb, scotoma=Scotoma.circle(6))
-    percept = model_for(scene).predict_percept(implant_at(0, 0), vmax=20)
+    percept = model_for(implant_at(0, 0)).predict_percept(scene, vmax=20)
     source = rgb.data.reshape((SCENE_PX, SCENE_PX, 3))
     x, y = scene._pixel_centers()
     intact = scene.scotoma(x, y) == 0
@@ -411,10 +420,11 @@ def test_the_phosphene_lands_where_the_electrode_looks():
     """Position and y orientation, all the way through the composed result"""
     vfmap = Curcio1990Map()
     scene = scene_of(scotoma=Scotoma.circle(12), scotoma_fill=0.0)
-    model = model_for(scene, rho=80, xrange=(-8, 8), yrange=(-8, 8), step=0.5)
     for x_dva, y_dva in [(4.0, 0.0), (0.0, 4.0), (-4.0, 0.0), (0.0, -4.0)]:
         implant = implant_at(*vfmap.dva_to_ret(x_dva, y_dva))
-        frame = model.predict_percept(implant, vmax=2).data[..., 0]
+        model = model_for(implant, rho=80, xrange=(-8, 8), yrange=(-8, 8),
+                          step=0.5)
+        frame = model.predict_percept(scene, vmax=2).data[..., 0]
         row, col = int(round(HALF - y_dva)), int(round(x_dva + HALF))
         # Brightest where the electrode looks, dark on the opposite side:
         npt.assert_equal(frame[row, col].mean() > 0.5, True)
@@ -424,11 +434,10 @@ def test_the_phosphene_lands_where_the_electrode_looks():
 
 def test_gaze_moves_the_scotoma_and_the_phosphene_together():
     scene = scene_of(scotoma=Scotoma.circle(4), scotoma_fill=0.3)
-    model = model_for(scene, rho=100, xrange=(-2, 2), yrange=(-2, 2),
-                      step=0.5)
-    implant = implant_at(0, 0)
-    fixating = model.predict_percept(implant, vmax=2).data[..., 0]
-    shifted = model.predict_percept(implant, gaze=(5, 0) * dva,
+    model = model_for(implant_at(0, 0), rho=100, xrange=(-2, 2),
+                      yrange=(-2, 2), step=0.5)
+    fixating = model.predict_percept(scene, vmax=2).data[..., 0]
+    shifted = model.predict_percept(scene, gaze=(5, 0) * dva,
                                     vmax=2).data[..., 0]
     # The whole eye-centered pair travelled 5 degrees right across the scene:
     npt.assert_almost_equal(shifted[HALF, HALF + 5], fixating[HALF, HALF],
@@ -442,9 +451,8 @@ def test_gaze_moves_the_scotoma_and_the_phosphene_together():
 def test_a_fixed_vmax_does_not_renormalize_when_gaze_changes():
     """Nothing rescales the display behind the user's back"""
     scene = scene_of(scotoma=Scotoma.circle(12), scotoma_fill=0.0)
-    model = model_for(scene, rho=100, xrange=(-4, 4), yrange=(-4, 4),
-                      step=0.5)
-    implant = implant_at(0, 0)
+    model = model_for(implant_at(0, 0), rho=100, xrange=(-4, 4),
+                      yrange=(-4, 4), step=0.5)
 
     def phosphene(gaze_x, **kwargs):
         """The composed pixel the foveal electrode paints
@@ -453,7 +461,7 @@ def test_a_fixed_vmax_does_not_renormalize_when_gaze_changes():
         ``gaze_x``. That pixel is pure phosphene; the intact periphery would
         otherwise dominate any whole-frame maximum.
         """
-        percept = model.predict_percept(implant, gaze=(gaze_x, 0) * dva,
+        percept = model.predict_percept(scene, gaze=(gaze_x, 0) * dva,
                                         **kwargs)
         return float(percept.data[HALF, HALF + gaze_x, 0, 0])
 
@@ -473,9 +481,9 @@ def test_a_video_scene_keeps_its_own_timing():
                        for v in (0.2, 0.5, 0.9)], axis=-1)
     scene = scene_of(VideoStimulus(frames, time=[0, 100, 200]),
                      scotoma=Scotoma.circle(6), scotoma_fill=0.0)
-    model = model_for(scene, rho=150, xrange=(-4, 4), yrange=(-4, 4),
-                      step=0.5)
-    percept = model.predict_percept(implant_at(0, 0), vmax=200)
+    model = model_for(implant_at(0, 0), rho=150, xrange=(-4, 4),
+                      yrange=(-4, 4), step=0.5)
+    percept = model.predict_percept(scene, vmax=200)
     npt.assert_equal(percept.shape, (SCENE_PX, SCENE_PX, 3, 3))
     npt.assert_almost_equal(percept.time, [0, 100, 200])
     # Brighter frames make brighter phosphenes, in the right order. Read at
@@ -494,19 +502,20 @@ def test_a_spatiotemporal_model_composes_against_a_video_scene():
     scene = Scene(source, fov=(SCENE_PX, SCENE_PX),
                   scotoma=Scotoma.circle(6), scotoma_fill=0.0)
 
-    def spatiotemporal(sc):
-        return Model(spatial=ScoreboardSpatial(rho=200, xrange=(-4, 4),
+    def spatiotemporal():
+        return Model(implant=implant_at(0, 0),
+                     spatial=ScoreboardSpatial(rho=200, xrange=(-4, 4),
                                                yrange=(-4, 4), step=0.5,
                                                vfmap=Curcio1990Map()),
-                     temporal=FadingTemporal(), scene=sc).build()
+                     temporal=FadingTemporal()).build()
 
-    prosthetic = spatiotemporal(Scene(source, fov=(SCENE_PX, SCENE_PX)))
-    raw = prosthetic.predict_percept(implant_at(0, 0))
+    raw = spatiotemporal().predict_percept(
+        Scene(source, fov=(SCENE_PX, SCENE_PX)))
     # The premise: the two clocks really do differ, frame for frame.
     npt.assert_almost_equal(raw.time, [100, 200, 300])
     npt.assert_almost_equal(scene.time, [0, 100, 200])
 
-    percept = spatiotemporal(scene).predict_percept(implant_at(0, 0), vmax=5)
+    percept = spatiotemporal().predict_percept(scene, vmax=5)
     npt.assert_equal(percept.shape, (SCENE_PX, SCENE_PX, 3, 3))
     # The percept's clock describes the output, not the video's onsets:
     npt.assert_almost_equal(percept.time, [100, 200, 300])
@@ -516,12 +525,12 @@ def test_a_spatiotemporal_model_composes_against_a_video_scene():
 
 def test_a_temporal_stage_does_not_lose_the_visual_field_grid():
     """A percept rewritten frame by frame has not moved in the visual field"""
-    implant = implant_at(0, 0)
-    implant.stim = BiphasicPulseTrain(20, 30, 0.45, stim_dur=50)
-    model = Model(spatial=ScoreboardSpatial(rho=200, xrange=(-2, 2),
+    model = Model(implant=implant_at(0, 0),
+                  spatial=ScoreboardSpatial(rho=200, xrange=(-2, 2),
                                             yrange=(-2, 2), step=1),
                   temporal=FadingTemporal()).build()
-    percept = model.predict_percept(implant)
+    percept = model.predict_percept(
+        BiphasicPulseTrain(20, 30, 0.45, stim_dur=50))
     npt.assert_equal(percept._has_space, True)
     npt.assert_almost_equal(percept.xdva, [-2, -1, 0, 1, 2])
     npt.assert_almost_equal(percept.ydva, [-2, -1, 0, 1, 2])
@@ -531,8 +540,8 @@ def test_a_single_timed_percept_is_not_broadcast_over_a_video():
     """One frame at a named instant happened then, not throughout"""
     source = VideoStimulus(np.zeros((5, 5, 3)), time=[0, 10, 20])
     scene = Scene(source, fov=(5, 5), scotoma=Scotoma.circle(3))
-    grid = ScoreboardModel(xrange=(-2, 2), yrange=(-2, 2),
-                           step=1).build().spatial.grid
+    grid = ScoreboardModel(implant=implant_at(0, 0), xrange=(-2, 2),
+                           yrange=(-2, 2), step=1).build().spatial.grid
     at_10 = Percept(np.full((5, 5, 1), 20.0), space=grid, time=[10])
     with pytest.raises(ValueError) as excinfo:
         scene._compose(at_10, vmax=20)
@@ -551,8 +560,8 @@ def test_a_temporal_percept_must_cover_the_video():
     source = VideoStimulus(np.zeros((5, 5, 3)), time=[0, 10, 20])
     scene = Scene(source, fov=(5, 5), scotoma=Scotoma.circle(3))
     values = np.stack([np.full((5, 5), b) for b in (0.0, 20.0)], axis=-1)
-    grid = ScoreboardModel(xrange=(-2, 2), yrange=(-2, 2),
-                           step=1).build().spatial.grid
+    grid = ScoreboardModel(implant=implant_at(0, 0), xrange=(-2, 2),
+                           yrange=(-2, 2), step=1).build().spatial.grid
     short = Percept(values, space=grid, time=[5, 15])
     with pytest.raises(ValueError) as excinfo:
         scene._compose(short, vmax=20)
@@ -569,8 +578,8 @@ def test_the_time_range_check_crosses_units():
     """A percept in seconds is held against a video in milliseconds"""
     source = VideoStimulus(np.zeros((5, 5, 3)), time=[0, 10, 20])
     scene = Scene(source, fov=(5, 5), scotoma=Scotoma.circle(3))
-    grid = ScoreboardModel(xrange=(-2, 2), yrange=(-2, 2),
-                           step=1).build().spatial.grid
+    grid = ScoreboardModel(implant=implant_at(0, 0), xrange=(-2, 2),
+                           yrange=(-2, 2), step=1).build().spatial.grid
     values = np.stack([np.full((5, 5), b) for b in (0.0, 20.0)], axis=-1)
     # 0-20 ms is exactly 0-0.02 s:
     covering = Percept(values, space=grid, time=[0, 0.02], time_unit=s)
@@ -586,34 +595,31 @@ def test_per_frame_gaze_moves_the_eye_between_video_frames():
     frames = np.repeat(ramp_source().data.reshape(
         (SCENE_PX, SCENE_PX, 1)), 3, axis=-1)
     scene = scene_of(VideoStimulus(frames, time=[0, 100, 200]))
-    model = model_for(scene)
+    model = model_for(implant_at(0, 0))
     gaze = np.array([[-6.0, 0.0], [0.0, 0.0], [6.0, 0.0]])
-    seen = seen_by(model, implant_at(0, 0), gaze=gaze * dva)
+    seen = seen_by(model, scene, gaze=gaze * dva)
     npt.assert_almost_equal(seen.ravel(), ramp_at(gaze[:, 0]), decimal=4)
     # A still scene has one frame, so there is no per-frame gaze to give it:
     with pytest.raises(ValueError):
-        seen_by(model_for(scene_of()), implant_at(0, 0), gaze=gaze)
+        seen_by(model, scene_of(), gaze=gaze)
 
 
-def test_find_threshold_refuses_a_scene_model():
-    """Thresholding rescales a stimulus this model does not take from you"""
-    model = model_for(scene_of())
-    implant = implant_at(0, 0)
-    implant.stim = BiphasicPulse(20, 0.45)
-    with pytest.raises(NotImplementedError):
-        model.find_threshold(implant, 0.1)
+def test_find_threshold_works_on_a_scene_capable_model():
+    """A scene is trial input, so it takes nothing away from thresholding"""
+    model = model_for(implant_at(0, 0))
+    amp_th = model.find_threshold(
+        model.implant.prepare_stim(BiphasicPulse(20, 0.45)), 0.1,
+        amp_range=(0, 200), amp_tol=1)
+    npt.assert_equal(0 < amp_th < 200, True)
 
 
-def test_a_scene_survives_a_deepcopy():
-    """Scene is composite state, so it must not reach the sub-models"""
+def test_a_bound_implant_survives_a_deepcopy():
+    """A copied model describes the same physical implant"""
     from copy import deepcopy
-    scene = scene_of()
-    model = model_for(scene)
+    implant = implant_at(0, 0)
+    model = model_for(implant)
     copied = deepcopy(model)
-    npt.assert_equal(isinstance(copied.scene, Scene), True)
-    npt.assert_equal(copied.scene.fov, scene.fov)
-    npt.assert_almost_equal(seen_by(copied, implant_at(0, 0)),
-                            seen_by(model, implant_at(0, 0)))
-    # A Model built from components carries one just as well:
-    built = Model(spatial=ScoreboardSpatial(), scene=scene)
-    npt.assert_equal(built.scene is scene, True)
+    npt.assert_equal(copied.implant is implant, True)
+    npt.assert_equal(copied.is_built, True)
+    npt.assert_almost_equal(seen_by(copied, scene_of()),
+                            seen_by(model, scene_of()))

--- a/pulse2percept/models/tests/test_scene.py
+++ b/pulse2percept/models/tests/test_scene.py
@@ -13,8 +13,8 @@ import pytest
 
 from pulse2percept.implants import (ElectrodeGrid, PointSource,
                                     ProsthesisSystem)
-from pulse2percept.models import (FadingTemporal, Model, NotBuiltError,
-                                  ScoreboardModel, ScoreboardSpatial)
+from pulse2percept.models import (FadingTemporal, Model, ScoreboardModel,
+                                  ScoreboardSpatial)
 from pulse2percept.models.base import _scene_stim
 from pulse2percept.models.cortex import ScoreboardModel as CortexScoreboard
 from pulse2percept.percepts import Percept
@@ -329,16 +329,17 @@ def test_a_scene_needs_an_encoder_and_a_retina():
         temporal.predict_percept(scene)
 
 
-def test_an_unbuilt_model_says_so_before_it_samples_anything():
-    """The oldest mistake is reported first, not after two newer ones"""
+def test_an_unbuilt_model_builds_itself_before_it_samples_anything():
+    """A scene is sampled through a bound implant, so the build comes first"""
     unbuilt = ScoreboardModel(implant=implant_at(0, 0), rho=200,
                               xrange=(-3, 3), yrange=(-3, 3), step=1)
-    with pytest.raises(NotBuiltError):
-        unbuilt.predict_percept(scene_of())
-    # ... including when there is a newer mistake waiting behind it:
+    npt.assert_equal(unbuilt.predict_percept(scene_of()) is not None, True)
+    npt.assert_equal(unbuilt.is_built, True)
+    # An implant with no encoder still cannot turn gray levels into current,
+    # and that is now the first thing the caller hears about:
     unbuilt = ScoreboardModel(implant=implant_at(0, 0, encoder=False),
                               rho=200, xrange=(-3, 3), yrange=(-3, 3), step=1)
-    with pytest.raises(NotBuiltError):
+    with pytest.raises(ValueError, match='encoder'):
         unbuilt.predict_percept(scene_of())
 
 

--- a/pulse2percept/models/tests/test_temporal.py
+++ b/pulse2percept/models/tests/test_temporal.py
@@ -433,9 +433,9 @@ def test_TemporalModel_reduce_fallback():
 
 def test_TemporalModel_blank_percept_warning():
     # Brightness in FadingTemporal is driven by cathodic (negative) current,
-    # so an all-positive stimulus -- which is what assigning a grayscale image
-    # or video directly to `implant.stim` produces -- integrates away to
-    # nothing. That used to be silent:
+    # so an all-positive stimulus -- which is what an unencoded grayscale image
+    # or video amounts to -- integrates away to nothing. That used to be
+    # silent:
     anodic = Stimulus(np.ones((4, 10)), time=np.arange(10) * 10.0)
     model = FadingTemporal().build()
     with pytest.warns(UserWarning, match='all-zero percept'):

--- a/pulse2percept/models/tests/test_thompson2003.py
+++ b/pulse2percept/models/tests/test_thompson2003.py
@@ -17,7 +17,7 @@ from pulse2percept.utils.testing import assert_warns_msg
 
 def test_Thompson2003Spatial():
     # Thompson2003Spatial automatically sets `radius`:
-    model = Thompson2003Spatial(step=5)
+    model = Thompson2003Spatial(implant=ArgusI(), step=5)
     # User can set `radius`:
     model.radius = 123
     npt.assert_equal(model.radius, 123)
@@ -25,25 +25,25 @@ def test_Thompson2003Spatial():
     npt.assert_equal(model.radius, 987)
 
     # Nothing in, None out:
-    npt.assert_equal(model.predict_percept(ArgusI()), None)
+    npt.assert_equal(model.predict_percept(None), None)
 
     # Converting ret <=> dva
-    model2 = Thompson2003Spatial(vfmap=Watson2014DisplaceMap())
+    model2 = Thompson2003Spatial(implant=ArgusI(),
+                                 vfmap=Watson2014DisplaceMap())
     npt.assert_equal(isinstance(model2.vfmap, Watson2014DisplaceMap),
                      True)
 
-    implant = ArgusI(stim=np.zeros(16))
     # Zero in = zero out:
-    percept = model.predict_percept(implant)
+    percept = model.predict_percept(np.zeros(16))
     npt.assert_equal(isinstance(percept, Percept), True)
     npt.assert_equal(percept.shape, list(model.grid.x.shape) + [1])
     npt.assert_almost_equal(percept.data, 0)
 
     # Multiple frames are processed independently:
-    model = Thompson2003Spatial(radius=200, step=5,
+    model = Thompson2003Spatial(implant=ArgusI(), radius=200, step=5,
                                 xrange=(-20, 20), yrange=(-15, 15))
     model.build()
-    percept = model.predict_percept(ArgusI(stim={'A1': [1, 0], 'B3': [0, 2]}))
+    percept = model.predict_percept({'A1': [1, 0], 'B3': [0, 2]})
     npt.assert_equal(percept.shape, list(model.grid.x.shape) + [2])
     pmax = percept.data.max(axis=(0, 1))
     npt.assert_almost_equal(percept.data[2, 3, 0], pmax[0])
@@ -54,7 +54,7 @@ def test_Thompson2003Spatial():
 
 
 def test_deepcopy_Thompson2003Spatial():
-    original = Thompson2003Spatial()
+    original = Thompson2003Spatial(implant=ArgusII())
     copied = copy.deepcopy(original)
 
     # Assert they are different objects
@@ -81,7 +81,7 @@ def test_deepcopy_Thompson2003Spatial():
 
 
 def test_Thompson2003Model():
-    model = Thompson2003Model(step=5)
+    model = Thompson2003Model(implant=ArgusI(), step=5)
     npt.assert_equal(model.has_space, True)
     npt.assert_equal(model.has_time, False)
     npt.assert_equal(hasattr(model.spatial, 'radius'), True)
@@ -98,21 +98,21 @@ def test_Thompson2003Model():
     npt.assert_equal(isinstance(model.vfmap, Curcio1990Map), True)
     npt.assert_almost_equal(model.vfmap.ret_to_dva(0, 0), (0, 0))
     npt.assert_almost_equal(model.vfmap.dva_to_ret(0, 0), (0, 0))
-    model2 = Thompson2003Model(vfmap=Watson2014DisplaceMap())
+    model2 = Thompson2003Model(implant=ArgusI(),
+                               vfmap=Watson2014DisplaceMap())
     npt.assert_equal(isinstance(model2.vfmap, Watson2014DisplaceMap),
                      True)
     # Nothing in, None out:
-    npt.assert_equal(model.predict_percept(ArgusI()), None)
+    npt.assert_equal(model.predict_percept(None), None)
 
     # Zero in = zero out:
-    implant = ArgusI(stim=np.zeros(16))
-    npt.assert_almost_equal(model.predict_percept(implant).data, 0)
+    npt.assert_almost_equal(model.predict_percept(np.zeros(16)).data, 0)
 
     # Multiple frames are processed independently:
-    model = Thompson2003Model(radius=1000, step=5,
+    model = Thompson2003Model(implant=ArgusI(), radius=1000, step=5,
                               xrange=(-20, 20), yrange=(-15, 15))
     model.build()
-    percept = model.predict_percept(ArgusI(stim={'A1': [1, 2]}))
+    percept = model.predict_percept({'A1': [1, 2]})
     npt.assert_equal(percept.shape, list(model.grid.x.shape) + [2])
     pmax = percept.data.max(axis=(0, 1))
     npt.assert_almost_equal(percept.data[2, 3, :], pmax)
@@ -122,13 +122,13 @@ def test_Thompson2003Model():
 
 
 def test_Thompson2003Model_predict_percept():
-    model = Thompson2003Model(step=0.55, radius=100, thresh_percept=0,
+    model = Thompson2003Model(implant=ArgusII(), step=0.55, radius=100, thresh_percept=0,
                               xrange=(-20, 20), yrange=(-15, 15))
     model.build()
     # Single-electrode stim:
     img_stim = np.zeros(60)
     img_stim[47] = 1
-    percept = model.predict_percept(ArgusII(stim=img_stim))
+    percept = model.predict_percept(img_stim)
     # Single bright pixel, very small Gaussian kernel:
     npt.assert_equal(np.sum(percept.data > 0.5), 1)
     npt.assert_equal(np.sum(percept.data > 0.00001), 1)
@@ -136,28 +136,29 @@ def test_Thompson2003Model_predict_percept():
     npt.assert_almost_equal(percept.data[33, 46, 0], np.max(percept.data))
 
     # Full Argus II: 60 bright spots
-    model = Thompson2003Model(step=0.55, radius=100)
+    model = Thompson2003Model(implant=ArgusII(), step=0.55, radius=100)
     model.build()
-    percept = model.predict_percept(ArgusII(stim=np.ones(60)))
+    percept = model.predict_percept(np.ones(60))
     npt.assert_equal(np.sum(np.isclose(percept.data, 1.0, rtol=0.1, atol=0.1)),
                      84)
 
     # Model gives same outcome as Spatial:
-    spatial = Thompson2003Spatial(step=1, radius=100)
+    spatial = Thompson2003Spatial(implant=ArgusII(), step=1, radius=100)
     spatial.build()
-    spatial_percept = model.predict_percept(ArgusII(stim=np.ones(60)))
+    spatial_percept = model.predict_percept(np.ones(60))
     npt.assert_almost_equal(percept.data, spatial_percept.data)
     npt.assert_equal(percept.time, None)
 
     # Warning for nonzero electrode-retina distances
-    implant = ArgusI(stim=np.ones(16), z=10)
+    raised = Thompson2003Model(implant=ArgusII(z=10), step=0.55, radius=100)
+    raised.build()
     msg = ("Nonzero electrode-retina distances do not have any effect on the "
            "model output.")
-    assert_warns_msg(UserWarning, model.predict_percept, msg, implant)
+    assert_warns_msg(UserWarning, raised.predict_percept, msg, np.ones(60))
 
 
 def test_deepcopy_Thompson2003Model():
-    original = Thompson2003Model()
+    original = Thompson2003Model(implant=ArgusII())
     copied = copy.deepcopy(original)
 
     # Assert they are different objects

--- a/pulse2percept/models/tests/test_thompson2003.py
+++ b/pulse2percept/models/tests/test_thompson2003.py
@@ -152,9 +152,13 @@ def test_Thompson2003Model_predict_percept():
     # Warning for nonzero electrode-retina distances
     raised = Thompson2003Model(implant=ArgusII(z=10), step=0.55, radius=100)
     raised.build()
-    msg = ("Nonzero electrode-retina distances do not have any effect on the "
-           "model output.")
-    assert_warns_msg(UserWarning, raised.predict_percept, msg, np.ones(60))
+    # Framed as a limitation of the model, not as a claim that distance is
+    # irrelevant, and named so the reader knows which model is silent about it:
+    assert_warns_msg(UserWarning, raised.predict_percept,
+                     "Thompson2003Spatial does not model electrode-retina distance",
+                     np.ones(60))
+    assert_warns_msg(UserWarning, raised.predict_percept,
+                     "not parameterized by this model", np.ones(60))
 
 
 def test_deepcopy_Thompson2003Model():

--- a/pulse2percept/models/thompson2003.py
+++ b/pulse2percept/models/thompson2003.py
@@ -30,6 +30,13 @@ class Thompson2003Spatial(SpatialModel):
 
     Parameters
     ----------
+    implant : :py:class:`~pulse2percept.implants.ProsthesisSystem`
+        The device this model predicts percepts for. Required: a percept is
+        what a particular implant produces, and ``predict_percept`` takes what
+        is presented to that device.
+
+        .. versionadded:: 0.11.0
+
     radius : double, optional
         Disk radius describing phosphene size (microns).
         If None, disk diameter is chosen as the electrode-to-electrode spacing
@@ -125,6 +132,15 @@ class Thompson2003Model(Model):
         Use this class if you want a standalone model.
         Use :py:class:`~pulse2percept.models.Thompson2003Spatial` if you want
         to combine the spatial model with a temporal model.
+
+    Parameters
+    ----------
+    implant : :py:class:`~pulse2percept.implants.ProsthesisSystem`
+        The device this model predicts percepts for. Required: a percept is
+        what a particular implant produces, and ``predict_percept`` takes what
+        is presented to that device.
+
+        .. versionadded:: 0.11.0
 
     radius : double, optional
         Disk radius describing phosphene size (microns).

--- a/pulse2percept/models/thompson2003.py
+++ b/pulse2percept/models/thompson2003.py
@@ -7,6 +7,7 @@ from ..utils import sample
 from ..topography import Curcio1990Map
 from ..units import um
 from ..models import Model, SpatialModel
+from .base import _warn_ignores_z
 from ._thompson2003 import fast_thompson2003
 
 # Log all warnings.warn() at the WARNING level:
@@ -90,10 +91,7 @@ class Thompson2003Spatial(SpatialModel):
 
     def _predict_spatial(self, earray, stim):
         """Predicts the brightness at spatial locations"""
-        if not np.allclose([e.z for e in earray.electrode_objects], 0):
-            msg = ("Nonzero electrode-retina distances do not have any effect "
-                   "on the model output.")
-            warnings.warn(msg)
+        _warn_ignores_z(self, earray)
         radius = self.radius
         if radius is None:
             if not hasattr(earray, 'spacing'):

--- a/pulse2percept/models/thompson2003.py
+++ b/pulse2percept/models/thompson2003.py
@@ -31,9 +31,8 @@ class Thompson2003Spatial(SpatialModel):
     Parameters
     ----------
     implant : :py:class:`~pulse2percept.implants.ProsthesisSystem`
-        The device this model predicts percepts for. Required: a percept is
-        what a particular implant produces, and ``predict_percept`` takes what
-        is presented to that device.
+        The implant whose stimulation this model predicts. Required before
+        building or predicting.
 
         .. versionadded:: 0.11.0
 
@@ -80,7 +79,7 @@ class Thompson2003Spatial(SpatialModel):
     .. important ::
 
         Changing a model parameter outside the constructor (e.g., by directly
-        setting ``model.xrange = (-10, 10)``) un-builds the model, and the
+        setting ``model.xrange = (-10, 10)``) invalidates the build, and the
         next ``predict_percept`` builds it again.
     """
 
@@ -136,9 +135,8 @@ class Thompson2003Model(Model):
     Parameters
     ----------
     implant : :py:class:`~pulse2percept.implants.ProsthesisSystem`
-        The device this model predicts percepts for. Required: a percept is
-        what a particular implant produces, and ``predict_percept`` takes what
-        is presented to that device.
+        The implant whose stimulation this model predicts. Required before
+        building or predicting.
 
         .. versionadded:: 0.11.0
 
@@ -185,7 +183,7 @@ class Thompson2003Model(Model):
     .. important ::
 
         Changing a model parameter outside the constructor (e.g., by directly
-        setting ``model.xrange = (-10, 10)``) un-builds the model, and the
+        setting ``model.xrange = (-10, 10)``) invalidates the build, and the
         next ``predict_percept`` builds it again.
 
     """

--- a/pulse2percept/models/thompson2003.py
+++ b/pulse2percept/models/thompson2003.py
@@ -71,9 +71,9 @@ class Thompson2003Spatial(SpatialModel):
 
     .. important ::
 
-        If you change important model parameters outside the constructor (e.g.,
-        by directly setting ``model.xrange = (-10, 10)``), you will have to call
-        ``model.build()`` again for your changes to take effect.
+        Changing a model parameter outside the constructor (e.g., by directly
+        setting ``model.xrange = (-10, 10)``) un-builds the model, and the
+        next ``predict_percept`` builds it again.
     """
 
     def get_default_params(self):        
@@ -170,9 +170,9 @@ class Thompson2003Model(Model):
 
     .. important ::
 
-        If you change important model parameters outside the constructor (e.g.,
-        by directly setting ``model.xrange = (-10, 10)``), you will have to call
-        ``model.build()`` again for your changes to take effect.
+        Changing a model parameter outside the constructor (e.g., by directly
+        setting ``model.xrange = (-10, 10)``) un-builds the model, and the
+        next ``predict_percept`` builds it again.
 
     """
 

--- a/pulse2percept/percepts/tests/test_base.py
+++ b/pulse2percept/percepts/tests/test_base.py
@@ -1144,9 +1144,9 @@ def test_model_prediction_stays_grayscale():
     """Adding RGB must not change what a model returns"""
     from pulse2percept.implants import ArgusII
     from pulse2percept.models import ScoreboardModel
-    model = ScoreboardModel(rho=200, xrange=(-4, 4), yrange=(-4, 4),
-                            step=1).build()
-    percept = model.predict_percept(ArgusII(stim={'A8': 30}))
+    model = ScoreboardModel(implant=ArgusII(), rho=200, xrange=(-4, 4),
+                            yrange=(-4, 4), step=1).build()
+    percept = model.predict_percept({'A8': 30})
     npt.assert_equal(percept.is_rgb, False)
     npt.assert_equal(percept.data.ndim, 3)
     npt.assert_equal(percept.shape, (9, 9, 1))

--- a/pulse2percept/stimuli/encoders.py
+++ b/pulse2percept/stimuli/encoders.py
@@ -319,7 +319,7 @@ class StimulusEncoder(PrettyPrint, metaclass=ABCMeta):
         if (implant is not None and
                 isinstance(stim, (ImageStimulus, VideoStimulus))):
             # Sample the source at the electrode locations. This is the same
-            # step that assigning an image or a video to `implant.stim` would
+            # step that presenting an image or a video to an implant would
             # perform, done here so that the pulse trains below are built at
             # electrode resolution rather than at pixel resolution. It is also
             # where RGB becomes gray. Row count is not a usable test of whether
@@ -806,7 +806,7 @@ class StimulusEncoder(PrettyPrint, metaclass=ABCMeta):
         Returns
         -------
         stim : :py:class:`~pulse2percept.stimuli.Stimulus`
-            The encoded stimulus, ready to assign to ``implant.stim``.
+            The encoded stimulus, ready for the implant to deliver.
             Its amplitudes are in microamps and its time axis in
             milliseconds, whatever units the encoder's own parameters were
             given in.
@@ -874,7 +874,7 @@ class AmplitudeEncoder(StimulusEncoder):
     >>> import pulse2percept as p2p
     >>> implant = p2p.implants.ArgusII()
     >>> implant.encoder = p2p.stimuli.AmplitudeEncoder(amp_range=(0, 50))
-    >>> implant.stim = p2p.stimuli.BostonTrain()
+    >>> stim = implant.prepare_stim(p2p.stimuli.BostonTrain())
 
     The same thing spelled out, for an implant that is not to keep the encoder:
 
@@ -1016,7 +1016,7 @@ frame_dur, stretch
     >>> implant = p2p.implants.ArgusII(raster=None)
     >>> implant.encoder = p2p.stimuli.FrequencyEncoder(freq_range=(0, 300),
     ...                                                amp=50, clock=1)
-    >>> implant.stim = p2p.stimuli.BostonTrain()
+    >>> stim = implant.prepare_stim(p2p.stimuli.BostonTrain())
 
     """
     __slots__ = ('freq_range', 'amp')

--- a/pulse2percept/stimuli/tests/test_encoders.py
+++ b/pulse2percept/stimuli/tests/test_encoders.py
@@ -290,9 +290,8 @@ def test_AmplitudeEncoder_implant():
     npt.assert_equal(np.abs(enc.data).max() <= 50, True)
     # ... and it is small enough to be worth doing:
     npt.assert_equal(enc.data.nbytes < 1e6, True)
-    # It can be assigned to the implant without any further reshaping:
-    implant.stim = enc
-    npt.assert_equal(implant.stim.shape, enc.shape)
+    # It can be prepared by the implant without any further reshaping:
+    npt.assert_equal(implant.prepare_stim(enc).shape, enc.shape)
     # Sampling first and encoding second gives the same answer as encoding an
     # already-downsampled video, which is what makes this a pure optimization
     # for amplitude modulation:
@@ -440,8 +439,7 @@ def test_FrequencyEncoder_implant():
         BostonTrain(), implant=implant)
     npt.assert_equal(enc.shape[0], implant.n_electrodes)
     npt.assert_almost_equal(np.abs(enc.data).max(), 50)
-    implant.stim = enc
-    npt.assert_equal(implant.stim.shape, enc.shape)
+    npt.assert_equal(implant.prepare_stim(enc).shape, enc.shape)
     # The clock is what makes this tractable at all: without one, the same
     # clip needs several times as many time points:
     unclocked = FrequencyEncoder(freq_range=(0, 300), amp=50).encode(
@@ -560,12 +558,14 @@ def test_StimulusEncoder_raster_current_limit():
     implant.max_current = 1000
     vid = VideoStimulus(np.ones((6, 10, 3)), metadata={'fps': 30})
     with pytest.raises(ValueError, match='raster'):
-        implant.stim = AmplitudeEncoder(amp_range=(50, 50), freq=30).encode(
-            vid, implant=implant)
+        implant.prepare_stim(AmplitudeEncoder(amp_range=(50, 50),
+                                              freq=30).encode(vid,
+                                                              implant=implant))
     implant.raster = SequentialRaster(6)
-    implant.stim = AmplitudeEncoder(amp_range=(50, 50), freq=30).encode(
-        vid, implant=implant)
-    npt.assert_almost_equal(np.abs(implant.stim.data).sum(axis=0).max(), 500)
+    stim = implant.prepare_stim(
+        AmplitudeEncoder(amp_range=(50, 50), freq=30).encode(vid,
+                                                             implant=implant))
+    npt.assert_almost_equal(np.abs(stim.data).sum(axis=0).max(), 500)
     # A raster that cannot get through all its groups within a frame is not a
     # usable schedule:
     implant.raster = SequentialRaster(6, group_dur=20)
@@ -1352,17 +1352,17 @@ def test_encoded_stimulus_validates_while_it_schedules():
                      'deliver no pulse at all')
 
 
-def test_encoded_stimulus_survives_assignment_unrendered():
-    # An implant stores a copy of what it is given; that copy has no more
+def test_encoded_stimulus_survives_preparation_unrendered():
+    # Preparation returns a copy of what it is given; that copy has no more
     # reason to hold a waveform than the original did.
     implant = ArgusII()
-    implant.stim = AmplitudeEncoder().encode(
-        ImageStimulus(np.linspace(0, 1, 64).reshape(8, 8)), implant=implant)
-    npt.assert_equal(_rendered(implant.stim), False)
-    npt.assert_equal(len(implant.stim.electrodes), 60)
-    # Assigning the picture itself goes through the implant's own encoder, and
-    # arrives just as unexpanded:
-    encoded = ArgusII(encoder=AmplitudeEncoder())
-    encoded.stim = ImageStimulus(np.linspace(0, 1, 64).reshape(8, 8))
-    npt.assert_equal(_rendered(encoded.stim), False)
-    npt.assert_equal(encoded.stim.data.shape[0], 60)
+    img = ImageStimulus(np.linspace(0, 1, 64).reshape(8, 8))
+    stim = implant.prepare_stim(AmplitudeEncoder().encode(img,
+                                                          implant=implant))
+    npt.assert_equal(_rendered(stim), False)
+    npt.assert_equal(len(stim.electrodes), 60)
+    # Presenting the picture itself goes through the implant's own encoder,
+    # and arrives just as unexpanded:
+    stim = ArgusII(encoder=AmplitudeEncoder()).prepare_stim(img)
+    npt.assert_equal(_rendered(stim), False)
+    npt.assert_equal(stim.data.shape[0], 60)

--- a/pulse2percept/stimuli/tests/test_encoders.py
+++ b/pulse2percept/stimuli/tests/test_encoders.py
@@ -1295,7 +1295,7 @@ def test_encoded_stimulus_transformations_degrade(modify):
 def test_encoded_stimulus_scaling_scales_both_descriptions(factor):
     # Scaling changes how hard each electrode is driven, not when. So the
     # schedule survives -- and the waveform and the modulation behind it move
-    # together, which is what `find_threshold` varies from trial to trial.
+    # together, so a spatial and a spatiotemporal model see the same change.
     stim = AmplitudeEncoder().encode(
         ImageStimulus(np.linspace(0, 1, 64).reshape(8, 8)))
     view = stim._spatial_view()

--- a/pulse2percept/topography/tests/test_neuropythy.py
+++ b/pulse2percept/topography/tests/test_neuropythy.py
@@ -564,13 +564,12 @@ def test_fsaverage_scoreboard(fsaverage):
     # `meridian_blend=0`: the sums below pin the neuropythy map, not the
     # default postprocessing. The blend is covered by
     # `test_CortexSpatial_meridian_blend`.
-    model = ScoreboardModel(rho=800, step=.25, vfmap=fsaverage,
-                            meridian_blend=0).build()
     implants = [Neuralink.from_neuropythy(fsaverage, xrange=(-3, 3),
                                           yrange=(-3, 3), region=region)
                 for region in ['v1', 'v2', 'v3']]
     implant = EnsembleImplant(implants)
-    implant.stim = {e: 1 for e in implant.electrode_names}
-    percept = model.predict_percept(implant)
+    model = ScoreboardModel(implant=implant, rho=800, step=.25,
+                            vfmap=fsaverage, meridian_blend=0)
+    percept = model.predict_percept({e: 1 for e in implant.electrode_names})
     npt.assert_almost_equal(np.sum(percept.data), 20245.445, decimal=1)
     npt.assert_almost_equal(np.max(percept.data), 86.4913, decimal=1)

--- a/pulse2percept/units/tests/test_integration.py
+++ b/pulse2percept/units/tests/test_integration.py
@@ -164,23 +164,24 @@ def test_every_spelling_builds_the_same_object():
           'ElectrodeGrid.spacing')
     # A central electrode and a grid wide enough to hold its phosphene, so
     # that the comparisons below have something in them:
-    implant = ArgusII(stim={'C5': BiphasicPulseTrain(20, 41.7, 0.45,
-                                                     stim_dur=100)})
-    grid = dict(xrange=(-8, 8), yrange=(-8, 8), step=2)
+    implant = ArgusII()
+    source = {'C5': BiphasicPulseTrain(20, 41.7, 0.45, stim_dur=100)}
+    grid = dict(implant=implant, xrange=(-8, 8), yrange=(-8, 8), step=2)
     _same(lambda r: ScoreboardSpatial(rho=r, **grid).build(), length, lengths,
-          lambda m: m.predict_percept(implant).data, 'ScoreboardSpatial.rho')
+          lambda m: m.predict_percept(source).data, 'ScoreboardSpatial.rho')
     _same(lambda lam: AxonMapSpatial(lam=lam, rho=575, n_axons=100,
                                      n_ax_segments=50, **grid).build(),
           length, lengths,
-          lambda m: m.predict_percept(implant).data, 'AxonMapSpatial.lam')
+          lambda m: m.predict_percept(source).data, 'AxonMapSpatial.lam')
 
     # --- Visual angle -----------------------------------------------------
     _same(lambda a: Grid2D((-a, a), (-a, a), step=0.5), angle, angles,
           lambda g: g.x, 'Grid2D.x_range')
-    _same(lambda a: ScoreboardSpatial(rho=575, xrange=(-4 * a, 4 * a),
+    _same(lambda a: ScoreboardSpatial(implant=implant, rho=575,
+                                      xrange=(-4 * a, 4 * a),
                                       yrange=(-4 * a, 4 * a),
                                       step=a).build(), angle, angles,
-          lambda m: m.predict_percept(implant).data,
+          lambda m: m.predict_percept(source).data,
           'ScoreboardSpatial.xrange')
     _same(lambda a: EnsembleImplant.from_cortical_map(
         Cortivis, Polimeni2006Map(), xrange=(-a, a), yrange=(-a, a),
@@ -192,19 +193,23 @@ def test_every_spelling_builds_the_same_object():
           lambda xy: np.asarray(xy, dtype=float), 'Watson2014Map.dva_to_ret')
 
     # --- And a whole pipeline, spelled unitfully end to end ---------------
-    bare = Model(spatial=ScoreboardSpatial(rho=575, **grid),
+    imp_bare = ArgusII(x=575)
+    imp_unit = ArgusII(x=0.575 * mm)
+    bare = Model(implant=imp_bare,
+                 spatial=ScoreboardSpatial(rho=575, xrange=(-8, 8),
+                                           yrange=(-8, 8), step=2),
                  temporal=FadingTemporal(tau=20)).build()
-    unitful = Model(spatial=ScoreboardSpatial(rho=0.575 * mm,
+    unitful = Model(implant=imp_unit,
+                    spatial=ScoreboardSpatial(rho=0.575 * mm,
                                               xrange=(-8 * dva, 8 * dva),
                                               yrange=(-8 * dva, 8 * dva),
                                               step=2 * dva),
                     temporal=FadingTemporal(tau=0.02 * s)).build()
-    imp_bare = ArgusII(x=575, stim={'C5': BiphasicPulseTrain(
-        20, 41.7, 0.45, stim_dur=100)})
-    imp_unit = ArgusII(x=0.575 * mm, stim={'C5': BiphasicPulseTrain(
-        0.02 * (1 / ms), 0.0417 * mA, 450 * us, stim_dur=0.1 * s)})
-    p_bare = bare.predict_percept(imp_bare, t_percept=[0, 20, 40])
-    p_unit = unitful.predict_percept(imp_unit, t_percept=[0, 0.02 * s,
+    src_bare = {'C5': BiphasicPulseTrain(20, 41.7, 0.45, stim_dur=100)}
+    src_unit = {'C5': BiphasicPulseTrain(
+        0.02 * (1 / ms), 0.0417 * mA, 450 * us, stim_dur=0.1 * s)}
+    p_bare = bare.predict_percept(src_bare, t_percept=[0, 20, 40])
+    p_unit = unitful.predict_percept(src_unit, t_percept=[0, 0.02 * s,
                                                           40000 * us])
     npt.assert_equal(np.any(p_bare.data), True)
     npt.assert_allclose(p_unit.data, p_bare.data, rtol=1e-6)
@@ -222,14 +227,15 @@ def test_the_whole_rejection_matrix():
     """
     img = ImageStimulus(np.linspace(0, 1, 36).reshape((6, 6)))
     current = Stimulus({'A1': BiphasicPulseTrain(20, 50, 0.45, stim_dur=100)})
-    model = ScoreboardSpatial(xrange=(-2, 2), yrange=(-2, 2), step=1).build()
+    model = ScoreboardSpatial(implant=ArgusII(), xrange=(-2, 2),
+                              yrange=(-2, 2), step=1).build()
 
     # dimensionless -> implant: an implant delivers current, so a picture is
-    # refused where it is assigned rather than where it is eventually read.
+    # refused where it is prepared rather than where it is eventually read.
     # (Argus II ships with an encoder, which would otherwise turn the picture
     # into the current the implant does deliver.)
     with pytest.raises(DimensionMismatchError):
-        ArgusII(preprocess=False, encoder=None, stim=img)
+        ArgusII(preprocess=False, encoder=None).prepare_stim(img)
 
     # dimensionless -> model: gray levels are not small currents. The implant
     # above is the outer boundary; this is the one behind it, so it is reached
@@ -238,7 +244,8 @@ def test_the_whole_rejection_matrix():
         stimulus_unit = dimensionless
 
     with pytest.raises(DimensionMismatchError):
-        model.predict_percept(Projector(preprocess=False, stim=img))
+        ScoreboardSpatial(implant=Projector(preprocess=False), xrange=(-2, 2),
+                          yrange=(-2, 2), step=1).build().predict_percept(img)
 
     # current -> encoder: an encoder is what *makes* current out of pictures.
     with pytest.raises(DimensionMismatchError):
@@ -261,9 +268,10 @@ def test_the_whole_rejection_matrix():
     # (see `SpatialModel._retinal_range_to_dva`), but that is shorthand for a
     # visual field extent, not a conversion, and it is offered nowhere else:
     with pytest.raises(DimensionMismatchError):
-        ScoreboardSpatial(step=100 * um)
+        ScoreboardSpatial(implant=ArgusII(), step=100 * um)
     with pytest.raises(DimensionMismatchError):
-        CortexScoreboardSpatial(xrange=(-2 * mm, 2 * mm))
+        CortexScoreboardSpatial(implant=ArgusII(),
+                                xrange=(-2 * mm, 2 * mm))
 
     # current -> time, and time -> current.
     with pytest.raises(DimensionMismatchError):
@@ -271,17 +279,17 @@ def test_the_whole_rejection_matrix():
     with pytest.raises(DimensionMismatchError):
         BiphasicPulse(50 * ms, 0.45)
     with pytest.raises(DimensionMismatchError):
-        model.predict_percept(ArgusII(stim=current), t_percept=[0, 20] * uA)
+        model.predict_percept(current, t_percept=[0, 20] * uA)
     with pytest.raises(DimensionMismatchError):
         ProsthesisSystem(ArgusII().earray, max_current=5 * ms)
 
     # dimensionless -> safety check: there is no charge in a picture.
     with pytest.raises(DimensionMismatchError):
-        ProsthesisSystem(ArgusII().earray, safe_mode=True, preprocess=False,
-                         stim=img)
+        ProsthesisSystem(ArgusII().earray, safe_mode=True,
+                         preprocess=False).prepare_stim(img)
     with pytest.raises(DimensionMismatchError):
-        ProsthesisSystem(ArgusII().earray, max_current=20, preprocess=False,
-                         stim=img)
+        ProsthesisSystem(ArgusII().earray, max_current=20,
+                         preprocess=False).prepare_stim(img)
 
     # A bare number is never rejected, anywhere. That is the other half of the
     # contract, and the reason none of the above needs a deprecation cycle:

--- a/pulse2percept/viz/argus.py
+++ b/pulse2percept/viz/argus.py
@@ -2,6 +2,7 @@
    :py:class:`~pulse2percept.viz.plot_argus_simulated_phosphenes`"""
 import numpy as np
 import pandas as pd
+from copy import copy
 from os.path import dirname, join
 from skimage.io import imread
 from skimage.measure import moments as img_moments
@@ -210,7 +211,13 @@ def plot_argus_phosphenes(data, argus=None, scale=1.0, axon_map=None,
                    zorder=ZORDER['foreground'])
 
     if axon_map is not None:
-        axon_bundles = axon_map.grow_axon_bundles(n_bundles=100, prune=False)
+        # `argus` is the implant this plot is about, so it is also what says
+        # which eye the bundles run in. A shallow copy takes the model's axon
+        # parameters without pointing the caller's model somewhere else:
+        spatial = copy(axon_map.spatial)
+        spatial.implant = argus
+        spatial._correct_loc_od()
+        axon_bundles = spatial.grow_axon_bundles(n_bundles=100, prune=False)
         # Draw axon pathways:
         for bundle in axon_bundles:
             # Flip y upside down for dva:

--- a/pulse2percept/viz/tests/test_argus.py
+++ b/pulse2percept/viz/tests/test_argus.py
@@ -28,7 +28,9 @@ def test_plot_argus_phosphenes():
 
     # Add axon map:
     _, ax = plt.subplots()
-    plot_argus_phosphenes(df, ArgusI(), ax=ax, axon_map=AxonMapModel())
+    argus = ArgusI()
+    plot_argus_phosphenes(df, argus, ax=ax,
+                          axon_map=AxonMapModel(implant=argus))
 
     # Data must be a DataFrame:
     with pytest.raises(TypeError):
@@ -45,7 +47,8 @@ def test_plot_argus_phosphenes():
         plot_argus_phosphenes(df, AlphaAMS())
     # Works only for axon maps:
     with pytest.raises(TypeError):
-        plot_argus_phosphenes(df, ArgusI(), ax=ax, axon_map=ScoreboardModel())
+        plot_argus_phosphenes(df, argus, ax=ax,
+                              axon_map=ScoreboardModel(implant=argus))
     # Manual subject selection
     plot_argus_phosphenes(df[df.electrode == 'B2'], ArgusI(), ax=ax)
     # If no implant given, dataframe must have additional columns:

--- a/pulse2percept/viz/tests/test_argus.py
+++ b/pulse2percept/viz/tests/test_argus.py
@@ -1,7 +1,8 @@
 from pulse2percept.viz import (plot_argus_phosphenes,
                                plot_argus_simulated_phosphenes)
 from pulse2percept.implants import ArgusI, ArgusII, AlphaAMS
-from pulse2percept.models import AxonMapModel, ScoreboardModel
+from pulse2percept.models import (AxonMapModel, AxonMapSpatial,
+                                  ScoreboardModel)
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
@@ -28,9 +29,7 @@ def test_plot_argus_phosphenes():
 
     # Add axon map:
     _, ax = plt.subplots()
-    argus = ArgusI()
-    plot_argus_phosphenes(df, argus, ax=ax,
-                          axon_map=AxonMapModel(implant=argus))
+    plot_argus_phosphenes(df, ArgusI(), ax=ax, axon_map=AxonMapModel())
 
     # Data must be a DataFrame:
     with pytest.raises(TypeError):
@@ -47,8 +46,7 @@ def test_plot_argus_phosphenes():
         plot_argus_phosphenes(df, AlphaAMS())
     # Works only for axon maps:
     with pytest.raises(TypeError):
-        plot_argus_phosphenes(df, argus, ax=ax,
-                              axon_map=ScoreboardModel(implant=argus))
+        plot_argus_phosphenes(df, ArgusI(), ax=ax, axon_map=ScoreboardModel())
     # Manual subject selection
     plot_argus_phosphenes(df[df.electrode == 'B2'], ArgusI(), ax=ax)
     # If no implant given, dataframe must have additional columns:
@@ -62,8 +60,8 @@ def test_plot_argus_phosphenes():
 
 
 # Parametrize over the class, not over instances: arguments to `parametrize`
-# are built at import time and shared across invocations, so mutating one
-# (as this test does with `implant.stim`) would leak state between tests.
+# are built at import time and shared across invocations, so a test that
+# mutated one would leak state into the others.
 @pytest.mark.parametrize('ImplantType', (ArgusI, ArgusII))
 def test_plot_argus_simulated_phosphenes(ImplantType):
     implant = ImplantType()
@@ -76,4 +74,34 @@ def test_plot_argus_simulated_phosphenes(ImplantType):
     # Add axon map:
     _, ax = plt.subplots()
     plot_argus_simulated_phosphenes(percepts, implant, ax=ax,
-                                    axon_map=AxonMapModel(implant=implant))
+                                    axon_map=AxonMapModel())
+
+
+def test_the_plotted_implant_owns_the_axon_laterality(monkeypatch):
+    """One implant in the picture, so one eye -- the caller's `argus`
+
+    Asserted on where the bundles are grown from rather than on the drawn
+    lines: this plot windows bundles to the array's own extent, and nothing
+    survives that in a synthetic dataset.
+    """
+    df = pd.DataFrame([
+        {'subject': 'S1', 'electrode': 'A1', 'image': np.random.rand(10, 10),
+         'xrange': (-10, 10), 'yrange': (-10, 10)},
+    ])
+    grown = []
+    unwrapped = AxonMapSpatial.grow_axon_bundles
+
+    def spy(self, **kwargs):
+        grown.append((self.implant.eye, tuple(self.loc_od)))
+        return unwrapped(self, **kwargs)
+
+    monkeypatch.setattr(AxonMapSpatial, 'grow_axon_bundles', spy)
+    # A model bound to the other eye, which used to be what decided:
+    axon_map = AxonMapModel(implant=ArgusII(eye='RE'), loc_od=(15.5, 1.5))
+    _, ax = plt.subplots()
+    plot_argus_phosphenes(df, ArgusII(eye='LE'), ax=ax, axon_map=axon_map)
+    # The optic disc is nasal, so a left eye puts it at negative x:
+    npt.assert_equal(grown, [('LE', (-15.5, 1.5))])
+    # ... and the caller's model is left pointed where it was:
+    npt.assert_equal(axon_map.implant.eye, 'RE')
+    npt.assert_equal(tuple(axon_map.loc_od), (15.5, 1.5))

--- a/pulse2percept/viz/tests/test_argus.py
+++ b/pulse2percept/viz/tests/test_argus.py
@@ -64,12 +64,13 @@ def test_plot_argus_phosphenes():
 @pytest.mark.parametrize('ImplantType', (ArgusI, ArgusII))
 def test_plot_argus_simulated_phosphenes(ImplantType):
     implant = ImplantType()
-    implant.stim = {'A1': [1, 0, 0], 'B2': [0, 1, 0], 'C3': [0, 0, 1]}
-    percepts = ScoreboardModel().build().predict_percept(implant)
+    source = {'A1': [1, 0, 0], 'B2': [0, 1, 0], 'C3': [0, 0, 1]}
+    model = ScoreboardModel(implant=implant).build()
+    percepts = model.predict_percept(source)
 
     plot_argus_simulated_phosphenes(percepts, implant)
 
     # Add axon map:
     _, ax = plt.subplots()
     plot_argus_simulated_phosphenes(percepts, implant, ax=ax,
-                                    axon_map=AxonMapModel())
+                                    axon_map=AxonMapModel(implant=implant))


### PR DESCRIPTION
Models are now bound to the implant they describe, and `predict_percept` takes the stimulus source directly:
```
implant = p2p.implants.ArgusII()
model = p2p.models.AxonMapModel(implant=implant)
percept = model.predict_percept(stim)
```

Or with a bit more customization:
```
implant = p2p.implants.ArgusII(
    encoder=p2p.stimuli.AmplitudeEncoder()
)

model = p2p.models.AxonMapModel(
    implant=implant,
    rho=200,
    lam=500,
)

stim = p2p.stimuli.LogoUCSB()
percept = model.predict_percept(stim)
```

Implants no longer store mutable stimulus state. Models now build automatically on first prediction and rebuild automatically
after model parameters change. Binding the model to the implant also makes it easier to catch unintended use cases (e.g., using `AxonMapModel` with `PRIMA`).

If the user wants to inspect what the device actually delivers:
```
delivered = implant.prepare_stim(stim)
delivered.plot()
```

Loops look natural:
```
implant = ArgusII()
model = AxonMapModel(implant=implant)

for stim in stimuli:
    percept = model.predict_percept(stim)
```

Scenes and gaze are easily incorporated as well:
```
percept = model.predict_percept(scene, gaze=...)
```

Closes #860. Closes #858. 