### PR TITLE
[MNT] Remove percept noise

### DIFF
--- a/doc/topics/models.rst
+++ b/doc/topics/models.rst
@@ -292,10 +292,10 @@ RGB values are display intensities and must be finite and lie in ``[0, 1]``;
 anything else raises at construction rather than saturating quietly later. The
 RGB axis is not a spatial dimension: ``space`` still describes ``(Y, X)``.
 
-Operations defined on perceived brightness -- ``n_gray``, ``noise``,
-``argmax``, ``max``, and the ``vmin``/``vmax`` display range -- raise a
-``ValueError`` for an RGB percept rather than inventing a conversion from
-color to brightness. Ranking three channels by one number would have to pick a
+Operations defined on perceived brightness (i.e., ``n_gray``, ``argmax``,
+``max``, ``vmin``, ``vmax``) raise a ``ValueError`` for an RGB
+percept rather than inventing a conversion from color to brightness. 
+Ranking three channels by one number would have to pick a
 color metric, which is also why a multi-frame RGB percept has no brightest
 frame to ``plot()``; animate it with ``play()`` instead. ``percept.data`` is
 always available for the plain numerical answer.

--- a/doc/users/release_notes.rst
+++ b/doc/users/release_notes.rst
@@ -106,6 +106,9 @@ Models
   :py:meth:`~pulse2percept.implants.EnsembleImplant.from_coords` replaces
   positioning named implants through their constructors (:pull:`884`).
 
+* The generic ``noise`` parameter has been removed from
+  :py:class:`~pulse2percept.percepts.Percept` and all models (:pull:`885`).
+
 * New ``location_noise`` parameter displaces each electrode's phosphene by a
   fixed, subject-specific offset in the visual field (dva) rather than at the
   location the ``visual_field_map`` gives it. Requires a 2D, invertible map
@@ -145,7 +148,7 @@ Bug fixes
 * Corrected PRIMA-family pixel dimensions and layouts (:pull:`865`).
 
 * :py:class:`~pulse2percept.models.BiphasicAxonMapSpatial` now respects
-  ``n_gray`` and ``noise`` and preserves the full stimulus in percept metadata
+  ``n_gray`` and preserves the full stimulus in percept metadata
   (:pull:`869`).
 
 

--- a/pulse2percept/models/base.py
+++ b/pulse2percept/models/base.py
@@ -941,9 +941,6 @@ class SpatialModel(BaseModel, metaclass=ABCMeta):
     n_gray : int or None, optional
         Number of gray levels in the returned percept. ``None`` disables
         gray-level quantization.
-    noise : float, int, or None, optional
-        Salt-and-pepper noise applied to each percept frame. An integer gives
-        the number of affected pixels; a float in [0, 1] gives their fraction.
     location_noise : float or None, optional
         Standard deviation of fixed electrode-specific phosphene offsets, in
         dva. Requires an invertible 2D ``visual_field_map``. Moving the effective
@@ -1099,7 +1096,6 @@ class SpatialModel(BaseModel, metaclass=ABCMeta):
             'min_current_spread': 1e-8,
             'visual_field_map': Curcio1990Map(),
             'n_gray': None,
-            'noise': None,
             'location_noise': None,  # dva
             'verbose': True,
             'ndim' : [2],
@@ -1345,7 +1341,7 @@ class SpatialModel(BaseModel, metaclass=ABCMeta):
         return Percept(resp.reshape(list(self.grid.x.shape) + [-1]),
                        space=self.grid, time=t_percept,
                        time_unit=self.time_unit,
-                       metadata={'stim': stim}, n_gray=self.n_gray, noise=self.noise)
+                       metadata={'stim': stim}, n_gray=self.n_gray)
 
     def plot(self, use_dva=False, style='hull', autoscale=True, ax=None,
              figsize=None, show_implant=False):

--- a/pulse2percept/models/beyeler2019.py
+++ b/pulse2percept/models/beyeler2019.py
@@ -136,9 +136,6 @@ class ScoreboardSpatial(SpatialModel):
     n_gray : int or None, optional
         Number of gray levels in the returned percept. ``None`` disables
         gray-level quantization.
