### PR TITLE
[ENH] Add PRIMA optical stimulus encoding

### DIFF
--- a/benchmarks/scenarios.py
+++ b/benchmarks/scenarios.py
@@ -15,14 +15,17 @@ first two correspond to these one-liners::
                             xrange=(-12, 12)).predict_percept(
         as_current(implant, p2p.stimuli.LogoBVL()))
 
-    implant = p2p.implants.PRIMAPivotal()
-    p2p.models.ScoreboardModel(implant=implant, yrange=(-4, 4),
-                               xrange=(-4, 4), rho=50,
+    p2p.models.ScoreboardModel(implant=p2p.implants.PRIMAPivotal(),
+                               yrange=(-4, 4), xrange=(-4, 4), rho=50,
                                step=0.1).predict_percept(
-        as_current(implant, p2p.stimuli.LogoBVL().invert()))
+        p2p.stimuli.LogoBVL().invert())
 
-The :func:`as_current` wrapper is a benchmark-only detail; see its docstring
-for why these workloads do not go through an encoder the way user code should.
+The PRIMA scenario needs no wrapper: the device is illuminated rather than
+driven by a current source, and what its encoder hands a spatial model is one
+normalized-drive frame -- the same shape of workload the electrical scenarios
+measure. The :func:`as_current` wrapper is a benchmark-only detail for those;
+see its docstring for why they do not go through an encoder the way user code
+should.
 
 Between them the scenarios reach every compiled kernel a percept prediction can
 go through -- ``_beyeler2019``, ``_granley2021``, ``_nanduri2012``,
