### PR TITLE
[FIX] NameError in Dynaphos for non-split visual field maps

### DIFF
--- a/pulse2percept/models/cortex/dynaphos.py
+++ b/pulse2percept/models/cortex/dynaphos.py
@@ -427,12 +427,11 @@ class DynaphosModel(BaseModel):
             brightness = np.divide(1, 1 + np.exp(-self.sig_slope * (A - self.a50)))
             # create gaussian blobs & add to frame
             def create_gaussian(x0,y0,sigma,x_el):
+                gaussX = np.exp(-(xRange - x0)**2 / (2 * sigma ** 2))
+                # Only a split map has hemifields to keep current out of.
                 if separate:
-                    if x_el < boundary:
-                        cutoff = xRange <= 0
-                    else:
-                        cutoff = xRange > 0
-                gaussX = np.where(cutoff, 0, np.exp(-(xRange - x0)**2 / (2 * sigma ** 2)))
+                    cutoff = xRange <= 0 if x_el < boundary else xRange > 0
+                    gaussX = np.where(cutoff, 0, gaussX)
                 gaussY = np.exp(-(yRange - y0)**2 / (2 * sigma ** 2))
                 gauss = np.outer(gaussY, gaussX)
                 return gauss

--- a/pulse2percept/models/cortex/tests/test_dynaphos.py
+++ b/pulse2percept/models/cortex/tests/test_dynaphos.py
@@ -57,6 +57,24 @@ def test_predict_spatial():
     npt.assert_equal(np.all(percept[:, half+1:] == 0), True)
     npt.assert_equal(np.all(percept[:, :half] != 0), True)
 
+def test_predict_spatial_unsplit_map():
+    # A map without hemifields must not be masked (used to raise NameError)
+    class UnsplitMap(Polimeni2006Map):
+        split_map = False
+
+    implant = Orion(x=15000)
+    model = DynaphosModel(implant=implant, xrange=(-3, 3), yrange=(-3, 3),
+                          step=0.5, visual_field_map=UnsplitMap()).build()
+    source = {e: BiphasicPulseTrain(freq=300, amp=2000, phase_dur=0.17)
+              for e in implant.electrode_names}
+    percept = model.predict_percept(source).max(axis='frames')
+    npt.assert_equal(np.all(np.isfinite(percept)), True)
+    npt.assert_equal(np.any(percept > 0), True)
+    # Nothing is zeroed out by hemifield, so both halves get light
+    half = percept.shape[1] // 2
+    npt.assert_equal(np.any(percept[:, half + 1:] > 0), True)
+
+
 def test_temporal_predict():
     model = DynaphosModel(implant=Cortivis(), step=0.1).build()
     # User can set params


### PR DESCRIPTION
`DynaphosModel._predict_percept`'s nested `create_gaussian()` only defined `cutoff` when `visual_field_map.split_map` was true, but referenced it unconditionally. Any map without hemifields (e.g. `split_map = False`) raised `NameError` on `predict_percept()`.

The Gaussian is now computed across the full `xRange` and the hemifield mask is applied only when the map is split, so split-map behavior is unchanged