-    noise : float, int, or None, optional
-        Salt-and-pepper noise applied to each percept frame. An integer gives
-        the number of affected pixels; a float in [0, 1] gives their fraction.
     implant_position : (x, y) or Quantity, optional
         Position of the device-local origin, in tissue coordinates or dva.
 
@@ -177,7 +174,7 @@ class ScoreboardSpatial(SpatialModel):
                  yrange=(-15, 15), step=0.25, grid_type='rect',
                  thresh_percept=0, min_current_spread=1e-8,
                  visual_field_map=None,
-                 n_gray=None, noise=None,
+                 n_gray=None,
                  implant_position=(0, 0), implant_rotation=0,
                  implant_depth=0,
                  location_noise=None, verbose=True, ndim=None,
@@ -188,7 +185,7 @@ class ScoreboardSpatial(SpatialModel):
             min_current_spread=min_current_spread,
             visual_field_map=(Watson2014Map() if visual_field_map is None else
                               visual_field_map),
-            n_gray=n_gray, noise=noise,
+            n_gray=n_gray,
             implant_position=implant_position,
             implant_rotation=implant_rotation,
             implant_depth=implant_depth,
@@ -293,9 +290,6 @@ class ScoreboardModel(Model):
     n_gray : int or None, optional
         Number of gray levels in the returned percept. ``None`` disables
         gray-level quantization.
-    noise : float, int, or None, optional
-        Salt-and-pepper noise applied to each percept frame. An integer gives
-        the number of affected pixels; a float in [0, 1] gives their fraction.
     implant_position : (x, y) or Quantity, optional
         Position of the device-local origin, in tissue coordinates or dva.
 
@@ -331,7 +325,7 @@ class ScoreboardModel(Model):
                  yrange=(-15, 15), step=0.25, grid_type='rect',
                  thresh_percept=0, min_current_spread=1e-8,
                  visual_field_map=None,
-                 n_gray=None, noise=None,
+                 n_gray=None,
                  implant_position=(0, 0), implant_rotation=0,
                  implant_depth=0,
                  location_noise=None, verbose=True, ndim=None,
@@ -342,7 +336,7 @@ class ScoreboardModel(Model):
                 grid_type=grid_type, thresh_percept=thresh_percept,
                 min_current_spread=min_current_spread,
                 visual_field_map=visual_field_map,
-                n_gray=n_gray, noise=noise,
+                n_gray=n_gray,
                 implant_position=implant_position,
                 implant_rotation=implant_rotation,
                 implant_depth=implant_depth,
@@ -430,9 +424,6 @@ class AxonMapSpatial(SpatialModel):
     n_gray : int or None, optional
         Number of gray levels in the returned percept. ``None`` disables
         gray-level quantization.
-    noise : float, int, or None, optional
-        Salt-and-pepper noise applied to each percept frame. An integer gives
-        the number of affected pixels; a float in [0, 1] gives their fraction.
     implant_position : (x, y) or Quantity, optional
         Position of the device-local origin, in tissue coordinates or dva.
 
@@ -497,7 +488,7 @@ class AxonMapSpatial(SpatialModel):
                  yrange=(-15, 15), step=0.25, grid_type='rect',
                  thresh_percept=0, min_current_spread=1e-8,
                  visual_field_map=None,
-                 n_gray=None, noise=None,
+                 n_gray=None,
                  implant_position=(0, 0), implant_rotation=0,
                  implant_depth=0,
                  location_noise=None, loc_od=(15.5, 1.5), n_axons=1000,
@@ -512,7 +503,7 @@ class AxonMapSpatial(SpatialModel):
             min_current_spread=min_current_spread,
             visual_field_map=(Watson2014Map() if visual_field_map is None else
                               visual_field_map),
-            n_gray=n_gray, noise=noise,
+            n_gray=n_gray,
             implant_position=implant_position,
             implant_rotation=implant_rotation,
             implant_depth=implant_depth,
