### PR TITLE
[API] Rename ProsthesisSystem to Implant

### DIFF
--- a/benchmarks/scenarios.py
+++ b/benchmarks/scenarios.py
@@ -119,7 +119,7 @@ class Scenario:
     stimulus : callable
         Takes no arguments, returns a stimulus.
     implant : callable
-        Takes no arguments, returns a ``ProsthesisSystem``.
+        Takes no arguments, returns an ``Implant``.
     source : callable, optional
         Takes the implant and the stimulus, returns what ``predict_percept``
         is given. Defaults to the stimulus unchanged; the image scenarios use

--- a/doc/topics/implants.rst
+++ b/doc/topics/implants.rst
@@ -8,7 +8,7 @@ An implant describes the device: its electrodes, their geometry and location,
 and how a source stimulus becomes the current those electrodes deliver.
 
 All implants derive from
-:py:class:`~pulse2percept.implants.ProsthesisSystem`. The attributes used most
+:py:class:`~pulse2percept.implants.Implant`. The attributes used most
 often are:
 
 ``earray``
@@ -35,7 +35,7 @@ often are:
 
 New in v0.11.0: An implant holds no stimulus. What it delivers is derived from
 a source, on demand, by
-:py:meth:`~pulse2percept.implants.ProsthesisSystem.prepare_stim`.
+:py:meth:`~pulse2percept.implants.Implant.prepare_stim`.
 
 Basic use
 ---------
@@ -58,7 +58,7 @@ directly:
 Preparing a stimulus
 --------------------
 
-:py:meth:`~pulse2percept.implants.ProsthesisSystem.prepare_stim` converts a
+:py:meth:`~pulse2percept.implants.Implant.prepare_stim` converts a
 source into stimulation the device can deliver:
 
 .. code-block:: python
@@ -210,7 +210,7 @@ stimulation. Images and videos are encoded with an
 rastered one row at a time using a
 :py:class:`~pulse2percept.implants.SequentialRaster` with six groups separated
 by 2 ms. Thus visual stimuli can be passed directly to
-:py:meth:`~pulse2percept.implants.ProsthesisSystem.prepare_stim`:
+:py:meth:`~pulse2percept.implants.Implant.prepare_stim`:
 
 .. code-block:: python
 
@@ -301,16 +301,16 @@ arguments for electrodes with a physical extent:
 
 :py:class:`~pulse2percept.implants.GridImplant` is a convenience only:
 :py:class:`~pulse2percept.implants.ElectrodeGrid` describes the geometry,
-:py:class:`~pulse2percept.implants.ProsthesisSystem` describes the device, and
+:py:class:`~pulse2percept.implants.Implant` describes the device, and
 the two can still be combined by hand. Do that for an irregular array, built
 from individual electrodes:
 
 .. code-block:: python
 
-    from pulse2percept.implants import ElectrodeArray, ProsthesisSystem
+    from pulse2percept.implants import ElectrodeArray, Implant
 
     earray = ElectrodeArray(...)
-    implant = ProsthesisSystem(earray)
+    implant = Implant(earray)
 
 :py:class:`~pulse2percept.implants.EnsembleImplant` combines multiple implants
 into one system.

--- a/doc/users/faq.rst
+++ b/doc/users/faq.rst
@@ -316,7 +316,7 @@ Most pulse2percept simulations involve four objects, plus an optional encoder:
     this specifies which electrodes are active, with what amplitudes, and
     optionally how stimulation changes over time.
 
-:py:class:`~pulse2percept.implants.ProsthesisSystem`
+:py:class:`~pulse2percept.implants.Implant`
     Describes the prosthetic device, including its electrode array, placement,
     and stimulus. Specific devices such as
     :py:class:`~pulse2percept.implants.ArgusII` are subclasses of this object.
@@ -453,7 +453,7 @@ existing retinal and cortical prostheses.
 Choose one of these when you want to simulate a particular device. If your
 electrode layout does not correspond to an existing implant, you can construct
 your own :py:class:`~pulse2percept.implants.ElectrodeArray` and
-:py:class:`~pulse2percept.implants.ProsthesisSystem`.
+:py:class:`~pulse2percept.implants.Implant`.
 
 The implant matters because electrode size, spacing, location, and orientation
 can all affect the predicted response.

--- a/doc/users/faq.rst
+++ b/doc/users/faq.rst
@@ -318,7 +318,7 @@ Most pulse2percept simulations involve four objects, plus an optional encoder:
 
 :py:class:`~pulse2percept.implants.Implant`
     Describes the prosthetic device, including its electrode array, placement,
-    and stimulus. Specific devices such as
+    and input/encoding pipeline. Specific devices such as
     :py:class:`~pulse2percept.implants.ArgusII` are subclasses of this object.
 
 :py:class:`~pulse2percept.models.Model`

--- a/doc/users/release_notes.rst
+++ b/doc/users/release_notes.rst
@@ -51,6 +51,10 @@ Stimuli and encoding
 Implants
 ~~~~~~~~
 
+* ``ProsthesisSystem`` is renamed
+  :py:class:`~pulse2percept.implants.Implant`; the old name is a deprecated
+  alias for the same class until 0.12.0 (:pull:`876`).
+
 * ``PRIMA`` is renamed :py:class:`~pulse2percept.implants.PRIMAPivotal`,
   ``PRIMA75`` becomes :py:class:`~pulse2percept.implants.Lorach2015Array`, and
   ``PRIMA55``/``PRIMA40`` become ``Ho2019FlatArray(55)``/
@@ -63,10 +67,11 @@ Implants
   rendering, and hexagonal pixel orientation were corrected to match the
   corresponding devices (:pull:`865`).
 
-* :py:class:`~pulse2percept.implants.ProsthesisSystem` adds descriptive
-  ``placement``, ``technology``, and ``family`` attributes (:pull:`865`) and
-  accepts ``thresholds`` at construction; :py:class:`~pulse2percept.implants.ArgusII`
-  likewise accepts ``thresholds`` (:pull:`869`).
+* :py:class:`~pulse2percept.implants.Implant` adds descriptive ``placement``,
+  ``technology``, and ``family`` attributes (:pull:`865`) and accepts
+  ``thresholds`` at construction;
+  :py:class:`~pulse2percept.implants.ArgusII` likewise accepts ``thresholds``
+  (:pull:`869`).
 
 * :py:class:`~pulse2percept.implants.RectangleImplant` is deprecated in favor
   of :py:class:`~pulse2percept.implants.GridImplant` (:pull:`859`).
@@ -180,7 +185,8 @@ API changes:
 * Image and video stimuli now use grid-style electrode names such as ``'A1'``
   and ``'C12_G'`` instead of integer pixel indices (:pull:`805`)
 
-* :py:class:`~pulse2percept.implants.ProsthesisSystem` now supports stimulus
+* ``ProsthesisSystem`` (now
+  :py:class:`~pulse2percept.implants.Implant`) supports stimulus
   encoders, raster strategies, and maximum-current limits. Dimensionless
   image/video stimuli can be encoded automatically when assigned to an implant
   (:pull:`810`, :pull:`833`)

--- a/examples/implants/README.rst
+++ b/examples/implants/README.rst
@@ -12,4 +12,4 @@ state-of-the-art retinal prostheses, such as
 as well as :py:class:`~pulse2percept.implants.BVT24` (suprachoroidal).
 
 Other implants can be added by creating a new 
-:py:class:`~pulse2percept.implants.ProsthesisSystem` object.
+:py:class:`~pulse2percept.implants.Implant` object.