@@ -180,10 +183,13 @@ SCENARIOS = [
         caches_axons=True,
     ),
     Scenario(
+        # The one scenario that runs an encoder: PRIMA is illuminated, so its
+        # implant refuses microamps outright, and the optical stimulus its
+        # encoder builds stays a schedule until a model asks for samples --
+        # which a spatial model never does.
         id='prima_scoreboard_logobvl',
         stimulus=lambda: p2p.stimuli.LogoBVL().invert(),
         implant=p2p.implants.PRIMAPivotal,
-        source=as_current,
         model=lambda **kwargs: p2p.models.ScoreboardModel(xrange=(-4, 4),
                                                           yrange=(-4, 4),
                                                           rho=50, step=0.1,

--- a/benchmarks/scenarios.py
+++ b/benchmarks/scenarios.py
@@ -20,12 +20,8 @@ first two correspond to these one-liners::
                                step=0.1).predict_percept(
         p2p.stimuli.LogoBVL().invert())
 
-The PRIMA scenario needs no wrapper: the device is illuminated rather than
-driven by a current source, and what its encoder hands a spatial model is one
-normalized-drive frame -- the same shape of workload the electrical scenarios
-measure. The :func:`as_current` wrapper is a benchmark-only detail for those;
-see its docstring for why they do not go through an encoder the way user code
-should.
+The PRIMA scenario runs its optical encoder directly. Electrical scenarios
+use :func:`as_current` to preserve their historical benchmark workload.
 
 Between them the scenarios reach every compiled kernel a percept prediction can
 go through -- ``_beyeler2019``, ``_granley2021``, ``_nanduri2012``,
@@ -183,10 +179,7 @@ SCENARIOS = [
         caches_axons=True,
     ),
     Scenario(
-        # The one scenario that runs an encoder: PRIMA is illuminated, so its
-        # implant refuses microamps outright, and the optical stimulus its
-        # encoder builds stays a schedule until a model asks for samples --
-        # which a spatial model never does.
+        # Benchmark the image-to-optical encoding path for PRIMA.
         id='prima_scoreboard_logobvl',
         stimulus=lambda: p2p.stimuli.LogoBVL().invert(),
         implant=p2p.implants.PRIMAPivotal,

--- a/doc/topics/encoders.rst
+++ b/doc/topics/encoders.rst
@@ -115,10 +115,12 @@ is fixed either way. Contrast inversion and edge enhancement are not part of
 the device, so they are ordinary ``ImageStimulus`` operations applied first
 (``image.invert()``, ``image.filter('canny')``).
 
-The projector clock samples a video; it does not re-time it. Every ``1 / freq``
-the device looks at whatever frame the source is showing (zero-order hold), so
-a 15 fps source has its frames re-sent and a 60 fps source has frames skipped,
-and either way the content keeps its own duration.
+The projector clock samples a video; it does not re-time it. Starting at the
+source's first frame, every ``1 / freq`` the device looks at whatever frame the
+source is showing (zero-order hold), so a 15 fps source has its frames re-sent
+and a 60 fps source has frames skipped, and either way the content keeps its
+own timing -- including a nonzero start time, as a cropped video has. A pulse
+that would not finish before the presentation ends is not started.
 
 Converting light into retinal current is the job of a photovoltaic model, which
 pulse2percept does not have yet. Until it does, the encoded stimulus offers

--- a/doc/topics/encoders.rst
+++ b/doc/topics/encoders.rst
@@ -95,12 +95,9 @@ Optical encoding
 
 .. versionadded:: 0.11.0
 
-:py:class:`~pulse2percept.implants.PRIMAPivotal` is photovoltaic: a projector
-paints an 880 nm image onto the implant, and each pixel turns the light it
-receives into local electrical stimulation. Intensity is set by *how long* a
-pixel is lit rather than by how brightly, so
-:py:class:`~pulse2percept.stimuli.PRIMAEncoder` returns absolute irradiance in
-``mW/mm^2``, not microamps:
+:py:class:`~pulse2percept.implants.PRIMAPivotal` is illuminated by an
+880 nm projector. :py:class:`~pulse2percept.stimuli.PRIMAEncoder` maps image
+intensity to pulse duration and returns irradiance in ``mW/mm^2``:
 
 .. code-block:: python
 
@@ -108,56 +105,37 @@ pixel is lit rather than by how brightly, so
     stim = implant.prepare_stim(p2p.stimuli.LogoBVL())
     stim.unit  # mW/mm^2
 
-The projector offers 14 discrete ON durations, 0.7 to 9.8 ms in 0.7 ms steps,
-plus off. By default the encoder maps normalized image intensity linearly onto
-those levels; that linear map is a pulse2percept convention, since the clinical
-camera-gray-level to pulse-duration transfer function is not published. Pass
-``grayscale=False`` for a binary approximation, in which a pixel is off or on
-for ``pulse_dur``. Peak irradiance is fixed either way.
+At the default settings, the projector runs at 30 Hz and 3.5 mW/mm^2. It has
+14 nonzero ON durations from 0.7 to 9.8 ms. The default linear mapping from
+image intensity to these levels is a pulse2percept convention; the clinical
+camera-to-pulse-duration transfer function is not published. Set
+``grayscale=False`` for binary encoding.
 
-The clinical system processes the camera image before projecting it, including
-ambient-light adaptation, contrast enhancement and zoom, and contrast inversion
-has been used deliberately in testing. ``PRIMAEncoder`` models the optical
-encoding stage that follows; preprocessing stays explicit in pulse2percept
-because the clinical pipeline is not specified in enough detail to reproduce,
-so it is applied to the source first (``image.invert()``,
-``image.filter('canny')``).
+The clinical system also applies ambient-light adaptation, contrast
+enhancement, zoom, and, in some tests, contrast inversion. These operations
+remain explicit preprocessing steps in pulse2percept.
 
-The projector clock samples a video; it does not re-time it. Starting at the
-source's first frame, every ``1 / freq`` the device looks at whatever frame the
-source is showing (zero-order hold), so a 15 fps source has its frames re-sent
-and a 60 fps source has frames skipped, and either way the content keeps its
-own timing -- including a nonzero start time, as a cropped video has. A pulse
-that would not finish before the presentation ends is not started.
-
-Converting light into retinal current is the job of a photovoltaic model, which
-pulse2percept does not have yet. Until it does, the encoded stimulus offers
-spatial-only models a *normalized optical drive* -- peak irradiance times duty
-cycle, divided by the largest drive the pivotal device is documented to
-produce -- and
-:py:class:`~pulse2percept.models.ScoreboardModel` reads it:
+For videos, source frames are sampled on the projector clock using zero-order
+hold. Spatial-only models can read the resulting *normalized optical drive*.
+For example:
 
 .. code-block:: python
 
     model = p2p.models.ScoreboardModel(implant=implant)
     percept = model.predict_percept(p2p.stimuli.LogoBVL())
 
-That is a visualization of implant geometry and stimulation pattern. It does
-not model photodiode transduction, retinal electric fields, bipolar-cell
-activation, electrode-retina distance, or temporal retinal dynamics.
+Here ``ScoreboardModel`` visualizes implant geometry and optical drive. It does
+not model photovoltaic transduction or retinal activation.
 
 Device constraints
 ------------------
 
 An implant's :py:class:`~pulse2percept.implants.Raster` determines which
-electrodes may pulse together; see :ref:`topics-rasters`. PRIMA has none: all
-378 photovoltaic pixels may be illuminated at once. With ``safe_mode=True`` it
-instead checks the documented operating envelope -- at most 3.5 mW/mm^2, ON
-durations on the 0.7 ms grid and no longer than 9.8 ms, a duty cycle of at most
-0.294, and the 30 Hz the pivotal system is reported to run at. That is what the
-device is documented to do, not a biological safety limit and not a
-demonstrated hardware maximum, and it is read off the stimulus' own schedule: a
-stimulus that has been reduced to samples cannot be verified and is refused.
+electrodes may pulse together; see :ref:`topics-rasters`. PRIMA uses no raster;
+all 378 pixels may be illuminated at once. With ``safe_mode=True``,
+:py:class:`~pulse2percept.implants.PRIMAPivotal` checks the documented projector
+settings (3.5 mW/mm^2, 30 Hz, 0.7--9.8 ms ON durations, and duty cycle <= 0.294).
+This is not a biological safety check or a demonstrated hardware maximum.
 
 Encoders can also quantize timing with ``clock`` and gray levels with
 ``n_levels``. These constraints are conservative: quantization may lower a

--- a/doc/topics/encoders.rst
+++ b/doc/topics/encoders.rst
@@ -6,9 +6,11 @@ Stimulus Encoders
 
 .. versionadded:: 0.10.0
 
-A visual source contains gray levels; an implant delivers electrical pulses. A
-:py:class:`~pulse2percept.stimuli.StimulusEncoder` defines the mapping between
-the two.
+A visual source contains gray levels; an implant delivers stimulation. An
+:py:class:`~pulse2percept.stimuli.Encoder` defines the mapping between the two.
+:py:class:`~pulse2percept.stimuli.StimulusEncoder` covers devices driven by a
+current source; :py:class:`~pulse2percept.stimuli.PRIMAEncoder` covers the
+photovoltaic PRIMA system, which is driven by light.
 
 Basic usage
 -----------
@@ -88,11 +90,55 @@ whether encoding happened explicitly or inside ``prepare_stim``.
 Waveform samples are generated lazily, so encoding a large image or video does
 not allocate the full electrical waveform until something needs it.
 
+Optical encoding
+----------------
+
+.. versionadded:: 0.11.0
+
+:py:class:`~pulse2percept.implants.PRIMAPivotal` is photovoltaic: a projector
+paints an 880 nm image onto the implant, and each pixel turns the light it
+receives into local electrical stimulation. Intensity is set by *how long* a
+pixel is lit rather than by how brightly, so
+:py:class:`~pulse2percept.stimuli.PRIMAEncoder` returns absolute irradiance in
+``mW/mm^2``, not microamps:
+
+.. code-block:: python
+
+    implant = p2p.implants.PRIMAPivotal()
+    stim = implant.prepare_stim(p2p.stimuli.LogoBVL())
+    stim.unit  # mW/mm^2
+
+Encoding is binary by default (a pixel is off, or on for ``pulse_dur``), which
+matches current clinical operation; ``grayscale=True`` pulse-width modulates
+gray levels onto the projector's 0.7 ms duration grid instead. Peak irradiance
+is fixed either way. Contrast inversion and edge enhancement are not part of
+the device, so they are ordinary ``ImageStimulus`` operations applied first
+(``image.invert()``, ``image.filter('canny')``).
+
+Converting light into retinal current is the job of a photovoltaic model, which
+pulse2percept does not have yet. Until it does, the encoded stimulus offers
+spatial-only models a *normalized optical drive* -- irradiance times ON
+duration times frame rate, divided by the largest drive the pivotal device is
+documented to produce -- and
+:py:class:`~pulse2percept.models.ScoreboardModel` reads it:
+
+.. code-block:: python
+
+    model = p2p.models.ScoreboardModel(implant=implant)
+    percept = model.predict_percept(p2p.stimuli.LogoBVL())
+
+That is a visualization of implant geometry and stimulation pattern. It does
+not model photodiode transduction, retinal electric fields, bipolar-cell
+activation, electrode-retina distance, or temporal retinal dynamics.
+
 Device constraints
 ------------------
 
 An implant's :py:class:`~pulse2percept.implants.Raster` determines which
-electrodes may pulse together; see :ref:`topics-rasters`.
+electrodes may pulse together; see :ref:`topics-rasters`. PRIMA has none: all
+378 photovoltaic pixels may be illuminated at once. With ``safe_mode=True`` it
+instead checks the projector envelope -- at most 3.5 mW/mm^2, ON durations on
+the 0.7 ms grid and no longer than 9.8 ms, and a duty cycle of at most 0.294.
 
 Encoders can also quantize timing with ``clock`` and gray levels with
 ``n_levels``. These constraints are conservative: quantization may lower a

--- a/doc/topics/encoders.rst
+++ b/doc/topics/encoders.rst
@@ -115,11 +115,16 @@ is fixed either way. Contrast inversion and edge enhancement are not part of
 the device, so they are ordinary ``ImageStimulus`` operations applied first
 (``image.invert()``, ``image.filter('canny')``).
 
+The projector clock samples a video; it does not re-time it. Every ``1 / freq``
+the device looks at whatever frame the source is showing (zero-order hold), so
+a 15 fps source has its frames re-sent and a 60 fps source has frames skipped,
+and either way the content keeps its own duration.
+
 Converting light into retinal current is the job of a photovoltaic model, which
 pulse2percept does not have yet. Until it does, the encoded stimulus offers
-spatial-only models a *normalized optical drive* -- irradiance times ON
-duration times frame rate, divided by the largest drive the pivotal device is
-documented to produce -- and
+spatial-only models a *normalized optical drive* -- peak irradiance times duty
+cycle, divided by the largest drive the pivotal device is documented to
+produce -- and
 :py:class:`~pulse2percept.models.ScoreboardModel` reads it:
 
 .. code-block:: python
@@ -137,8 +142,11 @@ Device constraints
 An implant's :py:class:`~pulse2percept.implants.Raster` determines which
 electrodes may pulse together; see :ref:`topics-rasters`. PRIMA has none: all
 378 photovoltaic pixels may be illuminated at once. With ``safe_mode=True`` it
-instead checks the projector envelope -- at most 3.5 mW/mm^2, ON durations on
-the 0.7 ms grid and no longer than 9.8 ms, and a duty cycle of at most 0.294.
+instead checks the projector envelope -- at most 3.5 mW/mm^2, at most 30 Hz,
+ON durations on the 0.7 ms grid and no longer than 9.8 ms, and a duty cycle of
+at most 0.294. That is the *device* envelope, not a biological safety limit,
+and it is read off the stimulus' own schedule: a stimulus that has been reduced
+to samples cannot be verified and is refused.
 
 Encoders can also quantize timing with ``clock`` and gray levels with
 ``n_levels``. These constraints are conservative: quantization may lower a

--- a/doc/topics/encoders.rst
+++ b/doc/topics/encoders.rst
@@ -108,12 +108,20 @@ pixel is lit rather than by how brightly, so
     stim = implant.prepare_stim(p2p.stimuli.LogoBVL())
     stim.unit  # mW/mm^2
 
-Encoding is binary by default (a pixel is off, or on for ``pulse_dur``), which
-matches current clinical operation; ``grayscale=True`` pulse-width modulates
-gray levels onto the projector's 0.7 ms duration grid instead. Peak irradiance
-is fixed either way. Contrast inversion and edge enhancement are not part of
-the device, so they are ordinary ``ImageStimulus`` operations applied first
-(``image.invert()``, ``image.filter('canny')``).
+The projector offers 14 discrete ON durations, 0.7 to 9.8 ms in 0.7 ms steps,
+plus off. By default the encoder maps normalized image intensity linearly onto
+those levels; that linear map is a pulse2percept convention, since the clinical
+camera-gray-level to pulse-duration transfer function is not published. Pass
+``grayscale=False`` for a binary approximation, in which a pixel is off or on
+for ``pulse_dur``. Peak irradiance is fixed either way.
+
+The clinical system processes the camera image before projecting it, including
+ambient-light adaptation, contrast enhancement and zoom, and contrast inversion
+has been used deliberately in testing. ``PRIMAEncoder`` models the optical
+encoding stage that follows; preprocessing stays explicit in pulse2percept
+because the clinical pipeline is not specified in enough detail to reproduce,
+so it is applied to the source first (``image.invert()``,
+``image.filter('canny')``).
 
 The projector clock samples a video; it does not re-time it. Starting at the
 source's first frame, every ``1 / freq`` the device looks at whatever frame the
@@ -144,11 +152,12 @@ Device constraints
 An implant's :py:class:`~pulse2percept.implants.Raster` determines which
 electrodes may pulse together; see :ref:`topics-rasters`. PRIMA has none: all
 378 photovoltaic pixels may be illuminated at once. With ``safe_mode=True`` it
-instead checks the projector envelope -- at most 3.5 mW/mm^2, at most 30 Hz,
-ON durations on the 0.7 ms grid and no longer than 9.8 ms, and a duty cycle of
-at most 0.294. That is the *device* envelope, not a biological safety limit,
-and it is read off the stimulus' own schedule: a stimulus that has been reduced
-to samples cannot be verified and is refused.
+instead checks the documented operating envelope -- at most 3.5 mW/mm^2, ON
+durations on the 0.7 ms grid and no longer than 9.8 ms, a duty cycle of at most
+0.294, and the 30 Hz the pivotal system is reported to run at. That is what the
+device is documented to do, not a biological safety limit and not a
+demonstrated hardware maximum, and it is read off the stimulus' own schedule: a
+stimulus that has been reduced to samples cannot be verified and is refused.
 
 Encoders can also quantize timing with ``clock`` and gray levels with
 ``n_levels``. These constraints are conservative: quantization may lower a

--- a/doc/users/release_notes.rst
+++ b/doc/users/release_notes.rst
@@ -32,6 +32,23 @@ API changes:
 * :py:class:`~pulse2percept.implants.RectangleImplant` is deprecated in favor
   of :py:class:`~pulse2percept.implants.GridImplant` (:pull:`859`)
 
+* New :py:class:`~pulse2percept.stimuli.PRIMAEncoder` models the PRIMA
+  projector: 880 nm illumination at 30 Hz, 3.5 mW/mm^2, intensity set by pulse
+  duration on a 0.7 ms grid. It returns irradiance (``mW/mm^2``), not current;
+  :py:class:`~pulse2percept.implants.PRIMAPivotal` brings one along and its
+  ``safe_mode`` now checks the projector envelope rather than charge balance.
+
+* New :py:class:`~pulse2percept.stimuli.Encoder` base class, so that
+  ``implant.encoder`` accepts non-electrical encoders.
+  :py:class:`~pulse2percept.stimuli.StimulusEncoder` inherits from it.
+
+* New ``W``, ``mW`` and ``uW`` units, from which irradiance follows as
+  ``mW / mm ** 2``.
+
+* :py:class:`~pulse2percept.models.ScoreboardSpatial` also accepts a
+  dimensionless stimulus, so it can visualize the normalized optical drive of a
+  photovoltaic implant.
+
 * New :py:class:`~pulse2percept.implants.Ho2019FlatArray` models the 55
   and 40 um flat arrays of [Ho2019]_; new
   :py:class:`~pulse2percept.implants.Huang2021Array` models the 55, 40, 30 and

--- a/doc/users/release_notes.rst
+++ b/doc/users/release_notes.rst
@@ -47,9 +47,10 @@ API changes:
 * New ``W``, ``mW`` and ``uW`` units, from which irradiance follows as
   ``mW / mm ** 2``.
 
-* :py:class:`~pulse2percept.models.ScoreboardSpatial` also accepts a
-  dimensionless stimulus, so it can visualize the normalized optical drive of a
-  photovoltaic implant.
+* :py:class:`~pulse2percept.models.ScoreboardSpatial` can also read the
+  normalized dimensionless drive produced by photovoltaic encoders such as
+  :py:class:`~pulse2percept.stimuli.PRIMAEncoder`; arbitrary dimensionless
+  stimuli such as image gray levels remain invalid.
 
 * New :py:class:`~pulse2percept.implants.Ho2019FlatArray` models the 55
   and 40 um flat arrays of [Ho2019]_; new

--- a/doc/users/release_notes.rst
+++ b/doc/users/release_notes.rst
@@ -34,7 +34,8 @@ API changes:
 
 * New :py:class:`~pulse2percept.stimuli.PRIMAEncoder` models the PRIMA
   projector: 880 nm illumination at 30 Hz, 3.5 mW/mm^2, intensity set by pulse
-  duration on a 0.7 ms grid. It returns irradiance (``mW/mm^2``), not current;
+  duration on a 0.7 ms grid. It samples a source at the projector clock rather
+  than re-timing it, and returns irradiance (``mW/mm^2``), not current;
   :py:class:`~pulse2percept.implants.PRIMAPivotal` brings one along and its
   ``safe_mode`` now checks the projector envelope rather than charge balance.
 

--- a/doc/users/release_notes.rst
+++ b/doc/users/release_notes.rst
@@ -32,13 +32,11 @@ API changes:
 * :py:class:`~pulse2percept.implants.RectangleImplant` is deprecated in favor
   of :py:class:`~pulse2percept.implants.GridImplant` (:pull:`859`)
 
-* New :py:class:`~pulse2percept.stimuli.PRIMAEncoder` models the PRIMA
-  projector: 880 nm illumination at 30 Hz and 3.5 mW/mm^2, with intensity set
-  by the projector's 14 pulse durations (0.7 to 9.8 ms). It samples a source at
-  the projector clock rather than re-timing it, and returns irradiance
-  (``mW/mm^2``), not current;
-  :py:class:`~pulse2percept.implants.PRIMAPivotal` brings one along and its
-  ``safe_mode`` now checks the projector envelope rather than charge balance.
+* New :py:class:`~pulse2percept.stimuli.PRIMAEncoder` maps images and videos
+  to 880 nm irradiance for :py:class:`~pulse2percept.implants.PRIMAPivotal`,
+  using the pivotal system's 30 Hz projector and 14 pulse-duration levels
+  (0.7--9.8 ms). ``PRIMAPivotal`` uses this encoder by default, and its
+  ``safe_mode`` checks the documented projector operating envelope.
 
 * New :py:class:`~pulse2percept.stimuli.Encoder` base class, so that
   ``implant.encoder`` accepts non-electrical encoders.

--- a/doc/users/release_notes.rst
+++ b/doc/users/release_notes.rst
@@ -33,9 +33,10 @@ API changes:
   of :py:class:`~pulse2percept.implants.GridImplant` (:pull:`859`)
 
 * New :py:class:`~pulse2percept.stimuli.PRIMAEncoder` models the PRIMA
-  projector: 880 nm illumination at 30 Hz, 3.5 mW/mm^2, intensity set by pulse
-  duration on a 0.7 ms grid. It samples a source at the projector clock rather
-  than re-timing it, and returns irradiance (``mW/mm^2``), not current;
+  projector: 880 nm illumination at 30 Hz and 3.5 mW/mm^2, with intensity set
+  by the projector's 14 pulse durations (0.7 to 9.8 ms). It samples a source at
+  the projector clock rather than re-timing it, and returns irradiance
+  (``mW/mm^2``), not current;
   :py:class:`~pulse2percept.implants.PRIMAPivotal` brings one along and its
   ``safe_mode`` now checks the projector envelope rather than charge balance.
 

--- a/examples/implants/plot_prima.py
+++ b/examples/implants/plot_prima.py
@@ -1,0 +1,104 @@
+"""
+===============================================================================
+Simulating PRIMA
+===============================================================================
+
+Background
+----------
+
+:py:class:`~pulse2percept.implants.PRIMAPivotal` is the subretinal photovoltaic
+array used in the PRIMAvera pivotal trial [Holz2026]_ and in the earlier
+first-in-human study [Palanker2020]_. Its 378 pixels sit on a 100 um hexagonal
+grid on a 2 x 2 mm substrate.
+
+PRIMA is not driven by a current source. A goggle-mounted projector paints an
+880 nm near-infrared image onto the implant, and each photovoltaic pixel turns
+the light it receives into local electrical stimulation. The projector runs at
+a fixed frame rate (30 Hz) and a fixed peak irradiance (3.5 mW/mm^2), and
+encodes intensity in *how long* a pixel is lit -- 0.7 to 9.8 ms per frame --
+rather than in how brightly.
+
+:py:class:`~pulse2percept.stimuli.PRIMAEncoder` implements that projector, and
+:py:class:`~pulse2percept.implants.PRIMAPivotal` brings one along, so a picture
+can be presented directly:
+"""
+# sphinx_gallery_thumbnail_number = 2
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pulse2percept as p2p
+
+implant = p2p.implants.PRIMAPivotal()
+image = p2p.stimuli.LogoBVL()
+stim = implant.prepare_stim(image)
+print(stim.unit)
+
+###############################################################################
+# What comes back is 880 nm optical irradiance versus time at each pixel, not
+# electrical current. Turning light into retinal current depends on photodiode
+# behavior, electrode capacitance, and the surrounding tissue, none of which
+# pulse2percept models yet.
+#
+# One projector period looks the same at every lit pixel: irradiance rises to
+# 3.5 mW/mm^2 for the pixel's ON duration and is zero for the rest of the
+# 33.3 ms frame.
+
+lit = np.flatnonzero(stim.data.max(axis=1) > 0)[0]
+fig, ax = plt.subplots(figsize=(8, 2.5))
+ax.plot(stim.time, stim.data[lit], lw=1.5)
+ax.set_xlim(0, 100)
+ax.set_xlabel('Time (ms)')
+ax.set_ylabel('Irradiance (mW/mm$^2$)')
+ax.set_title(f'Pixel {stim.electrodes[lit]}: 9.8 ms on, 33.3 ms period')
+fig.tight_layout()
+
+###############################################################################
+# Visualizing the stimulation pattern
+# -----------------------------------
+#
+# :py:class:`~pulse2percept.models.ScoreboardModel` places a Gaussian blob at
+# every pixel. For a photovoltaic implant it weights each blob by *normalized
+# optical drive*: irradiance times ON duration times frame rate, divided by the
+# largest drive the pivotal device is documented to produce. A dark pixel is 0,
+# a pixel at the full documented drive is 1.
+#
+# This is a simple visualization of implant geometry and stimulation pattern.
+# It does not model photodiode transduction, retinal electric fields,
+# bipolar-cell activation, electrode-retina distance, or temporal retinal
+# dynamics.
+
+model = p2p.models.ScoreboardModel(implant=implant, rho=100)
+
+###############################################################################
+# Image processing is not PRIMA-specific
+# --------------------------------------
+#
+# The encoder binarizes at ``threshold=0.5`` by default, which is
+# pulse2percept's approximation of an unpublished clinical algorithm. Contrast
+# inversion and edge enhancement are *not* intrinsic to the device, so they are
+# ordinary :py:class:`~pulse2percept.stimuli.ImageStimulus` operations applied
+# before encoding:
+
+sources = [('As is', image),
+           ('Inverted', image.invert()),
+           ('Canny edges', image.rgb2gray().filter('canny'))]
+
+fig, axes = plt.subplots(nrows=2, ncols=3, figsize=(11, 6))
+for (title, source), top, bottom in zip(sources, axes[0], axes[1]):
+    source.plot(ax=top)
+    top.set_title(title)
+    model.predict_percept(source).plot(ax=bottom)
+fig.tight_layout()
+
+###############################################################################
+# Grayscale mode
+# --------------
+#
+# Current clinical operation is effectively binary, which is why that is the
+# default. The projector hardware does support several pulse durations, though,
+# and ``grayscale=True`` pulse-width modulates gray levels onto that 0.7 ms
+# grid. Peak irradiance stays fixed either way:
+
+implant.encoder = p2p.stimuli.PRIMAEncoder(grayscale=True)
+gray = implant.prepare_stim(image)
+print(np.unique(np.round(gray.pulse_dur, 3)))

--- a/examples/implants/plot_prima.py
+++ b/examples/implants/plot_prima.py
@@ -1,132 +1,149 @@
 """
 ===============================================================================
-Simulating PRIMA
+Simulating PRIMA: from image to optical drive
 ===============================================================================
 
-Background
-----------
+:class:`~pulse2percept.implants.PRIMAPivotal` models the 378-pixel
+photovoltaic array used in the PRIMAvera trial [Holz2025]_. Unlike other
+implants, PRIMA is not driven by injected current. A near-infrared projector
+illuminates the array at 880 nm, and image intensity is encoded by how long
+each pixel is illuminated during a projector frame.
 
-:py:class:`~pulse2percept.implants.PRIMAPivotal` is the subretinal photovoltaic
-array used in the PRIMAvera pivotal trial [Holz2026]_ and in the earlier
-first-in-human study [Palanker2020]_. Its 378 pixels sit on a 100 um hexagonal
-grid on a 2 x 2 mm substrate.
+This example follows the path currently implemented in pulse2percept:
 
-PRIMA is not driven by a current source. A goggle-mounted projector paints an
-880 nm near-infrared image onto the implant, and each photovoltaic pixel turns
-the light it receives into local electrical stimulation. The projector runs at
-a fixed frame rate (30 Hz) and a fixed peak irradiance (3.5 mW/mm^2), and
-encodes intensity in *how long* a pixel is lit: 14 levels from 0.7 to 9.8 ms in
-0.7 ms steps, plus off.
+``image -> preprocessing -> implant sampling -> optical drive -> percept``
 
-:py:class:`~pulse2percept.stimuli.PRIMAEncoder` implements that projector, and
-:py:class:`~pulse2percept.implants.PRIMAPivotal` brings one along, so a picture
-can be presented directly:
+The last step uses :class:`~pulse2percept.models.ScoreboardModel` only as a
+visualization of the stimulation pattern. pulse2percept does not yet model
+photodiode transduction or the retinal response to PRIMA.
 """
 # sphinx_gallery_thumbnail_number = 2
 
 import matplotlib.pyplot as plt
 import numpy as np
+from skimage.morphology import binary_dilation, disk
 import pulse2percept as p2p
 
 implant = p2p.implants.PRIMAPivotal()
-image = p2p.stimuli.LogoBVL()
-stim = implant.prepare_stim(image)
-print(stim.unit)
+encoder = implant.encoder
 
 ###############################################################################
-# What comes back is 880 nm optical irradiance versus time at each pixel, not
-# electrical current. Turning light into retinal current depends on photodiode
-# behavior, electrode capacitance, and the surrounding tissue, none of which
-# pulse2percept models yet.
+# From gray level to optical stimulation
+# ---------------------------------------
 #
-# One projector period looks the same at every lit pixel: irradiance rises to
-# 3.5 mW/mm^2 for the pixel's ON duration and is zero for the rest of the
-# 33.3 ms frame.
+# PRIMA uses a fixed peak irradiance and encodes intensity using pulse
+# duration. The default encoder maps normalized image intensity onto the 14
+# nonzero durations supported by the pivotal projector.
 
-lit = np.argmax(stim.pulse_dur[:, 0])
-fig, ax = plt.subplots(figsize=(8, 2.5))
-ax.plot(stim.time, stim.data[lit], lw=1.5)
-ax.set_xlim(0, 100)
+levels = np.array([0.25, 0.5, 1.0], dtype=np.float32)
+probe = p2p.stimuli.ImageStimulus(levels[np.newaxis, :])
+encoded = encoder.encode(probe)
+
+fig, ax = plt.subplots(figsize=(7, 2.5))
+for idx, gray in enumerate(levels):
+    dur = encoded.pulse_dur[idx, 0]
+    ax.plot(encoded.time, encoded.data[idx],
+            label=f'gray={gray:g}  ({dur:g} ms)')
+ax.set_xlim(0, encoder.period)
 ax.set_xlabel('Time (ms)')
-ax.set_ylabel('Irradiance (mW/mm$^2$)')
-ax.set_title(f'Pixel {stim.electrodes[lit]}: '
-             f'{stim.pulse_dur[lit, 0]:.1f} ms on, 33.3 ms period')
+ax.set_ylabel(r'Irradiance (mW/mm$^2$)')
+ax.legend(frameon=False)
 fig.tight_layout()
 
 ###############################################################################
-# Visualizing the stimulation pattern
-# -----------------------------------
+# Peak irradiance is the same for every illuminated pixel. A brighter image
+# pixel stays on longer, so it delivers more optical energy per projector
+# frame. For the spatial visualization below, pulse2percept normalizes the
+# time-averaged optical drive so that 0 is dark and 1 is the largest documented
+# drive of the pivotal system. At the default projector settings, this is simply
+# ``pulse_dur / 9.8 ms``.
 #
-# :py:class:`~pulse2percept.models.ScoreboardModel` places a Gaussian blob at
-# every pixel. For a photovoltaic implant it weights each blob by *normalized
-# optical drive*: the irradiance a pixel delivers averaged over a projector
-# period (peak irradiance times duty cycle), divided by the largest drive the
-# pivotal device is documented to produce. A dark pixel is 0, a pixel at the
-# full documented drive is 1.
-#
-# This is a simple visualization of implant geometry and stimulation pattern.
-# It does not model photodiode transduction, retinal electric fields,
-# bipolar-cell activation, electrode-retina distance, or temporal retinal
-# dynamics.
-
-model = p2p.models.ScoreboardModel(implant=implant, rho=100)
-
-###############################################################################
-# Image processing stays outside the encoder
-# ------------------------------------------
-#
-# The clinical system processes the camera image before projecting it --
-# ambient-light adaptation, contrast enhancement, zoom -- and contrast
-# inversion has been used deliberately in testing.
-# :py:class:`~pulse2percept.stimuli.PRIMAEncoder` models the optical encoding
-# stage that follows. Preprocessing stays explicit here because the clinical
-# pipeline is not specified in enough detail to reproduce, so it is an ordinary
-# :py:class:`~pulse2percept.stimuli.ImageStimulus` operation applied first:
-
-sources = [('As is', image),
-           ('Inverted', image.invert()),
-           ('Canny edges', image.rgb2gray().filter('canny'))]
-
-fig, axes = plt.subplots(nrows=2, ncols=3, figsize=(11, 6))
-for (title, source), top, bottom in zip(sources, axes[0], axes[1]):
-    source.plot(ax=top)
-    top.set_title(title)
-    model.predict_percept(source).plot(ax=bottom)
-fig.tight_layout()
-
-###############################################################################
-# Video keeps its own timing
+# From an image to a percept
 # --------------------------
 #
-# The projector clock samples the source; it does not re-time it. Every 33.3 ms
-# the device looks at whatever frame the video is showing (zero-order hold), so
-# a slow source has frames re-sent and a fast one has frames skipped -- and the
-# content plays at the speed it was recorded at either way:
+# Preprocessing happens before optical encoding. We convert the logo to
+# grayscale before comparing different transforms. For edge extraction, the
+# image is first resized to roughly twice the nominal implant-grid resolution.
+# Thin edges otherwise tend to disappear when sampled onto the 378 PRIMA
+# pixels. A one-pixel dilation makes the edge map a little more robust to that
+# sampling step.
 
-for fps in (15, 30, 60):
-    n = fps  # one second of video
-    clip = p2p.stimuli.VideoStimulus(np.random.rand(16, 16, n),
-                                     time=np.arange(n) * (1000.0 / fps))
-    encoded = implant.prepare_stim(clip)
-    print(f'{fps:>2} fps source -> {encoded.duration:.0f} ms, '
-          f'{encoded.pulse_dur.shape[1]} projector frames')
+image = p2p.stimuli.LogoBVL().rgb2gray()
+edge_shape = tuple(2 * n for n in implant.shape)
+edges = image.resize(edge_shape).filter('canny', sigma=1.0)
+edges = edges.apply(binary_dilation, footprint=disk(1))
+
+sources = [
+    ('Grayscale', image),
+    ('Inverted grayscale', image.invert()),
+    ('Edge-enhanced', edges),
+]
+
+model = p2p.models.ScoreboardModel(
+    implant=implant,
+    rho=100,
+    xrange=(-4, 4),
+    yrange=(-4, 4),
+    step=0.05,
+)
+
+
+def normalized_drive(stim):
+    """Normalized time-averaged optical drive for a static PRIMA image."""
+    return (stim.irradiance * stim.duty_cycle[:, 0]
+            / implant.encoder.ref_drive)
+
+
+xy = implant.earray.coordinates()
+fig, axes = plt.subplots(3, 3, figsize=(10, 9), constrained_layout=True)
+
+for col, (title, source) in enumerate(sources):
+    # Image entering the PRIMA encoder:
+    ax = axes[0, col]
+    ax.imshow(source.data.reshape(source.img_shape), cmap='gray',
+              vmin=0, vmax=1)
+    ax.set_title(title)
+    ax.axis('off')
+
+    # Normalized optical drive on the actual 378-pixel array:
+    stim = implant.prepare_stim(source)
+    drive = normalized_drive(stim)
+    ax = axes[1, col]
+    ax.scatter(xy[:, 0], xy[:, 1], c=drive, cmap='gray',
+               vmin=0, vmax=1, marker='h', s=55, linewidths=0)
+    ax.set_aspect('equal')
+    ax.axis('off')
+
+    # Scoreboard visualization of that drive:
+    model.predict_percept(source).plot(ax=axes[2, col], cmap='gray')
+
+axes[0, 0].text(-0.10, 0.5, 'Source', rotation=90,
+                va='center', ha='right', transform=axes[0, 0].transAxes,
+                fontsize=12)
+axes[1, 0].text(-0.10, 0.5, 'Optical drive', rotation=90,
+                va='center', ha='right', transform=axes[1, 0].transAxes,
+                fontsize=12)
+axes[2, 0].text(-0.18, 0.5, 'Scoreboard percept', rotation=90,
+                va='center', ha='right', transform=axes[2, 0].transAxes,
+                fontsize=12)
 
 ###############################################################################
-# Pulse-duration levels
-# ---------------------
+# How optical drive becomes percept brightness
+# --------------------------------------------
 #
-# By default the encoder maps normalized image intensity linearly onto the
-# projector's 14 durations. That linear map is a pulse2percept convention: the
-# clinical camera-gray-level to pulse-duration transfer function is not
-# published. Peak irradiance never varies -- only how long each pixel is lit:
-
-ramp = p2p.stimuli.ImageStimulus(np.tile(np.linspace(0, 1, 64), (64, 1)))
-print(np.unique(np.round(implant.prepare_stim(ramp).pulse_dur, 3)))
-
-###############################################################################
-# ``grayscale=False`` gives a binary approximation instead, in which a pixel is
-# off or lit for the full ``pulse_dur``. The 0.5 threshold is arbitrary, not a
-# clinical setting:
-
-implant.encoder = p2p.stimuli.PRIMAEncoder(grayscale=False, threshold=0.5)
-print(np.unique(np.round(implant.prepare_stim(ramp).pulse_dur, 3)))
+# ``ScoreboardModel`` places a Gaussian at each implant pixel. For PRIMA, the
+# Gaussian is weighted by the normalized optical drive shown in the middle row.
+# A longer optical pulse therefore produces a brighter Gaussian in this
+# visualization. ``rho=100`` controls how broadly neighboring pixels overlap
+# and is approximately one PRIMA pixel pitch.
+#
+# This is not a biological PRIMA brightness model. Real percepts depend on
+# photovoltaic conversion, electrode-retina distance, retinal current spread,
+# neural activation and temporal dynamics. Those steps require a PRIMA-specific
+# retinal model that is not yet implemented.
+#
+# The three preprocessing columns are examples, not a reconstruction of the
+# clinical image-processing pipeline. The clinical system performs its own
+# preprocessing before projection, but it is not specified in enough detail to
+# reproduce here. Keeping preprocessing explicit makes its effect on implant
+# sampling easy to inspect.

--- a/examples/implants/plot_prima.py
+++ b/examples/implants/plot_prima.py
@@ -15,8 +15,8 @@ PRIMA is not driven by a current source. A goggle-mounted projector paints an
 880 nm near-infrared image onto the implant, and each photovoltaic pixel turns
 the light it receives into local electrical stimulation. The projector runs at
 a fixed frame rate (30 Hz) and a fixed peak irradiance (3.5 mW/mm^2), and
-encodes intensity in *how long* a pixel is lit -- 0.7 to 9.8 ms per frame --
-rather than in how brightly.
+encodes intensity in *how long* a pixel is lit: 14 levels from 0.7 to 9.8 ms in
+0.7 ms steps, plus off.
 
 :py:class:`~pulse2percept.stimuli.PRIMAEncoder` implements that projector, and
 :py:class:`~pulse2percept.implants.PRIMAPivotal` brings one along, so a picture
@@ -43,13 +43,14 @@ print(stim.unit)
 # 3.5 mW/mm^2 for the pixel's ON duration and is zero for the rest of the
 # 33.3 ms frame.
 
-lit = np.flatnonzero(stim.data.max(axis=1) > 0)[0]
+lit = np.argmax(stim.pulse_dur[:, 0])
 fig, ax = plt.subplots(figsize=(8, 2.5))
 ax.plot(stim.time, stim.data[lit], lw=1.5)
 ax.set_xlim(0, 100)
 ax.set_xlabel('Time (ms)')
 ax.set_ylabel('Irradiance (mW/mm$^2$)')
-ax.set_title(f'Pixel {stim.electrodes[lit]}: 9.8 ms on, 33.3 ms period')
+ax.set_title(f'Pixel {stim.electrodes[lit]}: '
+             f'{stim.pulse_dur[lit, 0]:.1f} ms on, 33.3 ms period')
 fig.tight_layout()
 
 ###############################################################################
@@ -71,14 +72,16 @@ fig.tight_layout()
 model = p2p.models.ScoreboardModel(implant=implant, rho=100)
 
 ###############################################################################
-# Image processing is not PRIMA-specific
-# --------------------------------------
+# Image processing stays outside the encoder
+# ------------------------------------------
 #
-# The encoder binarizes at ``threshold=0.5`` by default, which is
-# pulse2percept's approximation of an unpublished clinical algorithm. Contrast
-# inversion and edge enhancement are *not* intrinsic to the device, so they are
-# ordinary :py:class:`~pulse2percept.stimuli.ImageStimulus` operations applied
-# before encoding:
+# The clinical system processes the camera image before projecting it --
+# ambient-light adaptation, contrast enhancement, zoom -- and contrast
+# inversion has been used deliberately in testing.
+# :py:class:`~pulse2percept.stimuli.PRIMAEncoder` models the optical encoding
+# stage that follows. Preprocessing stays explicit here because the clinical
+# pipeline is not specified in enough detail to reproduce, so it is an ordinary
+# :py:class:`~pulse2percept.stimuli.ImageStimulus` operation applied first:
 
 sources = [('As is', image),
            ('Inverted', image.invert()),
@@ -109,14 +112,21 @@ for fps in (15, 30, 60):
           f'{encoded.pulse_dur.shape[1]} projector frames')
 
 ###############################################################################
-# Grayscale mode
-# --------------
+# Pulse-duration levels
+# ---------------------
 #
-# Current clinical operation is effectively binary, which is why that is the
-# default. The projector hardware does support several pulse durations, though,
-# and ``grayscale=True`` pulse-width modulates gray levels onto that 0.7 ms
-# grid. Peak irradiance stays fixed either way:
+# By default the encoder maps normalized image intensity linearly onto the
+# projector's 14 durations. That linear map is a pulse2percept convention: the
+# clinical camera-gray-level to pulse-duration transfer function is not
+# published. Peak irradiance never varies -- only how long each pixel is lit:
 
-implant.encoder = p2p.stimuli.PRIMAEncoder(grayscale=True)
-gray = implant.prepare_stim(image)
-print(np.unique(np.round(gray.pulse_dur, 3)))
+ramp = p2p.stimuli.ImageStimulus(np.tile(np.linspace(0, 1, 64), (64, 1)))
+print(np.unique(np.round(implant.prepare_stim(ramp).pulse_dur, 3)))
+
+###############################################################################
+# ``grayscale=False`` gives a binary approximation instead, in which a pixel is
+# off or lit for the full ``pulse_dur``. The 0.5 threshold is arbitrary, not a
+# clinical setting:
+
+implant.encoder = p2p.stimuli.PRIMAEncoder(grayscale=False, threshold=0.5)
+print(np.unique(np.round(implant.prepare_stim(ramp).pulse_dur, 3)))

--- a/examples/implants/plot_prima.py
+++ b/examples/implants/plot_prima.py
@@ -3,19 +3,13 @@
 Simulating PRIMA: from image to optical drive
 ===============================================================================
 
-:class:`~pulse2percept.implants.PRIMAPivotal` models the 378-pixel
-photovoltaic array used in the PRIMAvera trial [Holz2025]_. Unlike other
-implants, PRIMA is not driven by injected current. A near-infrared projector
-illuminates the array at 880 nm, and image intensity is encoded by how long
-each pixel is illuminated during a projector frame.
+:class:`~pulse2percept.implants.PRIMAPivotal` models the 378-pixel array used
+in the PRIMAvera trial [Holz2025]_. PRIMA uses 880 nm illumination rather than
+injected current, with image intensity encoded by pulse duration.
 
-This example follows the path currently implemented in pulse2percept:
-
-``image -> preprocessing -> implant sampling -> optical drive -> percept``
-
-The last step uses :class:`~pulse2percept.models.ScoreboardModel` only as a
-visualization of the stimulation pattern. pulse2percept does not yet model
-photodiode transduction or the retinal response to PRIMA.
+This example shows image preprocessing, optical drive on the array, and a
+:class:`~pulse2percept.models.ScoreboardModel` visualization. The Scoreboard
+output is not a PRIMA retinal-response model.
 """
 # sphinx_gallery_thumbnail_number = 2
 
@@ -31,9 +25,8 @@ encoder = implant.encoder
 # From gray level to optical stimulation
 # ---------------------------------------
 #
-# PRIMA uses a fixed peak irradiance and encodes intensity using pulse
-# duration. The default encoder maps normalized image intensity onto the 14
-# nonzero durations supported by the pivotal projector.
+# PRIMA uses fixed peak irradiance; gray level controls pulse duration.
+# The default encoder maps [0, 1] onto 14 nonzero duration levels.
 
 levels = np.array([0.25, 0.5, 1.0], dtype=np.float32)
 probe = p2p.stimuli.ImageStimulus(levels[np.newaxis, :])
@@ -51,22 +44,15 @@ ax.legend(frameon=False)
 fig.tight_layout()
 
 ###############################################################################
-# Peak irradiance is the same for every illuminated pixel. A brighter image
-# pixel stays on longer, so it delivers more optical energy per projector
-# frame. For the spatial visualization below, pulse2percept normalizes the
-# time-averaged optical drive so that 0 is dark and 1 is the largest documented
-# drive of the pivotal system. At the default projector settings, this is simply
-# ``pulse_dur / 9.8 ms``.
+# Normalized optical drive is time-averaged irradiance relative to the
+# documented maximum. At the default settings it is ``pulse_dur / 9.8 ms``.
 #
 # From an image to a percept
 # --------------------------
 #
-# Preprocessing happens before optical encoding. We convert the logo to
-# grayscale before comparing different transforms. For edge extraction, the
-# image is first resized to roughly twice the nominal implant-grid resolution.
-# Thin edges otherwise tend to disappear when sampled onto the 378 PRIMA
-# pixels. A one-pixel dilation makes the edge map a little more robust to that
-# sampling step.
+# Convert to grayscale before preprocessing. Canny edges are computed at
+# about twice the nominal array resolution and dilated once so thin edges
+# survive sampling onto the implant.
 
 image = p2p.stimuli.LogoBVL().rgb2gray()
 edge_shape = tuple(2 * n for n in implant.shape)
@@ -98,14 +84,14 @@ xy = implant.earray.coordinates()
 fig, axes = plt.subplots(3, 3, figsize=(10, 9), constrained_layout=True)
 
 for col, (title, source) in enumerate(sources):
-    # Image entering the PRIMA encoder:
+    # Source image
     ax = axes[0, col]
     ax.imshow(source.data.reshape(source.img_shape), cmap='gray',
               vmin=0, vmax=1)
     ax.set_title(title)
     ax.axis('off')
 
-    # Normalized optical drive on the actual 378-pixel array:
+    # Drive after sampling onto PRIMA pixels
     stim = implant.prepare_stim(source)
     drive = normalized_drive(stim)
     ax = axes[1, col]
@@ -114,7 +100,7 @@ for col, (title, source) in enumerate(sources):
     ax.set_aspect('equal')
     ax.axis('off')
 
-    # Scoreboard visualization of that drive:
+    # Scoreboard visualization
     model.predict_percept(source).plot(ax=axes[2, col], cmap='gray')
 
 axes[0, 0].text(-0.10, 0.5, 'Source', rotation=90,
@@ -131,19 +117,10 @@ axes[2, 0].text(-0.18, 0.5, 'Scoreboard percept', rotation=90,
 # How optical drive becomes percept brightness
 # --------------------------------------------
 #
-# ``ScoreboardModel`` places a Gaussian at each implant pixel. For PRIMA, the
-# Gaussian is weighted by the normalized optical drive shown in the middle row.
-# A longer optical pulse therefore produces a brighter Gaussian in this
-# visualization. ``rho=100`` controls how broadly neighboring pixels overlap
-# and is approximately one PRIMA pixel pitch.
+# ``ScoreboardModel`` weights one Gaussian per pixel by normalized optical
+# drive. ``rho=100`` sets the spatial spread, approximately one PRIMA pixel
+# pitch.
 #
-# This is not a biological PRIMA brightness model. Real percepts depend on
-# photovoltaic conversion, electrode-retina distance, retinal current spread,
-# neural activation and temporal dynamics. Those steps require a PRIMA-specific
-# retinal model that is not yet implemented.
-#
-# The three preprocessing columns are examples, not a reconstruction of the
-# clinical image-processing pipeline. The clinical system performs its own
-# preprocessing before projection, but it is not specified in enough detail to
-# reproduce here. Keeping preprocessing explicit makes its effect on implant
-# sampling easy to inspect.
+# This is not a PRIMA brightness model: photovoltaic conversion and retinal
+# activation are not modeled. The preprocessing examples are illustrative and
+# do not reproduce the clinical image-processing pipeline.

--- a/examples/implants/plot_prima.py
+++ b/examples/implants/plot_prima.py
@@ -58,9 +58,10 @@ fig.tight_layout()
 #
 # :py:class:`~pulse2percept.models.ScoreboardModel` places a Gaussian blob at
 # every pixel. For a photovoltaic implant it weights each blob by *normalized
-# optical drive*: irradiance times ON duration times frame rate, divided by the
-# largest drive the pivotal device is documented to produce. A dark pixel is 0,
-# a pixel at the full documented drive is 1.
+# optical drive*: the irradiance a pixel delivers averaged over a projector
+# period (peak irradiance times duty cycle), divided by the largest drive the
+# pivotal device is documented to produce. A dark pixel is 0, a pixel at the
+# full documented drive is 1.
 #
 # This is a simple visualization of implant geometry and stimulation pattern.
 # It does not model photodiode transduction, retinal electric fields,
@@ -89,6 +90,23 @@ for (title, source), top, bottom in zip(sources, axes[0], axes[1]):
     top.set_title(title)
     model.predict_percept(source).plot(ax=bottom)
 fig.tight_layout()
+
+###############################################################################
+# Video keeps its own timing
+# --------------------------
+#
+# The projector clock samples the source; it does not re-time it. Every 33.3 ms
+# the device looks at whatever frame the video is showing (zero-order hold), so
+# a slow source has frames re-sent and a fast one has frames skipped -- and the
+# content plays at the speed it was recorded at either way:
+
+for fps in (15, 30, 60):
+    n = fps  # one second of video
+    clip = p2p.stimuli.VideoStimulus(np.random.rand(16, 16, n),
+                                     time=np.arange(n) * (1000.0 / fps))
+    encoded = implant.prepare_stim(clip)
+    print(f'{fps:>2} fps source -> {encoded.duration:.0f} ms, '
+          f'{encoded.pulse_dur.shape[1]} projector frames')
 
 ###############################################################################
 # Grayscale mode

--- a/pulse2percept/implants/base.py
+++ b/pulse2percept/implants/base.py
@@ -5,6 +5,7 @@ import numpy as np
 from copy import deepcopy
 from collections import OrderedDict
 from scipy.interpolate import RegularGridInterpolator
+from skimage.color import rgb2gray
 
 from .electrodes import Electrode, DiskElectrode, PointSource
 from .electrode_arrays import ElectrodeArray, ElectrodeGrid
@@ -419,21 +420,28 @@ class ProsthesisSystem(PrettyPrint):
 
     def reshape_stim(self, stim):
         if isinstance(stim, (ImageStimulus, VideoStimulus)):
-            # Convert to grayscale:
-            img = stim.rgb2gray()
-
             # Extract electrode coordinates, in the same units the image grid
             # below is laid out in:
             x, y = self.earray.coordinates(um)[:, :2].T
 
-            # Define image coordinate space
+            # Define image coordinate space. The color axis, if there is one,
+            # is left on the data and reduced after sampling: `rgb2gray` is a
+            # fixed linear combination of the channels, so sampling first
+            # gives the same answer without ever building a full-resolution
+            # grayscale copy of the source.
             if isinstance(stim, ImageStimulus):
-                img_h, img_w = img.img_shape
-                data = img.data.reshape(img_h, img_w)  # Ensure 2D format
-            elif isinstance(stim, VideoStimulus):
-                img_h, img_w, n_frames = img.vid_shape
-                data = img.data.reshape(img_h, img_w, n_frames)  # 3D format
-
+                shape = stim.img_shape          # (h, w[, n_channels])
+                colored = len(shape) == 3
+            else:
+                shape = stim.vid_shape          # (h, w[, n_channels], frames)
+                colored = len(shape) == 4
+            img_h, img_w = shape[:2]
+            data = stim.data.reshape(shape)
+            if colored and isinstance(stim, ImageStimulus) and shape[2] == 4:
+                # Blending an alpha channel with black is a product, not a
+                # linear combination, so unlike rgb2gray it cannot be deferred
+                # until after the interpolation:
+                data = np.clip(data[..., :3] * data[..., 3:4], 0.0, 1.0)
 
             x_min, x_max = np.min(x), np.max(x)
             y_min, y_max = np.min(y), np.max(y)
@@ -442,16 +450,23 @@ class ProsthesisSystem(PrettyPrint):
             img_x = np.linspace(x_min, x_max, img_w)
             img_y = np.linspace(y_min, y_max, img_h)
 
-            # One interpolator covers every frame: the grid is the leading two
-            # axes of `data`, and anything past them -- the frame axis of a
-            # video -- is carried along, so a video comes back as
-            # (n_electrodes, n_frames) from a single call. Building one per
-            # frame instead meant re-deriving the same grid for each of them.
+            # One interpolator covers every frame and every color channel: the
+            # grid is the leading two axes of `data`, and anything past them --
+            # the color and frame axes -- is carried along, so a video comes
+            # back as (n_electrodes, [n_channels,] n_frames) from a single
+            # call. Building one per frame instead meant re-deriving the same
+            # grid for each of them.
             interpolator = RegularGridInterpolator(
                 (img_y, img_x), data, method='linear',
                 bounds_error=False, fill_value=0
             )
             pixel_values = interpolator(np.vstack((y, x)).T)
+            if colored:
+                # `rgb2gray` reads the channel axis last, which is already
+                # where an image's is; a video's sits in front of its frames:
+                if pixel_values.ndim == 3:
+                    pixel_values = pixel_values.transpose((0, 2, 1))
+                pixel_values = rgb2gray(pixel_values)
 
             return Stimulus(
                 pixel_values, electrodes=self.electrode_names,

--- a/pulse2percept/implants/base.py
+++ b/pulse2percept/implants/base.py
@@ -99,7 +99,9 @@ class ProsthesisSystem(PrettyPrint):
     __slots__ = ('_earray', '_eye', 'safe_mode', 'preprocess',
                  '_encoder', '_raster', '_max_current', '_thresholds')
 
-    #: Physical quantity delivered by the implant. Subclasses may override.
+    #: Physical quantity a prepared stimulus is measured in: what drives the
+    #: device. Current for a device driven by a current source, irradiance for
+    #: one that is illuminated. Subclasses may override.
     stimulus_unit = uA
 
     #: Where the device sits relative to the tissue it stimulates, where the
@@ -276,7 +278,7 @@ class ProsthesisSystem(PrettyPrint):
         if stim.unit.dimension == xTh.dimension:
             return
         raise DimensionMismatchError(
-            f"{type(self).__name__} delivers "
+            f"{type(self).__name__} is driven by "
             f"{_describe_unit(self.stimulus_unit)}, but this stimulus is "
             f"measured in {_describe_unit(stim.unit)}. Give the implant an "
             f"'encoder' (a pulse2percept.stimuli.Encoder that produces "

--- a/pulse2percept/implants/base.py
+++ b/pulse2percept/implants/base.py
@@ -9,8 +9,8 @@ from scipy.interpolate import RegularGridInterpolator
 from .electrodes import Electrode, DiskElectrode, PointSource
 from .electrode_arrays import ElectrodeArray, ElectrodeGrid
 from .rasters import Raster
-from ..stimuli import (BiphasicPulseTrain, Stimulus, ImageStimulus,
-                       StimulusEncoder, VideoStimulus)
+from ..stimuli import (BiphasicPulseTrain, Encoder, Stimulus, ImageStimulus,
+                       VideoStimulus)
 from ..stimuli.base import _describe_unit
 from ..stimuli.pulse_trains import _as_threshold_amp
 from ..units import DimensionMismatchError, as_value, uA, um, xTh
@@ -52,14 +52,19 @@ class ProsthesisSystem(PrettyPrint):
         If safe mode is enabled, only charge-balanced stimuli are allowed.
         Safety is an electrical property, so this also requires the stimulus
         to be measured in units of current.
-    encoder : :py:class:`~pulse2percept.stimuli.StimulusEncoder`, optional
+    encoder : :py:class:`~pulse2percept.stimuli.Encoder`, optional
         How the device turns a picture into stimulation. If given, preparing an
-        image or a video encodes it first, so that what comes back is always
-        electrical. If None, such a stimulus is refused, since there is no
-        principled default mapping from a gray level to an amplitude or a
-        frequency.
+        image or a video encodes it first, so that what comes back is in the
+        unit the device delivers. If None, such a stimulus is refused, since
+        there is no principled default mapping from a gray level to
+        stimulation.
 
         .. versionadded:: 0.10.0
+
+        .. versionchanged:: 0.11.0
+            Accepts any :py:class:`~pulse2percept.stimuli.Encoder`, not only
+            an electrical
+            :py:class:`~pulse2percept.stimuli.StimulusEncoder`.
     raster : :py:class:`~pulse2percept.implants.Raster`, optional
         How the stimulator takes turns between electrodes that it cannot drive
         at the same time. If None, every electrode may fire at once. Assigning
@@ -148,8 +153,8 @@ class ProsthesisSystem(PrettyPrint):
     @encoder.setter
     def encoder(self, encoder):
         """Encoder setter (called upon ``self.encoder = encoder``)"""
-        if encoder is not None and not isinstance(encoder, StimulusEncoder):
-            raise TypeError(f"'encoder' must be a StimulusEncoder object, not "
+        if encoder is not None and not isinstance(encoder, Encoder):
+            raise TypeError(f"'encoder' must be an Encoder object, not "
                             f"{type(encoder)}.")
         self._encoder = encoder
 

--- a/pulse2percept/implants/base.py
+++ b/pulse2percept/implants/base.py
@@ -50,8 +50,10 @@ class ProsthesisSystem(PrettyPrint):
         function (callable).
     safe_mode : bool, optional
         If safe mode is enabled, only charge-balanced stimuli are allowed.
-        Safety is an electrical property, so this also requires the stimulus
-        to be measured in units of current.
+        Charge balance is an electrical property, so this also requires the
+        stimulus to be measured in units of current. A device that is not
+        driven by a current source overrides the check with one that fits it;
+        see :py:class:`~pulse2percept.implants.PRIMAPivotal`.
     encoder : :py:class:`~pulse2percept.stimuli.Encoder`, optional
         How the device turns a picture into stimulation. If given, preparing an
         image or a video encodes it first, so that what comes back is in the
@@ -277,10 +279,10 @@ class ProsthesisSystem(PrettyPrint):
             f"{type(self).__name__} delivers "
             f"{_describe_unit(self.stimulus_unit)}, but this stimulus is "
             f"measured in {_describe_unit(stim.unit)}. Give the implant an "
-            f"'encoder' (pulse2percept.stimuli.AmplitudeEncoder or "
-            f"FrequencyEncoder) so that image or video input is encoded during "
-            f"'prepare_stim', encode it yourself first, or give the implant a "
-            f"'preprocess' function that does.")
+            f"'encoder' (a pulse2percept.stimuli.Encoder that produces "
+            f"{_describe_unit(self.stimulus_unit)}) so that image or video "
+            f"input is encoded during 'prepare_stim', encode it yourself "
+            f"first, or give the implant a 'preprocess' function that does.")
 
     @staticmethod
     def _require_current_stim(stim, check):
@@ -530,6 +532,12 @@ class ProsthesisSystem(PrettyPrint):
         input when an encoder is present, reshapes it to the electrode array, removes
         deactivated electrodes, applies threshold calibration, and runs safety checks.
         The input is not modified and the result is not stored.
+
+        What comes back is measured in the implant's
+        :py:attr:`~pulse2percept.implants.ProsthesisSystem.stimulus_unit`, which
+        is electrical current for most devices but not for all: a photovoltaic
+        implant such as :py:class:`~pulse2percept.implants.PRIMAPivotal` is
+        illuminated, and prepares optical irradiance.
 
         Images and videos require an encoder unless preprocessing already converts
         them to the implant's

--- a/pulse2percept/implants/base.py
+++ b/pulse2percept/implants/base.py
@@ -273,9 +273,12 @@ class ProsthesisSystem(PrettyPrint):
         """Require a stimulus with a physical dimension this implant can deliver."""
         if stim.unit.dimension == self.stimulus_unit.dimension:
             return
-        # Threshold-relative pulse trains may be assigned before
-        # calibration.
-        if stim.unit.dimension == xTh.dimension:
+        # Threshold-relative pulse trains may be assigned before calibration.
+        # A multiple of threshold is a current that has not been named yet, so
+        # this exemption belongs to devices that are driven by current: there
+        # is no such thing as threshold-relative irradiance.
+        if (self.stimulus_unit.dimension == uA.dimension and
+                stim.unit.dimension == xTh.dimension):
             return
         raise DimensionMismatchError(
             f"{type(self).__name__} is driven by "

--- a/pulse2percept/implants/base.py
+++ b/pulse2percept/implants/base.py
@@ -51,16 +51,11 @@ class ProsthesisSystem(PrettyPrint):
         function (callable).
     safe_mode : bool, optional
         If safe mode is enabled, only charge-balanced stimuli are allowed.
-        Charge balance is an electrical property, so this also requires the
-        stimulus to be measured in units of current. A device that is not
-        driven by a current source overrides the check with one that fits it;
-        see :py:class:`~pulse2percept.implants.PRIMAPivotal`.
+        Charge balance is an electrical property and requires current units.
+        Non-current-driven devices may override this check.
     encoder : :py:class:`~pulse2percept.stimuli.Encoder`, optional
-        How the device turns a picture into stimulation. If given, preparing an
-        image or a video encodes it first, so that what comes back is in the
-        unit the device delivers. If None, such a stimulus is refused, since
-        there is no principled default mapping from a gray level to
-        stimulation.
+        Maps image or video gray levels to device stimulation. If None,
+        dimensionless visual input is rejected.
 
         .. versionadded:: 0.10.0
 
@@ -100,9 +95,7 @@ class ProsthesisSystem(PrettyPrint):
     __slots__ = ('_earray', '_eye', 'safe_mode', 'preprocess',
                  '_encoder', '_raster', '_max_current', '_thresholds')
 
-    #: Physical quantity a prepared stimulus is measured in: what drives the
-    #: device. Current for a device driven by a current source, irradiance for
-    #: one that is illuminated. Subclasses may override.
+    #: Unit used by prepared stimuli. Defaults to electrical current.
     stimulus_unit = uA
 
     #: Where the device sits relative to the tissue it stimulates, where the
@@ -274,10 +267,7 @@ class ProsthesisSystem(PrettyPrint):
         """Require a stimulus with a physical dimension this implant can deliver."""
         if stim.unit.dimension == self.stimulus_unit.dimension:
             return
-        # Threshold-relative pulse trains may be assigned before calibration.
-        # A multiple of threshold is a current that has not been named yet, so
-        # this exemption belongs to devices that are driven by current: there
-        # is no such thing as threshold-relative irradiance.
+        # xTh is valid only for current-driven implants before calibration.
         if (self.stimulus_unit.dimension == uA.dimension and
                 stim.unit.dimension == xTh.dimension):
             return
@@ -420,15 +410,11 @@ class ProsthesisSystem(PrettyPrint):
 
     def reshape_stim(self, stim):
         if isinstance(stim, (ImageStimulus, VideoStimulus)):
-            # Extract electrode coordinates, in the same units the image grid
-            # below is laid out in:
+            # Electrode coordinates define the image sampling grid.
             x, y = self.earray.coordinates(um)[:, :2].T
 
-            # Define image coordinate space. The color axis, if there is one,
-            # is left on the data and reduced after sampling: `rgb2gray` is a
-            # fixed linear combination of the channels, so sampling first
-            # gives the same answer without ever building a full-resolution
-            # grayscale copy of the source.
+            # Sample color channels before grayscale conversion to avoid a
+            # full-resolution grayscale copy.
             if isinstance(stim, ImageStimulus):
                 shape = stim.img_shape          # (h, w[, n_channels])
                 colored = len(shape) == 3
@@ -438,9 +424,7 @@ class ProsthesisSystem(PrettyPrint):
             img_h, img_w = shape[:2]
             data = stim.data.reshape(shape)
             if colored and isinstance(stim, ImageStimulus) and shape[2] == 4:
-                # Blending an alpha channel with black is a product, not a
-                # linear combination, so unlike rgb2gray it cannot be deferred
-                # until after the interpolation:
+                # RGBA alpha blending is nonlinear; apply it before interpolation.
                 data = np.clip(data[..., :3] * data[..., 3:4], 0.0, 1.0)
 
             x_min, x_max = np.min(x), np.max(x)
@@ -450,20 +434,14 @@ class ProsthesisSystem(PrettyPrint):
             img_x = np.linspace(x_min, x_max, img_w)
             img_y = np.linspace(y_min, y_max, img_h)
 
-            # One interpolator covers every frame and every color channel: the
-            # grid is the leading two axes of `data`, and anything past them --
-            # the color and frame axes -- is carried along, so a video comes
-            # back as (n_electrodes, [n_channels,] n_frames) from a single
-            # call. Building one per frame instead meant re-deriving the same
-            # grid for each of them.
+            # RegularGridInterpolator carries color and frame axes in one call.
             interpolator = RegularGridInterpolator(
                 (img_y, img_x), data, method='linear',
                 bounds_error=False, fill_value=0
             )
             pixel_values = interpolator(np.vstack((y, x)).T)
             if colored:
-                # `rgb2gray` reads the channel axis last, which is already
-                # where an image's is; a video's sits in front of its frames:
+                # rgb2gray expects the channel axis last.
                 if pixel_values.ndim == 3:
                     pixel_values = pixel_values.transpose((0, 2, 1))
                 pixel_values = rgb2gray(pixel_values)
@@ -553,11 +531,9 @@ class ProsthesisSystem(PrettyPrint):
         deactivated electrodes, applies threshold calibration, and runs safety checks.
         The input is not modified and the result is not stored.
 
-        What comes back is measured in the implant's
-        :py:attr:`~pulse2percept.implants.ProsthesisSystem.stimulus_unit`, which
-        is electrical current for most devices but not for all: a photovoltaic
-        implant such as :py:class:`~pulse2percept.implants.PRIMAPivotal` is
-        illuminated, and prepares optical irradiance.
+        Prepared stimuli use the implant's
+        :py:attr:`~pulse2percept.implants.ProsthesisSystem.stimulus_unit`
+        (electrical current for most devices; irradiance for PRIMA).
 
         Images and videos require an encoder unless preprocessing already converts
         them to the implant's

--- a/pulse2percept/implants/base.py
+++ b/pulse2percept/implants/base.py
@@ -424,8 +424,10 @@ class ProsthesisSystem(PrettyPrint):
             img_h, img_w = shape[:2]
             data = stim.data.reshape(shape)
             if colored and isinstance(stim, ImageStimulus) and shape[2] == 4:
-                # RGBA alpha blending is nonlinear; apply it before interpolation.
-                data = np.clip(data[..., :3] * data[..., 3:4], 0.0, 1.0)
+                # RGBA alpha blending is nonlinear; apply it before
+                # interpolation (avoids second full-size copy)
+                data = np.multiply(data[..., :3], data[..., 3:4])
+                np.clip(data, 0.0, 1.0, out=data)
 
             x_min, x_max = np.min(x), np.max(x)
             y_min, y_max = np.min(y), np.max(y)

--- a/pulse2percept/implants/prima.py
+++ b/pulse2percept/implants/prima.py
@@ -323,28 +323,28 @@ class PRIMAPivotal(ProsthesisSystem):
         function (callable).
     safe_mode : bool, optional
         If safe mode is enabled, only stimuli that stay inside the projector's
-        documented envelope are allowed: at most 3.5 mW/mm^2 of irradiance, a
-        frame rate of at most 30 Hz, ON durations on the 0.7 ms hardware grid
-        and no longer than 9.8 ms, and a duty cycle of at most 0.294. There is
-        no limit on how many pixels may be lit at once; all 378 of them may be.
-        Charge balance is not checked, because PRIMA is not driven by a current
-        source.
+        documented envelope are allowed: at most 3.5 mW/mm^2 of irradiance, ON
+        durations on the 0.7 ms hardware grid and no longer than 9.8 ms, a duty
+        cycle of at most 0.294, and the 30 Hz the pivotal system is reported to
+        run at. There is no limit on how many pixels may be lit at once; all
+        378 of them may be. Charge balance is not checked, because PRIMA is not
+        driven by a current source.
 
-        This validates the *device envelope*, not biological safety. 3.5
-        mW/mm^2 is what the pivotal projector emits, not what the retina
-        tolerates; published thermal modeling puts the near-infrared ceiling
-        higher. A stimulus that no longer carries its projector schedule
-        cannot be verified and is refused; set ``safe_mode=False`` to check
-        the envelope yourself.
+        This validates the *documented operating envelope*, not biological
+        safety and not a demonstrated hardware maximum. 3.5 mW/mm^2 is what the
+        pivotal projector emits, not what the retina tolerates; published
+        thermal modeling puts the near-infrared ceiling higher. A stimulus that
+        no longer carries its projector schedule cannot be verified and is
+        refused; set ``safe_mode=False`` to explore beyond the envelope.
 
         .. versionchanged:: 0.11.0
             Checks the optical envelope instead of electrical charge balance.
     encoder : :py:class:`~pulse2percept.stimuli.Encoder`, optional
         How the device turns a picture into stimulation. Defaults to a fresh
-        :py:class:`~pulse2percept.stimuli.PRIMAEncoder`, i.e. binary 880 nm
-        illumination at 30 Hz. Pass ``encoder=None`` to switch automatic
-        encoding off, so that an image or video input is refused rather than
-        encoded.
+        :py:class:`~pulse2percept.stimuli.PRIMAEncoder`, i.e. 880 nm
+        illumination at 30 Hz on the projector's 14 pulse-duration levels.
+        Pass ``encoder=None`` to switch automatic encoding off, so that an
+        image or video input is refused rather than encoded.
 
         .. versionadded:: 0.11.0
 
@@ -506,7 +506,7 @@ class PRIMAPivotal(ProsthesisSystem):
         if freq > PRIMAEncoder.max_freq + 1e-9:
             raise ValueError(
                 f"Safety check: stimulus runs the projector at {freq:g} Hz, "
-                f"and the pivotal device runs at "
+                f"and the pivotal system is reported to run at "
                 f"{PRIMAEncoder.max_freq:g} Hz. Set safe_mode=False to "
                 f"explore other frame rates.")
 

--- a/pulse2percept/implants/prima.py
+++ b/pulse2percept/implants/prima.py
@@ -20,20 +20,12 @@ from ..units import DimensionMismatchError, as_value, mW, mm, um
 from ..utils import deprecated
 from ..utils.constants import MS_PER_S, ZORDER
 
-# Sentinel for "the device's own default", so that `encoder=None` can mean
-# "no automatic encoding" (see `PRIMAPivotal`):
+# Distinguish the default PRIMAEncoder from ``encoder=None``.
 _DEVICE_DEFAULT = object()
 
 
 def _projector(stim):
-    """The stimulus itself if it still describes a projector, else None
-
-    Only a stimulus that carries its own schedule can be checked against the
-    device envelope. Anything that has been reduced to samples -- by arithmetic
-    that invalidates a schedule, or by being built out of raw numbers -- says
-    nothing about the period its pulses sit in, whatever metadata was copied
-    along with it.
-    """
+    """Return ``stim`` if it retains a PRIMA projector schedule."""
     return stim if isinstance(stim, _OpticalStimulus) else None
 
 
@@ -322,29 +314,18 @@ class PRIMAPivotal(ProsthesisSystem):
         preprocessing method whenever a stimulus is prepared, or a custom
         function (callable).
     safe_mode : bool, optional
-        If safe mode is enabled, only stimuli that stay inside the projector's
-        documented envelope are allowed: at most 3.5 mW/mm^2 of irradiance, ON
-        durations on the 0.7 ms hardware grid and no longer than 9.8 ms, a duty
-        cycle of at most 0.294, and the 30 Hz the pivotal system is reported to
-        run at. There is no limit on how many pixels may be lit at once; all
-        378 of them may be. Charge balance is not checked, because PRIMA is not
-        driven by a current source.
-
-        This validates the *documented operating envelope*, not biological
-        safety and not a demonstrated hardware maximum. 3.5 mW/mm^2 is what the
-        pivotal projector emits, not what the retina tolerates; published
-        thermal modeling puts the near-infrared ceiling higher. A stimulus that
-        no longer carries its projector schedule cannot be verified and is
-        refused; set ``safe_mode=False`` to explore beyond the envelope.
+        Enforces the documented projector operating envelope: irradiance
+        <= 3.5 mW/mm^2, ON durations on the 0.7 ms grid and <= 9.8 ms,
+        duty cycle <= 0.294, and frame rate <= 30 Hz. All 378 pixels may be
+        illuminated simultaneously. This is not a biological safety limit or a
+        demonstrated hardware maximum.
 
         .. versionchanged:: 0.11.0
             Checks the optical envelope instead of electrical charge balance.
     encoder : :py:class:`~pulse2percept.stimuli.Encoder`, optional
-        How the device turns a picture into stimulation. Defaults to a fresh
-        :py:class:`~pulse2percept.stimuli.PRIMAEncoder`, i.e. 880 nm
-        illumination at 30 Hz on the projector's 14 pulse-duration levels.
-        Pass ``encoder=None`` to switch automatic encoding off, so that an
-        image or video input is refused rather than encoded.
+        Image/video encoder. Defaults to
+        :py:class:`~pulse2percept.stimuli.PRIMAEncoder`. Pass ``None`` to
+        disable automatic encoding.
 
         .. versionadded:: 0.11.0
 
@@ -352,11 +333,9 @@ class PRIMAPivotal(ProsthesisSystem):
     -----
     *  The active-electrode diameter was estimated from Fig. 1 of
        [Palanker2020]_.
-    *  The device is stimulated optically, so
-       :py:meth:`~pulse2percept.implants.ProsthesisSystem.prepare_stim` returns
-       irradiance in ``mW/mm^2``, not electrical current. How much current a
-       pixel injects depends on photodiode and circuit behavior that p2p does
-       not model yet.
+    *  :py:meth:`~pulse2percept.implants.ProsthesisSystem.prepare_stim`
+       returns optical irradiance (``mW/mm^2``). Photovoltaic conversion is not
+       modeled.
     """
     # Frozen class: User cannot add more class attributes
     __slots__ = ('shape', 'spacing', 'pixel_width', 'gap',
@@ -380,8 +359,7 @@ class PRIMAPivotal(ProsthesisSystem):
         self.eye = eye
         self.preprocess = preprocess
         self.safe_mode = safe_mode
-        # Built per instance rather than shared between them: an encoder is a
-        # mutable object the caller may go on to tweak.
+        # Do not share mutable encoder state between implant instances.
         self.encoder = (PRIMAEncoder() if encoder is _DEVICE_DEFAULT
                         else encoder)
 
@@ -422,18 +400,12 @@ class PRIMAPivotal(ProsthesisSystem):
                 elec.z = z_elec
 
     def _require_physical_light(self, stim):
-        """Require irradiance that could be light at all.
-
-        Unlike the envelope below, this is not about the pivotal projector: a
-        negative or undefined power density is not dim light, it is not light,
-        so it is refused whatever ``safe_mode`` says.
-        """
+        """Reject negative or nonfinite irradiance."""
         if stim.unit.dimension != self.stimulus_unit.dimension:
             return
         projector = _projector(stim)
         if projector is not None:
-            # A schedule validates its own irradiance when it is built, and
-            # reading it costs nothing:
+            # Read peak irradiance directly from the projector schedule.
             values = np.array([projector.irradiance], dtype=np.float64)
         else:
             values = np.asarray(stim.data, dtype=np.float64)
@@ -448,12 +420,7 @@ class PRIMAPivotal(ProsthesisSystem):
                 f"a dark pixel is zero.")
 
     def _require_within_optical_envelope(self, stim):
-        """Require a stimulus the PRIMA projector could actually produce.
-
-        Read off the schedule the stimulus carries, never off its metadata:
-        metadata is an ordinary dict that arithmetic may copy onto a waveform
-        it no longer describes.
-        """
+        """Check the documented PRIMA projector operating envelope."""
         if stim.unit.dimension != self.stimulus_unit.dimension:
             raise DimensionMismatchError(
                 f"Safety check 'safe_mode' needs an optical stimulus to "
@@ -463,10 +430,7 @@ class PRIMAPivotal(ProsthesisSystem):
                 f"irradiance first.")
         projector = _projector(stim)
         if projector is None:
-            # Peak irradiance can be read off any waveform, but duty cycle
-            # cannot: it needs the projector period the pulses belong to.
-            # Calling a stimulus safe on half a check would be worse than
-            # refusing it:
+            # Duty cycle requires the projector schedule, not waveform samples.
             raise ValueError(
                 "Safety check: this stimulus no longer describes a projector "
                 "(irradiance, frame rate, per-pixel ON durations), so its "
@@ -487,15 +451,13 @@ class PRIMAPivotal(ProsthesisSystem):
                 f"Safety check: stimulus lights a pixel for {longest:.3f} ms, "
                 f"which exceeds the longest documented ON duration of "
                 f"{PRIMAEncoder.max_pulse_dur} ms.")
-        # Nonzero durations sit on the 0.7 ms grid, whatever produced them:
+        # Require 0.7 ms ON-duration steps.
         steps = dur[dur > 0] / step
         if steps.size and np.any(np.abs(steps - np.round(steps)) > 1e-6):
             raise ValueError(
                 f"Safety check: ON durations must be whole multiples of "
                 f"{step} ms, the step the projector modulates in.")
-        # Before the frame rate on its own: a fast clock and a long pulse is a
-        # problem with the combination, and saying so is more use than naming
-        # whichever half is checked first.
+        # Check duty cycle before frame rate to catch combined violations.
         duty = freq * longest / MS_PER_S
         if duty > PRIMAEncoder.max_duty_cycle + 1e-9:
             raise ValueError(
@@ -511,12 +473,7 @@ class PRIMAPivotal(ProsthesisSystem):
                 f"explore other frame rates.")
 
     def check_stim(self, stim):
-        """Quality-check the stimulus
-
-        PRIMA is stimulated optically, so ``safe_mode`` checks the projector's
-        documented envelope (see the class docstring) rather than electrical
-        charge balance. Irradiance that could not be light at all is refused
-        either way.
+        """Validate optical stimulation and, in safe mode, projector limits.
 
         .. versionadded:: 0.11.0
         """
@@ -524,8 +481,7 @@ class PRIMAPivotal(ProsthesisSystem):
         if self.safe_mode:
             self._require_within_optical_envelope(stim)
         if self.max_current is not None:
-            # A current limit does not describe this device, and the inherited
-            # check says so rather than reading irradiance as microamps:
+            # The inherited current-limit check rejects optical units.
             self._require_within_current_limit(stim)
 
     def plot(self, annotate=False, autoscale=True, ax=None, stim=None,

--- a/pulse2percept/implants/prima.py
+++ b/pulse2percept/implants/prima.py
@@ -13,9 +13,35 @@ from collections.abc import Sequence
 from .base import ProsthesisSystem
 from .electrodes import HexElectrode
 from .electrode_arrays import ElectrodeGrid
-from ..units import as_value, um
+from ..stimuli import PRIMAEncoder
+from ..stimuli.base import _describe_unit
+from ..units import DimensionMismatchError, as_value, mW, mm, um
 from ..utils import deprecated
-from ..utils.constants import ZORDER
+from ..utils.constants import MS_PER_S, ZORDER
+
+# Sentinel for "the device's own default", so that `encoder=None` can mean
+# "no automatic encoding" (see `PRIMAPivotal`):
+_DEVICE_DEFAULT = object()
+
+
+def _optical_params(stim):
+    """Projector settings a stimulus was built from, or None
+
+    ``Stimulus`` files metadata it does not recognize under a ``'user'`` key,
+    so an encoded stimulus that has been wrapped up in another one carries its
+    encoder record one level down.
+    """
+    meta = getattr(stim, 'metadata', None)
+    if not isinstance(meta, dict):
+        return None
+    enc = meta.get('encoder')
+    if not isinstance(enc, dict):
+        user = meta.get('user')
+        enc = user.get('encoder') if isinstance(user, dict) else None
+    if not isinstance(enc, dict):
+        return None
+    optical = enc.get('optical')
+    return optical if isinstance(optical, dict) else None
 
 
 #: F55 layout reconstructed from Fig. 2(a) of [Ho2019]_.
@@ -303,12 +329,33 @@ class PRIMAPivotal(ProsthesisSystem):
         preprocessing method whenever a stimulus is prepared, or a custom
         function (callable).
     safe_mode : bool, optional
-        If safe mode is enabled, only charge-balanced stimuli are allowed.
-    
+        If safe mode is enabled, only stimuli that stay inside the projector's
+        documented envelope are allowed: at most 3.5 mW/mm^2 of irradiance, ON
+        durations on the 0.7 ms hardware grid and no longer than 9.8 ms, and a
+        duty cycle of at most 0.294. There is no limit on how many pixels may
+        be lit at once; all 378 of them may be. Charge balance is not checked,
+        because PRIMA is not driven by a current source.
+
+        .. versionchanged:: 0.11.0
+            Checks the optical envelope instead of electrical charge balance.
+    encoder : :py:class:`~pulse2percept.stimuli.Encoder`, optional
+        How the device turns a picture into stimulation. Defaults to a fresh
+        :py:class:`~pulse2percept.stimuli.PRIMAEncoder`, i.e. binary 880 nm
+        illumination at 30 Hz. Pass ``encoder=None`` to switch automatic
+        encoding off, so that an image or video input is refused rather than
+        encoded.
+
+        .. versionadded:: 0.11.0
+
     Notes
     -----
     *  The active-electrode diameter was estimated from Fig. 1 of
        [Palanker2020]_.
+    *  The device is stimulated optically, so
+       :py:meth:`~pulse2percept.implants.ProsthesisSystem.prepare_stim` returns
+       irradiance in ``mW/mm^2``, not electrical current. How much current a
+       pixel injects depends on photodiode and circuit behavior that p2p does
+       not model yet.
     """
     # Frozen class: User cannot add more class attributes
     __slots__ = ('shape', 'spacing', 'pixel_width', 'gap',
@@ -318,8 +365,11 @@ class PRIMAPivotal(ProsthesisSystem):
     technology = 'photovoltaic'
     family = 'PRIMA'
 
+    #: The device is illuminated, not driven by a current source.
+    stimulus_unit = mW / mm ** 2
+
     def __init__(self, x=0, y=0, z=-100, rot=0, eye='RE', preprocess=False,
-                 safe_mode=False):
+                 safe_mode=False, encoder=_DEVICE_DEFAULT):
         self.spacing = 100  # um, nearest-neighbor center-to-center
         self.pixel_width = 100  # um, flat-to-flat
         self.gap = self.spacing - self.pixel_width  # um, open inter-pixel gap
@@ -329,6 +379,10 @@ class PRIMAPivotal(ProsthesisSystem):
         self.eye = eye
         self.preprocess = preprocess
         self.safe_mode = safe_mode
+        # Built per instance rather than shared between them: an encoder is a
+        # mutable object the caller may go on to tweak.
+        self.encoder = (PRIMAEncoder() if encoder is _DEVICE_DEFAULT
+                        else encoder)
 
         # Normalized here rather than in ElectrodeGrid, because a
         # per-electrode list of heights never reaches the grid at all -- it is
@@ -365,6 +419,72 @@ class PRIMAPivotal(ProsthesisSystem):
                                  f"{z_arr.size}.")
             for elec, z_elec in zip(self.earray.electrode_objects, z):
                 elec.z = z_elec
+
+    def _require_within_optical_envelope(self, stim):
+        """Require a stimulus the PRIMA projector could actually produce."""
+        if stim.unit.dimension != self.stimulus_unit.dimension:
+            raise DimensionMismatchError(
+                f"Safety check 'safe_mode' needs an optical stimulus to "
+                f"check, and this one is measured in "
+                f"{_describe_unit(stim.unit)}. Give the implant a "
+                f"PRIMAEncoder so that image or video input is encoded into "
+                f"irradiance first.")
+        optical = _optical_params(stim)
+        if optical is None:
+            # Peak irradiance can be read off any waveform, but duty cycle
+            # cannot: it needs the projector period the pulses belong to.
+            # Calling a stimulus safe on half a check would be worse than
+            # refusing it:
+            raise ValueError(
+                "Safety check: this stimulus does not record the projector "
+                "settings behind it (irradiance, frame rate, per-pixel ON "
+                "durations), so its duty cycle cannot be verified. Build it "
+                "with a PRIMAEncoder, or set safe_mode=False and check the "
+                "device envelope yourself.")
+        irradiance = float(optical['irradiance'])
+        freq = float(optical['freq'])
+        dur = np.asarray(optical['pulse_dur'], dtype=np.float64)
+        step = PRIMAEncoder.pulse_step
+        if irradiance > PRIMAEncoder.max_irradiance + 1e-9:
+            raise ValueError(
+                f"Safety check: stimulus projects {irradiance:.3f} mW/mm^2, "
+                f"which exceeds the {PRIMAEncoder.max_irradiance} mW/mm^2 the "
+                f"device delivers.")
+        longest = float(dur.max(initial=0.0))
+        if longest > PRIMAEncoder.max_pulse_dur + 1e-9:
+            raise ValueError(
+                f"Safety check: stimulus lights a pixel for {longest:.3f} ms, "
+                f"which exceeds the longest documented ON duration of "
+                f"{PRIMAEncoder.max_pulse_dur} ms.")
+        # Nonzero durations sit on the 0.7 ms grid, whatever produced them:
+        steps = dur[dur > 0] / step
+        if steps.size and np.any(np.abs(steps - np.round(steps)) > 1e-6):
+            raise ValueError(
+                f"Safety check: ON durations must be whole multiples of "
+                f"{step} ms, the step the projector modulates in.")
+        duty = freq * longest / MS_PER_S
+        if duty > PRIMAEncoder.max_duty_cycle + 1e-9:
+            raise ValueError(
+                f"Safety check: stimulus asks for a duty cycle of "
+                f"{duty:.3f} ({freq:g} Hz x {longest:.3f} ms), which exceeds "
+                f"the {PRIMAEncoder.max_duty_cycle:.3f} the device delivers. "
+                f"Lower 'freq' or shorten 'pulse_dur'.")
+
+    def check_stim(self, stim):
+        """Quality-check the stimulus
+
+        PRIMA is stimulated optically, so ``safe_mode`` checks the projector's
+        documented envelope (see the class docstring) rather than electrical
+        charge balance.
+
+        .. versionadded:: 0.11.0
+        """
+        if self.safe_mode:
+            self._require_within_optical_envelope(stim)
+        if self.max_current is not None:
+            # A current limit does not describe this device, and the inherited
+            # check says so rather than reading irradiance as microamps:
+            self._require_within_current_limit(stim)
 
     def plot(self, annotate=False, autoscale=True, ax=None, stim=None,
              stim_cmap=False):

--- a/pulse2percept/implants/prima.py
+++ b/pulse2percept/implants/prima.py
@@ -15,6 +15,7 @@ from .electrodes import HexElectrode
 from .electrode_arrays import ElectrodeGrid
 from ..stimuli import PRIMAEncoder
 from ..stimuli.base import _describe_unit
+from ..stimuli.encoders import _OpticalStimulus
 from ..units import DimensionMismatchError, as_value, mW, mm, um
 from ..utils import deprecated
 from ..utils.constants import MS_PER_S, ZORDER
@@ -24,24 +25,16 @@ from ..utils.constants import MS_PER_S, ZORDER
 _DEVICE_DEFAULT = object()
 
 
-def _optical_params(stim):
-    """Projector settings a stimulus was built from, or None
+def _projector(stim):
+    """The stimulus itself if it still describes a projector, else None
 
-    ``Stimulus`` files metadata it does not recognize under a ``'user'`` key,
-    so an encoded stimulus that has been wrapped up in another one carries its
-    encoder record one level down.
+    Only a stimulus that carries its own schedule can be checked against the
+    device envelope. Anything that has been reduced to samples -- by arithmetic
+    that invalidates a schedule, or by being built out of raw numbers -- says
+    nothing about the period its pulses sit in, whatever metadata was copied
+    along with it.
     """
-    meta = getattr(stim, 'metadata', None)
-    if not isinstance(meta, dict):
-        return None
-    enc = meta.get('encoder')
-    if not isinstance(enc, dict):
-        user = meta.get('user')
-        enc = user.get('encoder') if isinstance(user, dict) else None
-    if not isinstance(enc, dict):
-        return None
-    optical = enc.get('optical')
-    return optical if isinstance(optical, dict) else None
+    return stim if isinstance(stim, _OpticalStimulus) else None
 
 
 #: F55 layout reconstructed from Fig. 2(a) of [Ho2019]_.
@@ -330,11 +323,19 @@ class PRIMAPivotal(ProsthesisSystem):
         function (callable).
     safe_mode : bool, optional
         If safe mode is enabled, only stimuli that stay inside the projector's
-        documented envelope are allowed: at most 3.5 mW/mm^2 of irradiance, ON
-        durations on the 0.7 ms hardware grid and no longer than 9.8 ms, and a
-        duty cycle of at most 0.294. There is no limit on how many pixels may
-        be lit at once; all 378 of them may be. Charge balance is not checked,
-        because PRIMA is not driven by a current source.
+        documented envelope are allowed: at most 3.5 mW/mm^2 of irradiance, a
+        frame rate of at most 30 Hz, ON durations on the 0.7 ms hardware grid
+        and no longer than 9.8 ms, and a duty cycle of at most 0.294. There is
+        no limit on how many pixels may be lit at once; all 378 of them may be.
+        Charge balance is not checked, because PRIMA is not driven by a current
+        source.
+
+        This validates the *device envelope*, not biological safety. 3.5
+        mW/mm^2 is what the pivotal projector emits, not what the retina
+        tolerates; published thermal modeling puts the near-infrared ceiling
+        higher. A stimulus that no longer carries its projector schedule
+        cannot be verified and is refused; set ``safe_mode=False`` to check
+        the envelope yourself.
 
         .. versionchanged:: 0.11.0
             Checks the optical envelope instead of electrical charge balance.
@@ -420,8 +421,39 @@ class PRIMAPivotal(ProsthesisSystem):
             for elec, z_elec in zip(self.earray.electrode_objects, z):
                 elec.z = z_elec
 
+    def _require_physical_light(self, stim):
+        """Require irradiance that could be light at all.
+
+        Unlike the envelope below, this is not about the pivotal projector: a
+        negative or undefined power density is not dim light, it is not light,
+        so it is refused whatever ``safe_mode`` says.
+        """
+        if stim.unit.dimension != self.stimulus_unit.dimension:
+            return
+        projector = _projector(stim)
+        if projector is not None:
+            # A schedule validates its own irradiance when it is built, and
+            # reading it costs nothing:
+            values = np.array([projector.irradiance], dtype=np.float64)
+        else:
+            values = np.asarray(stim.data, dtype=np.float64)
+        if values.size == 0:
+            return
+        if not np.all(np.isfinite(values)):
+            raise ValueError("Optical stimulus has non-finite irradiance.")
+        if values.min() < 0:
+            raise ValueError(
+                f"Optical stimulus asks for {values.min():.3f} mW/mm^2. "
+                f"Irradiance is a power density and cannot be negative; "
+                f"a dark pixel is zero.")
+
     def _require_within_optical_envelope(self, stim):
-        """Require a stimulus the PRIMA projector could actually produce."""
+        """Require a stimulus the PRIMA projector could actually produce.
+
+        Read off the schedule the stimulus carries, never off its metadata:
+        metadata is an ordinary dict that arithmetic may copy onto a waveform
+        it no longer describes.
+        """
         if stim.unit.dimension != self.stimulus_unit.dimension:
             raise DimensionMismatchError(
                 f"Safety check 'safe_mode' needs an optical stimulus to "
@@ -429,21 +461,20 @@ class PRIMAPivotal(ProsthesisSystem):
                 f"{_describe_unit(stim.unit)}. Give the implant a "
                 f"PRIMAEncoder so that image or video input is encoded into "
                 f"irradiance first.")
-        optical = _optical_params(stim)
-        if optical is None:
+        projector = _projector(stim)
+        if projector is None:
             # Peak irradiance can be read off any waveform, but duty cycle
             # cannot: it needs the projector period the pulses belong to.
             # Calling a stimulus safe on half a check would be worse than
             # refusing it:
             raise ValueError(
-                "Safety check: this stimulus does not record the projector "
-                "settings behind it (irradiance, frame rate, per-pixel ON "
-                "durations), so its duty cycle cannot be verified. Build it "
-                "with a PRIMAEncoder, or set safe_mode=False and check the "
+                "Safety check: this stimulus no longer describes a projector "
+                "(irradiance, frame rate, per-pixel ON durations), so its "
+                "duty cycle cannot be verified. Build it with a PRIMAEncoder "
+                "and keep it intact, or set safe_mode=False and check the "
                 "device envelope yourself.")
-        irradiance = float(optical['irradiance'])
-        freq = float(optical['freq'])
-        dur = np.asarray(optical['pulse_dur'], dtype=np.float64)
+        irradiance, freq = projector.irradiance, projector.freq
+        dur = np.asarray(projector.pulse_dur, dtype=np.float64)
         step = PRIMAEncoder.pulse_step
         if irradiance > PRIMAEncoder.max_irradiance + 1e-9:
             raise ValueError(
@@ -462,6 +493,9 @@ class PRIMAPivotal(ProsthesisSystem):
             raise ValueError(
                 f"Safety check: ON durations must be whole multiples of "
                 f"{step} ms, the step the projector modulates in.")
+        # Before the frame rate on its own: a fast clock and a long pulse is a
+        # problem with the combination, and saying so is more use than naming
+        # whichever half is checked first.
         duty = freq * longest / MS_PER_S
         if duty > PRIMAEncoder.max_duty_cycle + 1e-9:
             raise ValueError(
@@ -469,16 +503,24 @@ class PRIMAPivotal(ProsthesisSystem):
                 f"{duty:.3f} ({freq:g} Hz x {longest:.3f} ms), which exceeds "
                 f"the {PRIMAEncoder.max_duty_cycle:.3f} the device delivers. "
                 f"Lower 'freq' or shorten 'pulse_dur'.")
+        if freq > PRIMAEncoder.max_freq + 1e-9:
+            raise ValueError(
+                f"Safety check: stimulus runs the projector at {freq:g} Hz, "
+                f"and the pivotal device runs at "
+                f"{PRIMAEncoder.max_freq:g} Hz. Set safe_mode=False to "
+                f"explore other frame rates.")
 
     def check_stim(self, stim):
         """Quality-check the stimulus
 
         PRIMA is stimulated optically, so ``safe_mode`` checks the projector's
         documented envelope (see the class docstring) rather than electrical
-        charge balance.
+        charge balance. Irradiance that could not be light at all is refused
+        either way.
 
         .. versionadded:: 0.11.0
         """
+        self._require_physical_light(stim)
         if self.safe_mode:
             self._require_within_optical_envelope(stim)
         if self.max_current is not None:

--- a/pulse2percept/implants/tests/test_prima.py
+++ b/pulse2percept/implants/tests/test_prima.py
@@ -10,14 +10,15 @@ import matplotlib.pyplot as plt
 from matplotlib.patches import Circle, Polygon, RegularPolygon
 from scipy.spatial import cKDTree
 
-from pulse2percept.implants import (PhotovoltaicPixel, PRIMAPivotal,
+from pulse2percept.implants import (ArgusII, PhotovoltaicPixel, PRIMAPivotal,
                                     Lorach2015Array, Ho2019FlatArray,
                                     Huang2021Array, PointSource,
                                     ProsthesisSystem, PRIMA, PRIMA75,
                                     PRIMA55, PRIMA40)
-from pulse2percept.stimuli import (BiphasicPulse, ImageStimulus, LogoBVL,
-                                   PRIMAEncoder, Stimulus)
-from pulse2percept.units import DimensionMismatchError, deg, mW, mm, um
+from pulse2percept.stimuli import (BiphasicPulse, BiphasicPulseTrain,
+                                   ImageStimulus, LogoBVL, PRIMAEncoder,
+                                   Stimulus)
+from pulse2percept.units import DimensionMismatchError, deg, mW, mm, um, xTh
 from pulse2percept.utils.constants import ZORDER
 from pulse2percept.models import ScoreboardModel
 
@@ -639,6 +640,18 @@ def test_PRIMAPivotal_is_stimulated_optically():
         PRIMAPivotal(encoder=None).prepare_stim(LogoBVL())
     with pytest.raises(TypeError):
         PRIMAPivotal(encoder='binary')
+
+
+def test_PRIMAPivotal_rejects_threshold_relative_stimuli():
+    # A multiple of threshold is a current that has not been named yet. The
+    # implant is illuminated, so there is nothing for it to be a multiple of:
+    train = Stimulus({'A5': BiphasicPulseTrain(20, 2 * xTh, 0.45,
+                                               stim_dur=50)})
+    with pytest.raises(DimensionMismatchError) as excinfo:
+        PRIMAPivotal().prepare_stim(train)
+    npt.assert_equal('irradiance' in str(excinfo.value), True)
+    # An electrically driven implant still takes one, before calibration:
+    npt.assert_equal(ArgusII(encoder=None).prepare_stim(train).unit, xTh)
 
 
 @pytest.mark.parametrize('implant_type', [Lorach2015Array,

--- a/pulse2percept/implants/tests/test_prima.py
+++ b/pulse2percept/implants/tests/test_prima.py
@@ -45,7 +45,7 @@ def test_PhotovoltaicPixel():
 @pytest.mark.parametrize('y', (-200, 400))
 @pytest.mark.parametrize('rot', (-45, 60))
 def test_PRIMAPivotal(ztype, x, y, rot):
-    # 85 um pixel with 15 um trenches:
+    # 100 um pixel on a 100 um grid, so no open gap between pixel bodies:
     spacing = 100
     # Roughly a 12x15 grid, but edges are trimmed off:
     n_elec = 378
@@ -672,8 +672,12 @@ def test_PRIMAPivotal_safe_mode_accepts_the_full_device():
 @pytest.mark.parametrize('encoder, msg', [
     (LooseEncoder(irradiance=5.0), 'exceeds the 3.5 mW/mm^2'),
     (LooseEncoder(pulse_dur=14.0), 'longest documented ON duration'),
-    (PRIMAEncoder(freq=60), 'duty cycle'),
     (LooseEncoder(pulse_dur=1.05), 'whole multiples of 0.7 ms'),
+    # A fast clock and a long pulse is a problem with the combination, and the
+    # duty cycle is what says so:
+    (PRIMAEncoder(freq=60), 'duty cycle'),
+    # ... but a legal duty cycle does not make an illegal clock legal:
+    (PRIMAEncoder(freq=60, pulse_dur=4.9), 'runs the projector at 60 Hz'),
 ])
 def test_PRIMAPivotal_safe_mode_rejects(encoder, msg):
     implant = PRIMAPivotal(safe_mode=True, encoder=encoder)
@@ -684,6 +688,50 @@ def test_PRIMAPivotal_safe_mode_rejects(encoder, msg):
     npt.assert_equal(
         PRIMAPivotal(encoder=encoder).prepare_stim(LogoBVL()).unit,
         mW / mm ** 2)
+
+
+def test_PRIMAPivotal_safe_mode_reads_the_schedule_not_the_metadata():
+    # Metadata is an ordinary mutable dict, and generic stimulus operations
+    # copy it onto results it no longer describes. The envelope check must not
+    # be talked into approving a stimulus by editing it.
+    implant = PRIMAPivotal(safe_mode=True)
+    stim = PRIMAPivotal(encoder=PRIMAEncoder(freq=60)).prepare_stim(LogoBVL())
+    stim.metadata['encoder'] = {'frame_time': np.zeros(1), 'frame_dur': 500.0,
+                                'optical': {'wavelength': 880.0,
+                                            'irradiance': 3.5, 'freq': 30.0,
+                                            'pulse_dur': np.zeros((378, 1)),
+                                            'grayscale': False}}
+    with pytest.raises(ValueError) as excinfo:
+        implant.check_stim(stim)
+    npt.assert_equal('duty cycle' in str(excinfo.value), True)
+
+
+def test_PRIMAPivotal_refuses_light_that_is_not_light():
+    # Not an envelope question, so it holds whatever `safe_mode` says: a
+    # negative or undefined power density is not dim light.
+    stim = PRIMAPivotal().prepare_stim(LogoBVL())
+    # A negative factor never reaches a waveform: the schedule refuses it.
+    with pytest.raises(ValueError):
+        stim * -1
+    # Zero is fine: it simply turns the projector off.
+    npt.assert_almost_equal((stim * 0).irradiance, 0)
+    PRIMAPivotal().check_stim(stim * 0)
+    # A non-finite factor is dropped by generic stimulus arithmetic before the
+    # schedule sees it, so what arrives is a degraded waveform. The implant
+    # still refuses it, on its samples:
+    for factor in (np.nan, np.inf):
+        with pytest.raises(ValueError) as excinfo:
+            PRIMAPivotal().check_stim(stim * factor)
+        npt.assert_equal('non-finite irradiance' in str(excinfo.value), True)
+    # ... and likewise a hand-built waveform of negative irradiance:
+    negative = Stimulus(stim)
+    negative.metadata = {'user': None}
+    negative._stim = {'data': -np.abs(negative.data),
+                      'electrodes': negative.electrodes,
+                      'time': negative.time}
+    with pytest.raises(ValueError) as excinfo:
+        PRIMAPivotal().check_stim(negative)
+    npt.assert_equal('cannot be negative' in str(excinfo.value), True)
 
 
 def test_PRIMAPivotal_safe_mode_needs_the_projector_settings():
@@ -698,6 +746,8 @@ def test_PRIMAPivotal_safe_mode_needs_the_projector_settings():
         implant.check_stim(handmade)
     npt.assert_equal('duty cycle cannot be verified' in str(excinfo.value),
                      True)
+    # Without safe_mode it goes through: nobody claimed it was checked.
+    PRIMAPivotal().check_stim(handmade)
     # Nor is safety an electrical question here:
     with pytest.raises(DimensionMismatchError):
         implant.check_stim(Stimulus({'A5': BiphasicPulse(10, 0.45)}))

--- a/pulse2percept/implants/tests/test_prima.py
+++ b/pulse2percept/implants/tests/test_prima.py
@@ -15,8 +15,9 @@ from pulse2percept.implants import (PhotovoltaicPixel, PRIMAPivotal,
                                     Huang2021Array, PointSource,
                                     ProsthesisSystem, PRIMA, PRIMA75,
                                     PRIMA55, PRIMA40)
-from pulse2percept.stimuli import LogoBVL
-from pulse2percept.units import deg, mm, um
+from pulse2percept.stimuli import (BiphasicPulse, ImageStimulus, LogoBVL,
+                                   PRIMAEncoder, Stimulus)
+from pulse2percept.units import DimensionMismatchError, deg, mW, mm, um
 from pulse2percept.utils.constants import ZORDER
 from pulse2percept.models import ScoreboardModel
 
@@ -600,3 +601,108 @@ def test_PRIMA_device_center(implant_type, offset):
     R = np.array([[np.cos(th), -np.sin(th)], [np.sin(th), np.cos(th)]])
     rotated = implant_type(x=x, y=y, rot=rot).earray.coordinates()[:, :2]
     npt.assert_almost_equal(rotated, (R @ (xy - [x, y]).T).T + [x, y])
+
+
+class LooseEncoder(PRIMAEncoder):
+    """A projector without PRIMA's own limits, to test the implant's
+
+    The encoder refuses to build a stimulus outside the documented envelope, so
+    a stimulus that has to reach ``safe_mode`` has to come from somewhere that
+    does not check.
+    """
+    __slots__ = ()
+
+    pulse_step = 0.35
+    max_pulse_dur = 21.0
+    max_irradiance = 100.0
+
+
+def test_PRIMAPivotal_is_stimulated_optically():
+    implant = PRIMAPivotal()
+    npt.assert_equal(implant.stimulus_unit, mW / mm ** 2)
+    npt.assert_equal(isinstance(implant.encoder, PRIMAEncoder), True)
+    # Photovoltaic pixels are all illuminated at once; nothing multiplexes them.
+    npt.assert_equal(implant.raster, None)
+    # Each instance gets its own encoder, so tweaking one leaves the next alone:
+    implant.encoder.threshold = 0.9
+    npt.assert_almost_equal(PRIMAPivotal().encoder.threshold, 0.5)
+
+    stim = implant.prepare_stim(LogoBVL())
+    npt.assert_equal(stim.unit, mW / mm ** 2)
+    npt.assert_equal(stim.shape[0], 378)
+    npt.assert_almost_equal(stim.data.max(), 3.5)
+    npt.assert_almost_equal(stim.duration, 500)
+
+    # Explicitly switching the encoder off refuses image input rather than
+    # guessing at a mapping:
+    with pytest.raises(DimensionMismatchError):
+        PRIMAPivotal(encoder=None).prepare_stim(LogoBVL())
+    with pytest.raises(TypeError):
+        PRIMAPivotal(encoder='binary')
+
+
+@pytest.mark.parametrize('implant_type', [Lorach2015Array,
+                                          partial(Ho2019FlatArray, 55),
+                                          partial(Huang2021Array, 55)])
+def test_other_photovoltaic_arrays_have_no_encoder(implant_type):
+    # Their stimulation protocols differ from the pivotal PRIMA system, so
+    # they do not inherit its projector.
+    npt.assert_equal(implant_type().encoder, None)
+
+
+def test_PRIMA_deprecated_alias_keeps_the_encoder():
+    with pytest.deprecated_call():
+        implant = PRIMA()
+    npt.assert_equal(isinstance(implant.encoder, PRIMAEncoder), True)
+    npt.assert_equal(implant.prepare_stim(LogoBVL()).unit, mW / mm ** 2)
+
+
+def test_PRIMAPivotal_safe_mode_accepts_the_full_device():
+    # All 378 pixels lit at once, at the largest documented drive, is legal:
+    implant = PRIMAPivotal(safe_mode=True)
+    stim = implant.prepare_stim(ImageStimulus(np.ones((32, 32))))
+    npt.assert_equal(np.count_nonzero(stim.data.max(axis=1)), 378)
+    npt.assert_almost_equal(stim.duty_cycle.max(), 0.294)
+    # ... and so is every legal duration on the way down:
+    for pulse_dur in np.arange(1, 15) * 0.7:
+        implant.encoder = PRIMAEncoder(pulse_dur=pulse_dur, grayscale=True)
+        implant.prepare_stim(LogoBVL())
+
+
+@pytest.mark.parametrize('encoder, msg', [
+    (LooseEncoder(irradiance=5.0), 'exceeds the 3.5 mW/mm^2'),
+    (LooseEncoder(pulse_dur=14.0), 'longest documented ON duration'),
+    (PRIMAEncoder(freq=60), 'duty cycle'),
+    (LooseEncoder(pulse_dur=1.05), 'whole multiples of 0.7 ms'),
+])
+def test_PRIMAPivotal_safe_mode_rejects(encoder, msg):
+    implant = PRIMAPivotal(safe_mode=True, encoder=encoder)
+    with pytest.raises(ValueError) as excinfo:
+        implant.prepare_stim(LogoBVL())
+    npt.assert_equal(msg in str(excinfo.value), True)
+    # The same stimulus is fine when nobody claims it was checked:
+    npt.assert_equal(
+        PRIMAPivotal(encoder=encoder).prepare_stim(LogoBVL()).unit,
+        mW / mm ** 2)
+
+
+def test_PRIMAPivotal_safe_mode_needs_the_projector_settings():
+    implant = PRIMAPivotal(safe_mode=True)
+    encoded = PRIMAPivotal().prepare_stim(LogoBVL())
+    # A waveform on its own says nothing about the period its pulses sit in,
+    # so its duty cycle cannot be verified and it is refused rather than
+    # reported as safe:
+    handmade = Stimulus(encoded)
+    handmade.metadata = {'user': None}
+    with pytest.raises(ValueError) as excinfo:
+        implant.check_stim(handmade)
+    npt.assert_equal('duty cycle cannot be verified' in str(excinfo.value),
+                     True)
+    # Nor is safety an electrical question here:
+    with pytest.raises(DimensionMismatchError):
+        implant.check_stim(Stimulus({'A5': BiphasicPulse(10, 0.45)}))
+    # A current limit does not describe this device either:
+    implant = PRIMAPivotal()
+    implant.max_current = 100
+    with pytest.raises(DimensionMismatchError):
+        implant.prepare_stim(LogoBVL())

--- a/pulse2percept/implants/tests/test_prima.py
+++ b/pulse2percept/implants/tests/test_prima.py
@@ -605,12 +605,7 @@ def test_PRIMA_device_center(implant_type, offset):
 
 
 class LooseEncoder(PRIMAEncoder):
-    """A projector without PRIMA's own limits, to test the implant's
-
-    The encoder refuses to build a stimulus outside the documented envelope, so
-    a stimulus that has to reach ``safe_mode`` has to come from somewhere that
-    does not check.
-    """
+    """PRIMAEncoder variant used to exercise ``safe_mode`` limits."""
     __slots__ = ()
 
     pulse_step = 0.35
@@ -622,9 +617,9 @@ def test_PRIMAPivotal_is_stimulated_optically():
     implant = PRIMAPivotal()
     npt.assert_equal(implant.stimulus_unit, mW / mm ** 2)
     npt.assert_equal(isinstance(implant.encoder, PRIMAEncoder), True)
-    # Photovoltaic pixels are all illuminated at once; nothing multiplexes them.
+    # All photovoltaic pixels may be illuminated simultaneously.
     npt.assert_equal(implant.raster, None)
-    # Each instance gets its own encoder, so tweaking one leaves the next alone:
+    # Encoder state is per implant instance.
     implant.encoder.threshold = 0.9
     npt.assert_almost_equal(PRIMAPivotal().encoder.threshold, 0.5)
 
@@ -634,8 +629,7 @@ def test_PRIMAPivotal_is_stimulated_optically():
     npt.assert_almost_equal(stim.data.max(), 3.5)
     npt.assert_almost_equal(stim.duration, 500)
 
-    # Explicitly switching the encoder off refuses image input rather than
-    # guessing at a mapping:
+    # Disabling the encoder rejects image input.
     with pytest.raises(DimensionMismatchError):
         PRIMAPivotal(encoder=None).prepare_stim(LogoBVL())
     with pytest.raises(TypeError):
@@ -643,14 +637,13 @@ def test_PRIMAPivotal_is_stimulated_optically():
 
 
 def test_PRIMAPivotal_rejects_threshold_relative_stimuli():
-    # A multiple of threshold is a current that has not been named yet. The
-    # implant is illuminated, so there is nothing for it to be a multiple of:
+    # Threshold-relative current is invalid for an optical implant.
     train = Stimulus({'A5': BiphasicPulseTrain(20, 2 * xTh, 0.45,
                                                stim_dur=50)})
     with pytest.raises(DimensionMismatchError) as excinfo:
         PRIMAPivotal().prepare_stim(train)
     npt.assert_equal('irradiance' in str(excinfo.value), True)
-    # An electrically driven implant still takes one, before calibration:
+    # Current-driven implants still accept xTh before calibration.
     npt.assert_equal(ArgusII(encoder=None).prepare_stim(train).unit, xTh)
 
 
@@ -658,8 +651,7 @@ def test_PRIMAPivotal_rejects_threshold_relative_stimuli():
                                           partial(Ho2019FlatArray, 55),
                                           partial(Huang2021Array, 55)])
 def test_other_photovoltaic_arrays_have_no_encoder(implant_type):
-    # Their stimulation protocols differ from the pivotal PRIMA system, so
-    # they do not inherit its projector.
+    # Other photovoltaic arrays do not assume the pivotal PRIMA protocol.
     npt.assert_equal(implant_type().encoder, None)
 
 
@@ -671,12 +663,12 @@ def test_PRIMA_deprecated_alias_keeps_the_encoder():
 
 
 def test_PRIMAPivotal_safe_mode_accepts_the_full_device():
-    # All 378 pixels lit at once, at the largest documented drive, is legal:
+    # Full-array illumination at the documented maximum is valid.
     implant = PRIMAPivotal(safe_mode=True)
     stim = implant.prepare_stim(ImageStimulus(np.ones((32, 32))))
     npt.assert_equal(np.count_nonzero(stim.data.max(axis=1)), 378)
     npt.assert_almost_equal(stim.duty_cycle.max(), 0.294)
-    # ... and so is every legal duration on the way down:
+    # All documented pulse-duration levels are valid.
     for pulse_dur in np.arange(1, 15) * 0.7:
         implant.encoder = PRIMAEncoder(pulse_dur=pulse_dur, grayscale=True)
         implant.prepare_stim(LogoBVL())
@@ -686,10 +678,9 @@ def test_PRIMAPivotal_safe_mode_accepts_the_full_device():
     (LooseEncoder(irradiance=5.0), 'exceeds the 3.5 mW/mm^2'),
     (LooseEncoder(pulse_dur=14.0), 'longest documented ON duration'),
     (LooseEncoder(pulse_dur=1.05), 'whole multiples of 0.7 ms'),
-    # A fast clock and a long pulse is a problem with the combination, and the
-    # duty cycle is what says so:
+    # Combined frequency/pulse-duration violations are caught by duty cycle.
     (PRIMAEncoder(freq=60), 'duty cycle'),
-    # ... but a legal duty cycle does not make an illegal clock legal:
+    # Frame rate is checked independently.
     (PRIMAEncoder(freq=60, pulse_dur=4.9), 'runs the projector at 60 Hz'),
 ])
 def test_PRIMAPivotal_safe_mode_rejects(encoder, msg):
@@ -697,16 +688,14 @@ def test_PRIMAPivotal_safe_mode_rejects(encoder, msg):
     with pytest.raises(ValueError) as excinfo:
         implant.prepare_stim(LogoBVL())
     npt.assert_equal(msg in str(excinfo.value), True)
-    # The same stimulus is fine when nobody claims it was checked:
+    # The operating-envelope check is disabled when safe_mode=False.
     npt.assert_equal(
         PRIMAPivotal(encoder=encoder).prepare_stim(LogoBVL()).unit,
         mW / mm ** 2)
 
 
 def test_PRIMAPivotal_safe_mode_reads_the_schedule_not_the_metadata():
-    # Metadata is an ordinary mutable dict, and generic stimulus operations
-    # copy it onto results it no longer describes. The envelope check must not
-    # be talked into approving a stimulus by editing it.
+    # Envelope checks use schedule state, not mutable metadata.
     implant = PRIMAPivotal(safe_mode=True)
     stim = PRIMAPivotal(encoder=PRIMAEncoder(freq=60)).prepare_stim(LogoBVL())
     stim.metadata['encoder'] = {'frame_time': np.zeros(1), 'frame_dur': 500.0,
@@ -720,23 +709,20 @@ def test_PRIMAPivotal_safe_mode_reads_the_schedule_not_the_metadata():
 
 
 def test_PRIMAPivotal_refuses_light_that_is_not_light():
-    # Not an envelope question, so it holds whatever `safe_mode` says: a
-    # negative or undefined power density is not dim light.
+    # Negative or nonfinite irradiance is invalid regardless of safe_mode.
     stim = PRIMAPivotal().prepare_stim(LogoBVL())
-    # A negative factor never reaches a waveform: the schedule refuses it.
+    # Negative scaling is rejected by the schedule.
     with pytest.raises(ValueError):
         stim * -1
-    # Zero is fine: it simply turns the projector off.
+    # Zero scaling turns illumination off.
     npt.assert_almost_equal((stim * 0).irradiance, 0)
     PRIMAPivotal().check_stim(stim * 0)
-    # A non-finite factor is dropped by generic stimulus arithmetic before the
-    # schedule sees it, so what arrives is a degraded waveform. The implant
-    # still refuses it, on its samples:
+    # Nonfinite waveform samples are rejected.
     for factor in (np.nan, np.inf):
         with pytest.raises(ValueError) as excinfo:
             PRIMAPivotal().check_stim(stim * factor)
         npt.assert_equal('non-finite irradiance' in str(excinfo.value), True)
-    # ... and likewise a hand-built waveform of negative irradiance:
+    # Hand-built negative irradiance is also rejected.
     negative = Stimulus(stim)
     negative.metadata = {'user': None}
     negative._stim = {'data': -np.abs(negative.data),
@@ -750,21 +736,19 @@ def test_PRIMAPivotal_refuses_light_that_is_not_light():
 def test_PRIMAPivotal_safe_mode_needs_the_projector_settings():
     implant = PRIMAPivotal(safe_mode=True)
     encoded = PRIMAPivotal().prepare_stim(LogoBVL())
-    # A waveform on its own says nothing about the period its pulses sit in,
-    # so its duty cycle cannot be verified and it is refused rather than
-    # reported as safe:
+    # Duty cycle cannot be checked after the projector schedule is lost.
     handmade = Stimulus(encoded)
     handmade.metadata = {'user': None}
     with pytest.raises(ValueError) as excinfo:
         implant.check_stim(handmade)
     npt.assert_equal('duty cycle cannot be verified' in str(excinfo.value),
                      True)
-    # Without safe_mode it goes through: nobody claimed it was checked.
+    # Without safe_mode, the incomplete envelope check is skipped.
     PRIMAPivotal().check_stim(handmade)
-    # Nor is safety an electrical question here:
+    # Optical safe_mode does not accept electrical stimulation.
     with pytest.raises(DimensionMismatchError):
         implant.check_stim(Stimulus({'A5': BiphasicPulse(10, 0.45)}))
-    # A current limit does not describe this device either:
+    # max_current is not defined for this optical device.
     implant = PRIMAPivotal()
     implant.max_current = 100
     with pytest.raises(DimensionMismatchError):

--- a/pulse2percept/models/base.py
+++ b/pulse2percept/models/base.py
@@ -173,9 +173,7 @@ def _require_stim_dimension(model, stim):
     if stim.unit.dimension in {unit.dimension for unit in accepted}:
         if (stim.unit.dimension.is_dimensionless and
                 not stim._is_normalized_drive):
-            # A picture is dimensionless too. A model that reads a
-            # dimensionless stimulus reads an encoded drive (see
-            # `pulse2percept.stimuli.PRIMAEncoder`), never gray levels:
+            # Dimensionless model input must be encoded drive, not gray levels.
             raise DimensionMismatchError(
                 f"{type(model).__name__} expects {expected}, and this "
                 f"stimulus is dimensionless but is not a normalized drive: "
@@ -451,12 +449,7 @@ class BaseModel(Parametrized, metaclass=ABCMeta):
         pass
 
     def _stim_unit(self, stim):
-        """The unit this model reads ``stim`` in.
-
-        ``stimulus_unit`` for a stimulus of that dimension, otherwise the
-        matching entry of ``extra_stimulus_units``. A stimulus of neither
-        dimension has already been refused by ``_require_stim_dimension``.
-        """
+        """Return the model unit matching ``stim``."""
         if stim.unit.dimension == self.stimulus_unit.dimension:
             return self.stimulus_unit
         for unit in self.extra_stimulus_units:
@@ -930,10 +923,7 @@ class SpatialModel(BaseModel, metaclass=ABCMeta):
                 # np.asarray: indexing a single-electrode stimulus returns a
                 # scalar, which has no `reshape`:
                 at = self._to_stim_time(t_percept, stim)
-                # Resampling in time changes nothing about what the values
-                # *are*, so the rebuilt stimulus has to keep saying it: a
-                # normalized drive that came back as a plain dimensionless
-                # `Stimulus` would be read as gray levels and refused.
+                # Preserve the normalized-drive marker through resampling.
                 rebuild = type(stim) if stim._is_normalized_drive else Stimulus
                 stim = rebuild(
                     np.asarray(stim[:, at]).reshape((-1, n_time)),
@@ -1598,10 +1588,7 @@ class Model(Frozen, PrettyPrint):
         if stim is None or (not self.has_space and not self.has_time):
             # Nothing to see here:
             return None
-        # A spatial-only model reads the stimulus' spatial view, which need not
-        # be measured in the same quantity as the waveform behind it: a
-        # photovoltaic implant delivers irradiance but reports normalized
-        # optical drive. Check what the stages will actually read:
+        # Spatial-only models validate the spatial view, not the waveform.
         _require_stim_dimension(
             self, _spatial_input(stim) if self.has_space and not self.has_time
             else stim)

--- a/pulse2percept/models/base.py
+++ b/pulse2percept/models/base.py
@@ -439,8 +439,22 @@ class BaseModel(Parametrized, metaclass=ABCMeta):
         """Customize the building process by implementing this method"""
         pass
 
+    def _stim_unit(self, stim):
+        """The unit this model reads ``stim`` in.
+
+        ``stimulus_unit`` for a stimulus of that dimension, otherwise the
+        matching entry of ``extra_stimulus_units``. A stimulus of neither
+        dimension has already been refused by ``_require_stim_dimension``.
+        """
+        if stim.unit.dimension == self.stimulus_unit.dimension:
+            return self.stimulus_unit
+        for unit in self.extra_stimulus_units:
+            if stim.unit.dimension == unit.dimension:
+                return unit
+        return self.stimulus_unit
+
     def _stim_values(self, stim):
-        """Return stimulus values in ``stimulus_unit``.
+        """Return stimulus values in the unit this model reads them in.
 
         Stimuli are converted at the model boundary; percept values are passed
         through because brightness is not a physical stimulus quantity.
@@ -448,7 +462,7 @@ class BaseModel(Parametrized, metaclass=ABCMeta):
         if not isinstance(stim, Stimulus):
             return stim.data
         _require_stim_dimension(self, stim)
-        return stim.values(self.stimulus_unit)
+        return stim.values(self._stim_unit(stim))
 
     def _stim_times(self, stim):
         """Return the time axis in ``time_unit``.
@@ -1568,7 +1582,13 @@ class Model(Frozen, PrettyPrint):
         if stim is None or (not self.has_space and not self.has_time):
             # Nothing to see here:
             return None
-        _require_stim_dimension(self, stim)
+        # A spatial-only model reads the stimulus' spatial view, which need not
+        # be measured in the same quantity as the waveform behind it: a
+        # photovoltaic implant delivers irradiance but reports normalized
+        # optical drive. Check what the stages will actually read:
+        _require_stim_dimension(
+            self, _spatial_input(stim) if self.has_space and not self.has_time
+            else stim)
         # `_has_time_axis`, not `stim.time`: whether there is a time axis is a
         # question a stimulus can answer from its structure, and asking it for
         # the axis itself would generate the waveform behind it.

--- a/pulse2percept/models/base.py
+++ b/pulse2percept/models/base.py
@@ -169,9 +169,19 @@ def _require_stim_dimension(model, stim):
     if not isinstance(stim, Stimulus):
         return
     accepted = (model.stimulus_unit,) + tuple(model.extra_stimulus_units)
-    if stim.unit.dimension in {unit.dimension for unit in accepted}:
-        return
     expected = ' or '.join(_describe_unit(unit) for unit in accepted)
+    if stim.unit.dimension in {unit.dimension for unit in accepted}:
+        if (stim.unit.dimension.is_dimensionless and
+                not stim._is_normalized_drive):
+            # A picture is dimensionless too. A model that reads a
+            # dimensionless stimulus reads an encoded drive (see
+            # `pulse2percept.stimuli.PRIMAEncoder`), never gray levels:
+            raise DimensionMismatchError(
+                f"{type(model).__name__} expects {expected}, and this "
+                f"stimulus is dimensionless but is not a normalized drive: "
+                f"gray levels are not stimulation. Encode the picture first, "
+                f"or hand the implant the picture and let its encoder do it.")
+        return
     raise DimensionMismatchError(
         f"{type(model).__name__} expects {expected}, got "
         f"{_describe_unit(stim.unit)}.")

--- a/pulse2percept/models/base.py
+++ b/pulse2percept/models/base.py
@@ -930,7 +930,12 @@ class SpatialModel(BaseModel, metaclass=ABCMeta):
                 # np.asarray: indexing a single-electrode stimulus returns a
                 # scalar, which has no `reshape`:
                 at = self._to_stim_time(t_percept, stim)
-                stim = Stimulus(
+                # Resampling in time changes nothing about what the values
+                # *are*, so the rebuilt stimulus has to keep saying it: a
+                # normalized drive that came back as a plain dimensionless
+                # `Stimulus` would be read as gray levels and refused.
+                rebuild = type(stim) if stim._is_normalized_drive else Stimulus
+                stim = rebuild(
                     np.asarray(stim[:, at]).reshape((-1, n_time)),
                     electrodes=stim.electrodes, time=at
                 )._inherit_units(stim)._inherit_metadata(stim)
@@ -951,7 +956,7 @@ class SpatialModel(BaseModel, metaclass=ABCMeta):
                     uniq_time = None
                 # `_predict_spatial` only ever sees this de-duplicated
                 # copy, so the stimulus' metadata has to come along:
-                stim_unique = Stimulus(
+                stim_unique = rebuild(
                     stim[:, stim.time[t_unique]], electrodes=stim.electrodes,
                     time=uniq_time
                 )._inherit_units(stim)._inherit_metadata(stim)

--- a/pulse2percept/models/base.py
+++ b/pulse2percept/models/base.py
@@ -255,8 +255,9 @@ def _scene_stim(model, scene, gaze):
     if implant.encoder is None:
         raise ValueError(
             "A scene is a picture, and there is no principled default for "
-            "turning a gray level into current. Give the implant an "
-            "'encoder' (e.g. an AmplitudeEncoder) to say how.")
+            "turning a gray level into stimulation. Give the implant an "
+            "'encoder' (e.g. an AmplitudeEncoder, or a PRIMAEncoder for a "
+            "photovoltaic device) to say how.")
     device_scene = _device_scene(scene, implant)
     xy = implant.earray.coordinates(vfmap.tissue_unit)[:, :2].T
     x_vf, y_vf = vfmap.ret_to_dva(*xy)

--- a/pulse2percept/models/beyeler2019.py
+++ b/pulse2percept/models/beyeler2019.py
@@ -83,9 +83,18 @@ class ScoreboardSpatial(SpatialModel):
             -\frac{(x-x_e)^2 + (y-y_e)^2}{2\rho^2}
         \right),
 
-    where :math:`a_e` is the amplitude delivered by electrode :math:`e`, and
-    :math:`\rho` controls the spatial spread of activation. Larger values of
+    where :math:`a_e` is the drive at site :math:`e`, and :math:`\rho`
+    controls the spatial spread of activation. Larger values of
     :math:`\rho` produce broader phosphenes.
+
+    For an electrically driven implant, :math:`a_e` is the current
+    amplitude delivered by electrode :math:`e`. For a photovoltaic
+    implant it is the normalized optical drive its encoder reports
+    (see :py:class:`~pulse2percept.stimuli.PRIMAEncoder`), which makes
+    the percept a visualization of implant geometry and stimulation
+    pattern rather than a model of photodiode transduction, retinal
+    electric fields, bipolar-cell activation, electrode-retina
+    distance, or temporal retinal dynamics.
 
     Parameters
     ----------
@@ -194,9 +203,18 @@ class ScoreboardModel(Model):
                 -\frac{(x-x_e)^2 + (y-y_e)^2}{2\rho^2}
             \right),
     