@@ -1218,9 +1209,6 @@ class AxonMapModel(Model):
     n_gray : int or None, optional
         Number of gray levels in the returned percept. ``None`` disables
         gray-level quantization.
-    noise : float, int, or None, optional
-        Salt-and-pepper noise applied to each percept frame. An integer gives
-        the number of affected pixels; a float in [0, 1] gives their fraction.
     implant_position : (x, y) or Quantity, optional
         Position of the device-local origin, in tissue coordinates or dva.
 
@@ -1285,7 +1273,7 @@ class AxonMapModel(Model):
                  yrange=(-15, 15), step=0.25, grid_type='rect',
                  thresh_percept=0, min_current_spread=1e-8,
                  visual_field_map=None,
-                 n_gray=None, noise=None,
+                 n_gray=None,
                  implant_position=(0, 0), implant_rotation=0,
                  implant_depth=0,
                  location_noise=None, loc_od=(15.5, 1.5), n_axons=1000,
@@ -1301,7 +1289,7 @@ class AxonMapModel(Model):
                 thresh_percept=thresh_percept,
                 min_current_spread=min_current_spread,
                 visual_field_map=visual_field_map,
-                n_gray=n_gray, noise=noise,
+                n_gray=n_gray,
                 implant_position=implant_position,
                 implant_rotation=implant_rotation,
                 implant_depth=implant_depth,

--- a/pulse2percept/models/cortex/base.py
+++ b/pulse2percept/models/cortex/base.py
@@ -65,11 +65,6 @@ class CortexSpatial(SpatialModel):
         The number of gray levels to use. If an integer is given, k-means
         clustering is used to compress the color space of the percept into
         ``n_gray`` bins. If None, no compression is performed.
-    noise : float or int, optional
-        Adds salt-and-pepper noise to each percept frame. An integer will be
-        interpreted as the number of pixels to subject to noise in each frame.
-        A float between 0 and 1 will be interpreted as a ratio of pixels to
-        subject to noise in each frame.
     implant_position : (x, y) or Quantity, optional
         Position of the device-local origin, in tissue coordinates or dva.
 
@@ -313,11 +308,6 @@ class ScoreboardSpatial(CortexSpatial):
         The number of gray levels to use. If an integer is given, k-means
         clustering is used to compress the color space of the percept into
         ``n_gray`` bins. If None, no compression is performed.
-    noise : float or int, optional
-        Adds salt-and-pepper noise to each percept frame. An integer will be
-        interpreted as the number of pixels to subject to noise in each frame.
-        A float between 0 and 1 will be interpreted as a ratio of pixels to
-        subject to noise in each frame.
     implant_position : (x, y) or Quantity, optional
         Position of the device-local origin, in tissue coordinates or dva.
 
@@ -357,7 +347,6 @@ class ScoreboardSpatial(CortexSpatial):
                  xrange=(-5, 5), yrange=(-5, 5), step=0.1,
                  grid_type='rect', thresh_percept=0,
                  min_current_spread=1e-8, visual_field_map=None, n_gray=None,
-                 noise=None,
                  implant_position=(0, 0), implant_rotation=0,
                  implant_depth=0,
                  location_noise=None,
@@ -368,7 +357,7 @@ class ScoreboardSpatial(CortexSpatial):
             step=step, grid_type=grid_type, thresh_percept=thresh_percept,
             min_current_spread=min_current_spread,
             visual_field_map=visual_field_map,
-            n_gray=n_gray, noise=noise,
+            n_gray=n_gray,
             implant_position=implant_position,
             implant_rotation=implant_rotation,
             implant_depth=implant_depth,
@@ -515,11 +504,6 @@ class ScoreboardModel(Model):
         The number of gray levels to use. If an integer is given, k-means
         clustering is used to compress the color space of the percept into
         ``n_gray`` bins. If None, no compression is performed.
