### PR TITLE
[ENH] Add phosphene location variability

### DIFF
--- a/doc/users/release_notes.rst
+++ b/doc/users/release_notes.rst
@@ -95,9 +95,9 @@ Models
 * ``find_threshold`` has been removed; threshold searches belong at the
   experiment level rather than in the model API (:pull:`862`).
 
-* New ``location_noise`` parameter gives a model a subject-specific
-  retinotopic distortion (dva), warping the rendered percept away from the
-  canonical ``visual_field_map`` (:pull:`881`).
+* New ``location_noise`` parameter displaces each electrode's phosphene by a
+  fixed, subject-specific offset in the visual field (dva) rather than at the
+  location the ``visual_field_map`` gives it (:pull:`881`).
 
 
 Residual vision

--- a/doc/users/release_notes.rst
+++ b/doc/users/release_notes.rst
@@ -95,6 +95,10 @@ Models
 * ``find_threshold`` has been removed; threshold searches belong at the
   experiment level rather than in the model API (:pull:`862`).
 
+* New ``location_noise`` parameter on every
+  :py:class:`~pulse2percept.models.SpatialModel` jitters where each
+  electrode's percept appears in the visual field, in dva (:pull:`881`).
+
 
 Residual vision
 ~~~~~~~~~~~~~~~

--- a/doc/users/release_notes.rst
+++ b/doc/users/release_notes.rst
@@ -95,9 +95,9 @@ Models
 * ``find_threshold`` has been removed; threshold searches belong at the
   experiment level rather than in the model API (:pull:`862`).
 
-* New ``location_noise`` parameter on every
-  :py:class:`~pulse2percept.models.SpatialModel` jitters where each
-  electrode's percept appears in the visual field, in dva (:pull:`881`).
+* New ``location_noise`` parameter gives a model a subject-specific
+  retinotopic distortion (dva), warping the rendered percept away from the
+  canonical ``visual_field_map`` (:pull:`881`).
 
 
 Residual vision

--- a/doc/users/release_notes.rst
+++ b/doc/users/release_notes.rst
@@ -97,7 +97,8 @@ Models
 
 * New ``location_noise`` parameter displaces each electrode's phosphene by a
   fixed, subject-specific offset in the visual field (dva) rather than at the
-  location the ``visual_field_map`` gives it (:pull:`881`).
+  location the ``visual_field_map`` gives it. Requires a 2D, invertible map
+  (:pull:`881`).
 
 
 Residual vision

--- a/examples/models/plot_visual_field_maps.py
+++ b/examples/models/plot_visual_field_maps.py
@@ -157,7 +157,9 @@ for ax, noise, title in zip(
 ###############################################################################
 # The phosphenes move; they do not change shape. Each one is still the circular
 # Gaussian the Scoreboard model draws, sitting somewhere else in the visual
-# field.
+# field. On cortex the same is true of coherence but not of size: a displaced
+# electrode samples a different cortical magnification, so its phosphene
+# covers a different extent of the visual field.
 #
 # The same mechanism applies to cortical stimulation. Here a sparse subset of
 # CORTIVIS electrodes is mapped through V1 with ``Polimeni2006Map``. The
@@ -217,14 +219,13 @@ for ax, noise, title in zip(
 
 ###############################################################################
 # The logo stays legible but its mosaic is spatially jumbled: the phosphenes
-# are the same, only misplaced.
+# remain coherent, but appear at subject-specific locations.
 #
 # ``location_noise`` changes the predicted percept, not the physical electrode
 # locations or the canonical visual-field map. It therefore captures
 # subject-specific phosphene-location variability while leaving the anatomical
-# model intact. It requires a map that can place electrodes in the visual
-# field, so a map without an inverse (such as ``Watson2014DisplaceMap``) is not
-# supported.
+# model intact. It requires an invertible map, so one without an inverse (such
+# as ``Watson2014DisplaceMap``) is not supported.
 #
 # Creating your own visual field map
 # ----------------------------------

--- a/examples/models/plot_visual_field_maps.py
+++ b/examples/models/plot_visual_field_maps.py
@@ -11,30 +11,29 @@ several built-in maps.
 Retinal maps derive from :py:class:`~pulse2percept.topography.RetinalMap`
 and include:
 
-* :py:class:`~pulse2percept.topography.Curcio1990Map` uses a linear retinal
-  scaling of 280 microns per degree of visual angle (dva).
-* :py:class:`~pulse2percept.topography.Watson2014Map` uses the nonlinear
+* :py:class:`~pulse2percept.topography.Curcio1990Map`, which uses a linear
+  retinal scaling of 280 microns per degree of visual angle (dva).
+* :py:class:`~pulse2percept.topography.Watson2014Map`, which uses the nonlinear
   retinal magnification model from [Watson2014]_.
-* :py:class:`~pulse2percept.topography.Watson2014DisplaceMap` additionally
+* :py:class:`~pulse2percept.topography.Watson2014DisplaceMap`, which also
   accounts for retinal ganglion-cell displacement near the fovea.
 
 Cortical maps derive from :py:class:`~pulse2percept.topography.CorticalMap`
 and include:
 
-* :py:class:`~pulse2percept.topography.Polimeni2006Map` maps visual field
-  locations onto V1, V2, and V3 using the wedge-dipole model from
-  [Polimeni2006]_.
-* :py:class:`~pulse2percept.topography.NeuropythyMap` uses Neuropythy to
+* :py:class:`~pulse2percept.topography.Polimeni2006Map`, which maps the visual
+  field onto V1, V2, and V3 using the wedge-dipole model from [Polimeni2006]_.
+* :py:class:`~pulse2percept.topography.NeuropythyMap`, which uses Neuropythy to
   estimate subject-specific cortical maps from MRI data [Benson2018]_.
 
-Visual field maps
------------------
+Retinal visual field maps
+-------------------------
 
 To see how the retinal maps differ, start with a regular grid in the visual
 field:
 """
 
-# sphinx_gallery_thumbnail_number = 4
+# sphinx_gallery_thumbnail_number = 5
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -73,76 +72,6 @@ for ax, transform in zip(axes, transforms):
 # nonlinear. ``Watson2014DisplaceMap`` adds the prominent foveal distortion
 # caused by retinal ganglion-cell displacement.
 #
-# Perceptual consequences
-# -----------------------
-#
-# These differences matter because the visual-field map determines where an
-# implant lies relative to the simulated visual field. Here we stimulate an
-# :py:class:`~pulse2percept.implants.AlphaAMS` with the same encoded image under
-# each retinal map:
-
-implant = p2p.implants.AlphaAMS()
-stim = p2p.stimuli.LogoUCSB().encode(implant=implant)
-
-fig, axes = plt.subplots(ncols=3, sharey=True, figsize=(13, 4))
-for ax, transform in zip(axes, transforms):
-    model = p2p.models.ScoreboardModel(
-        implant=implant,
-        xrange=(-6, 6),
-        yrange=(-6, 6),
-        visual_field_map=transform,
-    )
-    model.predict_percept(stim).plot(ax=ax)
-    ax.set_title(transform.__class__.__name__)
-
-###############################################################################
-# The first two maps give very similar percepts at this scale. The RGC
-# displacement map produces a much stronger foveal distortion.
-#
-# Subject-specific phosphene locations
-# ------------------------------------
-#
-# A visual-field map is still only a canonical mapping. In an individual
-# implant user, a phosphene may appear somewhere else than the map predicts.
-# ``location_noise`` models this subject-specific variability without changing
-# the underlying ``visual_field_map``.
-#
-# For electrode :math:`i`, pulse2percept draws a fixed visual-field offset
-#
-# .. math::
-#
-#    \mathbf{p}'_i = \mathbf{p}_i + \boldsymbol{\epsilon}_i,
-#    \qquad
-#    \boldsymbol{\epsilon}_i \sim \mathcal{N}(0, \sigma^2 I),
-#
-# where :math:`\mathbf{p}_i` is the canonical phosphene location and
-# :math:`\sigma` is ``location_noise`` in dva. The offsets are fixed for a
-# model instance, so repeated stimulation of the same simulated subject gives
-# the same spatial distortion.
-
-np.random.seed(1)
-
-fig, axes = plt.subplots(ncols=2, sharey=True, figsize=(9, 4))
-for ax, noise, title in zip(
-        axes,
-        [None, 1],
-        ['Canonical map', 'Subject-specific variation']):
-    model = p2p.models.ScoreboardModel(
-        implant=implant,
-        xrange=(-6, 6),
-        yrange=(-6, 6),
-        visual_field_map=p2p.topography.Watson2014Map(),
-        location_noise=noise,
-    )
-    model.predict_percept(stim).plot(ax=ax)
-    ax.set_title(title)
-
-###############################################################################
-# ``location_noise`` changes where the percept appears, not the physical
-# electrode locations or the canonical map itself. This makes it useful for
-# simulating individual phosphene-location variability while keeping the same
-# anatomical model.
-#
 # Cortical visual field maps
 # --------------------------
 #
@@ -172,9 +101,116 @@ plt.show()
 # parameters ``a`` and ``b``, and azimuthal shear parameters ``alpha1``,
 # ``alpha2``, and ``alpha3`` for V1--V3. The defaults come from
 # [Polimeni2006]_, but cortical retinotopy varies substantially across people.
-# When subject-specific anatomy is available, a
-# :py:class:`~pulse2percept.topography.NeuropythyMap` can provide a more
+# When subject-specific anatomy is available,
+# :py:class:`~pulse2percept.topography.NeuropythyMap` can provide an
 # individualized mapping.
+#
+# Subject-specific phosphene locations
+# ------------------------------------
+#
+# Retinal and cortical maps describe a canonical relationship between tissue
+# and visual-field location. An individual phosphene may appear somewhere else
+# than that canonical map predicts. ``location_noise`` models this variability
+# without changing the underlying ``visual_field_map``.
+#
+# For electrode :math:`i`, pulse2percept draws a fixed visual-field offset:
+#
+# .. math::
+#
+#    \mathbf{p}'_i = \mathbf{p}_i + \boldsymbol{\epsilon}_i,
+#    \qquad
+#    \boldsymbol{\epsilon}_i \sim \mathcal{N}(0, \sigma^2 I),
+#
+# where :math:`\mathbf{p}_i` is the canonical phosphene location and
+# :math:`\sigma` is ``location_noise`` in dva. The offsets remain fixed for a
+# model instance.
+#
+# A sparse retinal pattern makes the effect easiest to see. With the linear
+# ``Curcio1990Map``, stimulating a regular subset of Argus II electrodes
+# produces an approximately regular grid of phosphenes. Adding
+# ``location_noise`` moves those phosphenes off the grid:
+
+implant = p2p.implants.ArgusII(raster=None)
+stim = {
+    electrode: 50
+    for electrode in ['A1', 'A3', 'A5',
+                      'C1', 'C3', 'C5',
+                      'E1', 'E3', 'E5']
+}
+
+fig, axes = plt.subplots(ncols=2, sharex=True, sharey=True, figsize=(9, 4))
+for ax, noise, title in zip(
+        axes,
+        [None, 1],
+        ['Canonical locations', 'Subject-specific locations']):
+    np.random.seed(1)
+    model = p2p.models.ScoreboardModel(
+        implant=implant,
+        xrange=(-10, 10),
+        yrange=(-7, 7),
+        visual_field_map=p2p.topography.Curcio1990Map(),
+        location_noise=noise,
+    )
+    model.predict_percept(stim).plot(ax=ax)
+    ax.set_title(title)
+
+###############################################################################
+# The same mechanism applies to cortical stimulation. Here a sparse set of
+# CORTIVIS electrodes is mapped through V1 with ``Polimeni2006Map``. The
+# cortical implant and retinotopic map are unchanged; only the predicted
+# phosphene locations differ:
+
+implant_cortex = p2p.implants.cortex.Cortivis()
+stim_cortex = {
+    electrode: 100
+    for electrode in implant_cortex.electrode_names[::12]
+}
+
+fig, axes = plt.subplots(ncols=2, sharex=True, sharey=True, figsize=(9, 4))
+for ax, noise, title in zip(
+        axes,
+        [None, 1],
+        ['Canonical locations', 'Subject-specific locations']):
+    np.random.seed(2)
+    model = p2p.models.cortex.ScoreboardModel(
+        implant=implant_cortex,
+        regions=['v1'],
+        xrange=(-6, 6),
+        yrange=(-6, 6),
+        location_noise=noise,
+    )
+    model.predict_percept(stim_cortex).plot(ax=ax)
+    ax.set_title(title)
+
+###############################################################################
+# With a more complex stimulus, the same location errors distort the percept
+# as a whole. Here the retinal implant sees the same encoded UCSB logo with and
+# without subject-specific phosphene displacement:
+
+implant = p2p.implants.AlphaAMS()
+stim = p2p.stimuli.LogoUCSB().encode(implant=implant)
+
+fig, axes = plt.subplots(ncols=2, sharex=True, sharey=True, figsize=(9, 4))
+for ax, noise, title in zip(
+        axes,
+        [None, 1],
+        ['Canonical locations', 'Subject-specific locations']):
+    np.random.seed(3)
+    model = p2p.models.ScoreboardModel(
+        implant=implant,
+        xrange=(-6, 6),
+        yrange=(-6, 6),
+        visual_field_map=p2p.topography.Watson2014Map(),
+        location_noise=noise,
+    )
+    model.predict_percept(stim).plot(ax=ax)
+    ax.set_title(title)
+
+###############################################################################
+# ``location_noise`` changes the predicted percept, not the physical electrode
+# locations or the canonical visual-field map. It therefore captures
+# subject-specific phosphene-location variability while leaving the anatomical
+# model intact.
 #
 # Creating your own visual field map
 # ----------------------------------

--- a/examples/models/plot_visual_field_maps.py
+++ b/examples/models/plot_visual_field_maps.py
@@ -1,75 +1,64 @@
 # -*- coding: utf-8 -*-
 """
 ===============================================================================
-Predicting the perceptual effects of different visual field maps
+Visual field maps and phosphene locations
 ===============================================================================
 
-Every computational model needs to assume a mapping between retinal and visual
-field coordinates (``visual_field_map``). A number of these visual field maps are provided in the
-:py:mod:`~pulse2percept.topography` module:
+A :py:class:`~pulse2percept.topography.VisualFieldMap` describes how locations
+in the visual field map onto retinal or cortical tissue. pulse2percept includes
+several built-in maps.
 
-*  :py:class:`~pulse2percept.topography.Curcio1990Map`: The [Curcio1990]_ model
-   simply assumes that one degree of visual angle (dva) is equal to 280 um on
-   the retina.
-*  :py:class:`~pulse2percept.topography.Watson2014Map`: The [Watson2014]_ model
-   extends [Curcio1990]_ by recognizing that the transformation between dva and
-   retinal eccentricity is not linear (see Eq. A5 in [Watson2014]_). However,
-   within 40 degrees of eccentricity, the transform is virtually
-   indistuingishable from [Curcio1990]_.
-*  :py:class:`~pulse2percept.topography.Watson2014DisplaceMap`: [Watson2014]_ also
-   describes the retinal ganglion cell (RGC) density at different retinal
-   eccentricities. In specific, there is a central retinal zone where RGC bodies
-   are displaced centrifugally some distance from the inner segments of the
-   cones to which they are connected through the bipolar cells, and thus from
-   their receptive field (see Eq. 5 [Watson2014]_).
-*  :py:class:`~pulse2percept.topography.Polimeni2006Map`: The [Polimeni2006]_
-   model is based on a high-resolution MRI scan of the human visual cortex. It
-   provides a mapping between visual field coordinates and cortical coordinates 
-   using a wedge-dipole model for regions V1, V2, and V3. See Appendix B of 
-   [Polimeni2006]_ for details.
-* :py:class:`~pulse2percept.topography.NeuropythyMap`: Neuropythy is a python
-   package that predicts patient-specific visuotopies based on MRI scans of the
-   human visual cortex. It provides a mapping between visual field coordinates
-   and 3D cortical coordinates for regions V1, V2, V3. See [Benson2018]_ for details.
+Retinal maps derive from :py:class:`~pulse2percept.topography.RetinalMap`
+and include:
 
-All of these visual field maps follow the templates in either 
-:py:class:`~pulse2percept.topography.RetinalMap` or 
-:py:class:`~pulse2percept.topography.CorticalMap`.
-This means that all retinal visual field maps have to specify a ``dva_to_ret`` method, 
-which transforms visual field coordinates into retinal coordinates, and all cortical 
-visual field maps have to specify atleast a ``dva_to_v1`` method, which transforms visual 
-field coordinates into cortical V1 coordinates. Cortical models map also specify ``dva_to_v2``
-and ``dva_to_v3`` methods, which transform visual field coordinates into cortical V2 and V3.
-Most visual field maps also specify the inverse transform, e.g. ``ret_to_dva`` or ``v1_to_dva``.
+* :py:class:`~pulse2percept.topography.Curcio1990Map` uses a linear retinal
+  scaling of 280 microns per degree of visual angle (dva).
+* :py:class:`~pulse2percept.topography.Watson2014Map` uses the nonlinear
+  retinal magnification model from [Watson2014]_.
+* :py:class:`~pulse2percept.topography.Watson2014DisplaceMap` additionally
+  accounts for retinal ganglion-cell displacement near the fovea.
+
+Cortical maps derive from :py:class:`~pulse2percept.topography.CorticalMap`
+and include:
+
+* :py:class:`~pulse2percept.topography.Polimeni2006Map` maps visual field
+  locations onto V1, V2, and V3 using the wedge-dipole model from
+  [Polimeni2006]_.
+* :py:class:`~pulse2percept.topography.NeuropythyMap` uses Neuropythy to
+  estimate subject-specific cortical maps from MRI data [Benson2018]_.
 
 Visual field maps
 -----------------
 
-To appreciate the difference between the available visual field maps, let us
-look at a rectangular grid in visual field coordinates:
-
+To see how the retinal maps differ, start with a regular grid in the visual
+field:
 """
-# sphinx_gallery_thumbnail_number = 3
+
+# sphinx_gallery_thumbnail_number = 4
+
+import matplotlib.pyplot as plt
+import numpy as np
 
 import pulse2percept as p2p
-import matplotlib.pyplot as plt
+
 
 grid = p2p.topography.Grid2D((-50, 50), (-50, 50), step=5)
 grid.plot(style='scatter', use_dva=True)
-plt.xlabel('x (degrees of visual angle)')
-plt.ylabel('y (degrees of visual angle)')
+plt.xlabel('x (dva)')
+plt.ylabel('y (dva)')
 plt.axis('square')
 
 ###############################################################################
-# Such a grid is typically created during a model's ``build`` process and
-# defines at which (x,y) locations the percept is to be evaluated.
-#
-# However, these visual field coordinates are mapped onto different retinal
-# coordinates under the three visual field maps:
+# A model creates a similar grid during ``build`` and maps it onto the tissue
+# coordinates required by its spatial model. The same visual-field grid looks
+# different under the available retinal maps:
 
-transforms = [p2p.topography.Curcio1990Map(),
-              p2p.topography.Watson2014Map(),
-              p2p.topography.Watson2014DisplaceMap()]
+transforms = [
+    p2p.topography.Curcio1990Map(),
+    p2p.topography.Watson2014Map(),
+    p2p.topography.Watson2014DisplaceMap(),
+]
+
 fig, axes = plt.subplots(ncols=3, sharey=True, figsize=(13, 4))
 for ax, transform in zip(axes, transforms):
     grid.build(transform)
@@ -80,91 +69,120 @@ for ax, transform in zip(axes, transforms):
     ax.axis('equal')
 
 ###############################################################################
-# Whereas the [Curcio1990]_ map applies a simple scaling factor to the visual
-# field coordinates, [Watson2014]_ uses a nonlinear transform.
-# One thing to note is the RGC displacement zone in the third panel, which might
-# lead to distortions in the fovea.
+# ``Curcio1990Map`` is a simple scaling, whereas ``Watson2014Map`` is
+# nonlinear. ``Watson2014DisplaceMap`` adds the prominent foveal distortion
+# caused by retinal ganglion-cell displacement.
 #
-# Perceptual distortions
-# ----------------------
+# Perceptual consequences
+# -----------------------
 #
-# The perceptual consequences of these visual field maps become apparent when
-# used in combination with an implant.
-#
-# For this purpose, let us create an :py:class:`~pulse2percept.models.AlphaAMS`
-# device on the fovea and feed it a suitable stimulus:
+# These differences matter because the visual-field map determines where an
+# implant lies relative to the simulated visual field. Here we stimulate an
+# :py:class:`~pulse2percept.implants.AlphaAMS` with the same encoded image under
+# each retinal map:
 
-# The image has to be encoded into current before a model can read it: gray
-# levels are not microamps, and `encode` is the step that says how much
-# current each one stands for.
 implant = p2p.implants.AlphaAMS()
 stim = p2p.stimuli.LogoUCSB().encode(implant=implant)
-stim
-
-###############################################################################
-# We can easily switch out the visual field maps by passing a
-# ``visual_field_map`` attribute to
-# :py:class:`~pulse2percept.models.ScoreboardModel` (by default, the
-# scoreboard model will use [Curcio1990]_):
 
 fig, axes = plt.subplots(ncols=3, sharey=True, figsize=(13, 4))
 for ax, transform in zip(axes, transforms):
-    model = p2p.models.ScoreboardModel(implant=implant, xrange=(-6, 6),
-                                       yrange=(-6, 6),
-                                       visual_field_map=transform)
+    model = p2p.models.ScoreboardModel(
+        implant=implant,
+        xrange=(-6, 6),
+        yrange=(-6, 6),
+        visual_field_map=transform,
+    )
     model.predict_percept(stim).plot(ax=ax)
     ax.set_title(transform.__class__.__name__)
 
 ###############################################################################
-# Whereas the left and center panel look virtually identical, the rightmost
-# panel predicts a rather striking perceptual effect of the RGC displacement
-# zone.
+# The first two maps give very similar percepts at this scale. The RGC
+# displacement map produces a much stronger foveal distortion.
 #
+# Subject-specific phosphene locations
+# ------------------------------------
+#
+# A visual-field map is still only a canonical mapping. In an individual
+# implant user, a phosphene may appear somewhere else than the map predicts.
+# ``location_noise`` models this subject-specific variability without changing
+# the underlying ``visual_field_map``.
+#
+# For electrode :math:`i`, pulse2percept draws a fixed visual-field offset
+#
+# .. math::
+#
+#    \mathbf{p}'_i = \mathbf{p}_i + \boldsymbol{\epsilon}_i,
+#    \qquad
+#    \boldsymbol{\epsilon}_i \sim \mathcal{N}(0, \sigma^2 I),
+#
+# where :math:`\mathbf{p}_i` is the canonical phosphene location and
+# :math:`\sigma` is ``location_noise`` in dva. The offsets are fixed for a
+# model instance, so repeated stimulation of the same simulated subject gives
+# the same spatial distortion.
+
+np.random.seed(1)
+
+fig, axes = plt.subplots(ncols=2, sharey=True, figsize=(9, 4))
+for ax, noise, title in zip(
+        axes,
+        [None, 1],
+        ['Canonical map', 'Subject-specific variation']):
+    model = p2p.models.ScoreboardModel(
+        implant=implant,
+        xrange=(-6, 6),
+        yrange=(-6, 6),
+        visual_field_map=p2p.topography.Watson2014Map(),
+        location_noise=noise,
+    )
+    model.predict_percept(stim).plot(ax=ax)
+    ax.set_title(title)
+
+###############################################################################
+# ``location_noise`` changes where the percept appears, not the physical
+# electrode locations or the canonical map itself. This makes it useful for
+# simulating individual phosphene-location variability while keeping the same
+# anatomical model.
 #
 # Cortical visual field maps
 # --------------------------
 #
-# When working with a cortical model (e.g. from pulse2percept.models.cortex),
-# then you should use a cortical visual field map. These maps are subclasses of
-# :py:class:`~pulse2percept.topography.CorticalMap`. Each cortical map has a 
-# ``regions`` attribute, which specifies the cortical regions that the map uses.
-# 
-# Cortical maps simulate both hemispheres of the visual cortex on a single coordinate 
-# plane. The left hemisphere fovea is located at ``visual_field_map.left_offset`` (default: 
-# -20 mm), and current is not allowed to spread between hemispheres. 
-# 
-# The standard cortical map is :py:class:`~pulse2percept.topography.Polimeni2006Map`, 
-# which uses a wedge-dipole model to map visual field coordinates onto cortical 
-# coordinates in V1, V2, and V3. 
-fig, ax = plt.subplots(ncols=2, figsize=(9, 4))
-visual_field_map = p2p.topography.Polimeni2006Map(regions=['v1', 'v2', 'v3']) # simulate all 3 regions
-model = p2p.models.cortex.ScoreboardModel(implant=p2p.implants.cortex.Orion(),
-                                          visual_field_map=visual_field_map)
+# Cortical models use a
+# :py:class:`~pulse2percept.topography.CorticalMap`. The standard choice is
+# :py:class:`~pulse2percept.topography.Polimeni2006Map`, which maps the visual
+# field onto V1, V2, and V3:
+
+fig, axes = plt.subplots(ncols=2, figsize=(9, 4))
+
+visual_field_map = p2p.topography.Polimeni2006Map(
+    regions=['v1', 'v2', 'v3'])
+model = p2p.models.cortex.ScoreboardModel(
+    implant=p2p.implants.cortex.Orion(),
+    visual_field_map=visual_field_map,
+)
 model.build()
-visual_field_map.plot(ax=ax[0])
-ax[0].set_title('Polimeni Mapping')
-model.plot(ax=ax[1])
-ax[1].set_title('Points in Cortex')
+
+visual_field_map.plot(ax=axes[0])
+axes[0].set_title('Polimeni map')
+model.plot(ax=axes[1])
+axes[1].set_title('Model grid')
 plt.show()
 
 ###############################################################################
-# The Polimeni map has 6 parameters that can be adjusted: ``k``, a global scaling
-# factor; ``a``, and ``b``, which are global wedge-dipole parameters, and 
-# ``alpha1``, ``alpha2``, and ``alpha3``, which are azimuthal shear parameters 
-# for V1, V2, and V3, respectively. The default values for these parameters are
-# taken from [Polimeni2006]_ based on MRI fits to human visual cortex. These 
-# values are known to change dramatically between individuals, so it may be important
-# to adjust these parameters to fit the individual subject.
-#
+# ``Polimeni2006Map`` has six parameters: the global scale ``k``, wedge-dipole
+# parameters ``a`` and ``b``, and azimuthal shear parameters ``alpha1``,
+# ``alpha2``, and ``alpha3`` for V1--V3. The defaults come from
+# [Polimeni2006]_, but cortical retinotopy varies substantially across people.
+# When subject-specific anatomy is available, a
+# :py:class:`~pulse2percept.topography.NeuropythyMap` can provide a more
+# individualized mapping.
 #
 # Creating your own visual field map
 # ----------------------------------
 #
-# To create your own (retinal) visual field map, you need to subclass the
-# :py:class:`~pulse2percept.topography.RetinalMap` template and provide your own
-# ``dva_to_ret`` and ``ret_to_dva`` methods.
-# For example, the following class would (wrongly) assume that retinal
-# coordinates are identical to visual field coordinates:
+# Custom retinal maps subclass
+# :py:class:`~pulse2percept.topography.RetinalMap` and implement ``dva_to_ret``.
+# An inverse ``ret_to_dva`` should also be provided when the mapping can be
+# inverted. For example:
 #
 # .. code-block:: python
 #
@@ -176,6 +194,5 @@ plt.show()
 #         def ret_to_dva(self, xret, yret):
 #             return xret, yret
 #
-# To use it with a model, you need to pass
-# ``visual_field_map=MyVisualFieldMap()`` to the model's constructor.
-#
+# Pass the map to a model with
+# ``visual_field_map=MyVisualFieldMap()``.

--- a/examples/models/plot_visual_field_maps.py
+++ b/examples/models/plot_visual_field_maps.py
@@ -146,7 +146,7 @@ for ax, noise, title in zip(
     np.random.seed(1)
     model = p2p.models.ScoreboardModel(
         implant=implant,
-        xrange=(-10, 10),
+        xrange=(-12, 2),
         yrange=(-7, 7),
         visual_field_map=p2p.topography.Curcio1990Map(),
         location_noise=noise,
@@ -155,37 +155,46 @@ for ax, noise, title in zip(
     ax.set_title(title)
 
 ###############################################################################
-# The same mechanism applies to cortical stimulation. Here a sparse set of
+# The phosphenes move; they do not change shape. Each one is still the circular
+# Gaussian the Scoreboard model draws, sitting somewhere else in the visual
+# field.
+#
+# The same mechanism applies to cortical stimulation. Here a sparse subset of
 # CORTIVIS electrodes is mapped through V1 with ``Polimeni2006Map``. The
 # cortical implant and retinotopic map are unchanged; only the predicted
 # phosphene locations differ:
 
 implant_cortex = p2p.implants.cortex.Cortivis()
+cortex_coords = implant_cortex.electrode_array.coordinates(p2p.units.um)
 stim_cortex = {
     electrode: 100
-    for electrode in implant_cortex.electrode_names[::12]
+    for electrode, (x, y) in zip(implant_cortex.electrode_names,
+                                 cortex_coords[:, :2])
+    if round(x) in (18600, 20200, 21400) and round(y) in (-6400, -4800, -3600)
 }
 
 fig, axes = plt.subplots(ncols=2, sharex=True, sharey=True, figsize=(9, 4))
 for ax, noise, title in zip(
         axes,
-        [None, 1],
+        [None, 0.5],
         ['Canonical locations', 'Subject-specific locations']):
     np.random.seed(2)
     model = p2p.models.cortex.ScoreboardModel(
         implant=implant_cortex,
         regions=['v1'],
-        xrange=(-6, 6),
-        yrange=(-6, 6),
+        rho=300,
+        xrange=(-4, 0.5),
+        yrange=(-1, 3.5),
+        step=0.02,
         location_noise=noise,
     )
     model.predict_percept(stim_cortex).plot(ax=ax)
     ax.set_title(title)
 
 ###############################################################################
-# With a more complex stimulus, the same location errors distort the percept
-# as a whole. Here the retinal implant sees the same encoded UCSB logo with and
-# without subject-specific phosphene displacement:
+# With a dense stimulus, the same per-electrode offsets scramble the percept as
+# a whole. Here the retinal implant sees the same encoded UCSB logo with and
+# without subject-specific phosphene locations:
 
 implant = p2p.implants.AlphaAMS()
 stim = p2p.stimuli.LogoUCSB().encode(implant=implant)
@@ -193,7 +202,7 @@ stim = p2p.stimuli.LogoUCSB().encode(implant=implant)
 fig, axes = plt.subplots(ncols=2, sharex=True, sharey=True, figsize=(9, 4))
 for ax, noise, title in zip(
         axes,
-        [None, 1],
+        [None, 0.3],
         ['Canonical locations', 'Subject-specific locations']):
     np.random.seed(3)
     model = p2p.models.ScoreboardModel(
@@ -207,10 +216,15 @@ for ax, noise, title in zip(
     ax.set_title(title)
 
 ###############################################################################
+# The logo stays legible but its mosaic is spatially jumbled: the phosphenes
+# are the same, only misplaced.
+#
 # ``location_noise`` changes the predicted percept, not the physical electrode
 # locations or the canonical visual-field map. It therefore captures
 # subject-specific phosphene-location variability while leaving the anatomical
-# model intact.
+# model intact. It requires a map that can place electrodes in the visual
+# field, so a map without an inverse (such as ``Watson2014DisplaceMap``) is not
+# supported.
 #
 # Creating your own visual field map
 # ----------------------------------

--- a/pulse2percept/models/base.py
+++ b/pulse2percept/models/base.py
@@ -746,7 +746,11 @@ class SpatialModel(BaseModel, metaclass=ABCMeta):
     location_noise : float or None, optional
         Standard deviation of the variation in phosphene location from the
         ``visual_field_map``, in dva. Locations are fixed for a model instance.
-        ``None`` or 0 disables the variation.
+        ``None`` or 0 disables the variation. Requires a ``visual_field_map``
+        that implements ``to_dva``, which is what places the electrodes in the
+        visual field. Phenomenological: the standard deviation is not
+        empirically calibrated, and trial-to-trial or gaze-dependent shifts
+        are not modeled.
 
         .. versionadded:: 0.11.0
 

--- a/pulse2percept/models/base.py
+++ b/pulse2percept/models/base.py
@@ -356,18 +356,19 @@ def _blend_meridian(resp, grid, meridian, width):
 
 
 def _electrode_dva(model):
-    """Return the implant's electrode coordinates in dva.
+    """Return the implant's electrode locations in dva.
 
-    Requires an invertible ``visual_field_map``. On a map with several
-    regions, the electrodes sit in one place, so the model's first region is
-    the one that locates them.
+    Requires an invertible ``visual_field_map``, which is handed as many
+    tissue coordinates as it has dimensions. On a map with several regions the
+    electrodes still sit in one place, so the model's first region is the one
+    that locates them. Locations the map cannot resolve come back non-finite.
     """
     vfmap = model.visual_field_map
     coords = model.implant.electrode_array.coordinates(vfmap.tissue_unit)
     try:
         inverse = vfmap.to_dva()
         regions = getattr(model, 'regions', None) or list(inverse)
-        x, y = inverse[regions[0]](coords[:, 0], coords[:, 1])
+        x, y = inverse[regions[0]](*coords[:, :vfmap.ndim].T)
     except (NotImplementedError, KeyError):
         raise NotImplementedError(
             f"location_noise places electrodes in the visual field, which "
@@ -376,6 +377,22 @@ def _electrode_dva(model):
             f"dva.") from None
     return (np.asarray(x, dtype=np.float64).ravel(),
             np.asarray(y, dtype=np.float64).ravel())
+
+
+def _electrode_offsets(model, sigma):
+    """Return this subject's electrode displacements in dva.
+
+    The latent standard normals are drawn once per model instance and cached,
+    so rebuilding (after a change to ``rho``, ``step``, ...) rescales the same
+    subject instead of simulating a new one. A new model instance, or a new
+    implant, is a new subject.
+    """
+    n_electrodes = len(model.implant.electrode_array.electrodes)
+    latent = model._location_noise_z
+    if latent is None or latent.shape[0] != n_electrodes:
+        latent = np.random.normal(size=(n_electrodes, 2))
+        model._location_noise_z = latent
+    return sigma * latent
 
 
 def _axis_origin_step(along):
@@ -398,17 +415,16 @@ def _fractional_index(axis, coord):
 
 
 def _location_noise_field(model):
-    """Return the sampling coordinates that displace percepts on the grid.
+    """Return the sampling coordinates of the location-noise warp.
 
-    Draws one Gaussian ``(dx, dy)`` offset per electrode in dva, interpolates
-    those offsets across ``model.grid``, and expresses the result as fractional
-    row/column indices for ``map_coordinates``: a grid point reads the
-    undisplaced response one offset away, so a phosphene at ``e`` is rendered
-    at ``e + offset(e)``. Returns None when the noise is disabled.
-
-    ``location_noise`` is the standard deviation in dva, and the offsets are
-    drawn from the global NumPy random state, so ``np.random.seed`` makes a
-    build reproducible.
+    The subject's offsets (see ``_electrode_offsets``) put the percept of an
+    electrode whose canonical location is ``e`` at ``e + offset``. The
+    *inverse* displacement is what warps the rendered field, so ``-offset`` is
+    interpolated at the displaced locations ``e + offset``: that makes those
+    correspondences exact rather than only true for a uniform shift. The
+    result is returned as fractional row/column indices for
+    ``map_coordinates``, which pulls each grid point from where the
+    undisplaced response holds its value. Returns None when the warp is off.
     """
     sigma = model.location_noise
     if sigma is None:
@@ -426,9 +442,18 @@ def _location_noise_field(model):
         # A single grid point cannot be displaced:
         return None
     x_el, y_el = _electrode_dva(model)
-    offsets = np.random.normal(0.0, sigma, size=(x_el.size, 2))
-    points = np.column_stack([x_el, y_el])
-    # One interpolation node per location: electrodes that map to the same
+    offsets = _electrode_offsets(model, sigma)
+    # Electrodes the map places outside the visual field (`NeuropythyMap`
+    # returns NaN beyond its mesh) cannot anchor the warp:
+    seen = np.isfinite(x_el) & np.isfinite(y_el)
+    if not np.any(seen):
+        raise ValueError(
+            f"location_noise needs at least one electrode that "
+            f"{type(model.visual_field_map).__name__} can place in the visual "
+            f"field, and it maps none of this implant's electrodes there.")
+    offsets = offsets[seen]
+    points = np.column_stack([x_el[seen], y_el[seen]]) + offsets
+    # One interpolation node per location: electrodes displaced onto the same
     # visual-field point cannot pull the field in two directions, and a
     # repeated node makes the interpolation matrix singular.
     points, inverse = np.unique(points, axis=0, return_inverse=True)
@@ -440,15 +465,15 @@ def _location_noise_field(model):
         offsets = merged / counts[:, np.newaxis]
     query = np.column_stack([grid.x.ravel(), grid.y.ravel()])
     if points.shape[0] == 1:
-        shift = np.broadcast_to(offsets[0], query.shape)
+        back = np.broadcast_to(-offsets[0], query.shape)
     else:
         # The linear kernel (-r) needs no shape parameter and stays solvable
         # for collinear electrodes, which a thin-plate spline is not:
-        shift = RBFInterpolator(points, offsets, kernel='linear')(query)
-    dx = shift[:, 0].reshape(grid.x.shape)
-    dy = shift[:, 1].reshape(grid.y.shape)
-    return np.stack([_fractional_index(rows, grid.y - dy),
-                     _fractional_index(cols, grid.x - dx)]).astype(np.float64)
+        back = RBFInterpolator(points, -offsets, kernel='linear')(query)
+    dx = back[:, 0].reshape(grid.x.shape)
+    dy = back[:, 1].reshape(grid.y.shape)
+    return np.stack([_fractional_index(rows, grid.y + dy),
+                     _fractional_index(cols, grid.x + dx)])
 
 
 def _warp_visual_field(resp, grid, sample):
@@ -456,7 +481,8 @@ def _warp_visual_field(resp, grid, sample):
 
     ``sample`` holds the fractional row/column indices built by
     ``_location_noise_field``. Time points are warped independently by bilinear
-    interpolation; a sample falling off the grid repeats its edge value.
+    interpolation. A grid point that pulls from outside the simulated field
+    reads zero, since nothing is known about the percept out there.
     """
     if sample is None:
         return resp
@@ -464,7 +490,7 @@ def _warp_visual_field(resp, grid, sample):
     warped = np.empty_like(work)
     for t in range(work.shape[-1]):
         warped[..., t] = map_coordinates(work[..., t], sample, order=1,
-                                         mode='nearest')
+                                         mode='constant', cval=0)
     return warped.reshape(resp.shape).astype(resp.dtype, copy=False)
 
 
@@ -745,12 +771,15 @@ class SpatialModel(BaseModel, metaclass=ABCMeta):
         Salt-and-pepper noise applied to each percept frame. An integer gives
         the number of affected pixels; a float in [0, 1] gives their fraction.
     location_noise : float or None, optional
-        Standard deviation (dva) of the retinotopic jitter between where an
-        electrode sits and where its percept appears. One offset is drawn per
-        electrode at build time and interpolated across the grid, so the
-        displacement is smooth and fixed until the model is rebuilt. ``None``
-        or 0 leaves the percept untouched. Offsets come from the global NumPy
-        random state; seed it for a reproducible build.
+        Standard deviation (dva) of a subject-specific retinotopic distortion:
+        how far the percept of an electrode lands from where the canonical
+        ``visual_field_map`` predicts it. One offset is drawn per electrode and
+        interpolated smoothly across the grid, then warps the rendered percept
+        as a whole, so overlapping phosphenes stay consistent with each other.
+        The distortion belongs to the model instance and survives a rebuild;
+        a new instance is a new subject. ``None`` or 0 leaves the percept
+        untouched. Offsets come from the global NumPy random state; seed it
+        before constructing the model to reproduce a subject.
 
         .. versionadded:: 0.11.0
 
@@ -785,7 +814,9 @@ class SpatialModel(BaseModel, metaclass=ABCMeta):
         # `_visual_field_map_first`.
         super().__init__(**_visual_field_map_first(params))
         self.grid = None
-        # Set by `build`; see `_location_noise_field`:
+        # This subject's electrode offsets and the grid warp they produce; see
+        # `_electrode_offsets` and `_location_noise_field`:
+        self._location_noise_z = None
         self._location_noise = None
 
     @property
@@ -810,6 +841,8 @@ class SpatialModel(BaseModel, metaclass=ABCMeta):
         if implant is not self._implant:
             # Spatial build state depends on implant geometry:
             self._is_built = False
+            # A different implant is a different set of electrodes to displace:
+            self._location_noise_z = None
         self._implant = implant
 
     def set_params(self, **params):

--- a/pulse2percept/models/base.py
+++ b/pulse2percept/models/base.py
@@ -384,24 +384,30 @@ def _electrode_offsets(model, electrodes):
     """Return the (n, 2) dva displacements of the named electrodes.
 
     ``None`` where ``location_noise`` is disabled. Matched by electrode name,
-    since a compressed stimulus carries only a subset of the implant.
+    since a compressed stimulus carries only a subset of the implant. Names
+    are matched by identity: an array may name its electrodes with integers,
+    for which ``0`` and ``'0'`` are different electrodes.
     """
     sigma = _location_noise_sigma(model)
     if sigma is None:
         return None
     names, latent = _latent_offsets(model)
     row = {name: i for i, name in enumerate(names)}
-    return sigma * latent[[row[str(e)] for e in electrodes]]
+    return sigma * latent[[row[e] for e in electrodes]]
 
 
-def _displaced_coords(model, region, xyz, offsets):
+def _displaced_coords(model, region, electrodes, xyz, offsets):
     """Return the effective tissue coordinates of displaced electrodes.
 
     Round-trips each electrode through ``region`` of the visual field map:
     tissue -> dva, add the electrode's fixed offset, dva -> tissue. Only the
-    percept prediction sees these; the implant is not moved. Electrodes the
-    map cannot place in the visual field (NaN) keep their canonical
-    coordinates.
+    percept prediction sees these; the implant is not moved.
+
+    Raises if the map places an electrode nowhere, before or after the offset.
+    Substituting the canonical location would set that electrode's offset to
+    zero, which censors the Gaussian near the edge of a map's domain and makes
+    ``location_noise`` mean something different depending on where an
+    electrode sits.
     """
     vfmap = model.visual_field_map
     try:
@@ -412,21 +418,33 @@ def _displaced_coords(model, region, xyz, offsets):
     except (NotImplementedError, KeyError):
         raise NotImplementedError(
             f"location_noise places electrodes in the visual field, which "
-            f"requires a visual field map that can map tissue coordinates "
-            f"back to dva. {type(vfmap).__name__} cannot.") from None
+            f"requires an invertible visual field map. "
+            f"{type(vfmap).__name__} cannot map tissue coordinates back to "
+            f"dva.") from None
+    _require_placed(model, region, electrodes, [x_dva, y_dva], 'canonical')
     moved = [np.asarray(c, dtype=np.float64) for c in
              vfmap.from_dva()[region](x_dva + offsets[:, 0],
                                       y_dva + offsets[:, 1])]
