### PR TITLE
[MNT] Remove xystep and axlambda

### DIFF
--- a/doc/users/release_notes.rst
+++ b/doc/users/release_notes.rst
@@ -9,49 +9,25 @@ v0.11.0 Residual Vision (unreleased)
 
 Highlights:
 
+* **New backwards-incompatible API**: Models are now bound to the implant
+  they describe, they build automatically, and ``predict_percept`` takes a
+  stimulus directly:
+
+  .. code-block:: python
+
+      implant = p2p.implants.ArgusII()
+      model = p2p.models.AxonMapModel(implant=implant)
+      percept = model.predict_percept(stim)
+
 * New :py:mod:`pulse2percept.vision` introduces
   :py:class:`~pulse2percept.vision.Scene` and
   :py:class:`~pulse2percept.vision.Scotoma` for gaze-aware simulation of
   residual vision and retinal prostheses (:pull:`854`).
 
-Model/implant API
-~~~~~~~~~~~~~~~~~
-
-Models are now bound to the implant they describe, and ``predict_percept``
-takes the stimulus source directly:
-
-.. code-block:: python
-
-    implant = p2p.implants.ArgusII()
-    model = p2p.models.AxonMapModel(implant=implant)
-    percept = model.predict_percept(stim)
-
-* Implants no longer store mutable stimulus state. Use
-  ``implant.prepare_stim(source)`` to inspect the stimulation delivered by the
-  device.
-
-* A :py:class:`~pulse2percept.vision.Scene` is prediction input like any other
-  source: ``model.predict_percept(scene, gaze=...)``.
-
-* Models now build automatically on first prediction, and a parameter change
-  rebuilds only the component it belongs to, so a sweep over a temporal
-  parameter no longer regrows the spatial model. ``model.build()`` still
-  forces a full rebuild. ``NotBuiltError`` is gone.
-
-* :py:class:`~pulse2percept.models.AxonMapModel` no longer takes ``eye``; it
-  reads ``implant.eye``. It warns when built against a non-epiretinal implant,
-  and both retinal Beyeler models warn when ``rho`` is wider than the electrode
-  pitch.
-
-* ``find_threshold`` has been removed. Threshold searches are
-  experiment-specific optimizations over stimulus parameters and should be
-  implemented at that level.
-
 API changes:
 
-* :py:class:`~pulse2percept.implants.ProsthesisSystem` gains ``placement``,
-  naming where a device sits relative to the tissue it stimulates for the
-  device families where the literature is unambiguous.
+* :py:class:`~pulse2percept.implants.ProsthesisSystem` now has ``placement``
+  to specify where it is implanted.
 
 * :py:class:`~pulse2percept.implants.RectangleImplant` is deprecated in favor
   of :py:class:`~pulse2percept.implants.GridImplant` (:pull:`859`)
@@ -59,9 +35,9 @@ API changes:
 * New ``deg`` and ``rad`` units for ordinary geometric angle, accepted
   wherever p2p already took an angle in degrees.
 
-* :py:class:`~pulse2percept.models.BiphasicAxonMapModel` no longer overrides
-  ``predict_percept``, so it takes ``gaze``, ``vmax`` and ``vmin`` like every
-  other model.
+* ``find_threshold`` has been removed. Threshold searches are
+  experiment-specific optimizations over stimulus parameters and should be
+  implemented at that level.
 
 Bug fixes:
 

--- a/pulse2percept/implants/cortex/neuralink.py
+++ b/pulse2percept/implants/cortex/neuralink.py
@@ -11,7 +11,7 @@ from ..electrodes import Electrode
 from ..electrode_arrays import ElectrodeArray
 from ..base import ProsthesisSystem
 from ...units import as_value, deg, dva, um
-from ...utils import parse_3d_orient, rename_parameter
+from ...utils import parse_3d_orient
 
 
 class EllipsoidElectrode(Electrode):
@@ -261,8 +261,6 @@ class Neuralink(EnsembleImplant):
     placement = 'intracortical'
 
     @classmethod
-    @rename_parameter('xystep', 'step', deprecated_version='0.10.0',
-                      removed_version='0.11.0')
     def from_neuropythy(cls, vfmap, locs=None, xrange=None, yrange=None, step=None,
                         rand_insertion_angle=None, region='v1', Thread=LinearEdgeThread):
         """
@@ -285,12 +283,6 @@ class Neuralink(EnsembleImplant):
             Range of x and y coordinates (dva) to create threads at.
         step : float or (x_step, y_step), optional
             Spacing (dva) between threads.
-
-            .. versionchanged:: 0.10.0
-
-                Renamed from ``xystep``, which suggested that one step size
-                applies to both axes. The old name still works as a keyword
-                argument, but is deprecated and will be removed in v0.11.0.
         rand_insertion_angle : float or Quantity, optional
             If not none, insert threads at a random offset from perpendicular,
             with a maximum azimuthal rotation of rand_insertion_angle degrees.
@@ -386,8 +378,6 @@ class Neuralink(EnsembleImplant):
         return cls(threads)
     
     @classmethod
-    @rename_parameter('xystep', 'step', deprecated_version='0.10.0',
-                      removed_version='0.11.0')
     def from_cortical_map(cls, implant_type, vfmap, locs=None, xrange=None,
                           yrange=None, step=None, region='v1'):
         """
@@ -408,12 +398,6 @@ class Neuralink(EnsembleImplant):
             Range of x and y coordinates to create threads at.
         step : float or (x_step, y_step), optional
             Spacing between threads.
-
-            .. versionchanged:: 0.10.0
-
-                Renamed from ``xystep``, which suggested that one step size
-                applies to both axes. The old name still works as a keyword
-                argument, but is deprecated and will be removed in v0.11.0.
         region : str, optional
             Region of cortex to create implant in.
 

--- a/pulse2percept/implants/cortex/tests/test_neuralink.py
+++ b/pulse2percept/implants/cortex/tests/test_neuralink.py
@@ -1,5 +1,4 @@
 from string import ascii_uppercase
