### PR TITLE
[FIX] [ENH] Support encoded images in BiphasicAxonMapModel

### DIFF
--- a/doc/users/release_notes.rst
+++ b/doc/users/release_notes.rst
@@ -61,6 +61,10 @@ API changes:
   ``PRIMA40`` become ``Ho2019FlatArray(55)``/``Ho2019FlatArray(40)``.
   The old names are deprecated until 0.12.0 (:pull:`865`).
 
+* :py:class:`~pulse2percept.implants.ProsthesisSystem` and
+  :py:class:`~pulse2percept.implants.ArgusII` take ``thresholds`` at
+  construction, e.g. ``ArgusII(thresholds=80 * uA)``.
+
 * New ``deg`` and ``rad`` units for ordinary geometric angle, accepted
   wherever p2p already took an angle in degrees.
 

--- a/doc/users/release_notes.rst
+++ b/doc/users/release_notes.rst
@@ -65,6 +65,11 @@ API changes:
   :py:class:`~pulse2percept.implants.ArgusII` take ``thresholds`` at
   construction, e.g. ``ArgusII(thresholds=80 * uA)``.
 
+* :py:class:`~pulse2percept.stimuli.AmplitudeEncoder` accepts an ``amp_range``
+  in threshold multiples, e.g. ``amp_range=(0 * xTh, 3 * xTh)``. The encoded
+  stimulus stays in ``xTh`` until the implant calibrates it against its
+  ``thresholds``. Bare numbers still mean uA.
+
 * New ``deg`` and ``rad`` units for ordinary geometric angle, accepted
   wherever p2p already took an angle in degrees.
 

--- a/doc/users/release_notes.rst
+++ b/doc/users/release_notes.rst
@@ -82,6 +82,10 @@ API changes:
 
 Bug fixes:
 
+* :py:class:`~pulse2percept.models.BiphasicAxonMapSpatial` ignored ``n_gray``
+  and ``noise``, and stored only the stimulus metadata (not the stimulus) under
+  ``percept.metadata['stim']`` (:issue:`864`).
+
 * A hexagonal :py:class:`~pulse2percept.implants.ElectrodeGrid` with a single
   row (or, in vertical orientation, a single column) is now centered on
   ``(x, y)`` rather than offset by a quarter of the electrode spacing

--- a/doc/users/release_notes.rst
+++ b/doc/users/release_notes.rst
@@ -70,6 +70,12 @@ API changes:
   stimulus stays in ``xTh`` until the implant calibrates it against its
   ``thresholds``. Bare numbers still mean uA.
 
+* :py:class:`~pulse2percept.models.BiphasicAxonMapModel` predicts from a still
+  image encoded with the standard biphasic encoder pulse, not only from
+  retained :py:class:`~pulse2percept.stimuli.BiphasicPulseTrain` objects. It
+  reads the requested amplitude, frequency and phase duration, so a
+  :py:class:`~pulse2percept.implants.Raster` does not change the percept.
+
 * New ``deg`` and ``rad`` units for ordinary geometric angle, accepted
   wherever p2p already took an angle in degrees.
 

--- a/doc/users/release_notes.rst
+++ b/doc/users/release_notes.rst
@@ -101,7 +101,7 @@ Bug fixes:
 
 * :py:class:`~pulse2percept.models.BiphasicAxonMapSpatial` ignored ``n_gray``
   and ``noise``, and stored only the stimulus metadata (not the stimulus) under
-  ``percept.metadata['stim']`` (:issue:`864`).
+  ``percept.metadata['stim']`` (:pull:`869`).
 
 * A hexagonal :py:class:`~pulse2percept.implants.ElectrodeGrid` with a single
   row (or, in vertical orientation, a single column) is now centered on

--- a/doc/users/release_notes.rst
+++ b/doc/users/release_notes.rst
@@ -73,8 +73,10 @@ API changes:
 * :py:class:`~pulse2percept.models.BiphasicAxonMapModel` predicts from a still
   image encoded with the standard biphasic encoder pulse, not only from
   retained :py:class:`~pulse2percept.stimuli.BiphasicPulseTrain` objects. It
-  reads the requested amplitude, frequency and phase duration, so a
-  :py:class:`~pulse2percept.implants.Raster` does not change the percept.
+  reads amplitude, phase duration and the realized frequency, ignoring
+  pulse-onset timing, so a :py:class:`~pulse2percept.implants.Raster` leaves
+  amplitude encoding unchanged while a period the device lengthens is
+  respected.
 
 * New ``deg`` and ``rad`` units for ordinary geometric angle, accepted
   wherever p2p already took an angle in degrees.

--- a/pulse2percept/implants/argus.py
+++ b/pulse2percept/implants/argus.py
@@ -316,8 +316,7 @@ class ArgusII(ProsthesisSystem):
             # Assign the new ordered dict to earray:
             self.earray._electrodes = electrodes
 
-        # Set last: per-electrode thresholds are keyed by the final electrode
-        # names, which the left-eye branch above rewrites.
+        # Set after left-eye electrode renaming:
         self.thresholds = thresholds
 
     def _pprint_params(self):

--- a/pulse2percept/implants/argus.py
+++ b/pulse2percept/implants/argus.py
@@ -230,6 +230,14 @@ class ArgusII(ProsthesisSystem):
         ``raster=None`` to drive every electrode at once.
 
         .. versionadded:: 0.10.0
+    thresholds : float, Quantity, or dict, optional
+        Perceptual threshold current (uA) of the participant this device is
+        modeling, used to calibrate threshold-relative (``xTh``) stimuli. A
+        scalar applies to every electrode; a dict calibrates the named
+        electrodes only. See
+        :py:attr:`~pulse2percept.implants.ProsthesisSystem.thresholds`.
+
+        .. versionadded:: 0.11.0
 
     Examples
     --------
@@ -267,7 +275,7 @@ class ArgusII(ProsthesisSystem):
 
     def __init__(self, x=0, y=0, z=0, rot=0, eye='RE', preprocess=True,
                  safe_mode=False, encoder=_DEVICE_DEFAULT,
-                 raster=_DEVICE_DEFAULT):
+                 raster=_DEVICE_DEFAULT, thresholds=None):
         self.safe_mode = safe_mode
         self.preprocess = preprocess
         self.shape = (6, 10)
@@ -307,6 +315,10 @@ class ArgusII(ProsthesisSystem):
                 electrodes.update({name: obj})
             # Assign the new ordered dict to earray:
             self.earray._electrodes = electrodes
+
+        # Set last: per-electrode thresholds are keyed by the final electrode
+        # names, which the left-eye branch above rewrites.
+        self.thresholds = thresholds
 
     def _pprint_params(self):
         """Return dict of class attributes to pretty-print"""

--- a/pulse2percept/implants/base.py
+++ b/pulse2percept/implants/base.py
@@ -13,6 +13,7 @@ from .rasters import Raster
 from ..stimuli import (BiphasicPulseTrain, Encoder, Stimulus, ImageStimulus,
                        VideoStimulus)
 from ..stimuli.base import _describe_unit
+from ..stimuli.encoders import _EncodedStimulus
 from ..stimuli.pulse_trains import _as_threshold_amp
 from ..units import DimensionMismatchError, as_value, uA, um, xTh
 from ..utils import PrettyPrint, deprecated
@@ -241,11 +242,15 @@ class ProsthesisSystem(PrettyPrint):
         return normalized
 
     def _calibrated(self, stim):
-        """Apply implant thresholds to retained ``BiphasicPulseTrain`` sources.
+        """Apply implant thresholds to retained threshold-relative sources.
 
         Return ``stim`` unchanged if no source needs recalibration.
         """
         thresholds = getattr(self, '_thresholds', None) or {}
+        if isinstance(stim, _EncodedStimulus):
+            # An encoded schedule covers every electrode at once, so it
+            # calibrates itself rather than being taken apart source by source.
+            return stim._with_thresholds(thresholds)
         sources = stim._structured_sources()
         if sources is None:
             return stim

--- a/pulse2percept/implants/base.py
+++ b/pulse2percept/implants/base.py
@@ -129,8 +129,7 @@ class ProsthesisSystem(PrettyPrint):
         self.encoder = encoder
         self.raster = raster
         self.max_current = max_current
-        # Normalizing per-electrode thresholds needs the electrode names, so
-        # the array must already be in place:
+        # Threshold normalization needs electrode names:
         self.thresholds = thresholds
 
     def _pprint_params(self):
@@ -248,8 +247,6 @@ class ProsthesisSystem(PrettyPrint):
         """
         thresholds = getattr(self, '_thresholds', None) or {}
         if isinstance(stim, _EncodedStimulus):
-            # An encoded schedule covers every electrode at once, so it
-            # calibrates itself rather than being taken apart source by source.
             return stim._with_thresholds(thresholds)
         sources = stim._structured_sources()
         if sources is None:

--- a/pulse2percept/implants/base.py
+++ b/pulse2percept/implants/base.py
@@ -80,6 +80,13 @@ class ProsthesisSystem(PrettyPrint):
         (e.g. ``0.1 * mA``); see :py:mod:`pulse2percept.units`.
 
         .. versionadded:: 0.10.0
+    thresholds : float, Quantity, or dict, optional
+        Perceptual threshold current (uA) used to calibrate threshold-relative
+        (``xTh``) stimuli. A scalar applies to every electrode; a dict
+        calibrates the named electrodes only. See
+        :py:attr:`~pulse2percept.implants.ProsthesisSystem.thresholds`.
+
+        .. versionadded:: 0.11.0
 
     Examples
     --------
@@ -112,7 +119,8 @@ class ProsthesisSystem(PrettyPrint):
     family = None
 
     def __init__(self, earray, eye='RE', preprocess=False,
-                 safe_mode=False, encoder=None, raster=None, max_current=None):
+                 safe_mode=False, encoder=None, raster=None, max_current=None,
+                 thresholds=None):
         self.earray = earray
         self.eye = eye
         self.safe_mode = safe_mode
@@ -120,6 +128,9 @@ class ProsthesisSystem(PrettyPrint):
         self.encoder = encoder
         self.raster = raster
         self.max_current = max_current
+        # Normalizing per-electrode thresholds needs the electrode names, so
+        # the array must already be in place:
+        self.thresholds = thresholds
 
     def _pprint_params(self):
         """Return dict of class attributes to pretty-print"""

--- a/pulse2percept/implants/tests/test_base.py
+++ b/pulse2percept/implants/tests/test_base.py
@@ -879,7 +879,6 @@ def test_ProsthesisSystem_thresholds():
 
 
 def test_ProsthesisSystem_thresholds_at_construction():
-    # Thresholds are implant state, so the constructor takes them:
     npt.assert_equal(ArgusII().thresholds, {})
     for scalar in (80, 80 * uA, 0.08 * mA):
         implant = ArgusII(thresholds=scalar)
@@ -888,12 +887,10 @@ def test_ProsthesisSystem_thresholds_at_construction():
     implant = ArgusII(thresholds={'A1': 80, 'A2': 107 * uA})
     npt.assert_equal(sorted(implant.thresholds), ['A1', 'A2'])
     npt.assert_almost_equal(implant.thresholds['A2'], 107)
-    # Normalization needs the electrode names, which a left-eye array only
-    # settles at the end of construction:
+    # Threshold keys use the final left-eye electrode names:
     implant = ArgusII(eye='LE', thresholds={'A10': 80})
     npt.assert_equal(sorted(implant.thresholds), ['A10'])
     npt.assert_almost_equal(implant.thresholds['A10'], 80)
-    # And calibration works without a second statement:
     stim = ArgusII(thresholds=80).prepare_stim(
         {'A1': BiphasicPulseTrain(20, 2 * xTh, 0.45)})
     npt.assert_almost_equal(np.abs(stim.data).max(), 160)
@@ -910,7 +907,6 @@ def test_ProsthesisSystem_thresholds_at_construction_are_validated():
         ArgusII(thresholds={'ZZ9': 80 * uA})
     with pytest.raises(DimensionMismatchError):
         ArgusII(thresholds=5 * ms)
-    # The base class takes them too:
     implant = ProsthesisSystem(DiskElectrode(0, 0, 0, 100), thresholds=80)
     npt.assert_almost_equal(implant.thresholds[0], 80)
 

--- a/pulse2percept/implants/tests/test_base.py
+++ b/pulse2percept/implants/tests/test_base.py
@@ -878,6 +878,43 @@ def test_ProsthesisSystem_thresholds():
     npt.assert_equal(implant.thresholds, {})
 
 
+def test_ProsthesisSystem_thresholds_at_construction():
+    # Thresholds are implant state, so the constructor takes them:
+    npt.assert_equal(ArgusII().thresholds, {})
+    for scalar in (80, 80 * uA, 0.08 * mA):
+        implant = ArgusII(thresholds=scalar)
+        npt.assert_equal(len(implant.thresholds), implant.n_electrodes)
+        npt.assert_almost_equal(implant.thresholds['A1'], 80)
+    implant = ArgusII(thresholds={'A1': 80, 'A2': 107 * uA})
+    npt.assert_equal(sorted(implant.thresholds), ['A1', 'A2'])
+    npt.assert_almost_equal(implant.thresholds['A2'], 107)
+    # Normalization needs the electrode names, which a left-eye array only
+    # settles at the end of construction:
+    implant = ArgusII(eye='LE', thresholds={'A10': 80})
+    npt.assert_equal(sorted(implant.thresholds), ['A10'])
+    npt.assert_almost_equal(implant.thresholds['A10'], 80)
+    # And calibration works without a second statement:
+    stim = ArgusII(thresholds=80).prepare_stim(
+        {'A1': BiphasicPulseTrain(20, 2 * xTh, 0.45)})
+    npt.assert_almost_equal(np.abs(stim.data).max(), 160)
+    npt.assert_equal(stim.unit, uA)
+
+
+def test_ProsthesisSystem_thresholds_at_construction_are_validated():
+    for bad in (0, -5, np.nan, np.inf):
+        with pytest.raises(ValueError):
+            ArgusII(thresholds=bad)
+        with pytest.raises(ValueError):
+            ArgusII(thresholds={'A1': bad})
+    with pytest.raises(ValueError):
+        ArgusII(thresholds={'ZZ9': 80 * uA})
+    with pytest.raises(DimensionMismatchError):
+        ArgusII(thresholds=5 * ms)
+    # The base class takes them too:
+    implant = ProsthesisSystem(DiskElectrode(0, 0, 0, 100), thresholds=80)
+    npt.assert_almost_equal(implant.thresholds[0], 80)
+
+
 def test_ProsthesisSystem_thresholds_are_validated():
     implant = ArgusII()
     with pytest.raises(ValueError):

--- a/pulse2percept/models/base.py
+++ b/pulse2percept/models/base.py
@@ -1602,10 +1602,7 @@ class Model(Frozen, PrettyPrint):
                              f"have a time component.")
 
         if self.has_space and self.has_time:
-            # A spatial stage that defines `_combine_temporal` summarizes the
-            # stimulus rather than integrating its samples, so it is handed the
-            # stimulus as it stands. The generic path gets the delivered pulse
-            # train, which the temporal stage integrates.
+            # Custom temporal combiners need the structured stimulus:
             combine = getattr(self.spatial, '_combine_temporal', None)
             resp = self.spatial._predict_prepared(
                 stim if combine is not None else _delivered(stim),

--- a/pulse2percept/models/base.py
+++ b/pulse2percept/models/base.py
@@ -1602,12 +1602,15 @@ class Model(Frozen, PrettyPrint):
                              f"have a time component.")
 
         if self.has_space and self.has_time:
-            # Run the spatial stage on the delivered pulse train; the temporal
-            # stage integrates those pulses.
-            resp = self.spatial._predict_prepared(_delivered(stim),
-                                                  t_percept=None)
+            # A spatial stage that defines `_combine_temporal` summarizes the
+            # stimulus rather than integrating its samples, so it is handed the
+            # stimulus as it stands. The generic path gets the delivered pulse
+            # train, which the temporal stage integrates.
+            combine = getattr(self.spatial, '_combine_temporal', None)
+            resp = self.spatial._predict_prepared(
+                stim if combine is not None else _delivered(stim),
+                t_percept=None)
             if has_time_axis:
-                combine = getattr(self.spatial, '_combine_temporal', None)
                 if resp.time is None and combine is not None:
                     # Allow a spatial model to define custom temporal
                     # combination for a timeless intermediate percept:

--- a/pulse2percept/models/granley2021.py
+++ b/pulse2percept/models/granley2021.py
@@ -574,8 +574,8 @@ class BiphasicAxonMapSpatial(AxonMapSpatial):
         # Apply the same spatial postprocessing as the generic path.
         resp = self._postprocess_spatial(resp)
         return Percept(resp, space=self.grid, time=t_percept,
-                       time_unit=self.time_unit,
-                       metadata={'stim': stim.metadata})
+                       time_unit=self.time_unit, metadata={'stim': stim},
+                       n_gray=self.n_gray, noise=self.noise)
 
     def _combine_temporal(self, percept, temporal, stim, t_percept):
         """Apply a normalized temporal response to the spatial percept."""
@@ -592,8 +592,7 @@ class BiphasicAxonMapSpatial(AxonMapSpatial):
         fade = resp.data.reshape(-1) / peak
         return Percept(percept.data[..., 0][..., np.newaxis] * fade,
                        space=self.grid, time=resp.time,
-                       time_unit=probe.time_unit,
-                       metadata={'stim': stim.metadata})
+                       time_unit=probe.time_unit, metadata={'stim': stim})
 
     @staticmethod
     def _envelope_peak(temporal, envelope):

--- a/pulse2percept/models/granley2021.py
+++ b/pulse2percept/models/granley2021.py
@@ -274,8 +274,9 @@ def _pulse_train_params(stim, thresholds=None):
         If a current-valued amplitude has no threshold calibration.
     NotImplementedError
         If an encoded schedule has more than one frame."""
-    # An encoded schedule describes every electrode at once, and does so
-    # before raster timing, which this model has no representation for:
+    # An encoded schedule describes every electrode at once, in the terms the
+    # device resolved: the realized frequency, but not the pulse onsets, which
+    # this model has no representation for.
     described = getattr(stim, '_biphasic_params', None)
     if described is not None:
         encoded = described()
@@ -333,11 +334,16 @@ class BiphasicAxonMapSpatial(AxonMapSpatial):
     (:py:data:`~pulse2percept.units.xTh`) or as current when a threshold
     calibration is available.
 
-    An encoded schedule is read before raster timing, so amplitude, frequency
-    and phase duration are the ones requested and the pulse onsets a
-    :py:class:`~pulse2percept.implants.Raster` assigns are ignored -- this
-    model has no representation for them. A video is refused: its amplitude
-    changes from frame to frame, and there is no single representative one.
+    An encoded schedule supplies amplitude, phase duration, and the frequency
+    the device timing realizes; the pulse onsets a
+    :py:class:`~pulse2percept.implants.Raster` assigns are ignored, this model
+    having no representation for them. So a raster leaves the usual
+    fixed-frequency amplitude encoding unchanged, while a device constraint
+    that lengthens a pulse period -- a stimulator ``clock``, or a raster
+    quantizing the mixed periods of a
+    :py:class:`~pulse2percept.stimuli.FrequencyEncoder` -- is respected. A
+    video is refused: its amplitude changes from frame to frame, and there is
+    no single representative one.
 
     Custom effect models must be callables with signature ``f(freq, amp, pdur)``.
     Their arguments are frequency, amplitude in multiples of threshold, and phase
@@ -703,11 +709,16 @@ class BiphasicAxonMapModel(Model):
     phase duration [Granley2021]_; the model applies its own phase-duration
     correction.
 
-    An encoded schedule is read before raster timing, so amplitude, frequency
-    and phase duration are the ones requested and the pulse onsets a
-    :py:class:`~pulse2percept.implants.Raster` assigns are ignored -- this
-    model has no representation for them. A video is refused: its amplitude
-    changes from frame to frame, and there is no single representative one.
+    An encoded schedule supplies amplitude, phase duration, and the frequency
+    the device timing realizes; the pulse onsets a
+    :py:class:`~pulse2percept.implants.Raster` assigns are ignored, this model
+    having no representation for them. So a raster leaves the usual
+    fixed-frequency amplitude encoding unchanged, while a device constraint
+    that lengthens a pulse period -- a stimulator ``clock``, or a raster
+    quantizing the mixed periods of a
+    :py:class:`~pulse2percept.stimuli.FrequencyEncoder` -- is respected. A
+    video is refused: its amplitude changes from frame to frame, and there is
+    no single representative one.
 
     Custom effect models must be callables with signature ``f(freq, amp, pdur)``.
     Their arguments are frequency, amplitude in multiples of threshold, and phase
@@ -838,6 +849,8 @@ class BiphasicAxonMapModel(Model):
     threshold:
 
     .. code-block:: python
+
+        import pulse2percept as p2p
 
         implant = p2p.implants.ArgusII(thresholds=80 * p2p.units.uA)
         model = p2p.models.BiphasicAxonMapModel(implant=implant)

--- a/pulse2percept/models/granley2021.py
+++ b/pulse2percept/models/granley2021.py
@@ -242,20 +242,52 @@ _NO_THRESHOLD_MSG = (
 )
 
 
-def _pulse_train_params(stim):
+def _amp_factor(electrode, amp, unit, thresholds):
+    """Amplitude in multiples of threshold, calibrating current if need be"""
+    if unit.dimension == xTh.dimension:
+        return amp
+    threshold = (thresholds or {}).get(electrode)
+    if threshold is None:
+        raise ValueError(_NO_THRESHOLD_MSG.format(electrode=electrode,
+                                                  amp=amp))
+    return amp / threshold
+
+
+def _pulse_train_params(stim, thresholds=None):
     """Return Granley stimulus parameters for each active electrode.
 
     Parameters are read from retained
-    :py:class:`~pulse2percept.stimuli.BiphasicPulseTrain` objects without
-    rendering their waveforms. Amplitude is returned in multiples of threshold;
-    zero-amplitude electrodes are omitted.
+    :py:class:`~pulse2percept.stimuli.BiphasicPulseTrain` objects, or from an
+    encoded schedule, without rendering their waveforms. Amplitude is returned
+    in multiples of threshold; zero-amplitude electrodes are omitted.
+
+    ``thresholds`` calibrates current-valued amplitudes that carry no
+    threshold of their own, and is what
+    :py:attr:`~pulse2percept.implants.ProsthesisSystem.thresholds` supplies.
 
     Raises
     ------
     TypeError
-        If an active electrode is not an undelayed ``BiphasicPulseTrain``.
+        If an active electrode is not an undelayed ``BiphasicPulseTrain`` or
+        an encoded schedule of standard biphasic pulses.
     ValueError
-        If a current-valued amplitude has no threshold calibration."""
+        If a current-valued amplitude has no threshold calibration.
+    NotImplementedError
+        If an encoded schedule has more than one frame."""
+    # An encoded schedule describes every electrode at once, and does so
+    # before raster timing, which this model has no representation for:
+    described = getattr(stim, '_biphasic_params', None)
+    if described is not None:
+        encoded = described()
+        if encoded is None:
+            raise TypeError(
+                "All stimuli must be BiphasicPulseTrains with no delay dur. "
+                "This one was encoded with a 'pulse' shape of its own, whose "
+                "phase duration this model cannot read off.")
+        return [(electrode, freq,
+                 _amp_factor(electrode, amp, stim.unit, thresholds),
+                 phase_dur, stim_dur)
+                for electrode, freq, amp, phase_dur, stim_dur in encoded]
     sources = stim._structured_sources()
     if sources is None:
         # Preserve the historical zero-stimulus result; this is the only case
@@ -292,10 +324,20 @@ class BiphasicAxonMapSpatial(AxonMapSpatial):
     [Granley2021]_. The model returns one representative spatial percept for the
     full biphasic pulse train.
 
-    Stimuli must retain :py:class:`~pulse2percept.stimuli.BiphasicPulseTrain`
-    structure. Amplitude may be given in multiples of perceptual threshold
-    (:py:data:`~pulse2percept.units.xTh`) or as current when a threshold calibration
-    is available.
+    Stimuli must describe the pulse train they deliver, rather than only its
+    samples: either retained
+    :py:class:`~pulse2percept.stimuli.BiphasicPulseTrain` objects, or a still
+    image encoded with the standard biphasic encoder pulse (see
+    :py:class:`~pulse2percept.stimuli.AmplitudeEncoder`). Amplitude may be
+    given in multiples of perceptual threshold
+    (:py:data:`~pulse2percept.units.xTh`) or as current when a threshold
+    calibration is available.
+
+    An encoded schedule is read before raster timing, so amplitude, frequency
+    and phase duration are the ones requested and the pulse onsets a
+    :py:class:`~pulse2percept.implants.Raster` assigns are ignored -- this
+    model has no representation for them. A video is refused: its amplitude
+    changes from frame to frame, and there is no single representative one.
 
     Custom effect models must be callables with signature ``f(freq, amp, pdur)``.
     Their arguments are frequency, amplitude in multiples of threshold, and phase
@@ -504,7 +546,7 @@ class BiphasicAxonMapSpatial(AxonMapSpatial):
         if not isinstance(stim, Stimulus):
             raise TypeError(
                 "Stim must be of type Stimulus but it is " + str(type(stim)))
-        params = _pulse_train_params(stim)
+        params = _pulse_train_params(stim, self.implant.thresholds)
         active = [p[0] for p in params]
         elec_params = np.array([p[1:4] for p in params],
                                dtype=np.float32).reshape((-1, 3))
@@ -560,7 +602,7 @@ class BiphasicAxonMapSpatial(AxonMapSpatial):
         if stim is None:
             return None
         _require_stim_dimension(self, stim)
-        params = _pulse_train_params(stim)
+        params = _pulse_train_params(stim, self.implant.thresholds)
         t_percept = as_value(t_percept, self.time_unit, 't_percept')
         n_time = 1 if t_percept is None else np.array([t_percept]).size
         if not params:
@@ -623,7 +665,8 @@ class BiphasicAxonMapSpatial(AxonMapSpatial):
 
     def _envelope_dur(self, stim):
         """Return the common duration of the active pulse trains."""