-    noise : float or int, optional
-        Adds salt-and-pepper noise to each percept frame. An integer will be
-        interpreted as the number of pixels to subject to noise in each frame.
-        A float between 0 and 1 will be interpreted as a ratio of pixels to
-        subject to noise in each frame.
     implant_position : (x, y) or Quantity, optional
         Position of the device-local origin, in tissue coordinates or dva.
 
@@ -559,7 +543,6 @@ class ScoreboardModel(Model):
                  xrange=(-5, 5), yrange=(-5, 5), step=0.1,
                  grid_type='rect', thresh_percept=0,
                  min_current_spread=1e-8, visual_field_map=None, n_gray=None,
-                 noise=None,
                  implant_position=(0, 0), implant_rotation=0,
                  implant_depth=0,
                  location_noise=None,
@@ -572,7 +555,7 @@ class ScoreboardModel(Model):
                 thresh_percept=thresh_percept,
                 min_current_spread=min_current_spread,
                 visual_field_map=visual_field_map,
-                n_gray=n_gray, noise=noise,
+                n_gray=n_gray,
                 implant_position=implant_position,
                 implant_rotation=implant_rotation,
                 implant_depth=implant_depth,

--- a/pulse2percept/models/cortex/dynaphos.py
+++ b/pulse2percept/models/cortex/dynaphos.py
@@ -127,13 +127,6 @@ class DynaphosModel(BaseModel):
         
         .. versionadded:: 0.11.0
 
-    noise : float or int, optional
-        Adds salt-and-pepper noise to each percept frame. An integer will be
-        interpreted as the number of pixels to subject to noise in each 
-        frame. A float between 0 and 1 will be interpreted as a ratio of 
-        pixels to subject to noise in each frame.
-
-        
     .. important::
     
         Changing a model parameter outside the constructor (e.g., by directly
@@ -159,7 +152,6 @@ class DynaphosModel(BaseModel):
                  a50=1.057631326853325e-07, freq=300, p_dur=0.170,
                  xrange=(-5, 5), yrange=(-5, 5), step=0.25,
                  grid_type='rect', visual_field_map=None, n_gray=None,
-                 noise=None,
                  implant_position=(0, 0), implant_rotation=0,
                  implant_depth=0,
                  location_noise=None,
@@ -177,7 +169,7 @@ class DynaphosModel(BaseModel):
                 visual_field_map=(
                     Polimeni2006Map(a=0.75, k=17.3, b=120, alpha1=0.95)
                     if visual_field_map is None else visual_field_map),
-                n_gray=n_gray, noise=noise,
+                n_gray=n_gray,
                 implant_position=implant_position,
                 implant_rotation=implant_rotation,
                 implant_depth=implant_depth,
@@ -222,8 +214,6 @@ class DynaphosModel(BaseModel):
                                                     alpha1=0.95),
                 # Number of gray levels to use in the percept:
                 'n_gray': None,
-                # Salt-and-pepper noise on the output:
-                'noise': None,
                 # Tissue position of the implant's local origin, its
                 # rotation (deg) and its depth (um):
                 'implant_position': (0, 0),
@@ -561,7 +551,7 @@ class DynaphosModel(BaseModel):
         return Percept(resp.reshape(list(self.grid.x.shape) + [t_percept.size]),
                        space=self.grid, time=t_percept,
                        time_unit=self.time_unit,
-                       metadata={'stim': stim}, n_gray=self.n_gray, noise=self.noise)
+                       metadata={'stim': stim}, n_gray=self.n_gray)
 
     def plot(self, use_dva=False, style=None, autoscale=True, ax=None,
              figsize=None, fc=None, show_implant=False):

--- a/pulse2percept/models/granley2021.py
+++ b/pulse2percept/models/granley2021.py
@@ -399,9 +399,6 @@ class BiphasicAxonMapSpatial(AxonMapSpatial):
     n_gray : int or None, optional
         Number of gray levels in the returned percept. ``None`` disables
         gray-level quantization.