-    # An electrode the map cannot place, or cannot place once displaced, stays
-    # where it is rather than turning the kernel's input into NaN:
-    placed = np.isfinite(x_dva) & np.isfinite(y_dva)
-    for coord in moved:
-        placed &= np.isfinite(coord)
+    _require_placed(model, region, electrodes, moved, 'displaced')
     out = list(xyz)
     for i, coord in enumerate(moved[:len(out)]):
-        out[i] = np.ascontiguousarray(np.where(placed, coord, xyz[i]),
-                                      dtype=np.float32)
+        out[i] = np.ascontiguousarray(coord, dtype=np.float32)
     return tuple(out)
+
+
+def _require_placed(model, region, electrodes, coords, which):
+    """Raise if the map returned a non-finite coordinate for an electrode."""
+    placed = np.ones(len(electrodes), dtype=bool)
+    for coord in coords:
+        placed &= np.isfinite(np.asarray(coord, dtype=np.float64))
+    if np.all(placed):
+        return
+    lost = [str(e) for e, ok in zip(electrodes, placed) if not ok]
+    raise ValueError(
+        f"location_noise cannot displace electrode(s) "
+        f"{', '.join(repr(e) for e in lost[:5])} in region {region!r} because "
+        f"{type(model.visual_field_map).__name__} does not map their "
+        f"{which} location.")
 
 
 #: Parameter names declared by each model class, cached for ``__setattr__``.
@@ -713,8 +731,8 @@ class SpatialModel(BaseModel, metaclass=ABCMeta):
     location_noise : float or None, optional
         Standard deviation of the variation in phosphene location from the
         ``visual_field_map``, in dva. Locations are fixed for a model instance.
-        ``None`` or 0 disables the variation. Requires a ``visual_field_map``
-        that implements ``to_dva``, which is what places the electrodes in the
+        ``None`` or 0 disables the variation. Requires an invertible
+        ``visual_field_map``, which is what places the electrodes in the
         visual field. Phenomenological: the standard deviation is not
         empirically calibrated, and trial-to-trial or gaze-dependent shifts
         are not modeled.
@@ -991,7 +1009,7 @@ class SpatialModel(BaseModel, metaclass=ABCMeta):
                                  f"through, since {type(self).__name__} maps "
                                  f"{regions}.")
             region = regions[0]
-        return _displaced_coords(self, region, xyz, offsets)
+        return _displaced_coords(self, region, electrodes, xyz, offsets)
 
     def _postprocess_spatial(self, resp):
         """Hook for spatial-model postprocessing."""

--- a/pulse2percept/models/base.py
+++ b/pulse2percept/models/base.py
@@ -439,7 +439,11 @@ def _require_placed(model, region, electrodes, coords, which):
         placed &= np.isfinite(np.asarray(coord, dtype=np.float64))
     if np.all(placed):
         return
-    lost = [str(e) for e, ok in zip(electrodes, placed) if not ok]
+    # `.item()` unwraps the NumPy scalars a stimulus reports, so that an
+    # integer-named electrode prints as `0` rather than `np.int64(0)` -- and
+    # still not as `'0'`, which would be a different electrode.
+    lost = [e.item() if isinstance(e, np.generic) else e
+            for e, ok in zip(electrodes, placed) if not ok]
     raise ValueError(
         f"location_noise cannot displace electrode(s) "
         f"{', '.join(repr(e) for e in lost[:5])} in region {region!r} because "

--- a/pulse2percept/models/base.py
+++ b/pulse2percept/models/base.py
@@ -7,8 +7,7 @@ from abc import ABCMeta, abstractmethod
 from copy import deepcopy, copy
 import numpy as np
 import multiprocessing
-from scipy.interpolate import RBFInterpolator
-from scipy.ndimage import gaussian_filter1d, map_coordinates
+from scipy.ndimage import gaussian_filter1d
 from scipy.spatial import cKDTree
 
 from ..implants import Implant
@@ -355,59 +354,8 @@ def _blend_meridian(resp, grid, meridian, width):
     return blurred.reshape(resp.shape).astype(resp.dtype, copy=False)
 
 
-def _electrode_dva(model):
-    """Return the visual-field locations of the implant's electrodes."""
-    vfmap = model.visual_field_map
-    coords = model.implant.electrode_array.coordinates(vfmap.tissue_unit)
-    tissue = coords[:, :vfmap.ndim].T
-    try:
-        inverse = vfmap.to_dva()
-        regions = getattr(model, 'regions', None) or list(inverse)
-        placed = [inverse[region](*tissue) for region in regions]
-    except (NotImplementedError, KeyError):
-        raise NotImplementedError(
-            f"location_noise places electrodes in the visual field, which "
-            f"requires a visual field map that can be inverted. "
-            f"{type(vfmap).__name__} cannot map tissue coordinates back to "
-            f"dva.") from None
-    flat = [[np.asarray(c, dtype=np.float64).ravel() for c in xy]
-            for xy in placed]
-    electrode = np.tile(np.arange(coords.shape[0]), len(placed))
-    return (np.concatenate([xy[0] for xy in flat]),
-            np.concatenate([xy[1] for xy in flat]), electrode)
-
-
-def _electrode_offsets(model, sigma):
-    """Return this subject's electrode displacements in dva."""
-    n_electrodes = len(model.implant.electrode_array.electrodes)
-    latent = model._location_noise_z
-    if latent is None or latent.shape[0] != n_electrodes:
-        latent = np.random.normal(size=(n_electrodes, 2))
-        model._location_noise_z = latent
-    return sigma * latent
-
-
-def _axis_origin_step(along):
-    """Return (origin, signed spacing) of a regular grid axis.
-
-    Returns None for an axis with a single sample.
-    """
-    if along.size < 2:
-        return None
-    return float(along[0]), float(np.diff(along).mean())
-
-
-def _fractional_index(axis, coord):
-    """Position of ``coord`` along a grid axis, in fractional sample index"""
-    if axis is None:
-        # A single sample along this axis: nothing to shift into.
-        return np.zeros_like(coord)
-    origin, step = axis
-    return (coord - origin) / step
-
-
-def _location_noise_field(model):
-    """Return the sampling coordinates of the location-noise warp"""
+def _location_noise_sigma(model):
+    """Return ``location_noise`` in dva, or None where it is disabled."""
     sigma = model.location_noise
     if sigma is None:
         return None
@@ -415,56 +363,70 @@ def _location_noise_field(model):
     if sigma < 0:
         raise ValueError(f"location_noise must be non-negative (or None to "
                          f"disable it), not {sigma}.")
-    if sigma == 0:
-        return None
-    grid = model.grid
-    rows = _axis_origin_step(grid.y[:, 0])
-    cols = _axis_origin_step(grid.x[0, :])
-    if rows is None and cols is None:
-        # A single grid point cannot be displaced:
-        return None
-    x_el, y_el, electrode = _electrode_dva(model)
-    offsets = _electrode_offsets(model, sigma)[electrode]
-    # Electrodes the map places outside the visual field (`NeuropythyMap`
-    # returns NaN beyond its mesh) cannot anchor the warp:
-    seen = np.isfinite(x_el) & np.isfinite(y_el)
-    if not np.any(seen):
-        raise ValueError(
-            f"location_noise needs at least one electrode that "
-            f"{type(model.visual_field_map).__name__} can place in the visual "
-            f"field, and it maps none of this implant's electrodes there.")
-    offsets = offsets[seen]
-    points = np.column_stack([x_el[seen], y_el[seen]]) + offsets
-    # One interpolation node per location:
-    points, inverse = np.unique(points, axis=0, return_inverse=True)
-    inverse = np.ravel(inverse)
-    counts = np.bincount(inverse, minlength=points.shape[0])
-    merged = np.zeros((points.shape[0], 2))
-    np.add.at(merged, inverse, offsets)
-    offsets = merged / counts[:, np.newaxis]
-    query = np.column_stack([grid.x.ravel(), grid.y.ravel()])
-    if points.shape[0] == 1:
-        back = np.broadcast_to(-offsets[0], query.shape)
-    else:
-        # The linear kernel (-r) needs no shape parameter and stays solvable
-        # for collinear electrodes, which a thin-plate spline is not:
-        back = RBFInterpolator(points, -offsets, kernel='linear')(query)
-    dx = back[:, 0].reshape(grid.x.shape)
-    dy = back[:, 1].reshape(grid.y.shape)
-    return np.stack([_fractional_index(rows, grid.y + dy),
-                     _fractional_index(cols, grid.x + dx)])
+    return sigma if sigma > 0 else None
 
 
-def _warp_visual_field(resp, grid, sample):
-    """Resample a response at displaced visual-field locations"""
-    if sample is None:
-        return resp
-    work = np.asarray(resp).reshape(grid.x.shape + (-1,))
-    warped = np.empty_like(work)
-    for t in range(work.shape[-1]):
-        warped[..., t] = map_coordinates(work[..., t], sample, order=1,
-                                         mode='constant', cval=0)
-    return warped.reshape(resp.shape).astype(resp.dtype, copy=False)
+def _latent_offsets(model):
+    """Return (electrode names, this subject's (n, 2) standard normals).
+
+    Drawn once per implant and kept on the model, so that the same subject is
+    simulated across predictions, rebuilds and copies.
+    """
+    names = list(model.implant.electrode_array.electrodes)
+    latent = model._location_noise_z
+    if latent is None or latent.shape[0] != len(names):
+        latent = np.random.normal(size=(len(names), 2))
+        model._location_noise_z = latent
+    return names, latent
+
+
+def _electrode_offsets(model, electrodes):
+    """Return the (n, 2) dva displacements of the named electrodes.
+
+    ``None`` where ``location_noise`` is disabled. Matched by electrode name,
+    since a compressed stimulus carries only a subset of the implant.
+    """
+    sigma = _location_noise_sigma(model)
+    if sigma is None:
+        return None
+    names, latent = _latent_offsets(model)
+    row = {name: i for i, name in enumerate(names)}
+    return sigma * latent[[row[str(e)] for e in electrodes]]
+
+
+def _displaced_coords(model, region, xyz, offsets):
+    """Return the effective tissue coordinates of displaced electrodes.
+
+    Round-trips each electrode through ``region`` of the visual field map:
+    tissue -> dva, add the electrode's fixed offset, dva -> tissue. Only the
+    percept prediction sees these; the implant is not moved. Electrodes the
+    map cannot place in the visual field (NaN) keep their canonical
+    coordinates.
+    """
+    vfmap = model.visual_field_map
+    try:
+        inverse = vfmap.to_dva()[region]
+        args = xyz[:vfmap.ndim] if vfmap.ndim == 3 else xyz[:2]
+        # Copies, since a map is free to edit the array it is handed:
+        x_dva, y_dva = inverse(*[np.array(a, dtype=np.float64) for a in args])
+    except (NotImplementedError, KeyError):
+        raise NotImplementedError(
+            f"location_noise places electrodes in the visual field, which "
+            f"requires a visual field map that can map tissue coordinates "
+            f"back to dva. {type(vfmap).__name__} cannot.") from None
+    moved = [np.asarray(c, dtype=np.float64) for c in
+             vfmap.from_dva()[region](x_dva + offsets[:, 0],
+                                      y_dva + offsets[:, 1])]
+    # An electrode the map cannot place, or cannot place once displaced, stays
+    # where it is rather than turning the kernel's input into NaN:
+    placed = np.isfinite(x_dva) & np.isfinite(y_dva)
+    for coord in moved:
+        placed &= np.isfinite(coord)
+    out = list(xyz)
+    for i, coord in enumerate(moved[:len(out)]):
+        out[i] = np.ascontiguousarray(np.where(placed, coord, xyz[i]),
+                                      dtype=np.float32)
+    return tuple(out)
 
 
 #: Parameter names declared by each model class, cached for ``__setattr__``.
@@ -626,7 +588,7 @@ class BaseModel(Parametrized, metaclass=ABCMeta):
             return t
         return Quantity(t, self.time_unit).to_value(stim.time_unit)
 
-    def _electrode_coords(self, electrode_array, stim):
+    def _electrode_coords(self, electrode_array, stim, electrodes=None):
         """Return stimulus electrode coordinates in ``space_unit``.
 
         Coordinates follow ``stim.electrodes`` order and are returned as
@@ -638,14 +600,19 @@ class BaseModel(Parametrized, metaclass=ABCMeta):
             Electrode array containing the named electrodes.
         stim : :py:class:`~pulse2percept.stimuli.Stimulus`
             Stimulus whose electrode ordering is required.
+        electrodes : list of str, optional
+            Electrode names to return instead of ``stim.electrodes``, for a
+            model that reorders or drops rows before calling its kernel.
 
         Returns
         -------
         x, y, z : tuple of ndarray
             Coordinate arrays with shape ``(n_electrodes,)``.
         """
+        if electrodes is None:
+            electrodes = stim.electrodes
         xyz = electrode_array.coordinates(self.space_unit,
-                                          electrodes=stim.electrodes)
+                                          electrodes=electrodes)
         return tuple(np.ascontiguousarray(xyz[:, i], dtype=np.float32)
                      for i in range(3))
 