-import warnings
 
 import numpy.testing as npt
 from pulse2percept.units import (DimensionMismatchError, Quantity, deg, dva,
@@ -14,7 +13,6 @@ from pulse2percept.implants.cortex import (EllipsoidElectrode, LinearEdgeThread,
                                            NeuralinkThread, Neuralink, Cortivis)
 from pulse2percept.topography import Grid2D, NeuropythyMap, Polimeni2006Map
 from pulse2percept.topography.cortex import CorticalMap
-from pulse2percept.utils.testing import assert_warns_msg
 
 
 class StubNeuropythyMap(NeuropythyMap):
@@ -617,35 +615,3 @@ def test_LinearEdgeThread_units():
             LinearEdgeThread(**kwargs)
     with pytest.raises(DimensionMismatchError):
         EllipsoidElectrode(rx=1 * ms)
-
-
-@pytest.mark.parametrize('factory, vfmap', [
-    ('from_neuropythy', None),
-    ('from_cortical_map', Polimeni2006Map()),
-])
-def test_Neuralink_deprecated_xystep(factory, vfmap):
-    # `step` was called `xystep` until 0.10.0. Both `Neuralink` factories
-    # take it as an ordinary signature argument, so the old name is forwarded:
-    if factory == 'from_neuropythy':
-        args = (StubNeuropythyMap(),)
-    else:
-        args = (LinearEdgeThread, vfmap)
-    build = getattr(Neuralink, factory)
-    kwargs = {'xrange': (-1, 1), 'yrange': (0, 0)}
-
-    msg = f"The 'xystep' parameter of Neuralink.{factory} is deprecated"
-    assert_warns_msg(DeprecationWarning, build, msg, *args, xystep=1, **kwargs)
-    with pytest.warns(DeprecationWarning):
-        old = build(*args, xystep=1, **kwargs)
-    new = build(*args, step=1, **kwargs)
-    npt.assert_almost_equal([[t.x, t.y, t.z] for t in old.implants.values()],
-                            [[t.x, t.y, t.z] for t in new.implants.values()])
-
-    # Both names are the same parameter, so supplying both must raise:
-    with pytest.raises(TypeError, match="same parameter"):
-        build(*args, xystep=1, step=1, **kwargs)
-
-    # The new name stays silent:
-    with warnings.catch_warnings():
-        warnings.simplefilter("error", DeprecationWarning)
-        build(*args, step=1, **kwargs)

--- a/pulse2percept/implants/ensemble.py
+++ b/pulse2percept/implants/ensemble.py
@@ -6,7 +6,6 @@ from .electrode_arrays import ElectrodeArray
 from ..stimuli._merge import unique_time_points
 from ..stimuli.base import _describe_unit
 from ..units import DimensionMismatchError, as_value, dva, um
-from ..utils import rename_parameter
 
 class EnsembleImplant(ProsthesisSystem):
     
@@ -14,8 +13,6 @@ class EnsembleImplant(ProsthesisSystem):
     __slots__ = ('_implants', '_earray', 'safe_mode', 'preprocess')
 
     @classmethod
-    @rename_parameter('xystep', 'step', deprecated_version='0.10.0',
-                      removed_version='0.11.0')
     def from_cortical_map(cls, implant_type, vfmap, locs=None, xrange=None, yrange=None, step=None,
                         region='v1'):
         """
@@ -39,12 +36,6 @@ class EnsembleImplant(ProsthesisSystem):
             Range of x and y coordinates (dva) to create implants at.
         step : float or (x_step, y_step), optional
             Spacing (dva) between implant centers.
-
-            .. versionchanged:: 0.10.0
-
-                Renamed from ``xystep``, which suggested that one step size
-                applies to both axes. The old name still works as a keyword
-                argument, but is deprecated and will be removed in v0.11.0.
         region : str, optional
             Region of cortex to create implant in.
 
@@ -96,8 +87,6 @@ class EnsembleImplant(ProsthesisSystem):
 
 
     @classmethod
-    @rename_parameter('xystep', 'step', deprecated_version='0.10.0',
-                      removed_version='0.11.0')
     def from_coords(cls, implant_type, locs=None, xrange=None, yrange=None, step=None):
         """
         Create an ensemble implant using physical (cortical or retinal) coordinates.
@@ -114,12 +103,6 @@ class EnsembleImplant(ProsthesisSystem):
             (together with ``step``) if ``locs`` is not given.
         step : float or (x_step, y_step), optional
             Spacing (um) between implant centers.
-
-            .. versionchanged:: 0.10.0
-
-                Renamed from ``xystep``, which suggested that one step size
-                applies to both axes. The old name still works as a keyword
-                argument, but is deprecated and will be removed in v0.11.0.
 
         Raises
         ------

--- a/pulse2percept/implants/tests/test_ensemble.py
+++ b/pulse2percept/implants/tests/test_ensemble.py
@@ -1,4 +1,3 @@
-import warnings
 
 import numpy as np
 import numpy.testing as npt
@@ -11,7 +10,6 @@ from pulse2percept.topography import Polimeni2006Map
 from pulse2percept.models.cortex.base import ScoreboardModel
 from pulse2percept.stimuli import BiphasicPulseTrain, MonophasicPulse
 from pulse2percept.utils.constants import DT
-from pulse2percept.utils.testing import assert_warns_msg
 
 def test_EnsembleImplant():
     # Invalid instantiations:
@@ -290,34 +288,3 @@ def test_EnsembleImplant_from_coords_is_physical():
     with pytest.raises(DimensionMismatchError):
         EnsembleImplant.from_coords(Cortivis, xrange=(-2 * dva, 2 * dva),
                                     yrange=(0, 0), step=1)
-
-
-@pytest.mark.parametrize('factory, kwargs', [
-    ('from_coords', {'xrange': (-10000, 10000), 'yrange': (0, 0)}),
-    ('from_cortical_map', {'xrange': (-2, 2), 'yrange': (0, 0)}),
-])
-def test_EnsembleImplant_deprecated_xystep(factory, kwargs):
-    # `step` was called `xystep` until 0.10.0. Both factories are ordinary
-    # signatures, so the old name is forwarded rather than aliased:
-    args = ((Cortivis,) if factory == 'from_coords'
-            else (Cortivis, Polimeni2006Map()))
-    build = getattr(EnsembleImplant, factory)
-    step = 10000 if factory == 'from_coords' else 2
-
-    msg = f"The 'xystep' parameter of EnsembleImplant.{factory} is deprecated"
-    assert_warns_msg(DeprecationWarning, build, msg, *args,
-                     xystep=step, **kwargs)
-    with pytest.warns(DeprecationWarning):
-        old = build(*args, xystep=step, **kwargs)
-    npt.assert_allclose(old.earray.coordinates(),
-                        build(*args, step=step, **kwargs).earray.coordinates(),
-                        rtol=1e-12)
-
-    # Both names are the same parameter, so supplying both must raise:
-    with pytest.raises(TypeError, match="same parameter"):
-        build(*args, xystep=step, step=step, **kwargs)
-
-    # The new name stays silent:
-    with warnings.catch_warnings():
-        warnings.simplefilter("error", DeprecationWarning)
-        build(*args, step=step, **kwargs)

--- a/pulse2percept/models/base.py
+++ b/pulse2percept/models/base.py
@@ -19,8 +19,7 @@ from ..units import (DimensionMismatchError, Quantity, Unit, as_value, dva, ms,
                      um, uA)
 from ..vision import Scene
 from ..utils import (PrettyPrint, FreezeError, Frozen, Parametrized,
-                     deprecated_alias, warn_deprecated_params,
-                     rename_deprecated_params)
+                     warn_deprecated_params, rename_deprecated_params)
 from ..utils.base import _is_constructing
 from ..utils.constants import ZORDER
 