-        where :math:`a_e` is the amplitude delivered by electrode :math:`e`, and
-        :math:`\rho` controls the spatial spread of activation. Larger values of
+        where :math:`a_e` is the drive at site :math:`e`, and :math:`\rho`
+        controls the spatial spread of activation. Larger values of
         :math:`\rho` produce broader phosphenes.
+
+        For an electrically driven implant, :math:`a_e` is the current
+        amplitude delivered by electrode :math:`e`. For a photovoltaic
+        implant it is the normalized optical drive its encoder reports
+        (see :py:class:`~pulse2percept.stimuli.PRIMAEncoder`), which makes
+        the percept a visualization of implant geometry and stimulation
+        pattern rather than a model of photodiode transduction, retinal
+        electric fields, bipolar-cell activation, electrode-retina
+        distance, or temporal retinal dynamics.
 
     Parameters
     ----------

--- a/pulse2percept/models/beyeler2019.py
+++ b/pulse2percept/models/beyeler2019.py
@@ -87,14 +87,10 @@ class ScoreboardSpatial(SpatialModel):
     controls the spatial spread of activation. Larger values of
     :math:`\rho` produce broader phosphenes.
 
-    For an electrically driven implant, :math:`a_e` is the current
-    amplitude delivered by electrode :math:`e`. For a photovoltaic
-    implant it is the normalized optical drive its encoder reports
-    (see :py:class:`~pulse2percept.stimuli.PRIMAEncoder`), which makes
-    the percept a visualization of implant geometry and stimulation
-    pattern rather than a model of photodiode transduction, retinal
-    electric fields, bipolar-cell activation, electrode-retina
-    distance, or temporal retinal dynamics.
+    For current-driven implants, :math:`a_e` is current amplitude.
+    :py:class:`~pulse2percept.stimuli.PRIMAEncoder` instead provides normalized
+    optical drive. In that case, Scoreboard visualizes the stimulation pattern;
+    it does not model the retinal response.
 
     Parameters
     ----------