-    noise : float, int, or None, optional
-        Salt-and-pepper noise applied to each percept frame. An integer gives
-        the number of affected pixels; a float in [0, 1] gives their fraction.
     implant_position : (x, y) or Quantity, optional
         Position of the device-local origin, in tissue coordinates or dva.
 
@@ -468,7 +465,7 @@ class BiphasicAxonMapSpatial(AxonMapSpatial):
                  yrange=(-15, 15), step=0.25, grid_type='rect',
                  thresh_percept=0, min_current_spread=1e-8,
                  visual_field_map=None,
-                 n_gray=None, noise=None,
+                 n_gray=None,
                  implant_position=(0, 0), implant_rotation=0,
                  implant_depth=0,
                  location_noise=None, loc_od=(15.5, 1.5), n_axons=1000,
@@ -483,7 +480,7 @@ class BiphasicAxonMapSpatial(AxonMapSpatial):
             step=step, grid_type=grid_type, thresh_percept=thresh_percept,
             min_current_spread=min_current_spread,
             visual_field_map=visual_field_map,
-            n_gray=n_gray, noise=noise,
+            n_gray=n_gray,
             implant_position=implant_position,
             implant_rotation=implant_rotation,
             implant_depth=implant_depth,
@@ -616,7 +613,7 @@ class BiphasicAxonMapSpatial(AxonMapSpatial):
         resp = self._postprocess_spatial(resp)
         return Percept(resp, space=self.grid, time=t_percept,
                        time_unit=self.time_unit, metadata={'stim': stim},
-                       n_gray=self.n_gray, noise=self.noise)
+                       n_gray=self.n_gray)
 
     def _combine_temporal(self, percept, temporal, stim, t_percept):
         """Apply a normalized temporal response to the spatial percept."""
@@ -786,9 +783,6 @@ class BiphasicAxonMapModel(Model):
     n_gray : int or None, optional
         Number of gray levels in the returned percept. ``None`` disables
         gray-level quantization.
-    noise : float, int, or None, optional
-        Salt-and-pepper noise applied to each percept frame. An integer gives
-        the number of affected pixels; a float in [0, 1] gives their fraction.
     implant_position : (x, y) or Quantity, optional
         Position of the device-local origin, in tissue coordinates or dva.
 
@@ -879,7 +873,7 @@ class BiphasicAxonMapModel(Model):
                  yrange=(-15, 15), step=0.25, grid_type='rect',
                  thresh_percept=0, min_current_spread=1e-8,
                  visual_field_map=None,
-                 n_gray=None, noise=None,
+                 n_gray=None,
                  implant_position=(0, 0), implant_rotation=0,
                  implant_depth=0,
                  location_noise=None, loc_od=(15.5, 1.5), n_axons=1000,
@@ -896,7 +890,7 @@ class BiphasicAxonMapModel(Model):
                 thresh_percept=thresh_percept,
                 min_current_spread=min_current_spread,
                 visual_field_map=visual_field_map,
-                n_gray=n_gray, noise=noise,
+                n_gray=n_gray,
                 implant_position=implant_position,
                 implant_rotation=implant_rotation,
                 implant_depth=implant_depth,

--- a/pulse2percept/models/nanduri2012.py
+++ b/pulse2percept/models/nanduri2012.py
@@ -104,9 +104,6 @@ class Nanduri2012Spatial(SpatialModel):
         n_gray : int or None, optional
             Number of gray levels in the returned percept. ``None`` disables
             gray-level quantization.
-        noise : float, int, or None, optional
-            Salt-and-pepper noise applied to each percept frame. An integer gives
-            the number of affected pixels; a float in [0, 1] gives their fraction.
         implant_position : (x, y) or Quantity, optional
             Where the implant's local ``(0, 0)`` origin sits. A bare pair or
             a length is a tissue position in microns; ``(6, -2) * dva`` is a
@@ -147,7 +144,6 @@ class Nanduri2012Spatial(SpatialModel):
                  xrange=(-15, 15), yrange=(-15, 15), step=0.25,
                  grid_type='rect', thresh_percept=0,
                  min_current_spread=1e-8, visual_field_map=None, n_gray=None,