@@ -666,11 +665,6 @@ class SpatialModel(BaseModel, metaclass=ABCMeta):
 
     #: ``n_jobs`` is an alias for ``n_threads``; see ``_n_jobs_alias``.
     n_jobs = _n_jobs_alias()
-
-    #: ``step`` used to be called ``xystep``. The old name still reads and
-    #: writes ``step``, with a ``DeprecationWarning``:
-    xystep = deprecated_alias('step', deprecated_version='0.10.0',
-                              removed_version='0.11.0')
 
     def __init__(self, **params):
         # `vfmap` first: `xrange`/`yrange` may be given as a retinal extent,

--- a/pulse2percept/models/beyeler2019.py
+++ b/pulse2percept/models/beyeler2019.py
@@ -10,7 +10,6 @@ import matplotlib.pyplot as plt
 from matplotlib.patches import Ellipse
 
 from ..units import deg, dva, um
-from ..utils import deprecated_alias
 from ..utils.constants import UM_PER_MM, ZORDER
 from ..topography import Watson2014Map
 from ..implants import ElectrodeArray
@@ -125,12 +124,6 @@ class ScoreboardSpatial(SpatialModel):
         visual angle). For example, to create a grid with x values [0, 0.5, 1]
         use ``xrange=(0, 1)`` and ``step=0.5``. Pass a tuple to give the x
         and y axes different step sizes.
-
-        .. versionchanged:: 0.10.0
-
-            Renamed from ``xystep``, which suggested that one step size
-            applies to both axes. The old name still works, but is
-            deprecated and will be removed in v0.11.0.
     grid_type : {'rectangular', 'hexagonal'}, optional
         Whether to simulate points on a rectangular or hexagonal grid
     vfmap : :py:class:`~pulse2percept.topography.VisualFieldMap`, optional
@@ -232,12 +225,6 @@ class ScoreboardModel(Model):
         visual angle). For example, to create a grid with x values [0, 0.5, 1]
         use ``xrange=(0, 1)`` and ``step=0.5``. Pass a tuple to give the x
         and y axes different step sizes.
-
-        .. versionchanged:: 0.10.0
-
-            Renamed from ``xystep``, which suggested that one step size
-            applies to both axes. The old name still works, but is
-            deprecated and will be removed in v0.11.0.
     grid_type : {'rectangular', 'hexagonal'}, optional
         Whether to simulate points on a rectangular or hexagonal grid
     vfmap : :py:class:`~pulse2percept.topography.VisualFieldMap`, optional
@@ -296,12 +283,6 @@ class AxonMapSpatial(SpatialModel):
 
     lam : double, optional
         Exponential decay constant along the axon(microns).
-
-        .. versionchanged:: 0.10.0
-
-            Renamed from ``axlambda``, which reads poorly next to ``rho``. The
-            old name still works, but is deprecated and will be removed in
-            v0.11.0.
     rho : double, optional
         Exponential decay constant away from the axon(microns).
     min_current_spread : float, optional
@@ -325,12 +306,6 @@ class AxonMapSpatial(SpatialModel):
         visual angle). For example, to create a grid with x values [0, 0.5, 1]
         use ``xrange=(0, 1)`` and ``step=0.5``. Pass a tuple to give the x
         and y axes different step sizes.
-
-        .. versionchanged:: 0.10.0
-
-            Renamed from ``xystep``, which suggested that one step size
-            applies to both axes. The old name still works, but is
-            deprecated and will be removed in v0.11.0.
     grid_type : {'rectangular', 'hexagonal'}, optional
         Whether to simulate points on a rectangular or hexagonal grid
     vfmap : :py:class:`~pulse2percept.topography.VisualFieldMap`, optional