@@ -785,10 +752,8 @@ class SpatialModel(BaseModel, metaclass=ABCMeta):
         # `_visual_field_map_first`.
         super().__init__(**_visual_field_map_first(params))
         self.grid = None
-        # This subject's electrode offsets and the grid warp they produce; see
-        # `_electrode_offsets` and `_location_noise_field`:
+        # This subject's latent electrode offsets; see `_latent_offsets`:
         self._location_noise_z = None
-        self._location_noise = None
 
     @property
     def implant(self):
@@ -978,7 +943,10 @@ class SpatialModel(BaseModel, metaclass=ABCMeta):
         self.grid = Grid2D(self.xrange, self.yrange, step=self.step,
                            grid_type=self.grid_type)
         self.grid.build(self.visual_field_map)
-        self._location_noise = _location_noise_field(self)
+        if _location_noise_sigma(self) is not None:
+            # Draw the subject here so that the offsets do not depend on which
+            # stimulus is predicted first:
+            _latent_offsets(self)
         self._build()
         self._is_built = True
         return self
@@ -1001,19 +969,33 @@ class SpatialModel(BaseModel, metaclass=ABCMeta):
         """
         raise NotImplementedError
 
-    def _postprocess_spatial(self, resp):
-        """Displace the response by the ``location_noise`` field.
+    def _electrode_coords(self, electrode_array, stim, electrodes=None,
+                          region=None):
+        """Return the electrode coordinates the spatial kernel is given.
 
-        Subclasses that override this hook must chain to it first: the warp
-        renders the visual field, and corrections such as meridian blending
-        apply to the rendered field.
+        With ``location_noise`` set, these are the effective coordinates of
+        electrodes displaced in the visual field, not the implant's own; see
+        `_displaced_coords`. ``region`` names the visual field map region to
+        displace through, and defaults to the only one the map has.
         """
-        warped = _warp_visual_field(resp, self.grid, self._location_noise)
-        if warped is resp:
-            return resp
-        # Interpolation mixes in sub-threshold neighbours:
-        warped[np.abs(warped) < self.thresh_percept] = 0
-        return warped
+        if electrodes is None:
+            electrodes = stim.electrodes
+        xyz = super()._electrode_coords(electrode_array, stim, electrodes)
+        offsets = _electrode_offsets(self, electrodes)
+        if offsets is None:
+            return xyz
+        if region is None:
+            regions = list(self.visual_field_map.from_dva())
+            if len(regions) != 1:
+                raise ValueError(f"location_noise needs a region to displace "
+                                 f"through, since {type(self).__name__} maps "
+                                 f"{regions}.")
+            region = regions[0]
+        return _displaced_coords(self, region, xyz, offsets)
+
+    def _postprocess_spatial(self, resp):
+        """Hook for spatial-model postprocessing."""
+        return resp
 
     def predict_percept(self, source, t_percept=None):
         """Predict the spatial response.

--- a/pulse2percept/models/base.py
+++ b/pulse2percept/models/base.py
@@ -7,7 +7,8 @@ from abc import ABCMeta, abstractmethod
 from copy import deepcopy, copy
 import numpy as np
 import multiprocessing
-from scipy.ndimage import gaussian_filter1d
+from scipy.interpolate import RBFInterpolator
+from scipy.ndimage import gaussian_filter1d, map_coordinates
 from scipy.spatial import cKDTree
 
 from ..implants import Implant
@@ -354,6 +355,119 @@ def _blend_meridian(resp, grid, meridian, width):
     return blurred.reshape(resp.shape).astype(resp.dtype, copy=False)
 
 
+def _electrode_dva(model):
+    """Return the implant's electrode coordinates in dva.
+
+    Requires an invertible ``visual_field_map``. On a map with several
+    regions, the electrodes sit in one place, so the model's first region is
+    the one that locates them.
+    """
+    vfmap = model.visual_field_map
+    coords = model.implant.electrode_array.coordinates(vfmap.tissue_unit)
+    try:
+        inverse = vfmap.to_dva()
+        regions = getattr(model, 'regions', None) or list(inverse)
+        x, y = inverse[regions[0]](coords[:, 0], coords[:, 1])
+    except (NotImplementedError, KeyError):
+        raise NotImplementedError(
+            f"location_noise places electrodes in the visual field, which "
+            f"requires a visual field map that can be inverted. "
+            f"{type(vfmap).__name__} cannot map tissue coordinates back to "
+            f"dva.") from None
+    return (np.asarray(x, dtype=np.float64).ravel(),
+            np.asarray(y, dtype=np.float64).ravel())
+
+
+def _axis_origin_step(along):
+    """Return (origin, signed spacing) of a regular grid axis.
+
+    Returns None for an axis with a single sample.
+    """
+    if along.size < 2:
+        return None
+    return float(along[0]), float(np.diff(along).mean())
+
+
+def _fractional_index(axis, coord):
+    """Position of ``coord`` along a grid axis, in fractional sample index."""
+    if axis is None:
+        # A single sample along this axis: nothing to shift into.
+        return np.zeros_like(coord)
+    origin, step = axis
+    return (coord - origin) / step
+
+
+def _location_noise_field(model):
+    """Return the sampling coordinates that displace percepts on the grid.
+
+    Draws one Gaussian ``(dx, dy)`` offset per electrode in dva, interpolates
+    those offsets across ``model.grid``, and expresses the result as fractional
+    row/column indices for ``map_coordinates``: a grid point reads the
+    undisplaced response one offset away, so a phosphene at ``e`` is rendered
+    at ``e + offset(e)``. Returns None when the noise is disabled.
+
+    ``location_noise`` is the standard deviation in dva, and the offsets are
+    drawn from the global NumPy random state, so ``np.random.seed`` makes a
+    build reproducible.
+    """
+    sigma = model.location_noise
+    if sigma is None:
+        return None
+    sigma = float(sigma)
+    if sigma < 0:
+        raise ValueError(f"location_noise must be non-negative (or None to "
+                         f"disable it), not {sigma}.")
+    if sigma == 0:
+        return None
+    grid = model.grid
+    rows = _axis_origin_step(grid.y[:, 0])
+    cols = _axis_origin_step(grid.x[0, :])
+    if rows is None and cols is None:
+        # A single grid point cannot be displaced:
+        return None
+    x_el, y_el = _electrode_dva(model)
+    offsets = np.random.normal(0.0, sigma, size=(x_el.size, 2))
+    points = np.column_stack([x_el, y_el])
+    # One interpolation node per location: electrodes that map to the same
+    # visual-field point cannot pull the field in two directions, and a
+    # repeated node makes the interpolation matrix singular.
+    points, inverse = np.unique(points, axis=0, return_inverse=True)
+    inverse = np.ravel(inverse)
+    if points.shape[0] < offsets.shape[0]:
+        counts = np.bincount(inverse, minlength=points.shape[0])
+        merged = np.zeros((points.shape[0], 2))
+        np.add.at(merged, inverse, offsets)
+        offsets = merged / counts[:, np.newaxis]
+    query = np.column_stack([grid.x.ravel(), grid.y.ravel()])
+    if points.shape[0] == 1:
+        shift = np.broadcast_to(offsets[0], query.shape)
+    else:
+        # The linear kernel (-r) needs no shape parameter and stays solvable
+        # for collinear electrodes, which a thin-plate spline is not:
+        shift = RBFInterpolator(points, offsets, kernel='linear')(query)
+    dx = shift[:, 0].reshape(grid.x.shape)
+    dy = shift[:, 1].reshape(grid.y.shape)
+    return np.stack([_fractional_index(rows, grid.y - dy),
+                     _fractional_index(cols, grid.x - dx)]).astype(np.float64)
+
+
+def _warp_visual_field(resp, grid, sample):
+    """Resample a response at displaced visual-field locations.
+
+    ``sample`` holds the fractional row/column indices built by
+    ``_location_noise_field``. Time points are warped independently by bilinear
+    interpolation; a sample falling off the grid repeats its edge value.
+    """
+    if sample is None:
+        return resp
+    work = np.asarray(resp).reshape(grid.x.shape + (-1,))
+    warped = np.empty_like(work)
+    for t in range(work.shape[-1]):
+        warped[..., t] = map_coordinates(work[..., t], sample, order=1,
+                                         mode='nearest')
+    return warped.reshape(resp.shape).astype(resp.dtype, copy=False)
+
+
 #: Parameter names declared by each model class, cached for ``__setattr__``.
 _declared = {}
 
@@ -630,6 +744,16 @@ class SpatialModel(BaseModel, metaclass=ABCMeta):
     noise : float, int, or None, optional
         Salt-and-pepper noise applied to each percept frame. An integer gives
         the number of affected pixels; a float in [0, 1] gives their fraction.
+    location_noise : float or None, optional
+        Standard deviation (dva) of the retinotopic jitter between where an
+        electrode sits and where its percept appears. One offset is drawn per
+        electrode at build time and interpolated across the grid, so the
+        displacement is smooth and fixed until the model is rebuilt. ``None``
+        or 0 leaves the percept untouched. Offsets come from the global NumPy
+        random state; seed it for a reproducible build.
+
+        .. versionadded:: 0.11.0
+
     verbose : bool, optional
         Whether to print status messages.
     ndim : list of int, optional
@@ -661,6 +785,8 @@ class SpatialModel(BaseModel, metaclass=ABCMeta):
         # `_visual_field_map_first`.
         super().__init__(**_visual_field_map_first(params))
         self.grid = None
+        # Set by `build`; see `_location_noise_field`:
+        self._location_noise = None
 
     @property
     def implant(self):
@@ -772,6 +898,7 @@ class SpatialModel(BaseModel, metaclass=ABCMeta):
             'visual_field_map': Curcio1990Map(),
             'n_gray': None,
             'noise': None,
+            'location_noise': None,  # dva
             'verbose': True,
             'ndim' : [2],
             # `n_jobs` writes through to `n_threads`, so it must come last.
@@ -795,6 +922,8 @@ class SpatialModel(BaseModel, metaclass=ABCMeta):
             'xrange': dva,
             'yrange': dva,
             'step': dva,
+            # The percept is displaced in the visual field, not on tissue:
+            'location_noise': dva,
         }
 
     def _cutoff_r2(self, rho):
@@ -845,6 +974,7 @@ class SpatialModel(BaseModel, metaclass=ABCMeta):
         self.grid = Grid2D(self.xrange, self.yrange, step=self.step,
                            grid_type=self.grid_type)
         self.grid.build(self.visual_field_map)
+        self._location_noise = _location_noise_field(self)
         self._build()
         self._is_built = True
         return self
@@ -868,8 +998,18 @@ class SpatialModel(BaseModel, metaclass=ABCMeta):
         raise NotImplementedError
 
     def _postprocess_spatial(self, resp):
-        """Hook for spatial-model postprocessing."""
-        return resp
+        """Displace the response by the ``location_noise`` field.
+
+        Subclasses that override this hook must chain to it first: the warp
+        renders the visual field, and corrections such as meridian blending
+        apply to the rendered field.
+        """
+        warped = _warp_visual_field(resp, self.grid, self._location_noise)
+        if warped is resp:
+            return resp
+        # Interpolation mixes in sub-threshold neighbours:
+        warped[np.abs(warped) < self.thresh_percept] = 0
+        return warped
 
     def predict_percept(self, source, t_percept=None):
         """Predict the spatial response.

--- a/pulse2percept/models/base.py
+++ b/pulse2percept/models/base.py
@@ -356,37 +356,29 @@ def _blend_meridian(resp, grid, meridian, width):
 
 
 def _electrode_dva(model):
-    """Return the implant's electrode locations in dva.
-
-    Requires an invertible ``visual_field_map``, which is handed as many
-    tissue coordinates as it has dimensions. On a map with several regions the
-    electrodes still sit in one place, so the model's first region is the one
-    that locates them. Locations the map cannot resolve come back non-finite.
-    """
+    """Return the visual-field locations of the implant's electrodes."""
     vfmap = model.visual_field_map
     coords = model.implant.electrode_array.coordinates(vfmap.tissue_unit)
+    tissue = coords[:, :vfmap.ndim].T
     try:
         inverse = vfmap.to_dva()
         regions = getattr(model, 'regions', None) or list(inverse)
-        x, y = inverse[regions[0]](*coords[:, :vfmap.ndim].T)
+        placed = [inverse[region](*tissue) for region in regions]
     except (NotImplementedError, KeyError):
         raise NotImplementedError(
             f"location_noise places electrodes in the visual field, which "
             f"requires a visual field map that can be inverted. "
             f"{type(vfmap).__name__} cannot map tissue coordinates back to "
             f"dva.") from None
-    return (np.asarray(x, dtype=np.float64).ravel(),
-            np.asarray(y, dtype=np.float64).ravel())
+    flat = [[np.asarray(c, dtype=np.float64).ravel() for c in xy]
+            for xy in placed]
+    electrode = np.tile(np.arange(coords.shape[0]), len(placed))
+    return (np.concatenate([xy[0] for xy in flat]),
+            np.concatenate([xy[1] for xy in flat]), electrode)
 
 
 def _electrode_offsets(model, sigma):
-    """Return this subject's electrode displacements in dva.
-
-    The latent standard normals are drawn once per model instance and cached,
-    so rebuilding (after a change to ``rho``, ``step``, ...) rescales the same
-    subject instead of simulating a new one. A new model instance, or a new
-    implant, is a new subject.
-    """
+    """Return this subject's electrode displacements in dva."""
     n_electrodes = len(model.implant.electrode_array.electrodes)
     latent = model._location_noise_z
     if latent is None or latent.shape[0] != n_electrodes:
@@ -406,7 +398,7 @@ def _axis_origin_step(along):
 
 
 def _fractional_index(axis, coord):
-    """Position of ``coord`` along a grid axis, in fractional sample index."""
+    """Position of ``coord`` along a grid axis, in fractional sample index"""
     if axis is None:
         # A single sample along this axis: nothing to shift into.
         return np.zeros_like(coord)
@@ -415,17 +407,7 @@ def _fractional_index(axis, coord):
 
 
 def _location_noise_field(model):
-    """Return the sampling coordinates of the location-noise warp.
-
-    The subject's offsets (see ``_electrode_offsets``) put the percept of an
-    electrode whose canonical location is ``e`` at ``e + offset``. The
-    *inverse* displacement is what warps the rendered field, so ``-offset`` is
-    interpolated at the displaced locations ``e + offset``: that makes those
-    correspondences exact rather than only true for a uniform shift. The
-    result is returned as fractional row/column indices for
-    ``map_coordinates``, which pulls each grid point from where the
-    undisplaced response holds its value. Returns None when the warp is off.
-    """
+    """Return the sampling coordinates of the location-noise warp"""
     sigma = model.location_noise
     if sigma is None:
         return None
@@ -441,8 +423,8 @@ def _location_noise_field(model):
     if rows is None and cols is None:
         # A single grid point cannot be displaced:
         return None
-    x_el, y_el = _electrode_dva(model)
-    offsets = _electrode_offsets(model, sigma)
+    x_el, y_el, electrode = _electrode_dva(model)
+    offsets = _electrode_offsets(model, sigma)[electrode]
     # Electrodes the map places outside the visual field (`NeuropythyMap`
     # returns NaN beyond its mesh) cannot anchor the warp:
     seen = np.isfinite(x_el) & np.isfinite(y_el)
@@ -453,16 +435,13 @@ def _location_noise_field(model):
             f"field, and it maps none of this implant's electrodes there.")
     offsets = offsets[seen]
     points = np.column_stack([x_el[seen], y_el[seen]]) + offsets
-    # One interpolation node per location: electrodes displaced onto the same
-    # visual-field point cannot pull the field in two directions, and a
-    # repeated node makes the interpolation matrix singular.
+    # One interpolation node per location:
     points, inverse = np.unique(points, axis=0, return_inverse=True)
     inverse = np.ravel(inverse)
-    if points.shape[0] < offsets.shape[0]:
-        counts = np.bincount(inverse, minlength=points.shape[0])
-        merged = np.zeros((points.shape[0], 2))
-        np.add.at(merged, inverse, offsets)
-        offsets = merged / counts[:, np.newaxis]
+    counts = np.bincount(inverse, minlength=points.shape[0])
+    merged = np.zeros((points.shape[0], 2))
+    np.add.at(merged, inverse, offsets)
+    offsets = merged / counts[:, np.newaxis]
     query = np.column_stack([grid.x.ravel(), grid.y.ravel()])
     if points.shape[0] == 1:
         back = np.broadcast_to(-offsets[0], query.shape)
@@ -477,13 +456,7 @@ def _location_noise_field(model):
 
 
 def _warp_visual_field(resp, grid, sample):
-    """Resample a response at displaced visual-field locations.
-
-    ``sample`` holds the fractional row/column indices built by
-    ``_location_noise_field``. Time points are warped independently by bilinear
-    interpolation. A grid point that pulls from outside the simulated field
-    reads zero, since nothing is known about the percept out there.
-    """
+    """Resample a response at displaced visual-field locations"""
     if sample is None:
         return resp
     work = np.asarray(resp).reshape(grid.x.shape + (-1,))
@@ -771,15 +744,9 @@ class SpatialModel(BaseModel, metaclass=ABCMeta):
         Salt-and-pepper noise applied to each percept frame. An integer gives
         the number of affected pixels; a float in [0, 1] gives their fraction.
     location_noise : float or None, optional
-        Standard deviation (dva) of a subject-specific retinotopic distortion:
-        how far the percept of an electrode lands from where the canonical
-        ``visual_field_map`` predicts it. One offset is drawn per electrode and
-        interpolated smoothly across the grid, then warps the rendered percept
-        as a whole, so overlapping phosphenes stay consistent with each other.
-        The distortion belongs to the model instance and survives a rebuild;
-        a new instance is a new subject. ``None`` or 0 leaves the percept
-        untouched. Offsets come from the global NumPy random state; seed it
-        before constructing the model to reproduce a subject.
+        Standard deviation of the variation in phosphene location from the
+        ``visual_field_map``, in dva. Locations are fixed for a model instance.
+        ``None`` or 0 disables the variation.
 
         .. versionadded:: 0.11.0
 

--- a/pulse2percept/models/base.py
+++ b/pulse2percept/models/base.py
@@ -365,8 +365,7 @@ def _location_noise_sigma(model):
                          f"(or None to disable it), not {sigma}.")
     ndim = model.visual_field_map.ndim
     if sigma > 0 and ndim != 2:
-        # A visual field maps onto a surface, so the dva round trip in
-        # `_displaced_coords` cannot preserve a coordinate normal to it:
+        # Round-tripping through dva cannot preserve depth in a 3D map.
         raise NotImplementedError(
             f"location_noise is only defined for 2D visual field maps, and "
             f"{type(model.visual_field_map).__name__} is {ndim}D.")
@@ -374,11 +373,7 @@ def _location_noise_sigma(model):
 
 
 def _latent_offsets(model):
-    """Return (electrode names, this subject's (n, 2) standard normals).
-
-    Drawn once per implant and kept on the model, so that the same subject is
-    simulated across predictions, rebuilds and copies.
-    """
+    """Return electrode names and fixed per-electrode standard normals."""
     names = list(model.implant.electrode_array.electrodes)
     latent = model._location_noise_z
     if latent is None or latent.shape[0] != len(names):
@@ -388,12 +383,9 @@ def _latent_offsets(model):
 
 
 def _electrode_offsets(model, electrodes):
-    """Return the (n, 2) dva displacements of the named electrodes.
+    """Return fixed electrode offsets in dva, or None when disabled.
 
-    ``None`` where ``location_noise`` is disabled. Matched by electrode name,
-    since a compressed stimulus carries only a subset of the implant. Names
-    are matched by identity: an array may name its electrodes with integers,
-    for which ``0`` and ``'0'`` are different electrodes.
+    Electrode IDs are matched without string coercion.
     """
     sigma = _location_noise_sigma(model)
     if sigma is None:
@@ -404,23 +396,14 @@ def _electrode_offsets(model, electrodes):
 
 
 def _displaced_coords(model, region, electrodes, xyz, offsets):
-    """Return the effective tissue coordinates of displaced electrodes.
+    """Return displaced tissue coordinates via tissue -> dva -> tissue.
 
-    Round-trips each electrode through ``region`` of the visual field map:
-    tissue -> dva, add the electrode's fixed offset, dva -> tissue. Only the
-    percept prediction sees these; the implant is not moved. 2D maps only;
-    see `_location_noise_sigma`.
-
-    Raises if the map places an electrode nowhere, before or after the offset.
-    Substituting the canonical location would set that electrode's offset to
-    zero, which censors the Gaussian near the edge of a map's domain and makes
-    ``location_noise`` mean something different depending on where an
-    electrode sits.
+    The physical implant is unchanged. Raises if either location is unmappable.
     """
     vfmap = model.visual_field_map
     try:
         inverse = vfmap.to_dva()[region]
-        # Copies, since a map is free to edit the array it is handed:
+        # Some maps mutate their inputs.
         x_dva, y_dva = inverse(*[np.array(a, dtype=np.float64)
                                  for a in xyz[:2]])
     except (NotImplementedError, KeyError):
@@ -447,9 +430,7 @@ def _require_placed(model, region, electrodes, coords, which):
         placed &= np.isfinite(np.asarray(coord, dtype=np.float64))
     if np.all(placed):
         return
-    # `.item()` unwraps the NumPy scalars a stimulus reports, so that an
-    # integer-named electrode prints as `0` rather than `np.int64(0)` -- and
-    # still not as `'0'`, which would be a different electrode.
+    # Preserve integer electrode IDs in error messages.
     lost = [e.item() if isinstance(e, np.generic) else e
             for e, ok in zip(electrodes, placed) if not ok]
     raise ValueError(
@@ -741,16 +722,11 @@ class SpatialModel(BaseModel, metaclass=ABCMeta):
         Salt-and-pepper noise applied to each percept frame. An integer gives
         the number of affected pixels; a float in [0, 1] gives their fraction.
     location_noise : float or None, optional
-        Standard deviation of the variation in phosphene location from the
-        ``visual_field_map``, in dva. Locations are fixed for a model instance.
-        ``None`` or 0 disables the variation. Requires an invertible, 2D
-        ``visual_field_map``, which is what places the electrodes in the
-        visual field. Moves the effective stimulation location, so phosphene
-        shape and size change too wherever the model makes them
-        location-dependent (axon bundles, cortical magnification).
-        Phenomenological: the standard deviation is not empirically
-        calibrated, and trial-to-trial or gaze-dependent shifts are not
-        modeled.
+        Standard deviation of fixed electrode-specific phosphene offsets, in
+        dva. Requires an invertible 2D ``visual_field_map``. Moving the effective
+        stimulation location may also change phosphene shape or size in
+        location-dependent models. This phenomenological parameter is not
+        empirically calibrated and does not model trial-to-trial or gaze effects.
 
         .. versionadded:: 0.11.0
 
@@ -785,7 +761,6 @@ class SpatialModel(BaseModel, metaclass=ABCMeta):
         # `_visual_field_map_first`.
         super().__init__(**_visual_field_map_first(params))
         self.grid = None
-        # This subject's latent electrode offsets; see `_latent_offsets`:
         self._location_noise_z = None
 
     @property
@@ -810,7 +785,6 @@ class SpatialModel(BaseModel, metaclass=ABCMeta):
         if implant is not self._implant:
             # Spatial build state depends on implant geometry:
             self._is_built = False
-            # A different implant is a different set of electrodes to displace:
             self._location_noise_z = None
         self._implant = implant
 
@@ -924,7 +898,6 @@ class SpatialModel(BaseModel, metaclass=ABCMeta):
             'xrange': dva,
             'yrange': dva,
             'step': dva,
-            # The percept is displaced in the visual field, not on tissue:
             'location_noise': dva,
         }
 
@@ -977,8 +950,7 @@ class SpatialModel(BaseModel, metaclass=ABCMeta):
                            grid_type=self.grid_type)
         self.grid.build(self.visual_field_map)
         if _location_noise_sigma(self) is not None:
-            # Draw the subject here so that the offsets do not depend on which
-            # stimulus is predicted first:
+            # Draw once so the first stimulus does not determine the subject.
             _latent_offsets(self)
         self._build()
         self._is_built = True

--- a/pulse2percept/models/base.py
+++ b/pulse2percept/models/base.py
@@ -360,9 +360,16 @@ def _location_noise_sigma(model):
     if sigma is None:
         return None
     sigma = float(sigma)
-    if sigma < 0:
-        raise ValueError(f"location_noise must be non-negative (or None to "
-                         f"disable it), not {sigma}.")
+    if not np.isfinite(sigma) or sigma < 0:
+        raise ValueError(f"location_noise must be a finite non-negative number "
+                         f"(or None to disable it), not {sigma}.")
+    ndim = model.visual_field_map.ndim
+    if sigma > 0 and ndim != 2:
+        # A visual field maps onto a surface, so the dva round trip in
+        # `_displaced_coords` cannot preserve a coordinate normal to it:
+        raise NotImplementedError(
+            f"location_noise is only defined for 2D visual field maps, and "
+            f"{type(model.visual_field_map).__name__} is {ndim}D.")
     return sigma if sigma > 0 else None
 
 
@@ -401,7 +408,8 @@ def _displaced_coords(model, region, electrodes, xyz, offsets):
 
     Round-trips each electrode through ``region`` of the visual field map:
     tissue -> dva, add the electrode's fixed offset, dva -> tissue. Only the
-    percept prediction sees these; the implant is not moved.
+    percept prediction sees these; the implant is not moved. 2D maps only;
+    see `_location_noise_sigma`.
 
     Raises if the map places an electrode nowhere, before or after the offset.
     Substituting the canonical location would set that electrode's offset to
@@ -412,9 +420,9 @@ def _displaced_coords(model, region, electrodes, xyz, offsets):
     vfmap = model.visual_field_map
     try:
         inverse = vfmap.to_dva()[region]
-        args = xyz[:vfmap.ndim] if vfmap.ndim == 3 else xyz[:2]
         # Copies, since a map is free to edit the array it is handed:
-        x_dva, y_dva = inverse(*[np.array(a, dtype=np.float64) for a in args])
+        x_dva, y_dva = inverse(*[np.array(a, dtype=np.float64)
+                                 for a in xyz[:2]])
     except (NotImplementedError, KeyError):
         raise NotImplementedError(
             f"location_noise places electrodes in the visual field, which "
@@ -735,11 +743,14 @@ class SpatialModel(BaseModel, metaclass=ABCMeta):
     location_noise : float or None, optional
         Standard deviation of the variation in phosphene location from the
         ``visual_field_map``, in dva. Locations are fixed for a model instance.
-        ``None`` or 0 disables the variation. Requires an invertible
+        ``None`` or 0 disables the variation. Requires an invertible, 2D
         ``visual_field_map``, which is what places the electrodes in the
-        visual field. Phenomenological: the standard deviation is not
-        empirically calibrated, and trial-to-trial or gaze-dependent shifts
-        are not modeled.
+        visual field. Moves the effective stimulation location, so phosphene
+        shape and size change too wherever the model makes them
+        location-dependent (axon bundles, cortical magnification).
+        Phenomenological: the standard deviation is not empirically
+        calibrated, and trial-to-trial or gaze-dependent shifts are not
+        modeled.
 
         .. versionadded:: 0.11.0
 

--- a/pulse2percept/models/beyeler2019.py
+++ b/pulse2percept/models/beyeler2019.py
@@ -143,6 +143,9 @@ class ScoreboardSpatial(SpatialModel):
         Standard deviation of the variation in phosphene location from the
         ``visual_field_map``, in dva. Locations are fixed for a model instance.
         ``None`` or 0 disables the variation.
+        Moves the effective stimulation location, so phosphene shape and
+        size change too wherever the model makes them location-dependent
+        (axon bundles, cortical magnification).
 
         .. versionadded:: 0.11.0
 
@@ -280,6 +283,9 @@ class ScoreboardModel(Model):
         Standard deviation of the variation in phosphene location from the
         ``visual_field_map``, in dva. Locations are fixed for a model instance.
         ``None`` or 0 disables the variation.
+        Moves the effective stimulation location, so phosphene shape and
+        size change too wherever the model makes them location-dependent
+        (axon bundles, cortical magnification).
 
         .. versionadded:: 0.11.0
 
@@ -397,6 +403,9 @@ class AxonMapSpatial(SpatialModel):
         Standard deviation of the variation in phosphene location from the
         ``visual_field_map``, in dva. Locations are fixed for a model instance.
         ``None`` or 0 disables the variation.
+        Moves the effective stimulation location, so phosphene shape and
+        size change too wherever the model makes them location-dependent
+        (axon bundles, cortical magnification).
 
         .. versionadded:: 0.11.0
 
@@ -1151,6 +1160,9 @@ class AxonMapModel(Model):
         Standard deviation of the variation in phosphene location from the
         ``visual_field_map``, in dva. Locations are fixed for a model instance.
         ``None`` or 0 disables the variation.
+        Moves the effective stimulation location, so phosphene shape and
+        size change too wherever the model makes them location-dependent
+        (axon bundles, cortical magnification).
         
         .. versionadded:: 0.11.0
 

--- a/pulse2percept/models/beyeler2019.py
+++ b/pulse2percept/models/beyeler2019.py
@@ -952,18 +952,15 @@ class AxonMapSpatial(SpatialModel):
     def _postprocess_spatial(self, resp):
         """Blend the response across the horizontal meridian.
 
-        The seam correction applies to the rendered visual field, so it comes
-        after the base class' retinotopic warp.
+        The seam sits on the canonical meridian, so it is repaired before the
+        base class displaces the field.
         """
-        resp = super()._postprocess_spatial(resp)
         blended = _blend_meridian(resp, self.grid, 'horizontal',
                                   self.meridian_blend)
-        if blended is resp:
-            # Preserve the unblended response bit-for-bit.
-            return resp
-        # Reapply the percept threshold after blending:
-        blended[np.abs(blended) < self.thresh_percept] = 0
-        return blended
+        if blended is not resp:
+            # Reapply the percept threshold after blending:
+            blended[np.abs(blended) < self.thresh_percept] = 0
+        return super()._postprocess_spatial(blended)
 
     def plot(self, use_dva=False, style='hull', annotate=True, autoscale=True,
              ax=None, figsize=None):

--- a/pulse2percept/models/beyeler2019.py
+++ b/pulse2percept/models/beyeler2019.py
@@ -950,17 +950,15 @@ class AxonMapSpatial(SpatialModel):
                              self.n_threads)
 
     def _postprocess_spatial(self, resp):
-        """Blend the response across the horizontal meridian.
-
-        The seam sits on the canonical meridian, so it is repaired before the
-        base class displaces the field.
-        """
+        """Blend the response across the horizontal meridian."""
         blended = _blend_meridian(resp, self.grid, 'horizontal',
                                   self.meridian_blend)
-        if blended is not resp:
-            # Reapply the percept threshold after blending:
-            blended[np.abs(blended) < self.thresh_percept] = 0
-        return super()._postprocess_spatial(blended)
+        if blended is resp:
+            # Preserve the unblended response bit-for-bit.
+            return resp
+        # Reapply the percept threshold after blending:
+        blended[np.abs(blended) < self.thresh_percept] = 0
+        return blended
 
     def plot(self, use_dva=False, style='hull', annotate=True, autoscale=True,
              ax=None, figsize=None):

--- a/pulse2percept/models/beyeler2019.py
+++ b/pulse2percept/models/beyeler2019.py
@@ -140,9 +140,9 @@ class ScoreboardSpatial(SpatialModel):
         Salt-and-pepper noise applied to each percept frame. An integer gives
         the number of affected pixels; a float in [0, 1] gives their fraction.
     location_noise : float or None, optional
-        Standard deviation (dva) of this subject's retinotopic
-        distortion; see
-        :py:class:`~pulse2percept.models.SpatialModel`.
+        Standard deviation of the variation in phosphene location from the
+        ``visual_field_map``, in dva. Locations are fixed for a model instance.
+        ``None`` or 0 disables the variation.
 
         .. versionadded:: 0.11.0
 
@@ -277,9 +277,9 @@ class ScoreboardModel(Model):
         Salt-and-pepper noise applied to each percept frame. An integer gives
         the number of affected pixels; a float in [0, 1] gives their fraction.
     location_noise : float or None, optional
-        Standard deviation (dva) of this subject's retinotopic
-        distortion; see
-        :py:class:`~pulse2percept.models.SpatialModel`.
+        Standard deviation of the variation in phosphene location from the
+        ``visual_field_map``, in dva. Locations are fixed for a model instance.
+        ``None`` or 0 disables the variation.
 
         .. versionadded:: 0.11.0
 
@@ -394,9 +394,9 @@ class AxonMapSpatial(SpatialModel):
         Salt-and-pepper noise applied to each percept frame. An integer gives
         the number of affected pixels; a float in [0, 1] gives their fraction.
     location_noise : float or None, optional
-        Standard deviation (dva) of this subject's retinotopic
-        distortion; see
-        :py:class:`~pulse2percept.models.SpatialModel`.
+        Standard deviation of the variation in phosphene location from the
+        ``visual_field_map``, in dva. Locations are fixed for a model instance.
+        ``None`` or 0 disables the variation.
 
         .. versionadded:: 0.11.0
 
@@ -1153,10 +1153,10 @@ class AxonMapModel(Model):
         Salt-and-pepper noise applied to each percept frame. An integer gives
         the number of affected pixels; a float in [0, 1] gives their fraction.
     location_noise : float or None, optional
-        Standard deviation (dva) of this subject's retinotopic
-        distortion; see
-        :py:class:`~pulse2percept.models.SpatialModel`.
-
+        Standard deviation of the variation in phosphene location from the
+        ``visual_field_map``, in dva. Locations are fixed for a model instance.
+        ``None`` or 0 disables the variation.
+        
         .. versionadded:: 0.11.0
 
     loc_od : (float, float) or Quantity, optional

--- a/pulse2percept/models/beyeler2019.py
+++ b/pulse2percept/models/beyeler2019.py
@@ -923,7 +923,12 @@ class AxonMapSpatial(SpatialModel):
                              self.n_threads)
 
     def _postprocess_spatial(self, resp):
-        """Blend the response across the horizontal meridian."""
+        """Blend the response across the horizontal meridian.
+
+        The seam correction applies to the rendered visual field, so it comes
+        after the base class' retinotopic warp.
+        """
+        resp = super()._postprocess_spatial(resp)
         blended = _blend_meridian(resp, self.grid, 'horizontal',
                                   self.meridian_blend)
         if blended is resp:

--- a/pulse2percept/models/beyeler2019.py
+++ b/pulse2percept/models/beyeler2019.py
@@ -139,6 +139,13 @@ class ScoreboardSpatial(SpatialModel):
     noise : float, int, or None, optional
         Salt-and-pepper noise applied to each percept frame. An integer gives
         the number of affected pixels; a float in [0, 1] gives their fraction.
+    location_noise : float or None, optional
+        Standard deviation (dva) of this subject's retinotopic
+        distortion; see
+        :py:class:`~pulse2percept.models.SpatialModel`.
+
+        .. versionadded:: 0.11.0
+
     verbose : bool, optional
         Whether to print status messages.
     ndim : list of int, optional
@@ -155,7 +162,8 @@ class ScoreboardSpatial(SpatialModel):
                  yrange=(-15, 15), step=0.25, grid_type='rect',
                  thresh_percept=0, min_current_spread=1e-8,
                  visual_field_map=None,
-                 n_gray=None, noise=None, verbose=True, ndim=None,
+                 n_gray=None, noise=None,
+                 location_noise=None, verbose=True, ndim=None,
                  n_threads=None, n_jobs=None):
         super().__init__(
             implant, rho=rho, xrange=xrange, yrange=yrange, step=step,
@@ -163,7 +171,8 @@ class ScoreboardSpatial(SpatialModel):
             min_current_spread=min_current_spread,
             visual_field_map=(Watson2014Map() if visual_field_map is None else
                               visual_field_map),
-            n_gray=n_gray, noise=noise, verbose=verbose,
+            n_gray=n_gray, noise=noise,
+            location_noise=location_noise, verbose=verbose,
             ndim=[2] if ndim is None else ndim,
             **_thread_params(n_threads, n_jobs))
 
@@ -267,6 +276,13 @@ class ScoreboardModel(Model):
     noise : float, int, or None, optional
         Salt-and-pepper noise applied to each percept frame. An integer gives
         the number of affected pixels; a float in [0, 1] gives their fraction.
+    location_noise : float or None, optional
+        Standard deviation (dva) of this subject's retinotopic
+        distortion; see
+        :py:class:`~pulse2percept.models.SpatialModel`.
+
+        .. versionadded:: 0.11.0
+
     verbose : bool, optional
         Whether to print status messages.
     ndim : list of int, optional
@@ -280,7 +296,8 @@ class ScoreboardModel(Model):
                  yrange=(-15, 15), step=0.25, grid_type='rect',
                  thresh_percept=0, min_current_spread=1e-8,
                  visual_field_map=None,
-                 n_gray=None, noise=None, verbose=True, ndim=None,
+                 n_gray=None, noise=None,
+                 location_noise=None, verbose=True, ndim=None,
                  n_threads=None, n_jobs=None):
         super().__init__(
             spatial=ScoreboardSpatial(
@@ -288,7 +305,8 @@ class ScoreboardModel(Model):
                 grid_type=grid_type, thresh_percept=thresh_percept,
                 min_current_spread=min_current_spread,
                 visual_field_map=visual_field_map,
-                n_gray=n_gray, noise=noise, verbose=verbose, ndim=ndim,
+                n_gray=n_gray, noise=noise,
+                location_noise=location_noise, verbose=verbose, ndim=ndim,
                 n_threads=n_threads, n_jobs=n_jobs),
             temporal=None)
 
@@ -375,6 +393,13 @@ class AxonMapSpatial(SpatialModel):
     noise : float, int, or None, optional
         Salt-and-pepper noise applied to each percept frame. An integer gives
         the number of affected pixels; a float in [0, 1] gives their fraction.
+    location_noise : float or None, optional
+        Standard deviation (dva) of this subject's retinotopic
+        distortion; see
+        :py:class:`~pulse2percept.models.SpatialModel`.
+
+        .. versionadded:: 0.11.0
+
     loc_od : (float, float) or Quantity, optional
         Optic-disc location in degrees of visual angle. Its horizontal sign is
         set from the bound implant's eye.
@@ -417,7 +442,8 @@ class AxonMapSpatial(SpatialModel):
                  yrange=(-15, 15), step=0.25, grid_type='rect',
                  thresh_percept=0, min_current_spread=1e-8,
                  visual_field_map=None,
-                 n_gray=None, noise=None, loc_od=(15.5, 1.5), n_axons=1000,
+                 n_gray=None, noise=None,
+                 location_noise=None, loc_od=(15.5, 1.5), n_axons=1000,
                  axons_range=(-180, 180), n_ax_segments=500,
                  ax_segments_range=(0, 50), min_ax_sensitivity=1e-3,
                  meridian_blend=1, axon_pickle='axons.pickle',
@@ -429,7 +455,8 @@ class AxonMapSpatial(SpatialModel):
             min_current_spread=min_current_spread,
             visual_field_map=(Watson2014Map() if visual_field_map is None else
                               visual_field_map),
-            n_gray=n_gray, noise=noise, loc_od=loc_od, n_axons=n_axons,
+            n_gray=n_gray, noise=noise,
+            location_noise=location_noise, loc_od=loc_od, n_axons=n_axons,
             axons_range=axons_range, n_ax_segments=n_ax_segments,
             ax_segments_range=ax_segments_range,
             min_ax_sensitivity=min_ax_sensitivity,
@@ -1125,6 +1152,13 @@ class AxonMapModel(Model):
     noise : float, int, or None, optional
         Salt-and-pepper noise applied to each percept frame. An integer gives
         the number of affected pixels; a float in [0, 1] gives their fraction.
+    location_noise : float or None, optional
+        Standard deviation (dva) of this subject's retinotopic
+        distortion; see
+        :py:class:`~pulse2percept.models.SpatialModel`.
+
+        .. versionadded:: 0.11.0
+
     loc_od : (float, float) or Quantity, optional
         Optic-disc location in degrees of visual angle. Its horizontal sign is
         set from the bound implant's eye.
@@ -1167,7 +1201,8 @@ class AxonMapModel(Model):
                  yrange=(-15, 15), step=0.25, grid_type='rect',
                  thresh_percept=0, min_current_spread=1e-8,
                  visual_field_map=None,
-                 n_gray=None, noise=None, loc_od=(15.5, 1.5), n_axons=1000,
+                 n_gray=None, noise=None,
+                 location_noise=None, loc_od=(15.5, 1.5), n_axons=1000,
                  axons_range=(-180, 180), n_ax_segments=500,
                  ax_segments_range=(0, 50), min_ax_sensitivity=1e-3,
                  meridian_blend=1, axon_pickle='axons.pickle',
@@ -1180,7 +1215,8 @@ class AxonMapModel(Model):
                 thresh_percept=thresh_percept,
                 min_current_spread=min_current_spread,
                 visual_field_map=visual_field_map,
-                n_gray=n_gray, noise=noise, loc_od=loc_od, n_axons=n_axons,
+                n_gray=n_gray, noise=noise,
+                location_noise=location_noise, loc_od=loc_od, n_axons=n_axons,
                 axons_range=axons_range, n_ax_segments=n_ax_segments,
                 ax_segments_range=ax_segments_range,
                 min_ax_sensitivity=min_ax_sensitivity,

--- a/pulse2percept/models/beyeler2019.py
+++ b/pulse2percept/models/beyeler2019.py
@@ -140,12 +140,9 @@ class ScoreboardSpatial(SpatialModel):
         Salt-and-pepper noise applied to each percept frame. An integer gives
         the number of affected pixels; a float in [0, 1] gives their fraction.
     location_noise : float or None, optional
-        Standard deviation of the variation in phosphene location from the
-        ``visual_field_map``, in dva. Locations are fixed for a model instance.
-        ``None`` or 0 disables the variation.
-        Moves the effective stimulation location, so phosphene shape and
-        size change too wherever the model makes them location-dependent
-        (axon bundles, cortical magnification).
+        Standard deviation of fixed electrode-specific phosphene offsets, in dva.
+        Requires an invertible 2D ``visual_field_map``. ``None`` or 0 disables it.
+        Location-dependent models may also change phosphene shape or size.
 
         .. versionadded:: 0.11.0
 
@@ -280,12 +277,9 @@ class ScoreboardModel(Model):
         Salt-and-pepper noise applied to each percept frame. An integer gives
         the number of affected pixels; a float in [0, 1] gives their fraction.
     location_noise : float or None, optional
-        Standard deviation of the variation in phosphene location from the
-        ``visual_field_map``, in dva. Locations are fixed for a model instance.
-        ``None`` or 0 disables the variation.
-        Moves the effective stimulation location, so phosphene shape and
-        size change too wherever the model makes them location-dependent
-        (axon bundles, cortical magnification).
+        Standard deviation of fixed electrode-specific phosphene offsets, in dva.
+        Requires an invertible 2D ``visual_field_map``. ``None`` or 0 disables it.
+        Location-dependent models may also change phosphene shape or size.
 
         .. versionadded:: 0.11.0
 
@@ -400,12 +394,9 @@ class AxonMapSpatial(SpatialModel):
         Salt-and-pepper noise applied to each percept frame. An integer gives
         the number of affected pixels; a float in [0, 1] gives their fraction.
     location_noise : float or None, optional
-        Standard deviation of the variation in phosphene location from the
-        ``visual_field_map``, in dva. Locations are fixed for a model instance.
-        ``None`` or 0 disables the variation.
-        Moves the effective stimulation location, so phosphene shape and
-        size change too wherever the model makes them location-dependent
-        (axon bundles, cortical magnification).
+        Standard deviation of fixed electrode-specific phosphene offsets, in dva.
+        Requires an invertible 2D ``visual_field_map``. ``None`` or 0 disables it.
+        Location-dependent models may also change phosphene shape or size.
 
         .. versionadded:: 0.11.0
 
@@ -1157,12 +1148,9 @@ class AxonMapModel(Model):
         Salt-and-pepper noise applied to each percept frame. An integer gives
         the number of affected pixels; a float in [0, 1] gives their fraction.
     location_noise : float or None, optional
-        Standard deviation of the variation in phosphene location from the
-        ``visual_field_map``, in dva. Locations are fixed for a model instance.
-        ``None`` or 0 disables the variation.
-        Moves the effective stimulation location, so phosphene shape and
-        size change too wherever the model makes them location-dependent
-        (axon bundles, cortical magnification).
+        Standard deviation of fixed electrode-specific phosphene offsets, in dva.
+        Requires an invertible 2D ``visual_field_map``. ``None`` or 0 disables it.
+        Location-dependent models may also change phosphene shape or size.
         
         .. versionadded:: 0.11.0
 

--- a/pulse2percept/models/cortex/base.py
+++ b/pulse2percept/models/cortex/base.py
@@ -71,12 +71,9 @@ class CortexSpatial(SpatialModel):
         A float between 0 and 1 will be interpreted as a ratio of pixels to
         subject to noise in each frame.
     location_noise : float or None, optional
-        Standard deviation of the variation in phosphene location from the
-        ``visual_field_map``, in dva. Locations are fixed for a model instance.
-        ``None`` or 0 disables the variation.
-        Moves the effective stimulation location, so phosphene shape and
-        size change too wherever the model makes them location-dependent
-        (axon bundles, cortical magnification).
+        Standard deviation of fixed electrode-specific phosphene offsets, in dva.
+        Requires an invertible 2D ``visual_field_map``. ``None`` or 0 disables it.
+        Location-dependent models may also change phosphene shape or size.
 
         .. versionadded:: 0.11.0
 
@@ -295,12 +292,9 @@ class ScoreboardSpatial(CortexSpatial):
         A float between 0 and 1 will be interpreted as a ratio of pixels to
         subject to noise in each frame.
     location_noise : float or None, optional
-        Standard deviation of the variation in phosphene location from the
-        ``visual_field_map``, in dva. Locations are fixed for a model instance.
-        ``None`` or 0 disables the variation.
-        Moves the effective stimulation location, so phosphene shape and
-        size change too wherever the model makes them location-dependent
-        (axon bundles, cortical magnification).
+        Standard deviation of fixed electrode-specific phosphene offsets, in dva.
+        Requires an invertible 2D ``visual_field_map``. ``None`` or 0 disables it.
+        Location-dependent models may also change phosphene shape or size.
 
         .. versionadded:: 0.11.0
 
@@ -480,12 +474,9 @@ class ScoreboardModel(Model):
         A float between 0 and 1 will be interpreted as a ratio of pixels to
         subject to noise in each frame.
     location_noise : float or None, optional
-        Standard deviation of the variation in phosphene location from the
-        ``visual_field_map``, in dva. Locations are fixed for a model instance.
-        ``None`` or 0 disables the variation.
-        Moves the effective stimulation location, so phosphene shape and
-        size change too wherever the model makes them location-dependent
-        (axon bundles, cortical magnification).
+        Standard deviation of fixed electrode-specific phosphene offsets, in dva.
+        Requires an invertible 2D ``visual_field_map``. ``None`` or 0 disables it.
+        Location-dependent models may also change phosphene shape or size.
         
         .. versionadded:: 0.11.0
 

--- a/pulse2percept/models/cortex/base.py
+++ b/pulse2percept/models/cortex/base.py
@@ -355,19 +355,18 @@ class ScoreboardSpatial(CortexSpatial):
         On this model rather than on `CortexSpatial`: the seam is a property
         of the split map this one is built on, not of being cortical, and a
         future cortical model without one should not inherit a correction for
-        it. It sits on the canonical meridian, so it is repaired before the
-        base class displaces the field.
+        it.
         """
         blended = _blend_meridian(resp, self.grid, 'vertical',
                                   self.meridian_blend)
-        if blended is not resp:
-            # Restore percept threshold after blending:
-            blended[np.abs(blended) < self.thresh_percept] = 0
-        return super()._postprocess_spatial(blended)
+        if blended is resp:
+            return resp
+        # Restore percept threshold after blending:
+        blended[np.abs(blended) < self.thresh_percept] = 0
+        return blended
 
     def _predict_spatial(self, electrode_array, stim):
         """Predicts the brightness at spatial locations"""
-        x_el, y_el, z_el = self._electrode_coords(electrode_array, stim)
         amp = self._stim_values(stim)
 
         # whether to allow current to spread between hemispheres
@@ -377,9 +376,14 @@ class ScoreboardSpatial(CortexSpatial):
             separate = 1
             boundary = self.visual_field_map.left_offset/2
         cutoff_r2 = self._cutoff_r2(self.rho)
+        # `location_noise` displaces an electrode in the visual field, so its
+        # cortical coordinates are region-specific:
+        coords = {region: self._electrode_coords(electrode_array, stim,
+                                                 region=region)
+                  for region in self.regions}
         if self.visual_field_map.ndim == 3:
             return np.sum([
-                fast_scoreboard_3d(amp, x_el, y_el, z_el,
+                fast_scoreboard_3d(amp, *coords[region],
                                 self.grid[region].x.ravel(),
                                 self.grid[region].y.ravel(),
                                 self.grid[region].z.ravel(),
@@ -390,7 +394,7 @@ class ScoreboardSpatial(CortexSpatial):
             axis = 0)
         elif self.visual_field_map.ndim == 2:
             return np.sum([
-                fast_scoreboard(amp, x_el, y_el,
+                fast_scoreboard(amp, *coords[region][:2],
                                 self.grid[region].x.ravel(), self.grid[region].y.ravel(),
                                 self.rho, self.thresh_percept, cutoff_r2,
                                 separate, boundary,

--- a/pulse2percept/models/cortex/base.py
+++ b/pulse2percept/models/cortex/base.py
@@ -355,17 +355,15 @@ class ScoreboardSpatial(CortexSpatial):
         On this model rather than on `CortexSpatial`: the seam is a property
         of the split map this one is built on, not of being cortical, and a
         future cortical model without one should not inherit a correction for
-        it. It applies to the rendered visual field, so it comes after the
-        base class' retinotopic warp.
+        it. It sits on the canonical meridian, so it is repaired before the
+        base class displaces the field.
         """
-        resp = super()._postprocess_spatial(resp)
         blended = _blend_meridian(resp, self.grid, 'vertical',
                                   self.meridian_blend)
-        if blended is resp:
-            return resp
-        # Restore percept threshold after blending:
-        blended[np.abs(blended) < self.thresh_percept] = 0
-        return blended
+        if blended is not resp:
+            # Restore percept threshold after blending:
+            blended[np.abs(blended) < self.thresh_percept] = 0
+        return super()._postprocess_spatial(blended)
 
     def _predict_spatial(self, electrode_array, stim):
         """Predicts the brightness at spatial locations"""

--- a/pulse2percept/models/cortex/base.py
+++ b/pulse2percept/models/cortex/base.py
@@ -74,6 +74,9 @@ class CortexSpatial(SpatialModel):
         Standard deviation of the variation in phosphene location from the
         ``visual_field_map``, in dva. Locations are fixed for a model instance.
         ``None`` or 0 disables the variation.
+        Moves the effective stimulation location, so phosphene shape and
+        size change too wherever the model makes them location-dependent
+        (axon bundles, cortical magnification).
 
         .. versionadded:: 0.11.0
 
@@ -295,6 +298,9 @@ class ScoreboardSpatial(CortexSpatial):
         Standard deviation of the variation in phosphene location from the
         ``visual_field_map``, in dva. Locations are fixed for a model instance.
         ``None`` or 0 disables the variation.
+        Moves the effective stimulation location, so phosphene shape and
+        size change too wherever the model makes them location-dependent
+        (axon bundles, cortical magnification).
 
         .. versionadded:: 0.11.0
 
@@ -477,6 +483,9 @@ class ScoreboardModel(Model):
         Standard deviation of the variation in phosphene location from the
         ``visual_field_map``, in dva. Locations are fixed for a model instance.
         ``None`` or 0 disables the variation.
+        Moves the effective stimulation location, so phosphene shape and
+        size change too wherever the model makes them location-dependent
+        (axon bundles, cortical magnification).
         
         .. versionadded:: 0.11.0
 

--- a/pulse2percept/models/cortex/base.py
+++ b/pulse2percept/models/cortex/base.py
@@ -70,6 +70,13 @@ class CortexSpatial(SpatialModel):
         interpreted as the number of pixels to subject to noise in each frame.
         A float between 0 and 1 will be interpreted as a ratio of pixels to
         subject to noise in each frame.
+    location_noise : float or None, optional
+        Standard deviation (dva) of this subject's retinotopic
+        distortion; see
+        :py:class:`~pulse2percept.models.SpatialModel`.
+
+        .. versionadded:: 0.11.0
+
     n_threads : int, optional
         Number of CPU threads to use during parallelization using OpenMP.
         Defaults to max number of user CPU cores.
@@ -284,6 +291,13 @@ class ScoreboardSpatial(CortexSpatial):
         interpreted as the number of pixels to subject to noise in each frame.
         A float between 0 and 1 will be interpreted as a ratio of pixels to
         subject to noise in each frame.
+    location_noise : float or None, optional
+        Standard deviation (dva) of this subject's retinotopic
+        distortion; see
+        :py:class:`~pulse2percept.models.SpatialModel`.
+
+        .. versionadded:: 0.11.0
+
     n_threads : int, optional
         Number of CPU threads to use during parallelization using OpenMP.
         Defaults to max number of user CPU cores.