-                 noise=None,
                  implant_position=(0, 0), implant_rotation=0,
                  implant_depth=0,
                  location_noise=None,
@@ -159,7 +155,7 @@ class Nanduri2012Spatial(SpatialModel):
             min_current_spread=min_current_spread,
             visual_field_map=(Curcio1990Map() if visual_field_map is None else
                               visual_field_map),
-            n_gray=n_gray, noise=noise,
+            n_gray=n_gray,
             implant_position=implant_position,
             implant_rotation=implant_rotation,
             implant_depth=implant_depth,
@@ -392,8 +388,6 @@ class Nanduri2012Model(Model):
         n_gray : int or None, optional
             Number of gray levels in the returned percept. ``None`` disables
             gray-level quantization.
-        noise : float, int, or None, optional
-            Salt-and-pepper noise applied to each percept frame.
         implant_position : (x, y) or Quantity, optional
             Where the implant's local ``(0, 0)`` origin sits. A bare pair or
             a length is a tissue position in microns; ``(6, -2) * dva`` is a
@@ -465,7 +459,7 @@ class Nanduri2012Model(Model):
                  xrange=(-15, 15), yrange=(-15, 15), step=0.25,
                  grid_type='rect', min_current_spread=1e-8,
                  visual_field_map=None,
-                 n_gray=None, noise=None,
+                 n_gray=None,
                  implant_position=(0, 0), implant_rotation=0,
                  implant_depth=0,
                  location_noise=None, ndim=None, dt=0.005, tau1=0.42,
@@ -480,7 +474,7 @@ class Nanduri2012Model(Model):
                 yrange=yrange, step=step, grid_type=grid_type,
                 min_current_spread=min_current_spread,
                 visual_field_map=visual_field_map,
-                n_gray=n_gray, noise=noise,
+                n_gray=n_gray,
                 implant_position=implant_position,
                 implant_rotation=implant_rotation,
                 implant_depth=implant_depth,

--- a/pulse2percept/models/tests/test_granley2021.py
+++ b/pulse2percept/models/tests/test_granley2021.py
@@ -1048,17 +1048,6 @@ def test_BiphasicAxonMap_n_gray(model_cls):
     npt.assert_equal(np.unique(quantized.data).size, 2)
 
 
-@pytest.mark.parametrize('model_cls', [BiphasicAxonMapModel,
-                                       BiphasicAxonMapSpatial])
-def test_BiphasicAxonMap_noise(model_cls):
-    source = {'C5': BiphasicPulseTrain(20, 2 * xTh, 0.45, stim_dur=100)}
-    model = model_cls(implant=ArgusII(), xrange=(-4, 4), yrange=(-4, 4),
-                      step=1, n_ax_segments=30, noise=1.0).build()
-    frame = model.predict_percept(source).data[..., 0]
-    # noise=1 leaves only salt and pepper values
-    npt.assert_equal(np.unique(frame).size, 2)
-
-
 @pytest.mark.parametrize('temporal_cls', _TEMPORALS)
 def test_BiphasicAxonMapSpatial_composite_reads_an_encoded_image(temporal_cls):
     # `_envelope_dur` reads stim_dur through the same helper, so a composite

--- a/pulse2percept/models/thompson2003.py
+++ b/pulse2percept/models/thompson2003.py
@@ -88,9 +88,6 @@ class Thompson2003Spatial(SpatialModel):
     n_gray : int or None, optional
         Number of gray levels in the returned percept. ``None`` disables
         gray-level quantization.
-    noise : float, int, or None, optional
-        Salt-and-pepper noise applied to each percept frame. An integer gives
-        the number of affected pixels; a float in [0, 1] gives their fraction.
     implant_position : (x, y) or Quantity, optional
         Position of the device-local origin, in tissue coordinates or dva.
 