@@ -392,11 +367,6 @@ class AxonMapSpatial(SpatialModel):
     *  The axon map is not very accurate when the upper bound of
        `ax_segments_range` is greater than 90 deg.
     """
-
-    #: ``lam`` used to be called ``axlambda``. The old name still reads and
-    #: writes ``lam``, with a ``DeprecationWarning``:
-    axlambda = deprecated_alias('lam', deprecated_version='0.10.0',
-                                removed_version='0.11.0')
 
     def __init__(self, **params):
         super(AxonMapSpatial, self).__init__(**params)
@@ -962,9 +932,9 @@ class AxonMapSpatial(SpatialModel):
                 # here. Rather than try to read it, grow the bundles again and
                 # overwrite it; the file is derived data, so the only cost is
                 # one slow build. Settle this *before* looking at `params`,
-                # whose keys are versioned too -- an old cache names the grid
-                # step `xystep`, and probing that here would warn the user
-                # about a name they never used:
+                # whose keys are versioned too -- a cache written before
+                # 0.10.0 names the grid step `xystep`, which is no longer a
+                # parameter of this model:
                 if not _is_axon_cache(cached):
                     need_axons = True
                 else:
@@ -1178,12 +1148,6 @@ class AxonMapModel(Model):
 
     lam : double, optional
         Exponential decay constant along the axon(microns).
-
-        .. versionchanged:: 0.10.0
-
-            Renamed from ``axlambda``, which reads poorly next to ``rho``. The
-            old name still works, but is deprecated and will be removed in
-            v0.11.0.
     rho : double, optional
         Exponential decay constant away from the axon(microns).
     min_current_spread : float, optional
@@ -1207,12 +1171,6 @@ class AxonMapModel(Model):
         visual angle). For example, to create a grid with x values [0, 0.5, 1]
         use ``xrange=(0, 1)`` and ``step=0.5``. Pass a tuple to give the x
         and y axes different step sizes.
-
-        .. versionchanged:: 0.10.0
-
-            Renamed from ``xystep``, which suggested that one step size
-            applies to both axes. The old name still works, but is
-            deprecated and will be removed in v0.11.0.
     grid_type : {'rectangular', 'hexagonal'}, optional
         Whether to simulate points on a rectangular or hexagonal grid
     vfmap : :py:class:`~pulse2percept.topography.VisualFieldMap`, optional

--- a/pulse2percept/models/cortex/base.py
+++ b/pulse2percept/models/cortex/base.py
@@ -48,12 +48,6 @@ class CortexSpatial(SpatialModel):
         visual angle). For example, to create a grid with x values [0, 0.5, 1]
         use ``xrange=(0, 1)`` and ``step=0.5``. Pass a tuple to give the x
         and y axes different step sizes.
-
-        .. versionchanged:: 0.10.0
-
-            Renamed from ``xystep``, which suggested that one step size
-            applies to both axes. The old name still works, but is
-            deprecated and will be removed in v0.11.0.
     grid_type : {'rectangular', 'hexagonal'}, optional
         Whether to simulate points on a rectangular or hexagonal grid
     vfmap : :py:class:`~pulse2percept.topography.VisualFieldMap`, optional
@@ -258,12 +252,6 @@ class ScoreboardSpatial(CortexSpatial):
         visual angle). For example, to create a grid with x values [0, 0.5, 1]
         use ``xrange=(0, 1)`` and ``step=0.5``. Pass a tuple to give the x
         and y axes different step sizes.
-
-        .. versionchanged:: 0.10.0
-
-            Renamed from ``xystep``, which suggested that one step size
-            applies to both axes. The old name still works, but is
-            deprecated and will be removed in v0.11.0.
     grid_type : {'rectangular', 'hexagonal'}, optional
         Whether to simulate points on a rectangular or hexagonal grid
     meridian_blend : float, optional
@@ -421,12 +409,6 @@ class ScoreboardModel(Model):
         visual angle). For example, to create a grid with x values [0, 0.5, 1]
         use ``xrange=(0, 1)`` and ``step=0.5``. Pass a tuple to give the x
         and y axes different step sizes.
-
-        .. versionchanged:: 0.10.0
-
-            Renamed from ``xystep``, which suggested that one step size
-            applies to both axes. The old name still works, but is
-            deprecated and will be removed in v0.11.0.
     grid_type : {'rectangular', 'hexagonal'}, optional
         Whether to simulate points on a rectangular or hexagonal grid
     meridian_blend : float, optional

--- a/pulse2percept/models/cortex/dynaphos.py
+++ b/pulse2percept/models/cortex/dynaphos.py
@@ -8,7 +8,7 @@ from ...percepts import Percept
 from ...implants import ProsthesisSystem
 from ...stimuli import BiphasicPulseTrain
 from ...units import A, Quantity, as_value, dva, Hz, mm, ms, uA
-from ...utils import cart2pol, deprecated_alias
+from ...utils import cart2pol
 from ...utils.constants import MS_PER_S, UM_PER_MM, ZORDER
 from ...topography import Polimeni2006Map
 
@@ -94,12 +94,6 @@ class DynaphosModel(BaseModel):
         visual angle). For example, to create a grid with x values [0, 0.5, 1]
         use ``xrange=(0, 1)`` and ``step=0.5``. Pass a tuple to give the x
         and y axes different step sizes.
-
-        .. versionchanged:: 0.10.0
-
-            Renamed from ``xystep``, which suggested that one step size
-            applies to both axes. The old name still works, but is
-            deprecated and will be removed in v0.11.0.
     grid_type : {'rectangular', 'hexagonal'}, optional
         Whether to simulate points on a rectangular or hexagonal grid.
     vfmap : :py:class:`~pulse2percept.topography.VisualFieldMap`, optional
@@ -124,12 +118,6 @@ class DynaphosModel(BaseModel):
         setting ``model.xrange = (-10, 10)``) invalidates the build, and the
         next ``predict_percept`` builds it again.
     """
-    #: ``step`` used to be called ``xystep``. The old name still reads and
-    #: writes ``step``, with a ``DeprecationWarning``. Declared here rather
-    #: than inherited: this model derives from ``BaseModel``, not
-    #: ``SpatialModel``, and lays out its own grid.
-    xystep = deprecated_alias('step', deprecated_version='0.10.0',
-                              removed_version='0.11.0')
 
     @property
     def regions(self):

--- a/pulse2percept/models/cortex/tests/test_dynaphos.py
+++ b/pulse2percept/models/cortex/tests/test_dynaphos.py
@@ -2,7 +2,6 @@ import numpy.testing as npt
 import pytest
 import numpy as np
 import copy
-import warnings
 import matplotlib.pyplot as plt
 
 from pulse2percept.models.cortex import DynaphosModel
@@ -18,7 +17,6 @@ from pulse2percept.stimuli import (AmplitudeEncoder,
                                    Stimulus)
 from pulse2percept.units import (DimensionMismatchError, Quantity, mA,
                                  ms, s, uA, um)
-from pulse2percept.utils.testing import assert_warns_msg
 
 def test_DynaphosModel():
     model = DynaphosModel(implant=Cortivis(), xrange=(-3, 3), yrange=(-3, 3), step=0.1).build()
@@ -197,40 +195,6 @@ def test_DynaphosModel_default_frame_clock_stops_at_the_stimulus():
     npt.assert_equal(percept.time[-1] <= delivered.time[-1], True)
     # The endpoint is included, not dropped:
     npt.assert_allclose(percept.time[-1], delivered.time[-1], rtol=1e-12)
-
-
-def test_DynaphosModel_deprecated_xystep():
-    # `step` was called `xystep` until 0.10.0. Dynaphos derives from
-    # `BaseModel` rather than `SpatialModel` and lays out its own grid, so it
-    # declares the alias itself and has to be checked separately:
-    msg = "The 'xystep' parameter of DynaphosModel is deprecated"
-    assert_warns_msg(DeprecationWarning, DynaphosModel, msg, xystep=1)
-    with pytest.warns(DeprecationWarning):
-        model = DynaphosModel(implant=Cortivis(), xrange=(-2, 2), yrange=(-2, 2), xystep=1)
-    npt.assert_almost_equal(model.step, 1)
-
-    assert_warns_msg(DeprecationWarning, setattr, msg, model, 'xystep', 2)
-    npt.assert_almost_equal(model.step, 2)
-    with pytest.warns(DeprecationWarning):
-        npt.assert_almost_equal(model.xystep, 2)
-
-    assert_warns_msg(DeprecationWarning, model.set_params, msg, xystep=1)
-    npt.assert_almost_equal(model.step, 1)
-    assert_warns_msg(DeprecationWarning, model.build, msg, xystep=0.5)
-    npt.assert_almost_equal(model.step, 0.5)
-    npt.assert_almost_equal(np.unique(np.diff(model.grid.x[0, :]))[0], 0.5)
-
-    # Both names are the same parameter, so supplying both must raise:
-    for params in ({'xystep': 1, 'step': 2}, {'step': 2, 'xystep': 1}):
-        with pytest.raises(TypeError, match="same parameter"):
-            DynaphosModel(implant=Cortivis(), **params)
-
-    # The new name stays silent:
-    with warnings.catch_warnings():
-        warnings.simplefilter("error", DeprecationWarning)
-        model = DynaphosModel(implant=Cortivis(), step=1)
-        model.step = 2
-        npt.assert_almost_equal(model.step, 2)
 
 
 def test_dynaphos_reads_the_pulse_train_itself():