@@ -152,11 +148,7 @@ class ScoreboardSpatial(SpatialModel):
     n_jobs : int or None, optional
         Alias for ``n_threads``. ``None`` and -1 use all available CPU cores."""
 
-    #: A photovoltaic implant is not driven by a current source. Its encoder
-    #: reports normalized optical drive instead, which this model uses directly
-    #: as the weight of each Gaussian (see
-    #: :py:class:`~pulse2percept.stimuli.PRIMAEncoder`). Only an encoded drive
-    #: is accepted, not a picture that happens to be dimensionless too.
+    #: Also accepts encoded normalized optical drive from PRIMAEncoder.
     extra_stimulus_units = (dimensionless,)
 
     def get_default_params(self):
@@ -208,14 +200,10 @@ class ScoreboardModel(Model):
         controls the spatial spread of activation. Larger values of
         :math:`\rho` produce broader phosphenes.
 
-        For an electrically driven implant, :math:`a_e` is the current
-        amplitude delivered by electrode :math:`e`. For a photovoltaic
-        implant it is the normalized optical drive its encoder reports
-        (see :py:class:`~pulse2percept.stimuli.PRIMAEncoder`), which makes
-        the percept a visualization of implant geometry and stimulation
-        pattern rather than a model of photodiode transduction, retinal
-        electric fields, bipolar-cell activation, electrode-retina
-        distance, or temporal retinal dynamics.
+        For current-driven implants, :math:`a_e` is current amplitude.
+        :py:class:`~pulse2percept.stimuli.PRIMAEncoder` instead provides
+        normalized optical drive. In that case, Scoreboard visualizes the
+        stimulation pattern; it does not model the retinal response.
 
     Parameters
     ----------

--- a/pulse2percept/models/beyeler2019.py
+++ b/pulse2percept/models/beyeler2019.py
@@ -9,7 +9,7 @@ from scipy.spatial import cKDTree
 import matplotlib.pyplot as plt
 from matplotlib.patches import Ellipse
 
-from ..units import deg, dva, um
+from ..units import deg, dimensionless, dva, um
 from ..utils.constants import UM_PER_MM, ZORDER
 from ..topography import Watson2014Map
 from ..implants import ElectrodeArray
@@ -142,6 +142,12 @@ class ScoreboardSpatial(SpatialModel):
         Number of OpenMP threads.
     n_jobs : int or None, optional
         Alias for ``n_threads``. ``None`` and -1 use all available CPU cores."""
+
+    #: A photovoltaic implant is not driven by a current source. Its encoder
+    #: reports normalized optical drive instead, which this model uses directly
+    #: as the weight of each Gaussian (see
+    #: :py:class:`~pulse2percept.stimuli.PRIMAEncoder`).
+    extra_stimulus_units = (dimensionless,)
 
     def get_default_params(self):
         """Return all settable scoreboard parameters."""

--- a/pulse2percept/models/beyeler2019.py
+++ b/pulse2percept/models/beyeler2019.py
@@ -155,7 +155,8 @@ class ScoreboardSpatial(SpatialModel):
     #: A photovoltaic implant is not driven by a current source. Its encoder
     #: reports normalized optical drive instead, which this model uses directly
     #: as the weight of each Gaussian (see
-    #: :py:class:`~pulse2percept.stimuli.PRIMAEncoder`).
+    #: :py:class:`~pulse2percept.stimuli.PRIMAEncoder`). Only an encoded drive
+    #: is accepted, not a picture that happens to be dimensionless too.
     extra_stimulus_units = (dimensionless,)
 
     def get_default_params(self):

--- a/pulse2percept/models/tests/test_base.py
+++ b/pulse2percept/models/tests/test_base.py
@@ -1211,12 +1211,15 @@ def test_model_requires_a_current_stimulus():
         stimulus_unit = dimensionless
 
     implant = Projector(preprocess=False)
-    spatial = ScoreboardSpatial(implant=implant, xrange=(-2, 2),
-                                yrange=(-2, 2), step=1).build()
+    # `ScoreboardSpatial` is the deliberate exception: it also reads the
+    # normalized optical drive a photovoltaic implant reports (see
+    # `PRIMAEncoder`), so a model without such a reading makes the point.
+    spatial = AxonMapSpatial(implant=implant, xrange=(-2, 2),
+                             yrange=(-2, 2), step=1).build()
     temporal = FadingTemporal().build()
     composite = Model(implant=implant,
-                      spatial=ScoreboardSpatial(xrange=(-2, 2), yrange=(-2, 2),
-                                                step=1),
+                      spatial=AxonMapSpatial(xrange=(-2, 2), yrange=(-2, 2),
+                                             step=1),
                       temporal=FadingTemporal()).build()
     with pytest.raises(DimensionMismatchError):
         ArgusII(preprocess=False, encoder=None).prepare_stim(img)

--- a/pulse2percept/models/tests/test_base.py
+++ b/pulse2percept/models/tests/test_base.py
@@ -1211,15 +1211,12 @@ def test_model_requires_a_current_stimulus():
         stimulus_unit = dimensionless
 
     implant = Projector(preprocess=False)
-    # `ScoreboardSpatial` is the deliberate exception: it also reads the
-    # normalized optical drive a photovoltaic implant reports (see
-    # `PRIMAEncoder`), so a model without such a reading makes the point.
-    spatial = AxonMapSpatial(implant=implant, xrange=(-2, 2),
-                             yrange=(-2, 2), step=1).build()
+    spatial = ScoreboardSpatial(implant=implant, xrange=(-2, 2),
+                                yrange=(-2, 2), step=1).build()
     temporal = FadingTemporal().build()
     composite = Model(implant=implant,
-                      spatial=AxonMapSpatial(xrange=(-2, 2), yrange=(-2, 2),
-                                             step=1),
+                      spatial=ScoreboardSpatial(xrange=(-2, 2), yrange=(-2, 2),
+                                                step=1),
                       temporal=FadingTemporal()).build()
     with pytest.raises(DimensionMismatchError):
         ArgusII(preprocess=False, encoder=None).prepare_stim(img)

--- a/pulse2percept/models/tests/test_beyeler2019.py
+++ b/pulse2percept/models/tests/test_beyeler2019.py
@@ -13,7 +13,8 @@ import matplotlib.pyplot as plt
 
 from pulse2percept.implants import ArgusI, ArgusII, PRIMAPivotal
 from pulse2percept.percepts import Percept
-from pulse2percept.stimuli import ImageStimulus, LogoBVL, Stimulus
+from pulse2percept.stimuli import (ImageStimulus, LogoBVL, Stimulus,
+                                   VideoStimulus)
 from pulse2percept.models import (AxonMapSpatial, AxonMapModel,
                                   ScoreboardSpatial, ScoreboardModel)
 from pulse2percept.models.beyeler2019 import _AXON_CACHE_VERSION
@@ -1093,6 +1094,35 @@ def test_scoreboard_visualizes_a_photovoltaic_implant():
         warnings.simplefilter('ignore', UserWarning)
         dark = model.predict_percept(ImageStimulus(np.zeros((32, 32))))
     npt.assert_almost_equal(dark.data.max(), 0)
+
+
+def test_scoreboard_visualizes_a_photovoltaic_video():
+    """A PRIMA video survives the time resampling `_predict_prepared` does
+
+    The normalized drive is dimensionless, and a dimensionless stimulus is only
+    stimulation if it says it is one. Rebuilding it at `t_percept` as a plain
+    `Stimulus` would drop that and have the model read gray levels.
+    """
+    implant = PRIMAPivotal()
+    with warnings.catch_warnings():
+        warnings.simplefilter('ignore', UserWarning)
+        model = ScoreboardModel(implant=implant, rho=200, step=0.5,
+                                xrange=(-2, 2), yrange=(-2, 2))
+        # Only the middle frame is lit, so the percept has to follow the
+        # source frame by frame rather than smear it:
+        frames = np.zeros((8, 8, 3))
+        frames[..., 1] = 1.0
+        video = VideoStimulus(frames, time=[0.0, 40.0, 80.0])
+        percept = model.predict_percept(video)
+    npt.assert_equal(percept.shape[:2], tuple(model.grid.x.shape))
+    npt.assert_equal(np.all(np.isfinite(percept.data)), True)
+    npt.assert_equal(percept.data.max() > 0, True)
+    # One percept frame per projector frame, and only the lit source frame
+    # drives anything:
+    npt.assert_equal(percept.shape[-1], percept.time.size)
+    npt.assert_almost_equal(np.diff(percept.time), 1000 / 30, decimal=3)
+    lit = percept.data.max(axis=(0, 1)) > 0
+    npt.assert_equal(lit.any() and not lit.all(), True)
 
 
 def test_scoreboard_refuses_a_bare_optical_waveform():

--- a/pulse2percept/models/tests/test_beyeler2019.py
+++ b/pulse2percept/models/tests/test_beyeler2019.py
@@ -11,15 +11,16 @@ from matplotlib.axes import Subplot
 import matplotlib.pyplot as plt
 
 
-from pulse2percept.implants import ArgusI, ArgusII
+from pulse2percept.implants import ArgusI, ArgusII, PRIMAPivotal
 from pulse2percept.percepts import Percept
-from pulse2percept.stimuli import Stimulus
+from pulse2percept.stimuli import ImageStimulus, LogoBVL, Stimulus
 from pulse2percept.models import (AxonMapSpatial, AxonMapModel,
                                   ScoreboardSpatial, ScoreboardModel)
 from pulse2percept.models.beyeler2019 import _AXON_CACHE_VERSION
 from pulse2percept.models._beyeler2019 import fast_axon_map
 from pulse2percept.topography import Watson2014Map, Watson2014DisplaceMap
-from pulse2percept.units import DimensionMismatchError, deg, dva, rad
+from pulse2percept.units import (DimensionMismatchError, deg,
+                                 dimensionless, dva, mW, mm, rad)
 from pulse2percept.utils.testing import assert_warns_msg
 
 # Building an axon map writes a cache to a relative path; keep it in a
@@ -1063,3 +1064,48 @@ def test_electrode_pitch_ignores_a_dimension_the_model_drops(ModelClass):
                        yrange=(-2, 2), **extra)
     said = _user_warnings(model.build)
     npt.assert_equal(any('pitch (100 um)' in w for w in said), True)
