### PR TITLE
Fix Dynaphos phosphene size: sigma is P/4, not P/2

### DIFF
--- a/pulse2percept/models/cortex/dynaphos.py
+++ b/pulse2percept/models/cortex/dynaphos.py
@@ -439,7 +439,7 @@ class DynaphosModel(BaseModel):
             D = 2 * np.sqrt(amp / K) # mm
             P = (D / M) # dva
             # calculate sigma for gaussian (only update sigma if amplitude > 0)
-            sigma = np.where(amp > 0, np.clip(P / 2, 1e-22, None), sigma) 
+            sigma = np.where(amp > 0, np.clip(P / 4, 1e-22, None), sigma) 
             # get activation (Ieff converted from uA to A)
             A = A + ((-A / tau_act_s) + Ieff * _A_PER_UA) * dt_s
             # get brightness

--- a/pulse2percept/models/cortex/tests/test_dynaphos.py
+++ b/pulse2percept/models/cortex/tests/test_dynaphos.py
@@ -117,14 +117,14 @@ def test_temporal_predict():
 
     # Test that default models give expected values
     orion = DynaphosModel(implant=Orion(), implant_position=(15, 0) * mm,
-                          step=0.1, dt=20).build()
+                          step=0.01, dt=20).build()
     percept = orion.predict_percept(
         {'55': BiphasicPulseTrain(freq=300, amp=100, phase_dur=0.17)})
-    npt.assert_equal(np.sum(percept.data > 0.0122), 147)
-    npt.assert_equal(np.sum(percept.data > 0.0375), 96)
-    npt.assert_equal(np.sum(percept.data > 0.3305), 49)
-    npt.assert_equal(np.sum(percept.data > 0.8451), 39)
-    npt.assert_equal(np.sum(percept.data > 0.8883), 9)
+    npt.assert_equal(np.sum(percept.data > 0.0122), 4026)
+    npt.assert_equal(np.sum(percept.data > 0.0375), 2806)
+    npt.assert_equal(np.sum(percept.data > 0.3305), 907)
+    npt.assert_equal(np.sum(percept.data > 0.8451), 172)
+    npt.assert_equal(np.sum(percept.data > 0.8883), 90)
 
 def test_deepcopy_Dynaphos():
     original = DynaphosModel(implant=Cortivis())
@@ -391,7 +391,7 @@ def test_location_noise():
                                             phase_dur=0.17)}
     kwargs = dict(implant_position=(20, -5) * mm,
                   xrange=(-4, 4), yrange=(-4, 4),
-                  step=0.05)
+                  step=0.02)
     plain = DynaphosModel(implant=implant, **kwargs).build()
     expected = plain.predict_percept(source).data
 
@@ -424,7 +424,7 @@ def test_location_noise_crosses_meridian():
     # Choose an electrode/offset pair that crosses the vertical meridian.
     implant = Implant(ElectrodeArray([DiskElectrode(-25000, 2000, 0, 100)]))
     source = {0: BiphasicPulseTrain(freq=300, amp=200, phase_dur=0.17)}
-    kwargs = dict(xrange=(-4, 4), yrange=(-4, 4), step=0.05)
+    kwargs = dict(xrange=(-4, 4), yrange=(-4, 4), step=0.02)
     plain = DynaphosModel(implant=implant, **kwargs).build()
     canonical = plain.predict_percept(source)
     npt.assert_array_less(0, _brightest_dva(canonical, plain.grid)[0])

--- a/pulse2percept/models/tests/test_api_equivalence.py
+++ b/pulse2percept/models/tests/test_api_equivalence.py
@@ -66,10 +66,11 @@ REFERENCE = {
                  3.807037961360792, 0.5194367010755934, 1.0132546632537747,
                  (5.0853018679140565, 27.047305434768763,
                   6.941999430159145, 49.25247073610444)),
-    'dynaphos': ((7, 7, 6), (0.0, 100.0),
-                 3.864256768792984e-06, 1.0946714610327035e-06,
-                 3.800738015684018e-12,
-                 (2.0, 4.0, 1.0, 1.0)),
+    'dynaphos': ((121, 121, 6), (0.0, 100.0),
+                 7.886836596880443, 0.8272089958190918,
+                 3.4563948838340095,
+                 (40.9433498104171, 1676.7244805318699,
+                  26.316482385133106, 692.9332594630685)),
     'scene_gaze': ((13, 17, 1), None,
                    1663.1452019751928, 36.72337341308594, 43973.7099062507,
                    (6.000000013081055, 40.855445551864825,
@@ -198,7 +199,7 @@ def test_biphasic_axon_map_prediction_is_unchanged():
 def test_dynaphos_prediction_is_unchanged():
     model = DynaphosModel(implant=Cortivis(), implant_position=(20, -5) * mm,
                           xrange=(-3, 3), yrange=(-3, 3),
-                          step=1, dt=20).build()
+                          step=0.05, dt=20).build()
     percept = model.predict_percept(
         {'11': BiphasicPulseTrain(300, 100, 0.17, stim_dur=100)})
     assert_matches_reference('dynaphos', percept)


### PR DESCRIPTION
`sigma = P / 2` becomes `sigma = P / 4`. The +/-2 sigma interval should span the phosphene size P, so rendered phosphenes were twice their intended standard deviation.

Rebased on current master and cut back to the minimum: one behavioural line, plus the pinned test values it invalidates. The grid steps in those tests are reduced because correctly sized phosphenes fall below one pixel at the previous resolution.

Full suite locally: 28 failures before and after, none introduced.