-        durs = {p[4] for p in _pulse_train_params(stim)}
+        durs = {p[4] for p in _pulse_train_params(stim,
+                                                  self.implant.thresholds)}
         if len(durs) > 1:
             raise NotImplementedError(
                 f"{type(self).__name__} requires active electrodes to share "
@@ -633,6 +676,8 @@ class BiphasicAxonMapSpatial(AxonMapSpatial):
             return float(durs.pop())
 
         # No active electrodes; duration only determines the output time axis.
+        if getattr(stim, '_biphasic_params', None) is not None:
+            return float(stim.duration)
         sources = stim._structured_sources()
         if sources:
             return float(max(src.stim_dur for _, src in sources))
@@ -647,12 +692,22 @@ class BiphasicAxonMapModel(Model):
     [Granley2021]_. The model returns one representative percept for the full
     biphasic pulse train.
 
-    Stimuli must retain :py:class:`~pulse2percept.stimuli.BiphasicPulseTrain`
-    structure. Give amplitude in multiples of perceptual threshold
-    (:py:data:`~pulse2percept.units.xTh`) or provide a threshold calibration for
-    current-valued amplitudes. Threshold is the 50%-detection current for a train
-    at the same frequency and 0.45 ms phase duration [Granley2021]_; the model
-    applies its own phase-duration correction.
+    Stimuli must describe the pulse train they deliver, rather than only its
+    samples: either retained
+    :py:class:`~pulse2percept.stimuli.BiphasicPulseTrain` objects, or a still
+    image encoded with the standard biphasic encoder pulse (see
+    :py:class:`~pulse2percept.stimuli.AmplitudeEncoder`). Give amplitude in
+    multiples of perceptual threshold (:py:data:`~pulse2percept.units.xTh`) or
+    provide a threshold calibration for current-valued amplitudes. Threshold is
+    the 50%-detection current for a train at the same frequency and 0.45 ms
+    phase duration [Granley2021]_; the model applies its own phase-duration
+    correction.
+
+    An encoded schedule is read before raster timing, so amplitude, frequency
+    and phase duration are the ones requested and the pulse onsets a
+    :py:class:`~pulse2percept.implants.Raster` assigns are ignored -- this
+    model has no representation for them. A video is refused: its amplitude
+    changes from frame to frame, and there is no single representative one.
 
     Custom effect models must be callables with signature ``f(freq, amp, pdur)``.
     Their arguments are frequency, amplitude in multiples of threshold, and phase
@@ -775,7 +830,30 @@ class BiphasicAxonMapModel(Model):
     Notes
     -----
     ``ax_segments_range`` values above 90 are outside the range for which this
-    axon-map construction is considered reliable."""
+    axon-map construction is considered reliable.
+
+    Examples
+    --------
+    A picture, a device that encodes it, and a participant's measured
+    threshold:
+
+    .. code-block:: python
+
+        implant = p2p.implants.ArgusII(thresholds=80 * p2p.units.uA)
+        model = p2p.models.BiphasicAxonMapModel(implant=implant)
+        percept = model.predict_percept(p2p.stimuli.LogoBVL())
+
+    An encoder that asks for threshold multiples in the first place needs no
+    measured threshold:
+
+    .. code-block:: python
+
+        encoder = p2p.stimuli.AmplitudeEncoder(
+            amp_range=(0 * p2p.units.xTh, 3 * p2p.units.xTh))
+        implant = p2p.implants.ArgusII(encoder=encoder)
+        model = p2p.models.BiphasicAxonMapModel(implant=implant)
+        percept = model.predict_percept(p2p.stimuli.LogoBVL())
+    """
 
     def __init__(self, **params):
         super(BiphasicAxonMapModel, self).__init__(

--- a/pulse2percept/models/granley2021.py
+++ b/pulse2percept/models/granley2021.py
@@ -254,29 +254,7 @@ def _amp_factor(electrode, amp, unit, thresholds):
 
 
 def _pulse_train_params(stim, thresholds=None):
-    """Return Granley stimulus parameters for each active electrode.
-
-    Parameters are read from retained
-    :py:class:`~pulse2percept.stimuli.BiphasicPulseTrain` objects, or from an
-    encoded schedule, without rendering their waveforms. Amplitude is returned
-    in multiples of threshold; zero-amplitude electrodes are omitted.
-
-    ``thresholds`` calibrates current-valued amplitudes that carry no
-    threshold of their own, and is what
-    :py:attr:`~pulse2percept.implants.ProsthesisSystem.thresholds` supplies.
-
-    Raises
-    ------
-    TypeError
-        If an active electrode is not an undelayed ``BiphasicPulseTrain`` or
-        an encoded schedule of standard biphasic pulses.
-    ValueError
-        If a current-valued amplitude has no threshold calibration.
-    NotImplementedError
-        If an encoded schedule has more than one frame."""
-    # An encoded schedule describes every electrode at once, in the terms the
-    # device resolved: the realized frequency, but not the pulse onsets, which
-    # this model has no representation for.
+    """Return Granley pulse parameters for each active electrode."""
     described = getattr(stim, '_biphasic_params', None)
     if described is not None:
         encoded = described()
@@ -334,16 +312,8 @@ class BiphasicAxonMapSpatial(AxonMapSpatial):
     (:py:data:`~pulse2percept.units.xTh`) or as current when a threshold
     calibration is available.
 
-    An encoded schedule supplies amplitude, phase duration, and the frequency
-    the device timing realizes; the pulse onsets a
-    :py:class:`~pulse2percept.implants.Raster` assigns are ignored, this model
-    having no representation for them. So a raster leaves the usual
-    fixed-frequency amplitude encoding unchanged, while a device constraint
-    that lengthens a pulse period -- a stimulator ``clock``, or a raster
-    quantizing the mixed periods of a
-    :py:class:`~pulse2percept.stimuli.FrequencyEncoder` -- is respected. A
-    video is refused: its amplitude changes from frame to frame, and there is
-    no single representative one.
+    Encoded still images use the device-resolved amplitude, phase duration, and
+    frequency; exact pulse-onset timing is ignored. Videos are not supported.
 
     Custom effect models must be callables with signature ``f(freq, amp, pdur)``.
     Their arguments are frequency, amplitude in multiples of threshold, and phase
@@ -709,16 +679,8 @@ class BiphasicAxonMapModel(Model):
     phase duration [Granley2021]_; the model applies its own phase-duration
     correction.
 
-    An encoded schedule supplies amplitude, phase duration, and the frequency
-    the device timing realizes; the pulse onsets a
-    :py:class:`~pulse2percept.implants.Raster` assigns are ignored, this model
-    having no representation for them. So a raster leaves the usual
-    fixed-frequency amplitude encoding unchanged, while a device constraint
-    that lengthens a pulse period -- a stimulator ``clock``, or a raster
-    quantizing the mixed periods of a
-    :py:class:`~pulse2percept.stimuli.FrequencyEncoder` -- is respected. A
-    video is refused: its amplitude changes from frame to frame, and there is
-    no single representative one.
+    Encoded still images use the device-resolved amplitude, phase duration, and
+    frequency; exact pulse-onset timing is ignored. Videos are not supported.
 
     Custom effect models must be callables with signature ``f(freq, amp, pdur)``.
     Their arguments are frequency, amplitude in multiples of threshold, and phase

--- a/pulse2percept/models/tests/test_granley2021.py
+++ b/pulse2percept/models/tests/test_granley2021.py
@@ -177,9 +177,6 @@ def test_effects_models():
 
 
 def test_effects_models_units():
-    # `rho` and `lam` are constructor arguments rather than entries in
-    # `get_default_params`, but they are still lengths, and are still
-    # normalized before being stored:
     size = DefaultSizeModel(0.2 * mm, min_rho=20 * um)
     npt.assert_almost_equal(size.rho, 200)
     npt.assert_almost_equal(size.min_rho, 20)
@@ -242,8 +239,6 @@ def test_biphasicAxonMapSpatial():
     model.streak_model = streak_model
     model.build()
     axon_map = AxonMapSpatial(implant=ArgusII(), step=2).build()
-    # The axon map reads current and this model reads threshold multiples, so
-    # a 1 uA threshold is what makes the two numbers the same one:
     source = Stimulus({'A5': BiphasicPulseTrain(20, 1 * xTh, 0.45,
                                                       threshold_amp=1 * uA)})
     percept = model.predict_percept(source)
@@ -345,13 +340,11 @@ def test_biphasicAxonMapModel():
     class TestInitClassGood():
         def __init__(self):
             self.model = BiphasicAxonMapModel(implant=ArgusII())
-            # This shouldnt raise an error
             self.model.a0
 
     class TestInitClassBad():
         def __init__(self):
             self.model = BiphasicAxonMapModel(implant=ArgusII())
-            # This should
             self.model.a10 = 999
     # If this fails, something is wrong with getattr / setattr logic
     TestInitClassGood()
@@ -396,12 +389,8 @@ def test_DefaultStreakModel_removed_axlambda():
 
 @pytest.mark.parametrize('model_cls', [BiphasicAxonMapModel,
                                        BiphasicAxonMapSpatial])
-# Scaling the train itself, and scaling the stimulus the implant made of it;
-# the second is what a user reaches for:
 @pytest.mark.parametrize('compose', [False, True])
 def test_scaled_pulse_train_changes_percept(model_cls, compose):
-    # Scaling has to give what building the train at that amplitude in the
-    # first place gives:
     model = model_cls(implant=ArgusII(), xrange=(-12, 12), yrange=(-8, 8),
                       step=1, n_ax_segments=30).build()
     source = model.implant.prepare_stim(
@@ -425,9 +414,6 @@ def test_scaled_pulse_train_changes_percept(model_cls, compose):
 @pytest.mark.parametrize('modify', [lambda s: s + 5, lambda s: s * np.inf,
                                     lambda s: s.append(s >> 1)])
 def test_modified_pulse_train_rejected(model_cls, modify):
-    # A DC offset, a non-finite factor and an appended second train all leave
-    # something other than a biphasic pulse train. The model must say so rather
-    # than predict from pulse parameters that no longer describe the stimulus:
     model = model_cls(implant=ArgusII(), xrange=(-3, 3), yrange=(-2, 2),
                       step=1, n_ax_segments=30).build()
     source = model.implant.prepare_stim(
@@ -439,8 +425,6 @@ def test_modified_pulse_train_rejected(model_cls, modify):
 
 
 def test_pulse_train_amp_sign_does_not_change_percept():
-    # `BiphasicPulse` takes the magnitude of `amp`, so these two trains have
-    # the very same waveform, and must therefore predict the same percept:
     model = BiphasicAxonMapModel(implant=ArgusII(), xrange=(-12, 12),
                                  yrange=(-8, 8), step=1,
                                  n_ax_segments=30).build()
@@ -454,12 +438,6 @@ def test_pulse_train_amp_sign_does_not_change_percept():
 
 
 def test_BiphasicAxonMapModel_min_current_spread():
-    """The current-spread cutoff must reach this model's kernel too.
-
-    ``min_current_spread`` lives on ``SpatialModel``, so
-    ``BiphasicAxonMapSpatial`` inherits it; this pins that the biphasic
-    kernel actually honours it rather than accepting it and ignoring it.
-    """
     stim = {e: BiphasicPulseTrain(20, 30 * xTh, 0.45)
             for e in ('A2', 'C5', 'F8')}
     source = stim
@@ -470,14 +448,10 @@ def test_BiphasicAxonMapModel_min_current_spread():
         min_current_spread=0, **kwargs).build().predict_percept(source).data
     default = BiphasicAxonMapModel(implant=ArgusII(), 
         **kwargs).build().predict_percept(source).data
-    # For three electrodes the default cutoff is not worth thinking about;
-    # see `test_BiphasicAxonMapModel_min_current_spread_error_bound` for the
-    # case where it is:
     npt.assert_allclose(default, exact, rtol=1e-5,
                         atol=1e-6 * np.abs(exact).max())
 
-    # A coarse cutoff does change the result, which is how we know it is
-    # wired through rather than silently dropped:
+    # A coarse cutoff does change the result:
     coarse = BiphasicAxonMapModel(implant=ArgusII(), 
         min_current_spread=0.5, **kwargs).build().predict_percept(source).data
     assert np.abs(coarse - exact).max() > 1e-3
@@ -485,14 +459,6 @@ def test_BiphasicAxonMapModel_min_current_spread():
 
 @pytest.mark.parametrize('amp', (2.0, 50.0))
 def test_BiphasicAxonMapModel_min_current_spread_error_bound(amp):
-    """The cutoff is an approximation here too, with a bound to match.
-
-    The biphasic kernel tests ``r2`` against the cutoff before scaling the
-    exponential by ``F_bright``, so what it drops at a segment is
-    ``sum_i F_bright_i * exp(...)``. The error is therefore bounded by
-    ``min_current_spread * sum(F_bright)``, which grows with the array size
-    and with however hard the brightness model scales -- not by 1e-8 outright.
-    """
     min_spread = 1e-8
     freq, pdur = 20, 0.45
     source = {e: BiphasicPulseTrain(freq, amp * xTh, pdur)
@@ -515,12 +481,6 @@ def test_BiphasicAxonMapModel_min_current_spread_error_bound(amp):
 
 @pytest.mark.parametrize('attr', ('size_model', 'streak_model'))
 def test_BiphasicAxonMapModel_rejects_nonpositive_effects(attr):
-    """A scaling factor of zero would surface as NaN, so it is rejected.
-
-    Both factors enter the kernel through an exponent, so neither may be
-    zero or negative. The default models cannot produce that, but a custom
-    one could.
-    """
     model = BiphasicAxonMapModel(implant=ArgusII(), xrange=(-4, 4), yrange=(-4, 4), step=1,
                                  verbose=False).build()
     setattr(model.spatial, attr, lambda freq, amp, pdur: np.zeros_like(amp))
@@ -537,17 +497,7 @@ def test_BiphasicAxonMapModel_rejects_nonpositive_effects(attr):
                                   'streak_model'))
 @pytest.mark.parametrize('bad', (np.nan, np.inf, -np.inf))
 def test_BiphasicAxonMapModel_rejects_nonfinite_effects(attr, bad):
-    """A non-finite scaling factor is rejected before it reaches the kernel.
-
-    ``nan <= 0`` is false, so the positivity check above does not catch NaN.
-    Left alone it would flow into the kernel's exponent, and then
-    ``abs(nan) > abs(px_bright)`` is false too -- so the affected segments
-    would drop out of the max and the percept would come back quietly wrong
-    instead of raising. Infinities are no better: they turn the sum into
-    ``inf`` or ``nan`` depending on the signs involved. This covers
-    ``bright_model`` as well, which the positivity check deliberately does
-    not (a zero or negative brightness factor is legitimate).
-    """
+    # A non-finite scaling factor is rejected before it reaches the kernel
     model = BiphasicAxonMapModel(implant=ArgusII(), xrange=(-4, 4), yrange=(-4, 4), step=1,
                                  verbose=False).build()
     setattr(model.spatial, attr,
@@ -559,16 +509,7 @@ def test_BiphasicAxonMapModel_rejects_nonfinite_effects(attr, bad):
 
 
 def test_BiphasicAxonMapModel_reduces_to_AxonMapModel():
-    """With every effect factor at 1, this model *is* the axon map model.
-
-    The biphasic kernel computes
-    ``F_bright * exp(-r^2 / (2 rho^2 F_size)) * sens ** (1 / F_streak)``
-    as a single exponential of summed exponents. Setting all three factors to
-    1 collapses that to ``exp(-r^2 / (2 rho^2)) * sens``, which is exactly
-    what ``AxonMapModel`` computes for a unit-amplitude stimulus -- an
-    independently written kernel, so this pins the fused arithmetic against
-    something that does not share its code.
-    """
+    # With every effect factor at 1, this model *is* the axon map model
     from pulse2percept.models import AxonMapModel
 
     kwargs = {'xrange': (-8, 8), 'yrange': (-8, 8), 'step': 0.5,
@@ -595,7 +536,7 @@ def test_BiphasicAxonMapModel_reduces_to_AxonMapModel():
 
 
 def test_BiphasicAxonMap_t_percept_units():
-    """This model overrides `predict_percept`, so it normalizes for itself"""
+    # This model overrides `predict_percept`, so it normalizes for itself
     source = {'A1': BiphasicPulseTrain(20, 1 * xTh, 0.45,
                                                      stim_dur=100)}
     for model in (BiphasicAxonMapSpatial(implant=ArgusII(), step=2).build(),
@@ -613,17 +554,8 @@ def test_BiphasicAxonMap_t_percept_units():
 
 
 def test_BiphasicAxonMap_dimension_before_waveform():
-    """A picture is not an unsuitable pulse train, it is not a current at all
-
-    The dimensional contract is the outermost one, so a dimensionless stimulus
-    reports that rather than the model's own "must be BiphasicPulseTrains"
-    complaint, which is about a stimulus it never had.
-    """
     img = ImageStimulus(np.linspace(0, 1, 16).reshape((4, 4)))
 
-    # An ordinary implant refuses the picture outright (see
-    # `ProsthesisSystem.stimulus_unit`); one that delivers something else is
-    # what carries it as far as the model:
     class Projector(ArgusII):
         stimulus_unit = dimensionless
 
@@ -632,7 +564,6 @@ def test_BiphasicAxonMap_dimension_before_waveform():
                   BiphasicAxonMapModel(implant=projector, step=2).build()):
         with pytest.raises(DimensionMismatchError) as excinfo:
             model.predict_percept(img)
-        # Both dimensions this model reads are named, not just the one:
         for accepted in ('electric current', 'threshold ratio'):
             npt.assert_equal(accepted in str(excinfo.value), True)
         npt.assert_equal('dimensionless' in str(excinfo.value), True)
@@ -647,10 +578,6 @@ def test_BiphasicAxonMap_dimension_before_waveform():
 @pytest.mark.parametrize('ModelClass', [BiphasicAxonMapSpatial,
                                         BiphasicAxonMapModel])
 def test_BiphasicAxonMapSpatial_meridian_blend(ModelClass):
-    # This model replaces `predict_percept` instead of customizing
-    # `_predict_spatial`, so it has to call the postprocessing hook itself --
-    # otherwise `meridian_blend`, inherited from `AxonMapSpatial`, would be
-    # accepted and then quietly ignored.
     def make(**params):
         return ModelClass(implant=ArgusII(), xrange=(-6, 6), yrange=(-6, 6), step=0.25, rho=200,
                           lam=400, n_axons=250, n_ax_segments=200,
@@ -661,8 +588,7 @@ def test_BiphasicAxonMapSpatial_meridian_blend(ModelClass):
     plain = make(meridian_blend=0)
     unblended = plain.predict_percept(source).data
 
-    # Exercises the width inherited from `AxonMapSpatial` rather than one of
-    # its own -- the point of the test is that the hook runs at all here:
+    # Exercises the width inherited from `AxonMapSpatial`
     width = 1
     blended_model = make()
     npt.assert_equal(blended_model.meridian_blend, width)
@@ -670,7 +596,6 @@ def test_BiphasicAxonMapSpatial_meridian_blend(ModelClass):
     npt.assert_equal(blended.shape, unblended.shape)
     npt.assert_equal(blended.dtype, unblended.dtype)
     npt.assert_equal(np.array_equal(blended, unblended), False)
-    # It is the horizontal meridian here, so the change is a band around y=0:
     y = plain.grid.y[:, 0]
     delta = np.abs(blended - unblended)
     rows = delta.max(axis=(1, 2)) > delta.max() * 1e-3
@@ -679,11 +604,7 @@ def test_BiphasicAxonMapSpatial_meridian_blend(ModelClass):
 
 @contextmanager
 def _no_pulse_train_rendering():
-    """Make generating a pulse train's waveform an error
-
-    The only way to state "this model never asks for samples" as a test: if
-    anything on the prediction path reaches for one, it fails loudly.
-    """
+    # Make generating a pulse train's waveform an error
     original = BiphasicPulseTrain._render
 
     def refuse(self):
@@ -706,9 +627,6 @@ def _no_pulse_train_rendering():
                                                stim_dur=100)}) * 2,
 ])
 def test_BiphasicAxonMap_predicts_without_a_waveform(model_cls, build_stim):