+
+
+def test_scoreboard_visualizes_a_photovoltaic_implant():
+    """A picture straight into a PRIMA implant comes out as a percept
+
+    Scoreboard weights each Gaussian by the normalized optical drive the
+    implant's encoder reports. That is a picture of implant geometry and
+    stimulation pattern, not a model of photodiode transduction, retinal
+    electric fields, or temporal dynamics.
+    """
+    implant = PRIMAPivotal()
+    with warnings.catch_warnings():
+        warnings.simplefilter('ignore', UserWarning)
+        model = ScoreboardModel(implant=implant, rho=200, step=0.05,
+                                xrange=(-2, 2), yrange=(-2, 2))
+        percept = model.predict_percept(LogoBVL())
+    npt.assert_equal(isinstance(percept, Percept), True)
+    npt.assert_equal(percept.shape, tuple(model.grid.x.shape) + (1,))
+    npt.assert_equal(np.all(np.isfinite(percept.data)), True)
+    npt.assert_equal(percept.data.max() > 0, True)
+    # The stimulation itself is optical; only the spatial view is normalized:
+    delivered = implant.prepare_stim(LogoBVL())
+    npt.assert_equal(delivered.unit, mW / mm ** 2)
+    npt.assert_equal(delivered._spatial_view().unit, dimensionless)
+    # A dark picture drives nothing:
+    with warnings.catch_warnings():
+        warnings.simplefilter('ignore', UserWarning)
+        dark = model.predict_percept(ImageStimulus(np.zeros((32, 32))))
+    npt.assert_almost_equal(dark.data.max(), 0)
+
+
+def test_scoreboard_refuses_a_bare_optical_waveform():
+    # Without the normalized spatial view behind it, an optical stimulus is
+    # not something Scoreboard knows how to read: mW/mm^2 is neither a current
+    # nor an arbitrary brightness.
+    implant = PRIMAPivotal()
+    with warnings.catch_warnings():
+        warnings.simplefilter('ignore', UserWarning)
+        model = ScoreboardModel(implant=implant, rho=200, step=0.5,
+                                xrange=(-2, 2), yrange=(-2, 2))
+    bare = Stimulus(implant.prepare_stim(LogoBVL()))
+    npt.assert_equal(bare._has_spatial_view, False)
+    with pytest.raises(DimensionMismatchError) as excinfo:
+        model.predict_percept(bare)
+    npt.assert_equal('irradiance' in str(excinfo.value), True)

--- a/pulse2percept/models/tests/test_beyeler2019.py
+++ b/pulse2percept/models/tests/test_beyeler2019.py
@@ -1068,13 +1068,7 @@ def test_electrode_pitch_ignores_a_dimension_the_model_drops(ModelClass):
 
 
 def test_scoreboard_visualizes_a_photovoltaic_implant():
-    """A picture straight into a PRIMA implant comes out as a percept
-
-    Scoreboard weights each Gaussian by the normalized optical drive the
-    implant's encoder reports. That is a picture of implant geometry and
-    stimulation pattern, not a model of photodiode transduction, retinal
-    electric fields, or temporal dynamics.
-    """
+    """Scoreboard accepts normalized optical drive from PRIMA."""
     implant = PRIMAPivotal()
     with warnings.catch_warnings():
         warnings.simplefilter('ignore', UserWarning)
@@ -1085,11 +1079,11 @@ def test_scoreboard_visualizes_a_photovoltaic_implant():
     npt.assert_equal(percept.shape, tuple(model.grid.x.shape) + (1,))
     npt.assert_equal(np.all(np.isfinite(percept.data)), True)
     npt.assert_equal(percept.data.max() > 0, True)
-    # The stimulation itself is optical; only the spatial view is normalized:
+    # Delivered stimulation is optical; the spatial view is normalized.
     delivered = implant.prepare_stim(LogoBVL())
     npt.assert_equal(delivered.unit, mW / mm ** 2)
     npt.assert_equal(delivered._spatial_view().unit, dimensionless)
-    # A dark picture drives nothing:
+    # Dark input produces zero drive.
     with warnings.catch_warnings():
         warnings.simplefilter('ignore', UserWarning)
         dark = model.predict_percept(ImageStimulus(np.zeros((32, 32))))
@@ -1097,19 +1091,13 @@ def test_scoreboard_visualizes_a_photovoltaic_implant():
 
 
 def test_scoreboard_visualizes_a_photovoltaic_video():
-    """A PRIMA video survives the time resampling `_predict_prepared` does
-
-    The normalized drive is dimensionless, and a dimensionless stimulus is only
-    stimulation if it says it is one. Rebuilding it at `t_percept` as a plain
-    `Stimulus` would drop that and have the model read gray levels.
-    """
+    """Normalized-drive semantics survive video resampling."""
     implant = PRIMAPivotal()
     with warnings.catch_warnings():
         warnings.simplefilter('ignore', UserWarning)
         model = ScoreboardModel(implant=implant, rho=200, step=0.5,
                                 xrange=(-2, 2), yrange=(-2, 2))
-        # Only the middle frame is lit, so the percept has to follow the
-        # source frame by frame rather than smear it:
+        # Only the middle source frame is lit.
         frames = np.zeros((8, 8, 3))
         frames[..., 1] = 1.0
         video = VideoStimulus(frames, time=[0.0, 40.0, 80.0])
@@ -1117,8 +1105,7 @@ def test_scoreboard_visualizes_a_photovoltaic_video():
     npt.assert_equal(percept.shape[:2], tuple(model.grid.x.shape))
     npt.assert_equal(np.all(np.isfinite(percept.data)), True)
     npt.assert_equal(percept.data.max() > 0, True)
-    # One percept frame per projector frame, and only the lit source frame
-    # drives anything:
+    # One percept frame per projector frame.
     npt.assert_equal(percept.shape[-1], percept.time.size)
     npt.assert_almost_equal(np.diff(percept.time), 1000 / 30, decimal=3)
     lit = percept.data.max(axis=(0, 1)) > 0
@@ -1126,9 +1113,7 @@ def test_scoreboard_visualizes_a_photovoltaic_video():
 
 
 def test_scoreboard_refuses_a_bare_optical_waveform():
-    # Without the normalized spatial view behind it, an optical stimulus is
-    # not something Scoreboard knows how to read: mW/mm^2 is neither a current
-    # nor an arbitrary brightness.
+    # Bare irradiance is not a valid Scoreboard input.
     implant = PRIMAPivotal()
     with warnings.catch_warnings():
         warnings.simplefilter('ignore', UserWarning)

--- a/pulse2percept/stimuli/__init__.py
+++ b/pulse2percept/stimuli/__init__.py
@@ -25,7 +25,8 @@ from .pulse_trains import (PulseTrain, BiphasicPulseTrain,
                            BiphasicTripletTrain, AsymmetricBiphasicPulseTrain)
 from .images import ImageStimulus, LogoBVL, LogoUCSB, SnellenChart
 from .videos import VideoStimulus, BostonTrain, GirlPool