--- a/pulse2percept/models/granley2021.py
+++ b/pulse2percept/models/granley2021.py
@@ -8,7 +8,7 @@ from ..implants import ElectrodeArray
 from ..stimuli import BiphasicPulseTrain, Stimulus
 from ..percepts import Percept
 from ..units import as_value, um, xTh
-from ..utils import FreezeError, rename_parameter
+from ..utils import FreezeError
 from ..utils.base import has_own_attr
 from .base import BaseModel, _require_stim_dimension
 from ._granley2021 import fast_biphasic_axon_map
@@ -151,18 +151,11 @@ class DefaultStreakModel(BaseModel):
     ------------
     lam :  float32
         ``lam`` parameter of BiphasicAxonMapModel (axonal decay rate)
-
-        .. versionchanged:: 0.10.0
-
-            Renamed from ``axlambda``. The old name still works as a keyword
-            argument, but is deprecated and will be removed in v0.11.0.
     a7, a8, a9: float, optional
         Regression coefficients for streak length vs pulse duration (Eq 6)
         F_streak = -a7*pdur^a8 + a9
     """
 
-    @rename_parameter('axlambda', 'lam', deprecated_version='0.10.0',
-                      removed_version='0.11.0')
     def __init__(self, lam, **params):
         super(DefaultStreakModel, self).__init__(**params)
         self.lam = lam
@@ -310,12 +303,6 @@ class BiphasicAxonMapSpatial(AxonMapSpatial):
         --------
         lam: double, optional
             Exponential decay constant along the axon(microns).
-
-            .. versionchanged:: 0.10.0
-
-                Renamed from ``axlambda``, which reads poorly next to ``rho``.
-                The old name still works, but is deprecated and will be
-                removed in v0.11.0.
         rho: double, optional
             Exponential decay constant away from the axon(microns).
         min_current_spread: float, optional
@@ -343,12 +330,6 @@ class BiphasicAxonMapSpatial(AxonMapSpatial):
             visual angle). For example, to create a grid with x values [0, 0.5, 1]
             use ``xrange=(0, 1)`` and ``step=0.5``. Pass a tuple to give the x
             and y axes different step sizes.
-
-            .. versionchanged:: 0.10.0
-
-                Renamed from ``xystep``, which suggested that one step size
-                applies to both axes. The old name still works, but is
-                deprecated and will be removed in v0.11.0.
         grid_type : {'rectangular', 'hexagonal'}
             Whether to simulate points on a rectangular or hexagonal grid
         vfmap : :py:class:`~pulse2percept.topography.VisualFieldMap`, optional
@@ -737,12 +718,6 @@ class BiphasicAxonMapModel(Model):
         ^^^^^^^^
         lam: double, optional
             Exponential decay constant along the axon(microns).
-
-            .. versionchanged:: 0.10.0
-
-                Renamed from ``axlambda``, which reads poorly next to ``rho``.
-                The old name still works, but is deprecated and will be
-                removed in v0.11.0.
         rho: double, optional
             Exponential decay constant away from the axon(microns).
         min_current_spread: float, optional
@@ -773,12 +748,6 @@ class BiphasicAxonMapModel(Model):
             visual angle). For example, to create a grid with x values [0, 0.5, 1]
             use ``xrange=(0, 1)`` and ``step=0.5``. Pass a tuple to give the x
             and y axes different step sizes.
-
-            .. versionchanged:: 0.10.0
-
-                Renamed from ``xystep``, which suggested that one step size
-                applies to both axes. The old name still works, but is
-                deprecated and will be removed in v0.11.0.
         grid_type : {'rectangular', 'hexagonal'}
             Whether to simulate points on a rectangular or hexagonal grid
         vfmap : :py:class:`~pulse2percept.topography.VisualFieldMap`, optional

--- a/pulse2percept/models/tests/test_base.py
+++ b/pulse2percept/models/tests/test_base.py
@@ -25,7 +25,6 @@ from pulse2percept.units import (DimensionMismatchError, Quantity,
                                  dimensionless, dva, mA, mm, ms, s, uA, um,
                                  us)
 from pulse2percept.utils import FreezeError, frame_interval
-from pulse2percept.utils.testing import assert_warns_msg
 from pulse2percept.topography import (Curcio1990Map, Grid2D,
                                       Polimeni2006Map, RetinalMap,
                                       Watson2014Map)
@@ -214,161 +213,22 @@ def test_SpatialModel_predict_percept_keeps_metadata():
 
 
 @pytest.mark.parametrize('param, value', [('engine', 'serial'),
-                                          ('scheduler', 'dask')])
+                                          ('scheduler', 'dask'),
+                                          ('xystep', 2)])
 def test_SpatialModel_removed_params(param, value):
     # `engine` chose the Cython vs pure-Python axon-growth path and
-    # `scheduler` drove the joblib/dask backends. Both were deprecated in
-    # 0.9.1 and removed in 0.10.0, so they are now unknown parameters:
+    # `scheduler` drove the joblib/dask backends, both removed in 0.10.0;
+    # `xystep` was renamed to `step` in 0.10.0 and removed in 0.11.0. All
+    # three are now unknown parameters:
     with pytest.raises(AttributeError):
         ValidSpatialModel(**{param: value})
     with pytest.raises(AttributeError):
         ValidSpatialModel().set_params(**{param: value})
 
 
-@pytest.mark.parametrize('composite', [False, True])
-def test_SpatialModel_deprecated_xystep(composite):
-    # `step` was called `xystep` until 0.10.0. The old name still works
-    # everywhere the new one does, but warns:
-    def make(**params):
-        if composite:
-            return Model(spatial=ValidSpatialModel(), **params)
-        return ValidSpatialModel(**params)
-
-    msg = "The 'xystep' parameter of"
-    assert_warns_msg(DeprecationWarning, make, msg, xystep=2)
-    with pytest.warns(DeprecationWarning):
-        model = make(xystep=2)
-    npt.assert_almost_equal(model.step, 2)
-
-    # Setting and getting the attribute:
-    assert_warns_msg(DeprecationWarning, setattr, msg, model, 'xystep', 3)
-    npt.assert_almost_equal(model.step, 3)
-    with pytest.warns(DeprecationWarning):
-        npt.assert_almost_equal(model.xystep, 3)
-
-    # And `set_params` and `build`. `Model.set_params` takes a dict, whereas
-    # `SpatialModel.set_params` takes keyword arguments:
-    if composite:
-        set_params = lambda: model.set_params({'xystep': 4})
-    else:
-        set_params = lambda: model.set_params(xystep=4)
-    assert_warns_msg(DeprecationWarning, set_params, msg)
-    npt.assert_almost_equal(model.step, 4)
-    assert_warns_msg(DeprecationWarning, model.build, msg, xystep=5)
-    npt.assert_almost_equal(model.step, 5)
-    # The grid really was laid out at the value the old name carried:
-    npt.assert_almost_equal(np.unique(np.diff(model.grid.x[0, :]))[0], 5)
-
-    # The old name is still a per-axis step, which is the whole reason it
-    # reads poorly:
-    with pytest.warns(DeprecationWarning):
-        model = make(xystep=(2, 4))
-    npt.assert_almost_equal(model.step, (2, 4))
-
-    # The new name stays silent:
-    with warnings.catch_warnings():
-        warnings.simplefilter("error", DeprecationWarning)
-        model = make(step=2)
-        model.step = 3
-        npt.assert_almost_equal(model.step, 3)
-        model.build(step=4)
-        npt.assert_almost_equal(model.step, 4)
-
-
-@pytest.mark.parametrize('old, new', [('xystep', 'step'), ('axlambda', 'lam')])
-def test_Model_renamed_param_warns_once_for_a_class(old, new):
-    """A sub-model passed as a class is still only one use of the old name
-
-    `Model` accepts a class where it documents an instance, and then builds it
-    from the same ``params`` dict that `set_params` receives. Both of those
-    rewrite renamed parameters, so the old name reaches the machinery twice
-    even though the caller wrote it once.
-    """
-    for spatial in (AxonMapSpatial, AxonMapSpatial()):
-        with pytest.warns(DeprecationWarning) as record:
-            model = Model(spatial=spatial, **{old: 400})
-        deprecations = [w for w in record
-                        if issubclass(w.category, DeprecationWarning)]
-        npt.assert_equal(len(deprecations), 1)
-        # The message names the model the caller actually constructed, and
-        # points at the line that named the old parameter:
-        npt.assert_equal(f"The '{old}' parameter of Model is deprecated"
-                         in str(deprecations[0].message), True)
-        npt.assert_equal(deprecations[0].filename, __file__)
-        npt.assert_almost_equal(getattr(model, new), 400)
-
-        # Both names are still the same parameter through this path:
-        with pytest.raises(TypeError, match="same parameter"):
-            Model(spatial=spatial, **{old: 400, new: 500})
-
-        # ...and the new name stays silent:
-        with warnings.catch_warnings():
-            warnings.simplefilter("error", DeprecationWarning)
-            npt.assert_almost_equal(
-                getattr(Model(spatial=spatial, **{new: 500}), new), 500)
-
-
-@pytest.mark.parametrize('composite', [False, True])
-def test_SpatialModel_xystep_and_step_collide(composite):
-    # `xystep` and `step` are the same parameter, so supplying both must raise
-    # rather than let the order they were passed in decide the value.
-    # `**kwargs` preserves insertion order, so check both spellings:
-    for params in ({'xystep': 2, 'step': 3}, {'step': 3, 'xystep': 2}):
-        with pytest.raises(TypeError, match="same parameter"):
-            if composite:
-                Model(spatial=ValidSpatialModel(), **params)
-            else:
-                ValidSpatialModel(**params)
-        model = (Model(spatial=ValidSpatialModel()) if composite
-                 else ValidSpatialModel())
-        with pytest.raises(TypeError, match="same parameter"):
-            model.build(**params)
-        with pytest.raises(TypeError, match="same parameter"):
-            if composite:
-                model.set_params(params)
-            else:
-                model.set_params(**params)
-
-
-@pytest.mark.parametrize('composite', [False, True])
-def test_SpatialModel_xystep_warning_blames_caller(composite):
-    # A deprecation warning is only actionable if it points at the line that
-    # used the old name. The alias is reached directly on a spatial model, but
-    # through `Model.__getattr__`/`__setattr__` on a composite one:
-    model = (Model(spatial=ValidSpatialModel()) if composite
-             else ValidSpatialModel())
-    with pytest.warns(DeprecationWarning) as record:
-        model.xystep
-    npt.assert_equal(record[0].filename, __file__)
-    with pytest.warns(DeprecationWarning) as record:
-        model.xystep = 2
-    npt.assert_equal(record[0].filename, __file__)
-    # The constructor reaches it through a chain of `super().__init__` calls
-    # instead, whose depth differs between the two classes:
-    with pytest.warns(DeprecationWarning) as record:
-        if composite:
-            Model(spatial=ValidSpatialModel(), xystep=2)
-        else:
-            ValidSpatialModel(xystep=2)
-    npt.assert_equal(record[0].filename, __file__)
-
-
-def test_SpatialModel_xystep_units():
-    # The old name forwards to `step`, so it is normalized the same way:
-    with pytest.warns(DeprecationWarning):
-        model = ValidSpatialModel(xystep=0.5 * dva)
-    npt.assert_almost_equal(model.step, 0.5)
-    npt.assert_equal(isinstance(model.step, Quantity), False)
-    with pytest.warns(DeprecationWarning):
-        model.xystep = 1 * dva
-    npt.assert_almost_equal(model.step, 1)
-    with pytest.raises(DimensionMismatchError):
-        with pytest.warns(DeprecationWarning):
-            ValidSpatialModel(xystep=1 * um)
-
-
 @pytest.mark.parametrize('param, value', [('engine', 'serial'),
-                                          ('scheduler', 'dask')])
+                                          ('scheduler', 'dask'),
+                                          ('xystep', 2)])
 def test_Model_removed_params(param, value):
     # A Model built from instances never reaches BaseModel.__init__, so this
     # path needs checking separately:
@@ -509,8 +369,6 @@ def test_SpatialModel_units():
     # retina is a different grid, not a different spelling of this one.
     with pytest.raises(DimensionMismatchError):
         ScoreboardSpatial(implant=ArgusII(), step=100 * um)
-    with pytest.raises(DimensionMismatchError):
-        ScoreboardSpatial(implant=ArgusII(), xystep=100 * um)
 
 
 def test_SpatialModel_retinal_range():

--- a/pulse2percept/models/tests/test_beyeler2019.py
+++ b/pulse2percept/models/tests/test_beyeler2019.py
@@ -333,87 +333,19 @@ def test_AxonMapModel():
 
 
 @pytest.mark.parametrize('cls', [AxonMapSpatial, AxonMapModel])
-def test_AxonMap_deprecated_axlambda(cls):
-    # `lam` was called `axlambda` until 0.10.0. The old name still works,
-    # everywhere the new one does, but warns:
-    msg = "The 'axlambda' parameter of"
-    assert_warns_msg(DeprecationWarning, cls, msg, implant=ArgusII(),
-                     axlambda=400)
-    with pytest.warns(DeprecationWarning):
-        model = cls(implant=ArgusII(), axlambda=400)
-    npt.assert_equal(model.lam, 400)
-
-    # Setting and getting the attribute:
-    assert_warns_msg(DeprecationWarning, setattr, msg, model, 'axlambda', 500)
-    npt.assert_equal(model.lam, 500)
-    with pytest.warns(DeprecationWarning):
-        npt.assert_equal(model.axlambda, 500)
-
-    # And `set_params` and `build`. `Model.set_params` takes a dict, whereas
-    # `SpatialModel.set_params` takes keyword arguments:
-    if cls is AxonMapModel:
-        set_params = lambda: model.set_params({'axlambda': 600})
-    else:
-        set_params = lambda: model.set_params(axlambda=600)
-    assert_warns_msg(DeprecationWarning, set_params, msg)
-    npt.assert_equal(model.lam, 600)
-    # `build` reads the axon cache, which raises a ResourceWarning of its own,
-    # so this one cannot insist on a single warning:
-    with pytest.warns(DeprecationWarning, match="'axlambda' parameter"):
-        model.build(axlambda=700)
-    npt.assert_equal(model.lam, 700)
-
-    # The new name stays silent:
-    with warnings.catch_warnings():
-        warnings.simplefilter("error", DeprecationWarning)
-        model = cls(lam=400)
-        model.lam = 500
-        npt.assert_equal(model.lam, 500)
-
-
-@pytest.mark.parametrize('cls', [AxonMapSpatial, AxonMapModel])
-def test_AxonMap_axlambda_and_lam_collide(cls):
-    # `axlambda` and `lam` are the same parameter, so supplying both must
-    # raise rather than let the order they were passed in decide the value.
-    # `**kwargs` preserves insertion order, so check both spellings:
-    for params in ({'axlambda': 400, 'lam': 500},
-                   {'lam': 500, 'axlambda': 400}):
-        with pytest.raises(TypeError, match="same parameter"):
-            cls(**params)
-        model = cls(step=5)
-        with pytest.raises(TypeError, match="same parameter"):
-            model.build(**params)
-        with pytest.raises(TypeError, match="same parameter"):
-            if cls is AxonMapModel:
-                model.set_params(params)
-            else:
-                model.set_params(**params)
-
-
-@pytest.mark.parametrize('cls', [AxonMapSpatial, AxonMapModel])
-def test_AxonMap_axlambda_warning_blames_caller(cls):
-    # A deprecation warning is only actionable if it points at the line that
-    # used the old name. The alias is reached directly on a spatial model, but
-    # through `Model.__getattr__`/`__setattr__` on a composite one, so the
-    # attribution has to hold for both:
-    model = cls(step=5)
-    with pytest.warns(DeprecationWarning) as record:
-        model.axlambda
-    npt.assert_equal(record[0].filename, __file__)
-    with pytest.warns(DeprecationWarning) as record:
-        model.axlambda = 400
-    npt.assert_equal(record[0].filename, __file__)
-    # The constructor reaches it through a chain of `super().__init__` calls
-    # instead, whose depth differs between the two classes:
-    with pytest.warns(DeprecationWarning) as record:
+def test_AxonMap_removed_axlambda(cls):
+    # `lam` was called `axlambda` until 0.10.0; the old name was removed
+    # in 0.11.0, so it is now an unknown parameter:
+    with pytest.raises(AttributeError):
         cls(axlambda=400)
-    npt.assert_equal(record[0].filename, __file__)
+    with pytest.raises(AttributeError):
+        model = cls(step=5)
+        if cls is AxonMapModel:
+            model.set_params({'axlambda': 400})
+        else:
+            model.set_params(axlambda=400)
 
 
-# Build the model inside the test, not in the decorator: arguments to
-# `parametrize` are evaluated at import time, so building here would run on
-# every pytest invocation (even `--collect-only`, even when this test is
-# deselected) and would surface any failure as a collection error.
 @pytest.mark.parametrize('build', (False, True))
 def test_deepcopy_AxonMapModel(build):
     original = AxonMapModel(implant=ArgusII())
@@ -933,10 +865,8 @@ def test_AxonMapModel_build_rejects_pre_step_cache(tmp_path):
     """A cache naming the grid step `xystep` is regrown, and stays quiet
 
     The parameter dict is versioned along with the payload, so a cache written