@@ -302,6 +316,7 @@ class ScoreboardSpatial(CortexSpatial):
                  grid_type='rect', thresh_percept=0,
                  min_current_spread=1e-8, visual_field_map=None, n_gray=None,
                  noise=None,
+                 location_noise=None,
                  verbose=True, ndim=None, n_threads=None, n_jobs=None):
         super().__init__(
             implant, rho=rho, regions=regions,
@@ -309,7 +324,8 @@ class ScoreboardSpatial(CortexSpatial):
             step=step, grid_type=grid_type, thresh_percept=thresh_percept,
             min_current_spread=min_current_spread,
             visual_field_map=visual_field_map,
-            n_gray=n_gray, noise=noise, verbose=verbose,
+            n_gray=n_gray, noise=noise,
+            location_noise=location_noise, verbose=verbose,
             ndim=[2, 3] if ndim is None else ndim,
             **_thread_params(n_threads, n_jobs))
 
@@ -455,6 +471,13 @@ class ScoreboardModel(Model):
         interpreted as the number of pixels to subject to noise in each frame.
         A float between 0 and 1 will be interpreted as a ratio of pixels to
         subject to noise in each frame.
+    location_noise : float or None, optional
+        Standard deviation (dva) of this subject's retinotopic
+        distortion; see
+        :py:class:`~pulse2percept.models.SpatialModel`.
+
+        .. versionadded:: 0.11.0
+
     n_threads : int, optional
         Number of CPU threads to use during parallelization using OpenMP.
         Defaults to max number of user CPU cores.
@@ -473,6 +496,7 @@ class ScoreboardModel(Model):
                  grid_type='rect', thresh_percept=0,
                  min_current_spread=1e-8, visual_field_map=None, n_gray=None,
                  noise=None,
+                 location_noise=None,
                  verbose=True, ndim=None, n_threads=None, n_jobs=None):
         super().__init__(
             spatial=ScoreboardSpatial(
@@ -482,6 +506,7 @@ class ScoreboardModel(Model):
                 thresh_percept=thresh_percept,
                 min_current_spread=min_current_spread,
                 visual_field_map=visual_field_map,
-                n_gray=n_gray, noise=noise, verbose=verbose, ndim=ndim,
+                n_gray=n_gray, noise=noise,
+                location_noise=location_noise, verbose=verbose, ndim=ndim,
                 n_threads=n_threads, n_jobs=n_jobs),
             temporal=None)

--- a/pulse2percept/models/cortex/base.py
+++ b/pulse2percept/models/cortex/base.py
@@ -71,9 +71,9 @@ class CortexSpatial(SpatialModel):
         A float between 0 and 1 will be interpreted as a ratio of pixels to
         subject to noise in each frame.
     location_noise : float or None, optional
-        Standard deviation (dva) of this subject's retinotopic
-        distortion; see
-        :py:class:`~pulse2percept.models.SpatialModel`.
+        Standard deviation of the variation in phosphene location from the
+        ``visual_field_map``, in dva. Locations are fixed for a model instance.
+        ``None`` or 0 disables the variation.
 
         .. versionadded:: 0.11.0
 
@@ -292,9 +292,9 @@ class ScoreboardSpatial(CortexSpatial):
         A float between 0 and 1 will be interpreted as a ratio of pixels to
         subject to noise in each frame.
     location_noise : float or None, optional
-        Standard deviation (dva) of this subject's retinotopic
-        distortion; see
-        :py:class:`~pulse2percept.models.SpatialModel`.
+        Standard deviation of the variation in phosphene location from the
+        ``visual_field_map``, in dva. Locations are fixed for a model instance.
+        ``None`` or 0 disables the variation.
 
         .. versionadded:: 0.11.0
 
@@ -472,10 +472,10 @@ class ScoreboardModel(Model):
         A float between 0 and 1 will be interpreted as a ratio of pixels to
         subject to noise in each frame.
     location_noise : float or None, optional
-        Standard deviation (dva) of this subject's retinotopic
-        distortion; see
-        :py:class:`~pulse2percept.models.SpatialModel`.
-
+        Standard deviation of the variation in phosphene location from the
+        ``visual_field_map``, in dva. Locations are fixed for a model instance.
+        ``None`` or 0 disables the variation.
+        
         .. versionadded:: 0.11.0
 
     n_threads : int, optional

--- a/pulse2percept/models/cortex/base.py
+++ b/pulse2percept/models/cortex/base.py
@@ -339,8 +339,10 @@ class ScoreboardSpatial(CortexSpatial):
         On this model rather than on `CortexSpatial`: the seam is a property
         of the split map this one is built on, not of being cortical, and a
         future cortical model without one should not inherit a correction for
-        it.
+        it. It applies to the rendered visual field, so it comes after the
+        base class' retinotopic warp.
         """
+        resp = super()._postprocess_spatial(resp)
         blended = _blend_meridian(resp, self.grid, 'vertical',
                                   self.meridian_blend)
         if blended is resp:

--- a/pulse2percept/models/cortex/dynaphos.py
+++ b/pulse2percept/models/cortex/dynaphos.py
@@ -3,8 +3,9 @@ import numpy as np
 import warnings
 from copy import deepcopy, copy
 
-from ..base import (BaseModel, _check_implant, _location_noise_field,
-                    _require_stim_dimension, _warp_visual_field)
+from ..base import (BaseModel, _check_implant, _electrode_offsets,
+                    _latent_offsets, _location_noise_sigma,
+                    _require_stim_dimension)
 from ...percepts import Percept
 from ...stimuli import BiphasicPulseTrain
 from ...units import A, Quantity, as_value, dva, Hz, mm, ms, uA
@@ -165,10 +166,8 @@ class DynaphosModel(BaseModel):
 
             self.visual_field_map.regions = self.regions
             self.grid = None
-            # This subject's electrode offsets and the grid warp they produce;
-            # see `_electrode_offsets` and `_location_noise_field`:
+            # This subject's latent electrode offsets; see `_latent_offsets`:
             self._location_noise_z = None
-            self._location_noise = None
 
     @property
     def implant(self):
@@ -207,7 +206,7 @@ class DynaphosModel(BaseModel):
                 'n_gray': None,
                 # Salt-and-pepper noise on the output:
                 'noise': None,
-                # Retinotopic distortion of this subject's percepts (dva)
+                # Subject-specific phosphene displacement (dva):
                 'location_noise': None,
                 # True: print status messages, 0: silent
                 'verbose': True,
@@ -302,7 +301,10 @@ class DynaphosModel(BaseModel):
         self.grid = Grid2D(self.xrange, self.yrange, step=self.step,
                            grid_type=self.grid_type)
         self.grid.build(self.visual_field_map)
-        self._location_noise = _location_noise_field(self)
+        if _location_noise_sigma(self) is not None:
+            # Draw the subject here so that the offsets do not depend on which
+            # stimulus is predicted first:
+            _latent_offsets(self)
         self._build()
         self._is_built = True
         return self
@@ -322,6 +324,14 @@ class DynaphosModel(BaseModel):
             phosphene_locations[region] = self.visual_field_map.to_dva()[region](x_el, y_el)
 
         theta, r = cart2pol(*phosphene_locations['v1'])
+
+        # `location_noise` moves the phosphene, not the electrode: the size
+        # below still follows the canonical cortical magnification.
+        offsets = _electrode_offsets(self, stim.electrodes)
+        if offsets is not None:
+            for region, (px, py) in phosphene_locations.items():
+                phosphene_locations[region] = (px + offsets[:, 0],
+                                               py + offsets[:, 1])
 
         # magnification factors (mm/dva)
         M = self.visual_field_map.k * (self.visual_field_map.b - self.visual_field_map.a) / ((r + self.visual_field_map.a) * (r + self.visual_field_map.b))
@@ -518,7 +528,6 @@ class DynaphosModel(BaseModel):
         else:
             resp = self._predict_percept(self.implant.electrode_array, stim,
                                          t_percept, clocks)
-        resp = _warp_visual_field(resp, self.grid, self._location_noise)
         return Percept(resp.reshape(list(self.grid.x.shape) + [t_percept.size]),
                        space=self.grid, time=t_percept,
                        time_unit=self.time_unit,

--- a/pulse2percept/models/cortex/dynaphos.py
+++ b/pulse2percept/models/cortex/dynaphos.py
@@ -3,7 +3,8 @@ import numpy as np
 import warnings
 from copy import deepcopy, copy
 
-from ..base import BaseModel, _check_implant, _require_stim_dimension
+from ..base import (BaseModel, _check_implant, _location_noise_field,
+                    _require_stim_dimension, _warp_visual_field)
 from ...percepts import Percept
 from ...stimuli import BiphasicPulseTrain
 from ...units import A, Quantity, as_value, dva, Hz, mm, ms, uA
@@ -103,6 +104,14 @@ class DynaphosModel(BaseModel):
         The number of gray levels to use. If an integer is given, k-means
         clustering is used to compress the color space of the percept into
         ``n_gray`` bins. If None, no compression is performed.
+    location_noise : float or None, optional
+        Standard deviation (dva) of this subject's retinotopic distortion: how
+        far the percept of an electrode lands from where
+        ``visual_field_map`` predicts it. ``None`` or 0 leaves the percept
+        untouched.
+
+        .. versionadded:: 0.11.0
+
     noise : float or int, optional
         Adds salt-and-pepper noise to each percept frame. An integer will be
         interpreted as the number of pixels to subject to noise in each 
@@ -136,6 +145,7 @@ class DynaphosModel(BaseModel):
                  xrange=(-5, 5), yrange=(-5, 5), step=0.25,
                  grid_type='rect', visual_field_map=None, n_gray=None,
                  noise=None,
+                 location_noise=None,
                  verbose=True):
             _check_implant(implant)
             self._implant = implant
@@ -150,11 +160,16 @@ class DynaphosModel(BaseModel):
                 visual_field_map=(
                     Polimeni2006Map(a=0.75, k=17.3, b=120, alpha1=0.95)
                     if visual_field_map is None else visual_field_map),
-                n_gray=n_gray, noise=noise, verbose=verbose,
+                n_gray=n_gray, noise=noise,
+                location_noise=location_noise, verbose=verbose,
                 regions=['v1'] if regions is None else regions)
 
             self.visual_field_map.regions = self.regions
             self.grid = None
+            # This subject's electrode offsets and the grid warp they produce;
+            # see `_electrode_offsets` and `_location_noise_field`:
+            self._location_noise_z = None
+            self._location_noise = None
 
     @property
     def implant(self):
@@ -174,6 +189,8 @@ class DynaphosModel(BaseModel):
         _check_implant(implant)
         if implant is not self._implant:
             self._is_built = False
+            # A different implant is a different set of electrodes to displace:
+            self._location_noise_z = None
         self._implant = implant
 
     
@@ -191,6 +208,8 @@ class DynaphosModel(BaseModel):
                 'n_gray': None,
                 # Salt-and-pepper noise on the output:
                 'noise': None,
+                # Retinotopic distortion of this subject's percepts (dva)
+                'location_noise': None,
                 # True: print status messages, 0: silent
                 'verbose': True,
                 # Visual field regions to simulate
@@ -235,6 +254,8 @@ class DynaphosModel(BaseModel):
             'xrange': dva,
             'yrange': dva,
             'step': dva,
+            # The percept is displaced in the visual field, not on cortex:
+            'location_noise': dva,
             'dt': ms,
             # Decay constants, both converted to seconds where they are used:
             'tau_act': ms,
@@ -282,6 +303,7 @@ class DynaphosModel(BaseModel):
         self.grid = Grid2D(self.xrange, self.yrange, step=self.step,
                            grid_type=self.grid_type)
         self.grid.build(self.visual_field_map)
+        self._location_noise = _location_noise_field(self)
         self._build()
         self._is_built = True
         return self
@@ -497,6 +519,7 @@ class DynaphosModel(BaseModel):
         else:
             resp = self._predict_percept(self.implant.electrode_array, stim,
                                          t_percept, clocks)
+        resp = _warp_visual_field(resp, self.grid, self._location_noise)
         return Percept(resp.reshape(list(self.grid.x.shape) + [t_percept.size]),
                        space=self.grid, time=t_percept,
                        time_unit=self.time_unit,

--- a/pulse2percept/models/cortex/dynaphos.py
+++ b/pulse2percept/models/cortex/dynaphos.py
@@ -106,9 +106,8 @@ class DynaphosModel(BaseModel):
         clustering is used to compress the color space of the percept into
         ``n_gray`` bins. If None, no compression is performed.
     location_noise : float or None, optional
-        Standard deviation of the variation in phosphene location from the
-        ``visual_field_map``, in dva. Locations are fixed for a model instance.
-        ``None`` or 0 disables the variation.
+        Standard deviation of fixed electrode-specific phosphene offsets, in dva.
+        Requires an invertible 2D ``visual_field_map``. ``None`` or 0 disables it.
         
         .. versionadded:: 0.11.0
 
@@ -166,7 +165,6 @@ class DynaphosModel(BaseModel):
 
             self.visual_field_map.regions = self.regions
             self.grid = None
-            # This subject's latent electrode offsets; see `_latent_offsets`:
             self._location_noise_z = None
 
     @property
@@ -187,7 +185,6 @@ class DynaphosModel(BaseModel):
         _check_implant(implant)
         if implant is not self._implant:
             self._is_built = False
-            # A different implant is a different set of electrodes to displace:
             self._location_noise_z = None
         self._implant = implant
 
@@ -252,7 +249,6 @@ class DynaphosModel(BaseModel):
             'xrange': dva,
             'yrange': dva,
             'step': dva,
-            # The percept is displaced in the visual field, not on cortex:
             'location_noise': dva,
             'dt': ms,
             # Decay constants, both converted to seconds where they are used:
@@ -302,8 +298,7 @@ class DynaphosModel(BaseModel):
                            grid_type=self.grid_type)
         self.grid.build(self.visual_field_map)
         if _location_noise_sigma(self) is not None:
-            # Draw the subject here so that the offsets do not depend on which
-            # stimulus is predicted first:
+            # Draw once so the first stimulus does not determine the subject.
             _latent_offsets(self)
         self._build()
         self._is_built = True
@@ -325,18 +320,15 @@ class DynaphosModel(BaseModel):
 
         theta, r = cart2pol(*phosphene_locations['v1'])
 
-        # `location_noise` moves the phosphene, not the electrode: the size
-        # below still follows the canonical cortical magnification.
+        # Dynaphos moves the phosphene but keeps its canonical size.
         offsets = _electrode_offsets(self, stim.electrodes)
         x_split = x_el
         if offsets is not None:
             for region, (px, py) in phosphene_locations.items():
                 phosphene_locations[region] = (px + offsets[:, 0],
                                                py + offsets[:, 1])
-            # `create_gaussian` clips each phosphene to one hemifield, and a
-            # displaced phosphene belongs to the one it lands in. Ask the map
-            # rather than the sign of the displaced dva x: near the meridian
-            # the inverse is only accurate to a few hundredths of a degree.
+            # Use displaced cortical location for hemifield assignment;
+            # dva sign is unreliable near the meridian.
             split = self.visual_field_map.from_dva()['v1'](
                 *[np.array(c, dtype=np.float64)
                   for c in phosphene_locations['v1']])

--- a/pulse2percept/models/cortex/dynaphos.py
+++ b/pulse2percept/models/cortex/dynaphos.py
@@ -4,7 +4,7 @@ import warnings
 from copy import deepcopy, copy
 
 from ..base import (BaseModel, _check_implant, _electrode_offsets,
-                    _latent_offsets, _location_noise_sigma,
+                    _latent_offsets, _location_noise_sigma, _require_placed,
                     _require_stim_dimension)
 from ...percepts import Percept
 from ...stimuli import BiphasicPulseTrain
@@ -337,9 +337,11 @@ class DynaphosModel(BaseModel):
             # displaced phosphene belongs to the one it lands in. Ask the map
             # rather than the sign of the displaced dva x: near the meridian
             # the inverse is only accurate to a few hundredths of a degree.
-            x_split = self.visual_field_map.from_dva()['v1'](
+            split = self.visual_field_map.from_dva()['v1'](
                 *[np.array(c, dtype=np.float64)
-                  for c in phosphene_locations['v1']])[0]
+                  for c in phosphene_locations['v1']])
+            _require_placed(self, 'v1', stim.electrodes, split, 'displaced')
+            x_split = split[0]
 
         # magnification factors (mm/dva)
         M = self.visual_field_map.k * (self.visual_field_map.b - self.visual_field_map.a) / ((r + self.visual_field_map.a) * (r + self.visual_field_map.b))

--- a/pulse2percept/models/cortex/dynaphos.py
+++ b/pulse2percept/models/cortex/dynaphos.py
@@ -105,11 +105,10 @@ class DynaphosModel(BaseModel):
         clustering is used to compress the color space of the percept into
         ``n_gray`` bins. If None, no compression is performed.
     location_noise : float or None, optional
-        Standard deviation (dva) of this subject's retinotopic distortion: how
-        far the percept of an electrode lands from where
-        ``visual_field_map`` predicts it. ``None`` or 0 leaves the percept
-        untouched.
-
+        Standard deviation of the variation in phosphene location from the
+        ``visual_field_map``, in dva. Locations are fixed for a model instance.
+        ``None`` or 0 disables the variation.
+        
         .. versionadded:: 0.11.0
 
     noise : float or int, optional

--- a/pulse2percept/models/cortex/dynaphos.py
+++ b/pulse2percept/models/cortex/dynaphos.py
@@ -328,10 +328,18 @@ class DynaphosModel(BaseModel):
         # `location_noise` moves the phosphene, not the electrode: the size
         # below still follows the canonical cortical magnification.
         offsets = _electrode_offsets(self, stim.electrodes)
+        x_split = x_el
         if offsets is not None:
             for region, (px, py) in phosphene_locations.items():
                 phosphene_locations[region] = (px + offsets[:, 0],
                                                py + offsets[:, 1])
+            # `create_gaussian` clips each phosphene to one hemifield, and a
+            # displaced phosphene belongs to the one it lands in. Ask the map
+            # rather than the sign of the displaced dva x: near the meridian
+            # the inverse is only accurate to a few hundredths of a degree.
+            x_split = self.visual_field_map.from_dva()['v1'](
+                *[np.array(c, dtype=np.float64)
+                  for c in phosphene_locations['v1']])[0]
 
         # magnification factors (mm/dva)
         M = self.visual_field_map.k * (self.visual_field_map.b - self.visual_field_map.a) / ((r + self.visual_field_map.a) * (r + self.visual_field_map.b))
@@ -444,7 +452,7 @@ class DynaphosModel(BaseModel):
                     if A[el_idx] >= self.a_thr:
                         gauss = create_gaussian(phosphene_locations['v1'][0][el_idx], 
                                                 phosphene_locations['v1'][1][el_idx], 
-                                                sigma[el_idx], x_el[el_idx])
+                                                sigma[el_idx], x_split[el_idx])
                         bright[:,frame_idx] += gauss.ravel() * brightness[el_idx]
                 bright[:,frame_idx] = np.clip(bright[:,frame_idx], 0, 1)
                 frame_idx = frame_idx + 1

--- a/pulse2percept/models/cortex/tests/test_dynaphos.py
+++ b/pulse2percept/models/cortex/tests/test_dynaphos.py
@@ -377,3 +377,32 @@ def test_location_noise():
 
     with pytest.raises(ValueError):
         DynaphosModel(implant=implant, location_noise=-1, **kwargs).build()
+    # NaN is not a quiet no-op:
+    with pytest.raises(ValueError):
+        DynaphosModel(implant=implant, location_noise=np.nan, **kwargs).build()
+
+
+def test_location_noise_crosses_meridian():
+    # A phosphene displaced across the vertical meridian is drawn in the
+    # hemifield it lands in, not the one its electrode maps to. This
+    # electrode sits just left of the meridian (x = +0.24 dva) and the
+    # offset below carries it 0.83 dva to the right of it.
+    implant = Implant(ElectrodeArray([DiskElectrode(-25000, 2000, 0, 100)]))
+    source = {0: BiphasicPulseTrain(freq=300, amp=200, phase_dur=0.17)}
+    kwargs = dict(xrange=(-4, 4), yrange=(-4, 4), step=0.05)
+    plain = DynaphosModel(implant=implant, **kwargs).build()
+    canonical = plain.predict_percept(source)
+    npt.assert_array_less(0, _brightest_dva(canonical, plain.grid)[0])
+
+    np.random.seed(2)
+    offset = np.random.normal(size=(1, 2))[0] * 2.0
+    np.random.seed(2)
+    moved = DynaphosModel(implant=implant, location_noise=2.0,
+                          **kwargs).build()
+    got = moved.predict_percept(source)
+    npt.assert_allclose(_brightest_dva(got, moved.grid) -
+                        _brightest_dva(canonical, plain.grid), offset,
+                        atol=0.06)
+    # The whole phosphene came along; a hemifield mask left behind would
+    # have clipped most of it away:
+    npt.assert_allclose(got.data.sum(), canonical.data.sum(), rtol=0.05)

--- a/pulse2percept/models/cortex/tests/test_dynaphos.py
+++ b/pulse2percept/models/cortex/tests/test_dynaphos.py
@@ -335,11 +335,20 @@ def test_dynaphos_uses_its_defaults_for_an_encoded_stimulus():
     npt.assert_equal(_pulse_train_clocks(solo), None)
 
 
+
+def _brightest_dva(percept, grid):
+    """The (x, y) location of the brightest grid point of the last frame"""
+    frame = percept.data[..., -1]
+    idx = np.unravel_index(np.argmax(frame), frame.shape)
+    return np.array([float(grid.x[idx]), float(grid.y[idx])])
+
+
 def test_location_noise():
     implant = Cortivis()
-    source = {e: BiphasicPulseTrain(freq=300, amp=200, phase_dur=0.17)
-              for e in implant.electrode_names}
-    kwargs = dict(xrange=(-3, 3), yrange=(-3, 3), step=0.1)
+    electrode = implant.electrode_names[10]
+    source = {electrode: BiphasicPulseTrain(freq=300, amp=200,
+                                            phase_dur=0.17)}
+    kwargs = dict(xrange=(-4, 4), yrange=(-4, 4), step=0.05)
     plain = DynaphosModel(implant=implant, **kwargs).build()
     expected = plain.predict_percept(source).data
 
@@ -349,14 +358,22 @@ def test_location_noise():
                               **kwargs).build()
         npt.assert_array_equal(model.predict_percept(source).data, expected)
 
-    np.random.seed(0)
-    warped = DynaphosModel(implant=implant, location_noise=0.5,
-                           **kwargs).build()
-    got = warped.predict_percept(source).data
-    npt.assert_equal(got.shape, expected.shape)
-    npt.assert_equal(np.array_equal(got, expected), False)
-    # The distortion is the subject's, so it survives a rebuild:
-    npt.assert_array_equal(warped.build().predict_percept(source).data, got)
+    np.random.seed(3)
+    offset = np.random.normal(size=(len(implant.electrode_names), 2))[10]
+    np.random.seed(3)
+    moved = DynaphosModel(implant=implant, location_noise=1.0,
+                          **kwargs).build()
+    got = moved.predict_percept(source).data
+    # The phosphene moves by this electrode's offset, within a grid step:
+    npt.assert_allclose(_brightest_dva(moved.predict_percept(source),
+                                       moved.grid) -
+                        _brightest_dva(plain.predict_percept(source),
+                                       plain.grid),
+                        offset, atol=0.06)
+    # It is the same phosphene, just elsewhere:
+    npt.assert_allclose(got.max(), expected.max(), rtol=0.05)
+    # The offsets are the subject's, so they survive a rebuild:
+    npt.assert_array_equal(moved.build().predict_percept(source).data, got)
 
     with pytest.raises(ValueError):
         DynaphosModel(implant=implant, location_noise=-1, **kwargs).build()

--- a/pulse2percept/models/cortex/tests/test_dynaphos.py
+++ b/pulse2percept/models/cortex/tests/test_dynaphos.py
@@ -352,7 +352,6 @@ def test_location_noise():
     plain = DynaphosModel(implant=implant, **kwargs).build()
     expected = plain.predict_percept(source).data
 
-    # None and 0 are exact no-ops:
     for off in (None, 0):
         model = DynaphosModel(implant=implant, location_noise=off,
                               **kwargs).build()
@@ -364,29 +363,22 @@ def test_location_noise():
     moved = DynaphosModel(implant=implant, location_noise=1.0,
                           **kwargs).build()
     got = moved.predict_percept(source).data
-    # The phosphene moves by this electrode's offset, within a grid step:
     npt.assert_allclose(_brightest_dva(moved.predict_percept(source),
                                        moved.grid) -
                         _brightest_dva(plain.predict_percept(source),
                                        plain.grid),
                         offset, atol=0.06)
-    # It is the same phosphene, just elsewhere:
     npt.assert_allclose(got.max(), expected.max(), rtol=0.05)
-    # The offsets are the subject's, so they survive a rebuild:
     npt.assert_array_equal(moved.build().predict_percept(source).data, got)
 
     with pytest.raises(ValueError):
         DynaphosModel(implant=implant, location_noise=-1, **kwargs).build()
-    # NaN is not a quiet no-op:
     with pytest.raises(ValueError):
         DynaphosModel(implant=implant, location_noise=np.nan, **kwargs).build()
 
 
 def test_location_noise_crosses_meridian():
-    # A phosphene displaced across the vertical meridian is drawn in the
-    # hemifield it lands in, not the one its electrode maps to. This
-    # electrode sits just left of the meridian (x = +0.24 dva) and the
-    # offset below carries it 0.83 dva to the right of it.
+    # Choose an electrode/offset pair that crosses the vertical meridian.
     implant = Implant(ElectrodeArray([DiskElectrode(-25000, 2000, 0, 100)]))
     source = {0: BiphasicPulseTrain(freq=300, amp=200, phase_dur=0.17)}
     kwargs = dict(xrange=(-4, 4), yrange=(-4, 4), step=0.05)
@@ -403,12 +395,9 @@ def test_location_noise_crosses_meridian():
     npt.assert_allclose(_brightest_dva(got, moved.grid) -
                         _brightest_dva(canonical, plain.grid), offset,
                         atol=0.06)
-    # The whole phosphene came along; a hemifield mask left behind would
-    # have clipped most of it away:
     npt.assert_allclose(got.data.sum(), canonical.data.sum(), rtol=0.05)
 
-    # An offset that lands outside the map's domain (here beyond its 90 dva
-    # eccentricity) says so, rather than silently dropping the phosphene:
+    # Displacements outside the map domain must fail explicitly.
     np.random.seed(2)
     off_map = DynaphosModel(implant=implant, location_noise=300.0,
                             **kwargs).build()

--- a/pulse2percept/models/cortex/tests/test_dynaphos.py
+++ b/pulse2percept/models/cortex/tests/test_dynaphos.py
@@ -333,3 +333,30 @@ def test_dynaphos_uses_its_defaults_for_an_encoded_stimulus():
     solo = AmplitudeEncoder().encode(ImageStimulus(np.array([[0.7]])))
     npt.assert_equal(len(solo._structured_sources()), 1)
     npt.assert_equal(_pulse_train_clocks(solo), None)
+
+
+def test_location_noise():
+    implant = Cortivis()
+    source = {e: BiphasicPulseTrain(freq=300, amp=200, phase_dur=0.17)
+              for e in implant.electrode_names}
+    kwargs = dict(xrange=(-3, 3), yrange=(-3, 3), step=0.1)
+    plain = DynaphosModel(implant=implant, **kwargs).build()
+    expected = plain.predict_percept(source).data
+
+    # None and 0 are exact no-ops:
+    for off in (None, 0):
+        model = DynaphosModel(implant=implant, location_noise=off,
+                              **kwargs).build()
+        npt.assert_array_equal(model.predict_percept(source).data, expected)
+
+    np.random.seed(0)
+    warped = DynaphosModel(implant=implant, location_noise=0.5,
+                           **kwargs).build()
+    got = warped.predict_percept(source).data
+    npt.assert_equal(got.shape, expected.shape)
+    npt.assert_equal(np.array_equal(got, expected), False)
+    # The distortion is the subject's, so it survives a rebuild:
+    npt.assert_array_equal(warped.build().predict_percept(source).data, got)
+
+    with pytest.raises(ValueError):
+        DynaphosModel(implant=implant, location_noise=-1, **kwargs).build()

--- a/pulse2percept/models/cortex/tests/test_dynaphos.py
+++ b/pulse2percept/models/cortex/tests/test_dynaphos.py
@@ -406,3 +406,11 @@ def test_location_noise_crosses_meridian():
     # The whole phosphene came along; a hemifield mask left behind would
     # have clipped most of it away:
     npt.assert_allclose(got.data.sum(), canonical.data.sum(), rtol=0.05)
+
+    # An offset that lands outside the map's domain (here beyond its 90 dva
+    # eccentricity) says so, rather than silently dropping the phosphene:
+    np.random.seed(2)
+    off_map = DynaphosModel(implant=implant, location_noise=300.0,
+                            **kwargs).build()
+    with pytest.raises(ValueError):
+        off_map.predict_percept(source)

--- a/pulse2percept/models/granley2021.py
+++ b/pulse2percept/models/granley2021.py
@@ -531,9 +531,8 @@ class BiphasicAxonMapSpatial(AxonMapSpatial):
         elec_params = np.array([p[1:4] for p in params],
                                dtype=np.float32).reshape((-1, 3))
         # Match coordinates to the active-electrode order above.
-        xyz = electrode_array.coordinates(self.space_unit, electrodes=active)
-        x = np.ascontiguousarray(xyz[:, 0], dtype=np.float32)
-        y = np.ascontiguousarray(xyz[:, 1], dtype=np.float32)
+        x, y, _ = self._electrode_coords(electrode_array, stim,
+                                         electrodes=active)
 
         bright_effects = np.array(self.bright_model(elec_params[:, 0], elec_params[:, 1], elec_params[:, 2]),
                                   dtype=np.float32).reshape((-1))

--- a/pulse2percept/models/granley2021.py
+++ b/pulse2percept/models/granley2021.py
@@ -403,9 +403,9 @@ class BiphasicAxonMapSpatial(AxonMapSpatial):
         Salt-and-pepper noise applied to each percept frame. An integer gives
         the number of affected pixels; a float in [0, 1] gives their fraction.
     location_noise : float or None, optional
-        Standard deviation (dva) of this subject's retinotopic
-        distortion; see
-        :py:class:`~pulse2percept.models.SpatialModel`.
+        Standard deviation of the variation in phosphene location from the
+        ``visual_field_map``, in dva. Locations are fixed for a model instance.
+        ``None`` or 0 disables the variation.
 
         .. versionadded:: 0.11.0
 
@@ -771,10 +771,10 @@ class BiphasicAxonMapModel(Model):
         Salt-and-pepper noise applied to each percept frame. An integer gives
         the number of affected pixels; a float in [0, 1] gives their fraction.
     location_noise : float or None, optional
-        Standard deviation (dva) of this subject's retinotopic
-        distortion; see
-        :py:class:`~pulse2percept.models.SpatialModel`.
-
+        Standard deviation of the variation in phosphene location from the
+        ``visual_field_map``, in dva. Locations are fixed for a model instance.
+        ``None`` or 0 disables the variation.
+        
         .. versionadded:: 0.11.0
 
     loc_od : (float, float) or Quantity, optional

--- a/pulse2percept/models/granley2021.py
+++ b/pulse2percept/models/granley2021.py
@@ -402,6 +402,13 @@ class BiphasicAxonMapSpatial(AxonMapSpatial):
     noise : float, int, or None, optional
         Salt-and-pepper noise applied to each percept frame. An integer gives
         the number of affected pixels; a float in [0, 1] gives their fraction.
+    location_noise : float or None, optional
+        Standard deviation (dva) of this subject's retinotopic
+        distortion; see
+        :py:class:`~pulse2percept.models.SpatialModel`.
+
+        .. versionadded:: 0.11.0
+
     loc_od : (float, float) or Quantity, optional
         Optic-disc location in degrees of visual angle. Its horizontal sign is
         set from the bound implant's eye.
@@ -446,7 +453,8 @@ class BiphasicAxonMapSpatial(AxonMapSpatial):
                  yrange=(-15, 15), step=0.25, grid_type='rect',
                  thresh_percept=0, min_current_spread=1e-8,
                  visual_field_map=None,
-                 n_gray=None, noise=None, loc_od=(15.5, 1.5), n_axons=1000,
+                 n_gray=None, noise=None,
+                 location_noise=None, loc_od=(15.5, 1.5), n_axons=1000,
                  axons_range=(-180, 180), n_ax_segments=500,
                  ax_segments_range=(0, 50), min_ax_sensitivity=1e-3,
                  meridian_blend=1, axon_pickle='axons.pickle',
@@ -458,7 +466,8 @@ class BiphasicAxonMapSpatial(AxonMapSpatial):
             step=step, grid_type=grid_type, thresh_percept=thresh_percept,
             min_current_spread=min_current_spread,
             visual_field_map=visual_field_map,
-            n_gray=n_gray, noise=noise, loc_od=loc_od, n_axons=n_axons,
+            n_gray=n_gray, noise=noise,
+            location_noise=location_noise, loc_od=loc_od, n_axons=n_axons,
             axons_range=axons_range, n_ax_segments=n_ax_segments,
             ax_segments_range=ax_segments_range,
             min_ax_sensitivity=min_ax_sensitivity,
@@ -761,6 +770,13 @@ class BiphasicAxonMapModel(Model):
     noise : float, int, or None, optional
         Salt-and-pepper noise applied to each percept frame. An integer gives
         the number of affected pixels; a float in [0, 1] gives their fraction.
+    location_noise : float or None, optional
+        Standard deviation (dva) of this subject's retinotopic
+        distortion; see
+        :py:class:`~pulse2percept.models.SpatialModel`.
+
+        .. versionadded:: 0.11.0
+
     loc_od : (float, float) or Quantity, optional
         Optic-disc location in degrees of visual angle. Its horizontal sign is
         set from the bound implant's eye.
@@ -829,7 +845,8 @@ class BiphasicAxonMapModel(Model):
                  yrange=(-15, 15), step=0.25, grid_type='rect',
                  thresh_percept=0, min_current_spread=1e-8,
                  visual_field_map=None,
-                 n_gray=None, noise=None, loc_od=(15.5, 1.5), n_axons=1000,
+                 n_gray=None, noise=None,
+                 location_noise=None, loc_od=(15.5, 1.5), n_axons=1000,
                  axons_range=(-180, 180), n_ax_segments=500,
                  ax_segments_range=(0, 50), min_ax_sensitivity=1e-3,
                  meridian_blend=1, axon_pickle='axons.pickle',
@@ -843,7 +860,8 @@ class BiphasicAxonMapModel(Model):
                 thresh_percept=thresh_percept,
                 min_current_spread=min_current_spread,
                 visual_field_map=visual_field_map,
-                n_gray=n_gray, noise=noise, loc_od=loc_od, n_axons=n_axons,
+                n_gray=n_gray, noise=noise,
+                location_noise=location_noise, loc_od=loc_od, n_axons=n_axons,
                 axons_range=axons_range, n_ax_segments=n_ax_segments,
                 ax_segments_range=ax_segments_range,
                 min_ax_sensitivity=min_ax_sensitivity,

--- a/pulse2percept/models/granley2021.py
+++ b/pulse2percept/models/granley2021.py
@@ -403,12 +403,9 @@ class BiphasicAxonMapSpatial(AxonMapSpatial):
         Salt-and-pepper noise applied to each percept frame. An integer gives
         the number of affected pixels; a float in [0, 1] gives their fraction.
     location_noise : float or None, optional
-        Standard deviation of the variation in phosphene location from the
-        ``visual_field_map``, in dva. Locations are fixed for a model instance.
-        ``None`` or 0 disables the variation.
-        Moves the effective stimulation location, so phosphene shape and
-        size change too wherever the model makes them location-dependent
-        (axon bundles, cortical magnification).
+        Standard deviation of fixed electrode-specific phosphene offsets, in dva.
+        Requires an invertible 2D ``visual_field_map``. ``None`` or 0 disables it.
+        Location-dependent models may also change phosphene shape or size.
 
         .. versionadded:: 0.11.0
 
@@ -773,12 +770,9 @@ class BiphasicAxonMapModel(Model):
         Salt-and-pepper noise applied to each percept frame. An integer gives
         the number of affected pixels; a float in [0, 1] gives their fraction.
     location_noise : float or None, optional
-        Standard deviation of the variation in phosphene location from the
-        ``visual_field_map``, in dva. Locations are fixed for a model instance.
-        ``None`` or 0 disables the variation.
-        Moves the effective stimulation location, so phosphene shape and
-        size change too wherever the model makes them location-dependent
-        (axon bundles, cortical magnification).
+        Standard deviation of fixed electrode-specific phosphene offsets, in dva.
+        Requires an invertible 2D ``visual_field_map``. ``None`` or 0 disables it.
+        Location-dependent models may also change phosphene shape or size.
         
         .. versionadded:: 0.11.0
 

--- a/pulse2percept/models/granley2021.py
+++ b/pulse2percept/models/granley2021.py
@@ -406,6 +406,9 @@ class BiphasicAxonMapSpatial(AxonMapSpatial):
         Standard deviation of the variation in phosphene location from the
         ``visual_field_map``, in dva. Locations are fixed for a model instance.
         ``None`` or 0 disables the variation.
+        Moves the effective stimulation location, so phosphene shape and
+        size change too wherever the model makes them location-dependent
+        (axon bundles, cortical magnification).
 
         .. versionadded:: 0.11.0
 
@@ -773,6 +776,9 @@ class BiphasicAxonMapModel(Model):
         Standard deviation of the variation in phosphene location from the
         ``visual_field_map``, in dva. Locations are fixed for a model instance.
         ``None`` or 0 disables the variation.
+        Moves the effective stimulation location, so phosphene shape and
+        size change too wherever the model makes them location-dependent
+        (axon bundles, cortical magnification).
         
         .. versionadded:: 0.11.0
 

--- a/pulse2percept/models/nanduri2012.py
+++ b/pulse2percept/models/nanduri2012.py
@@ -111,6 +111,9 @@ class Nanduri2012Spatial(SpatialModel):
             Standard deviation of the variation in phosphene location from the
             ``visual_field_map``, in dva. Locations are fixed for a model instance.
             ``None`` or 0 disables the variation.
+            Moves the effective stimulation location, so phosphene shape and
+            size change too wherever the model makes them location-dependent
+            (axon bundles, cortical magnification).
             
             .. versionadded:: 0.11.0
 
@@ -374,6 +377,9 @@ class Nanduri2012Model(Model):
             Standard deviation of the variation in phosphene location from the
             ``visual_field_map``, in dva. Locations are fixed for a model instance.
             ``None`` or 0 disables the variation.
+            Moves the effective stimulation location, so phosphene shape and
+            size change too wherever the model makes them location-dependent
+            (axon bundles, cortical magnification).
             
             .. versionadded:: 0.11.0
 

--- a/pulse2percept/models/nanduri2012.py
+++ b/pulse2percept/models/nanduri2012.py
@@ -108,12 +108,9 @@ class Nanduri2012Spatial(SpatialModel):
             Salt-and-pepper noise applied to each percept frame. An integer gives
             the number of affected pixels; a float in [0, 1] gives their fraction.
         location_noise : float or None, optional
-            Standard deviation of the variation in phosphene location from the
-            ``visual_field_map``, in dva. Locations are fixed for a model instance.
-            ``None`` or 0 disables the variation.
-            Moves the effective stimulation location, so phosphene shape and
-            size change too wherever the model makes them location-dependent
-            (axon bundles, cortical magnification).
+            Standard deviation of fixed electrode-specific phosphene offsets, in dva.
+            Requires an invertible 2D ``visual_field_map``. ``None`` or 0 disables it.
+            Location-dependent models may also change phosphene shape or size.
             
             .. versionadded:: 0.11.0
 
@@ -374,12 +371,9 @@ class Nanduri2012Model(Model):
         noise : float, int, or None, optional
             Salt-and-pepper noise applied to each percept frame.
         location_noise : float or None, optional
-            Standard deviation of the variation in phosphene location from the
-            ``visual_field_map``, in dva. Locations are fixed for a model instance.
-            ``None`` or 0 disables the variation.
-            Moves the effective stimulation location, so phosphene shape and
-            size change too wherever the model makes them location-dependent
-            (axon bundles, cortical magnification).
+            Standard deviation of fixed electrode-specific phosphene offsets, in dva.
+            Requires an invertible 2D ``visual_field_map``. ``None`` or 0 disables it.
+            Location-dependent models may also change phosphene shape or size.
             
             .. versionadded:: 0.11.0
 

--- a/pulse2percept/models/nanduri2012.py
+++ b/pulse2percept/models/nanduri2012.py
@@ -107,6 +107,13 @@ class Nanduri2012Spatial(SpatialModel):
         noise : float, int, or None, optional
             Salt-and-pepper noise applied to each percept frame. An integer gives
             the number of affected pixels; a float in [0, 1] gives their fraction.
+        location_noise : float or None, optional
+            Standard deviation (dva) of this subject's retinotopic
+            distortion; see
+            :py:class:`~pulse2percept.models.SpatialModel`.
+
+            .. versionadded:: 0.11.0
+
         verbose : bool, optional
             Whether to print status messages.
         ndim : list of int, optional
@@ -122,6 +129,7 @@ class Nanduri2012Spatial(SpatialModel):
                  grid_type='rect', thresh_percept=0,
                  min_current_spread=1e-8, visual_field_map=None, n_gray=None,
                  noise=None,
+                 location_noise=None,
                  verbose=True, ndim=None, n_threads=None, n_jobs=None):
         super().__init__(
             implant, atten_a=atten_a, atten_n=atten_n, xrange=xrange,
@@ -130,7 +138,8 @@ class Nanduri2012Spatial(SpatialModel):
             min_current_spread=min_current_spread,
             visual_field_map=(Curcio1990Map() if visual_field_map is None else
                               visual_field_map),
-            n_gray=n_gray, noise=noise, verbose=verbose,
+            n_gray=n_gray, noise=noise,
+            location_noise=location_noise, verbose=verbose,
             ndim=[2] if ndim is None else ndim,
             **_thread_params(n_threads, n_jobs))
 
@@ -361,6 +370,13 @@ class Nanduri2012Model(Model):
             gray-level quantization.
         noise : float, int, or None, optional
             Salt-and-pepper noise applied to each percept frame.
+        location_noise : float or None, optional
+            Standard deviation (dva) of this subject's retinotopic
+            distortion; see
+            :py:class:`~pulse2percept.models.SpatialModel`.
+
+            .. versionadded:: 0.11.0
+
         min_current_spread : float, optional
             Inherited Gaussian current-spread cutoff. Not used by the Nanduri
             spatial model.
@@ -406,7 +422,8 @@ class Nanduri2012Model(Model):
                  xrange=(-15, 15), yrange=(-15, 15), step=0.25,
                  grid_type='rect', min_current_spread=1e-8,
                  visual_field_map=None,
-                 n_gray=None, noise=None, ndim=None, dt=0.005, tau1=0.42,
+                 n_gray=None, noise=None,
+                 location_noise=None, ndim=None, dt=0.005, tau1=0.42,
                  tau2=45.25, tau3=26.25, eps=8.73, asymptote=14.0, slope=3.0,
                  shift=16.0, scale_out=1.0, reduce='last', thresh_percept=0,
                  verbose=True, n_threads=None, n_jobs=None):
@@ -418,7 +435,8 @@ class Nanduri2012Model(Model):
                 yrange=yrange, step=step, grid_type=grid_type,
                 min_current_spread=min_current_spread,
                 visual_field_map=visual_field_map,
-                n_gray=n_gray, noise=noise, ndim=ndim,
+                n_gray=n_gray, noise=noise,
+                location_noise=location_noise, ndim=ndim,
                 thresh_percept=thresh_percept, verbose=verbose,
                 n_threads=n_threads, n_jobs=n_jobs),
             temporal=Nanduri2012Temporal(

--- a/pulse2percept/models/nanduri2012.py
+++ b/pulse2percept/models/nanduri2012.py
@@ -108,10 +108,10 @@ class Nanduri2012Spatial(SpatialModel):
             Salt-and-pepper noise applied to each percept frame. An integer gives
             the number of affected pixels; a float in [0, 1] gives their fraction.
         location_noise : float or None, optional
-            Standard deviation (dva) of this subject's retinotopic
-            distortion; see
-            :py:class:`~pulse2percept.models.SpatialModel`.
-
+            Standard deviation of the variation in phosphene location from the
+            ``visual_field_map``, in dva. Locations are fixed for a model instance.
+            ``None`` or 0 disables the variation.
+            
             .. versionadded:: 0.11.0
 
         verbose : bool, optional
@@ -371,10 +371,10 @@ class Nanduri2012Model(Model):
         noise : float, int, or None, optional
             Salt-and-pepper noise applied to each percept frame.
         location_noise : float or None, optional
-            Standard deviation (dva) of this subject's retinotopic
-            distortion; see
-            :py:class:`~pulse2percept.models.SpatialModel`.
-
+            Standard deviation of the variation in phosphene location from the
+            ``visual_field_map``, in dva. Locations are fixed for a model instance.
+            ``None`` or 0 disables the variation.
+            
             .. versionadded:: 0.11.0
 
         min_current_spread : float, optional

--- a/pulse2percept/models/tests/test_base.py
+++ b/pulse2percept/models/tests/test_base.py
@@ -1,6 +1,5 @@
 from contextlib import contextmanager
 import copy
-from types import SimpleNamespace
 import multiprocessing
 import warnings
 
@@ -24,9 +23,7 @@ from pulse2percept.models import (AxonMapModel, AxonMapSpatial, BaseModel,
                                   ScoreboardModel, ScoreboardSpatial,
                                   SpatialModel, TemporalModel,
                                   Thompson2003Model)
-from pulse2percept.models.base import (_blend_meridian, _electrode_dva,
-                                       _location_noise_field,
-                                       _warp_visual_field)
+from pulse2percept.models.base import _blend_meridian
 from pulse2percept.models.cortex import (DynaphosModel,
                                          ScoreboardModel as
                                          CortexScoreboardModel,
@@ -38,7 +35,8 @@ from pulse2percept.units import (DimensionMismatchError, Quantity,
 from pulse2percept.utils import FreezeError, frame_interval
 from pulse2percept.topography import (Curcio1990Map, Grid2D,
                                       Polimeni2006Map, RetinalMap,
-                                      VisualFieldMap, Watson2014Map)
+                                      VisualFieldMap, Watson2014DisplaceMap,
+                                      Watson2014Map)
 
 
 class ValidBaseModel(BaseModel):
@@ -1918,49 +1916,61 @@ def test_SpatialModel_visual_field_map_is_the_canonical_name():
         ScoreboardSpatial(ArgusII(), vfmap=Curcio1990Map())
 
 
-def _scoreboard_at(coords, location_noise=None, seed=0, step=0.25):
-    """A scoreboard on electrodes at the given retinal coordinates (um)
 
