### PR TITLE
[API] Require implants when constructing spatial models

### DIFF
--- a/.github/scripts/check_install.py
+++ b/.github/scripts/check_install.py
@@ -170,7 +170,10 @@ def check_model_builds() -> list[str]:
         # This runs against released versions too, and 0.10.0 renamed the
         # grid spacing parameter `xystep` -> `step`. Ask the installed model
         # which spelling it takes rather than assuming the current one.
-        spacing = "step" if hasattr(ScoreboardModel(), "step") else "xystep"
+        # `implant` is passed by keyword because that spelling works both
+        # before and after 0.11.0 made it a required positional argument.
+        probe = ScoreboardModel(implant=ArgusII())
+        spacing = "step" if hasattr(probe, "step") else "xystep"
         model = ScoreboardModel(implant=ArgusII(), xrange=(-4, 4),
                                 yrange=(-4, 4), **{spacing: 1})
         percept = model.predict_percept({e: 1 for e in ("A1", "F10")})

--- a/.github/scripts/check_install.py
+++ b/.github/scripts/check_install.py
@@ -170,8 +170,6 @@ def check_model_builds() -> list[str]:
         # This runs against released versions too, and 0.10.0 renamed the
         # grid spacing parameter `xystep` -> `step`. Ask the installed model
         # which spelling it takes rather than assuming the current one.