--- a/examples/implants/plot_electrode_grid.py
+++ b/examples/implants/plot_electrode_grid.py
@@ -127,9 +127,9 @@ offset_grid = ElectrodeGrid((11, 13), 500, type='hex', x=-600, y=200, z=150,
 
 # An axon map is grown for a particular eye, so the model needs the implant
 # the grid belongs to:
-from pulse2percept.implants import ProsthesisSystem
+from pulse2percept.implants import Implant
 
-AxonMapModel(implant=ProsthesisSystem(offset_grid)).plot()
+AxonMapModel(implant=Implant(offset_grid)).plot()
 offset_grid.plot()
 
 ##############################################################################
@@ -140,7 +140,7 @@ offset_grid.plot()
 # cannot hold a stimulus. To turn one into a device that a model can predict
 # from, use :py:class:`~pulse2percept.implants.GridImplant`, which takes the
 # same grid arguments and adds the ones a
-# :py:class:`~pulse2percept.implants.ProsthesisSystem` understands:
+# :py:class:`~pulse2percept.implants.Implant` understands:
 
 from pulse2percept.implants import GridImplant
 

--- a/examples/models/plot_nanduri2012.py
+++ b/examples/models/plot_nanduri2012.py
@@ -60,11 +60,11 @@ earray = ElectrodeArray(DiskElectrode(0, 0, 0, 260))
 # :py:class:`~pulse2percept.implants.ArgusII` or
 # :py:class:`~pulse2percept.implants.AlphaIMS`. Alternatively, we can wrap the
 # electrode array created above with a
-# :py:class:`~pulse2percept.implants.ProsthesisSystem` to create our own
+# :py:class:`~pulse2percept.implants.Implant` to create our own
 # retinal implant:
 
-from pulse2percept.implants import ProsthesisSystem
-implant = ProsthesisSystem(earray)
+from pulse2percept.implants import Implant
+implant = Implant(earray)
 
 ###############################################################################
 # Running the model

--- a/examples/stimuli/README.rst
+++ b/examples/stimuli/README.rst
@@ -7,7 +7,7 @@ The :py:mod:`~pulse2percept.stimuli` module provides a number of common
 electrical stimulus types, such as 
 :py:class:`~pulse2percept.stimuli.BiphasicPulseTrain`,
 which can be assigned to electrodes of a 
-:py:class:`~pulse2percept.implants.ProsthesisSystem` object.
+:py:class:`~pulse2percept.implants.Implant` object.
 
 Stimuli can also be created from images 
 (:py:class:`~pulse2percept.stimuli.ImageStimulus`) and videos

--- a/examples/stimuli/plot_image_stim.py
+++ b/examples/stimuli/plot_image_stim.py
@@ -164,7 +164,7 @@ logo_dilate.save('dilated_logo.png')
 # ---------------------------------------------
 #
 # :py:class:`~pulse2percept.stimuli.ImageStimulus` can be used in
-# combination with any :py:meth:`~pulse2percept.implants.ProsthesisSystem`.
+# combination with any :py:meth:`~pulse2percept.implants.Implant`.
 # We just have to resize the image first so that the number of pixels in the
 # image matches the number of electrodes in the implant.
 #

--- a/examples/stimuli/plot_video_stim.py
+++ b/examples/stimuli/plot_video_stim.py
@@ -98,7 +98,7 @@ video.resize((40, 40)).rotate(10).invert().filter('median').play()
 # ---------------------------------------------
 #
 # :py:class:`~pulse2percept.stimuli.VideoStimulus` can be used in
-# combination with any :py:meth:`~pulse2percept.implants.ProsthesisSystem`.
+# combination with any :py:meth:`~pulse2percept.implants.Implant`.
 # What an implant delivers is current, though, not gray levels, so the video
 # has to be encoded first: sampled at the electrode locations, and turned into
 # a pulse train whose amplitude says how bright each pixel was.

--- a/examples/vision/plot_amd_prima.py
+++ b/examples/vision/plot_amd_prima.py
@@ -13,7 +13,7 @@ Four objects capture that situation:
 
 *  :py:class:`~pulse2percept.vision.Scene`: what is visually present, and
    where native vision is lost.
-*  :py:class:`~pulse2percept.implants.ProsthesisSystem`: where the implant's
+*  :py:class:`~pulse2percept.implants.Implant`: where the implant's
    electrodes are, and how it turns gray levels into stimulation.
 *  :py:class:`~pulse2percept.models.Model`: the retinotopy, which is what
    connects the two.

--- a/pulse2percept/implants/__init__.py
+++ b/pulse2percept/implants/__init__.py
@@ -24,7 +24,7 @@ Different prosthetic implants, such as Argus II, Alpha-IMS, BVT-24, PRIMA, Corti
 
     *  :ref:`Basic Concepts > Visual Prostheses <topics-implants>`
 """
-from .base import GridImplant, ProsthesisSystem, RectangleImplant
+from .base import GridImplant, Implant, RectangleImplant
 from .electrodes import (Electrode, PointSource, DiskElectrode,
                          SquareElectrode, HexElectrode)
 from .electrode_arrays import ElectrodeArray, ElectrodeGrid
@@ -39,6 +39,7 @@ from .prima import (PhotovoltaicPixel, PRIMAPivotal, Lorach2015Array,
 from .imie import IMIE
 from .ensemble import EnsembleImplant
 from . import cortex
+from ..utils import deprecated_names
 
 __all__ = [
     'AlphaAMS',
@@ -59,6 +60,7 @@ __all__ = [
     'HexElectrode',
     'Ho2019FlatArray',
     'Huang2021Array',
+    'Implant',
     'Lorach2015Array',
     'PhotovoltaicPixel',
     'PointSource',
@@ -75,3 +77,9 @@ __all__ = [
     'SquareElectrode',
     'IMIE'
 ]
+
+# Deprecated in 0.11.0, removed in 0.12.0. Defined here as well as in
+# ``base`` so that both import paths warn.
+__getattr__ = deprecated_names(__name__, {'ProsthesisSystem': Implant},
+                               deprecated_version='0.11.0',
+                               removed_version='0.12.0')

--- a/pulse2percept/implants/__init__.py
+++ b/pulse2percept/implants/__init__.py
@@ -39,7 +39,7 @@ from .prima import (PhotovoltaicPixel, PRIMAPivotal, Lorach2015Array,
 from .imie import IMIE
 from .ensemble import EnsembleImplant
 from . import cortex
-from ..utils import deprecated_names
+from ..utils.deprecation import _deprecated_names
 
 __all__ = [
     'AlphaAMS',
@@ -80,6 +80,6 @@ __all__ = [
 
 # Deprecated in 0.11.0, removed in 0.12.0. Defined here as well as in
 # ``base`` so that both import paths warn.
-__getattr__ = deprecated_names(__name__, {'ProsthesisSystem': Implant},
-                               deprecated_version='0.11.0',
-                               removed_version='0.12.0')
+__getattr__ = _deprecated_names(__name__, {'ProsthesisSystem': Implant},
+                                deprecated_version='0.11.0',
+                                removed_version='0.12.0')

--- a/pulse2percept/implants/alpha.py
+++ b/pulse2percept/implants/alpha.py
@@ -3,13 +3,13 @@
 import numpy as np
 from collections import OrderedDict
 
-from .base import ProsthesisSystem
+from .base import Implant
 from .electrodes import SquareElectrode, DiskElectrode
 from .electrode_arrays import ElectrodeGrid
 from ..units import as_value, um
 
 
-class AlphaIMS(ProsthesisSystem):
+class AlphaIMS(Implant):
     """Alpha-IMS
 
     This class creates an Alpha-IMS array with 1500 photovoltaic pixels (each
@@ -151,7 +151,7 @@ class AlphaIMS(ProsthesisSystem):
         return params
 
 
-class AlphaAMS(ProsthesisSystem):
+class AlphaAMS(Implant):
     """Alpha-AMS
 
     This class creates an Alpha-AMS array with 1600 photovoltaic pixels (each

--- a/pulse2percept/implants/argus.py
+++ b/pulse2percept/implants/argus.py
@@ -3,7 +3,7 @@
 import numpy as np
 from collections import OrderedDict
 
-from .base import ProsthesisSystem
+from .base import Implant
 from .electrodes import DiskElectrode
 from .electrode_arrays import ElectrodeGrid
 from .rasters import SequentialRaster
@@ -16,7 +16,7 @@ from ..units import Hz, ms
 _DEVICE_DEFAULT = object()
 
 
-class ArgusI(ProsthesisSystem):
+class ArgusI(Implant):
     """Create an Argus I array on the retina
 
     This function creates an Argus I array and places it on the retina
@@ -157,7 +157,7 @@ class ArgusI(ProsthesisSystem):
         return params
 
 
-class ArgusII(ProsthesisSystem):
+class ArgusII(Implant):
     """Create an Argus II array on the retina
 
     This function creates an Argus II array and places it on the retina
@@ -235,7 +235,7 @@ class ArgusII(ProsthesisSystem):
         modeling, used to calibrate threshold-relative (``xTh``) stimuli. A
         scalar applies to every electrode; a dict calibrates the named
         electrodes only. See
-        :py:attr:`~pulse2percept.implants.ProsthesisSystem.thresholds`.
+        :py:attr:`~pulse2percept.implants.Implant.thresholds`.
 
         .. versionadded:: 0.11.0
 

--- a/pulse2percept/implants/base.py
+++ b/pulse2percept/implants/base.py
@@ -16,7 +16,8 @@ from ..stimuli.base import _describe_unit
 from ..stimuli.encoders import _EncodedStimulus
 from ..stimuli.pulse_trains import _as_threshold_amp
 from ..units import DimensionMismatchError, as_value, uA, um, xTh
-from ..utils import PrettyPrint, deprecated, deprecated_names
+from ..utils import PrettyPrint, deprecated
+from ..utils.deprecation import _deprecated_names
 
 
 class Implant(PrettyPrint):
@@ -896,6 +897,6 @@ class RectangleImplant(Implant):
 # ``ProsthesisSystem`` was renamed to ``Implant`` in 0.11.0. It resolves to the
 # class itself rather than to a subclass, so ``isinstance`` and ``issubclass``
 # checks written against the old name keep working during the deprecation.
-__getattr__ = deprecated_names(__name__, {'ProsthesisSystem': Implant},
-                               deprecated_version='0.11.0',
-                               removed_version='0.12.0')
+__getattr__ = _deprecated_names(__name__, {'ProsthesisSystem': Implant},
+                                deprecated_version='0.11.0',
+                                removed_version='0.12.0')

--- a/pulse2percept/implants/base.py
+++ b/pulse2percept/implants/base.py
@@ -1,4 +1,4 @@
-""":py:class:`~pulse2percept.implants.ProsthesisSystem`,
+""":py:class:`~pulse2percept.implants.Implant`,
    :py:class:`~pulse2percept.implants.GridImplant`,
    :py:class:`~pulse2percept.implants.RectangleImplant`"""
 import numpy as np
@@ -16,21 +16,24 @@ from ..stimuli.base import _describe_unit
 from ..stimuli.encoders import _EncodedStimulus
 from ..stimuli.pulse_trains import _as_threshold_amp
 from ..units import DimensionMismatchError, as_value, uA, um, xTh
-from ..utils import PrettyPrint, deprecated
+from ..utils import PrettyPrint, deprecated, deprecated_names
 
 
-class ProsthesisSystem(PrettyPrint):
-    """Visual prosthesis system
+class Implant(PrettyPrint):
+    """Visual prosthesis
 
     A visual prosthesis describes an electrode array together with the input
     pipeline that turns what is presented to the device into the stimulation
     its electrodes deliver (see
-    :py:meth:`~pulse2percept.implants.ProsthesisSystem.prepare_stim`). This is
-    the base class for prosthesis systems such as
-    :py:class:`~pulse2percept.implants.ArgusII` and
+    :py:meth:`~pulse2percept.implants.Implant.prepare_stim`). This is the base
+    class for implants such as :py:class:`~pulse2percept.implants.ArgusII` and
     :py:class:`~pulse2percept.implants.AlphaIMS`.
 
     .. versionadded:: 0.6
+
+    .. versionchanged:: 0.11.0
+        Renamed from ``ProsthesisSystem``, which stays available as a
+        deprecated alias until 0.12.0.
 
     .. versionchanged:: 0.11.0
         An implant no longer stores a stimulus. ``implant.stim = source``
@@ -85,7 +88,7 @@ class ProsthesisSystem(PrettyPrint):
         Perceptual threshold current (uA) used to calibrate threshold-relative
         (``xTh``) stimuli. A scalar applies to every electrode; a dict
         calibrates the named electrodes only. See
-        :py:attr:`~pulse2percept.implants.ProsthesisSystem.thresholds`.
+        :py:attr:`~pulse2percept.implants.Implant.thresholds`.
 
         .. versionadded:: 0.11.0
 
@@ -95,8 +98,8 @@ class ProsthesisSystem(PrettyPrint):
     :py:class:`~pulse2percept.implants.DiskElectrode` with radius
     r=100um sitting at x=200um, y=-50um, z=10um:
 
-    >>> from pulse2percept.implants import DiskElectrode, ProsthesisSystem
-    >>> implant = ProsthesisSystem(DiskElectrode(200, -50, 10, 100), eye='LE')
+    >>> from pulse2percept.implants import DiskElectrode, Implant
+    >>> implant = Implant(DiskElectrode(200, -50, 10, 100), eye='LE')
 
     """
     # Frozen class: User cannot add more class attributes
@@ -207,7 +210,7 @@ class ProsthesisSystem(PrettyPrint):
         Assign a single current for the whole array, a per-electrode dict,
         or None to clear the calibration. Threshold-relative pulse trains are
         calibrated against whatever is in force at the moment
-        :py:meth:`~pulse2percept.implants.ProsthesisSystem.prepare_stim` runs.
+        :py:meth:`~pulse2percept.implants.Implant.prepare_stim` runs.
 
         .. versionadded:: 0.10.0
 
@@ -344,7 +347,7 @@ class ProsthesisSystem(PrettyPrint):
         """Quality-check the stimulus
 
         This method is executed every time a stimulus is prepared (see
-        :py:meth:`~pulse2percept.implants.ProsthesisSystem.prepare_stim`).
+        :py:meth:`~pulse2percept.implants.Implant.prepare_stim`).
 
         If ``safe_mode`` is set to True, this function will only allow stimuli
         that are charge-balanced. If ``max_current`` is set, it will only allow
@@ -354,13 +357,13 @@ class ProsthesisSystem(PrettyPrint):
         a stimulus that is not a current, so each raises a
         :py:class:`~pulse2percept.units.DimensionMismatchError` on one. In the
         ordinary flow this cannot happen:
-        :py:meth:`~pulse2percept.implants.ProsthesisSystem.prepare_stim` has
+        :py:meth:`~pulse2percept.implants.Implant.prepare_stim` has
         already checked the stimulus against
-        :py:attr:`~pulse2percept.implants.ProsthesisSystem.stimulus_unit`.
+        :py:attr:`~pulse2percept.implants.Implant.stimulus_unit`.
         ``check_stim`` is public, though, and may be handed anything.
 
         The user can define their own checks in implants that inherit from
-        :py:class:`~pulse2percept.implants.ProsthesisSystem`.
+        :py:class:`~pulse2percept.implants.Implant`.
 
         Parameters
         ----------
@@ -402,7 +405,7 @@ class ProsthesisSystem(PrettyPrint):
         No preprocessing is performed by default, but the user can define their
         own method in implants that inherit from
         return stim
-        :py:class:`~pulse2percept.implants.ProsthesisSystem`.
+        :py:class:`~pulse2percept.implants.Implant`.
 
         A custom method must return a
         :py:class:`~pulse2percept.stimuli.Stimulus` object with the correct
@@ -486,7 +489,7 @@ class ProsthesisSystem(PrettyPrint):
             (if exists) or create a new Axes object.
         stim : :py:class:`~pulse2percept.stimuli.Stimulus` source type, optional
             What is presented to the device. Prepared through
-            :py:meth:`~pulse2percept.implants.ProsthesisSystem.prepare_stim`,
+            :py:meth:`~pulse2percept.implants.Implant.prepare_stim`,
             so the colors show what the electrodes actually deliver. Required
             by ``stim_cmap``.
 
@@ -547,12 +550,12 @@ class ProsthesisSystem(PrettyPrint):
         The input is not modified and the result is not stored.
 
         Prepared stimuli use the implant's
-        :py:attr:`~pulse2percept.implants.ProsthesisSystem.stimulus_unit`
+        :py:attr:`~pulse2percept.implants.Implant.stimulus_unit`
         (electrical current for most devices; irradiance for PRIMA).
 
         Images and videos require an encoder unless preprocessing already converts
         them to the implant's
-        :py:attr:`~pulse2percept.implants.ProsthesisSystem.stimulus_unit`.
+        :py:attr:`~pulse2percept.implants.Implant.stimulus_unit`.
 
         .. versionadded:: 0.11.0
             Replaces the stateful ``stim`` property.
@@ -571,9 +574,9 @@ class ProsthesisSystem(PrettyPrint):
 
         Examples
         --------
-        >>> from pulse2percept.implants import DiskElectrode, ProsthesisSystem
+        >>> from pulse2percept.implants import DiskElectrode, Implant
         >>> from pulse2percept.stimuli import BiphasicPulse
-        >>> implant = ProsthesisSystem(DiskElectrode(0, 0, 0, 100))
+        >>> implant = Implant(DiskElectrode(0, 0, 0, 100))
         >>> stim = implant.prepare_stim(BiphasicPulse(30, 0.45))
 
         Stimulate Electrode B7 in Argus II with 13 uA:
@@ -646,7 +649,7 @@ class ProsthesisSystem(PrettyPrint):
     def eye(self):
         """Implanted eye
 
-        A :py:class:`~pulse2percept.implants.ProsthesisSystem` can be implanted
+        A :py:class:`~pulse2percept.implants.Implant` can be implanted
         either in a left eye ('LE') or right eye ('RE'). Models such as
         :py:class:`~pulse2percept.models.AxonMapModel` will treat left and
         right eyes differently (for example, adjusting the location of the
@@ -716,12 +719,12 @@ class ProsthesisSystem(PrettyPrint):
 
 
 
-class GridImplant(ProsthesisSystem):
+class GridImplant(Implant):
     """A prosthesis system whose electrodes form a regular grid
 
     Convenience composition of an
     :py:class:`~pulse2percept.implants.ElectrodeGrid` and a
-    :py:class:`~pulse2percept.implants.ProsthesisSystem`, for the common case
+    :py:class:`~pulse2percept.implants.Implant`, for the common case
     where a custom implant is just a grid of electrodes:
 
     .. code-block:: python
@@ -732,7 +735,7 @@ class GridImplant(ProsthesisSystem):
 
     .. code-block:: python
 
-        implant = ProsthesisSystem(ElectrodeGrid(shape=(10, 10), spacing=500))
+        implant = Implant(ElectrodeGrid(shape=(10, 10), spacing=500))
 
     .. versionadded:: 0.11.0
 
@@ -819,7 +822,7 @@ class GridImplant(ProsthesisSystem):
                       '``etype=DiskElectrode, r=75, preprocess=True`` to keep '
                       'these defaults, and note that a left-eye grid keeps '
                       'the column names of a right-eye one.')
-class RectangleImplant(ProsthesisSystem):
+class RectangleImplant(Implant):
     """ A generic rectangular implant
 
     .. deprecated:: 0.11.0
@@ -888,3 +891,11 @@ class RectangleImplant(ProsthesisSystem):
         params.update({'shape': self.shape, 'safe_mode': self.safe_mode,
                        'preprocess': self.preprocess})
         return params
+
+
+# ``ProsthesisSystem`` was renamed to ``Implant`` in 0.11.0. It resolves to the
+# class itself rather than to a subclass, so ``isinstance`` and ``issubclass``
+# checks written against the old name keep working during the deprecation.
+__getattr__ = deprecated_names(__name__, {'ProsthesisSystem': Implant},
+                               deprecated_version='0.11.0',
+                               removed_version='0.12.0')

--- a/pulse2percept/implants/bvt.py
+++ b/pulse2percept/implants/bvt.py
@@ -3,13 +3,13 @@
 import numpy as np
 from skimage.transform import SimilarityTransform
 
-from .base import ProsthesisSystem
+from .base import Implant
 from .electrodes import DiskElectrode
 from .electrode_arrays import ElectrodeArray, ElectrodeGrid
 from ..units import as_value, deg, um
 
 
-class BVT24(ProsthesisSystem):
+class BVT24(Implant):
     """24-channel suprachoroidal retinal prosthesis
 
     This class creates a 24-channel suprachoroidal retinal prosthesis
@@ -137,7 +137,7 @@ class BVT24(ProsthesisSystem):
 
 
 