-    Seeded before construction, since the subject's offsets are drawn the
-    first time the model is built.
-    """
-    implant = Implant(ElectrodeArray(
+def _implant_at(coords):
+    """A disk-electrode implant at the given tissue coordinates (um)"""
+    return Implant(ElectrodeArray(
         {f'A{i}': DiskElectrode(x, y, 0, 100)
          for i, (x, y) in enumerate(coords)}))
+
+
+def _latents(n, seed):
+    """The standard normals a model seeded with `seed` draws for n electrodes"""
     np.random.seed(seed)
-    model = ScoreboardSpatial(implant, xrange=(-10, 10), yrange=(-10, 10),
-                              step=step, rho=500,
-                              location_noise=location_noise)
+    return np.random.normal(size=(n, 2))
+
+
+def _scoreboard_at(coords, location_noise=None, seed=0, step=0.1,
+                   visual_field_map=None):
+    """A scoreboard on electrodes at the given retinal coordinates (um)
+
+    Seeded before construction, since the subject's offsets are drawn when the
+    model is built.
+    """
+    np.random.seed(seed)
+    model = ScoreboardSpatial(
+        _implant_at(coords), xrange=(-10, 10), yrange=(-10, 10), step=step,
+        rho=400, location_noise=location_noise,
+        visual_field_map=(Curcio1990Map() if visual_field_map is None
+                          else visual_field_map))
     return model.build()
 
 
 def _one_electrode_model(location_noise=None, seed=0):
-    """A scoreboard on a single electrode at the fovea
-
-    One electrode means the displacement field is the one offset that was
-    drawn, everywhere, so the percept's peak is where that offset put it.
-    """
-    return _scoreboard_at([(0, 0)], location_noise=location_noise, seed=seed)
+    """A scoreboard on a single electrode 2 deg into the temporal retina"""
+    return _scoreboard_at([(560, 0)], location_noise=location_noise, seed=seed)
 
 
-def _peak_dva(percept, grid):
-    """The (x, y) location of the brightest grid point, in dva"""
-    idx = np.unravel_index(np.argmax(percept.data[..., 0]),
-                           percept.data[..., 0].shape)
-    return float(grid.x[idx]), float(grid.y[idx])
+def _blob_moments(percept, grid):
+    """Brightness-weighted centroid (dva) and 2x2 covariance of one frame"""
+    w = np.asarray(percept.data[..., 0], dtype=np.float64)
+    total = w.sum()
+    x, y = np.asarray(grid.x), np.asarray(grid.y)
+    cx, cy = (w * x).sum() / total, (w * y).sum() / total
+    dx, dy = x - cx, y - cy
+    cov = np.array([[(w * dx * dx).sum(), (w * dx * dy).sum()],
+                    [(w * dx * dy).sum(), (w * dy * dy).sum()]]) / total
+    return np.array([cx, cy]), cov
 
 
 @pytest.mark.parametrize('location_noise', (None, 0))
 def test_location_noise_off(location_noise):
-    # No noise is an exact no-op, down to the postprocessing hook returning
-    # the response it was handed:
+    # No noise is an exact no-op, down to no subject being drawn:
     model = _one_electrode_model(location_noise=location_noise)
-    npt.assert_equal(model._location_noise, None)
-    resp = np.arange(model.grid.x.size, dtype=np.float32).reshape(-1, 1)
-    npt.assert_equal(model._postprocess_spatial(resp) is resp, True)
-    plain = _one_electrode_model()
+    npt.assert_equal(model._location_noise_z, None)
     npt.assert_array_equal(model.predict_percept({'A0': 1}).data,
-                           plain.predict_percept({'A0': 1}).data)
+                           _one_electrode_model().predict_percept(
+                               {'A0': 1}).data)
 
 
 def test_location_noise_must_be_non_negative():
@@ -1970,60 +1980,6 @@ def test_location_noise_must_be_non_negative():
         model.build()
 
 
-def test_location_noise_displaces_the_percept():
-    # The offset the model drew, redrawn from the same seed:
-    np.random.seed(7)
-    dx, dy = 2.0 * np.random.normal(size=(1, 2))[0]
-    model = _one_electrode_model(location_noise=2.0, seed=7)
-    x, y = _peak_dva(model.predict_percept({'A0': 1}), model.grid)
-    # Within half a grid step of where the offset moved the phosphene:
-    npt.assert_almost_equal(x, dx, decimal=1)
-    npt.assert_almost_equal(y, dy, decimal=1)
-
-
-def test_location_noise_survives_a_rebuild():
-    # The distortion belongs to the subject, not to the build: changing an
-    # unrelated parameter must not hand the subject a new retinotopy.
-    model = _one_electrode_model(location_noise=2.0, seed=7)
-    first = model.predict_percept({'A0': 1}).data
-    npt.assert_array_equal(model.predict_percept({'A0': 1}).data, first)
-    subject = model._location_noise_z.copy()
-    np.random.seed(8)
-    model.rho = 501
-    model.build()
-    npt.assert_array_equal(model._location_noise_z, subject)
-    model.rho = 500
-    model.build()
-    npt.assert_array_equal(model.predict_percept({'A0': 1}).data, first)
-    # A deepcopy is the same subject, too:
-    npt.assert_array_equal(
-        copy.deepcopy(model).predict_percept({'A0': 1}).data, first)
-    # A new model is a new subject:
-    other = _one_electrode_model(location_noise=2.0, seed=8)
-    npt.assert_equal(np.array_equal(other.predict_percept({'A0': 1}).data,
-                                    first), False)
-
-
-def test_location_noise_places_every_electrode():
-    # Two electrodes far enough apart to be told apart, each stimulated on its
-    # own: a field fitted the wrong way round is only exact for one offset,
-    # a uniform shift.
-    sigma, seed, coords = 2.0, 2, [(-1400, 0), (1400, 0)]
-    np.random.seed(seed)
-    offsets = sigma * np.random.normal(size=(2, 2))
-    model = _scoreboard_at(coords, location_noise=sigma, seed=seed, step=0.1)
-    plain = _scoreboard_at(coords, step=0.1)
-    # Where the percept sits without the warp, since a retinal Gaussian is not
-    # quite centered on the electrode once the map has bent it:
-    for i, electrode in enumerate(model.implant.electrode_names):
-        was = np.array(_peak_dva(plain.predict_percept({electrode: 1}),
-                                 plain.grid))
-        now = np.array(_peak_dva(model.predict_percept({electrode: 1}),
-                                 model.grid))
-        # Snapping to the brightest grid point costs half a step per axis:
-        npt.assert_allclose(now - was, offsets[i], atol=0.15)
-
-
 def test_location_noise_is_a_visual_angle():
     model = _one_electrode_model(location_noise=2 * dva, seed=7)
     npt.assert_almost_equal(model.location_noise, 2.0)
@@ -2031,112 +1987,192 @@ def test_location_noise_is_a_visual_angle():
         _one_electrode_model(location_noise=500 * um)
 
 
-@pytest.mark.parametrize('model', (AxonMapSpatial(ArgusII(), xrange=(-8, 8),
-                                                 yrange=(-8, 8), step=0.5),
-                                   CortexScoreboardSpatial(Cortivis(),
-                                                           xrange=(-8, 8),
-                                                           yrange=(-8, 8),
-                                                           step=0.5)))
-def test_location_noise_reaches_blending_models(model):
-    # Models that override `_postprocess_spatial` to blend a meridian have to
-    # chain to the warp, or their percepts would ignore `location_noise`:
-    source = {model.implant.electrode_names[0]: 100}
-    np.random.seed(2)
-    plain = model.build().predict_percept(source).data
-    model.location_noise = 1.0
-    np.random.seed(2)
-    warped = model.build().predict_percept(source).data
-    npt.assert_equal(np.array_equal(plain, warped), False)
+def test_location_noise_moves_a_phosphene_without_deforming_it():
+    # A displaced electrode gives the same phosphene somewhere else, not a
+    # locally stretched image: under a linear map the blob is unchanged.
+    offset = 1.0 * _latents(1, 7)[0]
+    plain = _one_electrode_model()
+    moved = _one_electrode_model(location_noise=1.0, seed=7)
+    was, cov_was = _blob_moments(plain.predict_percept({'A0': 1}), plain.grid)
+    now, cov_now = _blob_moments(moved.predict_percept({'A0': 1}), moved.grid)
+    npt.assert_allclose(now - was, offset, atol=0.02)
+    npt.assert_allclose(cov_now, cov_was, atol=1e-3)
+    # Still circular, so it did not turn into a streak:
+    npt.assert_allclose(cov_now[0, 0], cov_now[1, 1], rtol=0.05)
+    npt.assert_allclose(cov_now[0, 1], 0, atol=1e-3)
 
 
-class _ZMap(VisualFieldMap):
-    """A 3D map whose inverse needs all three tissue coordinates
-
-    Electrodes off its (thin) slab of tissue come back as NaN, the way
-    :py:class:`~pulse2percept.topography.NeuropythyMap` reports a point its
-    mesh does not cover.
-    """
-    ndim = 3
-
-    def get_default_params(self):
-        return {**super().get_default_params(), 'ndim': 3}
-
-    def from_dva(self):
-        return {'ret': lambda x, y: (x, y, np.zeros_like(x))}
-
-    def ret_to_dva(self, x, y, z):
-        off_slab = np.abs(z) > 1
-        return (np.where(off_slab, np.nan, x / 280.0),
-                np.where(off_slab, np.nan, -y / 280.0))
-
-    def to_dva(self):
-        return {'ret': self.ret_to_dva}
+def test_location_noise_moves_sparse_phosphenes_independently():
+    # Each electrode carries its own offset, and each blob stays circular.
+    coords = [(-1400, -1400), (1400, -1400), (-1400, 1400), (1400, 1400)]
+    offsets = 1.0 * _latents(len(coords), 3)
+    plain = _scoreboard_at(coords)
+    moved = _scoreboard_at(coords, location_noise=1.0, seed=3)
+    for i, electrode in enumerate(moved.implant.electrode_names):
+        was, cov_was = _blob_moments(plain.predict_percept({electrode: 1}),
+                                     plain.grid)
+        now, cov_now = _blob_moments(moved.predict_percept({electrode: 1}),
+                                     moved.grid)
+        npt.assert_allclose(now - was, offsets[i], atol=0.02)
+        # Still the same circular blob, just off the electrode grid:
+        npt.assert_allclose(cov_now, cov_was, atol=0.02)
+        npt.assert_allclose(cov_now[0, 0], cov_now[1, 1], rtol=0.05)
 
 
-def _fake_model(zs, location_noise=1.0):
-    """The pieces of a spatial model that the warp helpers actually read"""
-    implant = Implant(ElectrodeArray(
-        {f'A{i}': DiskElectrode(280.0 * i, 0, z, 100)
-         for i, z in enumerate(zs)}))
-    grid = Grid2D((-5, 5), (-5, 5), step=0.5)
-    grid.build(Curcio1990Map())
-    return SimpleNamespace(implant=implant, grid=grid,
-                           visual_field_map=_ZMap(),
-                           location_noise=location_noise,
-                           _location_noise_z=None)
+def test_location_noise_follows_the_stimulus_electrodes():
+    # A stimulus on a subset of the implant must still get each electrode's
+    # own offset, not the first few rows of the cached ones.
+    coords = [(-1400, 0), (0, 0), (1400, 0)]
+    offsets = 1.0 * _latents(len(coords), 4)
+    plain = _scoreboard_at(coords)
+    moved = _scoreboard_at(coords, location_noise=1.0, seed=4)
+    was, _ = _blob_moments(plain.predict_percept({'A2': 1}), plain.grid)
+    now, _ = _blob_moments(moved.predict_percept({'A2': 1}), moved.grid)
+    npt.assert_allclose(now - was, offsets[2], atol=0.02)
 
 
-def test_electrode_dva_passes_every_tissue_dimension():
-    # A 3D map is handed (x, y, z), not just (x, y):
-    x, y, _ = _electrode_dva(_fake_model([0, 0]))
-    npt.assert_almost_equal(x, [0, 1])
-    npt.assert_almost_equal(y, [0, 0])
-    # An electrode the map cannot place comes back non-finite, and is left out
-    # of the interpolation rather than poisoning it:
-    model = _fake_model([0, 5])
-    npt.assert_equal(np.isfinite(_electrode_dva(model)[0]), [True, False])
-    npt.assert_equal(np.all(np.isfinite(_location_noise_field(model))), True)
+def test_location_noise_is_fixed_for_a_subject():
+    # The offsets belong to the subject, not to the build: changing an
+    # unrelated parameter must not hand the subject a new retinotopy.
+    model = _one_electrode_model(location_noise=1.0, seed=7)
+    first = model.predict_percept({'A0': 1}).data
+    npt.assert_array_equal(model.predict_percept({'A0': 1}).data, first)
+    subject = model._location_noise_z.copy()
+    np.random.seed(8)
+    model.rho = 401
+    model.build()
+    npt.assert_array_equal(model._location_noise_z, subject)
+    model.rho = 400
+    model.build()
+    npt.assert_array_equal(model.predict_percept({'A0': 1}).data, first)
+    # A deepcopy is the same subject, too:
+    npt.assert_array_equal(
+        copy.deepcopy(model).predict_percept({'A0': 1}).data, first)
+    # A new model is a new subject:
+    other = _one_electrode_model(location_noise=1.0, seed=8)
+    npt.assert_equal(np.array_equal(other.predict_percept({'A0': 1}).data,
+                                    first), False)
 
 
-def test_location_noise_needs_a_placeable_electrode():
-    with pytest.raises(ValueError):
-        _location_noise_field(_fake_model([5, 5]))
+def test_location_noise_resets_on_a_new_implant():
+    model = _one_electrode_model(location_noise=1.0, seed=7)
+    model.predict_percept({'A0': 1})
+    model.implant = _implant_at([(560, 0), (0, 0)])
+    npt.assert_equal(model._location_noise_z, None)
+    model.build()
+    npt.assert_equal(model._location_noise_z.shape, (2, 2))
 
 
-def test_location_noise_ignores_region_order():
-    # A multi-region model sums its regions, so naming them in a different
-    # order describes the same simulation and must warp the same way:
+def test_location_noise_needs_an_invertible_map():
+    model = _one_electrode_model(location_noise=1.0, seed=7)
+    model.visual_field_map = Watson2014DisplaceMap()
+    model.build()
+    with pytest.raises(NotImplementedError):
+        model.predict_percept({'A0': 1})
+
+
+def test_location_noise_keeps_the_axon_map_kernel_joint():
+    # AxonMap sums electrode contributions per axon segment before picking the
+    # brightest one, so a displaced electrode must reach that same kernel.
+    implant = ArgusII()
+    both = ['C4', 'C6']
+    kwargs = dict(xrange=(-8, 8), yrange=(-8, 8), step=0.25, rho=200,
+                  lam=800, n_axons=250, n_ax_segments=200,
+                  ignore_pickle=True)
+    np.random.seed(5)
+    model = AxonMapSpatial(implant, location_noise=1.0, **kwargs).build()
+    joint = model.predict_percept({e: 1 for e in both}).data
+    npt.assert_equal(np.all(np.isfinite(joint)), True)
+    npt.assert_equal(joint.max() > 0, True)
+    # Superposition would make this equal; the joint kernel does not:
+    apart = sum(model.predict_percept({e: 1}).data for e in both)
+    npt.assert_equal(np.allclose(joint, apart), False)
+    # The percept is the canonical one for electrodes moved in the visual
+    # field, so the phosphenes stay coherent streaks:
+    vfmap = model.visual_field_map
+    xyz = implant.electrode_array.coordinates(um, electrodes=both)
+    rows = [implant.electrode_names.index(e) for e in both]
+    x_dva, y_dva = vfmap.ret_to_dva(xyz[:, 0].copy(), xyz[:, 1].copy())
+    offsets = model._location_noise_z[rows]
+    x_ret, y_ret = vfmap.dva_to_ret(x_dva + offsets[:, 0],
+                                    y_dva + offsets[:, 1])
+    displaced = AxonMapSpatial(_implant_at(list(zip(x_ret, y_ret))),
+                               **kwargs).build()
+    npt.assert_allclose(displaced.predict_percept({'A0': 1, 'A1': 1}).data,
+                        joint, atol=1e-5)
+
+
+def test_cortical_location_noise_moves_the_phosphene():
     implant = Cortivis()
-    source = {implant.electrode_names[0]: 100}
-    percepts, fields = [], []
+    electrode = implant.electrode_names[10]
+    offset = 1.0 * _latents(len(implant.electrode_names), 3)[10]
+    kwargs = dict(xrange=(-6, 6), yrange=(-6, 6), step=0.05)
+    plain = CortexScoreboardSpatial(implant, **kwargs).build()
+    np.random.seed(3)
+    moved = CortexScoreboardSpatial(implant, location_noise=1.0,
+                                    **kwargs).build()
+    was, cov_was = _blob_moments(plain.predict_percept({electrode: 100}),
+                                 plain.grid)
+    now, cov_now = _blob_moments(moved.predict_percept({electrode: 100}),
+                                 moved.grid)
+    npt.assert_allclose(now - was, offset, atol=0.1)
+    # A coherent phosphene, not a smeared one: it still reaches the drive it
+    # was given. Its dva extent does change, since cortical magnification
+    # falls off with eccentricity, so `cov` is only checked for compactness.
+    for percept in (plain.predict_percept({electrode: 100}),
+                    moved.predict_percept({electrode: 100})):
+        npt.assert_equal(percept.data.max() > 70, True)
+    npt.assert_equal(np.trace(cov_now) < 1.0, True)
+
+
+def test_cortical_location_noise_ignores_region_order():
+    # A multi-region model sums its regions, so naming them in a different
+    # order describes the same simulation and must displace the same way:
+    implant = Cortivis()
+    source = {implant.electrode_names[10]: 100}
+    percepts = []
     for regions in (['v1', 'v2'], ['v2', 'v1']):
         np.random.seed(11)
         model = CortexScoreboardSpatial(implant, regions=regions,
                                         xrange=(-6, 6), yrange=(-6, 6),
                                         step=0.25, location_noise=1.0).build()
-        fields.append(model._location_noise)
         percepts.append(model.predict_percept(source).data)
-    npt.assert_array_equal(*fields)
     npt.assert_array_equal(*percepts)
 
 
-def test_meridian_blend_precedes_the_warp():
-    # The seam is an artifact of the canonical split map, so it has to be
-    # repaired while it still lies on the canonical meridian:
-    np.random.seed(5)
-    model = CortexScoreboardSpatial(Cortivis(), xrange=(-6, 6),
-                                    yrange=(-6, 6), step=0.5,
-                                    meridian_blend=1.0,
-                                    location_noise=1.0).build()
-    resp = _step_across(model.grid, 'vertical')
-    blended = _blend_meridian(resp, model.grid, 'vertical', 1.0)
-    npt.assert_allclose(
-        model._postprocess_spatial(resp),
-        _warp_visual_field(blended, model.grid, model._location_noise))
-    # Blending the warped response instead would smooth a meridian the seam
-    # has already moved off:
-    other = _blend_meridian(
-        _warp_visual_field(resp, model.grid, model._location_noise),
-        model.grid, 'vertical', 1.0)
-    npt.assert_equal(np.allclose(model._postprocess_spatial(resp), other),
-                     False)
+class _Slab3DMap(VisualFieldMap):
+    """A 3D map whose inverse needs all three tissue coordinates
+
+    Linear, so a displaced phosphene is exactly the canonical one moved.
+    """
+
+    def get_default_params(self):
+        return {**super().get_default_params(), 'ndim': 3,
+                'regions': ['v1']}
+
+    def dva_to_v1(self, x, y):
+        return 280.0 * x, -280.0 * y, np.zeros_like(np.asarray(x))
+
+    def v1_to_dva(self, x, y, z):
+        return x / 280.0, -y / 280.0
+
+    def from_dva(self):
+        return {'v1': self.dva_to_v1}
+
+    def to_dva(self):
+        return {'v1': self.v1_to_dva}
+
+
+def test_location_noise_supports_3d_maps():
+    implant = _implant_at([(560, 0)])
+    offset = 1.0 * _latents(1, 6)[0]
+    kwargs = dict(visual_field_map=_Slab3DMap(), regions=['v1'], rho=400,
+                  xrange=(-10, 10), yrange=(-10, 10), step=0.1)
+    plain = CortexScoreboardSpatial(implant, **kwargs).build()
+    np.random.seed(6)
+    moved = CortexScoreboardSpatial(implant, location_noise=1.0,
+                                    **kwargs).build()
+    was, cov_was = _blob_moments(plain.predict_percept({'A0': 1}), plain.grid)
+    now, cov_now = _blob_moments(moved.predict_percept({'A0': 1}), moved.grid)
+    npt.assert_allclose(now - was, offset, atol=0.02)
+    npt.assert_allclose(cov_now, cov_was, atol=1e-3)

--- a/pulse2percept/models/tests/test_base.py
+++ b/pulse2percept/models/tests/test_base.py
@@ -25,7 +25,8 @@ from pulse2percept.models import (AxonMapModel, AxonMapSpatial, BaseModel,
                                   SpatialModel, TemporalModel,
                                   Thompson2003Model)
 from pulse2percept.models.base import (_blend_meridian, _electrode_dva,
-                                       _location_noise_field)
+                                       _location_noise_field,
+                                       _warp_visual_field)
 from pulse2percept.models.cortex import (DynaphosModel,
                                          ScoreboardModel as
                                          CortexScoreboardModel,
@@ -2117,3 +2118,25 @@ def test_location_noise_ignores_region_order():
         percepts.append(model.predict_percept(source).data)
     npt.assert_array_equal(*fields)
     npt.assert_array_equal(*percepts)
+
+
+def test_meridian_blend_precedes_the_warp():
+    # The seam is an artifact of the canonical split map, so it has to be
+    # repaired while it still lies on the canonical meridian:
+    np.random.seed(5)
+    model = CortexScoreboardSpatial(Cortivis(), xrange=(-6, 6),
+                                    yrange=(-6, 6), step=0.5,
+                                    meridian_blend=1.0,
+                                    location_noise=1.0).build()
+    resp = _step_across(model.grid, 'vertical')
+    blended = _blend_meridian(resp, model.grid, 'vertical', 1.0)
+    npt.assert_allclose(
+        model._postprocess_spatial(resp),
+        _warp_visual_field(blended, model.grid, model._location_noise))
+    # Blending the warped response instead would smooth a meridian the seam
+    # has already moved off:
+    other = _blend_meridian(
+        _warp_visual_field(resp, model.grid, model._location_noise),
+        model.grid, 'vertical', 1.0)
+    npt.assert_equal(np.allclose(model._postprocess_spatial(resp), other),
+                     False)

--- a/pulse2percept/models/tests/test_base.py
+++ b/pulse2percept/models/tests/test_base.py
@@ -10,7 +10,8 @@ from matplotlib.axes import Subplot
 import matplotlib.pyplot as plt
 import time
 
-from pulse2percept.implants import ArgusI, ArgusII
+from pulse2percept.implants import (ArgusI, ArgusII, DiskElectrode,
+                                    ElectrodeArray, Implant)
 from pulse2percept.implants.cortex import Cortivis
 from pulse2percept.stimuli import (AmplitudeEncoder, BiphasicPulseTrain,
                                    BostonTrain, ImageStimulus, LogoBVL,
@@ -23,6 +24,7 @@ from pulse2percept.models import (AxonMapModel, AxonMapSpatial, BaseModel,
                                   SpatialModel, TemporalModel,
                                   Thompson2003Model)
 from pulse2percept.models.base import _blend_meridian
+from pulse2percept.units import DimensionMismatchError, dva, um
 from pulse2percept.models.cortex import (DynaphosModel,
                                          ScoreboardModel as
                                          CortexScoreboardModel,
@@ -1912,3 +1914,92 @@ def test_SpatialModel_visual_field_map_is_the_canonical_name():
     npt.assert_equal(hasattr(spatial, 'vfmap'), False)
     with pytest.raises(TypeError):
         ScoreboardSpatial(ArgusII(), vfmap=Curcio1990Map())
+
+
+def _one_electrode_model(location_noise=None, seed=0, step=0.25):
+    """A scoreboard on a single electrode at the fovea, built with `seed`
+
+    One electrode means the interpolated displacement field is the one offset
+    that was drawn, everywhere, so the percept's peak is where that offset put
+    it.
+    """
+    implant = Implant(ElectrodeArray({'A1': DiskElectrode(0, 0, 0, 100)}))
+    model = ScoreboardSpatial(implant, xrange=(-10, 10), yrange=(-10, 10),
+                              step=step, rho=500)
+    model.location_noise = location_noise
+    np.random.seed(seed)
+    return model.build()
+
+
+def _peak_dva(percept, grid):
+    """The (x, y) location of the brightest grid point, in dva"""
+    idx = np.unravel_index(np.argmax(percept.data[..., 0]),
+                           percept.data[..., 0].shape)
+    return float(grid.x[idx]), float(grid.y[idx])
+
+
+@pytest.mark.parametrize('location_noise', (None, 0))
+def test_location_noise_off(location_noise):
+    # No noise is an exact no-op, down to the postprocessing hook returning
+    # the response it was handed:
+    model = _one_electrode_model(location_noise=location_noise)
+    npt.assert_equal(model._location_noise, None)
+    resp = np.arange(model.grid.x.size, dtype=np.float32).reshape(-1, 1)
+    npt.assert_equal(model._postprocess_spatial(resp) is resp, True)
+    plain = _one_electrode_model()
+    npt.assert_array_equal(model.predict_percept({'A1': 1}).data,
+                           plain.predict_percept({'A1': 1}).data)
+
+
+def test_location_noise_must_be_non_negative():
+    model = _one_electrode_model()
+    model.location_noise = -1
+    with pytest.raises(ValueError):
+        model.build()
+
+
+def test_location_noise_displaces_the_percept():
+    # The offset the model drew, redrawn from the same seed:
+    np.random.seed(7)
+    dx, dy = np.random.normal(0, 2.0, size=(1, 2))[0]
+    model = _one_electrode_model(location_noise=2.0, seed=7)
+    x, y = _peak_dva(model.predict_percept({'A1': 1}), model.grid)
+    # Within half a grid step of where the offset moved the phosphene:
+    npt.assert_almost_equal(x, dx, decimal=1)
+    npt.assert_almost_equal(y, dy, decimal=1)
+
+
+def test_location_noise_is_fixed_until_rebuild():
+    model = _one_electrode_model(location_noise=2.0, seed=7)
+    first = model.predict_percept({'A1': 1}).data
+    npt.assert_array_equal(model.predict_percept({'A1': 1}).data, first)
+    # Rebuilding draws a new field:
+    np.random.seed(8)
+    model.build()
+    npt.assert_equal(np.array_equal(model.predict_percept({'A1': 1}).data,
+                                    first), False)
+
+
+def test_location_noise_is_a_visual_angle():
+    model = _one_electrode_model(location_noise=2 * dva, seed=7)
+    npt.assert_almost_equal(model.location_noise, 2.0)
+    with pytest.raises(DimensionMismatchError):
+        _one_electrode_model(location_noise=500 * um)
+
+
+@pytest.mark.parametrize('model', (AxonMapSpatial(ArgusII(), xrange=(-8, 8),
+                                                 yrange=(-8, 8), step=0.5),
+                                   CortexScoreboardSpatial(Cortivis(),
+                                                           xrange=(-8, 8),
+                                                           yrange=(-8, 8),
+                                                           step=0.5)))
+def test_location_noise_reaches_blending_models(model):
+    # Models that override `_postprocess_spatial` to blend a meridian have to
+    # chain to the warp, or their percepts would ignore `location_noise`:
+    source = {model.implant.electrode_names[0]: 100}
+    np.random.seed(2)
+    plain = model.build().predict_percept(source).data
+    model.location_noise = 1.0
+    np.random.seed(2)
+    warped = model.build().predict_percept(source).data
+    npt.assert_equal(np.array_equal(plain, warped), False)

--- a/pulse2percept/models/tests/test_base.py
+++ b/pulse2percept/models/tests/test_base.py
@@ -2176,3 +2176,55 @@ def test_location_noise_supports_3d_maps():
     now, cov_now = _blob_moments(moved.predict_percept({'A0': 1}), moved.grid)
     npt.assert_allclose(now - was, offset, atol=0.02)
     npt.assert_allclose(cov_now, cov_was, atol=1e-3)
+
+
+def test_location_noise_matches_integer_electrode_names():
+    # A list-built array names its electrodes 0..N-1, and a stimulus carries
+    # those integers: matching them as strings would raise or mismatch.
+    array = ElectrodeArray([DiskElectrode(x, 0, 0, 100)
+                            for x in (-1400, 0, 1400)])
+    offsets = 1.0 * _latents(3, 4)
+    percepts = []
+    for noise, seed in ((None, 0), (1.0, 4)):
+        np.random.seed(seed)
+        model = ScoreboardSpatial(Implant(array), xrange=(-10, 10),
+                                  yrange=(-10, 10), step=0.1, rho=400,
+                                  location_noise=noise,
+                                  visual_field_map=Curcio1990Map()).build()
+        percepts.append(_blob_moments(model.predict_percept({2: 1}),
+                                      model.grid)[0])
+    npt.assert_allclose(percepts[1] - percepts[0], offsets[2], atol=0.02)
+
+
+class _BoundedMap(RetinalMap):
+    """Linear retinal map that covers only the central +/-5 dva"""
+
+    def dva_to_ret(self, xdva, ydva):
+        off = np.abs(xdva) > 5
+        return (np.where(off, np.nan, 280.0 * xdva),
+                np.where(off, np.nan, -280.0 * ydva))
+
+    def ret_to_dva(self, xret, yret):
+        off = np.abs(xret) > 1400
+        return (np.where(off, np.nan, xret / 280.0),
+                np.where(off, np.nan, -yret / 280.0))
+
+
+def _bounded_model(x_um, location_noise, seed):
+    np.random.seed(seed)
+    return ScoreboardSpatial(_implant_at([(x_um, 0)]), xrange=(-4, 4),
+                             yrange=(-4, 4), step=0.25, rho=400,
+                             location_noise=location_noise,
+                             visual_field_map=_BoundedMap()).build()
+
+
+def test_location_noise_refuses_an_unplaceable_electrode():
+    # Falling back to the canonical location would silently zero this
+    # electrode's offset, censoring the Gaussian at the edge of the map.
+    off_map = _bounded_model(2000, 1.0, 7)
+    with pytest.raises(ValueError, match='canonical'):
+        off_map.predict_percept({'A0': 1})
+    # Same for an electrode the offset pushes off the map:
+    displaced = _bounded_model(1300, 5.0, 7)
+    with pytest.raises(ValueError, match='displaced'):
+        displaced.predict_percept({'A0': 1})

--- a/pulse2percept/models/tests/test_base.py
+++ b/pulse2percept/models/tests/test_base.py
@@ -1,5 +1,6 @@
 from contextlib import contextmanager
 import copy
+from types import SimpleNamespace
 import multiprocessing
 import warnings
 
@@ -23,8 +24,8 @@ from pulse2percept.models import (AxonMapModel, AxonMapSpatial, BaseModel,
                                   ScoreboardModel, ScoreboardSpatial,
                                   SpatialModel, TemporalModel,
                                   Thompson2003Model)
-from pulse2percept.models.base import _blend_meridian
-from pulse2percept.units import DimensionMismatchError, dva, um
+from pulse2percept.models.base import (_blend_meridian, _electrode_dva,
+                                       _location_noise_field)
 from pulse2percept.models.cortex import (DynaphosModel,
                                          ScoreboardModel as
                                          CortexScoreboardModel,
@@ -36,7 +37,7 @@ from pulse2percept.units import (DimensionMismatchError, Quantity,
 from pulse2percept.utils import FreezeError, frame_interval
 from pulse2percept.topography import (Curcio1990Map, Grid2D,
                                       Polimeni2006Map, RetinalMap,
-                                      Watson2014Map)
+                                      VisualFieldMap, Watson2014Map)
 
 
 class ValidBaseModel(BaseModel):
@@ -1916,19 +1917,29 @@ def test_SpatialModel_visual_field_map_is_the_canonical_name():
         ScoreboardSpatial(ArgusII(), vfmap=Curcio1990Map())
 
 
-def _one_electrode_model(location_noise=None, seed=0, step=0.25):
-    """A scoreboard on a single electrode at the fovea, built with `seed`
+def _scoreboard_at(coords, location_noise=None, seed=0, step=0.25):
+    """A scoreboard on electrodes at the given retinal coordinates (um)
 
-    One electrode means the interpolated displacement field is the one offset
-    that was drawn, everywhere, so the percept's peak is where that offset put
-    it.
+    Seeded before construction, since the subject's offsets are drawn the
+    first time the model is built.
     """