-    # This model is a function of frequency, amplitude and phase duration, and
-    # it now takes them from the pulse trains themselves. None of them needs
-    # the train sampled, so predicting must not sample one.
     model = model_cls(implant=ArgusII(), xrange=(-3, 3), yrange=(-2, 2), step=1,
                       n_ax_segments=30).build()
     source = build_stim()
@@ -745,10 +663,7 @@ def test_BiphasicAxonMap_ignores_user_metadata(model_cls):
     lambda: {'C5': Stimulus([[0, 1, 1, 0]], time=[0, 1, 99, 100])},
 ])
 def test_BiphasicAxonMap_rejects_what_it_cannot_read(model_cls, build_stim):
-    # A sequence of two trains has no single frequency, an asymmetric train is
-    # not this model's protocol, a delayed one is outside what it was fit on,
-    # and a raw waveform has no parameters at all. Each is refused rather than
-    # predicted from whatever numbers happen to be lying around:
+    # A sequence of two trains has no single frequency
     model = model_cls(implant=ArgusII(), xrange=(-3, 3), yrange=(-2, 2), step=1,
                       n_ax_segments=30).build()
     source = build_stim()
@@ -759,8 +674,6 @@ def test_BiphasicAxonMap_rejects_what_it_cannot_read(model_cls, build_stim):
 @pytest.mark.parametrize('model_cls', [BiphasicAxonMapModel,
                                        BiphasicAxonMapSpatial])
 def test_BiphasicAxonMap_zero_amplitude_is_inactive(model_cls):
-    # A train at zero amplitude drives nothing, which is a zero percept rather
-    # than an error -- and is read off `amp`, not off the waveform:
     model = model_cls(implant=ArgusII(), xrange=(-3, 3), yrange=(-2, 2), step=1,
                       n_ax_segments=30).build()
     source = {'C5': BiphasicPulseTrain(20, 0 * xTh, 0.45,
@@ -789,15 +702,10 @@ def _granley(implant, model_cls=BiphasicAxonMapModel):
 @pytest.mark.parametrize('model_cls', [BiphasicAxonMapModel,
                                        BiphasicAxonMapSpatial])
 def test_BiphasicAxonMap_reads_an_encoded_image(model_cls):
-    # The workflow this model exists for: a picture, a device that encodes it,
-    # and a participant's measured threshold.
     model = _granley(ArgusII(thresholds=80 * uA), model_cls)
     with _no_pulse_train_rendering():
         percept = model.predict_percept(LogoBVL())
     npt.assert_equal(np.any(percept.data), True)
-    # A threshold-relative encoder needs no measured threshold, because it
-    # asks for xTh in the first place. 0-50 uA against an 80 uA threshold is
-    # the same request as 0-0.625 xTh:
     relative = _granley(
         ArgusII(encoder=AmplitudeEncoder(amp_range=(0 * xTh, 0.625 * xTh),
                                          freq=6 * Hz)), model_cls)
@@ -809,8 +717,6 @@ def test_BiphasicAxonMap_reads_an_encoded_image(model_cls):
 @pytest.mark.parametrize('model_cls', [BiphasicAxonMapModel,
                                        BiphasicAxonMapSpatial])
 def test_BiphasicAxonMap_ignores_the_raster(model_cls):
-    # A raster decides when each electrode pulses, not what it delivers. The
-    # rendered waveforms differ; the representative percept does not.
     with _no_pulse_train_rendering():
         rastered = _granley(ArgusII(thresholds=80),
                             model_cls).predict_percept(LogoBVL())
@@ -823,8 +729,6 @@ def test_BiphasicAxonMap_ignores_the_raster(model_cls):
                                           ('freq', 20 * Hz),
                                           ('phase_dur', 0.2 * ms)])
 def test_BiphasicAxonMap_reads_the_encoder_parameters(param, value):
-    # Whatever is on `implant.encoder` is the requested encoding, so changing
-    # any of the three quantities this model is a function of changes it:
     default = _granley(ArgusII(thresholds=80))
     tweaked = _granley(ArgusII(thresholds=80,
                                encoder=AmplitudeEncoder(**{param: value})))
@@ -835,8 +739,6 @@ def test_BiphasicAxonMap_reads_the_encoder_parameters(param, value):
 
 
 def test_BiphasicAxonMap_encoded_current_still_needs_a_threshold():
-    # Argus II encodes 0-50 uA by default, and there is no threshold to read
-    # that as a multiple of. No threshold is invented:
     model = _granley(ArgusII())
     with pytest.raises(ValueError) as err:
         model.predict_percept(LogoBVL())
@@ -844,8 +746,6 @@ def test_BiphasicAxonMap_encoded_current_still_needs_a_threshold():
 
 
 def test_BiphasicAxonMap_rejects_an_encoded_video():
-    # A video asks each electrode for a different amplitude on every frame,
-    # and there is no principled single one to hand the model:
     model = _granley(ArgusII(thresholds=80))
     video = VideoStimulus(np.random.rand(4, 4, 3), time=[0, 200, 400])
     with pytest.raises(NotImplementedError) as err:
@@ -854,8 +754,6 @@ def test_BiphasicAxonMap_rejects_an_encoded_video():
 
 
 def test_BiphasicAxonMap_rejects_a_custom_encoder_pulse():
-    # A caller-supplied pulse shape carries no biphasic phase duration, and
-    # this model does not reverse-engineer one from the waveform:
     encoder = AmplitudeEncoder(pulse=BiphasicPulse(1, 0.2), amp_range=(0, 50))
     model = _granley(ArgusII(thresholds=80, encoder=encoder))
     with pytest.raises(TypeError) as err:
@@ -871,19 +769,16 @@ def test_BiphasicAxonMap_encoded_extraction_is_lazy():
     npt.assert_equal(stim._Stimulus__stim['data'] is None, True)
 
 
-# The temporal models a Granley composite is expected to work with. Their
-# responses to one canonical drive peak at quite different moments, which is
-# what most of these tests are about.
+# The temporal models a Granley composite is expected to work with:
 _TEMPORALS = [FadingTemporal, Nanduri2012Temporal, Horsager2009Temporal]
 
-# Stimulation lasts this long, and the whole episode -- including the tail in
-# which a lagging cascade can still be rising -- fits in this window (ms):
+# Stimulation lasts this long:
 _STIM_DUR = 50
 _EPISODE = 200
 
 
 def _composite(temporal):
-    """A Granley spatial model paired with ``temporal``, and Granley alone"""
+    # A Granley spatial model paired with ``temporal``, and Granley alone
     grid = dict(xrange=(-3, 3), yrange=(-2, 2), step=1, n_ax_segments=30)
     composite = Model(spatial=BiphasicAxonMapSpatial(implant=ArgusII(), **grid),
                       temporal=temporal)
@@ -895,10 +790,7 @@ def _composite_source(stim_dur=_STIM_DUR):
 
 
 def _every_dt(temporal, until=_EPISODE):
-    """Every instant ``temporal`` integrates, up to ``until`` (ms)
-
-    Anything coarser reports the peak of the samples rather than the peak.
-    """
+    # Every instant ``temporal`` integrates, up to ``until`` (ms)
     return np.arange(int(round(until / temporal.dt)) + 1) * temporal.dt
 
 
@@ -907,14 +799,12 @@ def test_BiphasicAxonMapSpatial_with_temporal_model_runs(temporal_cls):
     # Issue #565: the spatial model collapses time, so the percept it hands
     # over has no time axis for a temporal model to integrate.
     composite, _ = _composite(temporal_cls())
-    # The drive is built from the retained pulse-train parameters, so pairing
-    # the two still asks for no waveform:
     with _no_pulse_train_rendering():
         percept = composite.predict_percept(_composite_source())
     npt.assert_equal(percept.data.ndim, 3)
     npt.assert_equal(percept.data.shape[-1] > 1, True)
     npt.assert_equal(np.all(np.isfinite(percept.data)), True)
-    # Temporal composition must not change what ``metadata['stim']`` holds:
+    # Composition preserves the metadata contract:
     npt.assert_equal(isinstance(percept.metadata['stim'], Stimulus), True)
 
 