-class BVT44(ProsthesisSystem):
+class BVT44(Implant):
     """    44-channel suprachoroidal retinal prosthesis
 
     This class creates a 44-channel suprachoroidal retinal prosthesis

--- a/pulse2percept/implants/cortex/cortivis.py
+++ b/pulse2percept/implants/cortex/cortivis.py
@@ -1,12 +1,12 @@
 """:py:class:`~pulse2percept.implants.cortex.Cortivis`"""
 import numpy as np
 
-from ..base import ProsthesisSystem
+from ..base import Implant
 from ..electrodes import DiskElectrode
 from ..electrode_arrays import ElectrodeGrid
 from ...units import as_value, um
 
-class Cortivis(ProsthesisSystem):
+class Cortivis(Implant):
     """Create a Cortivis array
     
     This function creates a Cortivis array and places it on the visual cortex

--- a/pulse2percept/implants/cortex/icvp.py
+++ b/pulse2percept/implants/cortex/icvp.py
@@ -1,13 +1,13 @@
 """:py:class:`~pulse2percept.implants.cortex.ICVP`"""
 import numpy as np
 
-from ..base import ProsthesisSystem
+from ..base import Implant
 from ..electrodes import DiskElectrode
 from ..electrode_arrays import ElectrodeGrid
 from ...units import as_value, um
 
 
-class ICVP(ProsthesisSystem):
+class ICVP(Implant):
     """Create an ICVP array
 
     This function creates a ICVP array and places it on the visual cortex

--- a/pulse2percept/implants/cortex/neuralink.py
+++ b/pulse2percept/implants/cortex/neuralink.py
@@ -9,7 +9,7 @@ import matplotlib.pyplot as plt
 from ..ensemble import EnsembleImplant
 from ..electrodes import Electrode
 from ..electrode_arrays import ElectrodeArray
-from ..base import ProsthesisSystem
+from ..base import Implant
 from ...units import as_value, deg, dva, um
 from ...utils import parse_3d_orient
 
@@ -114,7 +114,7 @@ class EllipsoidElectrode(Electrode):
         return ax
 
 
-class NeuralinkThread(ProsthesisSystem, metaclass=ABCMeta):
+class NeuralinkThread(Implant, metaclass=ABCMeta):
     """Base class for Neuralink threads"""
 
     placement = 'intracortical'
@@ -387,7 +387,7 @@ class Neuralink(EnsembleImplant):
 
         Parameters
         ----------
-        implant_type : p2p.implants.ProsthesisSystem
+        implant_type : p2p.implants.Implant
             Type of implant to create. Currently only NeuralinkThread is supported.
         vfmap : p2p.topography.CorticalMap
             Cortical map to create implant from.

--- a/pulse2percept/implants/cortex/orion.py
+++ b/pulse2percept/implants/cortex/orion.py
@@ -1,15 +1,14 @@
 """:py:class:`~pulse2percept.implants.cortex.Orion`"""
 import numpy as np
-from pulse2percept.implants import ProsthesisSystem
 
-from .. import ProsthesisSystem
+from .. import Implant
 from ..electrodes import DiskElectrode
 from ..electrode_arrays import ElectrodeGrid
 from ...units import as_value, um
 from ...utils.constants import UM_PER_MM
 
 
-class Orion(ProsthesisSystem):
+class Orion(Implant):
     """Create a Orion array
     
     This function creates a Orion array and places it on the visual cortex

--- a/pulse2percept/implants/cortex/tests/test_neuralink.py
+++ b/pulse2percept/implants/cortex/tests/test_neuralink.py
@@ -8,7 +8,7 @@ import pytest
 import matplotlib.pyplot as plt
 from matplotlib.patches import Ellipse
 
-from pulse2percept.implants import ProsthesisSystem
+from pulse2percept.implants import Implant
 from pulse2percept.implants.cortex import (EllipsoidElectrode, LinearEdgeThread,
                                            NeuralinkThread, Neuralink, Cortivis)
 from pulse2percept.topography import Grid2D, NeuropythyMap, Polimeni2006Map
@@ -290,7 +290,7 @@ def test_LinearEdgeThread_pprint():
     npt.assert_equal(params['r'], 8)
     npt.assert_equal(params['n_elecs'], 4)
     npt.assert_equal(params['spacing'], 25)
-    # Inherited from ProsthesisSystem:
+    # Inherited from Implant:
     npt.assert_equal(params['safe_mode'], False)
     npt.assert_equal('LinearEdgeThread' in str(thread), True)
 
@@ -558,7 +558,7 @@ def test_Neuralink_from_neuropythy_surface_mismatch():
 
 def test_Neuralink_from_cortical_map_requires_thread():
     # Only NeuralinkThreads can go into a Neuralink:
-    for implant_type in (Cortivis, ProsthesisSystem):
+    for implant_type in (Cortivis, Implant):
         with pytest.raises(TypeError):
             Neuralink.from_cortical_map(implant_type, Polimeni2006Map())
 

--- a/pulse2percept/implants/ensemble.py
+++ b/pulse2percept/implants/ensemble.py
@@ -1,13 +1,13 @@
 """:py:class:`~pulse2percept.implants.EnsembleImplant`"""
 import numpy as np
-from .base import ProsthesisSystem
+from .base import Implant
 from .electrodes import Electrode
 from .electrode_arrays import ElectrodeArray
 from ..stimuli._merge import unique_time_points
 from ..stimuli.base import _describe_unit
 from ..units import DimensionMismatchError, as_value, dva, um
 
-class EnsembleImplant(ProsthesisSystem):
+class EnsembleImplant(Implant):
     
     # Frozen class: User cannot add more class attributes
     __slots__ = ('_implants', '_earray', 'safe_mode', 'preprocess')
@@ -28,7 +28,7 @@ class EnsembleImplant(ProsthesisSystem):
             Visual field map to create implant from.
         implant_type : type
             Type of implant to create for the ensemble. Must subclass
-            p2p.implants.ProsthesisSystem
+            p2p.implants.Implant
         locs : np.ndarray with shape (n, 2), optional
             Array of visual field locations to create implants at (dva).
             Not needed if using xrange, yrange, and step.
@@ -55,8 +55,8 @@ class EnsembleImplant(ProsthesisSystem):
         from ..topography import CorticalMap, Grid2D
         if not isinstance(vfmap, CorticalMap):
             raise TypeError("vfmap must be a p2p.topography.CorticalMap")
-        if not issubclass(implant_type, ProsthesisSystem):
-            raise TypeError("implant_type must be a sub-type of ProsthesisSystem")
+        if not issubclass(implant_type, Implant):
+            raise TypeError("implant_type must be a sub-type of Implant")
 
         # Where in the *visual field* the implants go; `vfmap` turns that into
         # a physical location further down:
@@ -125,8 +125,8 @@ class EnsembleImplant(ProsthesisSystem):
         """
         from ..topography.base import _rectangular_mesh
 
-        if not issubclass(implant_type, ProsthesisSystem):
-            raise TypeError("implant_type must be a sub-type of ProsthesisSystem")
+        if not issubclass(implant_type, Implant):
+            raise TypeError("implant_type must be a sub-type of Implant")
 
         # Physical coordinates, unlike the dva ranges `from_cortical_map`
         # takes:
@@ -202,12 +202,12 @@ class EnsembleImplant(ProsthesisSystem):
         """Implant dict setter (called upon ``self.implants = implants``)"""
         # Assign the implant dict:
         if isinstance(implants, list):
-            if not all(isinstance(implant, ProsthesisSystem) for implant in implants):
-                raise TypeError(f"All elements in 'implants' must be ProsthesisSystem objects.")
+            if not all(isinstance(implant, Implant) for implant in implants):
+                raise TypeError(f"All elements in 'implants' must be Implant objects.")
             self._implants = {i:implant for i,implant in enumerate(implants)}
         elif isinstance(implants, dict):
-            if not all(isinstance(implant, ProsthesisSystem) for implant in implants.values()):
-                raise TypeError(f"All elements in 'implants' must be ProsthesisSystem objects.")
+            if not all(isinstance(implant, Implant) for implant in implants.values()):
+                raise TypeError(f"All elements in 'implants' must be Implant objects.")
             self._implants = implants.copy()
         else:
             raise TypeError(f"'implants' must be a list or a dict object, not "

--- a/pulse2percept/implants/imie.py
+++ b/pulse2percept/implants/imie.py
@@ -2,11 +2,11 @@
 import numpy as np
 from collections import OrderedDict
 
-from .base import ProsthesisSystem
+from .base import Implant
 from .electrodes import DiskElectrode
 from .electrode_arrays import ElectrodeGrid
 
-class IMIE(ProsthesisSystem):
+class IMIE(Implant):
     """The 256-channel epiretinal prosthesis system (IMIE 256)
 
     This class implements a 256-channel Intelligent Micro Implant Eye 

--- a/pulse2percept/implants/prima.py
+++ b/pulse2percept/implants/prima.py
@@ -10,7 +10,7 @@ from matplotlib.patches import Circle, Polygon, RegularPolygon
 import numpy as np
 from collections.abc import Sequence
 
-from .base import ProsthesisSystem
+from .base import Implant
 from .electrodes import HexElectrode
 from .electrode_arrays import ElectrodeGrid
 from ..stimuli import PRIMAEncoder
@@ -274,7 +274,7 @@ class PhotovoltaicPixel(HexElectrode):
         raise NotImplementedError
 
 
-class PRIMAPivotal(ProsthesisSystem):
+class PRIMAPivotal(Implant):
     """Create the PRIMA array used in the pivotal PRIMAvera trial
     
     The implant has 378 photovoltaic pixels, each 100 um wide on a 100 um
@@ -333,7 +333,7 @@ class PRIMAPivotal(ProsthesisSystem):
     -----
     *  The active-electrode diameter was estimated from Fig. 1 of
        [Palanker2020]_.
-    *  :py:meth:`~pulse2percept.implants.ProsthesisSystem.prepare_stim`
+    *  :py:meth:`~pulse2percept.implants.Implant.prepare_stim`
        returns optical irradiance (``mW/mm^2``). Photovoltaic conversion is not
        modeled.
     """
@@ -504,7 +504,7 @@ class PRIMAPivotal(ProsthesisSystem):
         return self.spacing * np.sqrt(3) / 2
 
 
-class Lorach2015Array(ProsthesisSystem):
+class Lorach2015Array(Implant):
     """Create the 70 um photovoltaic array of [Lorach2015]_
     
     The array has 142 pixels, each 70 um wide on a 75 um hexagonal grid, with a
@@ -624,7 +624,7 @@ class Lorach2015Array(ProsthesisSystem):
         return self.spacing * np.sqrt(3) / 2
 
 
-class Ho2019FlatArray(ProsthesisSystem):
+class Ho2019FlatArray(Implant):
     """Create a flat photovoltaic array of [Ho2019]_
     
     Supports the F55 and F40 arrays on a 1 mm substrate:
@@ -746,7 +746,7 @@ class Ho2019FlatArray(ProsthesisSystem):
         return self.spacing * np.sqrt(3) / 2
 
 
-class Huang2021Array(ProsthesisSystem):
+class Huang2021Array(Implant):
     """Create a vertical-junction photovoltaic array of [Huang2021]_
     
     Supports four arrays on a 1.5 mm substrate. Only exposed pixels are modeled

--- a/pulse2percept/implants/rasters.py
+++ b/pulse2percept/implants/rasters.py
@@ -34,7 +34,7 @@ def _electrode_array(implant):
     earray = getattr(implant, 'earray', implant)
     if (getattr(earray, 'electrode_names', None) is None or
             getattr(earray, 'coordinates', None) is None):
-        raise TypeError(f"'implant' must be a ProsthesisSystem or an "
+        raise TypeError(f"'implant' must be an Implant or an "
                         f"ElectrodeArray, not {type(implant)}.")
     return earray
 
@@ -74,7 +74,7 @@ class Raster(PrettyPrint, metaclass=ABCMeta):
 
     def _pprint_params(self):
         """Return a dict of class arguments to pretty-print"""
-        # Deliberately without the implant: a ProsthesisSystem pretty-prints
+        # Deliberately without the implant: an Implant pretty-prints
         # its raster, so naming it back here would recurse.
         return {'group_dur': self.group_dur, 'n_groups': self.n_groups}
 
@@ -83,7 +83,7 @@ class Raster(PrettyPrint, metaclass=ABCMeta):
         """The implant this raster is bound to, or None
 
         Set by assigning the raster to