-    implant = Implant(ElectrodeArray({'A1': DiskElectrode(0, 0, 0, 100)}))
-    model = ScoreboardSpatial(implant, xrange=(-10, 10), yrange=(-10, 10),
-                              step=step, rho=500)
-    model.location_noise = location_noise
+    implant = Implant(ElectrodeArray(
+        {f'A{i}': DiskElectrode(x, y, 0, 100)
+         for i, (x, y) in enumerate(coords)}))
     np.random.seed(seed)
+    model = ScoreboardSpatial(implant, xrange=(-10, 10), yrange=(-10, 10),
+                              step=step, rho=500,
+                              location_noise=location_noise)
     return model.build()
+
+
+def _one_electrode_model(location_noise=None, seed=0):
+    """A scoreboard on a single electrode at the fovea
+
+    One electrode means the displacement field is the one offset that was
+    drawn, everywhere, so the percept's peak is where that offset put it.
+    """
+    return _scoreboard_at([(0, 0)], location_noise=location_noise, seed=seed)
 
 
 def _peak_dva(percept, grid):
@@ -1947,8 +1958,8 @@ def test_location_noise_off(location_noise):
     resp = np.arange(model.grid.x.size, dtype=np.float32).reshape(-1, 1)
     npt.assert_equal(model._postprocess_spatial(resp) is resp, True)
     plain = _one_electrode_model()
-    npt.assert_array_equal(model.predict_percept({'A1': 1}).data,
-                           plain.predict_percept({'A1': 1}).data)
+    npt.assert_array_equal(model.predict_percept({'A0': 1}).data,
+                           plain.predict_percept({'A0': 1}).data)
 
 
 def test_location_noise_must_be_non_negative():
@@ -1961,23 +1972,55 @@ def test_location_noise_must_be_non_negative():
 def test_location_noise_displaces_the_percept():
     # The offset the model drew, redrawn from the same seed:
     np.random.seed(7)
-    dx, dy = np.random.normal(0, 2.0, size=(1, 2))[0]
+    dx, dy = 2.0 * np.random.normal(size=(1, 2))[0]
     model = _one_electrode_model(location_noise=2.0, seed=7)
-    x, y = _peak_dva(model.predict_percept({'A1': 1}), model.grid)
+    x, y = _peak_dva(model.predict_percept({'A0': 1}), model.grid)
     # Within half a grid step of where the offset moved the phosphene:
     npt.assert_almost_equal(x, dx, decimal=1)
     npt.assert_almost_equal(y, dy, decimal=1)
 
 
-def test_location_noise_is_fixed_until_rebuild():
+def test_location_noise_survives_a_rebuild():
+    # The distortion belongs to the subject, not to the build: changing an
+    # unrelated parameter must not hand the subject a new retinotopy.
     model = _one_electrode_model(location_noise=2.0, seed=7)
