### PR TITLE
[ENH] Iterate over video frames as ImageStimulus

### DIFF
--- a/doc/topics/stimuli.rst
+++ b/doc/topics/stimuli.rst
@@ -132,6 +132,21 @@ electrode sees the part of it that electrode actually looks at -- wrap it in a
 :py:class:`~pulse2percept.vision.Scene` and give that to a model; see
 :ref:`topics-models-scene`.
 
+A video can also be processed one frame at a time. Iterating over a
+:py:class:`~pulse2percept.stimuli.VideoStimulus` yields each frame as an
+:py:class:`~pulse2percept.stimuli.ImageStimulus`:
+
+.. code-block:: python
+
+    video = p2p.stimuli.BostonTrain()
+
+    for frame in video:
+        percept = model.predict_percept(frame)
+
+Each call treats the frame as an independent still image. Pass the complete
+video to ``predict_percept`` instead when temporal dynamics across frames
+matter.
+
 Plotting and time operations
 ----------------------------
 

--- a/pulse2percept/stimuli/tests/test_videos.py
+++ b/pulse2percept/stimuli/tests/test_videos.py
@@ -1,5 +1,5 @@
-from pulse2percept.stimuli import (AmplitudeEncoder, VideoStimulus,
-                                   BostonTrain, GirlPool)
+from pulse2percept.stimuli import (AmplitudeEncoder, ImageStimulus,
+                                   VideoStimulus, BostonTrain, GirlPool)
 from pulse2percept.stimuli.videos import _frame_index
 from pulse2percept.units import (DimensionMismatchError, Hz, kHz, deg, dva,
                                  ms, rad, s, uA)
@@ -580,6 +580,80 @@ def test_VideoStimulus_apply(tmp_path):
     # Dropping the color channels changes the pixel count too:
     rgb = VideoStimulus(np.random.rand(6, 8, 3, 4).astype(np.float32))
     npt.assert_equal(rgb.apply(rgb2gray).vid_shape, (6, 8, 4))
+
+    # 'apply' is a low-level array operation that doesn't go through the
+    # public iterator
+    def check(frame):
+        npt.assert_equal(isinstance(frame, np.ndarray), True)
+        npt.assert_equal(frame.flags.writeable, True)
+        return frame
+
+    npt.assert_almost_equal(stim.apply(check).data, stim.data)
+
+
+def test_VideoStimulus_iter():
+    # Iterating a video yields one standalone ImageStimulus per frame
+    ndarray = np.arange(2 * 3 * 4, dtype=np.float32).reshape((2, 3, 4)) / 23
+    video = VideoStimulus(ndarray, time=np.arange(4), metadata={'foo': 'bar'})
+
+    frames = list(video)
+    npt.assert_equal(len(frames), 4)
+    for idx, frame in enumerate(frames):
+        npt.assert_equal(isinstance(frame, ImageStimulus), True)
+        npt.assert_equal(frame.img_shape, video.vid_shape[:-1])
+        npt.assert_almost_equal(frame.data.reshape(frame.img_shape),
+                                ndarray[..., idx])
+        # A still image has no place on the video's time axis:
+        npt.assert_equal(frame.time, None)
+        npt.assert_equal(np.asarray(frame.electrodes),
+                         np.asarray(video.electrodes))
+        npt.assert_equal(frame.metadata['foo'], 'bar')
+
+
+def test_VideoStimulus_iter_rgb():
+    # The color axis is not the frame axis:
+    ndarray = np.arange(2 * 3 * 3 * 5, dtype=np.float32) / 89
+    ndarray = ndarray.reshape((2, 3, 3, 5))
+    video = VideoStimulus(ndarray)
+
+    frames = list(video)
+    npt.assert_equal(len(frames), 5)
+    for idx, frame in enumerate(frames):
+        npt.assert_equal(isinstance(frame, ImageStimulus), True)
+        npt.assert_equal(frame.img_shape, (2, 3, 3))
+        npt.assert_almost_equal(frame.data.reshape((2, 3, 3)),
+                                ndarray[..., idx])
+    npt.assert_equal(list(frames[0].electrodes[:4]),
+                     ['A1_R', 'A1_G', 'A1_B', 'A2_R'])
+
+
+def test_VideoStimulus_iter_is_stateless():
+    video = VideoStimulus(np.random.rand(2, 3, 4).astype(np.float32))
+
+    first, second = list(video), list(video)
+    npt.assert_equal(len(first), 4)
+    for one, two in zip(first, second):
+        npt.assert_almost_equal(one.data, two.data)
+
+    a, b = iter(video), iter(video)
+    npt.assert_almost_equal(next(a).data, first[0].data)
+    npt.assert_almost_equal(next(a).data, first[1].data)
+    npt.assert_almost_equal(next(b).data, first[0].data)
+
+
+def test_VideoStimulus_iter_compressed():
+    frame = np.random.rand(4, 5) * 0.5 + 0.5
+    other = np.random.rand(4, 5) * 0.5 + 0.5
+    video = VideoStimulus(np.stack([frame] * 4 + [other] * 4, axis=-1),
+                          time=np.arange(8), compress=True)
+    frames = list(video)
+    npt.assert_equal(len(frames), 4)
+    npt.assert_almost_equal(frames[0].data.reshape((4, 5)), frame, decimal=6)
+    sparse = np.zeros((4, 5, 6))
+    sparse[1, 1, :] = np.linspace(0, 1, 6)
+    compressed = VideoStimulus(sparse, time=np.arange(6), compress=True)
+    with pytest.raises(ValueError):
+        list(compressed)
 
 
 @pytest.mark.parametrize('n_frames', (1, 2, 3, 10, 14))