-        :py:attr:`~pulse2percept.implants.ProsthesisSystem.raster` (see
+        :py:attr:`~pulse2percept.implants.Implant.raster` (see
         :py:meth:`bind`).
         """
         return getattr(self, '_implant', None)
@@ -96,7 +96,7 @@ class Raster(PrettyPrint, metaclass=ABCMeta):
 
         Parameters
         ----------
-        implant : :class:`~pulse2percept.implants.ProsthesisSystem` or \
+        implant : :class:`~pulse2percept.implants.Implant` or \
                   :class:`~pulse2percept.implants.ElectrodeArray`
             Implant or electrode array to bind.
 
@@ -168,7 +168,7 @@ class Raster(PrettyPrint, metaclass=ABCMeta):
 
         Parameters
         ----------
-        implant : :class:`~pulse2percept.implants.ProsthesisSystem`, optional
+        implant : :class:`~pulse2percept.implants.Implant`, optional
             Implant to draw. If None, use the bound implant.
         annotate : bool, optional
             Write group indices on electrodes. If None, annotate arrays
@@ -652,7 +652,7 @@ class CheckerboardRaster(Raster):
 
     The pattern depends on where the electrodes are, so it is worked out when
     the raster is **bound** to an implant -- which assigning it to
-    :py:attr:`~pulse2percept.implants.ProsthesisSystem.raster` does. Until
+    :py:attr:`~pulse2percept.implants.Implant.raster` does. Until
     then the raster knows how many groups it will have but not which electrode
     goes in which, and :py:meth:`groups`, :py:attr:`min_spacing` and
     :py:meth:`~pulse2percept.implants.Raster.plot` all raise. Binding it to a
@@ -740,7 +740,7 @@ class CheckerboardRaster(Raster):
 
         See :py:meth:`~pulse2percept.implants.Raster.bind`. Called for you
         when the raster is assigned to
-        :py:attr:`~pulse2percept.implants.ProsthesisSystem.raster`.
+        :py:attr:`~pulse2percept.implants.Implant.raster`.
         """
         earray = _electrode_array(implant)
         names = list(earray.electrode_names)

--- a/pulse2percept/implants/tests/test_base.py
+++ b/pulse2percept/implants/tests/test_base.py
@@ -12,7 +12,7 @@ import matplotlib.pyplot as plt
 from skimage.measure import label, regionprops
 
 from pulse2percept.implants import (PointSource, ElectrodeArray, ElectrodeGrid,
-                                    GridImplant, ProsthesisSystem,
+                                    GridImplant, Implant,
                                     RectangleImplant, PhotovoltaicPixel)
 from pulse2percept.stimuli import (Stimulus, ImageStimulus, VideoStimulus,
                                    BostonTrain, LogoBVL)
@@ -23,7 +23,7 @@ from pulse2percept.implants import (ArgusII, DiskElectrode)
 from pulse2percept.models import ScoreboardModel
 
 
-class PhotovoltaicArray(ProsthesisSystem):
+class PhotovoltaicArray(Implant):
     def __init__(self, x=0, y=0, z=-100, r=5, spacing=40, rot=0,
                  preprocess=False, safe_mode=False):
         # 35 um pixels with 5 um trenches, 16 um active electrode:
@@ -50,16 +50,15 @@ class PhotovoltaicArray(ProsthesisSystem):
             self.earray.remove_electrode(e)
 
 
-def test_ProsthesisSystem():
+def test_Implant():
     # Invalid instantiations:
     with pytest.raises(ValueError):
-        ProsthesisSystem(ElectrodeArray(PointSource(0, 0, 0)),
-                         eye='both')
+        Implant(ElectrodeArray(PointSource(0, 0, 0)), eye='both')
     with pytest.raises(TypeError):
-        ProsthesisSystem(Stimulus)
+        Implant(Stimulus)
 
     # Iterating over the electrode array:
-    implant = ProsthesisSystem(PointSource(0, 0, 0))
+    implant = Implant(PointSource(0, 0, 0))
     npt.assert_equal(implant.n_electrodes, 1)
     npt.assert_equal(implant[0], implant.earray[0])
     npt.assert_equal(implant.electrode_names, implant.earray.electrode_names)
@@ -91,7 +90,7 @@ def test_ProsthesisSystem():
         implant.prepare_stim(Stimulus({'A1': 1}))
     # Safe mode requires charge-balanced pulses:
     with pytest.raises(ValueError):
-        implant = ProsthesisSystem(PointSource(0, 0, 0), safe_mode=True)
+        implant = Implant(PointSource(0, 0, 0), safe_mode=True)
         implant.prepare_stim(1)
 
     # Slots:
@@ -99,8 +98,8 @@ def test_ProsthesisSystem():
     npt.assert_equal(hasattr(implant, '__dict__'), False)
 
 
-def test_ProsthesisSystem_prepare_stim():
-    implant = ProsthesisSystem(ElectrodeGrid((13, 13), 20))
+def test_Implant_prepare_stim():
+    implant = Implant(ElectrodeGrid((13, 13), 20))
     with pytest.raises(ValueError):
         implant.prepare_stim(Stimulus(np.ones((13 * 13 + 1, 5))))
 
@@ -144,7 +143,7 @@ def test_ProsthesisSystem_prepare_stim():
     npt.assert_equal('H4' in implant.prepare_stim({'H4': 1}).electrodes, True)
 
 
-def test_ProsthesisSystem_prepare_stim_is_stateless():
+def test_Implant_prepare_stim_is_stateless():
     """Preparing leaves neither the implant nor the caller's source changed"""
     implant = ArgusII(preprocess=False)
     source = Stimulus({'A1': 10, 'B2': 20})
@@ -168,8 +167,8 @@ def test_ProsthesisSystem_prepare_stim_is_stateless():
 @pytest.mark.parametrize('rot', (0, 30, 92))
 @pytest.mark.parametrize('gtype', ('hex', 'rect'))
 @pytest.mark.parametrize('n_frames', (1, 3, 4))
-def test_ProsthesisSystem_reshape_stim(rot, gtype, n_frames):
-    implant = ProsthesisSystem(ElectrodeGrid((10, 10), 30, rot=rot, type=gtype))
+def test_Implant_reshape_stim(rot, gtype, n_frames):
+    implant = Implant(ElectrodeGrid((10, 10), 30, rot=rot, type=gtype))
     # Smoke test the reshaping. It runs inside `prepare_stim`, but
     # a picture is not a stimulus an implant can deliver, so it is exercised
     # directly here (which is also how an encoder reaches it):
@@ -205,8 +204,8 @@ def test_ProsthesisSystem_reshape_stim(rot, gtype, n_frames):
     implant.reshape_stim(LogoBVL())
 
 
-def test_ProsthesisSystem_deactivate():
-    implant = ProsthesisSystem(ElectrodeGrid((10, 10), 30))
+def test_Implant_deactivate():
+    implant = Implant(ElectrodeGrid((10, 10), 30))
     source = np.ones(implant.n_electrodes)
     electrode = 'A3'
     npt.assert_equal(electrode in implant.prepare_stim(source).electrodes, True)
@@ -313,9 +312,23 @@ def test_RectangleImplant_is_deprecated():
     npt.assert_almost_equal(le['A1'].x, implant['A4'].x)
 
 
-def test_GridImplant_is_a_grid_in_a_prosthesis_system():
+def test_ProsthesisSystem_is_a_deprecated_alias():
+    """Renamed to Implant in 0.11.0; the old name is the same class"""
+    for module in (implants, implants.base):
+        with pytest.deprecated_call(match='Use ``Implant``'):
+            alias = module.ProsthesisSystem
+        npt.assert_equal(alias is implants.Implant, True)
+    # An alias, not a subclass, so existing type checks still hold:
+    npt.assert_equal(isinstance(ArgusII(), alias), True)
+    npt.assert_equal(issubclass(GridImplant, alias), True)
+    npt.assert_equal(alias(PointSource(0, 0, 0)).n_electrodes, 1)
+    with pytest.raises(AttributeError):
+        implants.NotAnImplant
+
+
+def test_GridImplant_is_a_grid_in_an_implant():
     implant = GridImplant((3, 4), 100)
-    npt.assert_equal(isinstance(implant, ProsthesisSystem), True)
+    npt.assert_equal(isinstance(implant, Implant), True)
     npt.assert_equal(isinstance(implant.earray, ElectrodeGrid), True)
     npt.assert_equal(implant.n_electrodes, 12)
     npt.assert_equal(implant.earray.shape, (3, 4))
@@ -377,10 +390,10 @@ def test_GridImplant_geometry_passthrough():
         GridImplant((2, 3), 2 * dva)
 
 
-def test_GridImplant_device_arguments_reach_ProsthesisSystem():
-    """Everything that is not geometry is handed to ProsthesisSystem as given
+def test_GridImplant_device_arguments_reach_Implant():
+    """Everything that is not geometry is handed to Implant as given
 
-    What those arguments then do is ProsthesisSystem's business and is tested
+    What those arguments then do is Implant's business and is tested
     there; all a GridImplant owes them is not to drop or reinterpret one.
     """
     encoder = AmplitudeEncoder(amp_range=(0, 20))
@@ -406,7 +419,7 @@ def test_GridImplant_does_not_relabel_the_left_eye():
     npt.assert_almost_equal(le.earray.coordinates(), re.earray.coordinates())
 
 
-def test_ProsthesisSystem_reshape_stim_frames_independent():
+def test_Implant_reshape_stim_frames_independent():
     """Downsampling a video must treat each frame on its own.
 
     ``reshape_stim`` builds one interpolator for the whole video rather than
@@ -416,7 +429,7 @@ def test_ProsthesisSystem_reshape_stim_frames_independent():
     rng = np.random.default_rng(3)
     n_frames = 5
     vid = rng.random((24, 31, n_frames)).astype(np.float32)
-    implant = ProsthesisSystem(ElectrodeGrid((6, 8), 200))
+    implant = Implant(ElectrodeGrid((6, 8), 200))
 
     joint = implant.reshape_stim(VideoStimulus(vid,
                                                time=np.arange(n_frames))).data
@@ -435,7 +448,7 @@ def test_ProsthesisSystem_reshape_stim_frames_independent():
     npt.assert_equal(np.all(sampled.data[:, 2] == 0), True)
 
 
-def test_ProsthesisSystem_rgb_video_stim():
+def test_Implant_rgb_video_stim():
     """An RGB video can be presented to an implant directly (Issue #802)"""
     n_frames = 4
     vid = VideoStimulus(np.random.default_rng(0).random((6, 10, 3, n_frames)),
@@ -537,36 +550,36 @@ def test_implant_dimension_errors():
         implants.RectangleImplant(r=10 * uA)
 
 
-def test_ProsthesisSystem_max_current_units():
+def test_Implant_max_current_units():
     """`max_current` is a current, stored as a plain number of microamps"""
     earray = ElectrodeArray(DiskElectrode(0, 0, 0, 100))
     for value in (100, 100 * uA, 0.1 * mA, 100000 * nA):
-        implant = ProsthesisSystem(earray, max_current=value)
+        implant = Implant(earray, max_current=value)
         npt.assert_allclose(implant.max_current, 100, rtol=1e-12)
         npt.assert_equal(isinstance(implant.max_current, Quantity), False)
     # An awkward conversion is no different:
     npt.assert_allclose(
-        ProsthesisSystem(earray, max_current=0.0417 * mA).max_current, 41.7,
+        Implant(earray, max_current=0.0417 * mA).max_current, 41.7,
         rtol=1e-12)
     # None means no limit, and is left alone:
-    npt.assert_equal(ProsthesisSystem(earray).max_current, None)
+    npt.assert_equal(Implant(earray).max_current, None)
     # Assigning later goes through the same setter:
-    implant = ProsthesisSystem(earray)
+    implant = Implant(earray)
     implant.max_current = 0.1 * mA
     npt.assert_allclose(implant.max_current, 100, rtol=1e-12)
     with pytest.raises(DimensionMismatchError):
-        ProsthesisSystem(earray, max_current=5 * ms)
+        Implant(earray, max_current=5 * ms)
     with pytest.raises(DimensionMismatchError):
         implant.max_current = 5 * dva
     with pytest.raises(ValueError):
-        ProsthesisSystem(earray, max_current=-1 * uA)
+        Implant(earray, max_current=-1 * uA)
 
 
-def test_ProsthesisSystem_safety_checks_are_electrical():
+def test_Implant_safety_checks_are_electrical():
     """Electrical safety may only be asked about an electrical stimulus
 
     In the ordinary flow ``prepare_stim`` has already refused anything that is
-    not a current (see ``test_ProsthesisSystem_requires_an_electrical_stimulus``),
+    not a current (see ``test_Implant_requires_an_electrical_stimulus``),
     so these guards are reached by calling ``check_stim`` directly -- which is
     public, and which a subclass may call on a stimulus of its own making.
     """
@@ -598,7 +611,7 @@ def test_ProsthesisSystem_safety_checks_are_electrical():
                                 electrodes=ArgusII().electrode_names))
 
 
-def test_ProsthesisSystem_requires_an_electrical_stimulus():
+def test_Implant_requires_an_electrical_stimulus():
     """An implant delivers current, so a picture it cannot encode is refused
 
     Not when a model eventually reads it: the preparation is the line that was
@@ -607,7 +620,7 @@ def test_ProsthesisSystem_requires_an_electrical_stimulus():
     user's behalf.
     """
     img = ImageStimulus(np.linspace(0, 1, 16).reshape((4, 4)))
-    npt.assert_equal(ProsthesisSystem.stimulus_unit, uA)
+    npt.assert_equal(Implant.stimulus_unit, uA)
 
     for source in (img, VideoStimulus(np.ones((6, 10, 3)) * 0.5,
                                       time=[0, 20, 40]), BostonTrain()):
@@ -618,7 +631,7 @@ def test_ProsthesisSystem_requires_an_electrical_stimulus():
         npt.assert_equal('dimensionless' in str(excinfo.value), True)
         # A generic system has no encoder either:
         with pytest.raises(DimensionMismatchError):
-            ProsthesisSystem(ArgusII().earray).prepare_stim(source)
+            Implant(ArgusII().earray).prepare_stim(source)
 
     # Encoded, the very same picture goes through:
     implant = ArgusII(encoder=None)
@@ -630,7 +643,7 @@ def test_ProsthesisSystem_requires_an_electrical_stimulus():
                    {'A1': BiphasicPulse(0.02 * mA, 0.45, stim_dur=50)}):
         npt.assert_equal(ArgusII().prepare_stim(source).unit, uA)
     for source in (20, BiphasicPulse(20, 0.45, stim_dur=50)):
-        single = ProsthesisSystem(DiskElectrode(0, 0, 0, 100))
+        single = Implant(DiskElectrode(0, 0, 0, 100))
         npt.assert_equal(single.prepare_stim(source).unit, uA)
 
     # A subclass may declare that it delivers something else, in which case a
@@ -641,17 +654,17 @@ def test_ProsthesisSystem_requires_an_electrical_stimulus():
     npt.assert_equal(Projector().prepare_stim(img).unit, dimensionless)
 
 
-def test_ProsthesisSystem_encoder():
+def test_Implant_encoder():
     """A picture prepared by an implant with an encoder is encoded on the way
     through
     """
     img = ImageStimulus(np.linspace(0, 1, 16).reshape((4, 4)))
-    implant = ProsthesisSystem(ArgusII().earray)
+    implant = Implant(ArgusII().earray)
     npt.assert_equal(implant.encoder, None)
     with pytest.raises(TypeError):
         implant.encoder = 'amplitude'
     with pytest.raises(TypeError):
-        ProsthesisSystem(ArgusII().earray, encoder=ArgusII())
+        Implant(ArgusII().earray, encoder=ArgusII())
 
     # Giving it one is all it takes:
     implant.encoder = AmplitudeEncoder(amp_range=(0, 50), freq=20)
@@ -697,7 +710,7 @@ def test_ProsthesisSystem_encoder():
     npt.assert_equal(len(np.unique(np.abs(stim.data) > 0, axis=0)), 6)
 
 
-def test_ProsthesisSystem_encoded_stim_is_one_object():
+def test_Implant_encoded_stim_is_one_object():
     """An encoded stimulus knows both what it delivers and what it was asked
     for, so preparation returns one of it
     """
@@ -751,7 +764,7 @@ def test_ProsthesisSystem_encoded_stim_is_one_object():
     npt.assert_equal('A1' in stim._spatial_view().electrodes, False)
 
 
-def test_ProsthesisSystem_preprocess_crosses_the_boundary():
+def test_Implant_preprocess_crosses_the_boundary():
     """Preprocessing may turn a picture into current before the encoder sees it
     """
     img = ImageStimulus(np.linspace(0, 1, 16).reshape((4, 4)))