-from .encoders import StimulusEncoder, AmplitudeEncoder, FrequencyEncoder
+from .encoders import (Encoder, StimulusEncoder, AmplitudeEncoder,
+                       FrequencyEncoder, PRIMAEncoder)
 from .psychophysics import BarStimulus, GratingStimulus
 
 __all__ = [
@@ -38,6 +39,7 @@ __all__ = [
     'BiphasicTripletTrain',
     'BostonTrain',
     'ElectrodeNames',
+    'Encoder',
     'FrequencyEncoder',
     'GirlPool',
     'GratingStimulus',
@@ -45,6 +47,7 @@ __all__ = [
     'LogoBVL',
     'LogoUCSB',
     'MonophasicPulse',
+    'PRIMAEncoder',
     'PulseTrain',
     'SnellenChart',
     'Stimulus',

--- a/pulse2percept/stimuli/_plot.py
+++ b/pulse2percept/stimuli/_plot.py
@@ -8,7 +8,7 @@ import numpy as np
 from matplotlib.axes import Axes
 import matplotlib.pyplot as plt
 
-from ..units import uA
+from ..units import mW, mm, uA
 from ..utils.constants import DT
 
 
@@ -63,6 +63,10 @@ def _value_label(stim):
     if stim.unit == uA:
         # Spelled the way Matplotlib renders it:
         return r'Amplitude ($\mu$A)'
+    if stim.unit.dimension == (mW / mm ** 2).dimension:
+        # A photovoltaic implant is illuminated, not driven: calling its
+        # optical power an amplitude would name the wrong quantity.
+        return f'Irradiance ({stim.unit})'
     return f'Amplitude ({stim.unit})'
 
 

--- a/pulse2percept/stimuli/_plot.py
+++ b/pulse2percept/stimuli/_plot.py
@@ -64,8 +64,7 @@ def _value_label(stim):
         # Spelled the way Matplotlib renders it:
         return r'Amplitude ($\mu$A)'
     if stim.unit.dimension == (mW / mm ** 2).dimension:
-        # A photovoltaic implant is illuminated, not driven: calling its
-        # optical power an amplitude would name the wrong quantity.
+        # Optical stimuli use irradiance rather than current amplitude.
         return f'Irradiance ({stim.unit})'
     return f'Amplitude ({stim.unit})'
 

--- a/pulse2percept/stimuli/base.py
+++ b/pulse2percept/stimuli/base.py
@@ -258,6 +258,12 @@ class Stimulus(PrettyPrint):
     #: Whether this stimulus provides a separate spatial-only view
     _has_spatial_view = False
 
+    #: Whether dimensionless values are a normalized drive rather than raw
+    #: gray levels. A picture is dimensionless too, and no model reads gray
+    #: levels as stimulation, so a model that accepts a dimensionless stimulus
+    #: accepts only one that says it is already an encoded drive.
+    _is_normalized_drive = False
+
     #: whether the canonical state is a set of stim params
     _is_parametric = False
 

--- a/pulse2percept/stimuli/base.py
+++ b/pulse2percept/stimuli/base.py
@@ -258,10 +258,7 @@ class Stimulus(PrettyPrint):
     #: Whether this stimulus provides a separate spatial-only view
     _has_spatial_view = False
 
-    #: Whether dimensionless values are a normalized drive rather than raw
-    #: gray levels. A picture is dimensionless too, and no model reads gray
-    #: levels as stimulation, so a model that accepts a dimensionless stimulus
-    #: accepts only one that says it is already an encoded drive.
+    #: Whether dimensionless values represent encoded normalized drive.
     _is_normalized_drive = False
 
     #: whether the canonical state is a set of stim params

--- a/pulse2percept/stimuli/encoders.py
+++ b/pulse2percept/stimuli/encoders.py
@@ -1272,18 +1272,36 @@ class _OpticalStimulus(Stimulus):
     def _render(self):
         """Expand the schedule into rectangular pulses."""
         ticks = np.asarray(self._ticks)
-        # Which projector frame each time point falls in, and how far into it:
+        n_frames = self._onsets.size
+        # Which projector frame each time point falls in:
         at = np.searchsorted(self._onsets, ticks, side='right') - 1
-        np.clip(at, 0, self._onsets.size - 1, out=at)
-        since = ticks - self._onsets[at]
-        # The ON duration each pixel has in that frame, in ticks:
-        dur = np.round(self._dur / DT).astype(np.int64)[:, at]
-        # Rising and falling edges each take one DT, as elsewhere in p2p:
-        lit = (since[np.newaxis, :] >= 1) & (since <= dur - 1)
-        data = np.where(lit, np.float32(self._irradiance), np.float32(0))
+        np.clip(at, 0, n_frames - 1, out=at)
+        # The ON duration each pixel has in each frame, in ticks. Kept at
+        # n_frames columns rather than expanded to one per time point: the
+        # expanded form is int64 at the size of the output and dominates peak
+        # memory, and the frame-by-frame fill below does not need it.
+        dur = np.round(self._dur / DT).astype(np.int64)
+        data = np.zeros((dur.shape[0], ticks.size), dtype=np.float32)
+        # `ticks` and `_onsets` are both sorted, so `at` is nondecreasing and
+        # every frame owns a contiguous span of columns. Filling those spans in
+        # place keeps the output C-contiguous, which is the layout a stimulus
+        # installs without copying it again.
+        bounds = np.searchsorted(at, np.arange(n_frames + 1))
+        irradiance = np.float32(self._irradiance)
+        for j in range(n_frames):
+            lo, hi = bounds[j], bounds[j + 1]
+            if hi <= lo:
+                continue
+            # How far into frame `j` each of its time points is. Points before
+            # the first onset clip to frame 0 with a negative offset, which the
+            # rising-edge test below leaves dark:
+            since = ticks[lo:hi] - self._onsets[j]
+            # Rising and falling edges each take one DT, as elsewhere in p2p:
+            np.copyto(data[:, lo:hi], irradiance,
+                      where=(since >= 1) & (since <= dur[:, j, None] - 1))
         # The newly allocated array can be adopted without another copy:
-        return {'data': _adoptable(data.astype(np.float32, copy=False)),
-                'electrodes': self.electrodes, 'time': self.time}
+        return {'data': _adoptable(data), 'electrodes': self.electrodes,
+                'time': self.time}
 
     def _pprint_params(self):
         """Return a dict of class attributes to pretty-print"""

--- a/pulse2percept/stimuli/encoders.py
+++ b/pulse2percept/stimuli/encoders.py
@@ -157,7 +157,7 @@ class _EncodedStimulus(Stimulus):
             at = np.searchsorted(onset, self._ticks, side='right') - 1
             np.clip(at, 0, onset.size - 1, out=at)
             data[rows] = self._amp[rows][:, frame[at]] * wave
-        # The newly allocated array can be adopted without another copy:
+        # ``data`` is newly allocated and can be adopted without copying.
         return {'data': _adoptable(data), 'electrodes': self.electrodes,
                 'time': self.time}
 
@@ -172,16 +172,10 @@ class _EncodedStimulus(Stimulus):
 
 
 class Encoder(PrettyPrint, metaclass=ABCMeta):
-    """Abstract base class for encoders.
+    """Base class for image and video encoders.
 
-    An encoder turns a picture into the stimulation that drives a device. What
-    kind of stimulation that is depends on the device:
-    :py:class:`~pulse2percept.stimuli.StimulusEncoder` produces the electrical
-    pulse trains an implant delivers,
-    :py:class:`~pulse2percept.stimuli.PRIMAEncoder` the near-infrared
-    irradiance a photovoltaic implant is illuminated with.
-
-    Subclasses implement :py:meth:`encode`.
+    Encoders map dimensionless visual input to the physical quantity driving an
+    implant. Subclasses implement :py:meth:`encode`.
 
     .. versionadded:: 0.11.0
     """
@@ -230,49 +224,35 @@ class Encoder(PrettyPrint, metaclass=ABCMeta):
         if not isinstance(source, Stimulus):
             raise TypeError(f"'source' must be a Stimulus object, not "
                             f"{type(source)}.")
-        # This is where a picture becomes stimulation, so what goes in has to
-        # be a picture. An electrical stimulus read as gray levels would have
-        # its microamps clipped to [0, 1] below and silently re-modulated into
-        # a different current entirely:
+        # Encoders accept gray levels, not already-physical stimulation.
         if not source.unit.dimension.is_dimensionless:
             raise DimensionMismatchError(
                 f"An encoder turns gray levels into stimulation, so its "
                 f"source must be dimensionless, not "
                 f"{source.unit.dimension.name} ({source.unit}). Pass an "
                 f"ImageStimulus or a VideoStimulus.")
-        # Read the frame rate off the *source*: sampling at electrode locations
-        # does not necessarily carry it along.
+        # Read frame rate before sampling at implant coordinates.
         fps = _fps(source.metadata)
         stim = source
         if (implant is not None and
                 isinstance(stim, (ImageStimulus, VideoStimulus))):
-            # Sample the source at the electrode locations. This is the same
-            # step that presenting an image or a video to an implant would
-            # perform, done here so that the stimulation below is built at
-            # electrode resolution rather than at pixel resolution. It is also
-            # where RGB becomes gray. Row count is not a usable test of whether
-            # a source is already in electrode coordinates, so always reshape:
+            # Sample images/videos at implant coordinates and convert RGB to gray.
             stim = implant.reshape_stim(stim)
-        # `values` rather than `data`, to say out loud that these are the
-        # dimensionless numbers the modulation below is a function of:
+        # Modulation operates on dimensionless gray levels in [0, 1].
         gray = np.clip(np.asarray(stim.values(dimensionless),
                                   dtype=np.float32), 0, 1)
         if stim.time is None:
-            # A single frame, which has no duration of its own:
+            # Static images use the default presentation duration.
             gray = gray.reshape((-1, 1))
             frame_dur = (_DEFAULT_FRAME_DUR if frame_dur is None
                          else frame_dur)
             frame_time = np.zeros(1, dtype=np.float64)
         elif frame_dur is None:
-            # `frame_interval` rejects a time axis whose frames are not all
-            # the same length, so the frames tile the source exactly:
+            # Preserve the source frame interval.
             frame_dur = frame_interval(np.asarray(stim.time), fps=fps)
             frame_time = np.asarray(stim.time, dtype=np.float64)
         else:
-            # An explicit `frame_dur` re-times the source: the frames keep
-            # their order and their content, but each one now lasts
-            # `frame_dur` ms. Keeping the source's own frame times here would
-            # let neighboring frames overlap:
+            # Explicit frame_dur replaces source frame timing.
             frame_time = np.arange(gray.shape[1], dtype=np.float64) * frame_dur
         return gray, stim.electrodes, frame_time, frame_dur
 
@@ -1102,27 +1082,18 @@ _IRRADIANCE = mW / mm ** 2
 
 
 class _NormalizedStimulus(Stimulus):
-    """A stimulus whose values are a normalized drive rather than physical"""
+    """Dimensionless encoded drive for spatial models."""
     _default_unit = dimensionless
-
-    #: Dimensionless, but not a picture (see `Stimulus._is_normalized_drive`)
     _is_normalized_drive = True
 
     __slots__ = ()
 
 
 class _OpticalStimulus(Stimulus):
-    """A resolved projector schedule, expanded into a waveform on demand
+    """Lazy PRIMA projector schedule.
 
-    Every pixel sees the same rectangular pulse at the same projector clock and
-    the same peak irradiance; only how long it stays on differs. The waveform
-    is therefore fully described by one ON duration per pixel per projector
-    frame, which is what this holds on to until somebody asks for samples.
-
-    Those durations, together with ``irradiance`` and ``freq``, are the
-    authoritative description of what the projector does. They are deliberately
-    not mirrored into ``metadata``, which is an ordinary mutable dict that any
-    operation may copy onto a stimulus whose waveform no longer matches it.
+    Stores per-pixel ON duration for each projector frame, peak irradiance, and
+    frame rate. Waveform samples are generated on demand.
     """
     #: described by its schedule rather than by its samples
     _is_parametric = True
@@ -1138,9 +1109,7 @@ class _OpticalStimulus(Stimulus):
                  wavelength, grayscale, total, static, frame_time, frame_dur,
                  ref_drive):
         irradiance = float(irradiance)
-        # Light has a nonnegative power density. Checked here rather than only
-        # in the encoder, because this is also what a scaled or rebuilt
-        # schedule goes through:
+        # Rebuilt/scaled schedules must also have physical irradiance.
         if not math.isfinite(irradiance) or irradiance < 0:
             raise ValueError(f"'irradiance' must be a finite, nonnegative "
                              f"power density, not {irradiance}.")
@@ -1163,8 +1132,7 @@ class _OpticalStimulus(Stimulus):
         # Built lazily without rendering the waveform:
         self._time = None
         self._defer(electrodes, unit=_IRRADIANCE)
-        # Only the frame clock, which is not scientific state: it says when the
-        # frames are, and the durations above say what is in them.
+        # Metadata stores frame timing; optical settings remain schedule state.
         self.metadata['encoder'] = {'frame_time': self._frame_time,
                                     'frame_dur': self._frame_dur}
 
@@ -1213,18 +1181,11 @@ class _OpticalStimulus(Stimulus):
         return self._time
 
     def _spatial_view(self):
-        """Normalized time-averaged optical drive, one column per frame
-
-        Deliberately neither a current nor a brightness: it is the irradiance a
-        pixel delivers averaged over a projector period, divided by the largest
-        drive the pivotal device is documented to produce. A spatial-only model
-        can use it as a per-pixel weight without integrating pulse edges.
-        """
+        """Return normalized time-averaged optical drive per frame."""
         drive = (self._irradiance * self.duty_cycle / self._ref_drive).astype(
             np.float32)
         if self._static:
-            # Every projector frame repeats the one frame the source had, and
-            # a source with no time axis has no time axis here either:
+            # Collapse repeated projector periods for a static source.
             stim = _NormalizedStimulus(drive[:, 0].ravel(),
                                        electrodes=self.electrodes)
         else:
@@ -1244,14 +1205,7 @@ class _OpticalStimulus(Stimulus):
         return rebuilt
 
     def _scaled(self, factor):
-        """This schedule at a scaled irradiance
-
-        Pulse duration is what the projector modulates, and it is quantized
-        onto a hardware grid, so a scale factor changes optical power instead.
-        Zero simply turns the projector off; a negative factor has no optical
-        meaning, so it is refused rather than expanded into a waveform of
-        negative irradiance.
-        """
+        """Return this schedule with irradiance scaled by ``factor``."""
         if not np.isscalar(factor):
             return None
         factor = float(factor)
@@ -1273,33 +1227,25 @@ class _OpticalStimulus(Stimulus):
         """Expand the schedule into rectangular pulses."""
         ticks = np.asarray(self._ticks)
         n_frames = self._onsets.size
-        # Which projector frame each time point falls in:
+        # Map stored time points to projector frames.
         at = np.searchsorted(self._onsets, ticks, side='right') - 1
         np.clip(at, 0, n_frames - 1, out=at)
-        # The ON duration each pixel has in each frame, in ticks. Kept at
-        # n_frames columns rather than expanded to one per time point: the
-        # expanded form is int64 at the size of the output and dominates peak
-        # memory, and the frame-by-frame fill below does not need it.
+        # Keep durations per frame to avoid an n_electrodes x n_time int64 array.
         dur = np.round(self._dur / DT).astype(np.int64)
         data = np.zeros((dur.shape[0], ticks.size), dtype=np.float32)
-        # `ticks` and `_onsets` are both sorted, so `at` is nondecreasing and
-        # every frame owns a contiguous span of columns. Filling those spans in
-        # place keeps the output C-contiguous, which is the layout a stimulus
-        # installs without copying it again.
+        # Each projector frame occupies a contiguous time span.
         bounds = np.searchsorted(at, np.arange(n_frames + 1))
         irradiance = np.float32(self._irradiance)
         for j in range(n_frames):
             lo, hi = bounds[j], bounds[j + 1]
             if hi <= lo:
                 continue
-            # How far into frame `j` each of its time points is. Points before
-            # the first onset clip to frame 0 with a negative offset, which the
-            # rising-edge test below leaves dark:
+            # Time since the current projector-frame onset.
             since = ticks[lo:hi] - self._onsets[j]
-            # Rising and falling edges each take one DT, as elsewhere in p2p:
+            # Match the one-DT rise/fall convention used by other stimuli.
             np.copyto(data[:, lo:hi], irradiance,
                       where=(since >= 1) & (since <= dur[:, j, None] - 1))
-        # The newly allocated array can be adopted without another copy:
+        # ``data`` is newly allocated and can be adopted without copying.
         return {'data': _adoptable(data), 'electrodes': self.electrodes,
                 'time': self.time}
 
@@ -1315,78 +1261,40 @@ class _OpticalStimulus(Stimulus):
 
 
 class PRIMAEncoder(Encoder):
-    """Encode gray levels as PRIMA's near-infrared projector output
+    """Encode image/video gray levels for the PRIMA projector.
 
-    PRIMA is not told what current to inject. Its pixels are photovoltaic: a
-    goggle-mounted projector paints an 880 nm image onto the implant, and each
-    pixel turns the light it receives into local electrical stimulation. The
-    projector runs at a fixed frame rate and a fixed peak irradiance, and
-    encodes intensity in *how long* a pixel is lit rather than in how brightly
-    [Palanker2020]_, [Holz2026]_.
-
-    This encoder therefore returns absolute optical irradiance in ``mW/mm^2``,
-    not microamps. Turning that light into retinal current requires a
-    photovoltaic model, which p2p does not have yet; until it does,
-    spatial-only models read the normalized time-averaged drive this stimulus
-    exposes (see the Notes).
+    PRIMA uses 880 nm illumination rather than injected current. The projector
+    uses fixed peak irradiance and pulse-width modulation [Palanker2020]_,
+    [Holz2026]_. This encoder returns irradiance in ``mW/mm^2``.
 
     .. versionadded:: 0.11.0
 
     Parameters
     ----------
     irradiance : float or Quantity, optional
-        Peak irradiance (mW/mm^2) while a pixel is on. Not modulated by gray
-        level.
+        Peak irradiance (mW/mm^2) while a pixel is on.
     freq : float or Quantity, optional
-        Projector sampling rate (Hz). The source is sampled once per projector
-        period; source frames may therefore be repeated or skipped.
+        Projector frame rate (Hz).
     pulse_dur : float or Quantity, optional
-        Longest ON duration (ms) per projector period: the brightest level in
-        grayscale mode, and the duration a lit pixel receives in binary mode.
-        Must be a whole multiple of ``pulse_step`` and no longer than
-        ``max_pulse_dur``. The default is the longest documented duration, so
-        all 14 hardware levels are available.
+        Maximum ON duration (ms). Must lie on the ``pulse_step`` grid and not
+        exceed ``max_pulse_dur``.
     grayscale : bool, optional
-        If True (default), gray levels are pulse-width modulated onto the
-        projector's duration grid, which is how the device sets brightness. If
-        False, a pixel is either off or on for ``pulse_dur``.
+        If True (default), map gray levels to pulse duration. If False, use
+        binary off/on encoding.
     threshold : float, optional
-        Gray level at or above which a pixel is lit. Applies only when
-        ``grayscale`` is False, and 0.5 is an arbitrary p2p convention rather
-        than a clinical setting.
+        Binary-mode threshold. The default 0.5 is a pulse2percept convention.
 
     Notes
     -----
-    *  Every projector period looks the same: irradiance rises to
-       ``irradiance`` for the pixel's ON duration and is zero for the rest of
-       the period. Peak irradiance never depends on gray level.
-    *  The projector offers 14 discrete ON durations, 0.7 to 9.8 ms in 0.7 ms
-       steps, plus off. Grayscale mode maps normalized image intensity linearly
-       onto those levels. That linear map is a p2p convention: the clinical
-       camera-gray-level to pulse-duration transfer function is not published.
-    *  The projector clock samples the source; it does not re-time it. Starting
-       at the source's first frame, every ``1 / freq`` the device looks at
-       whatever frame the source is showing (zero-order hold), so a slow video
-       has frames re-sent and a fast one has frames skipped, and either way the
-       source keeps its own timing. A source with no time axis is held for the
-       standard static presentation.
-    *  A pulse that would not finish before the presentation ends is not
-       started, so the last projector period of a source that is not a whole
-       number of periods long may be dark.
-    *  ``_spatial_view`` reports normalized time-averaged optical drive:
-       ``irradiance * duty_cycle`` divided by the largest documented
-       pivotal-device drive (``ref_drive``), so 0 is a dark pixel and 1 a pixel
-       at the full documented drive. It is a physically interpretable optical
-       scalar, not retinal current and not perceived brightness.
-    *  The clinical PRIMA system processes the camera image before projecting
-       it, including ambient-light adaptation, contrast enhancement and zoom
-       [Palanker2020]_, and contrast inversion has been used deliberately in
-       testing. This encoder models the optical encoding stage that follows.
-       Preprocessing stays explicit in p2p because the clinical pipeline is not
-       specified in enough detail to reproduce: apply it to the source first
-       (e.g. ``image.invert()``, ``image.filter('canny')``).
-    *  Plain numbers use the units documented above; unitful values are
-       converted automatically. See :mod:`pulse2percept.units`.
+    *  Pivotal-system defaults are 3.5 mW/mm^2, 30 Hz, and 14 nonzero ON
+       durations from 0.7 to 9.8 ms.
+    *  Grayscale mode maps normalized intensity linearly to these duration
+       levels. The clinical camera-to-pulse-duration transfer function is not
+       published.
+    *  Videos are sampled at the projector clock using zero-order hold.
+    *  ``_spatial_view`` returns normalized time-averaged optical drive for
+       spatial models. It is neither retinal current nor perceptual brightness.
+    *  Clinical image preprocessing is outside this encoder.
 
     Examples
     --------
@@ -1436,8 +1344,7 @@ class PRIMAEncoder(Encoder):
         if pulse_dur < 0:
             raise ValueError("'pulse_dur' cannot be negative.")
         if pulse_dur > 0:
-            # The projector realizes durations in whole hardware steps, and
-            # rounding one silently would misreport the drive it delivers:
+            # Require exact hardware-grid durations; do not round silently.
             steps = pulse_dur / self.pulse_step
             if abs(steps - round(steps)) > 1e-9:
                 raise ValueError(
@@ -1486,13 +1393,11 @@ class PRIMAEncoder(Encoder):
         Binary mode lights a pixel for the full ``pulse_dur``; grayscale mode
         pulse-width modulates onto the projector's own duration grid.
         """
-        # In float64, so that a duration lands exactly on the hardware grid
-        # rather than a float32 step away from it:
+        # Use float64 so durations land exactly on the hardware grid.
         gray = np.asarray(gray, dtype=np.float64)
         if not self.grayscale:
             return np.where(gray >= self.threshold, self.pulse_dur, 0.0)
-        # `gray` is already clipped to [0, 1], so the rounded level cannot
-        # leave the 0..n_levels range the hardware offers:
+        # Gray levels are already clipped to [0, 1].
         return np.round(gray * self.n_levels) * self.pulse_step
 
     def encode(self, source, implant=None):
@@ -1529,33 +1434,21 @@ class PRIMAEncoder(Encoder):
                                                                   implant)
         n_el = len(electrodes)
         static = frame_time.size == 1 and getattr(source, 'time', None) is None
-        # The source keeps its own timing. What the projector clock decides is
-        # when the device looks at it, not when the content starts or how long
-        # it lasts: a cropped video keeps the timestamps it was cut from, and
-        # nothing is shown before its first frame is there to show.
+        # Preserve source start time and duration.
         start = float(frame_time[0])
         total = float(frame_time[-1] + frame_dur)
         n_periods = max(1, int(np.ceil((total - start) / period - 1e-9)))
         onset_ms = start + np.arange(n_periods, dtype=np.float64) * period
-        # Zero-order hold: a source frame stays on screen until the next one,
-        # so the projector re-sends a slow source's frames and skips a fast
-        # source's. Interpolating instead would invent frames the source never
-        # contained.
+        # Sample source frames at projector onsets using zero-order hold.
         at = np.searchsorted(frame_time, onset_ms, side='right') - 1
         np.clip(at, 0, frame_time.size - 1, out=at)
         dur = self._durations(gray[:, at])
 
-        # Onsets are rounded onto the DT grid one at a time rather than stepped
-        # by an already-rounded period: 30 Hz is 33333.33 ticks, and
-        # accumulating that error would walk the projector off the source over
-        # the course of a video.
+        # Round absolute onsets to DT to avoid accumulated 30 Hz period error.
         onsets = np.round(onset_ms / DT).astype(np.int64)
         end = int(np.round(total / DT))
         dur_ticks = np.round(dur / DT).astype(np.int64)
-        # A pulse that cannot finish before the presentation ends is not
-        # started, as with the electrical encoder. Truncating it instead would
-        # leave the stimulus lit at the instant it says it is over, and
-        # shortening it would land the projector off its 0.7 ms grid.
+        # Drop final pulses that do not fit without truncation or off-grid timing.
         fits = dur_ticks <= (end - onsets)[np.newaxis, :]
         dur = np.where(fits, dur, 0.0)
         dur_ticks = np.where(fits, dur_ticks, 0)
@@ -1564,7 +1457,7 @@ class PRIMAEncoder(Encoder):
             levels = np.unique(dur_ticks[:, j])
             levels = levels[levels > 0]
             if levels.size == 0:
-                # A dark frame has no edges of its own to place:
+                # No edges for a dark frame.
                 continue
             on = onsets[j]
             edges.append(np.concatenate(([on, on + 1],
@@ -1586,10 +1479,7 @@ class PRIMAEncoder(Encoder):
                 f"{n_el * n_time * 4 / 1e9:.1f} GB. Pass 'implant' to encode "
                 f"at pixel resolution instead.", category=UserWarning)
 
-        # The schedule is settled. Expanding it into an n_el x n_time matrix is
-        # the expensive half, and the half nothing needs until somebody asks
-        # for samples. A static source keeps its single frame; a video's frame
-        # clock is the projector's, since that is when the pixels change.
+        # Keep the projector schedule lazy; render waveform samples on demand.
         return _OpticalStimulus(
             electrodes, dur, ticks, onsets, self.irradiance, self.freq,
             self.wavelength, self.grayscale, total, static,

--- a/pulse2percept/stimuli/encoders.py
+++ b/pulse2percept/stimuli/encoders.py
@@ -1317,8 +1317,8 @@ class PRIMAEncoder(Encoder):
         Peak irradiance (mW/mm^2) while a pixel is on. Not modulated by gray
         level.
     freq : float or Quantity, optional
-        Projector frame rate (Hz). One source frame is shown per projector
-        period.
+        Projector sampling rate (Hz). The source is sampled once per projector
+        period; source frames may therefore be repeated or skipped.
     pulse_dur : float or Quantity, optional
         Longest ON duration (ms) per projector period, and the duration a lit
         pixel receives in binary mode. Must be a whole multiple of

--- a/pulse2percept/stimuli/encoders.py
+++ b/pulse2percept/stimuli/encoders.py
@@ -1102,8 +1102,11 @@ _IRRADIANCE = mW / mm ** 2
 
 
 class _NormalizedStimulus(Stimulus):
-    """A stimulus whose values are normalized rather than physical"""
+    """A stimulus whose values are a normalized drive rather than physical"""
     _default_unit = dimensionless
+
+    #: Dimensionless, but not a picture (see `Stimulus._is_normalized_drive`)
+    _is_normalized_drive = True
 
     __slots__ = ()
 
@@ -1320,25 +1323,29 @@ class PRIMAEncoder(Encoder):
         Projector sampling rate (Hz). The source is sampled once per projector
         period; source frames may therefore be repeated or skipped.
     pulse_dur : float or Quantity, optional
-        Longest ON duration (ms) per projector period, and the duration a lit
-        pixel receives in binary mode. Must be a whole multiple of
-        ``pulse_step`` and no longer than ``max_pulse_dur``. The default spans
-        the full documented hardware range; it is not a claim about the setting
-        used in any particular patient.
+        Longest ON duration (ms) per projector period: the brightest level in
+        grayscale mode, and the duration a lit pixel receives in binary mode.
+        Must be a whole multiple of ``pulse_step`` and no longer than
+        ``max_pulse_dur``. The default is the longest documented duration, so
+        all 14 hardware levels are available.
     grayscale : bool, optional
-        If True, gray levels are pulse-width modulated onto the projector's
-        duration grid. If False (default, matching current clinical operation),
-        a pixel is either off or on for ``pulse_dur``.
+        If True (default), gray levels are pulse-width modulated onto the
+        projector's duration grid, which is how the device sets brightness. If
+        False, a pixel is either off or on for ``pulse_dur``.
     threshold : float, optional
-        Gray level at or above which a pixel is lit in binary mode. This is a
-        p2p approximation: the thresholding the clinical system performs is not
-        published.
+        Gray level at or above which a pixel is lit. Applies only when
+        ``grayscale`` is False, and 0.5 is an arbitrary p2p convention rather
+        than a clinical setting.
 
     Notes
     -----
     *  Every projector period looks the same: irradiance rises to
        ``irradiance`` for the pixel's ON duration and is zero for the rest of
        the period. Peak irradiance never depends on gray level.
+    *  The projector offers 14 discrete ON durations, 0.7 to 9.8 ms in 0.7 ms
+       steps, plus off. Grayscale mode maps normalized image intensity linearly
+       onto those levels. That linear map is a p2p convention: the clinical
+       camera-gray-level to pulse-duration transfer function is not published.
     *  The projector clock samples the source; it does not re-time it. Starting
        at the source's first frame, every ``1 / freq`` the device looks at
        whatever frame the source is showing (zero-order hold), so a slow video
@@ -1353,9 +1360,13 @@ class PRIMAEncoder(Encoder):
        pivotal-device drive (``ref_drive``), so 0 is a dark pixel and 1 a pixel
        at the full documented drive. It is a physically interpretable optical
        scalar, not retinal current and not perceived brightness.
-    *  Contrast inversion and edge enhancement are not part of PRIMA. Apply
-       them to the source first (e.g. ``image.invert()``,
-       ``image.filter('canny')``).
+    *  The clinical PRIMA system processes the camera image before projecting
+       it, including ambient-light adaptation, contrast enhancement and zoom
+       [Palanker2020]_, and contrast inversion has been used deliberately in
+       testing. This encoder models the optical encoding stage that follows.
+       Preprocessing stays explicit in p2p because the clinical pipeline is not
+       specified in enough detail to reproduce: apply it to the source first
+       (e.g. ``image.invert()``, ``image.filter('canny')``).
     *  Plain numbers use the units documented above; unitful values are
        converted automatically. See :mod:`pulse2percept.units`.
 
@@ -1392,7 +1403,7 @@ class PRIMAEncoder(Encoder):
     __slots__ = ('irradiance', 'freq', 'pulse_dur', 'grayscale', 'threshold')
 
     def __init__(self, irradiance=3.5 * mW / mm ** 2, freq=30 * Hz,
-                 pulse_dur=9.8 * ms, grayscale=False, threshold=0.5):
+                 pulse_dur=9.8 * ms, grayscale=True, threshold=0.5):
         irradiance = as_value(irradiance, _IRRADIANCE, 'irradiance')
         freq = as_value(freq, Hz, 'freq')
         pulse_dur = as_value(pulse_dur, ms, 'pulse_dur')

--- a/pulse2percept/stimuli/encoders.py
+++ b/pulse2percept/stimuli/encoders.py
@@ -174,11 +174,12 @@ class _EncodedStimulus(Stimulus):
 class Encoder(PrettyPrint, metaclass=ABCMeta):
     """Abstract base class for encoders.
 
-    An encoder turns a picture into the stimulation a device delivers. What
+    An encoder turns a picture into the stimulation that drives a device. What
     kind of stimulation that is depends on the device:
-    :py:class:`~pulse2percept.stimuli.StimulusEncoder` produces electrical
-    pulse trains, :py:class:`~pulse2percept.stimuli.PRIMAEncoder` produces
-    near-infrared irradiance.
+    :py:class:`~pulse2percept.stimuli.StimulusEncoder` produces the electrical
+    pulse trains an implant delivers,
+    :py:class:`~pulse2percept.stimuli.PRIMAEncoder` the near-infrared
+    irradiance a photovoltaic implant is illuminated with.
 
     Subclasses implement :py:meth:`encode`.
 
@@ -201,7 +202,7 @@ class Encoder(PrettyPrint, metaclass=ABCMeta):
         Returns
         -------
         stim : :py:class:`~pulse2percept.stimuli.Stimulus`
-            The encoded stimulus, in the unit the device delivers.
+            The encoded stimulus, in the unit that drives the device.
         """
         raise NotImplementedError
 
@@ -1338,11 +1339,15 @@ class PRIMAEncoder(Encoder):
     *  Every projector period looks the same: irradiance rises to
        ``irradiance`` for the pixel's ON duration and is zero for the rest of
        the period. Peak irradiance never depends on gray level.
-    *  The projector clock samples the source; it does not re-time it. Every
-       ``1 / freq`` the device looks at whatever frame the source is showing
-       (zero-order hold), so a slow video has frames re-sent and a fast one has
-       frames skipped, and either way the source keeps its own duration. A
-       source with no time axis is held for the standard static presentation.
+    *  The projector clock samples the source; it does not re-time it. Starting
+       at the source's first frame, every ``1 / freq`` the device looks at
+       whatever frame the source is showing (zero-order hold), so a slow video
+       has frames re-sent and a fast one has frames skipped, and either way the
+       source keeps its own timing. A source with no time axis is held for the
+       standard static presentation.
+    *  A pulse that would not finish before the presentation ends is not
+       started, so the last projector period of a source that is not a whole
+       number of periods long may be dark.
     *  ``_spatial_view`` reports normalized time-averaged optical drive:
        ``irradiance * duty_cycle`` divided by the largest documented
        pivotal-device drive (``ref_drive``), so 0 is a dark pixel and 1 a pixel
@@ -1495,13 +1500,14 @@ class PRIMAEncoder(Encoder):
                                                                   implant)
         n_el = len(electrodes)
         static = frame_time.size == 1 and getattr(source, 'time', None) is None
-        # The source keeps its own duration. What the projector clock decides
-        # is when the device looks at it, not how long the content lasts:
+        # The source keeps its own timing. What the projector clock decides is
+        # when the device looks at it, not when the content starts or how long
+        # it lasts: a cropped video keeps the timestamps it was cut from, and
+        # nothing is shown before its first frame is there to show.
+        start = float(frame_time[0])
         total = float(frame_time[-1] + frame_dur)
-        # Enough frames to cover the source; the last one may be cut short by
-        # the end of the source, exactly as it would be on the device.
-        n_periods = max(1, int(np.ceil(total / period - 1e-9)))
-        onset_ms = np.arange(n_periods, dtype=np.float64) * period
+        n_periods = max(1, int(np.ceil((total - start) / period - 1e-9)))
+        onset_ms = start + np.arange(n_periods, dtype=np.float64) * period
         # Zero-order hold: a source frame stays on screen until the next one,
         # so the projector re-sends a slow source's frames and skips a fast
         # source's. Interpolating instead would invent frames the source never
@@ -1517,6 +1523,13 @@ class PRIMAEncoder(Encoder):
         onsets = np.round(onset_ms / DT).astype(np.int64)
         end = int(np.round(total / DT))
         dur_ticks = np.round(dur / DT).astype(np.int64)
+        # A pulse that cannot finish before the presentation ends is not
+        # started, as with the electrical encoder. Truncating it instead would
+        # leave the stimulus lit at the instant it says it is over, and
+        # shortening it would land the projector off its 0.7 ms grid.
+        fits = dur_ticks <= (end - onsets)[np.newaxis, :]
+        dur = np.where(fits, dur, 0.0)
+        dur_ticks = np.where(fits, dur_ticks, 0)
         edges = [np.array([0, end], dtype=np.int64)]
         for j in range(n_periods):
             levels = np.unique(dur_ticks[:, j])

--- a/pulse2percept/stimuli/encoders.py
+++ b/pulse2percept/stimuli/encoders.py
@@ -1,6 +1,8 @@
-""":py:class:`~pulse2percept.stimuli.StimulusEncoder`,
+""":py:class:`~pulse2percept.stimuli.Encoder`,
+   :py:class:`~pulse2percept.stimuli.StimulusEncoder`,
    :py:class:`~pulse2percept.stimuli.AmplitudeEncoder`,
-   :py:class:`~pulse2percept.stimuli.FrequencyEncoder`"""
+   :py:class:`~pulse2percept.stimuli.FrequencyEncoder`,
+   :py:class:`~pulse2percept.stimuli.PRIMAEncoder`"""
 from abc import ABCMeta, abstractmethod
 import numpy as np
 from copy import deepcopy
@@ -9,8 +11,8 @@ from .base import Stimulus, _adoptable
 from .images import ImageStimulus
 from .pulses import BiphasicPulse
 from .videos import VideoStimulus
-from ..units import (DimensionMismatchError, Hz, as_value, dimensionless, ms,
-                     uA)
+from ..units import (DimensionMismatchError, Hz, as_value, dimensionless, mW,
+                     mm, ms, uA)
 from ..utils import PrettyPrint, frame_interval
 # Point encoder warnings at the caller.
 from ..utils.deprecation import _warn_external
@@ -168,7 +170,112 @@ class _EncodedStimulus(Stimulus):
                 'metadata': self.metadata}
 
 
-class StimulusEncoder(PrettyPrint, metaclass=ABCMeta):
+class Encoder(PrettyPrint, metaclass=ABCMeta):
+    """Abstract base class for encoders.
+
+    An encoder turns a picture into the stimulation a device delivers. What
+    kind of stimulation that is depends on the device:
+    :py:class:`~pulse2percept.stimuli.StimulusEncoder` produces electrical
+    pulse trains, :py:class:`~pulse2percept.stimuli.PRIMAEncoder` produces
+    near-infrared irradiance.
+
+    Subclasses implement :py:meth:`encode`.
+
+    .. versionadded:: 0.11.0
+    """
+    __slots__ = ()
+
+    @abstractmethod
+    def encode(self, source, implant=None):
+        """Encode an image or a video as stimulation
+
+        Parameters
+        ----------
+        source : :py:class:`~pulse2percept.stimuli.Stimulus`
+            The image or video to encode. Must be dimensionless.
+        implant : :py:class:`~pulse2percept.implants.ProsthesisSystem`, optional
+            The implant to encode for. If None, every pixel of the source is
+            treated as its own stimulation site.
+
+        Returns
+        -------
+        stim : :py:class:`~pulse2percept.stimuli.Stimulus`
+            The encoded stimulus, in the unit the device delivers.
+        """
+        raise NotImplementedError
+
+    def _as_frames(self, source, implant=None, frame_dur=None):
+        """Reduce a source to one gray level per electrode per frame.
+
+        Parameters
+        ----------
+        frame_dur : float, optional
+            Frame duration (ms) to impose on the source. If None, a source
+            with a time axis keeps its own frame timing and one without a
+            time axis is presented for ``_DEFAULT_FRAME_DUR`` ms.
+
+        Returns
+        -------
+        gray : (n_electrodes, n_frames) array
+            Gray levels clipped to [0, 1].
+        electrodes : array
+            Electrode names.
+        frame_time : (n_frames,) array
+            Frame onset times (ms).
+        frame_dur : float
+            Frame duration (ms).
+        """
+        if not isinstance(source, Stimulus):
+            raise TypeError(f"'source' must be a Stimulus object, not "
+                            f"{type(source)}.")
+        # This is where a picture becomes stimulation, so what goes in has to
+        # be a picture. An electrical stimulus read as gray levels would have
+        # its microamps clipped to [0, 1] below and silently re-modulated into
+        # a different current entirely:
+        if not source.unit.dimension.is_dimensionless:
+            raise DimensionMismatchError(
+                f"An encoder turns gray levels into stimulation, so its "
+                f"source must be dimensionless, not "
+                f"{source.unit.dimension.name} ({source.unit}). Pass an "
+                f"ImageStimulus or a VideoStimulus.")
+        # Read the frame rate off the *source*: sampling at electrode locations
+        # does not necessarily carry it along.
+        fps = _fps(source.metadata)
+        stim = source
+        if (implant is not None and
+                isinstance(stim, (ImageStimulus, VideoStimulus))):
+            # Sample the source at the electrode locations. This is the same
+            # step that presenting an image or a video to an implant would
+            # perform, done here so that the stimulation below is built at
+            # electrode resolution rather than at pixel resolution. It is also
+            # where RGB becomes gray. Row count is not a usable test of whether
+            # a source is already in electrode coordinates, so always reshape:
+            stim = implant.reshape_stim(stim)
+        # `values` rather than `data`, to say out loud that these are the
+        # dimensionless numbers the modulation below is a function of:
+        gray = np.clip(np.asarray(stim.values(dimensionless),
+                                  dtype=np.float32), 0, 1)
+        if stim.time is None:
+            # A single frame, which has no duration of its own:
+            gray = gray.reshape((-1, 1))
+            frame_dur = (_DEFAULT_FRAME_DUR if frame_dur is None
+                         else frame_dur)
+            frame_time = np.zeros(1, dtype=np.float64)
+        elif frame_dur is None:
+            # `frame_interval` rejects a time axis whose frames are not all
+            # the same length, so the frames tile the source exactly:
+            frame_dur = frame_interval(np.asarray(stim.time), fps=fps)
+            frame_time = np.asarray(stim.time, dtype=np.float64)
+        else:
+            # An explicit `frame_dur` re-times the source: the frames keep
+            # their order and their content, but each one now lasts
+            # `frame_dur` ms. Keeping the source's own frame times here would
+            # let neighboring frames overlap:
+            frame_time = np.arange(gray.shape[1], dtype=np.float64) * frame_dur
+        return gray, stim.electrodes, frame_time, frame_dur
+
+
+class StimulusEncoder(Encoder):
     """Abstract base class for stimulus encoders.
 
     Encoders map image or video gray levels to electrical pulse trains.
@@ -284,70 +391,6 @@ class StimulusEncoder(PrettyPrint, metaclass=ABCMeta):
             Pulse frequencies (Hz), broadcastable to ``gray.shape``.
         """
         raise NotImplementedError
-
-    def _as_frames(self, source, implant=None):
-        """Reduce a source to one gray level per electrode per frame.
-
-        Returns
-        -------
-        gray : (n_electrodes, n_frames) array
-            Gray levels clipped to [0, 1].
-        electrodes : array
-            Electrode names.
-        frame_time : (n_frames,) array
-            Frame onset times (ms).
-        frame_dur : float
-            Frame duration (ms).
-        """
-        if not isinstance(source, Stimulus):
-            raise TypeError(f"'source' must be a Stimulus object, not "
-                            f"{type(source)}.")
-        # This is where a picture becomes stimulation, so what goes in has to
-        # be a picture. An electrical stimulus read as gray levels would have
-        # its microamps clipped to [0, 1] below and silently re-modulated into
-        # a different current entirely:
-        if not source.unit.dimension.is_dimensionless:
-            raise DimensionMismatchError(
-                f"An encoder turns gray levels into stimulation, so its "
-                f"source must be dimensionless, not "
-                f"{source.unit.dimension.name} ({source.unit}). Pass an "
-                f"ImageStimulus or a VideoStimulus.")
-        # Read the frame rate off the *source*: sampling at electrode locations
-        # does not necessarily carry it along.
-        fps = _fps(source.metadata)
-        stim = source
-        if (implant is not None and
-                isinstance(stim, (ImageStimulus, VideoStimulus))):
-            # Sample the source at the electrode locations. This is the same
-            # step that presenting an image or a video to an implant would
-            # perform, done here so that the pulse trains below are built at
-            # electrode resolution rather than at pixel resolution. It is also
-            # where RGB becomes gray. Row count is not a usable test of whether
-            # a source is already in electrode coordinates, so always reshape:
-            stim = implant.reshape_stim(stim)
-        # `values` rather than `data`, to say out loud that these are the
-        # dimensionless numbers the modulation below is a function of:
-        gray = np.clip(np.asarray(stim.values(dimensionless),
-                                  dtype=np.float32), 0, 1)
-        if stim.time is None:
-            # A single frame, which has no duration of its own:
-            gray = gray.reshape((-1, 1))
-            frame_dur = (_DEFAULT_FRAME_DUR if self.frame_dur is None
-                         else self.frame_dur)
-            frame_time = np.zeros(1, dtype=np.float64)
-        elif self.frame_dur is None:
-            # `frame_interval` rejects a time axis whose frames are not all
-            # the same length, so the frames tile the source exactly:
-            frame_dur = frame_interval(np.asarray(stim.time), fps=fps)
-            frame_time = np.asarray(stim.time, dtype=np.float64)
-        else:
-            # An explicit `frame_dur` re-times the source: the frames keep
-            # their order and their content, but each one now lasts
-            # `frame_dur` ms. Keeping the source's own frame times here would
-            # let neighboring frames overlap:
-            frame_dur = self.frame_dur
-            frame_time = np.arange(gray.shape[1], dtype=np.float64) * frame_dur
-        return gray, stim.electrodes, frame_time, frame_dur
 
     @staticmethod
     def _ticks(t):
@@ -762,8 +805,8 @@ class StimulusEncoder(PrettyPrint, metaclass=ABCMeta):
         Returns the arguments :py:meth:`_assemble` takes, in the order it
         takes them.
         """
-        gray, electrodes, frame_time, frame_dur = self._as_frames(source,
-                                                                  implant)
+        gray, electrodes, frame_time, frame_dur = self._as_frames(
+            source, implant, self.frame_dur)
         if self.stretch:
             gray = gray - gray.min()
             peak = gray.max()
@@ -1050,3 +1093,437 @@ frame_dur, stretch
         """Gray level in [0, 1] -> frequency in ``freq_range``"""
         freq_lo, freq_hi = self.freq_range
         return self.amp, freq_lo + gray * (freq_hi - freq_lo)
+
+
+#: The unit an optical encoder measures its output in
+_IRRADIANCE = mW / mm ** 2
+
+
+class _NormalizedStimulus(Stimulus):
+    """A stimulus whose values are normalized rather than physical"""
+    _default_unit = dimensionless
+
+    __slots__ = ()
+
+
+class _OpticalStimulus(Stimulus):
+    """A resolved projector schedule, expanded into a waveform on demand
+
+    Every pixel sees the same rectangular pulse at the same projector clock and
+    the same peak irradiance; only how long it stays on differs. The waveform
+    is therefore fully described by one ON duration per pixel per frame, which
+    is what this holds on to until somebody asks for samples.
+    """
+    #: described by its schedule rather than by its samples
+    _is_parametric = True
+
+    #: offers a normalized time-averaged view to spatial-only models
+    _has_spatial_view = True
+
+    __slots__ = ('_dur', '_ticks', '_onsets', '_irradiance', '_freq',
+                 '_wavelength', '_grayscale', '_reps', '_total', '_ref_drive',
+                 '_frame_time', '_frame_dur', '_time')
+
+    def __init__(self, electrodes, dur, ticks, onsets, irradiance, freq,
+                 wavelength, grayscale, reps, total, frame_time, frame_dur,
+                 ref_drive):
+        # ON duration (ms) per pixel and source frame:
+        self._dur = self._own(dur, np.float64)
+        self._ticks = self._own(ticks, np.int64)
+        # Onset (ticks) of every projector period, frame by source frame:
+        self._onsets = self._own(onsets, np.int64)
+        self._irradiance = float(irradiance)
+        self._freq = float(freq)
+        self._wavelength = float(wavelength)
+        self._grayscale = bool(grayscale)
+        # Projector periods per source frame:
+        self._reps = int(reps)
+        self._total = float(total)
+        # The time-averaged irradiance `_spatial_view` calls 1.0:
+        self._ref_drive = float(ref_drive)
+        self._frame_time = self._own(frame_time, np.float64)
+        self._frame_dur = float(frame_dur)
+        # Built lazily without rendering the waveform:
+        self._time = None
+        self._defer(electrodes, unit=_IRRADIANCE)
+        self.metadata['encoder'] = {
+            'frame_time': self._frame_time, 'frame_dur': self._frame_dur,
+            'optical': {'wavelength': self._wavelength,
+                        'irradiance': self._irradiance, 'freq': self._freq,
+                        'pulse_dur': self._dur, 'grayscale': self._grayscale}}
+
+    @property
+    def wavelength(self):
+        """Wavelength (nm) of the projected light"""
+        return self._wavelength
+
+    @property
+    def irradiance(self):
+        """Peak irradiance (mW/mm^2) while a pixel is on"""
+        return self._irradiance
+
+    @property
+    def freq(self):
+        """Projector frame rate (Hz)"""
+        return self._freq
+
+    @property
+    def pulse_dur(self):
+        """ON duration (ms) of every pixel, one column per source frame"""
+        return self._dur
+
+    @property
+    def duty_cycle(self):
+        """Fraction of each projector period every pixel spends on"""
+        return self._dur * self._freq / MS_PER_S
+
+    @property
+    def grayscale(self):
+        """Whether gray levels were pulse-width modulated, not binarized"""
+        return self._grayscale
+
+    @property
+    def duration(self):
+        """Duration of the stimulus (ms)"""
+        return self._total
+
+    @property
+    def time(self):
+        """Time points of the stimulus (ms)"""
+        if self._time is None:
+            time = self._ticks * DT
+            time[-1] = self._total
+            self._time = self._own(time, np.float64)
+        return self._time
+
+    def _spatial_view(self):
+        """Normalized time-averaged optical drive, one column per source frame
+
+        Deliberately neither a current nor a brightness: it is the irradiance a
+        pixel delivers averaged over a projector period, divided by the largest
+        drive the pivotal device is documented to produce. A spatial-only model
+        can use it as a per-pixel weight without integrating pulse edges.
+        """
+        drive = self._irradiance * self._dur * self._freq / self._ref_drive
+        drive = drive.astype(np.float32)
+        # A source with a single frame has no time axis of its own
+        if self._frame_time.size > 1:
+            stim = _NormalizedStimulus(drive, electrodes=self.electrodes,
+                                       time=self._frame_time)
+        else:
+            stim = _NormalizedStimulus(drive.ravel(),
+                                       electrodes=self.electrodes)
+        stim.metadata['encoder'] = {'frame_time': self._frame_time,
+                                    'frame_dur': self._frame_dur}
+        return stim
+
+    def _rebuilt(self, electrodes, dur, irradiance):
+        """This schedule, driving different pixels or at a different power"""
+        rebuilt = _OpticalStimulus(
+            electrodes, dur, self._ticks, self._onsets, irradiance, self._freq,
+            self._wavelength, self._grayscale, self._reps, self._total,
+            self._frame_time, self._frame_dur, self._ref_drive)
+        rebuilt.metadata['user'] = deepcopy(self.metadata.get('user'))
+        return rebuilt
+
+    def _scaled(self, factor):
+        """This schedule at a scaled irradiance
+
+        Pulse duration is what the projector modulates, and it is quantized
+        onto a hardware grid, so a scale factor changes optical power instead.
+        """
+        if not np.isscalar(factor):
+            return None
+        return self._rebuilt(self.electrodes, self._dur,
+                             self._irradiance * float(factor))
+
+    def _without_electrodes(self, electrodes):
+        """This schedule, no longer illuminating ``electrodes``"""
+        keep = self._keep_mask(electrodes)
+        return self._rebuilt(self.electrodes[keep], self._dur[keep],
+                             self._irradiance)
+
+    def _render(self):
+        """Expand the schedule into rectangular pulses."""
+        ticks = np.asarray(self._ticks)
+        # Which projector period each time point falls in, and how far into it:
+        at = np.searchsorted(self._onsets, ticks, side='right') - 1
+        np.clip(at, 0, self._onsets.size - 1, out=at)
+        since = ticks - self._onsets[at]
+        # The ON duration each pixel has in that period, in ticks:
+        dur = np.round(self._dur / DT).astype(np.int64)[:, at // self._reps]
+        # Rising and falling edges each take one DT, as elsewhere in p2p:
+        lit = (since[np.newaxis, :] >= 1) & (since <= dur - 1)
+        data = np.where(lit, np.float32(self._irradiance), np.float32(0))
+        # The newly allocated array can be adopted without another copy:
+        return {'data': _adoptable(data.astype(np.float32, copy=False)),
+                'electrodes': self.electrodes, 'time': self.time}
+
+    def _pprint_params(self):
+        """Return a dict of class attributes to pretty-print"""
+        return {'electrodes': self.electrodes,
+                'n_frames': self._dur.shape[1],
+                'n_time': self._ticks.size,
+                'irradiance': self._irradiance,
+                'freq': self._freq,
+                'duration': self._total,
+                'metadata': self.metadata}
+
+
+class PRIMAEncoder(Encoder):
+    """Encode gray levels as PRIMA's near-infrared projector output
+
+    PRIMA is not told what current to inject. Its pixels are photovoltaic: a
+    goggle-mounted projector paints an 880 nm image onto the implant, and each
+    pixel turns the light it receives into local electrical stimulation. The
+    projector runs at a fixed frame rate and a fixed peak irradiance, and
+    encodes intensity in *how long* a pixel is lit rather than in how brightly
+    [Palanker2020]_, [Holz2026]_.
+
+    This encoder therefore returns absolute optical irradiance in ``mW/mm^2``,
+    not microamps. Turning that light into retinal current requires a
+    photovoltaic model, which p2p does not have yet; until it does,
+    spatial-only models read the normalized time-averaged drive this stimulus
+    exposes (see the Notes).
+
+    .. versionadded:: 0.11.0
+
+    Parameters
+    ----------
+    irradiance : float or Quantity, optional
+        Peak irradiance (mW/mm^2) while a pixel is on. Not modulated by gray
+        level.
+    freq : float or Quantity, optional
+        Projector frame rate (Hz). One source frame is shown per projector
+        period.
+    pulse_dur : float or Quantity, optional
+        Longest ON duration (ms) per projector period, and the duration a lit
+        pixel receives in binary mode. Must be a whole multiple of
+        ``pulse_step`` and no longer than ``max_pulse_dur``. The default spans
+        the full documented hardware range; it is not a claim about the setting
+        used in any particular patient.
+    grayscale : bool, optional
+        If True, gray levels are pulse-width modulated onto the projector's
+        duration grid. If False (default, matching current clinical operation),
+        a pixel is either off or on for ``pulse_dur``.
+    threshold : float, optional
+        Gray level at or above which a pixel is lit in binary mode. This is a
+        p2p approximation: the thresholding the clinical system performs is not
+        published.
+
+    Notes
+    -----
+    *  Every projector period looks the same: irradiance rises to
+       ``irradiance`` for the pixel's ON duration and is zero for the rest of
+       the period. Peak irradiance never depends on gray level.
+    *  Timing is the projector's, not the source's. Each frame of a video
+       becomes one projector period, so a video is replayed on the device
+       clock; a source with no time axis is held for the standard static
+       presentation and simply repeats.
+    *  ``_spatial_view`` reports normalized time-averaged optical drive,
+       ``irradiance * pulse_dur * freq`` divided by the largest documented
+       pivotal-device drive, so 0 is a dark pixel and 1 a pixel at the full
+       documented drive. It is a physically interpretable optical scalar, not
+       retinal current and not perceived brightness.
+    *  Contrast inversion and edge enhancement are not part of PRIMA. Apply
+       them to the source first (e.g. ``image.invert()``,
+       ``image.filter('canny')``).
+    *  Plain numbers use the units documented above; unitful values are
+       converted automatically. See :mod:`pulse2percept.units`.
+
+    Examples
+    --------
+    >>> from pulse2percept.implants import PRIMAPivotal
+    >>> from pulse2percept.stimuli import LogoBVL, PRIMAEncoder
+    >>> PRIMAEncoder().encode(LogoBVL(), implant=PRIMAPivotal()).unit
+    mW/mm^2
+
+    """
+    #: Wavelength (nm) of the projected near-infrared light
+    wavelength = 880.0
+
+    #: Smallest nonzero ON duration (ms) the projector can produce; every other
+    #: duration is a whole multiple of it
+    pulse_step = 0.7
+
+    #: Longest documented ON duration (ms), i.e. 14 steps
+    max_pulse_dur = 9.8
+
+    #: Peak irradiance (mW/mm^2) of the pivotal-trial projector
+    max_irradiance = 3.5
+
+    #: Frame rate (Hz) of the pivotal-trial projector
+    max_freq = 30.0
+
+    #: Largest documented duty cycle, ``max_freq * max_pulse_dur``
+    max_duty_cycle = max_freq * max_pulse_dur / MS_PER_S
+
+    #: Time-averaged irradiance the normalized spatial view calls 1.0
+    ref_drive = max_irradiance * max_pulse_dur * max_freq
+
+    __slots__ = ('irradiance', 'freq', 'pulse_dur', 'grayscale', 'threshold')
+
+    def __init__(self, irradiance=3.5 * mW / mm ** 2, freq=30 * Hz,
+                 pulse_dur=9.8 * ms, grayscale=False, threshold=0.5):
+        irradiance = as_value(irradiance, _IRRADIANCE, 'irradiance')
+        freq = as_value(freq, Hz, 'freq')
+        pulse_dur = as_value(pulse_dur, ms, 'pulse_dur')
+        threshold = as_value(threshold, dimensionless, 'threshold')
+        _finite('irradiance', irradiance)
+        if irradiance <= 0:
+            raise ValueError("'irradiance' must be positive.")
+        _finite('freq', freq)
+        if freq <= 0:
+            raise ValueError("'freq' must be positive.")
+        _finite('pulse_dur', pulse_dur)
+        if pulse_dur < 0:
+            raise ValueError("'pulse_dur' cannot be negative.")
+        if pulse_dur > 0:
+            # The projector realizes durations in whole hardware steps, and
+            # rounding one silently would misreport the drive it delivers:
+            steps = pulse_dur / self.pulse_step
+            if abs(steps - round(steps)) > 1e-9:
+                raise ValueError(
+                    f"'pulse_dur' must be a whole multiple of "
+                    f"{self.pulse_step} ms, the step the projector modulates "
+                    f"in, not {pulse_dur:g} ms.")
+            if pulse_dur > self.max_pulse_dur + 1e-9:
+                raise ValueError(
+                    f"'pulse_dur' cannot exceed {self.max_pulse_dur} ms, the "
+                    f"longest documented ON duration, not {pulse_dur:g} ms.")
+            period = MS_PER_S / freq
+            if pulse_dur >= period:
+                raise ValueError(
+                    f"A {pulse_dur:g} ms pulse does not fit into the "
+                    f"{period:.3f} ms period of a {freq:g} Hz projector. "
+                    f"Shorten 'pulse_dur' or lower 'freq'.")
+        _finite('threshold', threshold)
+        if not 0 <= threshold <= 1:
+            raise ValueError(f"'threshold' must be a gray level in [0, 1], "
+                             f"not {threshold}.")
+        self.irradiance = irradiance
+        self.freq = freq
+        self.pulse_dur = pulse_dur
+        self.grayscale = bool(grayscale)
+        self.threshold = threshold
+
+    def _pprint_params(self):
+        """Return a dict of class arguments to pretty-print"""
+        return {'irradiance': self.irradiance, 'freq': self.freq,
+                'pulse_dur': self.pulse_dur, 'grayscale': self.grayscale,
+                'threshold': self.threshold}
+
+    @property
+    def period(self):
+        """Projector period (ms)"""
+        return MS_PER_S / self.freq
+
+    @property
+    def n_levels(self):
+        """Number of nonzero ON durations available up to ``pulse_dur``"""
+        return int(round(self.pulse_dur / self.pulse_step))
+
+    def _durations(self, gray):
+        """Map gray levels in [0, 1] to ON durations (ms)
+
+        Binary mode lights a pixel for the full ``pulse_dur``; grayscale mode
+        pulse-width modulates onto the projector's own duration grid.
+        """
+        # In float64, so that a duration lands exactly on the hardware grid
+        # rather than a float32 step away from it:
+        gray = np.asarray(gray, dtype=np.float64)
+        if not self.grayscale:
+            return np.where(gray >= self.threshold, self.pulse_dur, 0.0)
+        # `gray` is already clipped to [0, 1], so the rounded level cannot
+        # leave the 0..n_levels range the hardware offers:
+        return np.round(gray * self.n_levels) * self.pulse_step
+
+    def encode(self, source, implant=None):
+        """Encode an image or a video as near-infrared irradiance
+
+        Parameters
+        ----------
+        source : :py:class:`~pulse2percept.stimuli.Stimulus`
+            The image or video to encode. Gray levels are expected in [0, 1],
+            which is what :py:class:`~pulse2percept.stimuli.ImageStimulus` and
+            :py:class:`~pulse2percept.stimuli.VideoStimulus` produce. It must
+            be dimensionless.
+        implant : :py:class:`~pulse2percept.implants.ProsthesisSystem`, optional
+            The implant to encode for. Its pixel locations are used to sample
+            the source and its pixel names label the resulting stimulus. If
+            None, every pixel of the source is treated as its own photovoltaic
+            pixel.
+
+        Returns
+        -------
+        stim : :py:class:`~pulse2percept.stimuli.Stimulus`
+            The projected irradiance, in ``mW/mm^2``, with a time axis in
+            milliseconds. The waveform is generated only when samples are
+            asked for.
+
+        Raises
+        ------
+        :py:class:`~pulse2percept.units.DimensionMismatchError`
+            If ``source`` is not dimensionless.
+
+        """
+        period = self.period
+        # The encoder clock is the projector clock: one source frame per
+        # projector period. A source with no time axis of its own is held for
+        # the standard static presentation instead, and simply repeats.
+        static = getattr(source, 'time', None) is None
+        gray, electrodes, frame_time, frame_dur = self._as_frames(
+            source, implant, None if static else period)
+        reps = max(1, int(round(frame_dur / period)))
+        n_el, n_frames = len(electrodes), gray.shape[1]
+        dur = self._durations(gray).astype(np.float64)
+
+        # Onsets are rounded onto the DT grid one at a time rather than stepped
+        # by an already-rounded period: 30 Hz is 33333.33 ticks, and
+        # accumulating that error would walk the projector off its own frames
+        # over the course of a video.
+        n_periods = n_frames * reps
+        onsets = np.round(np.arange(n_periods, dtype=np.float64) * period /
+                          DT).astype(np.int64)
+        # Re-derive the frame clock from the periods that actually fit, so that
+        # frame boundaries and projector periods cannot drift apart:
+        end = int(np.round(n_periods * period / DT))
+        total = end * DT
+        frame_dur = total / n_frames
+        frame_time = np.arange(n_frames, dtype=np.float64) * frame_dur
+        dur_ticks = np.round(dur / DT).astype(np.int64)
+        edges = [np.array([0, end], dtype=np.int64)]
+        for j in range(n_frames):
+            levels = np.unique(dur_ticks[:, j])
+            levels = levels[levels > 0]
+            if levels.size == 0:
+                # A dark frame has no edges of its own to place:
+                continue
+            on = onsets[j * reps:(j + 1) * reps]
+            edges += [on, on + 1]
+            for level in levels:
+                edges += [on + level - 1, on + level]
+        ticks = np.unique(np.concatenate(edges))
+        ticks = ticks[(ticks >= 0) & (ticks <= end)]
+
+        n_time = ticks.size
+        if n_time > _BIG_TIME:
+            _warn_external(
+                f"This stimulus has {n_time} time points, which every model "
+                f"downstream will pay for. A lower 'freq' or a shorter source "
+                f"is the lever that helps most; in grayscale mode, so is a "
+                f"shorter 'pulse_dur', which offers fewer distinct durations.",
+                category=UserWarning)
+        if n_el * n_time > _BIG_STIM and implant is None:
+            _warn_external(
+                f"Encoding {n_el} pixels x {n_time} time points will allocate "
+                f"{n_el * n_time * 4 / 1e9:.1f} GB. Pass 'implant' to encode "
+                f"at pixel resolution instead.", category=UserWarning)
+
+        # The schedule is settled. Expanding it into an n_el x n_time matrix is
+        # the expensive half, and the half nothing needs until somebody asks
+        # for samples:
+        return _OpticalStimulus(
+            electrodes, dur, ticks, onsets, self.irradiance, self.freq,
+            self.wavelength, self.grayscale, reps, total, frame_time,
+            frame_dur, self.ref_drive)

--- a/pulse2percept/stimuli/encoders.py
+++ b/pulse2percept/stimuli/encoders.py
@@ -4,6 +4,7 @@
    :py:class:`~pulse2percept.stimuli.FrequencyEncoder`,
    :py:class:`~pulse2percept.stimuli.PRIMAEncoder`"""
 from abc import ABCMeta, abstractmethod
+import math
 import numpy as np
 from copy import deepcopy
 
@@ -1111,8 +1112,13 @@ class _OpticalStimulus(Stimulus):
 
     Every pixel sees the same rectangular pulse at the same projector clock and
     the same peak irradiance; only how long it stays on differs. The waveform
-    is therefore fully described by one ON duration per pixel per frame, which
-    is what this holds on to until somebody asks for samples.
+    is therefore fully described by one ON duration per pixel per projector
+    frame, which is what this holds on to until somebody asks for samples.
+
+    Those durations, together with ``irradiance`` and ``freq``, are the
+    authoritative description of what the projector does. They are deliberately
+    not mirrored into ``metadata``, which is an ordinary mutable dict that any
+    operation may copy onto a stimulus whose waveform no longer matches it.
     """
     #: described by its schedule rather than by its samples
     _is_parametric = True
@@ -1121,24 +1127,31 @@ class _OpticalStimulus(Stimulus):
     _has_spatial_view = True
 
     __slots__ = ('_dur', '_ticks', '_onsets', '_irradiance', '_freq',
-                 '_wavelength', '_grayscale', '_reps', '_total', '_ref_drive',
-                 '_frame_time', '_frame_dur', '_time')
+                 '_wavelength', '_grayscale', '_total', '_ref_drive',
+                 '_static', '_frame_time', '_frame_dur', '_time')
 
     def __init__(self, electrodes, dur, ticks, onsets, irradiance, freq,
-                 wavelength, grayscale, reps, total, frame_time, frame_dur,
+                 wavelength, grayscale, total, static, frame_time, frame_dur,
                  ref_drive):
-        # ON duration (ms) per pixel and source frame:
+        irradiance = float(irradiance)
+        # Light has a nonnegative power density. Checked here rather than only
+        # in the encoder, because this is also what a scaled or rebuilt
+        # schedule goes through:
+        if not math.isfinite(irradiance) or irradiance < 0:
+            raise ValueError(f"'irradiance' must be a finite, nonnegative "
+                             f"power density, not {irradiance}.")
+        # ON duration (ms) per pixel and projector frame:
         self._dur = self._own(dur, np.float64)
         self._ticks = self._own(ticks, np.int64)
-        # Onset (ticks) of every projector period, frame by source frame:
+        # Onset (ticks) of every projector frame:
         self._onsets = self._own(onsets, np.int64)
-        self._irradiance = float(irradiance)
+        self._irradiance = irradiance
         self._freq = float(freq)
         self._wavelength = float(wavelength)
         self._grayscale = bool(grayscale)
-        # Projector periods per source frame:
-        self._reps = int(reps)
         self._total = float(total)
+        # Whether the source had a time axis of its own:
+        self._static = bool(static)
         # The time-averaged irradiance `_spatial_view` calls 1.0:
         self._ref_drive = float(ref_drive)
         self._frame_time = self._own(frame_time, np.float64)
@@ -1146,11 +1159,10 @@ class _OpticalStimulus(Stimulus):
         # Built lazily without rendering the waveform:
         self._time = None
         self._defer(electrodes, unit=_IRRADIANCE)
-        self.metadata['encoder'] = {
-            'frame_time': self._frame_time, 'frame_dur': self._frame_dur,
-            'optical': {'wavelength': self._wavelength,
-                        'irradiance': self._irradiance, 'freq': self._freq,
-                        'pulse_dur': self._dur, 'grayscale': self._grayscale}}
+        # Only the frame clock, which is not scientific state: it says when the
+        # frames are, and the durations above say what is in them.
+        self.metadata['encoder'] = {'frame_time': self._frame_time,
+                                    'frame_dur': self._frame_dur}
 
     @property
     def wavelength(self):
@@ -1169,7 +1181,7 @@ class _OpticalStimulus(Stimulus):
 
     @property
     def pulse_dur(self):
-        """ON duration (ms) of every pixel, one column per source frame"""
+        """ON duration (ms) of every pixel, one column per projector frame"""
         return self._dur
 
     @property
@@ -1197,22 +1209,23 @@ class _OpticalStimulus(Stimulus):
         return self._time
 
     def _spatial_view(self):
-        """Normalized time-averaged optical drive, one column per source frame
+        """Normalized time-averaged optical drive, one column per frame
 
         Deliberately neither a current nor a brightness: it is the irradiance a
         pixel delivers averaged over a projector period, divided by the largest
         drive the pivotal device is documented to produce. A spatial-only model
         can use it as a per-pixel weight without integrating pulse edges.
         """
-        drive = self._irradiance * self._dur * self._freq / self._ref_drive
-        drive = drive.astype(np.float32)
-        # A source with a single frame has no time axis of its own
-        if self._frame_time.size > 1:
+        drive = (self._irradiance * self.duty_cycle / self._ref_drive).astype(
+            np.float32)
+        if self._static:
+            # Every projector frame repeats the one frame the source had, and
+            # a source with no time axis has no time axis here either:
+            stim = _NormalizedStimulus(drive[:, 0].ravel(),
+                                       electrodes=self.electrodes)
+        else:
             stim = _NormalizedStimulus(drive, electrodes=self.electrodes,
                                        time=self._frame_time)
-        else:
-            stim = _NormalizedStimulus(drive.ravel(),
-                                       electrodes=self.electrodes)
         stim.metadata['encoder'] = {'frame_time': self._frame_time,
                                     'frame_dur': self._frame_dur}
         return stim
@@ -1221,7 +1234,7 @@ class _OpticalStimulus(Stimulus):
         """This schedule, driving different pixels or at a different power"""
         rebuilt = _OpticalStimulus(
             electrodes, dur, self._ticks, self._onsets, irradiance, self._freq,
-            self._wavelength, self._grayscale, self._reps, self._total,
+            self._wavelength, self._grayscale, self._total, self._static,
             self._frame_time, self._frame_dur, self._ref_drive)
         rebuilt.metadata['user'] = deepcopy(self.metadata.get('user'))
         return rebuilt
@@ -1231,11 +1244,20 @@ class _OpticalStimulus(Stimulus):
 
         Pulse duration is what the projector modulates, and it is quantized
         onto a hardware grid, so a scale factor changes optical power instead.
+        Zero simply turns the projector off; a negative factor has no optical
+        meaning, so it is refused rather than expanded into a waveform of
+        negative irradiance.
         """
         if not np.isscalar(factor):
             return None
+        factor = float(factor)
+        if not math.isfinite(factor) or factor < 0:
+            raise ValueError(f"Scaling an optical stimulus by {factor} would "
+                             f"ask the projector for a negative or undefined "
+                             f"irradiance. Only nonnegative, finite factors "
+                             f"describe light.")
         return self._rebuilt(self.electrodes, self._dur,
-                             self._irradiance * float(factor))
+                             self._irradiance * factor)
 
     def _without_electrodes(self, electrodes):
         """This schedule, no longer illuminating ``electrodes``"""
@@ -1246,12 +1268,12 @@ class _OpticalStimulus(Stimulus):
     def _render(self):
         """Expand the schedule into rectangular pulses."""
         ticks = np.asarray(self._ticks)
-        # Which projector period each time point falls in, and how far into it:
+        # Which projector frame each time point falls in, and how far into it:
         at = np.searchsorted(self._onsets, ticks, side='right') - 1
         np.clip(at, 0, self._onsets.size - 1, out=at)
         since = ticks - self._onsets[at]
-        # The ON duration each pixel has in that period, in ticks:
-        dur = np.round(self._dur / DT).astype(np.int64)[:, at // self._reps]
+        # The ON duration each pixel has in that frame, in ticks:
+        dur = np.round(self._dur / DT).astype(np.int64)[:, at]
         # Rising and falling edges each take one DT, as elsewhere in p2p:
         lit = (since[np.newaxis, :] >= 1) & (since <= dur - 1)
         data = np.where(lit, np.float32(self._irradiance), np.float32(0))
@@ -1316,15 +1338,16 @@ class PRIMAEncoder(Encoder):
     *  Every projector period looks the same: irradiance rises to
        ``irradiance`` for the pixel's ON duration and is zero for the rest of
        the period. Peak irradiance never depends on gray level.
-    *  Timing is the projector's, not the source's. Each frame of a video
-       becomes one projector period, so a video is replayed on the device
-       clock; a source with no time axis is held for the standard static
-       presentation and simply repeats.
-    *  ``_spatial_view`` reports normalized time-averaged optical drive,
-       ``irradiance * pulse_dur * freq`` divided by the largest documented
-       pivotal-device drive, so 0 is a dark pixel and 1 a pixel at the full
-       documented drive. It is a physically interpretable optical scalar, not
-       retinal current and not perceived brightness.
+    *  The projector clock samples the source; it does not re-time it. Every
+       ``1 / freq`` the device looks at whatever frame the source is showing
+       (zero-order hold), so a slow video has frames re-sent and a fast one has
+       frames skipped, and either way the source keeps its own duration. A
+       source with no time axis is held for the standard static presentation.
+    *  ``_spatial_view`` reports normalized time-averaged optical drive:
+       ``irradiance * duty_cycle`` divided by the largest documented
+       pivotal-device drive (``ref_drive``), so 0 is a dark pixel and 1 a pixel
+       at the full documented drive. It is a physically interpretable optical
+       scalar, not retinal current and not perceived brightness.
     *  Contrast inversion and edge enhancement are not part of PRIMA. Apply
        them to the source first (e.g. ``image.invert()``,
        ``image.filter('canny')``).
@@ -1358,8 +1381,8 @@ class PRIMAEncoder(Encoder):
     #: Largest documented duty cycle, ``max_freq * max_pulse_dur``
     max_duty_cycle = max_freq * max_pulse_dur / MS_PER_S
 
-    #: Time-averaged irradiance the normalized spatial view calls 1.0
-    ref_drive = max_irradiance * max_pulse_dur * max_freq
+    #: Time-averaged irradiance (mW/mm^2) the normalized spatial view calls 1.0
+    ref_drive = max_irradiance * max_duty_cycle
 
     __slots__ = ('irradiance', 'freq', 'pulse_dur', 'grayscale', 'threshold')
 
@@ -1468,41 +1491,42 @@ class PRIMAEncoder(Encoder):
 
         """
         period = self.period
-        # The encoder clock is the projector clock: one source frame per
-        # projector period. A source with no time axis of its own is held for
-        # the standard static presentation instead, and simply repeats.
-        static = getattr(source, 'time', None) is None
-        gray, electrodes, frame_time, frame_dur = self._as_frames(
-            source, implant, None if static else period)
-        reps = max(1, int(round(frame_dur / period)))
-        n_el, n_frames = len(electrodes), gray.shape[1]
-        dur = self._durations(gray).astype(np.float64)
+        gray, electrodes, frame_time, frame_dur = self._as_frames(source,
+                                                                  implant)
+        n_el = len(electrodes)
+        static = frame_time.size == 1 and getattr(source, 'time', None) is None
+        # The source keeps its own duration. What the projector clock decides
+        # is when the device looks at it, not how long the content lasts:
+        total = float(frame_time[-1] + frame_dur)
+        # Enough frames to cover the source; the last one may be cut short by
+        # the end of the source, exactly as it would be on the device.
+        n_periods = max(1, int(np.ceil(total / period - 1e-9)))
+        onset_ms = np.arange(n_periods, dtype=np.float64) * period
+        # Zero-order hold: a source frame stays on screen until the next one,
+        # so the projector re-sends a slow source's frames and skips a fast
+        # source's. Interpolating instead would invent frames the source never
+        # contained.
+        at = np.searchsorted(frame_time, onset_ms, side='right') - 1
+        np.clip(at, 0, frame_time.size - 1, out=at)
+        dur = self._durations(gray[:, at])
 
         # Onsets are rounded onto the DT grid one at a time rather than stepped
         # by an already-rounded period: 30 Hz is 33333.33 ticks, and
-        # accumulating that error would walk the projector off its own frames
-        # over the course of a video.
-        n_periods = n_frames * reps
-        onsets = np.round(np.arange(n_periods, dtype=np.float64) * period /
-                          DT).astype(np.int64)
-        # Re-derive the frame clock from the periods that actually fit, so that
-        # frame boundaries and projector periods cannot drift apart:
-        end = int(np.round(n_periods * period / DT))
-        total = end * DT
-        frame_dur = total / n_frames
-        frame_time = np.arange(n_frames, dtype=np.float64) * frame_dur
+        # accumulating that error would walk the projector off the source over
+        # the course of a video.
+        onsets = np.round(onset_ms / DT).astype(np.int64)
+        end = int(np.round(total / DT))
         dur_ticks = np.round(dur / DT).astype(np.int64)
         edges = [np.array([0, end], dtype=np.int64)]
-        for j in range(n_frames):
+        for j in range(n_periods):
             levels = np.unique(dur_ticks[:, j])
             levels = levels[levels > 0]
             if levels.size == 0:
                 # A dark frame has no edges of its own to place:
                 continue
-            on = onsets[j * reps:(j + 1) * reps]
-            edges += [on, on + 1]
-            for level in levels:
-                edges += [on + level - 1, on + level]
+            on = onsets[j]
+            edges.append(np.concatenate(([on, on + 1],
+                                         levels + (on - 1), levels + on)))
         ticks = np.unique(np.concatenate(edges))
         ticks = ticks[(ticks >= 0) & (ticks <= end)]
 
@@ -1522,8 +1546,10 @@ class PRIMAEncoder(Encoder):
 
         # The schedule is settled. Expanding it into an n_el x n_time matrix is
         # the expensive half, and the half nothing needs until somebody asks
-        # for samples:
+        # for samples. A static source keeps its single frame; a video's frame
+        # clock is the projector's, since that is when the pixels change.
         return _OpticalStimulus(
             electrodes, dur, ticks, onsets, self.irradiance, self.freq,
-            self.wavelength, self.grayscale, reps, total, frame_time,
-            frame_dur, self.ref_drive)
+            self.wavelength, self.grayscale, total, static,
+            np.zeros(1) if static else onset_ms,
+            total if static else period, self.ref_drive)

--- a/pulse2percept/stimuli/tests/test_encoders.py
+++ b/pulse2percept/stimuli/tests/test_encoders.py
@@ -1604,6 +1604,71 @@ def test_PRIMAEncoder_samples_a_video_without_retiming_it(fps, n_source):
                             decimal=3)
 
 
+@pytest.mark.parametrize('fps', [15, 60])
+def test_PRIMAEncoder_repeats_slow_frames_and_skips_fast_ones(fps):
+    # One second of video whose frames alternate lit and dark, so which source
+    # frame the projector picked is visible in the drive it produced.
+    implant = PRIMAPivotal()
+    gray = np.zeros((8, 8, fps))
+    gray[..., ::2] = 1.0
+    video = VideoStimulus(gray, time=np.arange(fps) * (1000.0 / fps))
+    stim = PRIMAEncoder().encode(video, implant=implant)
+    lit = stim.pulse_dur.max(axis=0) > 0
+    npt.assert_equal(lit.size, 30)
+    if fps == 15:
+        # Half the projector's rate: every source frame is sent twice, so the
+        # pattern comes out in pairs.
+        npt.assert_array_equal(lit.reshape(-1, 2)[:, 0],
+                               lit.reshape(-1, 2)[:, 1])
+    else:
+        # Twice the projector's rate: only the even source frames are sampled,
+        # and those are the lit ones, so the dark frames never appear.
+        npt.assert_equal(lit.all(), True)
+
+
+def test_PRIMAEncoder_starts_where_the_source_does():
+    # A video need not start at t=0: cropping one keeps the timestamps it was
+    # cut from. The projector clock is anchored to the source, so nothing is
+    # projected before the first frame exists.
+    implant = PRIMAPivotal()
+    video = VideoStimulus(np.ones((8, 8, 3)),
+                          time=100 + np.arange(3) * (1000 / 30))
+    stim = PRIMAEncoder().encode(video, implant=implant)
+    npt.assert_almost_equal(stim.duration, 200, decimal=6)
+    npt.assert_equal(stim.pulse_dur.shape[1], 3)
+    npt.assert_almost_equal(stim._spatial_view().time[0], 100, decimal=6)
+    # Dark until the source starts:
+    npt.assert_almost_equal(stim.data[:, stim.time < 100].max(), 0)
+
+    # ... and the same through the operation that produces such a video.
+    # (`bottom`/`right` work around a spatial bounds check in `crop` that
+    # rejects the full frame; the time crop is what matters here.)
+    gray = np.zeros((8, 8, 9))
+    gray[..., 3:6] = 1.0
+    cropped = VideoStimulus(gray, time=np.arange(9) * (1000 / 30)).crop(
+        front=3, back=3, bottom=1, right=1)
+    npt.assert_almost_equal(cropped.time[0], 100, decimal=6)
+    stim = PRIMAEncoder().encode(cropped, implant=implant)
+    npt.assert_almost_equal(stim._spatial_view().time[0], 100, decimal=6)
+    npt.assert_almost_equal(stim.data[:, stim.time < 100].max(), 0)
+
+
+def test_PRIMAEncoder_finishes_every_pulse_it_starts():
+    # The last projector period of a 40 ms source has only 6.7 ms left in it,
+    # which a 9.8 ms pulse does not fit into. Starting it anyway would leave
+    # the stimulus lit at the instant it says it is over.
+    implant = PRIMAPivotal()
+    video = VideoStimulus(np.ones((8, 8, 2)), time=[0.0, 20.0])
+    stim = PRIMAEncoder().encode(video, implant=implant)
+    npt.assert_almost_equal(stim.duration, 40)
+    npt.assert_array_almost_equal(stim.pulse_dur.max(axis=0), [9.8, 0])
+    npt.assert_almost_equal(stim.data[:, -1].max(), 0)
+    # Nonzero durations stay on the hardware grid rather than being shortened
+    # to whatever happened to fit:
+    kept = stim.pulse_dur[stim.pulse_dur > 0]
+    npt.assert_almost_equal(kept / 0.7, np.round(kept / 0.7))
+
+
 def test_PRIMAEncoder_defers_the_waveform():
     implant = PRIMAPivotal()
     stim = PRIMAEncoder().encode(ImageStimulus(np.ones((16, 16))),

--- a/pulse2percept/stimuli/tests/test_encoders.py
+++ b/pulse2percept/stimuli/tests/test_encoders.py
@@ -1225,7 +1225,7 @@ ENCODED = [
 def test_encoded_stimulus_defers_only_the_waveform(name, build):
     stim = build()
     npt.assert_equal(_rendered(stim), False)
-    # Everything the schedule already settled, without expanding it:
+    # Schedule properties do not require waveform rendering.
     npt.assert_equal(len(stim.electrodes) > 0, True)
     npt.assert_equal(stim.unit, uA)
     npt.assert_equal(stim.time_unit, ms)
@@ -1380,7 +1380,7 @@ def on_intervals(stim, electrode=0):
     lit = row >= 0.99 * row.max() if row.max() > 0 else row > np.inf
     edges = np.diff(np.concatenate(([0], lit.astype(int), [0])))
     starts, stops = np.flatnonzero(edges > 0), np.flatnonzero(edges < 0) - 1
-    # The rise and the fall each take one DT outside the flat top:
+    # Include one-DT rise and fall edges.
     return [time[b] - time[a] + 2 * DT for a, b in zip(starts, stops)]
 
 
@@ -1389,18 +1389,17 @@ def test_PRIMAEncoder():
     npt.assert_almost_equal(encoder.irradiance, 3.5)
     npt.assert_almost_equal(encoder.freq, 30)
     npt.assert_almost_equal(encoder.pulse_dur, 9.8)
-    # The projector's own 14-level pulse-width modulation is the default; the
-    # 0.5 threshold only applies to the binary mode users opt into.
+    # Grayscale PWM is the default; threshold applies only in binary mode.
     npt.assert_equal(encoder.grayscale, True)
     npt.assert_almost_equal(encoder.threshold, 0.5)
     npt.assert_almost_equal(encoder.period, 1000 / 30)
     npt.assert_equal(encoder.n_levels, 14)
     npt.assert_equal(isinstance(encoder, Encoder), True)
-    # Not an electrical encoder, and not schedulable like one:
+    # PRIMAEncoder is not an electrical StimulusEncoder.
     npt.assert_equal(isinstance(encoder, StimulusEncoder), False)
     npt.assert_equal('PRIMAEncoder' in str(encoder), True)
 
-    # Unitful spellings mean the same thing as the bare numbers:
+    # Unitful and bare parameters are equivalent.
     unitful = PRIMAEncoder(irradiance=3500 * W / m ** 2, freq=0.03 * kHz,
                            pulse_dur=9800 * us)
     npt.assert_almost_equal(unitful.irradiance, 3.5)
@@ -1429,7 +1428,7 @@ def test_PRIMAEncoder_takes_a_picture():
                               implant=implant)
     with pytest.raises(TypeError):
         PRIMAEncoder().encode(np.ones((4, 4)), implant=implant)
-    # RGB becomes gray through the implant's own sampling path:
+    # RGB input is converted to gray during implant sampling.
     rgb = ImageStimulus(np.ones((8, 8, 3)))
     npt.assert_equal(PRIMAEncoder().encode(rgb, implant=implant).shape[0], 378)
 
@@ -1437,32 +1436,31 @@ def test_PRIMAEncoder_takes_a_picture():
 @pytest.mark.parametrize('grayscale', [True, False])
 @pytest.mark.parametrize('gray, n_lit', [(1.0, 378), (0.0, 0)])
 def test_PRIMAEncoder_extremes(gray, n_lit, grayscale):
-    # Black is off and white is the brightest level, in either mode:
+    # Black is off; white uses the maximum duration.
     implant = PRIMAPivotal()
     stim = PRIMAEncoder(grayscale=grayscale).encode(
         ImageStimulus(np.full((16, 16), gray)), implant=implant)
     npt.assert_equal(stim.shape[0], 378)
     npt.assert_equal(np.count_nonzero(stim.data.max(axis=1)), n_lit)
-    # All 378 pixels may be lit at once: there is no multiplexing to schedule.
+    # No raster limits simultaneous illumination.
     npt.assert_equal(implant.raster, None)
 
 
 @pytest.mark.parametrize('threshold', [0.25, 0.5, 0.75])
 def test_PRIMAEncoder_threshold(threshold):
-    # A left-to-right ramp: exactly the pixels at or above threshold light up.
+    # Binary mode lights pixels at or above threshold.
     ramp = np.tile(np.linspace(0, 1, 32), (32, 1))
     implant = PRIMAPivotal()
     encoder = PRIMAEncoder(grayscale=False, threshold=threshold)
     gray = implant.reshape_stim(ImageStimulus(ramp)).data.ravel()
     stim = encoder.encode(ImageStimulus(ramp), implant=implant)
     dur = stim.pulse_dur
-    # A still picture shows the same frame in every projector period:
+    # Static images repeat across projector periods.
     npt.assert_equal(dur.shape, (378, 15))
     npt.assert_equal(np.all(dur == dur[:, :1]), True)
     dur = dur[:, 0]
     npt.assert_array_equal(dur > 0, gray >= threshold)
-    # Binary means binary: a lit pixel gets the full pulse, whatever its gray
-    # level, and nothing in between exists.
+    # Binary mode uses only 0 and the full pulse duration.
     npt.assert_array_equal(np.unique(dur), np.array([0.0, 9.8]))
 
 
@@ -1470,14 +1468,13 @@ def test_PRIMAEncoder_optical_waveform():
     implant = PRIMAPivotal()
     stim = PRIMAEncoder().encode(ImageStimulus(np.ones((16, 16))),
                                  implant=implant)
-    # Irradiance, not current:
+    # Output is optical irradiance.
     npt.assert_equal(stim.unit, mW / mm ** 2)
     npt.assert_equal(stim.unit.dimension, (W / m ** 2).dimension)
     npt.assert_equal(stim.time_unit, ms)
     npt.assert_almost_equal(stim.data.max(), 3.5)
     npt.assert_almost_equal(stim.data.min(), 0)
-    # A picture with no time axis is held for the standard presentation, and
-    # the projector simply repeats over it:
+    # Static images use the standard presentation duration.
     npt.assert_almost_equal(stim.duration, 500)
     intervals = on_intervals(stim)
     npt.assert_equal(len(intervals), 15)
@@ -1494,7 +1491,7 @@ def test_PRIMAEncoder_irradiance_is_not_modulated():
     stim = PRIMAEncoder(grayscale=True, irradiance=2.0).encode(
         ImageStimulus(ramp), implant=implant)
     lit = stim.data[stim.data > 0]
-    # Every lit pixel sees the same peak, however long it is lit for:
+    # Gray level changes duration, not peak irradiance.
     npt.assert_almost_equal(np.unique(np.round(lit, 6)), np.array([2.0]))
 
 
@@ -1504,17 +1501,17 @@ def test_PRIMAEncoder_grayscale():
     stim = PRIMAEncoder(grayscale=True).encode(ImageStimulus(ramp),
                                                implant=implant)
     dur = stim.pulse_dur[:, :1]
-    # Durations fall exactly on the 0.7 ms hardware grid, 0 through 9.8 ms:
+    # Durations lie on the 0.7 ms hardware grid.
     npt.assert_almost_equal(dur / 0.7, np.round(dur / 0.7))
     npt.assert_almost_equal(dur.min(), 0)
     npt.assert_almost_equal(dur.max(), 9.8)
     npt.assert_equal(np.unique(np.round(dur, 6)).size > 2, True)
     npt.assert_equal(stim.grayscale, True)
-    # The gray level a pixel saw picks its level, one step at a time:
+    # Gray levels map linearly to duration levels.
     gray = implant.reshape_stim(ImageStimulus(ramp)).data
     npt.assert_almost_equal(dur, np.round(gray * 14) * 0.7, decimal=6)
 
-    # A lower maximum offers only the levels up through that maximum:
+    # pulse_dur limits the available duration levels.
     coarse = PRIMAEncoder(grayscale=True, pulse_dur=2.1).encode(
         ImageStimulus(ramp), implant=implant)
     levels = np.unique(coarse.pulse_dur)
@@ -1524,17 +1521,14 @@ def test_PRIMAEncoder_grayscale():
 def test_PRIMAEncoder_records_its_settings():
     stim = PRIMAEncoder(grayscale=True).encode(
         ImageStimulus(np.ones((8, 8))), implant=PRIMAPivotal())
-    # The projector settings are the stimulus' own state, readable without
-    # rendering a waveform:
+    # Projector settings are available without rendering.
     npt.assert_almost_equal(stim.wavelength, 880)
     npt.assert_almost_equal(stim.irradiance, 3.5)
     npt.assert_almost_equal(stim.freq, 30)
     npt.assert_almost_equal(stim.pulse_dur.max(), 9.8)
     npt.assert_almost_equal(stim.duty_cycle.max(), 0.294)
     npt.assert_equal(stim.grayscale, True)
-    # They are deliberately *not* mirrored into metadata, which is an ordinary
-    # mutable dict that arithmetic may copy onto a waveform it no longer
-    # describes. Only the frame clock lives there:
+    # Optical settings are schedule state; metadata stores only frame timing.
     npt.assert_equal(sorted(stim.metadata['encoder']),
                      ['frame_dur', 'frame_time'])
 
@@ -1544,19 +1538,18 @@ def test_PRIMAEncoder_spatial_view():
     ramp = np.tile(np.linspace(0, 1, 64), (64, 1))
     view = PRIMAEncoder(grayscale=True).encode(
         ImageStimulus(ramp), implant=implant)._spatial_view()
-    # Normalized optical drive: dimensionless, 0 for a dark pixel and 1 for one
-    # at the largest documented drive.
+    # Normalized drive ranges from 0 to 1.
     npt.assert_equal(view.unit, dimensionless)
     npt.assert_equal(view.time, None)
     npt.assert_equal(view.shape, (378, 1))
     npt.assert_almost_equal(view.data.min(), 0)
     npt.assert_almost_equal(view.data.max(), 1, decimal=6)
-    # Every pixel's drive follows its own ON duration:
+    # Drive is proportional to ON duration at default settings.
     dur = PRIMAEncoder(grayscale=True).encode(
         ImageStimulus(ramp), implant=implant).pulse_dur[:, 0]
     npt.assert_almost_equal(view.data.ravel(), dur / 9.8, decimal=6)
 
-    # Turn any of the three factors down and the drive goes down with it:
+    # Drive scales with irradiance, frequency, and pulse duration.
     half = PRIMAEncoder(irradiance=1.75).encode(
         ImageStimulus(np.ones((8, 8))), implant=implant)._spatial_view()
     npt.assert_almost_equal(half.data.max(), 0.5, decimal=6)
@@ -1570,19 +1563,16 @@ def test_PRIMAEncoder_spatial_view():
 
 def test_PRIMAEncoder_video():
     implant = PRIMAPivotal()
-    # Three 40 ms frames, alternately lit and dark:
+    # Three 40 ms source frames.
     frames = np.stack([np.ones((8, 8)), np.zeros((8, 8)), np.ones((8, 8))],
                       axis=-1)
     video = VideoStimulus(frames, time=np.arange(3) * 40.0)
     stim = PRIMAEncoder().encode(video, implant=implant)
-    # The source keeps its own 120 ms; the projector clock only decides when
-    # the device looks at it, which here is four times.
+    # A 30 Hz projector samples the 120 ms source four times.
     npt.assert_almost_equal(stim.duration, 120)
     npt.assert_almost_equal(stim.metadata['encoder']['frame_dur'], 1000 / 30)
     npt.assert_equal(stim.pulse_dur.shape, (378, 4))
-    # Projector frames at 0, 33.3, 66.7 and 100 ms sample source frames 0, 0,
-    # 1 and 2: zero-order hold, so the lit frame is re-sent and nothing is
-    # invented in between.
+    # Zero-order hold samples source frames 0, 0, 1, and 2.
     npt.assert_array_almost_equal(stim.pulse_dur.max(axis=0),
                                   [9.8, 9.8, 0, 9.8])
     view = stim._spatial_view()
@@ -1593,9 +1583,7 @@ def test_PRIMAEncoder_video():
 
 @pytest.mark.parametrize('fps, n_source', [(15, 15), (30, 30), (60, 60)])
 def test_PRIMAEncoder_samples_a_video_without_retiming_it(fps, n_source):
-    # One second of video at three frame rates. The projector runs at 30 Hz
-    # whatever the source does, so a slow source has frames re-sent and a fast
-    # one has frames skipped -- but the content keeps its own duration.
+    # Source frame rate does not change the 30 Hz projector clock.
     implant = PRIMAPivotal()
     gray = np.zeros((8, 8, n_source))
     gray[..., ::max(1, n_source // 5)] = 1.0
@@ -1603,15 +1591,14 @@ def test_PRIMAEncoder_samples_a_video_without_retiming_it(fps, n_source):
     stim = PRIMAEncoder().encode(video, implant=implant)
     npt.assert_almost_equal(stim.duration, 1000)
     npt.assert_equal(stim.pulse_dur.shape[1], 30)
-    # Projector frames stay one 33.3 ms period apart, whatever the source rate:
+    # Projector frames remain 33.3 ms apart.
     npt.assert_almost_equal(np.diff(stim._spatial_view().time), 1000 / 30,
                             decimal=3)
 
 
 @pytest.mark.parametrize('fps', [15, 60])
 def test_PRIMAEncoder_repeats_slow_frames_and_skips_fast_ones(fps):
-    # One second of video whose frames alternate lit and dark, so which source
-    # frame the projector picked is visible in the drive it produced.
+    # Alternating source frames expose repeat/skip behavior.
     implant = PRIMAPivotal()
     gray = np.zeros((8, 8, fps))
     gray[..., ::2] = 1.0
@@ -1620,20 +1607,16 @@ def test_PRIMAEncoder_repeats_slow_frames_and_skips_fast_ones(fps):
     lit = stim.pulse_dur.max(axis=0) > 0
     npt.assert_equal(lit.size, 30)
     if fps == 15:
-        # Half the projector's rate: every source frame is sent twice, so the
-        # pattern comes out in pairs.
+        # At 15 fps, each source frame is sampled twice.
         npt.assert_array_equal(lit.reshape(-1, 2)[:, 0],
                                lit.reshape(-1, 2)[:, 1])
     else:
-        # Twice the projector's rate: only the even source frames are sampled,
-        # and those are the lit ones, so the dark frames never appear.
+        # At 60 fps, only even source frames are sampled.
         npt.assert_equal(lit.all(), True)
 
 
 def test_PRIMAEncoder_starts_where_the_source_does():
-    # A video need not start at t=0: cropping one keeps the timestamps it was
-    # cut from. The projector clock is anchored to the source, so nothing is
-    # projected before the first frame exists.
+    # Preserve nonzero source start times.
     implant = PRIMAPivotal()
     video = VideoStimulus(np.ones((8, 8, 3)),
                           time=100 + np.arange(3) * (1000 / 30))
@@ -1644,9 +1627,8 @@ def test_PRIMAEncoder_starts_where_the_source_does():
     # Dark until the source starts:
     npt.assert_almost_equal(stim.data[:, stim.time < 100].max(), 0)
 
-    # ... and the same through the operation that produces such a video.
-    # (`bottom`/`right` work around a spatial bounds check in `crop` that
-    # rejects the full frame; the time crop is what matters here.)
+    # Cropping also preserves the nonzero start time.
+    # bottom/right avoid an unrelated spatial bounds check in VideoStimulus.crop.
     gray = np.zeros((8, 8, 9))
     gray[..., 3:6] = 1.0
     cropped = VideoStimulus(gray, time=np.arange(9) * (1000 / 30)).crop(
@@ -1658,17 +1640,14 @@ def test_PRIMAEncoder_starts_where_the_source_does():
 
 
 def test_PRIMAEncoder_finishes_every_pulse_it_starts():
-    # The last projector period of a 40 ms source has only 6.7 ms left in it,
-    # which a 9.8 ms pulse does not fit into. Starting it anyway would leave
-    # the stimulus lit at the instant it says it is over.
+    # A 9.8 ms pulse does not fit in the final 6.7 ms of this source.
     implant = PRIMAPivotal()
     video = VideoStimulus(np.ones((8, 8, 2)), time=[0.0, 20.0])
     stim = PRIMAEncoder().encode(video, implant=implant)
     npt.assert_almost_equal(stim.duration, 40)
     npt.assert_array_almost_equal(stim.pulse_dur.max(axis=0), [9.8, 0])
     npt.assert_almost_equal(stim.data[:, -1].max(), 0)
-    # Nonzero durations stay on the hardware grid rather than being shortened
-    # to whatever happened to fit:
+    # Final pulses are dropped rather than shortened off-grid.
     kept = stim.pulse_dur[stim.pulse_dur > 0]
     npt.assert_almost_equal(kept / 0.7, np.round(kept / 0.7))
 
@@ -1678,20 +1657,20 @@ def test_PRIMAEncoder_defers_the_waveform():
     stim = PRIMAEncoder().encode(ImageStimulus(np.ones((16, 16))),
                                  implant=implant)
     npt.assert_equal(_rendered(stim), False)
-    # Everything the schedule already settled, without expanding it:
+    # Schedule properties do not require waveform rendering.
     npt.assert_almost_equal(stim.duration, 500)
     npt.assert_equal(stim.unit, mW / mm ** 2)
     npt.assert_equal(len(stim.electrodes), 378)
     npt.assert_almost_equal(stim.pulse_dur.max(), 9.8)
     npt.assert_equal(_rendered(stim._spatial_view()), True)
     npt.assert_equal(_rendered(stim), False)
-    # Preparing it, and dropping a deactivated pixel, both stay unexpanded:
+    # Preparation and electrode removal preserve laziness.
     npt.assert_equal(_rendered(implant.prepare_stim(stim)), False)
     implant.deactivate('A5')
     prepared = implant.prepare_stim(ImageStimulus(np.ones((16, 16))))
     npt.assert_equal(_rendered(prepared), False)
     npt.assert_equal(len(prepared.electrodes), 377)
-    # Only asking for samples builds them:
+    # Accessing samples renders the waveform.
     npt.assert_equal(stim.data.shape, (378, stim.time.size))
     npt.assert_equal(_rendered(stim), True)
 
@@ -1699,8 +1678,7 @@ def test_PRIMAEncoder_defers_the_waveform():
 def test_PRIMAEncoder_scales_the_power():
     stim = PRIMAEncoder().encode(ImageStimulus(np.ones((8, 8))),
                                  implant=PRIMAPivotal())
-    # Pulse duration is quantized onto a hardware grid, so a scale factor is
-    # optical power rather than timing:
+    # Scaling changes irradiance, not quantized pulse duration.
     scaled = stim * 0.5
     npt.assert_equal(_rendered(scaled), False)
     npt.assert_almost_equal(scaled.irradiance, 1.75)

--- a/pulse2percept/stimuli/tests/test_encoders.py
+++ b/pulse2percept/stimuli/tests/test_encoders.py
@@ -7,17 +7,19 @@ import pytest
 from scipy.integrate import trapezoid
 
 from pulse2percept.implants import (ArgusII, CustomRaster, DiskElectrode,
-                                    GridImplant, SequentialRaster)
+                                    GridImplant, PRIMAPivotal,
+                                    SequentialRaster)
 from pulse2percept.stimuli import (AmplitudeEncoder, BiphasicPulse,
-                                   BiphasicPulseTrain, BostonTrain,
+                                   BiphasicPulseTrain, BostonTrain, Encoder,
                                    FrequencyEncoder, ImageStimulus,
-                                   MonophasicPulse, Stimulus, StimulusEncoder,
-                                   VideoStimulus)
+                                   MonophasicPulse, PRIMAEncoder, Stimulus,
+                                   StimulusEncoder, VideoStimulus)
 from pulse2percept.stimuli import encoders
 from pulse2percept.utils.constants import DT
 from pulse2percept.utils.testing import assert_warns_msg
-from pulse2percept.units import (DimensionMismatchError, Hz, Quantity,
-                                 dimensionless, kHz, mA, ms, uA, us)
+from pulse2percept.units import (DimensionMismatchError, Hz, Quantity, W,
+                                 dimensionless, kHz, m, mA, mW, mm, ms, uA,
+                                 us)
 from pulse2percept.units import s as sec
 
 
@@ -1366,3 +1368,248 @@ def test_encoded_stimulus_survives_preparation_unrendered():
     stim = ArgusII(encoder=AmplitudeEncoder()).prepare_stim(img)
     npt.assert_equal(_rendered(stim), False)
     npt.assert_equal(stim.data.shape[0], 60)
+
+
+# -----------------------------------------------------------------------------
+# PRIMAEncoder
+# -----------------------------------------------------------------------------
+
+def on_intervals(stim, electrode=0):
+    """Length (ms) of every interval one pixel spends at peak irradiance"""
+    row, time = stim.data[electrode], stim.time
+    lit = row >= 0.99 * row.max() if row.max() > 0 else row > np.inf
+    edges = np.diff(np.concatenate(([0], lit.astype(int), [0])))
+    starts, stops = np.flatnonzero(edges > 0), np.flatnonzero(edges < 0) - 1
+    # The rise and the fall each take one DT outside the flat top:
+    return [time[b] - time[a] + 2 * DT for a, b in zip(starts, stops)]
+
+
+def test_PRIMAEncoder():
+    encoder = PRIMAEncoder()
+    npt.assert_almost_equal(encoder.irradiance, 3.5)
+    npt.assert_almost_equal(encoder.freq, 30)
+    npt.assert_almost_equal(encoder.pulse_dur, 9.8)
+    npt.assert_equal(encoder.grayscale, False)
+    npt.assert_almost_equal(encoder.threshold, 0.5)
+    npt.assert_almost_equal(encoder.period, 1000 / 30)
+    npt.assert_equal(encoder.n_levels, 14)
+    npt.assert_equal(isinstance(encoder, Encoder), True)
+    # Not an electrical encoder, and not schedulable like one:
+    npt.assert_equal(isinstance(encoder, StimulusEncoder), False)
+    npt.assert_equal('PRIMAEncoder' in str(encoder), True)
+
+    # Unitful spellings mean the same thing as the bare numbers:
+    unitful = PRIMAEncoder(irradiance=3500 * W / m ** 2, freq=0.03 * kHz,
+                           pulse_dur=9800 * us)
+    npt.assert_almost_equal(unitful.irradiance, 3.5)
+    npt.assert_almost_equal(unitful.freq, 30)
+    npt.assert_almost_equal(unitful.pulse_dur, 9.8)
+
+
+@pytest.mark.parametrize('kwargs', [
+    {'irradiance': 0}, {'irradiance': -1}, {'irradiance': np.inf},
+    {'freq': 0}, {'freq': -30}, {'freq': np.nan},
+    {'pulse_dur': -0.7}, {'pulse_dur': np.inf},
+    {'pulse_dur': 1.0},        # off the 0.7 ms hardware grid
+    {'pulse_dur': 10.5},       # a grid step, but past the documented maximum
+    {'freq': 200},             # a 9.8 ms pulse does not fit a 5 ms period
+    {'threshold': -0.1}, {'threshold': 1.5},
+])
+def test_PRIMAEncoder_rejects(kwargs):
+    with pytest.raises(ValueError):
+        PRIMAEncoder(**kwargs)
+
+
+def test_PRIMAEncoder_takes_a_picture():
+    implant = PRIMAPivotal()
+    with pytest.raises(DimensionMismatchError):
+        PRIMAEncoder().encode(Stimulus([[1, 0]] * uA, time=[0, 10]),
+                              implant=implant)
+    with pytest.raises(TypeError):
+        PRIMAEncoder().encode(np.ones((4, 4)), implant=implant)
+    # RGB becomes gray through the implant's own sampling path:
+    rgb = ImageStimulus(np.ones((8, 8, 3)))
+    npt.assert_equal(PRIMAEncoder().encode(rgb, implant=implant).shape[0], 378)
+
+
+@pytest.mark.parametrize('gray, n_lit', [(1.0, 378), (0.0, 0)])
+def test_PRIMAEncoder_binary_extremes(gray, n_lit):
+    implant = PRIMAPivotal()
+    stim = PRIMAEncoder().encode(ImageStimulus(np.full((16, 16), gray)),
+                                 implant=implant)
+    npt.assert_equal(stim.shape[0], 378)
+    npt.assert_equal(np.count_nonzero(stim.data.max(axis=1)), n_lit)
+    # All 378 pixels may be lit at once: there is no multiplexing to schedule.
+    npt.assert_equal(implant.raster, None)
+
+
+@pytest.mark.parametrize('threshold', [0.25, 0.5, 0.75])
+def test_PRIMAEncoder_threshold(threshold):
+    # A left-to-right ramp: exactly the pixels at or above threshold light up.
+    ramp = np.tile(np.linspace(0, 1, 32), (32, 1))
+    implant = PRIMAPivotal()
+    encoder = PRIMAEncoder(threshold=threshold)
+    gray = implant.reshape_stim(ImageStimulus(ramp)).data.ravel()
+    stim = encoder.encode(ImageStimulus(ramp), implant=implant)
+    dur = stim.metadata['encoder']['optical']['pulse_dur'].ravel()
+    npt.assert_array_equal(dur > 0, gray >= threshold)
+    # Binary means binary: a lit pixel gets the full pulse, whatever its gray
+    # level, and nothing in between exists.
+    npt.assert_array_equal(np.unique(dur), np.array([0.0, 9.8]))
+
+
+def test_PRIMAEncoder_optical_waveform():
+    implant = PRIMAPivotal()
+    stim = PRIMAEncoder().encode(ImageStimulus(np.ones((16, 16))),
+                                 implant=implant)
+    # Irradiance, not current:
+    npt.assert_equal(stim.unit, mW / mm ** 2)
+    npt.assert_equal(stim.unit.dimension, (W / m ** 2).dimension)
+    npt.assert_equal(stim.time_unit, ms)
+    npt.assert_almost_equal(stim.data.max(), 3.5)
+    npt.assert_almost_equal(stim.data.min(), 0)
+    # A picture with no time axis is held for the standard presentation, and
+    # the projector simply repeats over it:
+    npt.assert_almost_equal(stim.duration, 500)
+    intervals = on_intervals(stim)
+    npt.assert_equal(len(intervals), 15)
+    npt.assert_almost_equal(intervals, 9.8, decimal=6)
+    # 30 Hz: the pulses are one projector period apart.
+    onsets = stim.time[np.flatnonzero(np.diff(stim.data[0]) > 0)]
+    npt.assert_almost_equal(np.diff(onsets), 1000 / 30, decimal=3)
+    npt.assert_almost_equal(stim.metadata['encoder']['frame_dur'], 500)
+
+
+def test_PRIMAEncoder_irradiance_is_not_modulated():
+    implant = PRIMAPivotal()
+    ramp = np.tile(np.linspace(0, 1, 32), (32, 1))
+    stim = PRIMAEncoder(grayscale=True, irradiance=2.0).encode(
+        ImageStimulus(ramp), implant=implant)
+    lit = stim.data[stim.data > 0]
+    # Every lit pixel sees the same peak, however long it is lit for:
+    npt.assert_almost_equal(np.unique(np.round(lit, 6)), np.array([2.0]))
+
+
+def test_PRIMAEncoder_grayscale():
+    implant = PRIMAPivotal()
+    ramp = np.tile(np.linspace(0, 1, 64), (64, 1))
+    stim = PRIMAEncoder(grayscale=True).encode(ImageStimulus(ramp),
+                                               implant=implant)
+    dur = stim.metadata['encoder']['optical']['pulse_dur']
+    # Durations fall exactly on the 0.7 ms hardware grid, 0 through 9.8 ms:
+    npt.assert_almost_equal(dur / 0.7, np.round(dur / 0.7))
+    npt.assert_almost_equal(dur.min(), 0)
+    npt.assert_almost_equal(dur.max(), 9.8)
+    npt.assert_equal(np.unique(np.round(dur, 6)).size > 2, True)
+    npt.assert_equal(stim.metadata['encoder']['optical']['grayscale'], True)
+    # The gray level a pixel saw picks its level, one step at a time:
+    gray = implant.reshape_stim(ImageStimulus(ramp)).data
+    npt.assert_almost_equal(dur, np.round(gray * 14) * 0.7, decimal=6)
+
+    # A lower maximum offers only the levels up through that maximum:
+    coarse = PRIMAEncoder(grayscale=True, pulse_dur=2.1).encode(
+        ImageStimulus(ramp), implant=implant)
+    levels = np.unique(coarse.metadata['encoder']['optical']['pulse_dur'])
+    npt.assert_almost_equal(levels, np.array([0.0, 0.7, 1.4, 2.1]))
+
+
+def test_PRIMAEncoder_records_its_settings():
+    stim = PRIMAEncoder(grayscale=True).encode(
+        ImageStimulus(np.ones((8, 8))), implant=PRIMAPivotal())
+    optical = stim.metadata['encoder']['optical']
+    npt.assert_equal(sorted(optical),
+                     ['freq', 'grayscale', 'irradiance', 'pulse_dur',
+                      'wavelength'])
+    npt.assert_almost_equal(optical['wavelength'], 880)
+    npt.assert_almost_equal(optical['irradiance'], 3.5)
+    npt.assert_almost_equal(optical['freq'], 30)
+    npt.assert_equal(optical['pulse_dur'].shape, (378, 1))
+    # ... and the same values are readable off the stimulus itself:
+    npt.assert_almost_equal(stim.wavelength, 880)
+    npt.assert_almost_equal(stim.irradiance, 3.5)
+    npt.assert_almost_equal(stim.freq, 30)
+    npt.assert_almost_equal(stim.duty_cycle.max(), 0.294)
+
+
+def test_PRIMAEncoder_spatial_view():
+    implant = PRIMAPivotal()
+    ramp = np.tile(np.linspace(0, 1, 64), (64, 1))
+    view = PRIMAEncoder(grayscale=True).encode(
+        ImageStimulus(ramp), implant=implant)._spatial_view()
+    # Normalized optical drive: dimensionless, 0 for a dark pixel and 1 for one
+    # at the largest documented drive.
+    npt.assert_equal(view.unit, dimensionless)
+    npt.assert_equal(view.time, None)
+    npt.assert_equal(view.shape, (378, 1))
+    npt.assert_almost_equal(view.data.min(), 0)
+    npt.assert_almost_equal(view.data.max(), 1, decimal=6)
+    # Every pixel's drive follows its own ON duration:
+    dur = PRIMAEncoder(grayscale=True).encode(
+        ImageStimulus(ramp), implant=implant).pulse_dur
+    npt.assert_almost_equal(view.data.ravel(), (dur / 9.8).ravel(), decimal=6)
+
+    # Turn any of the three factors down and the drive goes down with it:
+    half = PRIMAEncoder(irradiance=1.75).encode(
+        ImageStimulus(np.ones((8, 8))), implant=implant)._spatial_view()
+    npt.assert_almost_equal(half.data.max(), 0.5, decimal=6)
+    half = PRIMAEncoder(freq=15).encode(
+        ImageStimulus(np.ones((8, 8))), implant=implant)._spatial_view()
+    npt.assert_almost_equal(half.data.max(), 0.5, decimal=6)
+    half = PRIMAEncoder(pulse_dur=4.9).encode(
+        ImageStimulus(np.ones((8, 8))), implant=implant)._spatial_view()
+    npt.assert_almost_equal(half.data.max(), 0.5, decimal=6)
+
+
+def test_PRIMAEncoder_video():
+    implant = PRIMAPivotal()
+    # Three frames, alternately lit and dark:
+    frames = np.stack([np.ones((8, 8)), np.zeros((8, 8)), np.ones((8, 8))],
+                      axis=-1)
+    video = VideoStimulus(frames, time=np.arange(3) * 40.0)
+    stim = PRIMAEncoder().encode(video, implant=implant)
+    # The projector clock, not the movie's: one source frame per period.
+    npt.assert_almost_equal(stim.duration, 3 * 1000 / 30)
+    npt.assert_almost_equal(stim.metadata['encoder']['frame_dur'], 1000 / 30)
+    npt.assert_equal(stim.metadata['encoder']['optical']['pulse_dur'].shape,
+                     (378, 3))
+    intervals = on_intervals(stim)
+    npt.assert_equal(len(intervals), 2)
+    npt.assert_almost_equal(intervals, 9.8, decimal=6)
+    view = stim._spatial_view()
+    npt.assert_equal(view.shape, (378, 3))
+    npt.assert_almost_equal(view.data.max(axis=0), [1, 0, 1], decimal=6)
+
+
+def test_PRIMAEncoder_defers_the_waveform():
+    implant = PRIMAPivotal()
+    stim = PRIMAEncoder().encode(ImageStimulus(np.ones((16, 16))),
+                                 implant=implant)
+    npt.assert_equal(_rendered(stim), False)
+    # Everything the schedule already settled, without expanding it:
+    npt.assert_almost_equal(stim.duration, 500)
+    npt.assert_equal(stim.unit, mW / mm ** 2)
+    npt.assert_equal(len(stim.electrodes), 378)
+    npt.assert_almost_equal(stim.pulse_dur.max(), 9.8)
+    npt.assert_equal(_rendered(stim._spatial_view()), True)
+    npt.assert_equal(_rendered(stim), False)
+    # Preparing it, and dropping a deactivated pixel, both stay unexpanded:
+    npt.assert_equal(_rendered(implant.prepare_stim(stim)), False)
+    implant.deactivate('A5')
+    prepared = implant.prepare_stim(ImageStimulus(np.ones((16, 16))))
+    npt.assert_equal(_rendered(prepared), False)
+    npt.assert_equal(len(prepared.electrodes), 377)
+    # Only asking for samples builds them:
+    npt.assert_equal(stim.data.shape, (378, stim.time.size))
+    npt.assert_equal(_rendered(stim), True)
+
+
+def test_PRIMAEncoder_scales_the_power():
+    stim = PRIMAEncoder().encode(ImageStimulus(np.ones((8, 8))),
+                                 implant=PRIMAPivotal())
+    # Pulse duration is quantized onto a hardware grid, so a scale factor is
+    # optical power rather than timing:
+    scaled = stim * 0.5
+    npt.assert_equal(_rendered(scaled), False)
+    npt.assert_almost_equal(scaled.irradiance, 1.75)
+    npt.assert_array_almost_equal(scaled.pulse_dur, stim.pulse_dur)
+    npt.assert_almost_equal(scaled.data.max(), 1.75)

--- a/pulse2percept/stimuli/tests/test_encoders.py
+++ b/pulse2percept/stimuli/tests/test_encoders.py
@@ -1389,7 +1389,9 @@ def test_PRIMAEncoder():
     npt.assert_almost_equal(encoder.irradiance, 3.5)
     npt.assert_almost_equal(encoder.freq, 30)
     npt.assert_almost_equal(encoder.pulse_dur, 9.8)
-    npt.assert_equal(encoder.grayscale, False)
+    # The projector's own 14-level pulse-width modulation is the default; the
+    # 0.5 threshold only applies to the binary mode users opt into.
+    npt.assert_equal(encoder.grayscale, True)
     npt.assert_almost_equal(encoder.threshold, 0.5)
     npt.assert_almost_equal(encoder.period, 1000 / 30)
     npt.assert_equal(encoder.n_levels, 14)
@@ -1432,11 +1434,13 @@ def test_PRIMAEncoder_takes_a_picture():
     npt.assert_equal(PRIMAEncoder().encode(rgb, implant=implant).shape[0], 378)
 
 
+@pytest.mark.parametrize('grayscale', [True, False])
 @pytest.mark.parametrize('gray, n_lit', [(1.0, 378), (0.0, 0)])
-def test_PRIMAEncoder_binary_extremes(gray, n_lit):
+def test_PRIMAEncoder_extremes(gray, n_lit, grayscale):
+    # Black is off and white is the brightest level, in either mode:
     implant = PRIMAPivotal()
-    stim = PRIMAEncoder().encode(ImageStimulus(np.full((16, 16), gray)),
-                                 implant=implant)
+    stim = PRIMAEncoder(grayscale=grayscale).encode(
+        ImageStimulus(np.full((16, 16), gray)), implant=implant)
     npt.assert_equal(stim.shape[0], 378)
     npt.assert_equal(np.count_nonzero(stim.data.max(axis=1)), n_lit)
     # All 378 pixels may be lit at once: there is no multiplexing to schedule.
@@ -1448,7 +1452,7 @@ def test_PRIMAEncoder_threshold(threshold):
     # A left-to-right ramp: exactly the pixels at or above threshold light up.
     ramp = np.tile(np.linspace(0, 1, 32), (32, 1))
     implant = PRIMAPivotal()
-    encoder = PRIMAEncoder(threshold=threshold)
+    encoder = PRIMAEncoder(grayscale=False, threshold=threshold)
     gray = implant.reshape_stim(ImageStimulus(ramp)).data.ravel()
     stim = encoder.encode(ImageStimulus(ramp), implant=implant)
     dur = stim.pulse_dur

--- a/pulse2percept/stimuli/tests/test_encoders.py
+++ b/pulse2percept/stimuli/tests/test_encoders.py
@@ -1451,7 +1451,11 @@ def test_PRIMAEncoder_threshold(threshold):
     encoder = PRIMAEncoder(threshold=threshold)
     gray = implant.reshape_stim(ImageStimulus(ramp)).data.ravel()
     stim = encoder.encode(ImageStimulus(ramp), implant=implant)
-    dur = stim.metadata['encoder']['optical']['pulse_dur'].ravel()
+    dur = stim.pulse_dur
+    # A still picture shows the same frame in every projector period:
+    npt.assert_equal(dur.shape, (378, 15))
+    npt.assert_equal(np.all(dur == dur[:, :1]), True)
+    dur = dur[:, 0]
     npt.assert_array_equal(dur > 0, gray >= threshold)
     # Binary means binary: a lit pixel gets the full pulse, whatever its gray
     # level, and nothing in between exists.
@@ -1495,13 +1499,13 @@ def test_PRIMAEncoder_grayscale():
     ramp = np.tile(np.linspace(0, 1, 64), (64, 1))
     stim = PRIMAEncoder(grayscale=True).encode(ImageStimulus(ramp),
                                                implant=implant)
-    dur = stim.metadata['encoder']['optical']['pulse_dur']
+    dur = stim.pulse_dur[:, :1]
     # Durations fall exactly on the 0.7 ms hardware grid, 0 through 9.8 ms:
     npt.assert_almost_equal(dur / 0.7, np.round(dur / 0.7))
     npt.assert_almost_equal(dur.min(), 0)
     npt.assert_almost_equal(dur.max(), 9.8)
     npt.assert_equal(np.unique(np.round(dur, 6)).size > 2, True)
-    npt.assert_equal(stim.metadata['encoder']['optical']['grayscale'], True)
+    npt.assert_equal(stim.grayscale, True)
     # The gray level a pixel saw picks its level, one step at a time:
     gray = implant.reshape_stim(ImageStimulus(ramp)).data
     npt.assert_almost_equal(dur, np.round(gray * 14) * 0.7, decimal=6)
@@ -1509,26 +1513,26 @@ def test_PRIMAEncoder_grayscale():
     # A lower maximum offers only the levels up through that maximum:
     coarse = PRIMAEncoder(grayscale=True, pulse_dur=2.1).encode(
         ImageStimulus(ramp), implant=implant)
-    levels = np.unique(coarse.metadata['encoder']['optical']['pulse_dur'])
+    levels = np.unique(coarse.pulse_dur)
     npt.assert_almost_equal(levels, np.array([0.0, 0.7, 1.4, 2.1]))
 
 
 def test_PRIMAEncoder_records_its_settings():
     stim = PRIMAEncoder(grayscale=True).encode(
         ImageStimulus(np.ones((8, 8))), implant=PRIMAPivotal())
-    optical = stim.metadata['encoder']['optical']
-    npt.assert_equal(sorted(optical),
-                     ['freq', 'grayscale', 'irradiance', 'pulse_dur',
-                      'wavelength'])
-    npt.assert_almost_equal(optical['wavelength'], 880)
-    npt.assert_almost_equal(optical['irradiance'], 3.5)
-    npt.assert_almost_equal(optical['freq'], 30)
-    npt.assert_equal(optical['pulse_dur'].shape, (378, 1))
-    # ... and the same values are readable off the stimulus itself:
+    # The projector settings are the stimulus' own state, readable without
+    # rendering a waveform:
     npt.assert_almost_equal(stim.wavelength, 880)
     npt.assert_almost_equal(stim.irradiance, 3.5)
     npt.assert_almost_equal(stim.freq, 30)
+    npt.assert_almost_equal(stim.pulse_dur.max(), 9.8)
     npt.assert_almost_equal(stim.duty_cycle.max(), 0.294)
+    npt.assert_equal(stim.grayscale, True)
+    # They are deliberately *not* mirrored into metadata, which is an ordinary
+    # mutable dict that arithmetic may copy onto a waveform it no longer
+    # describes. Only the frame clock lives there:
+    npt.assert_equal(sorted(stim.metadata['encoder']),
+                     ['frame_dur', 'frame_time'])
 
 
 def test_PRIMAEncoder_spatial_view():
@@ -1545,8 +1549,8 @@ def test_PRIMAEncoder_spatial_view():
     npt.assert_almost_equal(view.data.max(), 1, decimal=6)
     # Every pixel's drive follows its own ON duration:
     dur = PRIMAEncoder(grayscale=True).encode(
-        ImageStimulus(ramp), implant=implant).pulse_dur
-    npt.assert_almost_equal(view.data.ravel(), (dur / 9.8).ravel(), decimal=6)
+        ImageStimulus(ramp), implant=implant).pulse_dur[:, 0]
+    npt.assert_almost_equal(view.data.ravel(), dur / 9.8, decimal=6)
 
     # Turn any of the three factors down and the drive goes down with it:
     half = PRIMAEncoder(irradiance=1.75).encode(
@@ -1562,22 +1566,42 @@ def test_PRIMAEncoder_spatial_view():
 
 def test_PRIMAEncoder_video():
     implant = PRIMAPivotal()
-    # Three frames, alternately lit and dark:
+    # Three 40 ms frames, alternately lit and dark:
     frames = np.stack([np.ones((8, 8)), np.zeros((8, 8)), np.ones((8, 8))],
                       axis=-1)
     video = VideoStimulus(frames, time=np.arange(3) * 40.0)
     stim = PRIMAEncoder().encode(video, implant=implant)
-    # The projector clock, not the movie's: one source frame per period.
-    npt.assert_almost_equal(stim.duration, 3 * 1000 / 30)
+    # The source keeps its own 120 ms; the projector clock only decides when
+    # the device looks at it, which here is four times.
+    npt.assert_almost_equal(stim.duration, 120)
     npt.assert_almost_equal(stim.metadata['encoder']['frame_dur'], 1000 / 30)
-    npt.assert_equal(stim.metadata['encoder']['optical']['pulse_dur'].shape,
-                     (378, 3))
-    intervals = on_intervals(stim)
-    npt.assert_equal(len(intervals), 2)
-    npt.assert_almost_equal(intervals, 9.8, decimal=6)
+    npt.assert_equal(stim.pulse_dur.shape, (378, 4))
+    # Projector frames at 0, 33.3, 66.7 and 100 ms sample source frames 0, 0,
+    # 1 and 2: zero-order hold, so the lit frame is re-sent and nothing is
+    # invented in between.
+    npt.assert_array_almost_equal(stim.pulse_dur.max(axis=0),
+                                  [9.8, 9.8, 0, 9.8])
     view = stim._spatial_view()
-    npt.assert_equal(view.shape, (378, 3))
-    npt.assert_almost_equal(view.data.max(axis=0), [1, 0, 1], decimal=6)
+    npt.assert_equal(view.shape, (378, 4))
+    npt.assert_almost_equal(view.data.max(axis=0), [1, 1, 0, 1], decimal=6)
+    npt.assert_almost_equal(view.time, np.arange(4) * (1000 / 30), decimal=3)
+
+
+@pytest.mark.parametrize('fps, n_source', [(15, 15), (30, 30), (60, 60)])
+def test_PRIMAEncoder_samples_a_video_without_retiming_it(fps, n_source):
+    # One second of video at three frame rates. The projector runs at 30 Hz
+    # whatever the source does, so a slow source has frames re-sent and a fast
+    # one has frames skipped -- but the content keeps its own duration.
+    implant = PRIMAPivotal()
+    gray = np.zeros((8, 8, n_source))
+    gray[..., ::max(1, n_source // 5)] = 1.0
+    video = VideoStimulus(gray, time=np.arange(n_source) * (1000.0 / fps))
+    stim = PRIMAEncoder().encode(video, implant=implant)
+    npt.assert_almost_equal(stim.duration, 1000)
+    npt.assert_equal(stim.pulse_dur.shape[1], 30)
+    # Projector frames stay one 33.3 ms period apart, whatever the source rate:
+    npt.assert_almost_equal(np.diff(stim._spatial_view().time), 1000 / 30,
+                            decimal=3)
 
 
 def test_PRIMAEncoder_defers_the_waveform():

--- a/pulse2percept/units/__init__.py
+++ b/pulse2percept/units/__init__.py
@@ -20,6 +20,8 @@ from .base import (Dimension, Unit, Quantity, DimensionMismatchError, as_value,
                    A, mA, uA, nA,
                    # voltage
                    V, mV, uV,
+                   # power
+                   W, mW, uW,
                    # charge
                    C, mC, uC, nC,
                    # angle
@@ -41,6 +43,7 @@ __all__ = [
     'm', 'cm', 'mm', 'um', 'nm',
     'A', 'mA', 'uA', 'nA',
     'V', 'mV', 'uV',
+    'W', 'mW', 'uW',
     'C', 'mC', 'uC', 'nC',
     'rad', 'deg',
     'dva',

--- a/pulse2percept/units/base.py
+++ b/pulse2percept/units/base.py
@@ -28,6 +28,8 @@ _DERIVED_LABELS = {
     (1, 0, 1, 0, 0, 0, 0): 'charge',
     (0, -2, 1, 0, 0, 0, 0): 'current density',
     (1, -2, 1, 0, 0, 0, 0): 'charge density',
+    (0, 0, 1, 1, 0, 0, 0): 'power',
+    (0, -2, 1, 1, 0, 0, 0): 'irradiance',
 }
 
 
@@ -755,6 +757,9 @@ VISUAL_ANGLE = Dimension(visual_angle=1)
 THRESHOLD_RATIO = Dimension(threshold_ratio=1)
 FREQUENCY = TIME ** -1
 CHARGE = CURRENT * TIME
+# Optical power, for photovoltaic implants. Not a new base dimension: power is
+# voltage times current, and irradiance is then ``mW / mm ** 2``.
+POWER = VOLTAGE * CURRENT
 
 #: The unit of a plain number, used for image intensities and other
 #: dimensionless data
@@ -801,6 +806,13 @@ mV = Unit(VOLTAGE, 1e-3, 'mV')
 #: Microvolt
 uV = Unit(VOLTAGE, 1e-6, 'uV')
 
+#: Watt
+W = Unit(POWER, 1, 'W')
+#: Milliwatt
+mW = Unit(POWER, 1e-3, 'mW')
+#: Microwatt
+uW = Unit(POWER, 1e-6, 'uW')
+
 #: Coulomb
 C = Unit(CHARGE, 1, 'C')
 #: Millicoulomb
@@ -840,6 +852,7 @@ _CANONICAL_UNITS = (dimensionless,
                     m, cm, mm, um, nm,
                     A, mA, uA, nA,
                     V, mV, uV,
+                    W, mW, uW,
                     C, mC, uC, nC,
                     rad, deg,
                     dva, xTh)

--- a/pulse2percept/units/tests/test_integration.py
+++ b/pulse2percept/units/tests/test_integration.py
@@ -239,16 +239,16 @@ def test_the_whole_rejection_matrix():
 
     # dimensionless -> model: gray levels are not small currents. The implant
     # above is the outer boundary; this is the one behind it, so it is reached
-    # through an implant that claims to deliver something else. Scoreboard is
-    # the deliberate exception -- it reads the normalized optical drive of a
-    # photovoltaic implant (see `PRIMAEncoder`) -- so the check lands on a
-    # model that has no such reading.
+    # through an implant that claims to deliver something else. Scoreboard does
+    # read one dimensionless quantity -- the normalized optical drive of a
+    # photovoltaic implant (see `PRIMAEncoder`) -- and still refuses a picture,
+    # because a picture does not claim to be an encoded drive.
     class Projector(ArgusII):
         stimulus_unit = dimensionless
 
     with pytest.raises(DimensionMismatchError):
-        AxonMapSpatial(implant=Projector(preprocess=False), xrange=(-2, 2),
-                       yrange=(-2, 2), step=1).build().predict_percept(img)
+        ScoreboardSpatial(implant=Projector(preprocess=False), xrange=(-2, 2),
+                          yrange=(-2, 2), step=1).build().predict_percept(img)
 
     # current -> encoder: an encoder is what *makes* current out of pictures.
     with pytest.raises(DimensionMismatchError):

--- a/pulse2percept/units/tests/test_integration.py
+++ b/pulse2percept/units/tests/test_integration.py
@@ -239,13 +239,16 @@ def test_the_whole_rejection_matrix():
 
     # dimensionless -> model: gray levels are not small currents. The implant
     # above is the outer boundary; this is the one behind it, so it is reached
-    # through an implant that claims to deliver something else.
+    # through an implant that claims to deliver something else. Scoreboard is
+    # the deliberate exception -- it reads the normalized optical drive of a
+    # photovoltaic implant (see `PRIMAEncoder`) -- so the check lands on a
+    # model that has no such reading.
     class Projector(ArgusII):
         stimulus_unit = dimensionless
 
     with pytest.raises(DimensionMismatchError):
-        ScoreboardSpatial(implant=Projector(preprocess=False), xrange=(-2, 2),
-                          yrange=(-2, 2), step=1).build().predict_percept(img)
+        AxonMapSpatial(implant=Projector(preprocess=False), xrange=(-2, 2),
+                       yrange=(-2, 2), step=1).build().predict_percept(img)
 
     # current -> encoder: an encoder is what *makes* current out of pictures.
     with pytest.raises(DimensionMismatchError):

--- a/pulse2percept/units/tests/test_units.py
+++ b/pulse2percept/units/tests/test_units.py
@@ -10,7 +10,8 @@ from pulse2percept.units import (Dimension, Unit, Quantity,
                                  DimensionMismatchError, as_value,
                                  dimensionless,
                                  s, ms, us, ns, Hz, kHz, m, cm, mm, um, nm,
-                                 A, mA, uA, nA, V, mV, uV, C, mC, uC, nC, deg,
+                                 A, mA, uA, nA, V, mV, uV, W, mW, uW,
+                                 C, mC, uC, nC, deg,
                                  rad, dva, xTh)
 from pulse2percept.units.base import (TIME, _CANONICAL_SYMBOLS,
                                       _CANONICAL_UNITS)
@@ -160,6 +161,8 @@ def test_unit_vocabulary():
                              (nA, 1e-9, 'electric current'),
                              (V, 1, 'voltage'), (mV, 1e-3, 'voltage'),
                              (uV, 1e-6, 'voltage'),
+                             (W, 1, 'power'), (mW, 1e-3, 'power'),
+                             (uW, 1e-6, 'power'),
                              (C, 1, 'charge'), (mC, 1e-3, 'charge'),
                              (uC, 1e-6, 'charge'), (nC, 1e-9, 'charge'),
                              (rad, 1, 'angle'), (deg, np.pi / 180, 'angle'),
@@ -326,6 +329,22 @@ def test_dimensionless_compound_units():
     # Quantity-to-quantity comparison already converted, and still does:
     npt.assert_equal(duty == 0.0225 * dimensionless, True)
     npt.assert_equal(ratio == 1000 * dimensionless, True)
+
+
+def test_power_and_irradiance():
+    # Power is not a new base dimension: it is voltage times current, so the
+    # unit algebra already knows what a watt is.
+    npt.assert_equal((V * A).dimension, W.dimension)
+    npt.assert_equal((1 * V * A).to_value(W), 1)
+    npt.assert_equal((1 * W).to_value(mW), 1000)
+    # Irradiance is then just power per area, whichever way it is spelled:
+    npt.assert_equal(3500 * W / m ** 2 == 3.5 * mW / mm ** 2, True)
+    npt.assert_almost_equal((3.5 * mW / mm ** 2).to_value(W / m ** 2), 3500)
+    npt.assert_equal((mW / mm ** 2).dimension.name, 'irradiance')
+    npt.assert_equal(str(mW / mm ** 2), 'mW/mm^2')
+    # ... and it is not a current density, however similar the two look:
+    with pytest.raises(DimensionMismatchError):
+        (3.5 * mW / mm ** 2).to_value(uA / mm ** 2)
 
 
 def test_Quantity_arrays():


### PR DESCRIPTION
Adds a device-specific encoding pipeline for `PRIMAPivotal`, mapping images and videos to 880 nm optical stimulation rather than electrical current.

- [x] adds optical power/irradiance units and a generic `Encoder` base class
- [x] adds `PRIMAEncoder` with binary and PWM grayscale encoding, projector timing, and documented device-envelope checks
keeps encoded optical waveforms lazy
- [x] allows `ScoreboardModel` to visualize normalized optical drive for PRIMA without pretending to model photovoltaic or retinal transduction
- [x] adds tests, docs, and a gallery example

Photovoltaic circuit and retinal-response modeling remain out of scope.