@@ -129,7 +126,6 @@ class Thompson2003Spatial(SpatialModel):
                  xrange=(-15, 15), yrange=(-15, 15), step=0.25,
                  grid_type='rect', thresh_percept=0,
                  min_current_spread=1e-8, visual_field_map=None, n_gray=None,
-                 noise=None,
                  implant_position=(0, 0), implant_rotation=0,
                  implant_depth=0,
                  location_noise=None,
@@ -141,7 +137,7 @@ class Thompson2003Spatial(SpatialModel):
             min_current_spread=min_current_spread,
             visual_field_map=(Curcio1990Map() if visual_field_map is None else
                               visual_field_map),
-            n_gray=n_gray, noise=noise,
+            n_gray=n_gray,
             implant_position=implant_position,
             implant_rotation=implant_rotation,
             implant_depth=implant_depth,
@@ -228,8 +224,6 @@ class Thompson2003Model(Model):
     n_gray : int or None, optional
         Number of gray levels in the returned percept. ``None`` disables
         gray-level quantization.
-    noise : float, int, or None, optional
-        Salt-and-pepper noise applied to each percept frame.
     implant_position : (x, y) or Quantity, optional
         Position of the device-local origin, in tissue coordinates or dva.
 
@@ -268,7 +262,6 @@ class Thompson2003Model(Model):
                  xrange=(-15, 15), yrange=(-15, 15), step=0.25,
                  grid_type='rect', thresh_percept=0,
                  min_current_spread=1e-8, visual_field_map=None, n_gray=None,
-                 noise=None,
                  implant_position=(0, 0), implant_rotation=0,
                  implant_depth=0,
                  location_noise=None,
@@ -280,7 +273,7 @@ class Thompson2003Model(Model):
                 thresh_percept=thresh_percept,
                 min_current_spread=min_current_spread,
                 visual_field_map=visual_field_map,
-                n_gray=n_gray, noise=noise,
+                n_gray=n_gray,
                 implant_position=implant_position,
                 implant_rotation=implant_rotation,
                 implant_depth=implant_depth,

--- a/pulse2percept/percepts/base.py
+++ b/pulse2percept/percepts/base.py
@@ -15,7 +15,7 @@ from skimage.color import rgb2gray, rgba2rgb
 from skimage.transform import resize
 
 from ..units import DimensionMismatchError, Hz, Quantity, Unit, as_value, ms
-from ..utils import Data, HTMLAnimation, frame_interval, sample
+from ..utils import Data, HTMLAnimation, frame_interval
 from ..utils.animation import _frame_timeline
 from ..utils.array import _interp_rows, _slice_times
 from ..utils.constants import VIDEO_BLOCK_SIZE
@@ -228,10 +228,6 @@ class Percept(Data):
     n_gray : int, optional
         Number of gray levels. If specified, k-means clustering is used to
         reduce the percept to ``n_gray`` levels. Not available for RGB.
-    noise : float or int, optional
-        Amount of salt-and-pepper noise per frame. Integers specify a number
-        of pixels; floats in [0, 1] specify a fraction of pixels. Not available
-        for RGB.
     time_unit : :py:class:`~pulse2percept.units.Unit`, optional
         Unit in which ``time`` is stored.
 
@@ -245,10 +241,9 @@ class Percept(Data):
     spatial dimension: ``space`` still describes ``(Y, X)``, and a frame comes
     out as ``(Y, X)`` or ``(Y, X, 3)``.
 
-    ``n_gray``, ``noise``, ``argmax``, ``max``, and the ``vmin``/``vmax``
-    display range are defined on perceived brightness and raise a
-    ``ValueError`` for an RGB percept, which already carries its own display
-    values. Reducing three channels to one number -- to rank pixels or pick a
+    ``n_gray``, ``argmax``, ``max``, and the ``vmin``/``vmax`` display range
+    are defined on perceived brightness and raise a ``ValueError`` for an RGB
+    percept, which already carries its own display values. Reducing three channels to one number -- to rank pixels or pick a
     brightest frame -- would have to choose a color metric, and a metric the
     models never produced is a decision for the caller, not for this class.
     ``percept.data`` is always there for the plain numerical answer.