@@ -780,7 +793,7 @@ def test_ProsthesisSystem_preprocess_crosses_the_boundary():
     npt.assert_equal(implant.prepare_stim(encoded).unit, uA)
 
 
-def test_ProsthesisSystem_historical_stimuli_unchanged():
+def test_Implant_historical_stimuli_unchanged():
     """A bare stimulus is electrical by contract, and is checked as before"""
     implant = ArgusII(preprocess=False, safe_mode=True)
     npt.assert_equal(implant.prepare_stim({'A1': BiphasicPulse(50, 0.45)}).unit,
@@ -799,7 +812,7 @@ def test_ProsthesisSystem_historical_stimuli_unchanged():
     npt.assert_equal(implant.prepare_stim(source).unit, uA)
 
 
-def test_ProsthesisSystem_deactivated_electrodes_do_not_mutate_the_source():
+def test_Implant_deactivated_electrodes_do_not_mutate_the_source():
     # Filtering out deactivated electrodes rewrites the stimulus, so it
     # happens on a copy. A stimulus defined by its pulse parameters cannot
     # lose an electrode and remain one, so what comes back for it is an
@@ -840,7 +853,7 @@ def test_ProsthesisSystem_deactivated_electrodes_do_not_mutate_the_source():
     npt.assert_equal(sorted(str(e) for e in stim.electrodes), ['A1', 'B2'])
 
 
-def test_ProsthesisSystem_deactivated_electrode_does_not_render_the_others():
+def test_Implant_deactivated_electrode_does_not_render_the_others():
     # An implant drops a deactivated electrode from a dict of pulse trains by
     # forgetting the entry that drives it, so the trains on the electrodes
     # that are still on never get sampled.
@@ -862,7 +875,7 @@ def test_ProsthesisSystem_deactivated_electrode_does_not_render_the_others():
     npt.assert_almost_equal(stim.time[-1], 200)
 
 
-def test_ProsthesisSystem_thresholds():
+def test_Implant_thresholds():
     implant = ArgusII()
     npt.assert_equal(implant.thresholds, {})
     implant.thresholds = 100 * uA
@@ -878,7 +891,7 @@ def test_ProsthesisSystem_thresholds():
     npt.assert_equal(implant.thresholds, {})
 
 
-def test_ProsthesisSystem_thresholds_at_construction():
+def test_Implant_thresholds_at_construction():
     npt.assert_equal(ArgusII().thresholds, {})
     for scalar in (80, 80 * uA, 0.08 * mA):
         implant = ArgusII(thresholds=scalar)
@@ -897,7 +910,7 @@ def test_ProsthesisSystem_thresholds_at_construction():
     npt.assert_equal(stim.unit, uA)
 
 
-def test_ProsthesisSystem_thresholds_at_construction_are_validated():
+def test_Implant_thresholds_at_construction_are_validated():
     for bad in (0, -5, np.nan, np.inf):
         with pytest.raises(ValueError):
             ArgusII(thresholds=bad)
@@ -907,11 +920,11 @@ def test_ProsthesisSystem_thresholds_at_construction_are_validated():
         ArgusII(thresholds={'ZZ9': 80 * uA})
     with pytest.raises(DimensionMismatchError):
         ArgusII(thresholds=5 * ms)
-    implant = ProsthesisSystem(DiskElectrode(0, 0, 0, 100), thresholds=80)
+    implant = Implant(DiskElectrode(0, 0, 0, 100), thresholds=80)
     npt.assert_almost_equal(implant.thresholds[0], 80)
 
 
-def test_ProsthesisSystem_thresholds_are_validated():
+def test_Implant_thresholds_are_validated():
     implant = ArgusII()
     with pytest.raises(ValueError):
         implant.thresholds = {'ZZ9': 80 * uA}
@@ -932,7 +945,7 @@ def test_ProsthesisSystem_thresholds_are_validated():
     npt.assert_equal(sorted(implant.thresholds), ['A1'])
 
 
-def test_ProsthesisSystem_thresholds_calibrate_pulse_trains():
+def test_Implant_thresholds_calibrate_pulse_trains():
     implant = ArgusII()
     source = {'A1': BiphasicPulseTrain(20, 2 * xTh, 0.45),
               'A2': BiphasicPulseTrain(20, 2 * xTh, 0.45)}
@@ -948,7 +961,7 @@ def test_ProsthesisSystem_thresholds_calibrate_pulse_trains():
     npt.assert_almost_equal(np.abs(stim['A1']).max(), 160, decimal=3)
 
 
-def test_ProsthesisSystem_thresholds_hold_current_stimuli_fixed():
+def test_Implant_thresholds_hold_current_stimuli_fixed():
     implant = ArgusII()
     train = {'A1': BiphasicPulseTrain(20, 160 * uA, 0.45)}
     source = implant.prepare_stim(train)._structured_sources()[0][1]
@@ -961,8 +974,7 @@ def test_ProsthesisSystem_thresholds_hold_current_stimuli_fixed():
 
 @pytest.mark.parametrize('amp, cleared_amp',
                          [(2 * xTh, 2), (160 * uA, 160)])
-def test_ProsthesisSystem_clearing_thresholds_restores_the_train(amp,
-                                                                 cleared_amp):
+def test_Implant_clearing_thresholds_restores_the_train(amp, cleared_amp):
     implant = ArgusII()
     train = {'A1': BiphasicPulseTrain(20, amp, 0.45)}
     implant.thresholds = 40 * uA
@@ -973,7 +985,7 @@ def test_ProsthesisSystem_clearing_thresholds_restores_the_train(amp,
     npt.assert_equal(source.amp_factor, None if cleared_amp == 160 else 2)
 
 
-def test_ProsthesisSystem_thresholds_beat_the_pulse_trains_own():
+def test_Implant_thresholds_beat_the_pulse_trains_own():
     implant = ArgusII()
     train = {'A1': BiphasicPulseTrain(20, 2 * xTh, 0.45,
                                       threshold_amp=50 * uA)}
@@ -987,7 +999,7 @@ def test_ProsthesisSystem_thresholds_beat_the_pulse_trains_own():
     npt.assert_almost_equal(source.threshold_amp, 50)
 
 
-def test_ProsthesisSystem_thresholds_leave_raw_waveforms_alone():
+def test_Implant_thresholds_leave_raw_waveforms_alone():
     implant = ArgusII()
     before = implant.prepare_stim({'A1': 30}).data.copy()
     implant.thresholds = 80 * uA
@@ -996,7 +1008,7 @@ def test_ProsthesisSystem_thresholds_leave_raw_waveforms_alone():
     npt.assert_equal(stim._structured_sources(), None)
 
 
-def test_ProsthesisSystem_thresholds_are_checked_when_the_stimulus_is():
+def test_Implant_thresholds_are_checked_when_the_stimulus_is():
     """A threshold that puts a stimulus over the limit is caught on preparation
 
     The implant holds no stimulus to recheck, so the pairing of thresholds and
@@ -1016,7 +1028,7 @@ def test_ProsthesisSystem_thresholds_are_checked_when_the_stimulus_is():
     npt.assert_almost_equal(stim._structured_sources()[0][1].amp, 180)
 
 
-def test_ProsthesisSystem_thresholds_do_not_render_the_stimulus():
+def test_Implant_thresholds_do_not_render_the_stimulus():
     implant = ArgusII()
     implant.thresholds = 80 * uA
     stim = implant.prepare_stim({'A1': BiphasicPulseTrain(20, 2 * xTh, 0.45)})
@@ -1025,7 +1037,7 @@ def test_ProsthesisSystem_thresholds_do_not_render_the_stimulus():
     npt.assert_equal(source._Stimulus__stim['data'], None)
 
 
-def test_ProsthesisSystem_thresholds_do_not_revive_deactivated_electrodes():
+def test_Implant_thresholds_do_not_revive_deactivated_electrodes():
     implant = ArgusII()
     source = {'A1': BiphasicPulseTrain(20, 2 * xTh, 0.45),
               'A2': BiphasicPulseTrain(20, 2 * xTh, 0.45)}
@@ -1039,7 +1051,7 @@ def test_ProsthesisSystem_thresholds_do_not_revive_deactivated_electrodes():
     npt.assert_equal(list(implant.prepare_stim(source).electrodes), ['A2'])
 
 
-def test_ProsthesisSystem_thresholds_preserve_metadata():
+def test_Implant_thresholds_preserve_metadata():
     implant = ArgusII()
     source = Stimulus({'A1': BiphasicPulseTrain(20, 2 * xTh, 0.45,
                                                 metadata='train'),
@@ -1052,7 +1064,7 @@ def test_ProsthesisSystem_thresholds_preserve_metadata():
                      'train')
 
 
-def test_ProsthesisSystem_thresholds_calibrate_from_the_original_source():
+def test_Implant_thresholds_calibrate_from_the_original_source():
     """Each preparation starts from the caller's source, not the last result
 
     Calibrating twice would compound the factors; calibrating from the source
@@ -1069,7 +1081,7 @@ def test_ProsthesisSystem_thresholds_calibrate_from_the_original_source():
     npt.assert_almost_equal(source.amp_factor, 2)
 
 
-def test_ProsthesisSystem_uncalibrated_xTh_is_not_yet_a_current():
+def test_Implant_uncalibrated_xTh_is_not_yet_a_current():
     implant = ArgusII()
     train = {'A1': BiphasicPulseTrain(20, 2 * xTh, 0.45)}
     stim = implant.prepare_stim(train)
@@ -1087,7 +1099,7 @@ def test_ProsthesisSystem_uncalibrated_xTh_is_not_yet_a_current():
     npt.assert_almost_equal(np.abs(stim.data).max(), 160, decimal=3)
 
 
-def test_ProsthesisSystem_partial_calibration_of_xTh_is_refused():
+def test_Implant_partial_calibration_of_xTh_is_refused():
     implant = ArgusII()
     xth_source = {'A1': BiphasicPulseTrain(20, 2 * xTh, 0.45),
                   'A2': BiphasicPulseTrain(20, 2 * xTh, 0.45)}
@@ -1124,5 +1136,5 @@ def test_a_generic_array_says_nothing_about_placement():
     # "no claim" rather than as a placement of its own.
     npt.assert_equal(implants.GridImplant(shape=(2, 2), spacing=500).placement, None)
     npt.assert_equal(
-        implants.ProsthesisSystem(implants.PointSource(0, 0, 0)).placement,
+        implants.Implant(implants.PointSource(0, 0, 0)).placement,
         None)

--- a/pulse2percept/implants/tests/test_bvt.py
+++ b/pulse2percept/implants/tests/test_bvt.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pytest
 import numpy.testing as npt
-from pulse2percept.implants.base import ProsthesisSystem
+from pulse2percept.implants.base import Implant
 from pulse2percept.implants.bvt import BVT24, BVT44
 from pulse2percept.units import DimensionMismatchError, deg, dva, rad
 

--- a/pulse2percept/implants/tests/test_ensemble.py
+++ b/pulse2percept/implants/tests/test_ensemble.py
@@ -4,7 +4,7 @@ import numpy.testing as npt
 from pulse2percept.units import DimensionMismatchError, mm, ms, um
 from pulse2percept.units import dva
 import pytest
-from pulse2percept.implants import (EnsembleImplant, PointSource, ProsthesisSystem)
+from pulse2percept.implants import (EnsembleImplant, PointSource, Implant)
 from pulse2percept.implants.cortex import Cortivis, Orion
 from pulse2percept.topography import Polimeni2006Map
 from pulse2percept.models.cortex.base import ScoreboardModel
@@ -21,8 +21,8 @@ def test_EnsembleImplant():
         EnsembleImplant(implants={'1': Cortivis(), '2': 'abcd'})
 
     # Instantiate with list
-    p1 = ProsthesisSystem(PointSource(0,0,0))
-    p2 = ProsthesisSystem(PointSource(1,1,1))
+    p1 = Implant(PointSource(0,0,0))
+    p2 = Implant(PointSource(1,1,1))
     ensemble = EnsembleImplant(implants=[p1,p2])
     npt.assert_equal(ensemble.n_electrodes, 2)
     npt.assert_equal(ensemble[0], p1[0])

--- a/pulse2percept/implants/tests/test_prima.py
+++ b/pulse2percept/implants/tests/test_prima.py
@@ -13,7 +13,7 @@ from scipy.spatial import cKDTree
 from pulse2percept.implants import (ArgusII, PhotovoltaicPixel, PRIMAPivotal,
                                     Lorach2015Array, Ho2019FlatArray,
                                     Huang2021Array, PointSource,
-                                    ProsthesisSystem, PRIMA, PRIMA75,
+                                    Implant, PRIMA, PRIMA75,
                                     PRIMA55, PRIMA40)
 from pulse2percept.stimuli import (BiphasicPulse, BiphasicPulseTrain,
                                    ImageStimulus, LogoBVL, PRIMAEncoder,
@@ -316,7 +316,7 @@ def test_implant_metadata():
     for cls in (Lorach2015Array, Ho2019FlatArray, Huang2021Array):
         npt.assert_equal(cls.family, None)
     # Unclassified implants default to None rather than to a guess:
-    generic = ProsthesisSystem(PointSource(0, 0, 0))
+    generic = Implant(PointSource(0, 0, 0))
     npt.assert_equal((generic.placement, generic.technology, generic.family),
                      (None, None, None))
 

--- a/pulse2percept/implants/tests/test_rasters.py
+++ b/pulse2percept/implants/tests/test_rasters.py
@@ -8,7 +8,7 @@ from scipy.spatial import cKDTree
 from pulse2percept.implants import (AlphaIMS, ArgusII, BVT24,
                                     CheckerboardRaster, CustomRaster,
                                     ElectrodeGrid, PRIMAPivotal,
-                                    ProsthesisSystem, Raster,
+                                    Implant, Raster,
                                     SequentialRaster)
 from pulse2percept.implants import rasters
 from pulse2percept.units import (DimensionMismatchError, Quantity, mA,
@@ -145,7 +145,7 @@ def test_CheckerboardRaster():
 def test_CheckerboardRaster_grids():
     # A hex grid is handled the same way, and its 7-group pattern is the one
     # that puts every group on a hex lattice of its own, sqrt(7) pitches wide:
-    hexgrid = ProsthesisSystem(ElectrodeGrid((14, 14), 200, type='hex'))
+    hexgrid = Implant(ElectrodeGrid((14, 14), 200, type='hex'))
     raster = CheckerboardRaster(7).bind(hexgrid)
     npt.assert_almost_equal(raster.min_spacing, 200 * np.sqrt(7), decimal=3)
     npt.assert_almost_equal(_min_spacing(hexgrid, raster), raster.min_spacing,
@@ -157,11 +157,11 @@ def test_CheckerboardRaster_grids():
 
     # Rotating the implant rotates the pattern with it, since the pattern is
     # read off the electrode positions:
-    upright = ProsthesisSystem(ElectrodeGrid((10, 10), 400))
+    upright = Implant(ElectrodeGrid((10, 10), 400))
     expected = CheckerboardRaster(5).bind(upright).groups(
         upright.electrode_names)
     for angle in [11, 37, 84]:
-        turned = ProsthesisSystem(ElectrodeGrid((10, 10), 400, rot=angle))
+        turned = Implant(ElectrodeGrid((10, 10), 400, rot=angle))
         npt.assert_equal(
             CheckerboardRaster(5).bind(turned).groups(turned.electrode_names),
             expected)
@@ -169,7 +169,7 @@ def test_CheckerboardRaster_grids():
     # comes out transposed. It is the same pattern in every way that matters --
     # which is what is checked here -- just not the same labelling:
     for angle in [117, 300]:
-        turned = ProsthesisSystem(ElectrodeGrid((10, 10), 400, rot=angle))
+        turned = Implant(ElectrodeGrid((10, 10), 400, rot=angle))
         raster = CheckerboardRaster(5).bind(turned)
         npt.assert_almost_equal(raster.min_spacing, 400 * np.sqrt(5),
                                 decimal=3)
@@ -265,7 +265,7 @@ def test_CheckerboardRaster_is_reproducible(monkeypatch):
                     row_d[at], row_i[at] = row_d[to], row_i[to]
             return dist, idx
 
-    hexgrid = ProsthesisSystem(ElectrodeGrid((10, 10), 400, type='hex'))
+    hexgrid = Implant(ElectrodeGrid((10, 10), 400, type='hex'))
     for implant in [ArgusII(), hexgrid, PRIMAPivotal()]:
         names = implant.electrode_names
         expected = CheckerboardRaster(5).bind(implant).groups(names)
@@ -283,7 +283,7 @@ def test_CheckerboardRaster_is_reproducible(monkeypatch):
     expected = CheckerboardRaster(5).bind(implant).groups(names)
     rng = np.random.RandomState(0)
     for _ in range(4):
-        nudged = ProsthesisSystem(deepcopy(implant.earray))
+        nudged = Implant(deepcopy(implant.earray))
         for elec in nudged.earray.electrode_objects:
             elec.x *= 1 + rng.uniform(-1, 1) * 1e-13
             elec.y *= 1 + rng.uniform(-1, 1) * 1e-13
@@ -418,10 +418,10 @@ def test_CustomRaster():
     npt.assert_equal(np.bincount(full.groups(names)), [4, 56])
 
 
-def test_ProsthesisSystem_raster():
+def test_Implant_raster():
     implant = ArgusII()
     # Implants that do not set a raster in their constructor still report one:
-    npt.assert_equal(ProsthesisSystem(implant.earray).raster, None)
+    npt.assert_equal(Implant(implant.earray).raster, None)
     implant.raster = SequentialRaster(6)
     npt.assert_equal(implant.raster.n_groups, 6)
     npt.assert_equal('raster' in str(implant), True)
@@ -429,11 +429,11 @@ def test_ProsthesisSystem_raster():
         implant.raster = 'line'
     # It can be set through the constructor too:
     npt.assert_equal(
-        ProsthesisSystem(implant.earray,
-                         raster=SequentialRaster(3)).raster.n_groups, 3)
+        Implant(implant.earray,
+                raster=SequentialRaster(3)).raster.n_groups, 3)
 
 
-def test_ProsthesisSystem_raster_binds():
+def test_Implant_raster_binds():
     # Assigning a raster binds it, which is what lets a geometry-dependent
     # pattern work itself out and what lets `plot` be called with no argument:
     implant = ArgusII()
@@ -458,7 +458,7 @@ def test_ProsthesisSystem_raster_binds():
 
     # Rebinding recomputes: the same object on a different array describes
     # *that* array, rather than answering about the one it came from:
-    other = ProsthesisSystem(ElectrodeGrid((4, 5), 400))
+    other = Implant(ElectrodeGrid((4, 5), 400))
     other.raster = raster
     npt.assert_equal(raster.implant is other, True)
     npt.assert_almost_equal(raster.min_spacing, 400 * np.sqrt(5), decimal=3)
@@ -478,7 +478,7 @@ def test_ProsthesisSystem_raster_binds():
         plt.close('all')
 
 
-def test_ProsthesisSystem_max_current():
+def test_Implant_max_current():
     implant = ArgusII()
     npt.assert_equal(implant.max_current, None)
     with pytest.raises(ValueError):

--- a/pulse2percept/models/base.py
+++ b/pulse2percept/models/base.py
@@ -10,7 +10,7 @@ import multiprocessing
 from scipy.ndimage import gaussian_filter1d
 from scipy.spatial import cKDTree
 
-from ..implants import ProsthesisSystem
+from ..implants import Implant
 from ..stimuli import ImageStimulus, Stimulus, VideoStimulus
 from ..stimuli.base import _describe_unit, _has_time_axis
 from ..percepts import Percept
@@ -206,9 +206,9 @@ def _delivered(stim):
 
 
 def _check_implant(implant):
-    """Raise unless ``implant`` is a ProsthesisSystem"""
-    if not isinstance(implant, ProsthesisSystem):
-        raise TypeError(f"'implant' must be a ProsthesisSystem object, not "
+    """Raise unless ``implant`` is an Implant"""
+    if not isinstance(implant, Implant):
+        raise TypeError(f"'implant' must be an Implant object, not "
                         f"{type(implant)}.")
 
 
@@ -580,7 +580,7 @@ class SpatialModel(BaseModel, metaclass=ABCMeta):
 
     Parameters
     ----------
-    implant : :py:class:`~pulse2percept.implants.ProsthesisSystem`
+    implant : :py:class:`~pulse2percept.implants.Implant`
         Implant whose electrode geometry is modeled.
 
         .. versionadded:: 0.11.0
@@ -858,7 +858,7 @@ class SpatialModel(BaseModel, metaclass=ABCMeta):
         ----------
         source : stimulus source
             Anything accepted by
-            :py:meth:`~pulse2percept.implants.ProsthesisSystem.prepare_stim`.
+            :py:meth:`~pulse2percept.implants.Implant.prepare_stim`.
         t_percept : float or array-like, optional
             Output times in ``time_unit``. If omitted, use the source time points.
             Unitful times are accepted.
@@ -1512,7 +1512,7 @@ class Model(Frozen, PrettyPrint):
         ----------
         source : stimulus source or :py:class:`~pulse2percept.vision.Scene`
             What is presented to the device: anything accepted by
-            :py:meth:`~pulse2percept.implants.ProsthesisSystem.prepare_stim`, or a
+            :py:meth:`~pulse2percept.implants.Implant.prepare_stim`, or a
             visual scene.
         t_percept : float or array-like, optional
             Output times in ``time_unit``. Unitful times are accepted.

--- a/pulse2percept/models/beyeler2019.py
+++ b/pulse2percept/models/beyeler2019.py
@@ -94,7 +94,7 @@ class ScoreboardSpatial(SpatialModel):
 
     Parameters
     ----------
-    implant : :py:class:`~pulse2percept.implants.ProsthesisSystem`
+    implant : :py:class:`~pulse2percept.implants.Implant`
         Implant whose electrode geometry is modeled.
 
         .. versionadded:: 0.11.0
@@ -206,7 +206,7 @@ class ScoreboardModel(Model):
 
     Parameters
     ----------
-    implant : :py:class:`~pulse2percept.implants.ProsthesisSystem`
+    implant : :py:class:`~pulse2percept.implants.Implant`
         Implant whose electrode geometry is modeled.
 
         .. versionadded:: 0.11.0
@@ -295,7 +295,7 @@ class AxonMapSpatial(SpatialModel):
 
     Parameters
     ----------
-    implant : :py:class:`~pulse2percept.implants.ProsthesisSystem`
+    implant : :py:class:`~pulse2percept.implants.Implant`
         Implant whose electrode geometry and eye are modeled.
 
         .. versionadded:: 0.11.0
@@ -1014,7 +1014,7 @@ class AxonMapModel(Model):
 
     Parameters
     ----------
-    implant : :py:class:`~pulse2percept.implants.ProsthesisSystem`
+    implant : :py:class:`~pulse2percept.implants.Implant`
         Implant whose electrode geometry and eye are modeled.
 
         .. versionadded:: 0.11.0

--- a/pulse2percept/models/cortex/base.py
+++ b/pulse2percept/models/cortex/base.py
@@ -22,7 +22,7 @@ class CortexSpatial(SpatialModel):
 
     Parameters:
     -----------
-    implant : :py:class:`~pulse2percept.implants.ProsthesisSystem`
+    implant : :py:class:`~pulse2percept.implants.Implant`
         The implant whose stimulation this model predicts.
 
         .. versionadded:: 0.11.0
@@ -225,7 +225,7 @@ class ScoreboardSpatial(CortexSpatial):
 
     Parameters
     ----------
-    implant : :py:class:`~pulse2percept.implants.ProsthesisSystem`
+    implant : :py:class:`~pulse2percept.implants.Implant`
         The implant whose stimulation this model predicts.
 
         .. versionadded:: 0.11.0
@@ -381,7 +381,7 @@ class ScoreboardModel(Model):
 
     Parameters
     ----------
-    implant : :py:class:`~pulse2percept.implants.ProsthesisSystem`
+    implant : :py:class:`~pulse2percept.implants.Implant`
         The implant whose stimulation this model predicts.
 
         .. versionadded:: 0.11.0

--- a/pulse2percept/models/cortex/dynaphos.py
+++ b/pulse2percept/models/cortex/dynaphos.py
@@ -50,7 +50,7 @@ class DynaphosModel(BaseModel):
     
     Parameters
     ----------
-    implant : :py:class:`~pulse2percept.implants.ProsthesisSystem`
+    implant : :py:class:`~pulse2percept.implants.Implant`
         The implant whose stimulation this model predicts.
 
         .. versionadded:: 0.11.0
@@ -410,7 +410,7 @@ class DynaphosModel(BaseModel):
         ----------
         source : :py:class:`~pulse2percept.stimuli.Stimulus` source type
             What is presented to the device; see
-            :py:meth:`~pulse2percept.implants.ProsthesisSystem.prepare_stim`.
+            :py:meth:`~pulse2percept.implants.Implant.prepare_stim`.
         t_percept: float or list of floats, optional
             The time points at which to output a percept (ms). This
             model's numerical contract is fixed to milliseconds.

--- a/pulse2percept/models/cortex/tests/test_dynaphos.py
+++ b/pulse2percept/models/cortex/tests/test_dynaphos.py
@@ -7,7 +7,7 @@ import matplotlib.pyplot as plt
 from pulse2percept.models.cortex import DynaphosModel
 from pulse2percept.models.cortex.dynaphos import _pulse_train_clocks
 from pulse2percept.implants import (DiskElectrode, ElectrodeArray,
-                                    EnsembleImplant, ProsthesisSystem)
+                                    EnsembleImplant, Implant)
 from pulse2percept.implants.cortex import Cortivis, Orion
 from pulse2percept.topography import Polimeni2006Map
 from pulse2percept.percepts import Percept
@@ -81,7 +81,7 @@ def test_temporal_predict():
     pdur = model.p_dur  # (ms)
     t_percept = np.arange(0, sdur, 20)
     single = DynaphosModel(
-        implant=ProsthesisSystem(ElectrodeArray(DiskElectrode(0, 0, 0, 260))),
+        implant=Implant(ElectrodeArray(DiskElectrode(0, 0, 0, 260))),
         step=0.1, dt=20).build()
     bright_amp = []
     for amp in np.linspace(20, 70, 5):
@@ -202,7 +202,7 @@ def test_dynaphos_reads_the_pulse_train_itself():
     # That used to be false: a bare train carried no per-electrode metadata
     # and was simulated on the model's default clock instead of its own.
     model = DynaphosModel(
-        implant=ProsthesisSystem(ElectrodeArray(DiskElectrode(0, 0, 0, 260))),
+        implant=Implant(ElectrodeArray(DiskElectrode(0, 0, 0, 260))),
         step=0.5, xrange=(-2, 2), yrange=(-2, 2)).build()
     model.dt = 20
     t_percept = np.arange(0, 200, 20)
@@ -227,7 +227,7 @@ def test_dynaphos_uses_its_defaults_for_an_arbitrary_waveform():
     # No pulse train behind the samples, so there is no clock to read and the
     # model simulates on its own -- which is what it has always done:
     model = DynaphosModel(
-        implant=ProsthesisSystem(ElectrodeArray(DiskElectrode(0, 0, 0, 260))),
+        implant=Implant(ElectrodeArray(DiskElectrode(0, 0, 0, 260))),
         step=0.5, xrange=(-2, 2), yrange=(-2, 2)).build()
     model.dt = 20
     source = Stimulus([[0, 100, 100, 0]], time=[0, 1, 199, 200])
@@ -246,7 +246,7 @@ def test_dynaphos_reads_the_clock_before_compression():
     # it no longer describe it. The parameters have to be taken first -- and
     # compression drops the electrodes driven at zero, so what is left has to
     # still line up with the right train.
-    implant = ProsthesisSystem(ElectrodeArray([
+    implant = Implant(ElectrodeArray([
         DiskElectrode(0, 0, 0, 260), DiskElectrode(1000, 0, 0, 260)]))
     model = DynaphosModel(implant=implant, step=0.5, xrange=(-2, 2),
                           yrange=(-2, 2)).build()

--- a/pulse2percept/models/granley2021.py
+++ b/pulse2percept/models/granley2021.py
@@ -348,7 +348,7 @@ class BiphasicAxonMapSpatial(AxonMapSpatial):
 
     Parameters
     ----------
-    implant : :py:class:`~pulse2percept.implants.ProsthesisSystem`
+    implant : :py:class:`~pulse2percept.implants.Implant`
         Implant whose electrode geometry and eye are modeled.
 
         .. versionadded:: 0.11.0
@@ -711,7 +711,7 @@ class BiphasicAxonMapModel(Model):
 
     Parameters
     ----------
-    implant : :py:class:`~pulse2percept.implants.ProsthesisSystem`
+    implant : :py:class:`~pulse2percept.implants.Implant`
         Implant whose electrode geometry and eye are modeled.
 
         .. versionadded:: 0.11.0

--- a/pulse2percept/models/nanduri2012.py
+++ b/pulse2percept/models/nanduri2012.py
@@ -63,7 +63,7 @@ class Nanduri2012Spatial(SpatialModel):
 
         Parameters
         ----------
-        implant : :py:class:`~pulse2percept.implants.ProsthesisSystem`
+        implant : :py:class:`~pulse2percept.implants.Implant`
             Implant whose electrode geometry is modeled.
 
             .. versionadded:: 0.11.0
@@ -296,7 +296,7 @@ class Nanduri2012Model(Model):
 
         Parameters
         ----------
-        implant : :py:class:`~pulse2percept.implants.ProsthesisSystem`
+        implant : :py:class:`~pulse2percept.implants.Implant`
             Implant whose electrode geometry is modeled.
 
             .. versionadded:: 0.11.0

--- a/pulse2percept/models/tests/test_base.py
+++ b/pulse2percept/models/tests/test_base.py
@@ -130,7 +130,7 @@ def test_SpatialModel():
     npt.assert_equal(fresh.predict_percept(np.ones(16)) is not None, True)
     npt.assert_equal(fresh.is_built, True)
     with pytest.raises(TypeError):
-        # the implant must be a ProsthesisSystem
+        # the implant must be an Implant
         ValidSpatialModel(Stimulus(3))
     with pytest.raises(TypeError):
         ValidSpatialModel(None)
@@ -1241,7 +1241,7 @@ def test_model_requires_a_current_stimulus():
     """
     img = ImageStimulus(np.linspace(0, 1, 16).reshape((4, 4)))
     # `implant.prepare_stim(img)` is either encoded by the implant or refused
-    # by it (see `ProsthesisSystem.stimulus_unit`), so the model-side guard is
+    # by it (see `Implant.stimulus_unit`), so the model-side guard is
     # reached through an implant that claims to deliver something else. Both
     # are needed: the implant one catches the call that was actually wrong,
     # and this one is what no model may be talked out of.

--- a/pulse2percept/models/tests/test_beyeler2019.py
+++ b/pulse2percept/models/tests/test_beyeler2019.py
@@ -1055,11 +1055,11 @@ def test_rho_wider_than_the_electrode_pitch_warns(ModelClass):
 def test_electrode_pitch_ignores_a_dimension_the_model_drops(ModelClass):
     """A retinal model reads x and y, so z cannot pull neighbours apart"""
     from pulse2percept.implants import (DiskElectrode, ElectrodeArray,
-                                        ProsthesisSystem)
+                                        Implant)
     extra = {'n_axons': 50, 'n_ax_segments': 30} if ModelClass is AxonMapModel         else {}
     # Three electrodes 100 um apart in x, but 1000 um apart in z. Reading all
     # three coordinates would call that a ~1005 um pitch and stay quiet:
-    stacked = ProsthesisSystem(ElectrodeArray(
+    stacked = Implant(ElectrodeArray(
         [DiskElectrode(100 * i, 0, 1000 * i, 50) for i in range(3)]))
     model = ModelClass(implant=stacked, rho=400, step=1, xrange=(-2, 2),
                        yrange=(-2, 2), **extra)

--- a/pulse2percept/models/tests/test_end_to_end.py
+++ b/pulse2percept/models/tests/test_end_to_end.py
@@ -21,7 +21,7 @@ import pytest
 from scipy.integrate import trapezoid
 
 from pulse2percept.implants import (ArgusII, CustomRaster, DiskElectrode,
-                                    ElectrodeArray, ProsthesisSystem)
+                                    ElectrodeArray, Implant)
 from pulse2percept.models import FadingTemporal, Model, ScoreboardSpatial
 from pulse2percept.stimuli import (AmplitudeEncoder, BostonTrain,
                                    FrequencyEncoder, ImageStimulus,
@@ -39,7 +39,7 @@ def make_implant(raster=None):
     """Four well-separated electrodes, one per raster group"""
     earray = ElectrodeArray({n: DiskElectrode(x, y, 0, 100)
                              for n, (x, y) in zip(NAMES, POS)})
-    return ProsthesisSystem(earray, raster=raster)
+    return Implant(earray, raster=raster)
 
 
 def one_per_group():

--- a/pulse2percept/models/tests/test_horsager2009.py
+++ b/pulse2percept/models/tests/test_horsager2009.py
@@ -4,7 +4,7 @@ import numpy as np
 import numpy.testing as npt
 import pytest
 
-from pulse2percept.implants import ProsthesisSystem, PointSource
+from pulse2percept.implants import Implant, PointSource
 from pulse2percept.stimuli import (BiphasicPulse, BiphasicPulseTrain,
                                    Stimulus)
 from pulse2percept.percepts import Percept
@@ -24,7 +24,7 @@ def test_Horsager2009Temporal():
         model.rho = 100
 
     # Nothing in, None out:
-    implant = ProsthesisSystem(PointSource(0, 0, 0))
+    implant = Implant(PointSource(0, 0, 0))
     npt.assert_equal(model.predict_percept(implant.prepare_stim(None)),
                      None)
 

--- a/pulse2percept/models/tests/test_nanduri2012.py
+++ b/pulse2percept/models/tests/test_nanduri2012.py
@@ -4,7 +4,7 @@ import pytest
 import copy
 
 from pulse2percept.implants import (DiskElectrode, PointSource, ElectrodeArray,
-                                    ProsthesisSystem, ArgusI)
+                                    Implant, ArgusI)
 from pulse2percept.stimuli import BiphasicPulseTrain
 from pulse2percept.percepts import Percept
 from pulse2percept.models import (Nanduri2012Model, Nanduri2012Spatial,
@@ -35,15 +35,15 @@ def test_Nanduri2012Spatial():
     # the model is bound to, so it is caught when that model is built:
     with pytest.raises(TypeError):
         Nanduri2012Spatial(
-            implant=ProsthesisSystem(ElectrodeArray(PointSource(0, 0, 0)))
+            implant=Implant(ElectrodeArray(PointSource(0, 0, 0)))
         ).build()
     with pytest.raises(TypeError):
-        Nanduri2012Spatial(implant=ProsthesisSystem(ElectrodeArray(
+        Nanduri2012Spatial(implant=Implant(ElectrodeArray(
             [DiskElectrode(0, 0, 0, 100), PointSource(100, 100, 0)]))).build()
 
     # The bound implant stays the caller's, so a build-time check alone would
     # let a swapped array through to a kernel that reads a radius off it:
-    model = Nanduri2012Spatial(implant=ProsthesisSystem(ElectrodeArray(
+    model = Nanduri2012Spatial(implant=Implant(ElectrodeArray(
         DiskElectrode(0, 0, 0, 100))), step=5).build()
     model.implant.earray = ElectrodeArray(PointSource(0, 0, 0))
     with pytest.raises(TypeError):
@@ -142,7 +142,7 @@ def test_Nanduri2012Temporal(scale_out):
     sdur = 1000.0  # stimulus duration (ms)
     pdur = 0.45  # (ms)
     t_percept = np.arange(0, sdur, 5)
-    implant = ProsthesisSystem(ElectrodeArray(DiskElectrode(0, 0, 0, 260)))
+    implant = Implant(ElectrodeArray(DiskElectrode(0, 0, 0, 260)))
     bright_amp = []
     for amp in np.linspace(0, 50, 5):
         stim = implant.prepare_stim(
@@ -234,7 +234,7 @@ def test_Nanduri2012Model_predict_percept():
     npt.assert_almost_equal(model.predict_percept(np.zeros(16)).data, 0)
 
     # Single-pixel model same as TemporalModel:
-    single = ProsthesisSystem(DiskElectrode(0, 0, 0, 100))
+    single = Implant(DiskElectrode(0, 0, 0, 100))
     model = Nanduri2012Model(implant=single, xrange=(0, 0), yrange=(0, 0))
     model.build()
     train = BiphasicPulseTrain(20, 20, 0.45, interphase_dur=0.45)
@@ -249,15 +249,15 @@ def test_Nanduri2012Model_predict_percept():
     # or is not, so it is caught when the model is built:
     with pytest.raises(TypeError):
         Nanduri2012Model(
-            implant=ProsthesisSystem(ElectrodeArray(PointSource(0, 0, 0))),
+            implant=Implant(ElectrodeArray(PointSource(0, 0, 0))),
             xrange=(0, 0), yrange=(0, 0)).build()
     with pytest.raises(TypeError):
-        Nanduri2012Model(implant=ProsthesisSystem(ElectrodeArray(
+        Nanduri2012Model(implant=Implant(ElectrodeArray(
             [DiskElectrode(0, 0, 0, 100), PointSource(100, 100, 0)])),
             xrange=(0, 0), yrange=(0, 0)).build()
 
     # Requested times must be multiples of model.dt:
-    implant = ProsthesisSystem(ElectrodeArray(DiskElectrode(0, 0, 0, 260)))
+    implant = Implant(ElectrodeArray(DiskElectrode(0, 0, 0, 260)))
     model = Nanduri2012Model(implant=implant, xrange=(0, 0), yrange=(0, 0))
     model.build()
     train = BiphasicPulseTrain(20, 20, 0.45)
@@ -288,7 +288,7 @@ def test_Nanduri2012Model_predict_percept():
                      (1, 1, 2))
 
     # Brightness vs. size (use values from Nanduri paper):
-    implant = ProsthesisSystem(ElectrodeArray(DiskElectrode(0, 0, 0, 260)))
+    implant = Implant(ElectrodeArray(DiskElectrode(0, 0, 0, 260)))
     model = Nanduri2012Model(implant=implant, step=0.5, xrange=(-4, 4),
                              yrange=(-4, 4))
     model.build()

--- a/pulse2percept/models/tests/test_scene.py
+++ b/pulse2percept/models/tests/test_scene.py
@@ -12,7 +12,7 @@ import numpy.testing as npt
 import pytest
 
 from pulse2percept.implants import (ElectrodeGrid, PointSource,
-                                    ProsthesisSystem)
+                                    Implant)
 from pulse2percept.models import (FadingTemporal, Model, ScoreboardModel,
                                   ScoreboardSpatial)
 from pulse2percept.models.base import _scene_stim
@@ -67,7 +67,7 @@ def scene_of(source=None, **kwargs):
 
 def implant_at(x_um=0, y_um=0, encoder=True):
     """An implant whose single electrode sits where we want to look"""
-    return ProsthesisSystem(
+    return Implant(
         PointSource(x_um, y_um, 0),
         encoder=AmplitudeEncoder(amp_range=(0, AMP_MAX)) if encoder else None)
 
@@ -128,8 +128,8 @@ def test_gaze_moves_the_scene_past_the_implant():
                             seen_by(model, scene, gaze=(6.0, 0.0)))
     # Several electrodes keep their separation in the visual field whatever
     # the gaze: shifting gaze shifts what all of them see by the same amount.
-    grid = ProsthesisSystem(ElectrodeGrid((1, 3), 280),
-                            encoder=AmplitudeEncoder(amp_range=(0, AMP_MAX)))
+    grid = Implant(ElectrodeGrid((1, 3), 280),
+                   encoder=AmplitudeEncoder(amp_range=(0, AMP_MAX)))
     on_grid = model_for(grid)
     here = seen_by(on_grid, scene).ravel()
     there = seen_by(on_grid, scene, gaze=(2, 0)).ravel()
@@ -175,8 +175,8 @@ def test_scene_driven_prediction_leaves_the_implant_alone():
 
 def test_a_scene_driven_stimulus_still_goes_through_the_device():
     """The sampled scene is prepared by the implant, not written behind it"""
-    grid = ProsthesisSystem(ElectrodeGrid((1, 3), 280),
-                            encoder=AmplitudeEncoder(amp_range=(0, AMP_MAX)))
+    grid = Implant(ElectrodeGrid((1, 3), 280),
+                   encoder=AmplitudeEncoder(amp_range=(0, AMP_MAX)))
     grid.deactivate('A2')
     stim = _scene_stim(model_for(grid), scene_of(), None)
     npt.assert_equal('A2' in list(stim.electrodes), False)
@@ -346,8 +346,8 @@ def test_an_unbuilt_model_builds_itself_before_it_samples_anything():
 
 def test_an_ordinary_source_is_not_registered_as_a_scene():
     """Only a Scene takes the registration path; a picture is stimulation"""
-    grid = ProsthesisSystem(ElectrodeGrid((3, 3), 280),
-                            encoder=AmplitudeEncoder(amp_range=(0, AMP_MAX)))
+    grid = Implant(ElectrodeGrid((3, 3), 280),
+                   encoder=AmplitudeEncoder(amp_range=(0, AMP_MAX)))
     model = model_for(grid)
     # The same pixels, not wrapped in a Scene, are sampled onto the electrodes
     # and encoded rather than registered through the retinotopy, so `gaze` is

--- a/pulse2percept/models/thompson2003.py
+++ b/pulse2percept/models/thompson2003.py
@@ -48,7 +48,7 @@ class Thompson2003Spatial(SpatialModel):
 
     Parameters
     ----------
-    implant : :py:class:`~pulse2percept.implants.ProsthesisSystem`
+    implant : :py:class:`~pulse2percept.implants.Implant`
         Implant whose electrode geometry is modeled.
 
         .. versionadded:: 0.11.0
@@ -145,7 +145,7 @@ class Thompson2003Model(Model):
 
     Parameters
     ----------
-    implant : :py:class:`~pulse2percept.implants.ProsthesisSystem`
+    implant : :py:class:`~pulse2percept.implants.Implant`
         Implant whose electrode geometry is modeled.
 
         .. versionadded:: 0.11.0

--- a/pulse2percept/stimuli/encoders.py
+++ b/pulse2percept/stimuli/encoders.py
@@ -240,7 +240,7 @@ class Encoder(PrettyPrint, metaclass=ABCMeta):
         ----------
         source : :py:class:`~pulse2percept.stimuli.Stimulus`
             The image or video to encode. Must be dimensionless.
-        implant : :py:class:`~pulse2percept.implants.ProsthesisSystem`, optional
+        implant : :py:class:`~pulse2percept.implants.Implant`, optional
             The implant to encode for. If None, every pixel of the source is
             treated as its own stimulation site.
 
@@ -871,11 +871,11 @@ class StimulusEncoder(Encoder):
             be dimensionless: this method is the boundary at which a picture
             becomes stimulation, so an electrical stimulus is not a valid
             source for it.
-        implant : :py:class:`~pulse2percept.implants.ProsthesisSystem`, optional
+        implant : :py:class:`~pulse2percept.implants.Implant`, optional
             The implant to encode for. Its electrode locations are used to
             sample the source, its electrode names label the resulting
             stimulus, and its
-            :py:attr:`~pulse2percept.implants.ProsthesisSystem.raster` decides
+            :py:attr:`~pulse2percept.implants.Implant.raster` decides
             which electrodes may pulse when. If None, every pixel of the source
             is treated as its own electrode and every electrode fires on the
             same schedule.
@@ -933,7 +933,7 @@ class AmplitudeEncoder(StimulusEncoder):
         spelling ``(0, 3 * xTh)`` is rejected rather than guessed at. A
         threshold-relative range encodes to a ``xTh`` stimulus, which an
         implant converts to current when it has
-        :py:attr:`~pulse2percept.implants.ProsthesisSystem.thresholds` for
+        :py:attr:`~pulse2percept.implants.Implant.thresholds` for
         every driven electrode.
 
         .. versionchanged:: 0.11.0
@@ -1505,7 +1505,7 @@ class PRIMAEncoder(Encoder):
             which is what :py:class:`~pulse2percept.stimuli.ImageStimulus` and
             :py:class:`~pulse2percept.stimuli.VideoStimulus` produce. It must
             be dimensionless.
-        implant : :py:class:`~pulse2percept.implants.ProsthesisSystem`, optional
+        implant : :py:class:`~pulse2percept.implants.Implant`, optional
             The implant to encode for. Its pixel locations are used to sample
             the source and its pixel names label the resulting stimulus. If
             None, every pixel of the source is treated as its own photovoltaic

--- a/pulse2percept/stimuli/images.py
+++ b/pulse2percept/stimuli/images.py
@@ -635,7 +635,7 @@ class ImageStimulus(Stimulus):
         freq : float, optional
             Pulse train frequency (Hz). The image is treated as a single frame
             lasting 500 ms unless ``frame_dur`` says otherwise.
-        implant : :py:class:`~pulse2percept.implants.ProsthesisSystem`, optional
+        implant : :py:class:`~pulse2percept.implants.Implant`, optional
             If given, the image is first sampled at the implant's electrode
             locations, so that the pulse trains are built at electrode rather
             than pixel resolution.

--- a/pulse2percept/stimuli/tests/test_base.py
+++ b/pulse2percept/stimuli/tests/test_base.py
@@ -78,7 +78,7 @@ def test_Stimulus():
     # Multiple specific electrodes in time:
     stim = Stimulus({'C3': [[0, 1, 2, 3]],
                      'F4': [[4, -1, 4, -1]]})
-    # Stimulus from a Stimulus (might happen in ProsthesisSystem):
+    # Stimulus from a Stimulus (might happen in Implant):
     stim = Stimulus(Stimulus(4), electrodes='B3')
     npt.assert_equal(stim.shape, (1, 1))
     npt.assert_equal(stim.electrodes, ['B3'])
@@ -767,7 +767,7 @@ def test_Stimulus_remove():
     stim.remove(['A1', 'C3'])
     npt.assert_equal(stim.shape, (0, 3))
 
-    # Removing "nothing" is a no-op. ProsthesisSystem relies on this when none
+    # Removing "nothing" is a no-op. Implant relies on this when none
     # of its electrodes are deactivated:
     for nothing in (None, [], (), np.array([])):
         stim = Stimulus([[0, 1, 2], [3, 4, 5]])

--- a/pulse2percept/stimuli/tests/test_pulses.py
+++ b/pulse2percept/stimuli/tests/test_pulses.py
@@ -604,7 +604,7 @@ def test_pulse_remove_refuses_to_outdate_its_parameters(cls, build, params):
         pulse.remove(pulse.electrodes[0])
     with pytest.raises(NotImplementedError):
         pulse.remove('all')
-    # Removing nothing is still a no-op, which ProsthesisSystem relies on:
+    # Removing nothing is still a no-op, which Implant relies on:
     for nothing in (None, [], (), np.array([])):
         pulse.remove(nothing)
     npt.assert_equal(pulse.shape[0], 1)

--- a/pulse2percept/stimuli/videos.py
+++ b/pulse2percept/stimuli/videos.py
@@ -749,7 +749,7 @@ class VideoStimulus(Stimulus):
             ``min_amp``, a gray level of 1 onto ``max_amp``.
         freq : float, optional
             Pulse train frequency (Hz).
-        implant : :py:class:`~pulse2percept.implants.ProsthesisSystem`, optional
+        implant : :py:class:`~pulse2percept.implants.Implant`, optional
             If given, the video is first sampled at the implant's electrode
             locations, so that the pulse trains are built at electrode rather
             than pixel resolution. Strongly recommended: a video has orders of

--- a/pulse2percept/units/tests/test_integration.py
+++ b/pulse2percept/units/tests/test_integration.py
@@ -13,7 +13,7 @@ import numpy.testing as npt
 import pytest
 
 from pulse2percept.implants import (ArgusII, DiskElectrode, ElectrodeGrid,
-                                    EnsembleImplant, ProsthesisSystem)
+                                    EnsembleImplant, Implant)
 from pulse2percept.implants.cortex import Cortivis
 from pulse2percept.models import (AlphaTemporal, AxonMapSpatial,
                                   FadingTemporal, Model, ScoreboardSpatial)
@@ -126,8 +126,8 @@ def test_every_spelling_builds_the_same_object():
           lambda p: p.data, 'BiphasicPulseTrain.amp', rtol=1e-6)
     _same(lambda a: Stimulus([a]), amp, amps, lambda s: s.data,
           'Stimulus', rtol=1e-6)
-    _same(lambda a: ProsthesisSystem(ArgusII().earray, max_current=a),
-          amp, amps, lambda p: p.max_current, 'ProsthesisSystem.max_current')
+    _same(lambda a: Implant(ArgusII().earray, max_current=a),
+          amp, amps, lambda p: p.max_current, 'Implant.max_current')
     _same(lambda a: AmplitudeEncoder(amp_range=(0, a), freq=20).encode(
               ImageStimulus(np.linspace(0, 1, 36).reshape((6, 6))),
               implant=ArgusII()),
@@ -283,15 +283,15 @@ def test_the_whole_rejection_matrix():
     with pytest.raises(DimensionMismatchError):
         model.predict_percept(current, t_percept=[0, 20] * uA)
     with pytest.raises(DimensionMismatchError):
-        ProsthesisSystem(ArgusII().earray, max_current=5 * ms)
+        Implant(ArgusII().earray, max_current=5 * ms)
 
     # dimensionless -> safety check: there is no charge in a picture.
     with pytest.raises(DimensionMismatchError):
-        ProsthesisSystem(ArgusII().earray, safe_mode=True,
-                         preprocess=False).prepare_stim(img)
+        Implant(ArgusII().earray, safe_mode=True,
+                preprocess=False).prepare_stim(img)
     with pytest.raises(DimensionMismatchError):
-        ProsthesisSystem(ArgusII().earray, max_current=20,
-                         preprocess=False).prepare_stim(img)
+        Implant(ArgusII().earray, max_current=20,
+                preprocess=False).prepare_stim(img)
 
     # A bare number is never rejected, anywhere. That is the other half of the
     # contract, and the reason none of the above needs a deprecation cycle:
@@ -299,6 +299,6 @@ def test_the_whole_rejection_matrix():
                   lambda: ArgusII(x=575),
                   lambda: Grid2D((-2, 2), (-2, 2)),
                   lambda: BiphasicPulse(50, 0.45),
-                  lambda: ProsthesisSystem(ArgusII().earray, max_current=20),
+                  lambda: Implant(ArgusII().earray, max_current=20),
                   lambda: Watson2014Map().dva_to_ret(2, 2)):
         build()

--- a/pulse2percept/utils/__init__.py
+++ b/pulse2percept/utils/__init__.py
@@ -26,7 +26,8 @@ from .convolution import center_vector, conv
 from .optimize import bisect
 from .stats import r2_score, circ_r2_score
 from .deprecation import (deprecated, deprecate_parameter, deprecated_alias,
-                          rename_parameter, warn_deprecated_params,
+                          deprecated_names, rename_parameter,
+                          warn_deprecated_params,
                           rename_deprecated_params)
 from .three_dim import parse_3d_orient
 
@@ -44,6 +45,7 @@ __all__ = [
     'deprecate_parameter',
     'deprecated',
     'deprecated_alias',
+    'deprecated_names',
     'frame_interval',
     'FreezeError',
     'Frozen',

--- a/pulse2percept/utils/__init__.py
+++ b/pulse2percept/utils/__init__.py
@@ -26,8 +26,7 @@ from .convolution import center_vector, conv
 from .optimize import bisect
 from .stats import r2_score, circ_r2_score
 from .deprecation import (deprecated, deprecate_parameter, deprecated_alias,
-                          deprecated_names, rename_parameter,
-                          warn_deprecated_params,
+                          rename_parameter, warn_deprecated_params,
                           rename_deprecated_params)
 from .three_dim import parse_3d_orient
 
@@ -45,7 +44,6 @@ __all__ = [
     'deprecate_parameter',
     'deprecated',
     'deprecated_alias',
-    'deprecated_names',
     'frame_interval',
     'FreezeError',
     'Frozen',

--- a/pulse2percept/utils/deprecation.py
+++ b/pulse2percept/utils/deprecation.py
@@ -1,7 +1,6 @@
 """:py:class:`~pulse2percept.utils.deprecated`,
    :py:class:`~pulse2percept.utils.deprecate_parameter`,
    :py:class:`~pulse2percept.utils.deprecated_alias`,
-   :py:func:`~pulse2percept.utils.deprecated_names`,
    :py:class:`~pulse2percept.utils.rename_parameter`,
    :py:class:`~pulse2percept.utils.is_deprecated`"""
 
@@ -192,31 +191,16 @@ class deprecated:
         return wrapped
 
 
-def deprecated_names(module, aliases, deprecated_version=None,
-                     removed_version=None):
-    """Build a module-level ``__getattr__`` for renamed module attributes.
+def _deprecated_names(module, aliases, deprecated_version=None,
+                      removed_version=None):
+    """Return a module ``__getattr__`` (:pep:`562`) for renamed classes.
 
-    The old name keeps resolving to the very same object, so ``isinstance``
-    and ``issubclass`` checks written against it behave as before; only
-    looking the name up warns. Use :class:`deprecated` instead when the old
-    name should keep its own (deprecated) implementation.
-
-    .. versionadded:: 0.11.0
-
-    Parameters
-    ----------
-    module : str
-        Name of the module installing the hook, i.e. its ``__name__``. Used in
-        the ``AttributeError`` raised for names that are not aliases.
-    aliases : dict
-        Maps each deprecated name to the object it now refers to.
-    deprecated_version, removed_version : float or str, optional
-        Versions in which the old names were deprecated and will be removed.
-
-    Returns
-    -------
-    __getattr__ : callable
-        Assign to the module's ``__getattr__`` (see :pep:`562`).
+    ``module`` is the installing module's ``__name__``, used in the
+    ``AttributeError`` raised for anything not in ``aliases``, which maps each
+    old name to the class it now refers to. The old name resolves to that very
+    class rather than to a deprecated subclass, so ``isinstance`` and
+    ``issubclass`` checks written against it keep working; only the lookup
+    warns.
     """
     clause = _version_clause(deprecated_version, removed_version)
 

--- a/pulse2percept/utils/deprecation.py
+++ b/pulse2percept/utils/deprecation.py
@@ -1,6 +1,7 @@
 """:py:class:`~pulse2percept.utils.deprecated`,
    :py:class:`~pulse2percept.utils.deprecate_parameter`,
    :py:class:`~pulse2percept.utils.deprecated_alias`,
+   :py:func:`~pulse2percept.utils.deprecated_names`,
    :py:class:`~pulse2percept.utils.rename_parameter`,
    :py:class:`~pulse2percept.utils.is_deprecated`"""
 
@@ -189,6 +190,48 @@ class deprecated:
         wrapped.__doc__ = self._update_doc(wrapped.__doc__, msg)
 
         return wrapped
+
+
+def deprecated_names(module, aliases, deprecated_version=None,
+                     removed_version=None):
+    """Build a module-level ``__getattr__`` for renamed module attributes.
+
+    The old name keeps resolving to the very same object, so ``isinstance``
+    and ``issubclass`` checks written against it behave as before; only
+    looking the name up warns. Use :class:`deprecated` instead when the old
+    name should keep its own (deprecated) implementation.
+
+    .. versionadded:: 0.11.0
+
+    Parameters
+    ----------
+    module : str
+        Name of the module installing the hook, i.e. its ``__name__``. Used in
+        the ``AttributeError`` raised for names that are not aliases.
+    aliases : dict
+        Maps each deprecated name to the object it now refers to.
+    deprecated_version, removed_version : float or str, optional
+        Versions in which the old names were deprecated and will be removed.
+
+    Returns
+    -------
+    __getattr__ : callable
+        Assign to the module's ``__getattr__`` (see :pep:`562`).
+    """
+    clause = _version_clause(deprecated_version, removed_version)
+
+    def __getattr__(name):
+        try:
+            obj = aliases[name]
+        except KeyError:
+            raise AttributeError(f"module {module!r} has no attribute "
+                                 f"{name!r}") from None
+        _warn_external(f"{name} is deprecated{clause}. Use "
+                       f"``{obj.__name__}`` instead.")
+        return obj
+
+    return __getattr__
+
 
 class deprecate_parameter:
     """Decorator for a deprecated function or method parameter.


### PR DESCRIPTION
`ProsthesisSystem` is the base class for everything we expose and document as an implant, but the name introduces an unnecessary distinction in the public API.

Long overdue, this PR renames the canonical base class to `Implant` and keeps `ProsthesisSystem` as a deprecated compatibility alias.