--- a/pulse2percept/stimuli/videos.py
+++ b/pulse2percept/stimuli/videos.py
@@ -14,6 +14,7 @@ from skimage import img_as_float32
 from imageio import get_reader as video_reader
 
 from .base import Stimulus, _adoptable
+from .images import ImageStimulus
 from ..units import as_value, deg, dimensionless, ms
 from .names import ElectrodeNames
 from ..utils import (center_image, shift_image, scale_image, trim_image,
@@ -149,7 +150,7 @@ class VideoStimulus(Stimulus):
         .. versionadded:: 0.10.0
 
     """
-    __slots__ = ('vid_shape', '_next_frame')
+    __slots__ = ('vid_shape',)
 
     #: Pixel intensities are gray levels in [0, 1], not currents; see
     #: :py:class:`~pulse2percept.stimuli.ImageStimulus`.
@@ -233,7 +234,6 @@ class VideoStimulus(Stimulus):
                                             metadata=metadata,
                                             compress=compress)
         self.metadata = metadata
-        self.rewind()
 
     def compress(self):
         """Compress the source data
@@ -330,10 +330,9 @@ class VideoStimulus(Stimulus):
         """
         # `func` gets a frame of its own: several of the scikit-image
         # transforms this exists to reach cannot take a read-only one.
-        shape = self.vid_shape[:-1]
-        vid = np.array([func(_as_writable(frame.reshape(shape)),
-                             *args, **kwargs)
-                        for frame in self])
+        frames = self._frames()
+        vid = np.array([func(_as_writable(frames[..., idx]), *args, **kwargs)
+                        for idx in range(frames.shape[-1])])
         # Move first axis (frames) to last:
         vid = np.moveaxis(vid, 0, -1)
         return VideoStimulus(vid, electrodes=self._names_for(vid, electrodes),
@@ -771,21 +770,29 @@ class VideoStimulus(Stimulus):
                                 **kwargs).encode(self, implant=implant)
 
     def __iter__(self):
-        """Iterate over all frames in self.data"""
-        self.rewind()
-        return self
+        """Iterate over the video, one frame at a time
 
-    def __next__(self):
-        """Returns the next frame when iterating over all frames"""
-        this_frame = self._next_frame
-        if this_frame >= self.data.shape[-1]:
-            raise StopIteration
-        self._next_frame += 1
-        return self.data[..., this_frame]
+        .. versionchanged:: 0.10.0
 
-    def rewind(self):
-        """Rewind the iterator"""
-        self._next_frame = 0
+            Each frame is handed out as a standalone
+            :py:class:`~pulse2percept.stimuli.ImageStimulus` that carries the
+            electrode names and metadata of the video, but no time axis
+
+        Yields
+        ------
+        frame : :py:class:`~pulse2percept.stimuli.ImageStimulus`
+            The frames of the video, in order.
+
+        Raises
+        ------
+        ValueError
+            If the video was compressed in space, in which case its frames
+            cannot be reconstructed (see ``compress``).
+        """
+        frames = self._frames()
+        for idx in range(frames.shape[-1]):
+            yield ImageStimulus(frames[..., idx], electrodes=self.electrodes,
+                                metadata=self.metadata)
 
     def play(self, fps=None, repeat=True, annotate_time=True, ax=None,
              fmt='jpg'):
@@ -832,27 +839,22 @@ class VideoStimulus(Stimulus):
             roughly two orders of magnitude faster than Matplotlib's
             ``to_jshtml`` and produces much smaller notebooks and doc pages.
         """
-        def update(data):
+        if self.time is None:
+            raise ValueError("Cannot animate a percept with time=None.")
+        frames = self._frames()
+
+        # Only the inherited Matplotlib machinery (``save``,
+        # ``to_html5_video``) runs these; the HTML player draws ``frames``
+        # itself. Frames are handed out by index so that the title can be
+        # looked up without tracking iterator state:
+        def update(idx):
             if annotate_time:
-                mat.axes.set_title(f't = {self.time[self._next_frame - 1]:.2f} ms')
-            mat.set_data(data.reshape(self.vid_shape[:-1]))
+                mat.axes.set_title(f't = {self.time[idx]:.2f} ms')
+            mat.set_data(frames[..., idx])
             return mat
 
         def data_gen():
-            try:
-                self.rewind()
-                # Advance to the next frame:
-                while True:
-                    yield next(self)
-            except StopIteration:
-                # End of the sequence, exit:
-                pass
-
-        if self.time is None:
-            raise ValueError("Cannot animate a percept with time=None.")
-        # Raises if the video was compressed in space, in which case there is
-        # no dense frame left to display:
-        frames = self._frames()
+            return iter(range(frames.shape[-1]))
 
         # There are several options to animate a percept in Jupyter/IPython
         # (see https://stackoverflow.com/a/46878531). Displaying the animation
@@ -863,8 +865,7 @@ class VideoStimulus(Stimulus):
             fig, ax = plt.subplots(figsize=(8, 5))
         else:
             fig = ax.figure
-        # Rewind the percept and show an empty frame:
-        self.rewind()
+        # Start from an empty frame:
         mat = ax.imshow(np.zeros(self.vid_shape[:-1]), cmap='gray',
                         vmin=0, vmax=self.data.max())
         plt.close(fig)

--- a/pulse2percept/stimuli/videos.py
+++ b/pulse2percept/stimuli/videos.py
@@ -772,7 +772,7 @@ class VideoStimulus(Stimulus):
     def __iter__(self):
         """Iterate over the video, one frame at a time
 
-        .. versionchanged:: 0.10.0
+        .. versionchanged:: 0.11.0
 
             Each frame is handed out as a standalone
             :py:class:`~pulse2percept.stimuli.ImageStimulus` that carries the


### PR DESCRIPTION
`VideoStimulus` is already iterable, but currently yields flattened NumPy arrays and maintains mutable iterator state. This PR makes iteration part of the public stimulus API by yielding each video frame as an `ImageStimulus`, so you can do:

```
for frame in p2p.stimuli.BostonTrain():
    percept = model.predict_percept(frame)
```