@@ -274,7 +269,7 @@ class Percept(Data):
     """
 
     def __init__(self, data, space=None, time=None, metadata=None, n_gray=None,
-                 noise=None, time_unit=ms):
+                 time_unit=ms):
         # import at runtime to avoid circular import
         from ..topography import Grid2D
         if not isinstance(time_unit, Unit):
@@ -311,23 +306,6 @@ class Percept(Data):
             data = np.asarray(data, dtype=np.float32)
             centroids, labels = kmeans2(data.ravel(), n_gray, minit='points')
             data = centroids[labels].reshape(data.shape)
-        # Add salt-and-pepper noise if requested:
-        if noise is not None:
-            if is_rgb:
-                raise _reject_rgb('noise', ' Salt and pepper are the darkest '
-                                           'and brightest values a percept '
-                                           'takes, which RGB does not define.')
-            n_pixels = np.prod(data.shape[:2])
-            vmin, vmax = data.min(), data.max()
-            for t in range(data.shape[2]):
-                idx_noise = sample(np.arange(n_pixels), k=noise)
-                n_noise = len(idx_noise)
-                xi, yi = np.unravel_index(idx_noise[:n_noise//2],
-                                          data.shape[:2])
-                data[xi, yi, t] = vmin
-                xi, yi = np.unravel_index(idx_noise[n_noise//2:n_noise],
-                                          data.shape[:2])
-                data[xi, yi, t] = vmax
         time = as_value(time, self._time_unit, 'time')
         if time is not None:
             time = np.array([time]).flatten()

--- a/pulse2percept/percepts/tests/test_base.py
+++ b/pulse2percept/percepts/tests/test_base.py
@@ -73,17 +73,6 @@ def test_Percept():
     with pytest.raises(ValueError):
         Percept(ndarray, n_gray=-3)
 
-    # Noise:
-    data = np.arange(100, dtype=float).reshape((5, 5, 4))
-    npt.assert_almost_equal(Percept(data, noise=0).data, data)
-    npt.assert_almost_equal(Percept(data, noise=0.0).data, data)
-    for noise in [0.5, 1.0]:
-        percept = Percept(data, noise=noise)
-        n_white = sum(np.isclose(percept.data.ravel(), 99.0))
-        n_black = sum(np.isclose(percept.data.ravel(), 0.0))
-        npt.assert_equal(abs(n_white - 0.5 * noise * data.size) <= 2, True)
-        npt.assert_equal(abs(n_black - 0.5 * noise * data.size) <= 2, True)
-
 
 def test_Percept__iter__():
     ndarray = np.zeros((2, 4, 3))
@@ -1112,10 +1101,9 @@ def test_Percept_rgb_save_movie_roundtrip(tmp_path):
 
 def test_Percept_rgb_rejects_brightness_operations():
     data = np.random.rand(4, 6, 3, 2)
-    for kwargs in ({'n_gray': 4}, {'noise': 0.5}):
-        with pytest.raises(ValueError):
-            Percept(data, **kwargs)
-    # Both remain available for a brightness percept:
+    with pytest.raises(ValueError):
+        Percept(data, n_gray=4)
+    # Still available for a brightness percept:
     npt.assert_equal(len(np.unique(Percept(np.random.rand(4, 6, 2),
                                            n_gray=4).data)), 4)
 


### PR DESCRIPTION
The generic `noise` parameter added salt-and-pepper corruption to percept outputs. Although originally intended to approximate spontaneous visual activity, its behavior was not scientifically meaningful: noise amplitude depended on the percept’s own global min/max, blank percepts produced no visible noise, and the random pattern depended on pixel sampling rather than visual-space or temporal statistics.

This PR removes `noise` from `Percept` and all models instead of carrying forward an ambiguous, non-reproducible image-processing effect as part of the scientific API. If background visual phenomena are modeled in the future, they should be introduced as an empirically motivated percept model with explicit spatial and temporal assumptions.