-    first = model.predict_percept({'A1': 1}).data
-    npt.assert_array_equal(model.predict_percept({'A1': 1}).data, first)
-    # Rebuilding draws a new field:
+    first = model.predict_percept({'A0': 1}).data
+    npt.assert_array_equal(model.predict_percept({'A0': 1}).data, first)
+    subject = model._location_noise_z.copy()
     np.random.seed(8)
+    model.rho = 501
     model.build()
-    npt.assert_equal(np.array_equal(model.predict_percept({'A1': 1}).data,
+    npt.assert_array_equal(model._location_noise_z, subject)
+    model.rho = 500
+    model.build()
+    npt.assert_array_equal(model.predict_percept({'A0': 1}).data, first)
+    # A deepcopy is the same subject, too:
+    npt.assert_array_equal(
+        copy.deepcopy(model).predict_percept({'A0': 1}).data, first)
+    # A new model is a new subject:
+    other = _one_electrode_model(location_noise=2.0, seed=8)
+    npt.assert_equal(np.array_equal(other.predict_percept({'A0': 1}).data,
                                     first), False)
+
+
+def test_location_noise_places_every_electrode():
+    # Two electrodes far enough apart to be told apart, each stimulated on its
+    # own: a field fitted the wrong way round is only exact for one offset,
+    # a uniform shift.
+    sigma, seed, coords = 2.0, 2, [(-1400, 0), (1400, 0)]
+    np.random.seed(seed)
+    offsets = sigma * np.random.normal(size=(2, 2))
+    model = _scoreboard_at(coords, location_noise=sigma, seed=seed, step=0.1)
+    plain = _scoreboard_at(coords, step=0.1)
+    # Where the percept sits without the warp, since a retinal Gaussian is not
+    # quite centered on the electrode once the map has bent it:
+    for i, electrode in enumerate(model.implant.electrode_names):
+        was = np.array(_peak_dva(plain.predict_percept({electrode: 1}),
+                                 plain.grid))
+        now = np.array(_peak_dva(model.predict_percept({electrode: 1}),
+                                 model.grid))
+        # Snapping to the brightest grid point costs half a step per axis:
+        npt.assert_allclose(now - was, offsets[i], atol=0.15)
 
 
 def test_location_noise_is_a_visual_angle():
@@ -2003,3 +2046,57 @@ def test_location_noise_reaches_blending_models(model):
     np.random.seed(2)
     warped = model.build().predict_percept(source).data
     npt.assert_equal(np.array_equal(plain, warped), False)
+
+
+class _ZMap(VisualFieldMap):
+    """A 3D map whose inverse needs all three tissue coordinates
+
+    Electrodes off its (thin) slab of tissue come back as NaN, the way
+    :py:class:`~pulse2percept.topography.NeuropythyMap` reports a point its
+    mesh does not cover.
+    """
+    ndim = 3
+
+    def get_default_params(self):
+        return {**super().get_default_params(), 'ndim': 3}
+
+    def from_dva(self):
+        return {'ret': lambda x, y: (x, y, np.zeros_like(x))}
+
+    def ret_to_dva(self, x, y, z):
+        off_slab = np.abs(z) > 1
+        return (np.where(off_slab, np.nan, x / 280.0),
+                np.where(off_slab, np.nan, -y / 280.0))
+
+    def to_dva(self):
+        return {'ret': self.ret_to_dva}
+
+
+def _fake_model(zs, location_noise=1.0):
+    """The pieces of a spatial model that the warp helpers actually read"""
+    implant = Implant(ElectrodeArray(
+        {f'A{i}': DiskElectrode(280.0 * i, 0, z, 100)
+         for i, z in enumerate(zs)}))
+    grid = Grid2D((-5, 5), (-5, 5), step=0.5)
+    grid.build(Curcio1990Map())
+    return SimpleNamespace(implant=implant, grid=grid,
+                           visual_field_map=_ZMap(),
+                           location_noise=location_noise,
+                           _location_noise_z=None)
+
+
+def test_electrode_dva_passes_every_tissue_dimension():
+    # A 3D map is handed (x, y, z), not just (x, y):
+    x, y = _electrode_dva(_fake_model([0, 0]))
+    npt.assert_almost_equal(x, [0, 1])
+    npt.assert_almost_equal(y, [0, 0])
+    # An electrode the map cannot place comes back non-finite, and is left out
+    # of the interpolation rather than poisoning it:
+    model = _fake_model([0, 5])
+    npt.assert_equal(np.isfinite(_electrode_dva(model)[0]), [True, False])
+    npt.assert_equal(np.all(np.isfinite(_location_noise_field(model))), True)
+
+
+def test_location_noise_needs_a_placeable_electrode():
+    with pytest.raises(ValueError):
+        _location_noise_field(_fake_model([5, 5]))

--- a/pulse2percept/models/tests/test_base.py
+++ b/pulse2percept/models/tests/test_base.py
@@ -1973,11 +1973,14 @@ def test_location_noise_off(location_noise):
                                {'A0': 1}).data)
 
 
-def test_location_noise_must_be_non_negative():
-    model = _one_electrode_model()
-    model.location_noise = -1
-    with pytest.raises(ValueError):
-        model.build()
+def test_location_noise_must_be_finite_and_non_negative():
+    # NaN would otherwise pass both the < 0 and > 0 tests and disable the
+    # noise silently:
+    for bad in (-1, np.nan, np.inf):
+        model = _one_electrode_model()
+        model.location_noise = bad
+        with pytest.raises(ValueError):
+            model.build()
 
 
 def test_location_noise_is_a_visual_angle():
@@ -2141,10 +2144,7 @@ def test_cortical_location_noise_ignores_region_order():
 
 
 class _Slab3DMap(VisualFieldMap):
-    """A 3D map whose inverse needs all three tissue coordinates
-
-    Linear, so a displaced phosphene is exactly the canonical one moved.
-    """
+    """A 3D map placing the visual field on the z=0 plane of a slab"""
 
     def get_default_params(self):
         return {**super().get_default_params(), 'ndim': 3,
@@ -2163,19 +2163,15 @@ class _Slab3DMap(VisualFieldMap):
         return {'v1': self.v1_to_dva}
 
 
-def test_location_noise_supports_3d_maps():
-    implant = _implant_at([(560, 0)])
-    offset = 1.0 * _latents(1, 6)[0]
+def test_location_noise_rejects_3d_maps():
+    # A visual field maps onto a surface embedded in the tissue, so the dva
+    # round trip cannot carry the coordinate normal to it (cortical depth).
     kwargs = dict(visual_field_map=_Slab3DMap(), regions=['v1'], rho=400,
-                  xrange=(-10, 10), yrange=(-10, 10), step=0.1)
-    plain = CortexScoreboardSpatial(implant, **kwargs).build()
-    np.random.seed(6)
-    moved = CortexScoreboardSpatial(implant, location_noise=1.0,
-                                    **kwargs).build()
-    was, cov_was = _blob_moments(plain.predict_percept({'A0': 1}), plain.grid)
-    now, cov_now = _blob_moments(moved.predict_percept({'A0': 1}), moved.grid)
-    npt.assert_allclose(now - was, offset, atol=0.02)
-    npt.assert_allclose(cov_now, cov_was, atol=1e-3)
+                  xrange=(-10, 10), yrange=(-10, 10), step=0.5)
+    CortexScoreboardSpatial(_implant_at([(560, 0)]), **kwargs).build()
+    with pytest.raises(NotImplementedError):
+        CortexScoreboardSpatial(_implant_at([(560, 0)]), location_noise=1.0,
+                                **kwargs).build()
 
 
 def test_location_noise_matches_integer_electrode_names():

--- a/pulse2percept/models/tests/test_base.py
+++ b/pulse2percept/models/tests/test_base.py
@@ -2087,7 +2087,7 @@ def _fake_model(zs, location_noise=1.0):
 
 def test_electrode_dva_passes_every_tissue_dimension():
     # A 3D map is handed (x, y, z), not just (x, y):
-    x, y = _electrode_dva(_fake_model([0, 0]))
+    x, y, _ = _electrode_dva(_fake_model([0, 0]))
     npt.assert_almost_equal(x, [0, 1])
     npt.assert_almost_equal(y, [0, 0])
     # An electrode the map cannot place comes back non-finite, and is left out
@@ -2100,3 +2100,20 @@ def test_electrode_dva_passes_every_tissue_dimension():
 def test_location_noise_needs_a_placeable_electrode():
     with pytest.raises(ValueError):
         _location_noise_field(_fake_model([5, 5]))
+
+
+def test_location_noise_ignores_region_order():
+    # A multi-region model sums its regions, so naming them in a different
+    # order describes the same simulation and must warp the same way:
+    implant = Cortivis()
+    source = {implant.electrode_names[0]: 100}
+    percepts, fields = [], []
+    for regions in (['v1', 'v2'], ['v2', 'v1']):
+        np.random.seed(11)
+        model = CortexScoreboardSpatial(implant, regions=regions,
+                                        xrange=(-6, 6), yrange=(-6, 6),
+                                        step=0.25, location_noise=1.0).build()
+        fields.append(model._location_noise)
+        percepts.append(model.predict_percept(source).data)
+    npt.assert_array_equal(*fields)
+    npt.assert_array_equal(*percepts)

--- a/pulse2percept/models/tests/test_base.py
+++ b/pulse2percept/models/tests/test_base.py
@@ -1965,7 +1965,6 @@ def _blob_moments(percept, grid):
 
 @pytest.mark.parametrize('location_noise', (None, 0))
 def test_location_noise_off(location_noise):
-    # No noise is an exact no-op, down to no subject being drawn:
     model = _one_electrode_model(location_noise=location_noise)
     npt.assert_equal(model._location_noise_z, None)
     npt.assert_array_equal(model.predict_percept({'A0': 1}).data,
@@ -1974,8 +1973,6 @@ def test_location_noise_off(location_noise):
 
 
 def test_location_noise_must_be_finite_and_non_negative():
-    # NaN would otherwise pass both the < 0 and > 0 tests and disable the
-    # noise silently:
     for bad in (-1, np.nan, np.inf):
         model = _one_electrode_model()
         model.location_noise = bad
@@ -1991,8 +1988,6 @@ def test_location_noise_is_a_visual_angle():
 
 
 def test_location_noise_moves_a_phosphene_without_deforming_it():
-    # A displaced electrode gives the same phosphene somewhere else, not a
-    # locally stretched image: under a linear map the blob is unchanged.
     offset = 1.0 * _latents(1, 7)[0]
     plain = _one_electrode_model()
     moved = _one_electrode_model(location_noise=1.0, seed=7)
@@ -2000,13 +1995,11 @@ def test_location_noise_moves_a_phosphene_without_deforming_it():
     now, cov_now = _blob_moments(moved.predict_percept({'A0': 1}), moved.grid)
     npt.assert_allclose(now - was, offset, atol=0.02)
     npt.assert_allclose(cov_now, cov_was, atol=1e-3)
-    # Still circular, so it did not turn into a streak:
     npt.assert_allclose(cov_now[0, 0], cov_now[1, 1], rtol=0.05)
     npt.assert_allclose(cov_now[0, 1], 0, atol=1e-3)
 
 
 def test_location_noise_moves_sparse_phosphenes_independently():
-    # Each electrode carries its own offset, and each blob stays circular.
     coords = [(-1400, -1400), (1400, -1400), (-1400, 1400), (1400, 1400)]
     offsets = 1.0 * _latents(len(coords), 3)
     plain = _scoreboard_at(coords)
@@ -2017,14 +2010,11 @@ def test_location_noise_moves_sparse_phosphenes_independently():
         now, cov_now = _blob_moments(moved.predict_percept({electrode: 1}),
                                      moved.grid)
         npt.assert_allclose(now - was, offsets[i], atol=0.02)
-        # Still the same circular blob, just off the electrode grid:
         npt.assert_allclose(cov_now, cov_was, atol=0.02)
         npt.assert_allclose(cov_now[0, 0], cov_now[1, 1], rtol=0.05)
 
 
 def test_location_noise_follows_the_stimulus_electrodes():
-    # A stimulus on a subset of the implant must still get each electrode's
-    # own offset, not the first few rows of the cached ones.
     coords = [(-1400, 0), (0, 0), (1400, 0)]
     offsets = 1.0 * _latents(len(coords), 4)
     plain = _scoreboard_at(coords)
@@ -2035,8 +2025,6 @@ def test_location_noise_follows_the_stimulus_electrodes():
 
 
 def test_location_noise_is_fixed_for_a_subject():
-    # The offsets belong to the subject, not to the build: changing an
-    # unrelated parameter must not hand the subject a new retinotopy.
     model = _one_electrode_model(location_noise=1.0, seed=7)
     first = model.predict_percept({'A0': 1}).data
     npt.assert_array_equal(model.predict_percept({'A0': 1}).data, first)
@@ -2048,10 +2036,8 @@ def test_location_noise_is_fixed_for_a_subject():
     model.rho = 400
     model.build()
     npt.assert_array_equal(model.predict_percept({'A0': 1}).data, first)
-    # A deepcopy is the same subject, too:
     npt.assert_array_equal(
         copy.deepcopy(model).predict_percept({'A0': 1}).data, first)
-    # A new model is a new subject:
     other = _one_electrode_model(location_noise=1.0, seed=8)
     npt.assert_equal(np.array_equal(other.predict_percept({'A0': 1}).data,
                                     first), False)
@@ -2075,8 +2061,7 @@ def test_location_noise_needs_an_invertible_map():
 
 
 def test_location_noise_keeps_the_axon_map_kernel_joint():
-    # AxonMap sums electrode contributions per axon segment before picking the
-    # brightest one, so a displaced electrode must reach that same kernel.
+    # Location offsets must enter the joint AxonMap kernel before summation.
     implant = ArgusII()
     both = ['C4', 'C6']
     kwargs = dict(xrange=(-8, 8), yrange=(-8, 8), step=0.25, rho=200,
@@ -2087,11 +2072,9 @@ def test_location_noise_keeps_the_axon_map_kernel_joint():
     joint = model.predict_percept({e: 1 for e in both}).data
     npt.assert_equal(np.all(np.isfinite(joint)), True)
     npt.assert_equal(joint.max() > 0, True)
-    # Superposition would make this equal; the joint kernel does not:
     apart = sum(model.predict_percept({e: 1}).data for e in both)
     npt.assert_equal(np.allclose(joint, apart), False)
-    # The percept is the canonical one for electrodes moved in the visual
-    # field, so the phosphenes stay coherent streaks:
+    # Compare against an equivalent implant physically displaced in tissue.
     vfmap = model.visual_field_map
     xyz = implant.electrode_array.coordinates(um, electrodes=both)
     rows = [implant.electrode_names.index(e) for e in both]
@@ -2119,9 +2102,7 @@ def test_cortical_location_noise_moves_the_phosphene():
     now, cov_now = _blob_moments(moved.predict_percept({electrode: 100}),
                                  moved.grid)
     npt.assert_allclose(now - was, offset, atol=0.1)
-    # A coherent phosphene, not a smeared one: it still reaches the drive it
-    # was given. Its dva extent does change, since cortical magnification
-    # falls off with eccentricity, so `cov` is only checked for compactness.
+    # Cortical magnification may change size, so only require compactness.
     for percept in (plain.predict_percept({electrode: 100}),
                     moved.predict_percept({electrode: 100})):
         npt.assert_equal(percept.data.max() > 70, True)
@@ -2129,8 +2110,6 @@ def test_cortical_location_noise_moves_the_phosphene():
 
 
 def test_cortical_location_noise_ignores_region_order():
-    # A multi-region model sums its regions, so naming them in a different
-    # order describes the same simulation and must displace the same way:
     implant = Cortivis()
     source = {implant.electrode_names[10]: 100}
     percepts = []
@@ -2164,8 +2143,7 @@ class _Slab3DMap(VisualFieldMap):
 
 
 def test_location_noise_rejects_3d_maps():
-    # A visual field maps onto a surface embedded in the tissue, so the dva
-    # round trip cannot carry the coordinate normal to it (cortical depth).
+    # A dva round trip cannot preserve cortical depth.
     kwargs = dict(visual_field_map=_Slab3DMap(), regions=['v1'], rho=400,
                   xrange=(-10, 10), yrange=(-10, 10), step=0.5)
     CortexScoreboardSpatial(_implant_at([(560, 0)]), **kwargs).build()
@@ -2175,8 +2153,7 @@ def test_location_noise_rejects_3d_maps():
 
 
 def test_location_noise_matches_integer_electrode_names():
-    # A list-built array names its electrodes 0..N-1, and a stimulus carries
-    # those integers: matching them as strings would raise or mismatch.
+    # Integer and string electrode IDs must remain distinct.
     array = ElectrodeArray([DiskElectrode(x, 0, 0, 100)
                             for x in (-1400, 0, 1400)])
     offsets = 1.0 * _latents(3, 4)
@@ -2215,12 +2192,10 @@ def _bounded_model(x_um, location_noise, seed):
 
 
 def test_location_noise_refuses_an_unplaceable_electrode():
-    # Falling back to the canonical location would silently zero this
-    # electrode's offset, censoring the Gaussian at the edge of the map.
+    # Do not silently discard offsets at the map boundary.
     off_map = _bounded_model(2000, 1.0, 7)
     with pytest.raises(ValueError, match='canonical'):
         off_map.predict_percept({'A0': 1})
-    # Same for an electrode the offset pushes off the map:
     displaced = _bounded_model(1300, 5.0, 7)
     with pytest.raises(ValueError, match='displaced'):
         displaced.predict_percept({'A0': 1})

--- a/pulse2percept/models/tests/test_signatures.py
+++ b/pulse2percept/models/tests/test_signatures.py
@@ -98,7 +98,7 @@ def test_inherited_params_are_in_the_signature(cls, _):
     npt.assert_equal('verbose' in params, True)
     if on_implant:
         # Every model that has electrodes to displace exposes the subject's
-        # retinotopic distortion:
+        # phosphene locations:
         npt.assert_equal('location_noise' in params, True)
 
 

--- a/pulse2percept/models/tests/test_signatures.py
+++ b/pulse2percept/models/tests/test_signatures.py
@@ -92,9 +92,14 @@ def test_constructor_signature_is_explicit(cls, own_param):
 def test_inherited_params_are_in_the_signature(cls, _):
     # Effect models are excluded: they declare no inherited parameters.
     params = inspect.signature(cls).parameters
-    inherited = 'step' if any(cls is m for m, _ in IMPLANT_MODELS) else 'dt'
+    on_implant = any(cls is m for m, _ in IMPLANT_MODELS)
+    inherited = 'step' if on_implant else 'dt'
     npt.assert_equal(inherited in params, True)
     npt.assert_equal('verbose' in params, True)
+    if on_implant:
+        # Every model that has electrodes to displace exposes the subject's
+        # retinotopic distortion:
+        npt.assert_equal('location_noise' in params, True)
 
 
 @pytest.mark.parametrize('cls,_', IMPLANT_MODELS)

--- a/pulse2percept/models/thompson2003.py
+++ b/pulse2percept/models/thompson2003.py
@@ -91,6 +91,13 @@ class Thompson2003Spatial(SpatialModel):
     noise : float, int, or None, optional
         Salt-and-pepper noise applied to each percept frame. An integer gives
         the number of affected pixels; a float in [0, 1] gives their fraction.
+    location_noise : float or None, optional
+        Standard deviation (dva) of this subject's retinotopic
+        distortion; see
+        :py:class:`~pulse2percept.models.SpatialModel`.
+
+        .. versionadded:: 0.11.0
+
     verbose : bool, optional
         Whether to print status messages.
     ndim : list of int, optional
@@ -108,6 +115,7 @@ class Thompson2003Spatial(SpatialModel):
                  grid_type='rect', thresh_percept=0,
                  min_current_spread=1e-8, visual_field_map=None, n_gray=None,
                  noise=None,
+                 location_noise=None,
                  verbose=True, ndim=None, n_threads=None, n_jobs=None):
         super().__init__(
             implant, radius=radius, dropout=dropout, xrange=xrange,
@@ -116,7 +124,8 @@ class Thompson2003Spatial(SpatialModel):
             min_current_spread=min_current_spread,
             visual_field_map=(Curcio1990Map() if visual_field_map is None else
                               visual_field_map),
-            n_gray=n_gray, noise=noise, verbose=verbose,
+            n_gray=n_gray, noise=noise,
+            location_noise=location_noise, verbose=verbose,
             ndim=[2] if ndim is None else ndim,
             **_thread_params(n_threads, n_jobs))
 
@@ -201,6 +210,13 @@ class Thompson2003Model(Model):
         gray-level quantization.
     noise : float, int, or None, optional
         Salt-and-pepper noise applied to each percept frame.
+    location_noise : float or None, optional
+        Standard deviation (dva) of this subject's retinotopic
+        distortion; see
+        :py:class:`~pulse2percept.models.SpatialModel`.
+
+        .. versionadded:: 0.11.0
+
     verbose : bool, optional
         Whether to print status messages.
     ndim : list of int, optional
@@ -218,6 +234,7 @@ class Thompson2003Model(Model):
                  grid_type='rect', thresh_percept=0,
                  min_current_spread=1e-8, visual_field_map=None, n_gray=None,
                  noise=None,
+                 location_noise=None,
                  verbose=True, ndim=None, n_threads=None, n_jobs=None):
         super().__init__(
             spatial=Thompson2003Spatial(
@@ -226,6 +243,7 @@ class Thompson2003Model(Model):
                 thresh_percept=thresh_percept,
                 min_current_spread=min_current_spread,
                 visual_field_map=visual_field_map,
-                n_gray=n_gray, noise=noise, verbose=verbose, ndim=ndim,
+                n_gray=n_gray, noise=noise,
+                location_noise=location_noise, verbose=verbose, ndim=ndim,
                 n_threads=n_threads, n_jobs=n_jobs),
             temporal=None)

--- a/pulse2percept/models/thompson2003.py
+++ b/pulse2percept/models/thompson2003.py
@@ -92,9 +92,9 @@ class Thompson2003Spatial(SpatialModel):
         Salt-and-pepper noise applied to each percept frame. An integer gives
         the number of affected pixels; a float in [0, 1] gives their fraction.
     location_noise : float or None, optional
-        Standard deviation (dva) of this subject's retinotopic
-        distortion; see
-        :py:class:`~pulse2percept.models.SpatialModel`.
+        Standard deviation of the variation in phosphene location from the
+        ``visual_field_map``, in dva. Locations are fixed for a model instance.
+        ``None`` or 0 disables the variation.
 
         .. versionadded:: 0.11.0
 
@@ -211,10 +211,10 @@ class Thompson2003Model(Model):
     noise : float, int, or None, optional
         Salt-and-pepper noise applied to each percept frame.
     location_noise : float or None, optional
-        Standard deviation (dva) of this subject's retinotopic
-        distortion; see
-        :py:class:`~pulse2percept.models.SpatialModel`.
-
+        Standard deviation of the variation in phosphene location from the
+        ``visual_field_map``, in dva. Locations are fixed for a model instance.
+        ``None`` or 0 disables the variation.
+        
         .. versionadded:: 0.11.0
 
     verbose : bool, optional

--- a/pulse2percept/models/thompson2003.py
+++ b/pulse2percept/models/thompson2003.py
@@ -95,6 +95,9 @@ class Thompson2003Spatial(SpatialModel):
         Standard deviation of the variation in phosphene location from the
         ``visual_field_map``, in dva. Locations are fixed for a model instance.
         ``None`` or 0 disables the variation.
+        Moves the effective stimulation location, so phosphene shape and
+        size change too wherever the model makes them location-dependent
+        (axon bundles, cortical magnification).
 
         .. versionadded:: 0.11.0
 
@@ -214,6 +217,9 @@ class Thompson2003Model(Model):
         Standard deviation of the variation in phosphene location from the
         ``visual_field_map``, in dva. Locations are fixed for a model instance.
         ``None`` or 0 disables the variation.
+        Moves the effective stimulation location, so phosphene shape and
+        size change too wherever the model makes them location-dependent
+        (axon bundles, cortical magnification).
         
         .. versionadded:: 0.11.0
 

--- a/pulse2percept/models/thompson2003.py
+++ b/pulse2percept/models/thompson2003.py
@@ -92,12 +92,9 @@ class Thompson2003Spatial(SpatialModel):
         Salt-and-pepper noise applied to each percept frame. An integer gives
         the number of affected pixels; a float in [0, 1] gives their fraction.
     location_noise : float or None, optional
-        Standard deviation of the variation in phosphene location from the
-        ``visual_field_map``, in dva. Locations are fixed for a model instance.
-        ``None`` or 0 disables the variation.
-        Moves the effective stimulation location, so phosphene shape and
-        size change too wherever the model makes them location-dependent
-        (axon bundles, cortical magnification).
+        Standard deviation of fixed electrode-specific phosphene offsets, in dva.
+        Requires an invertible 2D ``visual_field_map``. ``None`` or 0 disables it.
+        Location-dependent models may also change phosphene shape or size.
 
         .. versionadded:: 0.11.0
 
@@ -214,12 +211,9 @@ class Thompson2003Model(Model):
     noise : float, int, or None, optional
         Salt-and-pepper noise applied to each percept frame.
     location_noise : float or None, optional
-        Standard deviation of the variation in phosphene location from the
-        ``visual_field_map``, in dva. Locations are fixed for a model instance.
-        ``None`` or 0 disables the variation.
-        Moves the effective stimulation location, so phosphene shape and
-        size change too wherever the model makes them location-dependent
-        (axon bundles, cortical magnification).
+        Standard deviation of fixed electrode-specific phosphene offsets, in dva.
+        Requires an invertible 2D ``visual_field_map``. ``None`` or 0 disables it.
+        Location-dependent models may also change phosphene shape or size.
         
         .. versionadded:: 0.11.0
 


### PR DESCRIPTION
Closes #274.

Real implants do not follow canonical retinotopic maps perfectly: phosphene locations can deviate from where the anatomical map predicts them. This PR adds `location_noise` to spatial models to simulate that subject-specific variability.

```python
model = AxonMapModel(
    implant=ArgusII(),
    location_noise=1.0,  # dva
)
```

For electrode $i$,

$$
\mathbf{p}'_i = \mathbf{p}_i + \boldsymbol{\epsilon}_i,
\qquad
\boldsymbol{\epsilon}_i \sim \mathcal{N}(0, \sigma^2 I),
$$

where $\mathbf{p}_i$ is the phosphene location predicted by the canonical `visual_field_map` and $\sigma=\mathrm{location noise}$ in dva.

The offset is fixed for a model instance, so repeated stimulation produces the same subject-specific phosphene locations. `None` or `0` disables the variation.

Implementation-wise, the implant and `visual_field_map` remain unchanged. Instead, each electrode is mapped into visual space, displaced there, and mapped back to an effective tissue location used only by the percept model. This keeps phosphenes coherent rather than warping pixels in the rendered percept, and preserves existing multi-electrode interactions in models such as `AxonMap`.

Also:

- [x] supports retinal and cortical models, including Dynaphos
- [x] uses the same electrode-specific visual offset across cortical regions
- [x] preserves offsets across rebuilds and deep copies
- [x] resets offsets when the implant changes
- [x] supports 2D invertible visual-field maps
- [x] matches offsets by electrode identity, including integer electrode names
- [x] raises an error when an electrode cannot be mapped before or after displacement
- [x] leaves scene sampling and physical electrode geometry unchanged

The visual-field-map gallery now illustrates the effect with sparse retinal and cortical stimulation before showing a dense image example.