-        # `implant` is passed by keyword because that spelling works both
-        # before and after 0.11.0 made it a required positional argument.
         probe = ScoreboardModel(implant=ArgusII())
         spacing = "step" if hasattr(probe, "step") else "xystep"
         model = ScoreboardModel(implant=ArgusII(), xrange=(-4, 4),

--- a/benchmarks/README.rst
+++ b/benchmarks/README.rst
@@ -196,8 +196,8 @@ automatically and no other file changes. For example, a temporal model:
         id='argus2_axonmap_fading',
         stimulus=lambda: array_ptrain(p2p.implants.ArgusII),
         implant=p2p.implants.ArgusII,
-        model=lambda **kwargs: p2p.models.Model(
-            spatial=p2p.models.AxonMapSpatial(xrange=(-12, 12),
+        model=lambda implant, **kwargs: p2p.models.Model(
+            spatial=p2p.models.AxonMapSpatial(implant, xrange=(-12, 12),
                                               yrange=(-8, 8)),
             temporal=p2p.models.FadingTemporal(), **kwargs),
     )

--- a/benchmarks/scenarios.py
+++ b/benchmarks/scenarios.py
@@ -240,8 +240,8 @@ SCENARIOS = [
         id='argus2_scoreboard_fading_ptrain',
         stimulus=lambda: array_ptrain(p2p.implants.ArgusII),
         implant=p2p.implants.ArgusII,
-        model=lambda **kwargs: p2p.models.Model(
-            spatial=p2p.models.ScoreboardSpatial(xrange=(-4, 4),
+        model=lambda implant, **kwargs: p2p.models.Model(
+            spatial=p2p.models.ScoreboardSpatial(implant, xrange=(-4, 4),
                                                  yrange=(-4, 4), step=0.5),
             temporal=p2p.models.FadingTemporal(), **kwargs),
     ),

--- a/doc/topics/models.rst
+++ b/doc/topics/models.rst
@@ -281,18 +281,16 @@ Classes ending in ``Model`` are complete model objects. Classes ending in
 .. code-block:: python
 
     model = p2p.models.Model(
-        implant=implant,
-        spatial=p2p.models.ScoreboardSpatial(),
+        spatial=p2p.models.ScoreboardSpatial(implant),
         temporal=p2p.models.Nanduri2012Temporal(),
     )
 
-The implant belongs to the spatial component -- a temporal model never sees an
-electrode -- and naming it on the parent is shorthand for that. Naming a
-*different* one on both raises rather than silently picking a winner.
-
+The implant belongs to the spatial component, because a temporal model never
+sees an electrode. ``Model`` also takes ``implant=`` for the case where
+``spatial`` is given as a class rather than an instance.
 This is useful when the spatial and temporal assumptions come from different
 models. The combined model handles the intermediate representation and returns
-a Percept like any other Model.
+a ``Percept`` like any other Model.
 
 Components may also be used directly, but normal simulations are simpler
 through the complete Model interface.

--- a/doc/topics/models.rst
+++ b/doc/topics/models.rst
@@ -286,8 +286,8 @@ Classes ending in ``Model`` are complete model objects. Classes ending in
     )
 
 The implant belongs to the spatial component, because a temporal model never
-sees an electrode. ``Model`` also takes ``implant=`` for the case where
-``spatial`` is given as a class rather than an instance.
+sees an electrode. ``Model`` composes components; it never builds them, so
+``spatial`` must be an instance that already names its implant.
 This is useful when the spatial and temporal assumptions come from different
 models. The combined model handles the intermediate representation and returns
 a ``Percept`` like any other Model.

--- a/doc/users/faq.rst
+++ b/doc/users/faq.rst
@@ -232,17 +232,18 @@ Model parameters can usually be passed when the model is created:
 
 .. code-block:: python
 
+    from pulse2percept.implants import ArgusII
     from pulse2percept.models import AxonMapModel
     from pulse2percept.units import um
 
-    model = AxonMapModel(rho=250 * um, lam=700 * um)
+    model = AxonMapModel(ArgusII(), rho=250 * um, lam=700 * um)
     model.build()
 
 Bare numbers also work and retain their documented units:
 
 .. code-block:: python
 
-    model = AxonMapModel(rho=250, lam=700)
+    model = AxonMapModel(ArgusII(), rho=250, lam=700)
 
 Many models perform expensive precomputations in ``build()``. If you change a
 parameter that affects those computations after the model has been built, call
@@ -270,9 +271,11 @@ For example:
 
 .. code-block:: python
 
+    from pulse2percept.implants import ArgusII
     from pulse2percept.models import AxonMapModel
 
     model = AxonMapModel(
+        ArgusII(),
         xrange=(-15, 15),
         yrange=(-10, 10),
         step=0.25,
@@ -390,10 +393,11 @@ For example:
 
 .. code-block:: python
 
+    from pulse2percept.implants import ArgusII
     from pulse2percept.models import Model, ScoreboardSpatial, FadingTemporal
 
     model = Model(
-        spatial=ScoreboardSpatial(),
+        spatial=ScoreboardSpatial(ArgusII()),
         temporal=FadingTemporal(),
     )
     model.build()

--- a/examples/datasets/plot_data_beyeler2019.py
+++ b/examples/datasets/plot_data_beyeler2019.py
@@ -128,7 +128,7 @@ plot_argus_phosphenes(data, argus)
 # from the fovea:
 
 from pulse2percept.models import AxonMapModel
-model = AxonMapModel(loc_od=(16.2, 1.38))
+model = AxonMapModel(argus, loc_od=(16.2, 1.38))
 plot_argus_phosphenes(data, argus, axon_map=model)
 
 ###############################################################################

--- a/examples/implants/plot_implants_cortical.py
+++ b/examples/implants/plot_implants_cortical.py
@@ -81,12 +81,13 @@ plt.show()
 # .. code-block:: python
 #
 #     nmap = p2p.topography.NeuropythyMap(subject='fsaverage', regions=['v1'])
-#     model = p2p.models.cortex.ScoreboardModel(
-#         rho=500, xrange=(-6, 0), yrange=(-5, 5), step=.25, vfmap=nmap
-#     ).build()
+#     xrange, yrange = (-6, 0), (-5, 5)
 #     nlink = Neuralink.from_neuropythy(
-#         nmap, xrange=model.xrange, yrange=model.yrange, step=2, rand_insertion_angle=0
+#         nmap, xrange=xrange, yrange=yrange, step=2, rand_insertion_angle=0
 #     )
+#     model = p2p.models.cortex.ScoreboardModel(
+#         nlink, rho=500, xrange=xrange, yrange=yrange, step=.25, vfmap=nmap
+#     ).build()
 #     print(len(nlink.implants), " total threads")
 #     fig = plt.figure(figsize=(10, 4))
 #     ax1 = fig.add_subplot(121, projection='3d')

--- a/examples/models/plot_neuropythy.py
+++ b/examples/models/plot_neuropythy.py
@@ -88,7 +88,8 @@ Lets use all three regions and plot the result (note it can get a little messy):
 .. code-block:: python
 
     nmap = p2p.topography.NeuropythyMap(subject='fsaverage', regions=['v1', 'v2', 'v3'])
-    model = p2p.models.cortex.ScoreboardModel(xrange=(-20, 20), yrange=(-20, 20), step=0.5,
+    model = p2p.models.cortex.ScoreboardModel(p2p.implants.cortex.Cortivis(),
+                                              xrange=(-20, 20), yrange=(-20, 20), step=0.5,
                                               vfmap=nmap, regions=['v1', 'v2', 'v3'])
     fig = plt.figure(figsize=(10, 4))
     ax1 = fig.add_subplot(121, projection='3d')
@@ -120,11 +121,12 @@ Lets place a Neuralink implant across the right hemisphere of the cortex:
 .. code-block:: python
 
     nmap = p2p.topography.NeuropythyMap(subject='fsaverage', regions=['v1'])
-    model = p2p.models.cortex.ScoreboardModel(vfmap=nmap, xrange=(-4, 0), yrange=(-4, 4), step=.25)
+    xrange, yrange = (-4, 0), (-4, 4)
     nlink = p2p.implants.cortex.Neuralink.from_neuropythy(
-        nmap, xrange=model.xrange, yrange=model.yrange, step=1, rand_insertion_angle=0
+        nmap, xrange=xrange, yrange=yrange, step=1, rand_insertion_angle=0
     )
-    model.implant = nlink
+    model = p2p.models.cortex.ScoreboardModel(nlink, vfmap=nmap, xrange=xrange,
+                                              yrange=yrange, step=.25)
     model.build()
     print(len(nlink.implants), " total threads")
 
@@ -142,12 +144,13 @@ electrode on each thread, using the scoreboard model:
 .. code-block:: python
 
     nmap = p2p.topography.NeuropythyMap(subject='fsaverage', regions=['v1'], jitter_boundary=True)
-    model = p2p.models.cortex.ScoreboardModel(rho=800, xrange=(-15, 15), yrange=(-15, 15),
-                                              step=.25, vfmap=nmap)
+    xrange, yrange = (-15, 15), (-15, 15)
     nlink = p2p.implants.cortex.Neuralink.from_neuropythy(
-        nmap, xrange=model.xrange, yrange=model.yrange, step=3, rand_insertion_angle=0
+        nmap, xrange=xrange, yrange=yrange, step=3, rand_insertion_angle=0
     )
-    model.implant = nlink
+    model = p2p.models.cortex.ScoreboardModel(nlink, rho=800, xrange=xrange,
+                                              yrange=yrange, step=.25,
+                                              vfmap=nmap)
     stim = {e: 1 for e in [i for i in nlink.electrode_names if i[-1] == '1']}
     percept = model.predict_percept(stim)
     percept.plot()

--- a/examples/stimuli/plot_image_stim.py
+++ b/examples/stimuli/plot_image_stim.py
@@ -324,9 +324,9 @@ stim_dilate = logo_dilate.trim().resize(implant.shape).encode()
 # with a proper temporal model, such as
 # :py:class:`~pulse2percept.models.Horsager2009Temporal`:
 
-model = p2p.models.Model(implant=implant,
-                         spatial=p2p.models.ScoreboardSpatial,
-                         temporal=p2p.models.Horsager2009Temporal)
+model = p2p.models.Model(
+    spatial=p2p.models.ScoreboardSpatial(implant),
+    temporal=p2p.models.Horsager2009Temporal())
 
 ##############################################################################
 # .. note::

--- a/pulse2percept/models/base.py
+++ b/pulse2percept/models/base.py
@@ -632,10 +632,11 @@ class SpatialModel(BaseModel, metaclass=ABCMeta):
 
     def __init__(self, implant, **params):
         _check_implant(implant)
+        self._implant = implant
         # `vfmap` first: `xrange`/`yrange` may be given as a retinal extent,
         # which is resolved through the map as it is assigned. See
         # `_vfmap_first`.
-        super().__init__(implant=implant, **_vfmap_first(params))
+        super().__init__(**_vfmap_first(params))
         self.grid = None
 
     @property
@@ -646,7 +647,7 @@ class SpatialModel(BaseModel, metaclass=ABCMeta):
 
         .. versionadded:: 0.11.0
         """
-        return getattr(self, '_implant', None)
+        return self._implant
 
     @implant.setter
     def implant(self, implant):
@@ -656,11 +657,8 @@ class SpatialModel(BaseModel, metaclass=ABCMeta):
 
         .. versionadded:: 0.11.0
         """
-        # `get_default_params` declares the name and `__init__` supplies the
-        # value, so the placeholder None is tolerated only while constructing.
-        if not (implant is None and _is_constructing(self)):
-            _check_implant(implant)
-        if implant is not getattr(self, '_implant', None):
+        _check_implant(implant)
+        if implant is not self._implant:
             # Spatial build state depends on implant geometry:
             self._is_built = False
         self._implant = implant
@@ -737,7 +735,6 @@ class SpatialModel(BaseModel, metaclass=ABCMeta):
     def get_default_params(self):
         """Return a dictionary of default values for all model parameters"""
         params = {
-            'implant': None,
             'xrange': (-15, 15),  # dva
             'yrange': (-15, 15),  # dva
             'step': 0.25,  # dva
@@ -1239,15 +1236,10 @@ class Model(Frozen, PrettyPrint):
 
     Parameters
     ----------
-    spatial : :py:class:`~pulse2percept.models.SpatialModel` or type, optional
-        Spatial model instance or class.
+    spatial : :py:class:`~pulse2percept.models.SpatialModel`, optional
+        Spatial model instance, already bound to its implant.
     temporal : :py:class:`~pulse2percept.models.TemporalModel` or type, optional
         Temporal model instance or class.
-    implant : :py:class:`~pulse2percept.implants.ProsthesisSystem`, optional
-        Implant used by the spatial component. Required when ``spatial`` is
-        given as a class.
-
-        .. versionadded:: 0.11.0
     **params : keyword arguments
         Parameters forwarded to the spatial and temporal components. A name
         present on both components is applied to both.
@@ -1303,11 +1295,7 @@ class Model(Frozen, PrettyPrint):
             return self.spatial.time_unit
         return BaseModel.time_unit
 
-    def __init__(self, spatial=None, temporal=None, *, implant=None,
-                 **params):
-        # `implant` is named explicitly so it cannot reach the temporal
-        # component through `**params`; only the spatial one has geometry.
-        spatial_from_class = isinstance(spatial, type)
+    def __init__(self, spatial=None, temporal=None, **params):
         # Normalize renamed parameters once before class construction and
         # subsequent `set_params`, avoiding duplicate warnings.
         for model in (spatial, temporal):
@@ -1317,11 +1305,12 @@ class Model(Frozen, PrettyPrint):
                     getattr(model, '_renamed_params', {}))
         # Set the spatial model:
         if spatial is not None and not isinstance(spatial, SpatialModel):
-            if issubclass(spatial, SpatialModel):
-                spatial = spatial(implant, **params)
-            else:
+            if isinstance(spatial, type) and issubclass(spatial, SpatialModel):
                 raise TypeError(f"'spatial' must be a SpatialModel instance, "
-                                f"not {type(spatial)}.")
+                                f"not the class itself: "
+                                f"{spatial.__name__}(implant).")
+            raise TypeError(f"'spatial' must be a SpatialModel instance, "
+                            f"not {type(spatial)}.")
         self.spatial = spatial
         # Set the temporal model:
         if temporal is not None and not isinstance(temporal, TemporalModel):
@@ -1333,16 +1322,6 @@ class Model(Frozen, PrettyPrint):
         self.temporal = temporal
         # Use user-specified parameter values instead of defaults:
         self.set_params(params)
-        if implant is not None and not spatial_from_class:
-            if not self.has_space:
-                raise ValueError(
-                    "An implant is where a spatial model puts its electrodes, "
-                    "and this model has only a temporal component. A temporal "
-                    "model is given the stimulus and nothing else.")
-            raise ValueError(
-                f"This model's spatial component is already bound to "
-                f"{type(self.spatial.implant).__name__}. 'implant' is for "
-                f"passing 'spatial' as a class and leaving Model to build it.")
 
     def __getattr__(self, attr):
         """Forward missing attributes to model components.

--- a/pulse2percept/models/base.py
+++ b/pulse2percept/models/base.py
@@ -2,6 +2,7 @@
    :py:class:`~pulse2percept.models.Model`,
    :py:class:`~pulse2percept.models.SpatialModel`,
    :py:class:`~pulse2percept.models.TemporalModel`"""
+import inspect
 import warnings
 from abc import ABCMeta, abstractmethod
 from copy import deepcopy, copy
@@ -565,9 +566,8 @@ class SpatialModel(BaseModel, metaclass=ABCMeta):
 
     Parameters
     ----------
-    implant : :py:class:`~pulse2percept.implants.ProsthesisSystem`, optional
-        Implant whose electrode geometry is modeled. Required before building
-        or predicting.
+    implant : :py:class:`~pulse2percept.implants.ProsthesisSystem`
+        Implant whose electrode geometry is modeled.
 
         .. versionadded:: 0.11.0
 
@@ -624,11 +624,11 @@ class SpatialModel(BaseModel, metaclass=ABCMeta):
     #: ``n_jobs`` is an alias for ``n_threads``; see ``_n_jobs_alias``.
     n_jobs = _n_jobs_alias()
 
-    def __init__(self, **params):
+    def __init__(self, implant, **params):
         # `vfmap` first: `xrange`/`yrange` may be given as a retinal extent,
         # which is resolved through the map as it is assigned. See
         # `_vfmap_first`.
-        super().__init__(**_vfmap_first(params))
+        super().__init__(implant=implant, **_vfmap_first(params))
         self.grid = None
 
     @property
@@ -1236,7 +1236,7 @@ class Model(Frozen, PrettyPrint):
 
     .. code-block:: python
 
-        model = Model(spatial=ScoreboardSpatial(),
+        model = Model(spatial=ScoreboardSpatial(ArgusII()),
                       temporal=Nanduri2012Temporal())
 
     Parameters
@@ -1246,7 +1246,8 @@ class Model(Frozen, PrettyPrint):
     temporal : :py:class:`~pulse2percept.models.TemporalModel` or type, optional
         Temporal model instance or class.
     implant : :py:class:`~pulse2percept.implants.ProsthesisSystem`, optional
-        Implant used by the spatial component.
+        Implant used by the spatial component. Required only when ``spatial``
+        is given as a class.
 
         .. versionadded:: 0.11.0
     **params : keyword arguments
@@ -1304,10 +1305,10 @@ class Model(Frozen, PrettyPrint):
             return self.spatial.time_unit
         return BaseModel.time_unit
 
-    def __init__(self, spatial=None, temporal=None, **params):
-        # Only the spatial component depends on implant geometry, so do not
-        # forward `implant` to the temporal component:
-        implant = params.pop('implant', None)
+    def __init__(self, spatial=None, temporal=None, *, implant=None,
+                 **params):
+        # `implant` is named explicitly so it cannot reach the temporal
+        # component through `**params`; only the spatial one has geometry.
         # Normalize renamed parameters once before class construction and
         # subsequent `set_params`, avoiding duplicate warnings.
         for model in (spatial, temporal):
@@ -1319,7 +1320,7 @@ class Model(Frozen, PrettyPrint):
         if spatial is not None and not isinstance(spatial, SpatialModel):
             if issubclass(spatial, SpatialModel):
                 # User should have passed an instance, not a class:
-                spatial = spatial(**params)
+                spatial = spatial(implant, **params)
             else:
                 raise TypeError(f"'spatial' must be a SpatialModel instance, "
                                 f"not {type(spatial)}.")
@@ -1425,6 +1426,15 @@ class Model(Frozen, PrettyPrint):
         # the constructor, so those cannot be passed in as parameters:
         spatial = attributes.pop('spatial', None)
         temporal = attributes.pop('temporal', None)
+        # A subclass builds its own spatial component and so requires the
+        # implant, which lives on that component and not in `__dict__`.
+        # `Model` itself declares it optional and takes the copy back below.
+        implant_param = inspect.signature(
+            self.__class__.__init__).parameters.get('implant')
+        implant_required = getattr(implant_param, 'default',
+                                   None) is inspect.Parameter.empty
+        if spatial is not None and implant_required:
+            attributes['implant'] = spatial.implant
         result = self.__class__(**attributes)
         # Restore copied sub-models after construction; their parameters do not
         # live in the composite `__dict__`. Bypass forwarding `__setattr__`.

--- a/pulse2percept/models/base.py
+++ b/pulse2percept/models/base.py
@@ -206,6 +206,13 @@ def _delivered(stim):
     return Stimulus(stim)
 
 
+def _check_implant(implant):
+    """Raise unless ``implant`` is a ProsthesisSystem"""
+    if not isinstance(implant, ProsthesisSystem):
+        raise TypeError(f"'implant' must be a ProsthesisSystem object, not "
+                        f"{type(implant)}.")
+
+
 def _device_scene(scene, implant):
     """The visual scene the implant's own input pipeline sees"""
     source = implant._preprocess(scene.source)
@@ -625,6 +632,7 @@ class SpatialModel(BaseModel, metaclass=ABCMeta):
     n_jobs = _n_jobs_alias()
 
     def __init__(self, implant, **params):
+        _check_implant(implant)
         # `vfmap` first: `xrange`/`yrange` may be given as a retinal extent,
         # which is resolved through the map as it is assigned. See
         # `_vfmap_first`.
@@ -649,9 +657,10 @@ class SpatialModel(BaseModel, metaclass=ABCMeta):
 
         .. versionadded:: 0.11.0
         """
-        if implant is not None and not isinstance(implant, ProsthesisSystem):
-            raise TypeError(f"'implant' must be a ProsthesisSystem object, "
-                            f"not {type(implant)}.")
+        # `get_default_params` declares the name and `__init__` supplies the
+        # value, so the placeholder None is tolerated only while constructing.
+        if not (implant is None and _is_constructing(self)):
+            _check_implant(implant)
         if implant is not getattr(self, '_implant', None):
             # Spatial build state depends on implant geometry:
             self._is_built = False
@@ -1246,8 +1255,8 @@ class Model(Frozen, PrettyPrint):
     temporal : :py:class:`~pulse2percept.models.TemporalModel` or type, optional
         Temporal model instance or class.
     implant : :py:class:`~pulse2percept.implants.ProsthesisSystem`, optional
-        Implant used by the spatial component. Required only when ``spatial``
-        is given as a class.
+        Implant used by the spatial component. Required when ``spatial`` is
+        given as a class.
 
         .. versionadded:: 0.11.0
     **params : keyword arguments
@@ -1309,6 +1318,7 @@ class Model(Frozen, PrettyPrint):
                  **params):
         # `implant` is named explicitly so it cannot reach the temporal
         # component through `**params`; only the spatial one has geometry.
+        spatial_from_class = isinstance(spatial, type)
         # Normalize renamed parameters once before class construction and
         # subsequent `set_params`, avoiding duplicate warnings.
         for model in (spatial, temporal):
@@ -1319,7 +1329,6 @@ class Model(Frozen, PrettyPrint):
         # Set the spatial model:
         if spatial is not None and not isinstance(spatial, SpatialModel):
             if issubclass(spatial, SpatialModel):
-                # User should have passed an instance, not a class:
                 spatial = spatial(implant, **params)
             else:
                 raise TypeError(f"'spatial' must be a SpatialModel instance, "
@@ -1328,7 +1337,6 @@ class Model(Frozen, PrettyPrint):
         # Set the temporal model:
         if temporal is not None and not isinstance(temporal, TemporalModel):
             if issubclass(temporal, TemporalModel):
-                # User should have passed an instance, not a class:
                 temporal = temporal(**params)
             else:
                 raise TypeError(f"'temporal' must be a TemporalModel instance, "
@@ -1336,21 +1344,16 @@ class Model(Frozen, PrettyPrint):
         self.temporal = temporal
         # Use user-specified parameter values instead of defaults:
         self.set_params(params)
-        if implant is not None:
+        if implant is not None and not spatial_from_class:
             if not self.has_space:
                 raise ValueError(
                     "An implant is where a spatial model puts its electrodes, "
                     "and this model has only a temporal component. A temporal "
                     "model is given the stimulus and nothing else.")
-            bound = self.spatial.implant
-            if bound is not None and bound is not implant:
-                raise ValueError(
-                    f"This model was given two different implants: "
-                    f"'implant' is {type(implant).__name__} and the spatial "
-                    f"model is already bound to "
-                    f"{type(bound).__name__}. A model describes one device, "
-                    f"so name it once - either here or on the spatial model.")
-            self.spatial.implant = implant
+            raise ValueError(
+                f"This model's spatial component is already bound to "
+                f"{type(self.spatial.implant).__name__}. 'implant' is for "
+                f"passing 'spatial' as a class and leaving Model to build it.")
 
     def __getattr__(self, attr):
         """Forward missing attributes to model components.

--- a/pulse2percept/models/base.py
+++ b/pulse2percept/models/base.py
@@ -259,7 +259,6 @@ def _scene_stim(model, scene, gaze):
         raise ValueError("A scene is registered against the retina, which "
                          "needs a spatial model. This model has only a "
                          "temporal one.")
-    model.spatial._require_implant()
     implant = model.implant
     vfmap = getattr(model.spatial, 'vfmap', None)
     if not isinstance(vfmap, RetinalMap):
@@ -666,15 +665,6 @@ class SpatialModel(BaseModel, metaclass=ABCMeta):
             self._is_built = False
         self._implant = implant
 
-    def _require_implant(self):
-        """Raise if no implant is bound to the spatial model."""
-        if not isinstance(self.implant, ProsthesisSystem):
-            raise ValueError(
-                f"{type(self).__name__} predicts what a particular implant "
-                f"produces, so it needs one: "
-                f"{type(self).__name__}(implant=ArgusII()). The stimulus is "
-                f"what 'predict_percept' takes.")
-
     def set_params(self, **params):
         """Set the parameters of this model
 
@@ -824,7 +814,6 @@ class SpatialModel(BaseModel, metaclass=ABCMeta):
         """
         # See `BaseModel.build`:
         self.set_params(**build_params)
-        self._require_implant()
         if self.vfmap.ndim not in self.ndim:
             raise ValueError(f"Model expects one of {self.ndim} dimensions, but "
                              f"visual field map has {self.vfmap.ndim} dimensions.")
@@ -1589,7 +1578,6 @@ class Model(Frozen, PrettyPrint):
         """
         if not self.has_space:
             return source
-        self.spatial._require_implant()
         return self.implant.prepare_stim(source)
 
     def _predict_percept(self, stim, t_percept=None):

--- a/pulse2percept/models/base.py
+++ b/pulse2percept/models/base.py
@@ -2,7 +2,6 @@
    :py:class:`~pulse2percept.models.Model`,
    :py:class:`~pulse2percept.models.SpatialModel`,
    :py:class:`~pulse2percept.models.TemporalModel`"""
-import inspect
 import warnings
 from abc import ABCMeta, abstractmethod
 from copy import deepcopy, copy
@@ -211,6 +210,15 @@ def _check_implant(implant):
     if not isinstance(implant, ProsthesisSystem):
         raise TypeError(f"'implant' must be a ProsthesisSystem object, not "
                         f"{type(implant)}.")
+
+
+def _reject_implant_param(params):
+    """Raise if `implant` appears where a Model forwards parameters."""
+    if 'implant' in params:
+        raise AttributeError(
+            "'implant' is not a Model parameter. Bind the implant when "
+            "constructing the spatial model, or assign 'model.implant' to "
+            "rebind it.")
 
 
 def _device_scene(scene, implant):
@@ -1296,6 +1304,7 @@ class Model(Frozen, PrettyPrint):
         return BaseModel.time_unit
 
     def __init__(self, spatial=None, temporal=None, **params):
+        _reject_implant_param(params)
         # Normalize renamed parameters once before class construction and
         # subsequent `set_params`, avoiding duplicate warnings.
         for model in (spatial, temporal):
@@ -1399,12 +1408,8 @@ class Model(Frozen, PrettyPrint):
         temporal = attributes.pop('temporal', None)
         # A subclass builds its own spatial component and so requires the
         # implant, which lives on that component and not in `__dict__`.
-        # `Model` itself declares it optional and takes the copy back below.
-        implant_param = inspect.signature(
-            self.__class__.__init__).parameters.get('implant')
-        implant_required = getattr(implant_param, 'default',
-                                   None) is inspect.Parameter.empty
-        if spatial is not None and implant_required:
+        # `Model` itself is handed the copy back below instead.
+        if spatial is not None and type(self) is not Model:
             attributes['implant'] = spatial.implant
         result = self.__class__(**attributes)
         # Restore copied sub-models after construction; their parameters do not
@@ -1452,6 +1457,7 @@ class Model(Frozen, PrettyPrint):
         params : dict
             Parameter values to set.
         """
+        _reject_implant_param(params)
         # Instance-based composites bypass `BaseModel.__init__`; collect
         # deprecations from both components and warn once.
         specs = {}

--- a/pulse2percept/models/beyeler2019.py
+++ b/pulse2percept/models/beyeler2019.py
@@ -399,7 +399,6 @@ class AxonMapSpatial(SpatialModel):
 
         .. versionchanged:: 0.11.0
             ``eye`` is no longer a separate model parameter."""
-        self._require_implant()
         return self.implant.eye
 
     @property

--- a/pulse2percept/models/beyeler2019.py
+++ b/pulse2percept/models/beyeler2019.py
@@ -94,9 +94,8 @@ class ScoreboardSpatial(SpatialModel):
 
     Parameters
     ----------
-    implant : :py:class:`~pulse2percept.implants.ProsthesisSystem`, optional
-        Implant whose electrode geometry is modeled. Required before building
-        or predicting.
+    implant : :py:class:`~pulse2percept.implants.ProsthesisSystem`
+        Implant whose electrode geometry is modeled.
 
         .. versionadded:: 0.11.0
 
@@ -207,9 +206,8 @@ class ScoreboardModel(Model):
 
     Parameters
     ----------
-    implant : :py:class:`~pulse2percept.implants.ProsthesisSystem`, optional
-        Implant whose electrode geometry is modeled. Required before building
-        or predicting.
+    implant : :py:class:`~pulse2percept.implants.ProsthesisSystem`
+        Implant whose electrode geometry is modeled.
 
         .. versionadded:: 0.11.0
 
@@ -261,10 +259,9 @@ class ScoreboardModel(Model):
     n_jobs : int or None, optional
         Alias for ``n_threads``. ``None`` and -1 use all available CPU cores."""
 
-    def __init__(self, **params):
-        super(ScoreboardModel, self).__init__(spatial=ScoreboardSpatial(),
-                                              temporal=None,
-                                              **params)
+    def __init__(self, implant, **params):
+        super(ScoreboardModel, self).__init__(
+            spatial=ScoreboardSpatial(implant), temporal=None, **params)
 
 
 class AxonMapSpatial(SpatialModel):
@@ -298,9 +295,8 @@ class AxonMapSpatial(SpatialModel):
 
     Parameters
     ----------
-    implant : :py:class:`~pulse2percept.implants.ProsthesisSystem`, optional
-        Implant whose electrode geometry and eye are modeled. Required before
-        building or predicting.
+    implant : :py:class:`~pulse2percept.implants.ProsthesisSystem`
+        Implant whose electrode geometry and eye are modeled.
 
         .. versionadded:: 0.11.0
 
@@ -388,8 +384,8 @@ class AxonMapSpatial(SpatialModel):
     ``ax_segments_range`` values above 90 are outside the range for which this
     axon-map construction is considered reliable."""
 
-    def __init__(self, **params):
-        super(AxonMapSpatial, self).__init__(**params)
+    def __init__(self, implant, **params):
+        super(AxonMapSpatial, self).__init__(implant, **params)
         self.axon_contrib = None
         self.axon_idx_start = None
         self.axon_idx_end = None
@@ -1019,9 +1015,8 @@ class AxonMapModel(Model):
 
     Parameters
     ----------
-    implant : :py:class:`~pulse2percept.implants.ProsthesisSystem`, optional
-        Implant whose electrode geometry and eye are modeled. Required before
-        building or predicting.
+    implant : :py:class:`~pulse2percept.implants.ProsthesisSystem`
+        Implant whose electrode geometry and eye are modeled.
 
         .. versionadded:: 0.11.0
 
@@ -1116,8 +1111,7 @@ class AxonMapModel(Model):
     ``ax_segments_range`` values above 90 are outside the range for which this
     axon-map construction is considered reliable."""
 
-    def __init__(self, **params):
-        super(AxonMapModel, self).__init__(spatial=AxonMapSpatial(),
-                                           temporal=None,
-                                           **params)
+    def __init__(self, implant, **params):
+        super(AxonMapModel, self).__init__(
+            spatial=AxonMapSpatial(implant), temporal=None, **params)
 

--- a/pulse2percept/models/cortex/base.py
+++ b/pulse2percept/models/cortex/base.py
@@ -87,9 +87,9 @@ class CortexSpatial(SpatialModel):
             regions = [regions]
         self._regions = regions
 
-    def __init__(self, **params):
+    def __init__(self, implant, **params):
         self._regions = None
-        super(CortexSpatial, self).__init__(**params)
+        super(CortexSpatial, self).__init__(implant, **params)
 
         # Use [Polemeni2006]_ visual field map by default
         if 'vfmap' not in params.keys():
@@ -221,8 +221,7 @@ class ScoreboardSpatial(CortexSpatial):
     Parameters
     ----------
     implant : :py:class:`~pulse2percept.implants.ProsthesisSystem`
-        The implant whose stimulation this model predicts. Required before
-        building or predicting.
+        The implant whose stimulation this model predicts.
 
         .. versionadded:: 0.11.0
 
@@ -286,8 +285,8 @@ class ScoreboardSpatial(CortexSpatial):
         next ``predict_percept`` builds it again.
 
     """
-    def __init__(self, **params):
-        super(ScoreboardSpatial, self).__init__(**params)
+    def __init__(self, implant, **params):
+        super(ScoreboardSpatial, self).__init__(implant, **params)
 
     def get_default_params(self):
         """Returns all settable parameters of the scoreboard model"""
@@ -378,8 +377,7 @@ class ScoreboardModel(Model):
     Parameters
     ----------
     implant : :py:class:`~pulse2percept.implants.ProsthesisSystem`
-        The implant whose stimulation this model predicts. Required before
-        building or predicting.
+        The implant whose stimulation this model predicts.
 
         .. versionadded:: 0.11.0
 
@@ -443,6 +441,7 @@ class ScoreboardModel(Model):
 
     """
 
-    def __init__(self, **params):
+    def __init__(self, implant, **params):
         super(ScoreboardModel, self).__init__(
-            spatial=ScoreboardSpatial(**params), temporal=None, **params)
+            spatial=ScoreboardSpatial(implant, **params), temporal=None,
+            **params)

--- a/pulse2percept/models/cortex/base.py
+++ b/pulse2percept/models/cortex/base.py
@@ -22,6 +22,11 @@ class CortexSpatial(SpatialModel):
 
     Parameters:
     -----------
+    implant : :py:class:`~pulse2percept.implants.ProsthesisSystem`
+        The implant whose stimulation this model predicts.
+
+        .. versionadded:: 0.11.0
+
     regions : list of str, optional
         The regions to simulate. Options are any combination of 'v1', 'v2', 'v3'. 
         Default: ['v1']. 

--- a/pulse2percept/models/cortex/dynaphos.py
+++ b/pulse2percept/models/cortex/dynaphos.py
@@ -3,12 +3,13 @@ import numpy as np
 import warnings
 from copy import deepcopy, copy
 
-from ..base import BaseModel, _require_stim_dimension
+from ..base import BaseModel, _check_implant, _require_stim_dimension
 from ...percepts import Percept
 from ...implants import ProsthesisSystem
 from ...stimuli import BiphasicPulseTrain
 from ...units import A, Quantity, as_value, dva, Hz, mm, ms, uA
 from ...utils import cart2pol
+from ...utils.base import _is_constructing
 from ...utils.constants import MS_PER_S, UM_PER_MM, ZORDER
 from ...topography import Polimeni2006Map
 
@@ -52,8 +53,7 @@ class DynaphosModel(BaseModel):
     Parameters
     ----------
     implant : :py:class:`~pulse2percept.implants.ProsthesisSystem`
-        The implant whose stimulation this model predicts. Required before
-        building or predicting.
+        The implant whose stimulation this model predicts.
 
         .. versionadded:: 0.11.0
 
@@ -130,9 +130,10 @@ class DynaphosModel(BaseModel):
             regions = [regions]
         self._regions = regions
 
-    def __init__(self, **params):
+    def __init__(self, implant, **params):
+            _check_implant(implant)
             self._regions = None
-            super().__init__(**params)
+            super().__init__(implant=implant, **params)
 
             self.vfmap.regions = self.regions
             self.grid = None
@@ -152,9 +153,10 @@ class DynaphosModel(BaseModel):
     @implant.setter
     def implant(self, implant):
         """Implant setter (called upon ``self.implant = implant``)"""
-        if implant is not None and not isinstance(implant, ProsthesisSystem):
-            raise TypeError(f"'implant' must be a ProsthesisSystem object, "
-                            f"not {type(implant)}.")
+        # `get_default_params` declares the name and `__init__` supplies the
+        # value, so the placeholder None is tolerated only while constructing.
+        if not (implant is None and _is_constructing(self)):
+            _check_implant(implant)
         if implant is not getattr(self, '_implant', None):
             self._is_built = False
         self._implant = implant

--- a/pulse2percept/models/cortex/dynaphos.py
+++ b/pulse2percept/models/cortex/dynaphos.py
@@ -8,7 +8,6 @@ from ...percepts import Percept
 from ...stimuli import BiphasicPulseTrain
 from ...units import A, Quantity, as_value, dva, Hz, mm, ms, uA
 from ...utils import cart2pol
-from ...utils.base import _is_constructing
 from ...utils.constants import MS_PER_S, UM_PER_MM, ZORDER
 from ...topography import Polimeni2006Map
 
@@ -131,8 +130,9 @@ class DynaphosModel(BaseModel):
 
     def __init__(self, implant, **params):
             _check_implant(implant)
+            self._implant = implant
             self._regions = None
-            super().__init__(implant=implant, **params)
+            super().__init__(**params)
 
             self.vfmap.regions = self.regions
             self.grid = None
@@ -147,16 +147,13 @@ class DynaphosModel(BaseModel):
 
         .. versionadded:: 0.11.0
         """
-        return getattr(self, '_implant', None)
+        return self._implant
 
     @implant.setter
     def implant(self, implant):
         """Implant setter (called upon ``self.implant = implant``)"""
-        # `get_default_params` declares the name and `__init__` supplies the
-        # value, so the placeholder None is tolerated only while constructing.
-        if not (implant is None and _is_constructing(self)):
-            _check_implant(implant)
-        if implant is not getattr(self, '_implant', None):
+        _check_implant(implant)
+        if implant is not self._implant:
             self._is_built = False
         self._implant = implant
 
@@ -164,9 +161,6 @@ class DynaphosModel(BaseModel):
     def get_default_params(self):
             """Returns all settable parameters of the Dynaphos model"""
             params = {
-                # The device whose electrodes this model places in the visual
-                # field. Required before building or predicting:
-                'implant': None,
                 'xrange': (-5, 5),  # dva
                 'yrange': (-5, 5),  # dva
                 'step': 0.25,  # dva

--- a/pulse2percept/models/cortex/dynaphos.py
+++ b/pulse2percept/models/cortex/dynaphos.py
@@ -5,7 +5,6 @@ from copy import deepcopy, copy
 
 from ..base import BaseModel, _check_implant, _require_stim_dimension
 from ...percepts import Percept
-from ...implants import ProsthesisSystem
 from ...stimuli import BiphasicPulseTrain
 from ...units import A, Quantity, as_value, dva, Hz, mm, ms, uA
 from ...utils import cart2pol
@@ -258,12 +257,6 @@ class DynaphosModel(BaseModel):
         from ...topography import Grid2D
         # See `BaseModel.build`:
         self.set_params(**build_params)
-        if not isinstance(self.implant, ProsthesisSystem):
-            raise ValueError(
-                f"{type(self).__name__} predicts what a particular implant "
-                f"produces, so it needs one: "
-                f"{type(self).__name__}(implant=Cortivis()). The stimulus is "
-                f"what 'predict_percept' takes.")
         # check that freq/pdur fit. `freq` counts cycles per second, and every
         # duration in this model is in milliseconds:
         window_dur = MS_PER_S / self.freq

--- a/pulse2percept/models/granley2021.py
+++ b/pulse2percept/models/granley2021.py
@@ -348,9 +348,8 @@ class BiphasicAxonMapSpatial(AxonMapSpatial):
 
     Parameters
     ----------
-    implant : :py:class:`~pulse2percept.implants.ProsthesisSystem`, optional
-        Implant whose electrode geometry and eye are modeled. Required before
-        building or predicting.
+    implant : :py:class:`~pulse2percept.implants.ProsthesisSystem`
+        Implant whose electrode geometry and eye are modeled.
 
         .. versionadded:: 0.11.0
 
@@ -442,8 +441,8 @@ class BiphasicAxonMapSpatial(AxonMapSpatial):
     axon-map construction is considered reliable."""
     extra_stimulus_units = (xTh,)
 
-    def __init__(self, **params):
-        super(BiphasicAxonMapSpatial, self).__init__(**params)
+    def __init__(self, implant, **params):
+        super(BiphasicAxonMapSpatial, self).__init__(implant, **params)
         if self.bright_model is None:
             self.bright_model = DefaultBrightModel()
         if self.size_model is None:
@@ -712,9 +711,8 @@ class BiphasicAxonMapModel(Model):
 
     Parameters
     ----------
-    implant : :py:class:`~pulse2percept.implants.ProsthesisSystem`, optional
-        Implant whose electrode geometry and eye are modeled. Required before
-        building or predicting.
+    implant : :py:class:`~pulse2percept.implants.ProsthesisSystem`
+        Implant whose electrode geometry and eye are modeled.
 
         .. versionadded:: 0.11.0
 
@@ -830,6 +828,6 @@ class BiphasicAxonMapModel(Model):
         percept = model.predict_percept(p2p.stimuli.LogoBVL())
     """
 
-    def __init__(self, **params):
+    def __init__(self, implant, **params):
         super(BiphasicAxonMapModel, self).__init__(
-            spatial=BiphasicAxonMapSpatial(), temporal=None, **params)
+            spatial=BiphasicAxonMapSpatial(implant), temporal=None, **params)

--- a/pulse2percept/models/nanduri2012.py
+++ b/pulse2percept/models/nanduri2012.py
@@ -63,9 +63,8 @@ class Nanduri2012Spatial(SpatialModel):
 
         Parameters
         ----------
-        implant : :py:class:`~pulse2percept.implants.ProsthesisSystem`, optional
-            Implant whose electrode geometry is modeled. Required before building
-            or predicting.
+        implant : :py:class:`~pulse2percept.implants.ProsthesisSystem`
+            Implant whose electrode geometry is modeled.
 
             .. versionadded:: 0.11.0
 
@@ -297,9 +296,8 @@ class Nanduri2012Model(Model):
 
         Parameters
         ----------
-        implant : :py:class:`~pulse2percept.implants.ProsthesisSystem`, optional
-            Implant whose electrode geometry is modeled. Required before building
-            or predicting.
+        implant : :py:class:`~pulse2percept.implants.ProsthesisSystem`
+            Implant whose electrode geometry is modeled.
 
             .. versionadded:: 0.11.0
 
@@ -370,7 +368,7 @@ class Nanduri2012Model(Model):
             Alias for ``n_threads``. ``None`` and -1 use all available CPU cores.
         """
 
-    def __init__(self, **params):
-        super(Nanduri2012Model, self).__init__(spatial=Nanduri2012Spatial(),
-                                               temporal=Nanduri2012Temporal(),
-                                               **params)
+    def __init__(self, implant, **params):
+        super(Nanduri2012Model, self).__init__(
+            spatial=Nanduri2012Spatial(implant),
+            temporal=Nanduri2012Temporal(), **params)

--- a/pulse2percept/models/tests/test_api_equivalence.py
+++ b/pulse2percept/models/tests/test_api_equivalence.py
@@ -149,8 +149,7 @@ def test_axonmap_prediction_is_unchanged():
 
 
 def test_spatiotemporal_prediction_is_unchanged():
-    model = Model(implant=ArgusII(),
-                  spatial=ScoreboardSpatial(rho=200, **GRID),
+    model = Model(spatial=ScoreboardSpatial(ArgusII(), rho=200, **GRID),
                   temporal=FadingTemporal(tau=100)).build()
     percept = model.predict_percept(
         {'C5': BiphasicPulseTrain(20, 50, 0.45, stim_dur=100)},
@@ -177,8 +176,7 @@ def test_encoded_video_prediction_is_unchanged():
 def test_encoded_video_with_a_temporal_stage_is_unchanged():
     # With a temporal stage, the spatial model reads the delivered pulse
     # train rather than frame-level modulation.
-    model = Model(implant=ArgusII(),
-                  spatial=ScoreboardSpatial(rho=200, **GRID),
+    model = Model(spatial=ScoreboardSpatial(ArgusII(), rho=200, **GRID),
                   temporal=FadingTemporal(tau=100)).build()
     with warnings.catch_warnings():
         warnings.simplefilter('ignore')

--- a/pulse2percept/models/tests/test_base.py
+++ b/pulse2percept/models/tests/test_base.py
@@ -662,10 +662,6 @@ def test_Model():
 
     # SpatialModel, but no TemporalModel:
     model = Model(spatial=ValidSpatialModel(ArgusI()))
-    # An implant is what a spatial model needs; a temporal one never sees an
-    # electrode, so offering it one is a mistake worth naming:
-    with pytest.raises(ValueError, match='only a temporal'):
-        Model(temporal=ValidTemporalModel(), implant=ArgusI())
     npt.assert_equal(model.has_space, True)
     npt.assert_equal(model.has_time, False)
     npt.assert_almost_equal(model.step, 0.25)
@@ -726,10 +722,6 @@ def test_Model():
 def test_Model_set_params():
     # SpatialModel, but no TemporalModel:
     model = Model(spatial=ValidSpatialModel(ArgusI()))
-    # An implant is what a spatial model needs; a temporal one never sees an
-    # electrode, so offering it one is a mistake worth naming:
-    with pytest.raises(ValueError, match='only a temporal'):
-        Model(temporal=ValidTemporalModel(), implant=ArgusI())
     model.set_params({'step': 2.33})
     npt.assert_almost_equal(model.step, 2.33)
     npt.assert_almost_equal(model.spatial.step, 2.33)
@@ -798,10 +790,6 @@ def test_Model_build():
 
     # SpatialModel, but no TemporalModel:
     model = Model(spatial=ValidSpatialModel(ArgusI()))
-    # An implant is what a spatial model needs; a temporal one never sees an
-    # electrode, so offering it one is a mistake worth naming:
-    with pytest.raises(ValueError, match='only a temporal'):
-        Model(temporal=ValidTemporalModel(), implant=ArgusI())
     npt.assert_equal(model.is_built, False)
     model.build()
     npt.assert_equal(model.is_built, True)
@@ -922,28 +910,14 @@ def test_a_standalone_spatial_model_needs_an_implant(ModelClass, ImplantType):
 def test_a_temporal_only_model_takes_no_implant():
     """`Horsager2009Model` has no electrodes to place"""
     npt.assert_equal(Horsager2009Model().has_space, False)
-    with pytest.raises(ValueError, match='only a temporal'):
+    with pytest.raises(AttributeError, match='not a valid parameter'):
         Horsager2009Model(implant=ArgusII())
 
 
-def test_Model_builds_a_spatial_class_around_its_implant():
-    """`spatial` given as a class is handed the implant `Model` was named"""
-    implant = ArgusI()
-    model = Model(spatial=ValidSpatialModel, temporal=ValidTemporalModel,
-                  implant=implant)
-    npt.assert_equal(model.spatial.implant is implant, True)
-    for missing in ({}, {'implant': None}):
-        with pytest.raises(TypeError):
-            Model(spatial=ValidSpatialModel, **missing)
-
-
-def test_Model_names_one_implant():
-    """A spatial instance is already bound, so `implant` has nothing to say"""
-    implant = ArgusI()
-    with pytest.raises(ValueError, match='already bound'):
-        Model(implant=implant, spatial=ValidSpatialModel(implant))
-    with pytest.raises(ValueError, match='already bound'):
-        Model(implant=implant, spatial=ValidSpatialModel(ArgusII()))
+def test_Model_takes_a_bound_spatial_instance():
+    """`Model` composes spatial components; it does not construct them"""
+    with pytest.raises(TypeError, match='not the class itself'):
+        Model(spatial=ValidSpatialModel, temporal=ValidTemporalModel())
 
 
 def test_Model_predict_percept():

--- a/pulse2percept/models/tests/test_base.py
+++ b/pulse2percept/models/tests/test_base.py
@@ -910,7 +910,7 @@ def test_a_standalone_spatial_model_needs_an_implant(ModelClass, ImplantType):
 def test_a_temporal_only_model_takes_no_implant():
     """`Horsager2009Model` has no electrodes to place"""
     npt.assert_equal(Horsager2009Model().has_space, False)
-    with pytest.raises(AttributeError, match='not a valid parameter'):
+    with pytest.raises(AttributeError, match='not a Model parameter'):
         Horsager2009Model(implant=ArgusII())
 
 
@@ -918,6 +918,16 @@ def test_Model_takes_a_bound_spatial_instance():
     """`Model` composes spatial components; it does not construct them"""
     with pytest.raises(TypeError, match='not the class itself'):
         Model(spatial=ValidSpatialModel, temporal=ValidTemporalModel())
+    # `implant` is constructor context for the spatial model, not a parameter
+    # the composite forwards, so neither spelling reaches it:
+    with pytest.raises(AttributeError, match='not a Model parameter'):
+        Model(spatial=ValidSpatialModel(ArgusI()), implant=ArgusII())
+    model = Model(spatial=ValidSpatialModel(ArgusI()))
+    with pytest.raises(AttributeError, match='not a Model parameter'):
+        model.set_params({'implant': ArgusII()})
+    # Rebinding is an explicit mutation, and stays allowed:
+    model.implant = ArgusII()
+    npt.assert_equal(isinstance(model.implant, ArgusII), True)
 
 
 def test_Model_predict_percept():

--- a/pulse2percept/models/tests/test_base.py
+++ b/pulse2percept/models/tests/test_base.py
@@ -22,7 +22,8 @@ from pulse2percept.models import (AxonMapModel, AxonMapSpatial, BaseModel,
                                   SpatialModel, TemporalModel,
                                   Thompson2003Model)
 from pulse2percept.models.base import _blend_meridian
-from pulse2percept.models.cortex import (ScoreboardModel as
+from pulse2percept.models.cortex import (DynaphosModel,
+                                         ScoreboardModel as
                                          CortexScoreboardModel,
                                          ScoreboardSpatial as
                                          CortexScoreboardSpatial)
@@ -131,9 +132,11 @@ def test_SpatialModel():
     with pytest.raises(TypeError):
         # the implant must be a ProsthesisSystem
         ValidSpatialModel(Stimulus(3))
-    with pytest.raises(ValueError):
-        # ... and there must be one at all
-        ValidSpatialModel(None).build()
+    with pytest.raises(TypeError):
+        ValidSpatialModel(None)
+    with pytest.raises(TypeError):
+        # ... and it cannot be unbound afterwards either
+        model.implant = None
 
 
 def test_SpatialModel_predict_percept_time_order():
@@ -901,14 +904,19 @@ def test_predict_percept_builds_what_it_needs(make_model):
 @pytest.mark.parametrize('ModelClass, ImplantType', [
     (ScoreboardModel, ArgusII), (AxonMapModel, ArgusII),
     (Thompson2003Model, ArgusII), (Nanduri2012Model, ArgusII),
-    (BiphasicAxonMapModel, ArgusII), (CortexScoreboardModel, Cortivis)])
+    (BiphasicAxonMapModel, ArgusII), (CortexScoreboardModel, Cortivis),
+    (DynaphosModel, Cortivis)])
 def test_a_standalone_spatial_model_needs_an_implant(ModelClass, ImplantType):
     """Which device is modeled is not something to fill in later"""
     with pytest.raises(TypeError):
         ModelClass()
+    with pytest.raises(TypeError):
+        ModelClass(None)
     implant = ImplantType()
     for model in (ModelClass(implant), ModelClass(implant=implant)):
         npt.assert_equal(model.implant is implant, True)
+        with pytest.raises(TypeError):
+            model.implant = None
 
 
 def test_a_temporal_only_model_takes_no_implant():
@@ -924,16 +932,17 @@ def test_Model_builds_a_spatial_class_around_its_implant():
     model = Model(spatial=ValidSpatialModel, temporal=ValidTemporalModel,
                   implant=implant)
     npt.assert_equal(model.spatial.implant is implant, True)
+    for missing in ({}, {'implant': None}):
+        with pytest.raises(TypeError):
+            Model(spatial=ValidSpatialModel, **missing)
 
 
 def test_Model_names_one_implant():
-    """Two implants is contradictory model context, not a precedence question"""
+    """A spatial instance is already bound, so `implant` has nothing to say"""
     implant = ArgusI()
-    # The same object twice says nothing new:
-    model = Model(implant=implant, spatial=ValidSpatialModel(implant))
-    npt.assert_equal(model.implant is implant, True)
-    # Two different ones would have to silently pick a winner:
-    with pytest.raises(ValueError, match='two different implants'):
+    with pytest.raises(ValueError, match='already bound'):
+        Model(implant=implant, spatial=ValidSpatialModel(implant))
+    with pytest.raises(ValueError, match='already bound'):
         Model(implant=implant, spatial=ValidSpatialModel(ArgusII()))
 
 

--- a/pulse2percept/models/tests/test_base.py
+++ b/pulse2percept/models/tests/test_base.py
@@ -10,16 +10,21 @@ from matplotlib.axes import Subplot
 import time
 
 from pulse2percept.implants import ArgusI, ArgusII
+from pulse2percept.implants.cortex import Cortivis
 from pulse2percept.stimuli import (AmplitudeEncoder, BiphasicPulseTrain,
                                    BostonTrain, ImageStimulus, LogoBVL,
                                    Stimulus, VideoStimulus)
 from pulse2percept.percepts import Percept
 from pulse2percept.models import (AxonMapModel, AxonMapSpatial, BaseModel,
-                                  FadingTemporal, Model,
+                                  BiphasicAxonMapModel, FadingTemporal,
+                                  Horsager2009Model, Model, Nanduri2012Model,
                                   ScoreboardModel, ScoreboardSpatial,
-                                  SpatialModel, TemporalModel)
+                                  SpatialModel, TemporalModel,
+                                  Thompson2003Model)
 from pulse2percept.models.base import _blend_meridian
-from pulse2percept.models.cortex import (ScoreboardSpatial as
+from pulse2percept.models.cortex import (ScoreboardModel as
+                                         CortexScoreboardModel,
+                                         ScoreboardSpatial as
                                          CortexScoreboardSpatial)
 from pulse2percept.units import (DimensionMismatchError, Quantity,
                                  dimensionless, dva, mA, mm, ms, s, uA, um,
@@ -68,15 +73,11 @@ def test_BaseModel():
 
 
 class ValidSpatialModel(SpatialModel):
-    """A spatial model that predicts nothing, bound to a fresh ArgusI
-
-    A spatial model needs an implant before it can build, and which one is
-    beside the point for most of the tests below, so the double supplies one.
-    """
+    """A spatial model that predicts nothing"""
 
     def get_default_params(self):
         params = super(ValidSpatialModel, self).get_default_params()
-        params.update({'vfmap': Watson2014Map(), 'implant': ArgusI()})
+        params.update({'vfmap': Watson2014Map()})
         return params
 
     def _predict_spatial(self, earray, stim):
@@ -87,7 +88,7 @@ class ValidSpatialModel(SpatialModel):
 def test_SpatialModel():
     implant = ArgusI()
     # Build grid:
-    model = ValidSpatialModel(implant=implant)
+    model = ValidSpatialModel(implant)
     npt.assert_equal(model.grid, None)
     npt.assert_equal(model.is_built, False)
     model.build()
@@ -96,14 +97,14 @@ def test_SpatialModel():
     npt.assert_equal(isinstance(model.grid.ret.x, np.ndarray), True)
 
     # Can overwrite default values:
-    model = ValidSpatialModel(implant=implant, step=1.234)
+    model = ValidSpatialModel(implant, step=1.234)
     npt.assert_almost_equal(model.step, 1.234)
     model.build(step=2.345)
     npt.assert_almost_equal(model.step, 2.345)
 
     # Cannot add more attributes:
     with pytest.raises(AttributeError):
-        ValidSpatialModel(newparam=1)
+        ValidSpatialModel(ArgusI(), newparam=1)
     with pytest.raises(FreezeError):
         model.newparam = 1
 
@@ -124,15 +125,15 @@ def test_SpatialModel():
         # stim.time==None but requesting t_percept != None
         model.predict_percept(np.ones(16), t_percept=[0, 1, 2])
     # An unbuilt model builds itself rather than refusing:
-    fresh = ValidSpatialModel(implant=implant)
+    fresh = ValidSpatialModel(implant)
     npt.assert_equal(fresh.predict_percept(np.ones(16)) is not None, True)
     npt.assert_equal(fresh.is_built, True)
     with pytest.raises(TypeError):
         # the implant must be a ProsthesisSystem
-        ValidSpatialModel(implant=Stimulus(3))
+        ValidSpatialModel(Stimulus(3))
     with pytest.raises(ValueError):
         # ... and there must be one at all
-        ValidSpatialModel(implant=None).build()
+        ValidSpatialModel(None).build()
 
 
 def test_SpatialModel_predict_percept_time_order():
@@ -221,9 +222,9 @@ def test_SpatialModel_removed_params(param, value):
     # `xystep` was renamed to `step` in 0.10.0 and removed in 0.11.0. All
     # three are now unknown parameters:
     with pytest.raises(AttributeError):
-        ValidSpatialModel(**{param: value})
+        ValidSpatialModel(ArgusI(), **{param: value})
     with pytest.raises(AttributeError):
-        ValidSpatialModel().set_params(**{param: value})
+        ValidSpatialModel(ArgusI()).set_params(**{param: value})
 
 
 @pytest.mark.parametrize('param, value', [('engine', 'serial'),
@@ -233,13 +234,13 @@ def test_Model_removed_params(param, value):
     # A Model built from instances never reaches BaseModel.__init__, so this
     # path needs checking separately:
     with pytest.raises(AttributeError):
-        Model(spatial=ValidSpatialModel(), **{param: value})
+        Model(spatial=ValidSpatialModel(ArgusI()), **{param: value})
     with pytest.raises(AttributeError):
-        Model(spatial=ValidSpatialModel()).set_params({param: value})
+        Model(spatial=ValidSpatialModel(ArgusI())).set_params({param: value})
 
 
 def test_eq_SpatialModel():
-    valid = ValidSpatialModel()
+    valid = ValidSpatialModel(ArgusI())
 
     # Assert not equal for differing classes
     npt.assert_equal(valid == ValidBaseModel(), False)
@@ -256,11 +257,11 @@ def test_eq_SpatialModel():
     npt.assert_equal(valid == copied, True)
 
     # Assert different models do not equal each other
-    differing_model = ValidSpatialModel(xrange=(-10, 10))
+    differing_model = ValidSpatialModel(ArgusI(), xrange=(-10, 10))
     npt.assert_equal(valid != differing_model, True)
 
 def test_deepcopy_SpatialModel():
-    original = ValidSpatialModel()
+    original = ValidSpatialModel(ArgusI())
     copied = copy.deepcopy(original)
 
     # Assert they are different objects
@@ -287,10 +288,11 @@ def test_deepcopy_SpatialModel():
 
 
 def test_SpatialModel_plot():
-    model = ValidSpatialModel()
+    model = ValidSpatialModel(ArgusI())
     model.build()
     # Simulated area might be larger than that:
-    model = ValidSpatialModel(xrange=(-20.5, 20.5), yrange=(-16.1, 16.1))
+    model = ValidSpatialModel(ArgusI(), xrange=(-20.5, 20.5),
+                              yrange=(-16.1, 16.1))
     model.build()
     ax = model.plot(use_dva=True)
     npt.assert_almost_equal(ax.get_xlim(), (-22.55, 22.55))
@@ -466,7 +468,7 @@ def test_SpatialModel_retinal_range_needs_a_retinal_map():
     # ... or is the model's own default, which a cortical model installs only
     # after its parameters have been applied:
     with pytest.raises(DimensionMismatchError):
-        CortexScoreboardSpatial(yrange=(-2 * mm, 2 * mm))
+        CortexScoreboardSpatial(Cortivis(), yrange=(-2 * mm, 2 * mm))
 
     # A retinal map without an inverse cannot answer either, and says so:
     class NoInverse(RetinalMap):
@@ -557,7 +559,7 @@ def test_eq_TemporalModel():
     npt.assert_equal(valid == copied, True)
 
     # Assert different models do not equal each other
-    differing_model = ValidSpatialModel(xrange=(-10, 10))
+    differing_model = ValidSpatialModel(ArgusI(), xrange=(-10, 10))
     npt.assert_equal(valid != differing_model, True)
 
 
@@ -587,14 +589,18 @@ def test_deepcopy_TemporalModel():
     npt.assert_equal(copied is not None, True)
 
 
-@pytest.mark.parametrize('cls', [ValidSpatialModel, ValidTemporalModel])
-def test_n_jobs_aliases_n_threads(cls):
+@pytest.mark.parametrize('cls, ImplantType',
+                         [(ValidSpatialModel, ArgusI),
+                          (ValidTemporalModel, None)])
+def test_n_jobs_aliases_n_threads(cls, ImplantType):
+    # Only the spatial model takes an implant, and it is required there:
+    extra = {} if ImplantType is None else {'implant': ImplantType()}
     # `n_jobs` and `n_threads` are two names for the OpenMP thread count, and
     # must never disagree:
-    model = cls()
+    model = cls(**extra)
     npt.assert_equal(model.n_jobs, model.n_threads)
     # Setting either name moves both, whether in the constructor...
-    model = cls(n_jobs=3)
+    model = cls(n_jobs=3, **extra)
     npt.assert_equal(model.n_threads, 3)
     npt.assert_equal(model.n_jobs, 3)
     # ...or afterwards, by attribute or by set_params:
@@ -605,24 +611,26 @@ def test_n_jobs_aliases_n_threads(cls):
     model.set_params(n_jobs=2)
     npt.assert_equal(model.n_threads, 2)
     # The default must not quietly drop us to a single thread:
-    npt.assert_equal(cls().n_threads, multiprocessing.cpu_count())
+    npt.assert_equal(cls(**extra).n_threads, multiprocessing.cpu_count())
     # None and -1 both mean "every core", following scikit-learn:
-    npt.assert_equal(cls(n_jobs=None).n_threads, multiprocessing.cpu_count())
-    npt.assert_equal(cls(n_jobs=-1).n_threads, multiprocessing.cpu_count())
+    npt.assert_equal(cls(n_jobs=None, **extra).n_threads,
+                     multiprocessing.cpu_count())
+    npt.assert_equal(cls(n_jobs=-1, **extra).n_threads,
+                     multiprocessing.cpu_count())
     # Nonsense is rejected rather than silently ignored:
     for bad in (0, -2, 2.5, 'many'):
         with pytest.raises(ValueError):
-            cls(n_jobs=bad)
+            cls(n_jobs=bad, **extra)
     # It is an alias, not a deprecation -- it must not warn:
     with warnings.catch_warnings():
         warnings.simplefilter("error", DeprecationWarning)
-        cls(n_jobs=4)
+        cls(n_jobs=4, **extra)
 
 
 def test_Model_n_jobs_aliases_n_threads():
     # Through a Model, n_jobs has to reach both sub-models:
-    model = Model(spatial=ValidSpatialModel(), temporal=ValidTemporalModel(),
-                  n_jobs=3)
+    model = Model(spatial=ValidSpatialModel(ArgusI()),
+                  temporal=ValidTemporalModel(), n_jobs=3)
     npt.assert_equal(model.spatial.n_threads, 3)
     npt.assert_equal(model.temporal.n_threads, 3)
     model.n_jobs = 6
@@ -647,10 +655,10 @@ def test_Model():
     with pytest.raises(TypeError):
         Model(spatial=ValidTemporalModel())
     with pytest.raises(TypeError):
-        Model(temporal=ValidSpatialModel())
+        Model(temporal=ValidSpatialModel(ArgusI()))
 
     # SpatialModel, but no TemporalModel:
-    model = Model(spatial=ValidSpatialModel())
+    model = Model(spatial=ValidSpatialModel(ArgusI()))
     # An implant is what a spatial model needs; a temporal one never sees an
     # electrode, so offering it one is a mistake worth naming:
     with pytest.raises(ValueError, match='only a temporal'):
@@ -684,7 +692,8 @@ def test_Model():
         model.a = 1
 
     # SpatialModel and TemporalModel:
-    model = Model(spatial=ValidSpatialModel(), temporal=ValidTemporalModel())
+    model = Model(spatial=ValidSpatialModel(ArgusI()),
+                  temporal=ValidTemporalModel())
     npt.assert_equal(model.has_space, True)
     npt.assert_equal(model.has_time, True)
     npt.assert_almost_equal(model.step, 0.25)
@@ -713,7 +722,7 @@ def test_Model():
 
 def test_Model_set_params():
     # SpatialModel, but no TemporalModel:
-    model = Model(spatial=ValidSpatialModel())
+    model = Model(spatial=ValidSpatialModel(ArgusI()))
     # An implant is what a spatial model needs; a temporal one never sees an
     # electrode, so offering it one is a mistake worth naming:
     with pytest.raises(ValueError, match='only a temporal'):
@@ -729,7 +738,8 @@ def test_Model_set_params():
     npt.assert_almost_equal(model.temporal.dt, 2.33)
 
     # SpatialModel and TemporalModel:
-    model = Model(spatial=ValidSpatialModel(), temporal=ValidTemporalModel())
+    model = Model(spatial=ValidSpatialModel(ArgusI()),
+                  temporal=ValidTemporalModel())
     # Setting both using the convenience function:
     model.set_params({'step': 5, 'dt': 2.33})
     npt.assert_almost_equal(model.step, 5)
@@ -743,13 +753,14 @@ def test_Model_set_params():
 class ValidCompositeModel(Model):
     """A Model subclass that owns an attribute of its own"""
 
-    def __init__(self, **params):
-        super().__init__(spatial=ValidSpatialModel(), temporal=None, **params)
+    def __init__(self, implant, **params):
+        super().__init__(spatial=ValidSpatialModel(implant), temporal=None,
+                         **params)
         self.n_calls = 0
 
 
 def test_Model_subclass_constructor_owns_its_attributes():
-    model = ValidCompositeModel()
+    model = ValidCompositeModel(ArgusI())
     npt.assert_equal(model.n_calls, 0)
     npt.assert_equal('n_calls' in model.__dict__, True)
     npt.assert_equal(hasattr(model.spatial, 'n_calls'), False)
@@ -761,7 +772,7 @@ def test_Model_subclass_constructor_owns_its_attributes():
 def test_Model_subclass_params_go_to_the_component_model():
     # A user parameter belongs to the sub-model, even when it is passed to a
     # subclass constructor that is free to create attributes of its own:
-    model = ValidCompositeModel(step=2.5)
+    model = ValidCompositeModel(ArgusI(), step=2.5)
     npt.assert_almost_equal(model.spatial.step, 2.5)
     npt.assert_equal('step' in model.__dict__, False)
     model.set_params({'step': 0.5})
@@ -770,7 +781,7 @@ def test_Model_subclass_params_go_to_the_component_model():
     # A parameter no sub-model knows has nowhere to go, and must not quietly
     # become an attribute of the composite instead:
     with pytest.raises(FreezeError):
-        ValidCompositeModel(nonexistent=1)
+        ValidCompositeModel(ArgusI(), nonexistent=1)
 
 
 def test_Model_build():
@@ -783,7 +794,7 @@ def test_Model_build():
     npt.assert_equal(model.is_built, True)
 
     # SpatialModel, but no TemporalModel:
-    model = Model(spatial=ValidSpatialModel())
+    model = Model(spatial=ValidSpatialModel(ArgusI()))
     # An implant is what a spatial model needs; a temporal one never sees an
     # electrode, so offering it one is a mistake worth naming:
     with pytest.raises(ValueError, match='only a temporal'):
@@ -799,7 +810,8 @@ def test_Model_build():
     npt.assert_equal(model.is_built, True)
 
     # SpatialModel and TemporalModel:
-    model = Model(spatial=ValidSpatialModel(), temporal=ValidTemporalModel())
+    model = Model(spatial=ValidSpatialModel(ArgusI()),
+                  temporal=ValidTemporalModel())
     npt.assert_equal(model.is_built, False)
     model.build()
     npt.assert_equal(model.is_built, True)
@@ -807,7 +819,7 @@ def test_Model_build():
 
 def test_a_new_parameter_value_un_builds_the_model():
     """Which parameters a build depends on is not enumerated anywhere"""
-    model = ValidSpatialModel(step=1).build()
+    model = ValidSpatialModel(ArgusI(), step=1).build()
     # Assigning the value it already has changes nothing, so the build stands:
     model.step = model.step
     model.thresh_percept = 0
@@ -825,7 +837,7 @@ def test_a_new_parameter_value_un_builds_the_model():
 
 
 def test_a_composite_un_builds_the_stage_the_parameter_belongs_to():
-    model = Model(spatial=ValidSpatialModel(step=1),
+    model = Model(spatial=ValidSpatialModel(ArgusI(), step=1),
                   temporal=ValidTemporalModel()).build()
     model.step = 2
     npt.assert_equal(model.spatial.is_built, False)
@@ -851,7 +863,7 @@ def test_predict_percept_rebuilds_only_the_stale_stage():
             super()._build()
             builds['temporal'] += 1
 
-    model = Model(spatial=CountingSpatial(),
+    model = Model(spatial=CountingSpatial(ArgusI()),
                   temporal=CountingTemporal()).build()
     npt.assert_equal(builds, {'spatial': 1, 'temporal': 1})
 
@@ -873,9 +885,10 @@ def test_predict_percept_rebuilds_only_the_stale_stage():
 
 
 @pytest.mark.parametrize('make_model', [
-    lambda: ValidSpatialModel(),
-    lambda: Model(spatial=ValidSpatialModel()),
-    lambda: Model(spatial=ValidSpatialModel(), temporal=FadingTemporal()),
+    lambda: ValidSpatialModel(ArgusI()),
+    lambda: Model(spatial=ValidSpatialModel(ArgusI())),
+    lambda: Model(spatial=ValidSpatialModel(ArgusI()),
+                  temporal=FadingTemporal()),
 ])
 def test_predict_percept_builds_what_it_needs(make_model):
     model = make_model()
@@ -885,15 +898,43 @@ def test_predict_percept_builds_what_it_needs(make_model):
     npt.assert_equal(model.is_built, True)
 
 
+@pytest.mark.parametrize('ModelClass, ImplantType', [
+    (ScoreboardModel, ArgusII), (AxonMapModel, ArgusII),
+    (Thompson2003Model, ArgusII), (Nanduri2012Model, ArgusII),
+    (BiphasicAxonMapModel, ArgusII), (CortexScoreboardModel, Cortivis)])
+def test_a_standalone_spatial_model_needs_an_implant(ModelClass, ImplantType):
+    """Which device is modeled is not something to fill in later"""
+    with pytest.raises(TypeError):
+        ModelClass()
+    implant = ImplantType()
+    for model in (ModelClass(implant), ModelClass(implant=implant)):
+        npt.assert_equal(model.implant is implant, True)
+
+
+def test_a_temporal_only_model_takes_no_implant():
+    """`Horsager2009Model` has no electrodes to place"""
+    npt.assert_equal(Horsager2009Model().has_space, False)
+    with pytest.raises(ValueError, match='only a temporal'):
+        Horsager2009Model(implant=ArgusII())
+
+
+def test_Model_builds_a_spatial_class_around_its_implant():
+    """`spatial` given as a class is handed the implant `Model` was named"""
+    implant = ArgusI()
+    model = Model(spatial=ValidSpatialModel, temporal=ValidTemporalModel,
+                  implant=implant)
+    npt.assert_equal(model.spatial.implant is implant, True)
+
+
 def test_Model_names_one_implant():
     """Two implants is contradictory model context, not a precedence question"""
     implant = ArgusI()
     # The same object twice says nothing new:
-    model = Model(implant=implant, spatial=ValidSpatialModel(implant=implant))
+    model = Model(implant=implant, spatial=ValidSpatialModel(implant))
     npt.assert_equal(model.implant is implant, True)
     # Two different ones would have to silently pick a winner:
     with pytest.raises(ValueError, match='two different implants'):
-        Model(implant=implant, spatial=ValidSpatialModel(implant=ArgusII()))
+        Model(implant=implant, spatial=ValidSpatialModel(ArgusII()))
 
 
 def test_Model_predict_percept():
@@ -904,7 +945,7 @@ def test_Model_predict_percept():
     npt.assert_equal(model.predict_percept({'A1': 1}, t_percept=[0, 1]), None)
 
     # Just the spatial model:
-    model = Model(spatial=ValidSpatialModel()).build()
+    model = Model(spatial=ValidSpatialModel(ArgusI())).build()
     npt.assert_equal(model.predict_percept(None), None)
     # Just the temporal model:
     model = Model(temporal=ValidTemporalModel()).build()
@@ -912,7 +953,8 @@ def test_Model_predict_percept():
     # Both spatial and temporal:
 
     # Invalid calls:
-    model = Model(spatial=ValidSpatialModel(), temporal=ValidTemporalModel())
+    model = Model(spatial=ValidSpatialModel(ArgusI()),
+                  temporal=ValidTemporalModel())
     model.build()
     with pytest.raises(ValueError):
         # Cannot request t_percepts that are not multiples of dt:
@@ -952,9 +994,8 @@ def test_Model_predict_percept_frame_clock(fps):
     # Stimulus, so the frame clock has to survive that hop too. This leg needs
     # real models: `ValidTemporalModel` returns one row per electrode, not one
     # per grid point, so it cannot consume a spatial percept.
-    both = Model(implant=implant,
-                 spatial=ScoreboardSpatial(xrange=(-2, 2), yrange=(-2, 2),
-                                           step=1),
+    both = Model(spatial=ScoreboardSpatial(implant, xrange=(-2, 2),
+                                           yrange=(-2, 2), step=1),
                  temporal=FadingTemporal()).build()
     npt.assert_equal(both.predict_percept(stim).data.shape[-1], 6)
     # An explicit `t_percept` still wins:
@@ -1007,13 +1048,15 @@ def test_Model_predict_percept_frame_peak():
 
 def test_Model_predict_percept_correctly_parallelizes():
     # setup and time spatial model with 1 thread
-    one_thread_spatial = Model(spatial=ValidSpatialModel(n_threads=1)).build()
+    one_thread_spatial = Model(
+        spatial=ValidSpatialModel(ArgusI(), n_threads=1)).build()
     start_time_one_thread_spatial = time.perf_counter()
     one_thread_spatial.predict_percept(np.ones(16))
     one_thread_spatial_predict_time = time.perf_counter() - start_time_one_thread_spatial
 
     # setup and time spatial model with 2 threads
-    two_thread_spatial = Model(spatial=ValidSpatialModel(n_threads=2)).build()
+    two_thread_spatial = Model(
+        spatial=ValidSpatialModel(ArgusI(), n_threads=2)).build()
     start_time_two_thread_spatial = time.perf_counter()
     two_thread_spatial.predict_percept(np.ones(16))
     two_threaded_spatial_predict_time = time.perf_counter() - start_time_two_thread_spatial
@@ -1040,7 +1083,7 @@ def test_Model_predict_percept_correctly_parallelizes():
 
 
 def test_Model_deepcopy_memo():
-    model = Model(spatial=ValidSpatialModel())
+    model = Model(spatial=ValidSpatialModel(ArgusI()))
 
     # Called directly, without a memo dict:
     copied = model.__deepcopy__()
@@ -1052,26 +1095,26 @@ def test_Model_deepcopy_memo():
     npt.assert_equal(model.__deepcopy__({id(model): sentinel}), sentinel)
 
     # Shared references are copied once, not duplicated:
-    shared = ValidSpatialModel()
+    shared = ValidSpatialModel(ArgusI())
     pair = copy.deepcopy({'a': shared, 'b': shared})
     npt.assert_equal(pair['a'] is pair['b'], True)
 
 
 def test_SpatialModel_deepcopy_memo():
-    model = ValidSpatialModel()
+    model = ValidSpatialModel(ArgusI())
     npt.assert_equal(model.__deepcopy__() == model, True)
     sentinel = 'already copied'
     npt.assert_equal(model.__deepcopy__({id(model): sentinel}), sentinel)
 
 
 def test_Model_eq_and_hash():
-    model = Model(spatial=ValidSpatialModel())
+    model = Model(spatial=ValidSpatialModel(ArgusI()))
 
     # Identity short-circuit:
     npt.assert_equal(model == model, True)
     # Different type:
     npt.assert_equal(model == 'not a model', False)
-    npt.assert_equal(model == ValidSpatialModel(), False)
+    npt.assert_equal(model == ValidSpatialModel(ArgusI()), False)
 
     # Hashable, so models can go in sets/dicts:
     npt.assert_equal(isinstance(hash(model), int), True)
@@ -1080,7 +1123,8 @@ def test_Model_eq_and_hash():
 
 def test_Model_pprint_params():
     # Covers both the spatial and the temporal branch of _pprint_params:
-    both = Model(spatial=ValidSpatialModel(), temporal=ValidTemporalModel())
+    both = Model(spatial=ValidSpatialModel(ArgusI()),
+                 temporal=ValidTemporalModel())
     params = both._pprint_params()
     npt.assert_equal('spatial' in params, True)
     npt.assert_equal('temporal' in params, True)
@@ -1093,7 +1137,8 @@ def test_Model_pprint_params():
 def test_Model_deepcopy_preserves_submodels_and_params():
     # A plain Model takes spatial/temporal as constructor arguments and does
     # not recreate them, so they must survive the copy:
-    model = Model(spatial=ValidSpatialModel(), temporal=ValidTemporalModel())
+    model = Model(spatial=ValidSpatialModel(ArgusI()),
+                  temporal=ValidTemporalModel())
     copied = copy.deepcopy(model)
     npt.assert_equal(isinstance(copied.spatial, ValidSpatialModel), True)
     npt.assert_equal(isinstance(copied.temporal, ValidTemporalModel), True)
@@ -1105,7 +1150,8 @@ def test_Model_deepcopy_preserves_submodels_and_params():
     # Model parameters are forwarded to the sub-models, so they live in
     # `spatial`/`temporal` rather than in `Model.__dict__`. Rebuilding the
     # copy from the constructor alone would silently reset them to defaults:
-    model = Model(spatial=ValidSpatialModel(step=5, thresh_percept=0.5))
+    model = Model(spatial=ValidSpatialModel(ArgusI(), step=5,
+                                            thresh_percept=0.5))
     copied = copy.deepcopy(model)
     npt.assert_almost_equal(copied.step, 5)
     npt.assert_almost_equal(copied.thresh_percept, 0.5)
@@ -1116,7 +1162,7 @@ def test_Model_deepcopy_preserves_submodels_and_params():
     npt.assert_almost_equal(model.step, 5)
 
     # A built model stays built:
-    built = Model(spatial=ValidSpatialModel(step=5)).build()
+    built = Model(spatial=ValidSpatialModel(ArgusI(), step=5)).build()
     npt.assert_equal(copy.deepcopy(built).is_built, True)
 
 
@@ -1172,9 +1218,8 @@ def test_model_t_percept_units():
     spatial = ScoreboardSpatial(implant=implant, xrange=(-2, 2),
                                 yrange=(-2, 2), step=1).build()
     temporal = FadingTemporal().build()
-    composite = Model(implant=implant,
-                      spatial=ScoreboardSpatial(xrange=(-2, 2), yrange=(-2, 2),
-                                                step=1),
+    composite = Model(spatial=ScoreboardSpatial(implant, xrange=(-2, 2),
+                                                yrange=(-2, 2), step=1),
                       temporal=FadingTemporal()).build()
     for model, stim in [(spatial, source),
                         (temporal, implant.prepare_stim(source)),
@@ -1214,9 +1259,8 @@ def test_model_requires_a_current_stimulus():
     spatial = ScoreboardSpatial(implant=implant, xrange=(-2, 2),
                                 yrange=(-2, 2), step=1).build()
     temporal = FadingTemporal().build()
-    composite = Model(implant=implant,
-                      spatial=ScoreboardSpatial(xrange=(-2, 2), yrange=(-2, 2),
-                                                step=1),
+    composite = Model(spatial=ScoreboardSpatial(implant, xrange=(-2, 2),
+                                                yrange=(-2, 2), step=1),
                       temporal=FadingTemporal()).build()
     with pytest.raises(DimensionMismatchError):
         ArgusII(preprocess=False, encoder=None).prepare_stim(img)
@@ -1237,8 +1281,7 @@ def test_model_requires_a_current_stimulus():
     argus = ArgusII(encoder=None, raster=None)
     for model in (ScoreboardSpatial(implant=argus, xrange=(-2, 2),
                                     yrange=(-2, 2), step=1).build(),
-                  Model(implant=argus,
-                        spatial=ScoreboardSpatial(xrange=(-2, 2),
+                  Model(spatial=ScoreboardSpatial(argus, xrange=(-2, 2),
                                                   yrange=(-2, 2), step=1),
                         temporal=FadingTemporal()).build()):
         npt.assert_equal(model.predict_percept(encoded) is None, False)
@@ -1410,9 +1453,8 @@ def test_percept_time_crosses_model_boundary():
     npt.assert_allclose(temporal.seen['values'], percept.data, rtol=0, atol=0)
 
     # The same crossing through a composite, which is where it really happens:
-    model = Model(implant=ArgusII(),
-                  spatial=SecondSpatial(xrange=(-2, 2), yrange=(-2, 2),
-                                        step=1),
+    model = Model(spatial=SecondSpatial(ArgusII(), xrange=(-2, 2),
+                                        yrange=(-2, 2), step=1),
                   temporal=MilliTemporal()).build()
     # A composite reports the unit of the stage that reads `t_percept` and
     # writes the percept, which is the temporal model:
@@ -1442,7 +1484,7 @@ def test_Model_units_follow_their_component():
     npt.assert_equal((Model().stimulus_unit, Model().space_unit,
                       Model().time_unit), (uA, um, ms))
     # One component: its own.
-    space_only = Model(spatial=MilliSpatial())
+    space_only = Model(spatial=MilliSpatial(ArgusII()))
     npt.assert_equal(space_only.stimulus_unit, mA)
     npt.assert_equal(space_only.space_unit, mm)
     npt.assert_equal(space_only.time_unit, s)
@@ -1452,7 +1494,7 @@ def test_Model_units_follow_their_component():
     # Both, disagreeing: the stimulus goes into the spatial model and the
     # percept comes out of the temporal one, so they are read off different
     # components rather than merged into the dict `__getattr__` would return.
-    both = Model(spatial=MilliSpatial(), temporal=MilliTemporal())
+    both = Model(spatial=MilliSpatial(ArgusII()), temporal=MilliTemporal())
     npt.assert_equal(both.stimulus_unit, mA)
     npt.assert_equal(both.space_unit, mm)
     npt.assert_equal(both.time_unit, ms)
@@ -1570,8 +1612,8 @@ def test_spatial_model_reads_modulation_not_pulses():
             seen.append(float(stim.data.min()))
             return super()._predict_spatial(earray, stim)
 
-    both = Model(implant=implant,
-                 spatial=Recording(xrange=(-12, 12), yrange=(-8, 8), step=1),
+    both = Model(spatial=Recording(implant, xrange=(-12, 12), yrange=(-8, 8),
+                                   step=1),
                  temporal=FadingTemporal(tau=100)).build()
     both.predict_percept(logo)
     npt.assert_array_less(seen[-1], 0)
@@ -1874,8 +1916,8 @@ def test_combined_model_still_integrates_the_delivered_pulses():
             seen.append(float(stim.data.min()))
             return super()._predict_spatial(earray, stim)
 
-    both = Model(implant=implant,
-                 spatial=Recording(xrange=(-12, 12), yrange=(-8, 8), step=1),
+    both = Model(spatial=Recording(implant, xrange=(-12, 12), yrange=(-8, 8),
+                                   step=1),
                  temporal=FadingTemporal(tau=100)).build()
     both.predict_percept(LogoBVL())
     npt.assert_array_less(seen[-1], 0)

--- a/pulse2percept/models/tests/test_beyeler2019.py
+++ b/pulse2percept/models/tests/test_beyeler2019.py
@@ -339,9 +339,9 @@ def test_AxonMap_removed_axlambda(cls):
     # `lam` was called `axlambda` until 0.10.0; the old name was removed
     # in 0.11.0, so it is now an unknown parameter:
     with pytest.raises(AttributeError):
-        cls(axlambda=400)
+        cls(ArgusII(), axlambda=400)
     with pytest.raises(AttributeError):
-        model = cls(step=5)
+        model = cls(ArgusII(), step=5)
         if cls is AxonMapModel:
             model.set_params({'axlambda': 400})
         else:

--- a/pulse2percept/models/tests/test_end_to_end.py
+++ b/pulse2percept/models/tests/test_end_to_end.py
@@ -319,9 +319,8 @@ def test_endtoend_slow_train_stays_lit_for_the_whole_video():
     onset = delivered.time[np.any(delivered.data < 0, axis=0)]
     npt.assert_almost_equal(onset.max(), 3010.5, decimal=1)
 
-    model = Model(implant=implant,
-                  spatial=ScoreboardSpatial(xrange=(-12, 12), yrange=(-8, 8),
-                                            step=1),
+    model = Model(spatial=ScoreboardSpatial(implant, xrange=(-12, 12),
+                                            yrange=(-8, 8), step=1),
                   temporal=FadingTemporal(tau=100)).build()
     with pytest.warns(UserWarning, match='deliver no pulse'):
         percept = model.predict_percept(BostonTrain())

--- a/pulse2percept/models/tests/test_scene.py
+++ b/pulse2percept/models/tests/test_scene.py
@@ -505,8 +505,8 @@ def test_a_spatiotemporal_model_composes_against_a_video_scene():
                   scotoma=Scotoma.circle(6), scotoma_fill=0.0)
 
     def spatiotemporal():
-        return Model(implant=implant_at(0, 0),
-                     spatial=ScoreboardSpatial(rho=200, xrange=(-4, 4),
+        return Model(spatial=ScoreboardSpatial(implant_at(0, 0), rho=200,
+                                               xrange=(-4, 4),
                                                yrange=(-4, 4), step=0.5,
                                                vfmap=Curcio1990Map()),
                      temporal=FadingTemporal()).build()
@@ -527,9 +527,9 @@ def test_a_spatiotemporal_model_composes_against_a_video_scene():
 
 def test_a_temporal_stage_does_not_lose_the_visual_field_grid():
     """A percept rewritten frame by frame has not moved in the visual field"""
-    model = Model(implant=implant_at(0, 0),
-                  spatial=ScoreboardSpatial(rho=200, xrange=(-2, 2),
-                                            yrange=(-2, 2), step=1),
+    model = Model(spatial=ScoreboardSpatial(implant_at(0, 0), rho=200,
+                                            xrange=(-2, 2), yrange=(-2, 2),
+                                            step=1),
                   temporal=FadingTemporal()).build()
     percept = model.predict_percept(
         BiphasicPulseTrain(20, 30, 0.45, stim_dur=50))

--- a/pulse2percept/models/thompson2003.py
+++ b/pulse2percept/models/thompson2003.py
@@ -48,9 +48,8 @@ class Thompson2003Spatial(SpatialModel):
 
     Parameters
     ----------
-    implant : :py:class:`~pulse2percept.implants.ProsthesisSystem`, optional
-        Implant whose electrode geometry is modeled. Required before building
-        or predicting.
+    implant : :py:class:`~pulse2percept.implants.ProsthesisSystem`
+        Implant whose electrode geometry is modeled.
 
         .. versionadded:: 0.11.0
 
@@ -146,9 +145,8 @@ class Thompson2003Model(Model):
 
     Parameters
     ----------
-    implant : :py:class:`~pulse2percept.implants.ProsthesisSystem`, optional
-        Implant whose electrode geometry is modeled. Required before building
-        or predicting.
+    implant : :py:class:`~pulse2percept.implants.ProsthesisSystem`
+        Implant whose electrode geometry is modeled.
 
         .. versionadded:: 0.11.0
 
@@ -198,7 +196,6 @@ class Thompson2003Model(Model):
         use this parameter.
     """
 
-    def __init__(self, **params):
-        super(Thompson2003Model, self).__init__(spatial=Thompson2003Spatial(),
-                                                temporal=None,
-                                                **params)
+    def __init__(self, implant, **params):
+        super(Thompson2003Model, self).__init__(
+            spatial=Thompson2003Spatial(implant), temporal=None, **params)

--- a/pulse2percept/topography/tests/test_neuropythy.py
+++ b/pulse2percept/topography/tests/test_neuropythy.py
@@ -9,7 +9,7 @@ import pytest
 from scipy.spatial import cKDTree
 from types import SimpleNamespace
 
-from pulse2percept.implants import EnsembleImplant
+from pulse2percept.implants import ArgusII, EnsembleImplant
 from pulse2percept.implants.cortex import Neuralink
 from pulse2percept.models import ScoreboardModel as BeyelerScoreboard
 from pulse2percept.models.cortex import ScoreboardModel
@@ -325,7 +325,7 @@ def test_NeuropythyMap_units(neuropythy):
 
 def test_ndim_mixup():
     """A 3D cortical map cannot drive a model that only knows 2D grids."""
-    model = BeyelerScoreboard(vfmap=ToyNeuropythyMap())
+    model = BeyelerScoreboard(ArgusII(), vfmap=ToyNeuropythyMap())
     npt.assert_equal(2 in model.ndim, True)
     npt.assert_equal(3 in model.ndim, False)
     with pytest.raises(ValueError):

--- a/pulse2percept/units/tests/test_integration.py
+++ b/pulse2percept/units/tests/test_integration.py
@@ -195,12 +195,11 @@ def test_every_spelling_builds_the_same_object():
     # --- And a whole pipeline, spelled unitfully end to end ---------------
     imp_bare = ArgusII(x=575)
     imp_unit = ArgusII(x=0.575 * mm)
-    bare = Model(implant=imp_bare,
-                 spatial=ScoreboardSpatial(rho=575, xrange=(-8, 8),
-                                           yrange=(-8, 8), step=2),
+    bare = Model(spatial=ScoreboardSpatial(imp_bare, rho=575,
+                                           xrange=(-8, 8), yrange=(-8, 8),
+                                           step=2),
                  temporal=FadingTemporal(tau=20)).build()
-    unitful = Model(implant=imp_unit,
-                    spatial=ScoreboardSpatial(rho=0.575 * mm,
+    unitful = Model(spatial=ScoreboardSpatial(imp_unit, rho=0.575 * mm,
                                               xrange=(-8 * dva, 8 * dva),
                                               yrange=(-8 * dva, 8 * dva),
                                               step=2 * dva),

--- a/pulse2percept/viz/tests/test_argus.py
+++ b/pulse2percept/viz/tests/test_argus.py
@@ -29,7 +29,7 @@ def test_plot_argus_phosphenes():
 
     # Add axon map:
     _, ax = plt.subplots()
-    plot_argus_phosphenes(df, ArgusI(), ax=ax, axon_map=AxonMapModel())
+    plot_argus_phosphenes(df, ArgusI(), ax=ax, axon_map=AxonMapModel(ArgusI()))
 
     # Data must be a DataFrame:
     with pytest.raises(TypeError):
@@ -46,7 +46,8 @@ def test_plot_argus_phosphenes():
         plot_argus_phosphenes(df, AlphaAMS())
     # Works only for axon maps:
     with pytest.raises(TypeError):
-        plot_argus_phosphenes(df, ArgusI(), ax=ax, axon_map=ScoreboardModel())
+        plot_argus_phosphenes(df, ArgusI(), ax=ax,
+                              axon_map=ScoreboardModel(ArgusI()))
     # Manual subject selection
     plot_argus_phosphenes(df[df.electrode == 'B2'], ArgusI(), ax=ax)
     # If no implant given, dataframe must have additional columns:
@@ -74,7 +75,7 @@ def test_plot_argus_simulated_phosphenes(ImplantType):
     # Add axon map:
     _, ax = plt.subplots()
     plot_argus_simulated_phosphenes(percepts, implant, ax=ax,
-                                    axon_map=AxonMapModel())
+                                    axon_map=AxonMapModel(implant))
 
 
 def test_the_plotted_implant_owns_the_axon_laterality(monkeypatch):


### PR DESCRIPTION
Models require an implant to meaningfully build, plot, and predict. So `SpatialModel(implant, **params)` now requires a valid `ProsthesisSystem` and standalone spatial models take `implant` as their first argument, e.g.
```
p2p.models.ScoreboardModel(p2p.implants.PRIMAPivotal())
p2p.models.AxonMapModel(p2p.implants.ArgusII(), rho=300)
p2p.models.cortex.DynaphosModel(p2p.implants.cortex.Cortivis())
```

Generic `Model` now only composes already-constructed components:
```
p2p.models.Model(
    spatial=p2p.models.ScoreboardSpatial(implant),
    temporal=p2p.models.FadingTemporal(),
)
```
`implant` is no longer a generic model parameter, so `Model(..., implant=...)` and `model.set_params(implant=...)` are rejected. Explicit rebinding through `model.implant = other_implant` remains supported and invalidates the spatial build.

This also removes the old spatial-class construction path from `Model`, keeping implant ownership with the spatial component and simplifying parameter forwarding.