@@ -951,11 +841,8 @@ def test_BiphasicAxonMapSpatial_composite_peak_ignores_requested_sampling(
     composite, granley = _composite(temporal_cls())
     source = _composite_source()
     granley_max = granley.predict_percept(source).data.max()
-    # Asked only for instants that fall well before the peak, the percept must
-    # stay below the Granley maximum rather than renormalizing onto it:
     early = composite.predict_percept(source, t_percept=[10, 20])
     npt.assert_equal(early.data.max() < 0.9 * granley_max, True)
-    # And those samples are the ones a longer run reports at the same times:
     longer = composite.predict_percept(source, t_percept=[10, 20, 40, 80])
     npt.assert_array_almost_equal(early.data, longer.data[..., :2])
 
@@ -995,9 +882,6 @@ def test_BiphasicAxonMapSpatial_composite_temporal_params_only_move_time(
 @pytest.mark.parametrize('temporal_cls', _TEMPORALS)
 def test_BiphasicAxonMapSpatial_composite_ignores_temporal_thresh_percept(
         temporal_cls):
-    # The envelope is normalized, so a floor in the temporal model's own
-    # brightness units would apply to the wrong quantity. Brightness is
-    # Granley's to set, and the caller's own model is left alone:
     temporal = temporal_cls(thresh_percept=0.1)
     composite, _ = _composite(temporal)
     plain, _ = _composite(temporal_cls())
@@ -1009,8 +893,6 @@ def test_BiphasicAxonMapSpatial_composite_ignores_temporal_thresh_percept(
 
 
 def test_BiphasicAxonMapSpatial_composite_ignores_inactive_stim_dur():
-    # A train at zero amplitude is inactive everywhere, so it must not stretch
-    # the envelope the active one rides on either:
     composite, _ = _composite(FadingTemporal())
     short = {'A5': BiphasicPulseTrain(20, 1 * xTh, 0.45, stim_dur=100)}
     padded = {'A5': BiphasicPulseTrain(20, 1 * xTh, 0.45, stim_dur=100),
@@ -1024,8 +906,6 @@ def test_BiphasicAxonMapSpatial_composite_ignores_inactive_stim_dur():
 @pytest.mark.parametrize('temporal_cls', _TEMPORALS)
 def test_BiphasicAxonMapSpatial_composite_rejects_unequal_stim_dur(
         temporal_cls):
-    # One separable envelope cannot have one electrode's contribution stop at
-    # 100 ms and another's at 1000 ms:
     composite, _ = _composite(temporal_cls())
     source = {'A5': BiphasicPulseTrain(20, 1 * xTh, 0.45,
                                                      stim_dur=100),
@@ -1036,11 +916,7 @@ def test_BiphasicAxonMapSpatial_composite_rejects_unequal_stim_dur(
 
 
 def test_BiphasicAxonMapSpatial_composite_rides_an_alpha_envelope():
-    """`AlphaTemporal` gives the Granley percept a rise, not just a fade.
-
-    Sampled at every `dt`, so the peak the model normalizes by is one of the
-    samples rather than something between two of them.
-    """
+    # `AlphaTemporal` gives the Granley percept a rise, not just a fade
     temporal = AlphaTemporal(tau=20)
     composite, granley = _composite(temporal)
     source = _composite_source()
@@ -1054,9 +930,6 @@ def test_BiphasicAxonMapSpatial_composite_rides_an_alpha_envelope():
 
     trace = percept.data[np.unravel_index(np.argmax(granley_frame),
                                           granley_frame.shape)]
-    # An alpha envelope, not an exponential fade: it starts at zero and peaks
-    # well after onset, where `FadingTemporal` is already at its brightest one
-    # step in.
     npt.assert_equal(trace[0], 0)
     peak = int(np.argmax(trace))
     npt.assert_equal(0 < peak < len(trace) - 1, True)
@@ -1070,9 +943,7 @@ def test_BiphasicAxonMapSpatial_composite_rides_an_alpha_envelope():
 
 
 def test_BiphasicAxonMapSpatial_composite_normalizes_a_delayed_peak():
-    # This one peaks ~226 ms after a 50 ms drive, several windows past the
-    # first one searched. Normalizing by a value found before the peak would
-    # let the percept outshine the Granley frame it is supposed to peak at:
+    # This one peaks ~226 ms after a 50 ms drive
     temporal = Horsager2009Temporal(tau3=100)
     composite, granley = _composite(temporal)
     source = _composite_source()
@@ -1084,15 +955,15 @@ def test_BiphasicAxonMapSpatial_composite_normalizes_a_delayed_peak():
 
 
 def test_BiphasicAxonMapSpatial_composite_rejects_an_unlocatable_peak():
-    # Still rising where the search gives up (~624 ms for a 50 ms drive):
-    # saying so beats normalizing by a value known not to be the peak.
+    # Still rising where the search gives up (~624 ms for a 50 ms drive)
     composite, _ = _composite(Horsager2009Temporal(tau3=300))
     with pytest.raises(ValueError):
         composite.predict_percept(_composite_source())
 
 
 def _threshold_model():
-    return BiphasicAxonMapModel(implant=ArgusII(), xrange=(-3, 3), yrange=(-2, 2), step=1,
+    return BiphasicAxonMapModel(implant=ArgusII(), xrange=(-3, 3), 
+                                yrange=(-2, 2), step=1,
                                 n_ax_segments=30).build()
 
 
@@ -1144,7 +1015,6 @@ def test_BiphasicAxonMap_uncalibrated_current_raises(model_cls):
         model.predict_percept(source)
     for remedy in ('2 * xTh', 'threshold_amp', 'implant.thresholds'):
         npt.assert_equal(remedy in str(err.value), True)
-    # Any one of the three fixes it:
     model.implant.thresholds = 80 * uA
     npt.assert_equal(np.any(model.predict_percept(source).data), True)
 
@@ -1152,7 +1022,6 @@ def test_BiphasicAxonMap_uncalibrated_current_raises(model_cls):
 @pytest.mark.parametrize('model_cls', [BiphasicAxonMapModel,
                                        BiphasicAxonMapSpatial])
 def test_BiphasicAxonMap_zero_current_needs_no_threshold(model_cls):
-    # Zero-current electrodes need no threshold.
     model = model_cls(implant=ArgusII(), xrange=(-3, 3), yrange=(-2, 2), step=1,
                       n_ax_segments=30).build()
     source = {'A2': BiphasicPulseTrain(20, 0 * uA, 0.45,
@@ -1165,13 +1034,12 @@ def test_BiphasicAxonMap_zero_current_needs_no_threshold(model_cls):
 @pytest.mark.parametrize('model_cls', [BiphasicAxonMapModel,
                                        BiphasicAxonMapSpatial])
 def test_BiphasicAxonMap_n_gray(model_cls):
-    # n_gray must reach the Percept, as in the generic spatial path:
     source = {'C5': BiphasicPulseTrain(20, 2 * xTh, 0.45, stim_dur=100)}
     model = model_cls(implant=ArgusII(), xrange=(-3, 3), yrange=(-2, 2),
                       step=1, n_ax_segments=30).build()
     full = model.predict_percept(source)
     npt.assert_equal(np.unique(full.data).size > 2, True)
-    # The metadata should carry the stimulus itself, not just its metadata:
+    # Metadata stores the prepared Stimulus:
     npt.assert_equal(isinstance(full.metadata['stim'], Stimulus), True)
 
     model = model_cls(implant=ArgusII(), xrange=(-3, 3), yrange=(-2, 2),
@@ -1183,13 +1051,11 @@ def test_BiphasicAxonMap_n_gray(model_cls):
 @pytest.mark.parametrize('model_cls', [BiphasicAxonMapModel,
                                        BiphasicAxonMapSpatial])
 def test_BiphasicAxonMap_noise(model_cls):
-    # noise must reach the Percept, as in the generic spatial path:
     source = {'C5': BiphasicPulseTrain(20, 2 * xTh, 0.45, stim_dur=100)}
     model = model_cls(implant=ArgusII(), xrange=(-4, 4), yrange=(-4, 4),
                       step=1, n_ax_segments=30, noise=1.0).build()
     frame = model.predict_percept(source).data[..., 0]
-    # Salt and pepper are the brightest and darkest values in the frame, so
-    # noising every pixel leaves exactly those two values:
+    # noise=1 leaves only salt and pepper values
     npt.assert_equal(np.unique(frame).size, 2)
 
 

--- a/pulse2percept/models/tests/test_granley2021.py
+++ b/pulse2percept/models/tests/test_granley2021.py
@@ -1083,3 +1083,36 @@ def test_BiphasicAxonMap_zero_current_needs_no_threshold(model_cls):
     with _no_pulse_train_rendering():
         percept = model.predict_percept(source)
     npt.assert_almost_equal(percept.data, 0)
+
+
+@pytest.mark.parametrize('model_cls', [BiphasicAxonMapModel,
+                                       BiphasicAxonMapSpatial])
+def test_BiphasicAxonMap_n_gray(model_cls):
+    # n_gray must reach the Percept, as in the generic spatial path:
+    source = {'C5': BiphasicPulseTrain(20, 2 * xTh, 0.45, stim_dur=100)}
+    model = model_cls(implant=ArgusII(), xrange=(-3, 3), yrange=(-2, 2),
+                      step=1, n_ax_segments=30).build()
+    full = model.predict_percept(source)
+    npt.assert_equal(np.unique(full.data).size > 2, True)
+    # The metadata should carry the stimulus itself, not just its metadata:
+    npt.assert_equal(isinstance(full.metadata['stim'], Stimulus), True)
+
+    model = model_cls(implant=ArgusII(), xrange=(-3, 3), yrange=(-2, 2),
+                      step=1, n_ax_segments=30, n_gray=2).build()
+    quantized = model.predict_percept(source)
+    npt.assert_equal(np.unique(quantized.data).size, 2)
+
+
+@pytest.mark.parametrize('model_cls', [BiphasicAxonMapModel,
+                                       BiphasicAxonMapSpatial])
+def test_BiphasicAxonMap_noise(model_cls):
+    # noise must reach the Percept, as in the generic spatial path:
+    source = {'C5': BiphasicPulseTrain(20, 2 * xTh, 0.45, stim_dur=100)}
+    model = model_cls(implant=ArgusII(), xrange=(-4, 4), yrange=(-4, 4),
+                      step=1, n_ax_segments=30, noise=0.5).build()
+    frame = model.predict_percept(source).data[..., 0]
+    # Salt and pepper are the brightest and darkest values in the frame, and
+    # a fraction ``noise`` of the pixels are set to one or the other:
+    n_extreme = (np.sum(np.isclose(frame, frame.max())) +
+                 np.sum(np.isclose(frame, frame.min())))
+    npt.assert_equal(n_extreme >= int(0.5 * frame.size), True)

--- a/pulse2percept/models/tests/test_granley2021.py
+++ b/pulse2percept/models/tests/test_granley2021.py
@@ -839,6 +839,8 @@ def test_BiphasicAxonMapSpatial_with_temporal_model_runs(temporal_cls):
     npt.assert_equal(percept.data.ndim, 3)
     npt.assert_equal(percept.data.shape[-1] > 1, True)
     npt.assert_equal(np.all(np.isfinite(percept.data)), True)
+    # Temporal composition must not change what ``metadata['stim']`` holds:
+    npt.assert_equal(isinstance(percept.metadata['stim'], Stimulus), True)
 
 
 @pytest.mark.parametrize('temporal_cls', _TEMPORALS)
@@ -1109,10 +1111,8 @@ def test_BiphasicAxonMap_noise(model_cls):
     # noise must reach the Percept, as in the generic spatial path:
     source = {'C5': BiphasicPulseTrain(20, 2 * xTh, 0.45, stim_dur=100)}
     model = model_cls(implant=ArgusII(), xrange=(-4, 4), yrange=(-4, 4),
-                      step=1, n_ax_segments=30, noise=0.5).build()
+                      step=1, n_ax_segments=30, noise=1.0).build()
     frame = model.predict_percept(source).data[..., 0]
-    # Salt and pepper are the brightest and darkest values in the frame, and
-    # a fraction ``noise`` of the pixels are set to one or the other:
-    n_extreme = (np.sum(np.isclose(frame, frame.max())) +
-                 np.sum(np.isclose(frame, frame.min())))
-    npt.assert_equal(n_extreme >= int(0.5 * frame.size), True)
+    # Salt and pepper are the brightest and darkest values in the frame, so
+    # noising every pixel leaves exactly those two values:
+    npt.assert_equal(np.unique(frame).size, 2)

--- a/pulse2percept/models/tests/test_granley2021.py
+++ b/pulse2percept/models/tests/test_granley2021.py
@@ -9,8 +9,9 @@ from pulse2percept.implants import ArgusI, ArgusII
 from pulse2percept.percepts import Percept
 from pulse2percept.stimuli import (AmplitudeEncoder,
                                    AsymmetricBiphasicPulseTrain,
-                                   BiphasicPulseTrain, ImageStimulus,
-                                   MonophasicPulse, Stimulus)
+                                   BiphasicPulse, BiphasicPulseTrain,
+                                   ImageStimulus, LogoBVL, MonophasicPulse,
+                                   Stimulus, VideoStimulus)
 from pulse2percept.models import (AlphaTemporal, AxonMapSpatial,
                                   BiphasicAxonMapModel,
                                   BiphasicAxonMapSpatial, FadingTemporal,
@@ -18,7 +19,7 @@ from pulse2percept.models import (AlphaTemporal, AxonMapSpatial,
                                   Nanduri2012Temporal)
 from pulse2percept.models.granley2021 import DefaultBrightModel, \
     DefaultSizeModel, DefaultStreakModel
-from pulse2percept.units import (DimensionMismatchError, Quantity,
+from pulse2percept.units import (DimensionMismatchError, Hz, Quantity,
                                  dimensionless, mm, ms, s, uA, um,
                                  xTh)
 from pulse2percept.utils.base import FreezeError
@@ -778,22 +779,96 @@ def test_BiphasicAxonMap_zero_amplitude_is_inactive(model_cls):
     npt.assert_array_almost_equal(mixed, only)
 
 
+_GRID = dict(xrange=(-3, 3), yrange=(-2, 2), step=1, n_ax_segments=30)
+
+
+def _granley(implant, model_cls=BiphasicAxonMapModel):
+    return model_cls(implant=implant, **_GRID).build()
+
+
 @pytest.mark.parametrize('model_cls', [BiphasicAxonMapModel,
                                        BiphasicAxonMapSpatial])
-def test_BiphasicAxonMap_rejects_an_encoded_stimulus(model_cls):
-    # An encoder's output is a schedule, not a pulse train: its amplitude and
-    # frequency may differ from frame to frame, so there is no one `freq` for
-    # this model to read. It stays refused, and refusing it does not expand
-    # the schedule into a waveform either.
-    model = model_cls(implant=ArgusII(), xrange=(-3, 3), yrange=(-2, 2), step=1,
-                      n_ax_segments=30).build()
-    implant = ArgusII()
-    encoded = AmplitudeEncoder().encode(
-        ImageStimulus(np.linspace(0, 1, 64).reshape(8, 8)), implant=implant)
-    npt.assert_equal(encoded._structured_sources(), None)
-    source = encoded
-    with pytest.raises(TypeError):
-        model.predict_percept(source)
+def test_BiphasicAxonMap_reads_an_encoded_image(model_cls):
+    # The workflow this model exists for: a picture, a device that encodes it,
+    # and a participant's measured threshold.
+    model = _granley(ArgusII(thresholds=80 * uA), model_cls)
+    with _no_pulse_train_rendering():
+        percept = model.predict_percept(LogoBVL())
+    npt.assert_equal(np.any(percept.data), True)
+    # A threshold-relative encoder needs no measured threshold, because it
+    # asks for xTh in the first place. 0-50 uA against an 80 uA threshold is
+    # the same request as 0-0.625 xTh:
+    relative = _granley(
+        ArgusII(encoder=AmplitudeEncoder(amp_range=(0 * xTh, 0.625 * xTh),
+                                         freq=6 * Hz)), model_cls)
+    with _no_pulse_train_rendering():
+        npt.assert_array_almost_equal(relative.predict_percept(LogoBVL()).data,
+                                      percept.data)
+
+
+@pytest.mark.parametrize('model_cls', [BiphasicAxonMapModel,
+                                       BiphasicAxonMapSpatial])
+def test_BiphasicAxonMap_ignores_the_raster(model_cls):
+    # A raster decides when each electrode pulses, not what it delivers. The
+    # rendered waveforms differ; the representative percept does not.
+    with _no_pulse_train_rendering():
+        rastered = _granley(ArgusII(thresholds=80),
+                            model_cls).predict_percept(LogoBVL())
+        at_once = _granley(ArgusII(thresholds=80, raster=None),
+                           model_cls).predict_percept(LogoBVL())
+    npt.assert_array_equal(rastered.data, at_once.data)
+
+
+@pytest.mark.parametrize('param, value', [('amp_range', (0, 100)),
+                                          ('freq', 20 * Hz),
+                                          ('phase_dur', 0.2 * ms)])
+def test_BiphasicAxonMap_reads_the_encoder_parameters(param, value):
+    # Whatever is on `implant.encoder` is the requested encoding, so changing
+    # any of the three quantities this model is a function of changes it:
+    default = _granley(ArgusII(thresholds=80))
+    tweaked = _granley(ArgusII(thresholds=80,
+                               encoder=AmplitudeEncoder(**{param: value})))
+    with _no_pulse_train_rendering():
+        base = default.predict_percept(LogoBVL()).data
+        other = tweaked.predict_percept(LogoBVL()).data
+    npt.assert_equal(np.allclose(base, other), False)
+
+
+def test_BiphasicAxonMap_encoded_current_still_needs_a_threshold():
+    # Argus II encodes 0-50 uA by default, and there is no threshold to read
+    # that as a multiple of. No threshold is invented:
+    model = _granley(ArgusII())
+    with pytest.raises(ValueError) as err:
+        model.predict_percept(LogoBVL())
+    npt.assert_equal('threshold' in str(err.value), True)
+
+
+def test_BiphasicAxonMap_rejects_an_encoded_video():
+    # A video asks each electrode for a different amplitude on every frame,
+    # and there is no principled single one to hand the model:
+    model = _granley(ArgusII(thresholds=80))
+    video = VideoStimulus(np.random.rand(4, 4, 3), time=[0, 200, 400])
+    with pytest.raises(NotImplementedError) as err:
+        model.predict_percept(video)
+    npt.assert_equal('frames' in str(err.value), True)
+
+
+def test_BiphasicAxonMap_rejects_a_custom_encoder_pulse():
+    # A caller-supplied pulse shape carries no biphasic phase duration, and
+    # this model does not reverse-engineer one from the waveform:
+    encoder = AmplitudeEncoder(pulse=BiphasicPulse(1, 0.2), amp_range=(0, 50))
+    model = _granley(ArgusII(thresholds=80, encoder=encoder))
+    with pytest.raises(TypeError) as err:
+        model.predict_percept(LogoBVL())
+    npt.assert_equal('pulse' in str(err.value), True)
+
+
+def test_BiphasicAxonMap_encoded_extraction_is_lazy():
+    # Reading the schedule's parameters must not expand it into samples:
+    implant = ArgusII(thresholds=80)
+    stim = implant.prepare_stim(LogoBVL())
+    _granley(implant).predict_percept(stim)
+    npt.assert_equal(stim._Stimulus__stim['data'] is None, True)
 
 
 # The temporal models a Granley composite is expected to work with. Their
@@ -1116,3 +1191,17 @@ def test_BiphasicAxonMap_noise(model_cls):
     # Salt and pepper are the brightest and darkest values in the frame, so
     # noising every pixel leaves exactly those two values:
     npt.assert_equal(np.unique(frame).size, 2)
+
+
+@pytest.mark.parametrize('temporal_cls', _TEMPORALS)
+def test_BiphasicAxonMapSpatial_composite_reads_an_encoded_image(temporal_cls):
+    # `_envelope_dur` reads stim_dur through the same helper, so a composite
+    # has to understand an encoded schedule too:
+    implant = ArgusII(thresholds=80)
+    composite = Model(spatial=BiphasicAxonMapSpatial(implant=implant, **_GRID),
+                      temporal=temporal_cls()).build()
+    with _no_pulse_train_rendering():
+        percept = composite.predict_percept(LogoBVL())
+    npt.assert_equal(percept.data.shape[-1] > 1, True)
+    npt.assert_equal(np.all(np.isfinite(percept.data)), True)
+    npt.assert_equal(np.any(percept.data), True)

--- a/pulse2percept/stimuli/encoders.py
+++ b/pulse2percept/stimuli/encoders.py
@@ -83,18 +83,13 @@ class _EncodedStimulus(Stimulus):
         self._pulse_ticks = self._own(pulse_ticks, pulse_ticks.dtype)
         self._pulse_vals = self._own(pulse_vals, pulse_vals.dtype)
         self._total = float(total)
-        # Rate (Hz) of every electrode-frame, as the device timing actually
-        # realizes it: a clock or a raster can round a requested period up.
+        # Realized Hz after clock/raster quantization:
         self._freq = self._own(freq, np.float64)
         self._frame_time = self._own(frame_time, frame_time.dtype)
         self._frame_dur = float(frame_dur)
-        # Phase duration (ms) of the built-in biphasic pulse, or None when the
-        # caller supplied a pulse shape of their own.
         self._phase_dur = None if phase_dur is None else float(phase_dur)
         # Built lazily without rendering the waveform:
         self._time = None
-        # ``_amp`` stays a plain array; the unit it is measured in (uA, or xTh
-        # for a threshold-relative encoder) rides alongside it:
         self._defer(electrodes, unit=amp_unit)
         self.metadata['encoder'] = {'frame_time': self._frame_time,
                                     'frame_dur': self._frame_dur,
@@ -136,16 +131,9 @@ class _EncodedStimulus(Stimulus):
         return rebuilt
 
     def _biphasic_params(self):
-        """``(electrode, freq, amp, phase_dur, stim_dur)`` per driven electrode
-
-        The pulse-physiology half of the schedule, with no waveform rendered
-        and no pulse-onset timing in it: amplitudes are in :py:attr:`unit`,
-        frequencies (Hz) are the ones the device timing realizes, and
-        ``stim_dur`` (ms) is the whole schedule. Electrodes that deliver
-        nothing are omitted.
-
-        Returns None if the schedule was built from a caller-supplied pulse
-        shape, which has no biphasic phase duration to report.
+        """Return one realized biphasic condition per driven electrode.
+        
+        Returns None for custom pulses and rejects multi-frame schedules.
         """
         if self._phase_dur is None:
             return None
@@ -161,14 +149,7 @@ class _EncodedStimulus(Stimulus):
                 if a != 0 and f > 0]
 
     def _with_thresholds(self, thresholds):
-        """This schedule in uA, calibrated against per-electrode thresholds
-
-        A schedule already measured in current is returned unchanged, as is a
-        threshold-relative one none of whose driven electrodes has a threshold.
-        An electrode that delivers nothing needs no threshold. Calibrating only
-        some of the driven electrodes would leave the amplitudes measured in
-        two different things, so that raises instead.
-        """
+        """Calibrate a threshold-relative schedule to uA without rendering."""
         if self.unit != xTh:
             return self
         driven = np.any(self._firing & (self._amp != 0), axis=1)
@@ -182,7 +163,7 @@ class _EncodedStimulus(Stimulus):
                 f"{', '.join(missing)} measured in threshold multiples and "
                 f"the rest in uA. Give every driven electrode a threshold, or "
                 f"none of them.")
-        # Electrodes left out deliver nothing, so their scale is immaterial.
+        # Undriven electrodes need no threshold:
         scale = np.array([thresholds.get(n, 1.0) for n in self.electrodes],
                          dtype=np.float32)[:, np.newaxis]
         return self._rebuilt(self.electrodes, self._amp * scale, self._sched,
@@ -367,8 +348,7 @@ class StimulusEncoder(Encoder):
     __slots__ = ('phase_dur', 'interphase_dur', 'cathodic_first', 'pulse',
                  'clock', 'n_levels', 'frame_dur', 'stretch')
 
-    #: Unit the amplitudes from :py:meth:`_modulate` are measured in. An
-    #: encoder that lets the caller pick it overrides this per instance.
+    #: Unit of amplitudes returned by _modulate
     amp_unit = uA
 
     def __init__(self, phase_dur=0.46, interphase_dur=0,
@@ -842,15 +822,12 @@ class StimulusEncoder(Encoder):
         # The schedule is settled. Expanding it into an n_el x n_time matrix
         # is the expensive half, and the half nothing needs until somebody
         # asks for samples:
-        # Report the rate the device actually runs at, not the one that was
-        # asked for: a clock or a raster can have rounded the period up above.
         realized = np.zeros(shape, dtype=np.float64)
         realized[firing] = MS_PER_S / (period[firing] * DT)
         return _EncodedStimulus(
             electrodes, amp, ticks, sched, onsets, frames, pulse_ticks,
             pulse_vals, total, realized, frame_time, frame_dur,
             None if cycle is None else cycle * DT, amp_unit=self.amp_unit,
-            # A caller-supplied pulse shape has no biphasic phase duration.
             phase_dur=None if self.pulse is not None else self.phase_dur)
 
     def _modulation(self, source, implant=None):
@@ -1026,11 +1003,7 @@ class AmplitudeEncoder(StimulusEncoder):
 
     @staticmethod
     def _amp_range_unit(amp_range):
-        """The unit an ``amp_range`` is in: uA, or xTh if both ends say so
-
-        A bare number means uA, so a half-spelled range such as
-        ``(0, 3 * xTh)`` mixes two dimensions and is rejected.
-        """
+        """Return the uA or xTh unit of amp_range, rejecting mixtures."""
         dim = getattr(amp_range, 'dimension', None)
         if dim is not None:
             dims = [dim]

--- a/pulse2percept/stimuli/encoders.py
+++ b/pulse2percept/stimuli/encoders.py
@@ -13,7 +13,7 @@ from .images import ImageStimulus
 from .pulses import BiphasicPulse
 from .videos import VideoStimulus
 from ..units import (DimensionMismatchError, Hz, as_value, dimensionless, mW,
-                     mm, ms, uA)
+                     mm, ms, uA, xTh)
 from ..utils import PrettyPrint, frame_interval
 # Point encoder warnings at the caller.
 from ..utils.deprecation import _warn_external
@@ -74,7 +74,7 @@ class _EncodedStimulus(Stimulus):
 
     def __init__(self, electrodes, amp, ticks, sched, onsets, frames,
                  pulse_ticks, pulse_vals, total, firing, frame_time,
-                 frame_dur, cycle):
+                 frame_dur, cycle, amp_unit=uA):
         self._amp = self._own(amp, amp.dtype)
         self._ticks = self._own(ticks, ticks.dtype)
         self._sched = self._own(sched, sched.dtype)
@@ -89,7 +89,9 @@ class _EncodedStimulus(Stimulus):
         self._frame_dur = float(frame_dur)
         # Built lazily without rendering the waveform:
         self._time = None
-        self._defer(electrodes)
+        # ``_amp`` stays a plain array; the unit it is measured in (uA, or xTh
+        # for a threshold-relative encoder) rides alongside it:
+        self._defer(electrodes, unit=amp_unit)
         self.metadata['encoder'] = {'frame_time': self._frame_time,
                                     'frame_dur': self._frame_dur,
                                     'cycle': cycle}
@@ -106,17 +108,50 @@ class _EncodedStimulus(Stimulus):
             stim = Stimulus(data.ravel(), electrodes=self.electrodes)
         stim.metadata['encoder'] = {'frame_time': self._frame_time,
                                     'frame_dur': self._frame_dur}
-        return stim
+        return stim._inherit_units(self)
 
-    def _rebuilt(self, electrodes, amp, sched, firing):
-        """This schedule, driving different electrodes or amplitudes"""
+    def _rebuilt(self, electrodes, amp, sched, firing, amp_unit=None):
+        """This schedule, driving different electrodes or amplitudes
+
+        ``amp_unit`` defaults to the unit this schedule already uses; only
+        threshold calibration changes it.
+        """
         rebuilt = _EncodedStimulus(
             electrodes, amp, self._ticks, sched, self._onsets, self._frames,
             self._pulse_ticks, self._pulse_vals, self._total, firing,
             self._frame_time, self._frame_dur,
-            self.metadata['encoder']['cycle'])
+            self.metadata['encoder']['cycle'],
+            amp_unit=self.unit if amp_unit is None else amp_unit)
         rebuilt.metadata['user'] = deepcopy(self.metadata.get('user'))
         return rebuilt
+
+    def _with_thresholds(self, thresholds):
+        """This schedule in uA, calibrated against per-electrode thresholds
+
+        A schedule already measured in current is returned unchanged, as is a
+        threshold-relative one none of whose driven electrodes has a threshold.
+        An electrode that delivers nothing needs no threshold. Calibrating only
+        some of the driven electrodes would leave the amplitudes measured in
+        two different things, so that raises instead.
+        """
+        if self.unit != xTh:
+            return self
+        driven = np.any(self._firing & (self._amp != 0), axis=1)
+        names = [n for n, d in zip(self.electrodes, driven) if d]
+        missing = sorted(n for n in names if n not in thresholds)
+        if len(missing) == len(names):
+            return self
+        if missing:
+            raise DimensionMismatchError(
+                f"Calibrating only some electrodes would leave "
+                f"{', '.join(missing)} measured in threshold multiples and "
+                f"the rest in uA. Give every driven electrode a threshold, or "
+                f"none of them.")
+        # Electrodes left out deliver nothing, so their scale is immaterial.
+        scale = np.array([thresholds.get(n, 1.0) for n in self.electrodes],
+                         dtype=np.float32)[:, np.newaxis]
+        return self._rebuilt(self.electrodes, self._amp * scale, self._sched,
+                             self._firing, amp_unit=uA)
 
     def _scaled(self, factor):
         """This schedule, delivering amplitudes scaled by ``factor``"""
@@ -297,6 +332,10 @@ class StimulusEncoder(Encoder):
     __slots__ = ('phase_dur', 'interphase_dur', 'cathodic_first', 'pulse',
                  'clock', 'n_levels', 'frame_dur', 'stretch')
 
+    #: Unit the amplitudes from :py:meth:`_modulate` are measured in. An
+    #: encoder that lets the caller pick it overrides this per instance.
+    amp_unit = uA
+
     def __init__(self, phase_dur=0.46, interphase_dur=0,
                  cathodic_first=True, pulse=None, clock=None, n_levels=None,
                  frame_dur=None, stretch=False):
@@ -367,8 +406,8 @@ class StimulusEncoder(Encoder):
         Returns
         -------
         amp : array
-            Nonnegative pulse amplitudes (uA), broadcastable to
-            ``gray.shape``.
+            Nonnegative pulse amplitudes, measured in
+            :py:attr:`amp_unit`, broadcastable to ``gray.shape``.
         freq : array
             Pulse frequencies (Hz), broadcastable to ``gray.shape``.
         """
@@ -771,7 +810,7 @@ class StimulusEncoder(Encoder):
         return _EncodedStimulus(
             electrodes, amp, ticks, sched, onsets, frames, pulse_ticks,
             pulse_vals, total, freq > 0, frame_time, frame_dur,
-            None if cycle is None else cycle * DT)
+            None if cycle is None else cycle * DT, amp_unit=self.amp_unit)
 
     def _modulation(self, source, implant=None):
         """What the source asks each electrode for, frame by frame
@@ -831,9 +870,10 @@ class StimulusEncoder(Encoder):
         Returns
         -------
         stim : :py:class:`~pulse2percept.stimuli.Stimulus`
-            The encoded stimulus, ready for the implant to deliver.
-            Its amplitudes are in microamps and its time axis in
-            milliseconds, whatever units the encoder's own parameters were
+            The encoded stimulus, ready for the implant to deliver. Its
+            amplitudes are in microamps, or in threshold multiples (``xTh``)
+            if the encoder's amplitude parameters were, and its time axis is
+            in milliseconds, whatever units the encoder's own parameters were
             given in.
 
         Raises
@@ -866,8 +906,20 @@ class AmplitudeEncoder(StimulusEncoder):
     Parameters
     ----------
     amp_range : (min_amp, max_amp), optional
-        Range of pulse amplitudes (uA). A gray level of 0 maps onto
-        ``min_amp`` and a gray level of 1 onto ``max_amp``.
+        Range of pulse amplitudes, in uA or in multiples of perceptual
+        threshold (``xTh``). A gray level of 0 maps onto ``min_amp`` and a
+        gray level of 1 onto ``max_amp``.
+
+        Bare numbers mean uA. Both endpoints must carry the same dimension, so
+        a threshold-relative range is spelled ``(0 * xTh, 3 * xTh)``; the half
+        spelling ``(0, 3 * xTh)`` is rejected rather than guessed at. A
+        threshold-relative range encodes to a ``xTh`` stimulus, which an
+        implant converts to current when it has
+        :py:attr:`~pulse2percept.implants.ProsthesisSystem.thresholds` for
+        every driven electrode.
+
+        .. versionchanged:: 0.11.0
+            Accepts ``xTh`` as well as current.
     freq : float, optional
         Pulse train frequency (Hz), the same for every electrode. The pulse
         clock runs independently of the video, so the frame rate has no say in
@@ -907,13 +959,14 @@ class AmplitudeEncoder(StimulusEncoder):
     >>> stim = encoder.encode(p2p.stimuli.BostonTrain(), implant=implant)
 
     """
-    __slots__ = ('amp_range', 'freq')
+    __slots__ = ('amp_range', 'freq', 'amp_unit')
 
     def __init__(self, amp_range=(0, 50), freq=20, **kwargs):
         super().__init__(**kwargs)
+        amp_unit = self._amp_range_unit(amp_range)
         # See `StimulusEncoder.__init__`. `amp_range` is converted element by
         # element, so its two endpoints may be given in different units:
-        amp_range = as_value(amp_range, uA, 'amp_range')
+        amp_range = as_value(amp_range, amp_unit, 'amp_range')
         freq = as_value(freq, Hz, 'freq')
         if np.size(amp_range) != 2:
             raise ValueError(f"'amp_range' must be a (min_amp, max_amp) "
@@ -927,12 +980,40 @@ class AmplitudeEncoder(StimulusEncoder):
         if freq < 0:
             raise ValueError("'freq' cannot be negative.")
         self.amp_range = amp_range
+        self.amp_unit = amp_unit
         self.freq = freq
+
+    @staticmethod
+    def _amp_range_unit(amp_range):
+        """The unit an ``amp_range`` is in: uA, or xTh if both ends say so
+
+        A bare number means uA, so a half-spelled range such as
+        ``(0, 3 * xTh)`` mixes two dimensions and is rejected.
+        """
+        dim = getattr(amp_range, 'dimension', None)
+        if dim is not None:
+            dims = [dim]
+        else:
+            try:
+                dims = [getattr(a, 'dimension', uA.dimension)
+                        for a in amp_range]
+            except TypeError:
+                # Not a pair at all; the shape check reports that.
+                return uA
+        if all(d == xTh.dimension for d in dims):
+            return xTh
+        if any(d == xTh.dimension for d in dims):
+            raise DimensionMismatchError(
+                f"'amp_range' mixes threshold multiples with current. Give "
+                f"both endpoints in xTh, as in (0 * xTh, 3 * xTh), or both in "
+                f"current. Got {amp_range}.")
+        return uA
 
     def _pprint_params(self):
         """Return a dict of class arguments to pretty-print"""
         params = super()._pprint_params()
-        params.update({'amp_range': self.amp_range, 'freq': self.freq})
+        params.update({'amp_range': self.amp_range, 'amp_unit': self.amp_unit,
+                       'freq': self.freq})
         return params
 
     def _modulate(self, gray):

--- a/pulse2percept/stimuli/encoders.py
+++ b/pulse2percept/stimuli/encoders.py
@@ -69,12 +69,12 @@ class _EncodedStimulus(Stimulus):
     _has_spatial_view = True
 
     __slots__ = ('_amp', '_ticks', '_sched', '_onsets', '_frames',
-                 '_pulse_ticks', '_pulse_vals', '_total', '_firing',
-                 '_frame_time', '_frame_dur', '_time')
+                 '_pulse_ticks', '_pulse_vals', '_total', '_freq',
+                 '_frame_time', '_frame_dur', '_time', '_phase_dur')
 
     def __init__(self, electrodes, amp, ticks, sched, onsets, frames,
-                 pulse_ticks, pulse_vals, total, firing, frame_time,
-                 frame_dur, cycle, amp_unit=uA):
+                 pulse_ticks, pulse_vals, total, freq, frame_time,
+                 frame_dur, cycle, amp_unit=uA, phase_dur=None):
         self._amp = self._own(amp, amp.dtype)
         self._ticks = self._own(ticks, ticks.dtype)
         self._sched = self._own(sched, sched.dtype)
@@ -83,10 +83,14 @@ class _EncodedStimulus(Stimulus):
         self._pulse_ticks = self._own(pulse_ticks, pulse_ticks.dtype)
         self._pulse_vals = self._own(pulse_vals, pulse_vals.dtype)
         self._total = float(total)
-        # Electrode-frames with a nonzero requested rate:
-        self._firing = self._own(firing, bool)
+        # Rate (Hz) of every electrode-frame, as the device timing actually
+        # realizes it: a clock or a raster can round a requested period up.
+        self._freq = self._own(freq, np.float64)
         self._frame_time = self._own(frame_time, frame_time.dtype)
         self._frame_dur = float(frame_dur)
+        # Phase duration (ms) of the built-in biphasic pulse, or None when the
+        # caller supplied a pulse shape of their own.
+        self._phase_dur = None if phase_dur is None else float(phase_dur)
         # Built lazily without rendering the waveform:
         self._time = None
         # ``_amp`` stays a plain array; the unit it is measured in (uA, or xTh
@@ -95,6 +99,11 @@ class _EncodedStimulus(Stimulus):
         self.metadata['encoder'] = {'frame_time': self._frame_time,
                                     'frame_dur': self._frame_dur,
                                     'cycle': cycle}
+
+    @property
+    def _firing(self):
+        """Electrode-frames whose pulse clock is running"""
+        return self._freq > 0
 
     def _spatial_view(self):
         """One column per frame of the source and one row per electrode"""
@@ -110,7 +119,7 @@ class _EncodedStimulus(Stimulus):
                                     'frame_dur': self._frame_dur}
         return stim._inherit_units(self)
 
-    def _rebuilt(self, electrodes, amp, sched, firing, amp_unit=None):
+    def _rebuilt(self, electrodes, amp, sched, freq, amp_unit=None):
         """This schedule, driving different electrodes or amplitudes
 
         ``amp_unit`` defaults to the unit this schedule already uses; only
@@ -118,12 +127,38 @@ class _EncodedStimulus(Stimulus):
         """
         rebuilt = _EncodedStimulus(
             electrodes, amp, self._ticks, sched, self._onsets, self._frames,
-            self._pulse_ticks, self._pulse_vals, self._total, firing,
+            self._pulse_ticks, self._pulse_vals, self._total, freq,
             self._frame_time, self._frame_dur,
             self.metadata['encoder']['cycle'],
-            amp_unit=self.unit if amp_unit is None else amp_unit)
+            amp_unit=self.unit if amp_unit is None else amp_unit,
+            phase_dur=self._phase_dur)
         rebuilt.metadata['user'] = deepcopy(self.metadata.get('user'))
         return rebuilt
+
+    def _biphasic_params(self):
+        """``(electrode, freq, amp, phase_dur, stim_dur)`` per driven electrode
+
+        The pulse-physiology half of the schedule, with no waveform rendered
+        and no pulse-onset timing in it: amplitudes are in :py:attr:`unit`,
+        frequencies (Hz) are the ones the device timing realizes, and
+        ``stim_dur`` (ms) is the whole schedule. Electrodes that deliver
+        nothing are omitted.
+
+        Returns None if the schedule was built from a caller-supplied pulse
+        shape, which has no biphasic phase duration to report.
+        """
+        if self._phase_dur is None:
+            return None
+        if self._amp.shape[1] != 1:
+            raise NotImplementedError(
+                f"A schedule of {self._amp.shape[1]} frames describes a "
+                f"different pulse train on each frame, so it has no single "
+                f"(freq, amp, phase_dur) per electrode. Encode a still image, "
+                f"or drive the electrodes with BiphasicPulseTrain objects.")
+        return [(name, float(f), float(a), self._phase_dur, self._total)
+                for name, a, f in zip(self.electrodes, self._amp[:, 0],
+                                      self._freq[:, 0])
+                if a != 0 and f > 0]
 
     def _with_thresholds(self, thresholds):
         """This schedule in uA, calibrated against per-electrode thresholds
@@ -151,18 +186,18 @@ class _EncodedStimulus(Stimulus):
         scale = np.array([thresholds.get(n, 1.0) for n in self.electrodes],
                          dtype=np.float32)[:, np.newaxis]
         return self._rebuilt(self.electrodes, self._amp * scale, self._sched,
-                             self._firing, amp_unit=uA)
+                             self._freq, amp_unit=uA)
 
     def _scaled(self, factor):
         """This schedule, delivering amplitudes scaled by ``factor``"""
         return self._rebuilt(self.electrodes, self._amp * factor, self._sched,
-                             self._firing)
+                             self._freq)
 
     def _without_electrodes(self, electrodes):
         """This schedule, no longer driving ``electrodes``"""
         keep = self._keep_mask(electrodes)
         return self._rebuilt(self.electrodes[keep], self._amp[keep],
-                             self._sched[keep], self._firing[keep])
+                             self._sched[keep], self._freq[keep])
 
     @property
     def duration(self):
@@ -807,10 +842,16 @@ class StimulusEncoder(Encoder):
         # The schedule is settled. Expanding it into an n_el x n_time matrix
         # is the expensive half, and the half nothing needs until somebody
         # asks for samples:
+        # Report the rate the device actually runs at, not the one that was
+        # asked for: a clock or a raster can have rounded the period up above.
+        realized = np.zeros(shape, dtype=np.float64)
+        realized[firing] = MS_PER_S / (period[firing] * DT)
         return _EncodedStimulus(
             electrodes, amp, ticks, sched, onsets, frames, pulse_ticks,
-            pulse_vals, total, freq > 0, frame_time, frame_dur,
-            None if cycle is None else cycle * DT, amp_unit=self.amp_unit)
+            pulse_vals, total, realized, frame_time, frame_dur,
+            None if cycle is None else cycle * DT, amp_unit=self.amp_unit,
+            # A caller-supplied pulse shape has no biphasic phase duration.
+            phase_dur=None if self.pulse is not None else self.phase_dur)
 
     def _modulation(self, source, implant=None):
         """What the source asks each electrode for, frame by frame

--- a/pulse2percept/stimuli/pulse_trains.py
+++ b/pulse2percept/stimuli/pulse_trains.py
@@ -493,11 +493,7 @@ class BiphasicPulseTrain(Stimulus):
                 'time': self._train.time}
 
     def _rebuilt(self, amp, threshold_amp, cathodic_first=None):
-        """This train, with a different amplitude and/or threshold
-
-        ``threshold_amp`` is only what ``amp`` is resolved against; the
-        caller's threshold and any implant calibration carry across unchanged.
-        """
+        """Rebuild this schedule with new electrodes, amplitudes, or frequency."""
         if cathodic_first is None:
             cathodic_first = self.cathodic_first
         train = BiphasicPulseTrain(
@@ -513,11 +509,7 @@ class BiphasicPulseTrain(Stimulus):
         return train
 
     def _with_threshold(self, override):
-        """Return this train with an implant threshold override.
-
-        Threshold-relative trains preserve ``amp_factor``; current-valued
-        trains preserve ``amp``.
-        """
+        """Calibrate a threshold-relative schedule to uA without rendering."""
         if override == self._threshold_override:
             return self
         amp = self.amp_factor * xTh if self._amp_relative else self.amp

--- a/pulse2percept/stimuli/tests/test_encoders.py
+++ b/pulse2percept/stimuli/tests/test_encoders.py
@@ -1528,7 +1528,6 @@ def test_PRIMAEncoder_records_its_settings():
     npt.assert_almost_equal(stim.pulse_dur.max(), 9.8)
     npt.assert_almost_equal(stim.duty_cycle.max(), 0.294)
     npt.assert_equal(stim.grayscale, True)
-    # Optical settings are schedule state; metadata stores only frame timing.
     npt.assert_equal(sorted(stim.metadata['encoder']),
                      ['frame_dur', 'frame_time'])
 
@@ -1572,7 +1571,6 @@ def test_PRIMAEncoder_video():
     npt.assert_almost_equal(stim.duration, 120)
     npt.assert_almost_equal(stim.metadata['encoder']['frame_dur'], 1000 / 30)
     npt.assert_equal(stim.pulse_dur.shape, (378, 4))
-    # Zero-order hold samples source frames 0, 0, 1, and 2.
     npt.assert_array_almost_equal(stim.pulse_dur.max(axis=0),
                                   [9.8, 9.8, 0, 9.8])
     view = stim._spatial_view()
@@ -1591,14 +1589,12 @@ def test_PRIMAEncoder_samples_a_video_without_retiming_it(fps, n_source):
     stim = PRIMAEncoder().encode(video, implant=implant)
     npt.assert_almost_equal(stim.duration, 1000)
     npt.assert_equal(stim.pulse_dur.shape[1], 30)
-    # Projector frames remain 33.3 ms apart.
     npt.assert_almost_equal(np.diff(stim._spatial_view().time), 1000 / 30,
                             decimal=3)
 
 
 @pytest.mark.parametrize('fps', [15, 60])
 def test_PRIMAEncoder_repeats_slow_frames_and_skips_fast_ones(fps):
-    # Alternating source frames expose repeat/skip behavior.
     implant = PRIMAPivotal()
     gray = np.zeros((8, 8, fps))
     gray[..., ::2] = 1.0
@@ -1611,12 +1607,10 @@ def test_PRIMAEncoder_repeats_slow_frames_and_skips_fast_ones(fps):
         npt.assert_array_equal(lit.reshape(-1, 2)[:, 0],
                                lit.reshape(-1, 2)[:, 1])
     else:
-        # At 60 fps, only even source frames are sampled.
         npt.assert_equal(lit.all(), True)
 
 
 def test_PRIMAEncoder_starts_where_the_source_does():
-    # Preserve nonzero source start times.
     implant = PRIMAPivotal()
     video = VideoStimulus(np.ones((8, 8, 3)),
                           time=100 + np.arange(3) * (1000 / 30))
@@ -1627,8 +1621,6 @@ def test_PRIMAEncoder_starts_where_the_source_does():
     # Dark until the source starts:
     npt.assert_almost_equal(stim.data[:, stim.time < 100].max(), 0)
 
-    # Cropping also preserves the nonzero start time.
-    # bottom/right avoid an unrelated spatial bounds check in VideoStimulus.crop.
     gray = np.zeros((8, 8, 9))
     gray[..., 3:6] = 1.0
     cropped = VideoStimulus(gray, time=np.arange(9) * (1000 / 30)).crop(
@@ -1647,7 +1639,6 @@ def test_PRIMAEncoder_finishes_every_pulse_it_starts():
     npt.assert_almost_equal(stim.duration, 40)
     npt.assert_array_almost_equal(stim.pulse_dur.max(axis=0), [9.8, 0])
     npt.assert_almost_equal(stim.data[:, -1].max(), 0)
-    # Final pulses are dropped rather than shortened off-grid.
     kept = stim.pulse_dur[stim.pulse_dur > 0]
     npt.assert_almost_equal(kept / 0.7, np.round(kept / 0.7))
 
@@ -1657,20 +1648,17 @@ def test_PRIMAEncoder_defers_the_waveform():
     stim = PRIMAEncoder().encode(ImageStimulus(np.ones((16, 16))),
                                  implant=implant)
     npt.assert_equal(_rendered(stim), False)
-    # Schedule properties do not require waveform rendering.
     npt.assert_almost_equal(stim.duration, 500)
     npt.assert_equal(stim.unit, mW / mm ** 2)
     npt.assert_equal(len(stim.electrodes), 378)
     npt.assert_almost_equal(stim.pulse_dur.max(), 9.8)
     npt.assert_equal(_rendered(stim._spatial_view()), True)
     npt.assert_equal(_rendered(stim), False)
-    # Preparation and electrode removal preserve laziness.
     npt.assert_equal(_rendered(implant.prepare_stim(stim)), False)
     implant.deactivate('A5')
     prepared = implant.prepare_stim(ImageStimulus(np.ones((16, 16))))
     npt.assert_equal(_rendered(prepared), False)
     npt.assert_equal(len(prepared.electrodes), 377)
-    # Accessing samples renders the waveform.
     npt.assert_equal(stim.data.shape, (378, stim.time.size))
     npt.assert_equal(_rendered(stim), True)
 
@@ -1678,7 +1666,6 @@ def test_PRIMAEncoder_defers_the_waveform():
 def test_PRIMAEncoder_scales_the_power():
     stim = PRIMAEncoder().encode(ImageStimulus(np.ones((8, 8))),
                                  implant=PRIMAPivotal())
-    # Scaling changes irradiance, not quantized pulse duration.
     scaled = stim * 0.5
     npt.assert_equal(_rendered(scaled), False)
     npt.assert_almost_equal(scaled.irradiance, 1.75)
@@ -1687,17 +1674,14 @@ def test_PRIMAEncoder_scales_the_power():
 
 
 def test_AmplitudeEncoder_amp_range_unit():
-    # Bare numbers and current quantities both mean uA:
     for amp_range in ((0, 50), (0, 50 * uA), (0 * uA, 0.05 * mA)):
         encoder = AmplitudeEncoder(amp_range=amp_range)
         npt.assert_equal(encoder.amp_unit, uA)
         npt.assert_almost_equal(np.asarray(encoder.amp_range), [0, 50])
-    # Threshold multiples are kept as such:
     encoder = AmplitudeEncoder(amp_range=(0 * xTh, 3 * xTh))
     npt.assert_equal(encoder.amp_unit, xTh)
     npt.assert_almost_equal(np.asarray(encoder.amp_range), [0, 3])
     npt.assert_equal(isinstance(encoder.amp_range[1], Quantity), False)
-    # A whole-array spelling works too:
     npt.assert_equal(
         AmplitudeEncoder(amp_range=np.array([0, 3]) * xTh).amp_unit, xTh)
 
@@ -1705,7 +1689,6 @@ def test_AmplitudeEncoder_amp_range_unit():
 @pytest.mark.parametrize('amp_range', [(0, 3 * xTh), (0 * xTh, 3),
                                        (0 * uA, 3 * xTh), (0 * xTh, 50 * uA)])
 def test_AmplitudeEncoder_amp_range_rejects_mixed_units(amp_range):
-    # A bare number means uA, so half-spelled ranges are ambiguous:
     with pytest.raises(DimensionMismatchError):
         AmplitudeEncoder(amp_range=amp_range)
 
@@ -1729,12 +1712,9 @@ def test_AmplitudeEncoder_encodes_threshold_multiples():
     stim = AmplitudeEncoder(amp_range=(0 * xTh, 3 * xTh)).encode(img)
     npt.assert_equal(stim.unit, xTh)
     npt.assert_equal(stim.time_unit, ms)
-    # Gray 0 -> 0 xTh and gray 1 -> 3 xTh, as for a current range:
     npt.assert_almost_equal(np.abs(stim.data).max(axis=1).min(), 0, decimal=4)
     npt.assert_almost_equal(np.abs(stim.data).max(axis=1).max(), 3, decimal=4)
-    # Rendering does not quietly turn the samples into current:
     npt.assert_equal(stim.unit, xTh)
-    # An otherwise identical current encoding differs only by the unit:
     current = AmplitudeEncoder(amp_range=(0, 3)).encode(img)
     npt.assert_equal(current.unit, uA)
     npt.assert_array_equal(current.data, stim.data)
@@ -1748,23 +1728,19 @@ def test_AmplitudeEncoder_xTh_survives_the_schedule_operations():
     npt.assert_equal(stim._scaled(2).unit, xTh)
     npt.assert_almost_equal(stim._scaled(2)._spatial_view().data.max(), 6)
     npt.assert_equal(stim._without_electrodes([stim.electrodes[0]]).unit, xTh)
-    # None of that rendered a waveform:
     npt.assert_equal(_rendered(stim), False)
 
 
 def test_AmplitudeEncoder_xTh_is_calibrated_by_the_implant():
     img = ImageStimulus(np.ones((16, 16)))
     encoder = lambda: AmplitudeEncoder(amp_range=(0 * xTh, 2 * xTh))
-    # Without thresholds the schedule stays threshold-relative:
     plain = ArgusII(encoder=encoder()).prepare_stim(img)
     npt.assert_equal(plain.unit, xTh)
     npt.assert_almost_equal(plain._spatial_view().data.max(), 2)
-    # With them it is current, and calibration renders nothing:
     calibrated = ArgusII(thresholds=80, encoder=encoder()).prepare_stim(img)
     npt.assert_equal(calibrated.unit, uA)
     npt.assert_equal(_rendered(calibrated), False)
     npt.assert_almost_equal(calibrated._spatial_view().data.max(), 160)
-    # Per-electrode thresholds drive the same gray level differently:
     implant = ArgusII(thresholds={'A1': 40, 'A2': 80}, encoder=encoder())
     implant.thresholds = {**implant.thresholds,
                           **{name: 60 for name in implant.electrode_names
@@ -1776,8 +1752,6 @@ def test_AmplitudeEncoder_xTh_is_calibrated_by_the_implant():
 
 
 def test_AmplitudeEncoder_xTh_partial_calibration_raises():
-    # An all-white image drives every electrode, so every one needs a
-    # threshold; calibrating some would mix xTh with uA:
     implant = ArgusII(thresholds={'A1': 80},
                       encoder=AmplitudeEncoder(amp_range=(0 * xTh, 2 * xTh)))
     with pytest.raises(DimensionMismatchError) as err:
@@ -1786,14 +1760,11 @@ def test_AmplitudeEncoder_xTh_partial_calibration_raises():
 
 
 def test_AmplitudeEncoder_xTh_zero_amplitude_needs_no_threshold():
-    # A black image drives nothing, so no threshold is missing. It also has
-    # nothing to calibrate, so it stays in xTh:
     implant = ArgusII(thresholds={'A1': 80},
                       encoder=AmplitudeEncoder(amp_range=(0 * xTh, 2 * xTh)))
     stim = implant.prepare_stim(ImageStimulus(np.zeros((16, 16))))
     npt.assert_equal(stim.unit, xTh)
     npt.assert_almost_equal(np.abs(stim.data).max(), 0)
-    # Only 'A1' is lit, and only 'A1' has a threshold:
     img = np.zeros((6, 10))
     img[0, 0] = 1
     stim = implant.prepare_stim(ImageStimulus(img))
@@ -1802,8 +1773,6 @@ def test_AmplitudeEncoder_xTh_zero_amplitude_needs_no_threshold():
 
 
 def test_AmplitudeEncoder_xTh_fails_the_electrical_safety_checks():
-    # Charge balance and current limits are electrical properties, so they
-    # still require actual current:
     encoder = AmplitudeEncoder(amp_range=(0 * xTh, 2 * xTh))
     img = ImageStimulus(np.ones((16, 16)))
     limited = ArgusII(encoder=encoder)
@@ -1811,6 +1780,5 @@ def test_AmplitudeEncoder_xTh_fails_the_electrical_safety_checks():
     for implant in (ArgusII(encoder=encoder, safe_mode=True), limited):
         with pytest.raises(DimensionMismatchError):
             implant.prepare_stim(img)
-    # Calibrating first satisfies them:
     implant = ArgusII(encoder=encoder, thresholds=80, safe_mode=True)
     npt.assert_equal(implant.prepare_stim(img).unit, uA)

--- a/pulse2percept/stimuli/tests/test_encoders.py
+++ b/pulse2percept/stimuli/tests/test_encoders.py
@@ -19,7 +19,7 @@ from pulse2percept.utils.constants import DT
 from pulse2percept.utils.testing import assert_warns_msg
 from pulse2percept.units import (DimensionMismatchError, Hz, Quantity, W,
                                  dimensionless, kHz, m, mA, mW, mm, ms, uA,
-                                 us)
+                                 us, xTh)
 from pulse2percept.units import s as sec
 
 
@@ -1684,3 +1684,133 @@ def test_PRIMAEncoder_scales_the_power():
     npt.assert_almost_equal(scaled.irradiance, 1.75)
     npt.assert_array_almost_equal(scaled.pulse_dur, stim.pulse_dur)
     npt.assert_almost_equal(scaled.data.max(), 1.75)
+
+
+def test_AmplitudeEncoder_amp_range_unit():
+    # Bare numbers and current quantities both mean uA:
+    for amp_range in ((0, 50), (0, 50 * uA), (0 * uA, 0.05 * mA)):
+        encoder = AmplitudeEncoder(amp_range=amp_range)
+        npt.assert_equal(encoder.amp_unit, uA)
+        npt.assert_almost_equal(np.asarray(encoder.amp_range), [0, 50])
+    # Threshold multiples are kept as such:
+    encoder = AmplitudeEncoder(amp_range=(0 * xTh, 3 * xTh))
+    npt.assert_equal(encoder.amp_unit, xTh)
+    npt.assert_almost_equal(np.asarray(encoder.amp_range), [0, 3])
+    npt.assert_equal(isinstance(encoder.amp_range[1], Quantity), False)
+    # A whole-array spelling works too:
+    npt.assert_equal(
+        AmplitudeEncoder(amp_range=np.array([0, 3]) * xTh).amp_unit, xTh)
+
+
+@pytest.mark.parametrize('amp_range', [(0, 3 * xTh), (0 * xTh, 3),
+                                       (0 * uA, 3 * xTh), (0 * xTh, 50 * uA)])
+def test_AmplitudeEncoder_amp_range_rejects_mixed_units(amp_range):
+    # A bare number means uA, so half-spelled ranges are ambiguous:
+    with pytest.raises(DimensionMismatchError):
+        AmplitudeEncoder(amp_range=amp_range)
+
+
+@pytest.mark.parametrize('amp_range', [(0 * ms, 3 * ms), (0 * mW, 3 * mW)])
+def test_AmplitudeEncoder_amp_range_rejects_wrong_dimension(amp_range):
+    with pytest.raises(DimensionMismatchError):
+        AmplitudeEncoder(amp_range=amp_range)
+
+
+@pytest.mark.parametrize('bad', [(-1 * xTh, 3 * xTh),
+                                 (0 * xTh, np.inf * xTh),
+                                 (0 * xTh, np.nan * xTh)])
+def test_AmplitudeEncoder_amp_range_xTh_is_validated(bad):
+    with pytest.raises(ValueError):
+        AmplitudeEncoder(amp_range=bad)
+
+
+def test_AmplitudeEncoder_encodes_threshold_multiples():
+    img = ImageStimulus(np.linspace(0, 1, 16).reshape((4, 4)))
+    stim = AmplitudeEncoder(amp_range=(0 * xTh, 3 * xTh)).encode(img)
+    npt.assert_equal(stim.unit, xTh)
+    npt.assert_equal(stim.time_unit, ms)
+    # Gray 0 -> 0 xTh and gray 1 -> 3 xTh, as for a current range:
+    npt.assert_almost_equal(np.abs(stim.data).max(axis=1).min(), 0, decimal=4)
+    npt.assert_almost_equal(np.abs(stim.data).max(axis=1).max(), 3, decimal=4)
+    # Rendering does not quietly turn the samples into current:
+    npt.assert_equal(stim.unit, xTh)
+    # An otherwise identical current encoding differs only by the unit:
+    current = AmplitudeEncoder(amp_range=(0, 3)).encode(img)
+    npt.assert_equal(current.unit, uA)
+    npt.assert_array_equal(current.data, stim.data)
+
+
+def test_AmplitudeEncoder_xTh_survives_the_schedule_operations():
+    stim = AmplitudeEncoder(amp_range=(0 * xTh, 3 * xTh)).encode(
+        ImageStimulus(np.ones((4, 4))), implant=None)
+    npt.assert_equal(stim._spatial_view().unit, xTh)
+    npt.assert_almost_equal(stim._spatial_view().data.max(), 3)
+    npt.assert_equal(stim._scaled(2).unit, xTh)
+    npt.assert_almost_equal(stim._scaled(2)._spatial_view().data.max(), 6)
+    npt.assert_equal(stim._without_electrodes([stim.electrodes[0]]).unit, xTh)
+    # None of that rendered a waveform:
+    npt.assert_equal(_rendered(stim), False)
+
+
+def test_AmplitudeEncoder_xTh_is_calibrated_by_the_implant():
+    img = ImageStimulus(np.ones((16, 16)))
+    encoder = lambda: AmplitudeEncoder(amp_range=(0 * xTh, 2 * xTh))
+    # Without thresholds the schedule stays threshold-relative:
+    plain = ArgusII(encoder=encoder()).prepare_stim(img)
+    npt.assert_equal(plain.unit, xTh)
+    npt.assert_almost_equal(plain._spatial_view().data.max(), 2)
+    # With them it is current, and calibration renders nothing:
+    calibrated = ArgusII(thresholds=80, encoder=encoder()).prepare_stim(img)
+    npt.assert_equal(calibrated.unit, uA)
+    npt.assert_equal(_rendered(calibrated), False)
+    npt.assert_almost_equal(calibrated._spatial_view().data.max(), 160)
+    # Per-electrode thresholds drive the same gray level differently:
+    implant = ArgusII(thresholds={'A1': 40, 'A2': 80}, encoder=encoder())
+    implant.thresholds = {**implant.thresholds,
+                          **{name: 60 for name in implant.electrode_names
+                             if name not in ('A1', 'A2')}}
+    view = implant.prepare_stim(img)._spatial_view()
+    amps = dict(zip(view.electrodes, np.abs(view.data).max(axis=1)))
+    npt.assert_almost_equal(amps['A1'], 80)
+    npt.assert_almost_equal(amps['A2'], 160)
+
+
+def test_AmplitudeEncoder_xTh_partial_calibration_raises():
+    # An all-white image drives every electrode, so every one needs a
+    # threshold; calibrating some would mix xTh with uA:
+    implant = ArgusII(thresholds={'A1': 80},
+                      encoder=AmplitudeEncoder(amp_range=(0 * xTh, 2 * xTh)))
+    with pytest.raises(DimensionMismatchError) as err:
+        implant.prepare_stim(ImageStimulus(np.ones((16, 16))))
+    npt.assert_equal('threshold multiples' in str(err.value), True)
+
+
+def test_AmplitudeEncoder_xTh_zero_amplitude_needs_no_threshold():
+    # A black image drives nothing, so no threshold is missing. It also has
+    # nothing to calibrate, so it stays in xTh:
+    implant = ArgusII(thresholds={'A1': 80},
+                      encoder=AmplitudeEncoder(amp_range=(0 * xTh, 2 * xTh)))
+    stim = implant.prepare_stim(ImageStimulus(np.zeros((16, 16))))
+    npt.assert_equal(stim.unit, xTh)
+    npt.assert_almost_equal(np.abs(stim.data).max(), 0)
+    # Only 'A1' is lit, and only 'A1' has a threshold:
+    img = np.zeros((6, 10))
+    img[0, 0] = 1
+    stim = implant.prepare_stim(ImageStimulus(img))
+    npt.assert_equal(stim.unit, uA)
+    npt.assert_almost_equal(np.abs(stim.data).max(), 160)
+
+
+def test_AmplitudeEncoder_xTh_fails_the_electrical_safety_checks():
+    # Charge balance and current limits are electrical properties, so they
+    # still require actual current:
+    encoder = AmplitudeEncoder(amp_range=(0 * xTh, 2 * xTh))
+    img = ImageStimulus(np.ones((16, 16)))
+    limited = ArgusII(encoder=encoder)
+    limited.max_current = 1000
+    for implant in (ArgusII(encoder=encoder, safe_mode=True), limited):
+        with pytest.raises(DimensionMismatchError):
+            implant.prepare_stim(img)
+    # Calibrating first satisfies them:
+    implant = ArgusII(encoder=encoder, thresholds=80, safe_mode=True)
+    npt.assert_equal(implant.prepare_stim(img).unit, uA)


### PR DESCRIPTION
This PR makes `BiphasicAxonMapModel` work with image stimuli encoded by an implant, including the default `ArgusII` encoding pipeline.

- [x] Fix `n_gray`, `noise`, and stimulus metadata handling in `BiphasicAxonMapSpatial` (#864).
- [x] Allow implant thresholds to be provided at construction, e.g. `ArgusII(thresholds=80 * uA)`.
- [x] Allow `AmplitudeEncoder` to encode amplitudes directly in `xTh`.
- [x] Preserve encoded pulse parameters needed by Granley without rendering the waveform.
- [x] Let `BiphasicAxonMapModel` consume still-image encoder output while respecting realized amplitude, frequency, and phase duration. Raster onset timing is ignored where the model has no representation for it.
- [x] Keep multi-frame encoded stimuli and custom pulse shapes unsupported where no single Granley pulse condition can be defined.

This now works:

```python
implant = p2p.implants.ArgusII(thresholds=80 * p2p.units.uA)
model = p2p.models.BiphasicAxonMapModel(implant=implant)
percept = model.predict_percept(p2p.stimuli.LogoBVL())
```

Also supported is threshold-relative encoding via `AmplitudeEncoder(amp_range=(0 * xTh, 3 * xTh))`.

Closes #864.