-    before the rename is discarded outright. Reading it instead would probe
-    `self.xystep` -- a deprecated name the caller never used -- and warn about
-    it on every build, since the stale entry validates and the file is
-    therefore never rewritten.
+    before the 0.10.0 rename is discarded outright rather than validated
+    against a model that no longer has a `xystep` parameter.
     """
     pickle_file = str(tmp_path / 'axons.pickle')
 

--- a/pulse2percept/models/tests/test_granley2021.py
+++ b/pulse2percept/models/tests/test_granley2021.py
@@ -1,6 +1,5 @@
 from contextlib import contextmanager
 import copy
-import warnings
 
 import numpy as np
 import pytest
@@ -23,7 +22,6 @@ from pulse2percept.units import (DimensionMismatchError, Quantity,
                                  dimensionless, mm, ms, s, uA, um,
                                  xTh)
 from pulse2percept.utils.base import FreezeError
-from pulse2percept.utils.testing import assert_warns_msg
 
 # Building an axon map writes a cache to a relative path; keep it in a
 # temporary directory instead of wherever pytest was started from:
@@ -386,59 +384,13 @@ def test_biphasicAxonMapModel():
         BiphasicAxonMapModel(implant=ArgusII(), lam=9).build()
 
 
-@pytest.mark.parametrize('cls', [BiphasicAxonMapSpatial, BiphasicAxonMapModel])
-def test_biphasicAxonMap_deprecated_axlambda(cls):
-    # `lam` was called `axlambda` until 0.10.0. The old name still works, and
-    # still reaches the streak model, but warns. These classes inherit the
-    # alias from `AxonMapSpatial`, so pin the class the message names: it has
-    # to be the one the user is holding, not the one it was declared on.
-    msg = f"The 'axlambda' parameter of {cls.__name__} is deprecated"
-    assert_warns_msg(DeprecationWarning, cls, msg, axlambda=400)
-    with pytest.warns(DeprecationWarning):
-        model = cls(implant=ArgusII(), axlambda=400)
-    npt.assert_equal(model.lam, 400)
-    npt.assert_equal(model.streak_model.lam, 400)
-
-    # Reached through the descriptor rather than the constructor, the alias
-    # only ever sees the spatial model, even on the composite:
-    spatial_msg = ("The 'axlambda' parameter of BiphasicAxonMapSpatial is "
-                   "deprecated")
-    assert_warns_msg(DeprecationWarning, setattr, spatial_msg, model,
-                     'axlambda', 500)
-    npt.assert_equal(model.lam, 500)
-    npt.assert_equal(model.streak_model.lam, 500)
-    with pytest.warns(DeprecationWarning, match="BiphasicAxonMapSpatial"):
-        npt.assert_equal(model.axlambda, 500)
-
-    # Supplying both names is an error, whichever order they come in:
-    for params in ({'axlambda': 400, 'lam': 500},
-                   {'lam': 500, 'axlambda': 400}):
-        with pytest.raises(TypeError, match="same parameter"):
-            cls(implant=ArgusII(), **params)
-
-    # The new name stays silent:
-    with warnings.catch_warnings():
-        warnings.simplefilter("error", DeprecationWarning)
-        model = cls(implant=ArgusII(), lam=400)
-        model.lam = 500
-        npt.assert_equal(model.lam, 500)
-        npt.assert_equal(model.streak_model.lam, 500)
-
-
-def test_DefaultStreakModel_deprecated_axlambda():
-    # The streak model takes `lam` in its signature, so the old name is only
-    # forwarded as a keyword argument:
-    assert_warns_msg(DeprecationWarning, DefaultStreakModel,
-                     "The 'axlambda' parameter of DefaultStreakModel is "
-                     "deprecated since version 0.10.0, and will be removed in "
-                     "version 0.11.0. Use 'lam' instead.", axlambda=200)
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore", DeprecationWarning)
-        npt.assert_equal(DefaultStreakModel(axlambda=200).lam, 200)
-    with warnings.catch_warnings():
-        warnings.simplefilter("error", DeprecationWarning)
-        npt.assert_equal(DefaultStreakModel(lam=200).lam, 200)
-        npt.assert_equal(DefaultStreakModel(200).lam, 200)
+def test_DefaultStreakModel_removed_axlambda():
+    # The streak model took `axlambda` as a keyword until 0.10.0; the old
+    # name was removed in 0.11.0:
+    with pytest.raises(TypeError):
+        DefaultStreakModel(axlambda=200)
+    npt.assert_equal(DefaultStreakModel(lam=200).lam, 200)
+    npt.assert_equal(DefaultStreakModel(200).lam, 200)
 
 
 @pytest.mark.parametrize('model_cls', [BiphasicAxonMapModel,

--- a/pulse2percept/models/thompson2003.py
+++ b/pulse2percept/models/thompson2003.py
@@ -58,12 +58,6 @@ class Thompson2003Spatial(SpatialModel):
         visual angle). For example, to create a grid with x values [0, 0.5, 1]
         use ``xrange=(0, 1)`` and ``step=0.5``. Pass a tuple to give the x
         and y axes different step sizes.
-
-        .. versionchanged:: 0.10.0
-
-            Renamed from ``xystep``, which suggested that one step size
-            applies to both axes. The old name still works, but is
-            deprecated and will be removed in v0.11.0.
     grid_type : {'rectangular', 'hexagonal'}, optional
         Whether to simulate points on a rectangular or hexagonal grid
     vfmap : :py:class:`~pulse2percept.topography.VisualFieldMap`, optional
@@ -162,12 +156,6 @@ class Thompson2003Model(Model):
         visual angle). For example, to create a grid with x values [0, 0.5, 1]
         use ``xrange=(0, 1)`` and ``step=0.5``. Pass a tuple to give the x
         and y axes different step sizes.
-
-        .. versionchanged:: 0.10.0
-
-            Renamed from ``xystep``, which suggested that one step size
-            applies to both axes. The old name still works, but is
-            deprecated and will be removed in v0.11.0.
     grid_type : {'rectangular', 'hexagonal'}, optional
         Whether to simulate points on a rectangular or hexagonal grid
     vfmap : :py:class:`~pulse2percept.topography.VisualFieldMap`, optional

--- a/pulse2percept/utils/animation.py
+++ b/pulse2percept/utils/animation.py
@@ -665,6 +665,9 @@ class HTMLAnimation(FuncAnimation):
             kwargs.setdefault('interval', float(intervals.mean()))
         self._intervals = intervals
         super().__init__(fig, func, frames, *args, **kwargs)
+        # Avoid Matplotlib's "deleted without rendering warning", which
+        # turns into an unraisable exception wherever warnings are errors:
+        self._draw_was_started = True
 
     def _display_intervals(self, fps, n_frames):
         """How long each frame stays up (in ms), one value per frame"""
@@ -761,9 +764,6 @@ class HTMLAnimation(FuncAnimation):
             default_mode = 'loop' if self._repeat else 'once'
         intervals = self._display_intervals(
             fps, int(np.shape(self._frame_data)[-1]))
-        # We are rendering the animation ourselves, so silence Matplotlib's
-        # "Animation was deleted without rendering anything" warning:
-        self._draw_was_started = True
         # Rendering the sprite sheet is the expensive part, so only do it once:
         key = (tuple(intervals), default_mode)
         if self._html is None or self._html[0] != key:


### PR DESCRIPTION
Removes obsolete variables `xystep` and `axlambda`