### PR TITLE
[ENH] Add circular and binocular scene views

### DIFF
--- a/doc/topics/implants.rst
+++ b/doc/topics/implants.rst
@@ -116,7 +116,10 @@ electrode coordinates in microns. Placement is specified on the model with
 eye and is read by the models:
 :py:class:`~pulse2percept.models.retina.AxonMapModel` puts the optic disc on
 the side the eye calls for. Some devices also reverse their column names in
-the left eye; see each class's API documentation.
+the left eye; see each class's API documentation. A
+:py:class:`~pulse2percept.vision.Scene` carries no ``eye`` of its own; eye
+identity for a visual field comes from its side of a
+:py:class:`~pulse2percept.vision.BinocularScene`.
 
 PRIMA
 ^^^^^

--- a/doc/topics/implants.rst
+++ b/doc/topics/implants.rst
@@ -17,8 +17,8 @@ they stimulate, which is also where laterality lives:
             |
     generic Implant pipeline        (p2p.implants)
             |
-    retina.RetinalImplant  -> eye          ('LE', 'RE')
-    cortex.CorticalImplant -> hemisphere   ('LH', 'RH', None)
+    retina.RetinalImplant  -> eye          ('left', 'right')
+    cortex.CorticalImplant -> hemisphere   ('left', 'right', None)
 
 So a device is constructed from its own namespace,
 ``p2p.implants.retina.ArgusII()`` or ``p2p.implants.cortex.Orion()``, while
@@ -112,10 +112,11 @@ Retinal implants derive from
 electrode coordinates in microns. Placement is specified on the model with
 ``implant_position``, ``implant_rotation`` and ``implant_depth``.
 
-``eye`` (``'LE'`` or ``'RE'``, default ``'RE'``) records the implanted eye and
-is read by the models: :py:class:`~pulse2percept.models.retina.AxonMapModel`
-puts the optic disc on the side the eye calls for. Some devices also reverse
-their column names in the left eye; see each class's API documentation.
+``eye`` (``'left'`` or ``'right'``, default ``'right'``) records the implanted
+eye and is read by the models:
+:py:class:`~pulse2percept.models.retina.AxonMapModel` puts the optic disc on
+the side the eye calls for. Some devices also reverse their column names in
+the left eye; see each class's API documentation.
 
 PRIMA
 ^^^^^
@@ -305,7 +306,7 @@ the visual field.
 
 Ordinary cortical devices derive from
 :py:class:`~pulse2percept.implants.cortex.CorticalImplant` and take
-``hemisphere`` (``'LH'``, ``'RH'``, or ``None`` if unspecified);
+``hemisphere`` (``'left'``, ``'right'``, or ``None`` if unspecified);
 :py:class:`~pulse2percept.implants.cortex.Neuralink` is an ensemble of threads
 and offers the same attribute. In v0.11 ``hemisphere`` is device metadata
 only: the electrode coordinates and the model's ``implant_position`` remain
@@ -369,8 +370,8 @@ instead:
     from pulse2percept.implants.cortex import CorticalImplant
 
     array = ElectrodeGrid(shape=(10, 10), spacing=500)
-    retinal = RetinalImplant(array, eye='RE')
-    cortical = CorticalImplant(array, hemisphere='RH')
+    retinal = RetinalImplant(array, eye='right')
+    cortical = CorticalImplant(array, hemisphere='right')
 
 :py:class:`~pulse2percept.implants.EnsembleImplant` combines multiple implants
 into one system. Its
@@ -389,7 +390,7 @@ Migrating from v0.10
   :py:class:`~pulse2percept.implants.GridImplant` onto
   :py:class:`~pulse2percept.implants.retina.RetinalImplant`. Wrap an
   :py:class:`~pulse2percept.implants.ElectrodeGrid` in a ``RetinalImplant``
-  where a custom grid relied on the old implicit ``eye='RE'``;
+  where a custom grid relied on the old implicit ``eye='right'``;
   :py:class:`~pulse2percept.models.retina.AxonMapModel` requires one.
 * ``EnsembleImplant.from_cortical_map`` became
   :py:meth:`~pulse2percept.implants.EnsembleImplant.from_visual_field_map`,

--- a/doc/topics/models.rst
+++ b/doc/topics/models.rst
@@ -215,7 +215,9 @@ Simulating a visual scene
 
 The workflow above starts from a stimulus you built yourself. To start from
 what someone is *looking at* instead, give the model a
-:py:class:`~pulse2percept.vision.Scene`:
+:py:class:`~pulse2percept.vision.Scene`. A scene is **one monocular visual
+field**, not the person's final vision: it says what is present in front of
+one eye, and where that eye's native vision is lost.
 
 .. code-block:: python
 
@@ -332,6 +334,46 @@ gazes comparable.
 
 The scotoma affects *native* vision only. Prosthetic encoding samples the
 unmasked scene, including locations inside the scotoma.
+
+The rendered field boundary
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. versionadded:: 0.11.0
+
+A scene's source, pixel grid and sampling are rectangular. ``aperture='circle'``
+renders an eye-centered disc of radius ``min(fov) / 2`` instead, blacking out
+the corners around it and changing the rendered scene only:
+
+.. code-block:: python
+
+    scene = p2p.vision.Scene(image, fov=40 * dva, aperture='circle')
+
+Like the scotoma and the eccentricity rings, the disc is
+eye-centered, so gaze moves it through the scene.
+
+Both eyes
+~~~~~~~~~
+
+.. versionadded:: 0.11.0
+
+:py:class:`~pulse2percept.vision.BinocularScene` holds the left and right
+monocular views:
+
+.. code-block:: python
+
+    binocular = p2p.vision.BinocularScene(
+        left=p2p.vision.Scene(image, fov=40 * dva, scotoma=scotoma),
+        right=p2p.vision.Scene(image, fov=40 * dva),
+    )
+
+    ax_left, ax_right = binocular.plot(left_percept=percept, vmax=2)
+
+Models are monocular in v0.11, so a prediction names the eye it is about:
+
+.. code-block:: python
+
+    percept = model.predict_percept(binocular.left)
+
 
 Percept data layouts
 --------------------

--- a/doc/topics/models.rst
+++ b/doc/topics/models.rst
@@ -368,6 +368,15 @@ monocular views:
 
     ax_left, ax_right = binocular.plot(left_percept=percept, vmax=2)
 
+A bilateral loss is often symmetric about the vertical meridian.
+:py:meth:`~pulse2percept.vision.Scotoma.mirror` reflects a scotoma across it
+(``mirrored(x, y) == original(-x, y)``) and returns a new one:
+
+.. code-block:: python
+
+    left_scotoma = p2p.vision.Scotoma.circle(3 * dva, center=(6, 0) * dva)
+    right_scotoma = left_scotoma.mirror()
+
 Models are monocular in v0.11, so a prediction names the eye it is about:
 
 .. code-block:: python

--- a/doc/users/release_notes.rst
+++ b/doc/users/release_notes.rst
@@ -44,10 +44,11 @@ Highlights
       percept = model.predict_percept(stim)
 
 * New :py:mod:`pulse2percept.vision` module with
-  :py:class:`~pulse2percept.vision.Scene` and
+  :py:class:`~pulse2percept.vision.Scene`,
   :py:class:`~pulse2percept.vision.Scotoma` for gaze-aware simulation of
-  residual vision and retinal prostheses (:pull:`854`, :pull:`871`, 
-  :pull:`883`).
+  residual vision and retinal prostheses, and
+  :py:class:`~pulse2percept.vision.BinocularScene` for the two eyes' views
+  side by side (:pull:`854`, :pull:`871`, :pull:`883`, :pull:`890`).
 
 * New photovoltaic stimulation pipeline for
   :py:class:`~pulse2percept.implants.retina.PRIMAPivotal`, from image
@@ -79,17 +80,11 @@ remains in :py:mod:`pulse2percept.implants`; retinal and cortical devices
 moved to ``implants.retina`` and ``implants.cortex`` respectively
 (:pull:`887`).
 
-* ``eye`` now belongs to
+* ``eye`` (``left`` or ``right``) now belongs to
 :py:class:`~pulse2percept.implants.retina.RetinalImplant`, and
 :py:class:`~pulse2percept.implants.cortex.CorticalImplant` adds optional
-``hemisphere`` metadata. Generic implants carry neither. Custom retinal
-arrays used with :py:class:`~pulse2percept.models.retina.AxonMapModel`
-therefore need to be wrapped in a ``RetinalImplant``.
-
-* Anatomical side codes were replaced by canonical words, with no aliases:
-  ``eye='LE'`` / ``'RE'`` become ``eye='left'`` / ``'right'``, and
-  ``hemisphere='LH'`` / ``'RH'`` become ``hemisphere='left'`` / ``'right'``.
-  Input is case-insensitive; the stored value is lowercase.
+``hemisphere`` (``left`` or ``right``) metadata. 
+Generic implants carry neither. 
 
 * ``ProsthesisSystem`` was renamed :py:class:`~pulse2percept.implants.Implant`;
   the old name remains deprecated until v0.12.0. ``RectangleImplant`` was
@@ -185,6 +180,13 @@ Scene and plotting
   animated visualization. Inpainting is intentionally unavailable when
   composing prosthetic vision because its interaction with prosthetic
   brightness is not modeled (:pull:`871`, :pull:`884`).
+
+* ``Scene(aperture='circle')`` renders an eye-centered disc of radius
+  ``min(fov) / 2`` instead of the full rectangle (:pull:`890`).
+
+* New :py:class:`~pulse2percept.vision.BinocularScene` holds a left and a
+  right :py:class:`~pulse2percept.vision.Scene` and plots them side by side
+  (:pull:`890`).
 
 * New :py:mod:`pulse2percept.plotting` module provides combined
   stimulus/percept figures and animations. :py:mod:`pulse2percept.viz` is

--- a/doc/users/release_notes.rst
+++ b/doc/users/release_notes.rst
@@ -86,6 +86,11 @@ moved to ``implants.retina`` and ``implants.cortex`` respectively
 arrays used with :py:class:`~pulse2percept.models.retina.AxonMapModel`
 therefore need to be wrapped in a ``RetinalImplant``.
 
+* Anatomical side codes were replaced by canonical words, with no aliases:
+  ``eye='LE'`` / ``'RE'`` become ``eye='left'`` / ``'right'``, and
+  ``hemisphere='LH'`` / ``'RH'`` become ``hemisphere='left'`` / ``'right'``.
+  Input is case-insensitive; the stored value is lowercase.
+
 * ``ProsthesisSystem`` was renamed :py:class:`~pulse2percept.implants.Implant`;
   the old name remains deprecated until v0.12.0. ``RectangleImplant`` was
   removed in favor of :py:class:`~pulse2percept.implants.GridImplant`

--- a/examples/datasets/plot_data_beyeler2019.py
+++ b/examples/datasets/plot_data_beyeler2019.py
@@ -99,7 +99,7 @@ plt.imshow(data.loc[0, 'image'], cmap='gray')
 
 from pulse2percept.implants.retina import ArgusII
 from pulse2percept.units import um
-argus = ArgusII(eye='RE')
+argus = ArgusII(eye='right')
 implant_position = (-1331, -850) * um
 implant_rotation = -28.4
 

--- a/examples/plot_getting_started.py
+++ b/examples/plot_getting_started.py
@@ -58,8 +58,8 @@ plt.show()
 # Each piece owns a different scientific choice:
 #
 # * **Implant:** swap ``ArgusII`` for another retinal device, choose
-#   ``eye='LE'`` or ``'RE'``, provide measured electrode thresholds, or attach
-#   a different image/video encoder.
+#   ``eye='left'`` or ``'right'``, provide measured electrode thresholds, or
+#   attach a different image/video encoder.
 # * **Model:** change ``rho`` (spread across axons), ``lam`` (spread along
 #   axons), the visual-field map, or the model-side implant placement. Swap in
 #   :class:`~pulse2percept.models.retina.BiphasicScoreboardModel` if your

--- a/examples/vision/README.rst
+++ b/examples/vision/README.rst
@@ -1,10 +1,12 @@
 .. _examples-vision:
 
-Residual vision
-===============
+Visual scenes and residual vision
+=================================
 
 The :mod:`pulse2percept.vision` module describes the visual world an implanted
-eye is looking at: what is present (:py:class:`~pulse2percept.vision.Scene`)
-and where native vision is lost
-(:py:class:`~pulse2percept.vision.Scotoma`). A model registers a scene against
-an implant and returns what the person sees; see :ref:`topics-models-scene`.
+eye is looking at. A :py:class:`~pulse2percept.vision.Scene` is one monocular
+visual field: what is present in it, and where native vision is lost
+(:py:class:`~pulse2percept.vision.Scotoma`). A
+:py:class:`~pulse2percept.vision.BinocularScene` holds one such field per eye,
+side by side and uncombined. A model registers a scene against an implant and
+returns what the person sees; see :ref:`topics-models-scene`.

--- a/examples/vision/plot_amd_prima.py
+++ b/examples/vision/plot_amd_prima.py
@@ -28,7 +28,7 @@ from pulse2percept.implants.retina import PRIMAPivotal
 from pulse2percept.models.retina import ScoreboardModel
 from pulse2percept.stimuli import samples
 from pulse2percept.units import dva
-from pulse2percept.vision import Scene, Scotoma
+from pulse2percept.vision import BinocularScene, Scene, Scotoma
 
 ###############################################################################
 # Use the same eccentric center for the lesion and implant:
@@ -109,5 +109,45 @@ percept = model.predict_percept(scene, gaze=(0, 0) * dva, vmax=0.3)
 
 percept.plot()
 plt.title('Edge-filtered device input, intact vision around it')
+
+###############################################################################
+# Both eyes
+# ---------
+#
+# PRIMA is implanted in one eye. A :py:class:`~pulse2percept.vision.Scene` is
+# one monocular visual field, so the fellow eye needs a scene of its own.
+# The two are held together by a
+# :py:class:`~pulse2percept.vision.BinocularScene`.
+#
+# ``aperture='circle'`` renders each field as an eye-centered disc rather than
+# a rectangle, which reads as an ocular field. It changes the rendering only;
+# the implant is given the same scene values either way.
+
+implant.preprocess = False
+
+worse_eye = Scene(logo, fov=40 * dva, scotoma=scotoma, scotoma_fill=0,
+                  background=1, aperture='circle')
+fellow_eye = Scene(logo, fov=40 * dva, background=1, aperture='circle',
+                   scotoma=Scotoma.circle(3 * dva, center=center),
+                   scotoma_fill=0.4)
+
+binocular = BinocularScene(left=worse_eye, right=fellow_eye)
+
+###############################################################################
+# Differences in residual acuity or contrast sensitivity between the two eyes
+# are not currently modeled; the scenes differ only through explicitly
+# specified visual-field loss and source content.
+#
+# By default, models are monocular:
+
+prosthetic_input = Scene(logo, fov=40 * dva, background=1)
+percept = model.predict_percept(prosthetic_input, gaze=(0, 0) * dva)
+
+###############################################################################
+# But percepts can be assigned to an eye in the scene.
+# Here, ``left_percept`` puts it in the left eye alone.
+# The fellow eye shows whatever its own scene says it sees.
+
+binocular.plot(left_percept=percept, vmax=2, rings=True)
 
 ###############################################################################

--- a/pulse2percept/implants/cortex/base.py
+++ b/pulse2percept/implants/cortex/base.py
@@ -3,15 +3,15 @@ from ..base import Implant
 
 
 def _validate_hemisphere(hemisphere):
-    """Return ``hemisphere`` as 'LH', 'RH' or None."""
+    """Return ``hemisphere`` as 'left', 'right' or None."""
     if hemisphere is None:
         return None
     if not isinstance(hemisphere, str):
         raise TypeError(f"'hemisphere' must be a string or None, not "
                         f"{type(hemisphere)}.")
-    hemisphere = hemisphere.upper()
-    if hemisphere not in ('LH', 'RH'):
-        raise ValueError(f"'hemisphere' must be 'LH', 'RH' or None, not "
+    hemisphere = hemisphere.lower()
+    if hemisphere not in ('left', 'right'):
+        raise ValueError(f"'hemisphere' must be 'left', 'right' or None, not "
                          f"{hemisphere}.")
     return hemisphere
 
@@ -38,9 +38,9 @@ class CorticalImplant(Implant):
     electrode_array : :py:class:`~pulse2percept.implants.ElectrodeArray` or
                       :py:class:`~pulse2percept.implants.Electrode`
         The electrode array used to deliver electrical stimuli to cortex.
-    hemisphere : 'LH', 'RH' or None, optional
-        Which hemisphere the device is implanted in. Defaults to None, i.e.
-        unspecified.
+    hemisphere : 'left', 'right' or None, optional
+        Which hemisphere the device is implanted in. Case-insensitive on
+        input; stored lowercase. Defaults to None, i.e. unspecified.
     **kwargs :
         Keyword arguments accepted by
         :py:class:`~pulse2percept.implants.Implant`, such as ``preprocess``,
@@ -54,9 +54,9 @@ class CorticalImplant(Implant):
     >>> from pulse2percept.implants import ElectrodeGrid
     >>> from pulse2percept.implants.cortex import CorticalImplant
     >>> implant = CorticalImplant(ElectrodeGrid((4, 4), 400),
-    ...                           hemisphere='RH')
+    ...                           hemisphere='right')
     >>> implant.hemisphere
-    'RH'
+    'right'
 
     """
     # Frozen class: User cannot add more class attributes
@@ -78,9 +78,9 @@ class CorticalImplant(Implant):
     def hemisphere(self):
         """Implanted hemisphere
 
-        'LH', 'RH', or None if unspecified. Metadata: cortical models place
-        the array from its coordinates and their own ``implant_position``, not
-        from this attribute.
+        'left', 'right', or None if unspecified. Metadata: cortical models
+        place the array from its coordinates and their own
+        ``implant_position``, not from this attribute.
         """
         return getattr(self, '_hemisphere', None)
 

--- a/pulse2percept/implants/cortex/cortivis.py
+++ b/pulse2percept/implants/cortex/cortivis.py
@@ -28,7 +28,7 @@ class Cortivis(CorticalImplant):
         function (callable).
     safe_mode : bool, optional
         If safe mode is enabled, only charge-balanced stimuli are allowed.
-    hemisphere : 'LH', 'RH' or None, optional
+    hemisphere : 'left', 'right' or None, optional
         Which hemisphere the device is implanted in. Metadata: it does not
         move the array, which the model's ``implant_position`` places.
 

--- a/pulse2percept/implants/cortex/icvp.py
+++ b/pulse2percept/implants/cortex/icvp.py
@@ -31,7 +31,7 @@ class ICVP(CorticalImplant):
         function (callable).
     safe_mode : bool, optional
         If safe mode is enabled, only charge-balanced stimuli are allowed.
-    hemisphere : 'LH', 'RH' or None, optional
+    hemisphere : 'left', 'right' or None, optional
         Which hemisphere the device is implanted in. Metadata: it does not
         move the array, which the model's ``implant_position`` places.
 

--- a/pulse2percept/implants/cortex/neuralink.py
+++ b/pulse2percept/implants/cortex/neuralink.py
@@ -454,8 +454,8 @@ class Neuralink(EnsembleImplant):
     def hemisphere(self):
         """Implanted hemisphere
 
-        'LH', 'RH', or None if unspecified. Metadata: thread coordinates and
-        the model's ``implant_position`` place the implant, not this
+        'left', 'right', or None if unspecified. Metadata: thread coordinates
+        and the model's ``implant_position`` place the implant, not this
         attribute.
 
         .. versionadded:: 0.11.0
@@ -496,7 +496,7 @@ class Neuralink(EnsembleImplant):
             function (callable).
         safe_mode : bool, optional
             If safe mode is enabled, only charge-balanced stimuli are allowed.
-        hemisphere : 'LH', 'RH' or None, optional
+        hemisphere : 'left', 'right' or None, optional
             Which hemisphere the implant sits in. Metadata: thread
             coordinates place the implant, not this attribute.
         """

--- a/pulse2percept/implants/cortex/orion.py
+++ b/pulse2percept/implants/cortex/orion.py
@@ -28,7 +28,7 @@ class Orion(CorticalImplant):
         function (callable).
     safe_mode : bool, optional
         If safe mode is enabled, only charge-balanced stimuli are allowed.
-    hemisphere : 'LH', 'RH' or None, optional
+    hemisphere : 'left', 'right' or None, optional
         Which hemisphere the device is implanted in. Metadata: it does not
         move the array, which the model's ``implant_position`` places.
     

--- a/pulse2percept/implants/retina/alpha.py
+++ b/pulse2percept/implants/retina/alpha.py
@@ -37,7 +37,7 @@ class AlphaIMS(RetinalImplant):
         applies to every electrode, a list of 1500 entries gives each its own.
         May be given as unitful quantities (e.g. ``z=100 * um``); see
         :py:mod:`pulse2percept.units`.
-    eye : {'RE', 'LE'}, optional
+    eye : {'right', 'left'}, optional
         Eye in which array is implanted.
     preprocess : bool or callable, optional
         Either True/False to indicate whether to execute the implant's default
@@ -52,7 +52,7 @@ class AlphaIMS(RetinalImplant):
 
     >>> from pulse2percept.implants.retina import AlphaIMS
     >>> AlphaIMS()  # doctest: +NORMALIZE_WHITESPACE
-    AlphaIMS(electrode_array=ElectrodeGrid, eye='RE', preprocess=True,
+    AlphaIMS(electrode_array=ElectrodeGrid, eye='right', preprocess=True,
              safe_mode=False, shape=(39, 39))
 
     Get access to the third electrode in the top row (by name or by row/column
@@ -72,7 +72,7 @@ class AlphaIMS(RetinalImplant):
 
     placement = 'subretinal'
 
-    def __init__(self, z=0, eye='RE', preprocess=True,
+    def __init__(self, z=0, eye='right', preprocess=True,
                  safe_mode=False):
         self.eye = eye
         self.preprocess = preprocess
@@ -97,7 +97,7 @@ class AlphaIMS(RetinalImplant):
             electrode_type=SquareElectrode, side_length=elec_width)
 
         # Unfortunately, in the left eye the labeling of columns is reversed...
-        if self.eye == 'LE':
+        if self.eye == 'left':
             # FIXME: Would be better to have more flexibility in the naming
             # convention. This is a quick-and-dirty fix:
             names = self.electrode_array.electrode_names
@@ -167,7 +167,7 @@ class AlphaAMS(RetinalImplant):
         applies to every electrode, a list of 1600 entries gives each its own.
         May be given as unitful quantities (e.g. ``z=100 * um``); see
         :py:mod:`pulse2percept.units`.
-    eye : {'RE', 'LE'}, optional
+    eye : {'right', 'left'}, optional
         Eye in which array is implanted.
     preprocess : bool or callable, optional
         Either True/False to indicate whether to execute the implant's default
@@ -182,7 +182,7 @@ class AlphaAMS(RetinalImplant):
 
     >>> from pulse2percept.implants.retina import AlphaAMS
     >>> AlphaAMS()  # doctest: +NORMALIZE_WHITESPACE
-    AlphaAMS(electrode_array=ElectrodeGrid, eye='RE', preprocess=True,
+    AlphaAMS(electrode_array=ElectrodeGrid, eye='right', preprocess=True,
              safe_mode=False, shape=(40, 40))
 
     Get access to the third electrode in the top row (by name or by row/column
@@ -202,7 +202,7 @@ class AlphaAMS(RetinalImplant):
 
     placement = 'subretinal'
 
-    def __init__(self, z=0, eye='RE', preprocess=True,
+    def __init__(self, z=0, eye='right', preprocess=True,
                  safe_mode=False):
         self.eye = eye
         self.preprocess = preprocess
@@ -217,7 +217,7 @@ class AlphaAMS(RetinalImplant):
 
         # Set left/right eye:
         # Unfortunately, in the left eye the labeling of columns is reversed...
-        if self.eye == 'LE':
+        if self.eye == 'left':
             # FIXME: Would be better to have more flexibility in the naming
             # convention. This is a quick-and-dirty fix:
             names = self.electrode_array.electrode_names

--- a/pulse2percept/implants/retina/argus.py
+++ b/pulse2percept/implants/retina/argus.py
@@ -57,7 +57,7 @@ class ArgusI(RetinalImplant):
         applies to every electrode, a list of 16 entries gives each its own.
         May be given as unitful quantities (e.g. ``z=100 * um``); see
         :py:mod:`pulse2percept.units`.
-    eye : {'RE', 'LE'}, optional
+    eye : {'right', 'left'}, optional
         Eye in which array is implanted.
     preprocess : bool or callable, optional
         Either True/False to indicate whether to execute the implant's default
@@ -75,7 +75,7 @@ class ArgusI(RetinalImplant):
 
     >>> from pulse2percept.implants.retina import ArgusI
     >>> ArgusI()  # doctest: +NORMALIZE_WHITESPACE
-    ArgusI(electrode_array=ElectrodeGrid, eye='RE', preprocess=True,
+    ArgusI(electrode_array=ElectrodeGrid, eye='right', preprocess=True,
            safe_mode=False, shape=(4, 4))
 
     Get access to electrode 'B1', either by name or by row/column index:
@@ -95,7 +95,7 @@ class ArgusI(RetinalImplant):
     placement = 'epiretinal'
     _default_scene_input_frame = 'head'
 
-    def __init__(self, z=0, eye='RE', preprocess=True,
+    def __init__(self, z=0, eye='right', preprocess=True,
                  safe_mode=False, use_legacy_names=False):
         self.eye = eye
         self.preprocess = preprocess
@@ -117,7 +117,7 @@ class ArgusI(RetinalImplant):
             electrode_type=DiskElectrode, radius=r_arr, names=names)
 
         # Unfortunately, in the left eye the labeling of columns is reversed...
-        if self.eye == 'LE':
+        if self.eye == 'left':
             # FIXME: Would be better to have more flexibility in the naming
             # convention. This is a quick-and-dirty fix:
             names = self.electrode_array.electrode_names
@@ -179,7 +179,7 @@ class ArgusII(RetinalImplant):
         applies to every electrode, a list of 60 entries gives each its own.
         May be given as unitful quantities (e.g. ``z=100 * um``); see
         :py:mod:`pulse2percept.units`.
-    eye : {'RE', 'LE'}, optional
+    eye : {'right', 'left'}, optional
         Eye in which array is implanted.
     preprocess : bool or callable, optional
         Either True/False to indicate whether to execute the implant's default
@@ -217,9 +217,9 @@ class ArgusII(RetinalImplant):
 
     >>> from pulse2percept.implants.retina import ArgusII
     >>> ArgusII()  # doctest: +NORMALIZE_WHITESPACE
-    ArgusII(electrode_array=ElectrodeGrid, encoder=AmplitudeEncoder, eye='RE',
-            preprocess=True, raster=SequentialRaster, safe_mode=False,
-            shape=(6, 10))
+    ArgusII(electrode_array=ElectrodeGrid, encoder=AmplitudeEncoder,
+            eye='right', preprocess=True, raster=SequentialRaster,
+            safe_mode=False, shape=(6, 10))
 
     Get access to electrode 'E7', either by name or by row/column index:
 
@@ -245,7 +245,7 @@ class ArgusII(RetinalImplant):
     placement = 'epiretinal'
     _default_scene_input_frame = 'head'
 
-    def __init__(self, z=0, eye='RE', preprocess=True,
+    def __init__(self, z=0, eye='right', preprocess=True,
                  safe_mode=False, encoder=_DEVICE_DEFAULT,
                  raster=_DEVICE_DEFAULT, thresholds=None):
         self.safe_mode = safe_mode
@@ -269,7 +269,7 @@ class ArgusII(RetinalImplant):
         # Set left/right eye:
         self.eye = eye
         # Unfortunately, in the left eye the labeling of columns is reversed...
-        if self.eye == 'LE':
+        if self.eye == 'left':
             # TODO: Would be better to have more flexibility in the naming
             # convention. This is a quick-and-dirty fix:
             names = self.electrode_array.electrode_names

--- a/pulse2percept/implants/retina/base.py
+++ b/pulse2percept/implants/retina/base.py
@@ -19,9 +19,9 @@ class RetinalImplant(Implant):
     electrode_array : :py:class:`~pulse2percept.implants.ElectrodeArray` or
                       :py:class:`~pulse2percept.implants.Electrode`
         The electrode array used to deliver electrical stimuli to the retina.
-    eye : 'LE' or 'RE', optional
-        A string indicating whether the system is implanted in the left ('LE')
-        or right eye ('RE').
+    eye : 'left' or 'right', optional
+        A string indicating whether the system is implanted in the left or
+        right eye. Case-insensitive on input; stored lowercase.
     **kwargs :
         Keyword arguments accepted by
         :py:class:`~pulse2percept.implants.Implant`, such as ``preprocess``,
@@ -34,15 +34,15 @@ class RetinalImplant(Implant):
 
     >>> from pulse2percept.implants import ElectrodeGrid
     >>> from pulse2percept.implants.retina import RetinalImplant
-    >>> implant = RetinalImplant(ElectrodeGrid((4, 4), 400), eye='LE')
+    >>> implant = RetinalImplant(ElectrodeGrid((4, 4), 400), eye='left')
     >>> implant.eye
-    'LE'
+    'left'
 
     """
     # Frozen class: User cannot add more class attributes
     __slots__ = ('_eye',)
 
-    def __init__(self, electrode_array, eye='RE', **kwargs):
+    def __init__(self, electrode_array, eye='right', **kwargs):
         super().__init__(electrode_array, **kwargs)
         self.eye = eye
 
@@ -57,17 +57,18 @@ class RetinalImplant(Implant):
         """Implanted eye
 
         A :py:class:`~pulse2percept.implants.retina.RetinalImplant` can be
-        implanted either in a left eye ('LE') or right eye ('RE'). Models such
-        as :py:class:`~pulse2percept.models.retina.AxonMapModel` will treat
-        left and right eyes differently (for example, adjusting the location
-        of the optic disc).
+        implanted either in a left eye ('left') or right eye ('right').
+        Models such as
+        :py:class:`~pulse2percept.models.retina.AxonMapModel` will treat left
+        and right eyes differently (for example, adjusting the location of the
+        optic disc).
 
         Examples
         --------
         Implant Argus II in a left eye:
 
         >>> from pulse2percept.implants.retina import ArgusII
-        >>> implant = ArgusII(eye='LE')
+        >>> implant = ArgusII(eye='left')
         """
         return self._eye
 
@@ -76,8 +77,8 @@ class RetinalImplant(Implant):
         """Eye setter (called upon `self.eye = eye`)"""
         if not isinstance(eye, str):
             raise TypeError(f"'eye' must be a string, not {type(eye)}.")
-        eye = eye.upper()
-        if eye != 'LE' and eye != 'RE':
-            raise ValueError(f"'eye' must be either 'LE' or 'RE', not "
+        eye = eye.lower()
+        if eye not in ('left', 'right'):
+            raise ValueError(f"'eye' must be either 'left' or 'right', not "
                              f"{eye}.")
         self._eye = eye

--- a/pulse2percept/implants/retina/bvt.py
+++ b/pulse2percept/implants/retina/bvt.py
@@ -45,7 +45,7 @@ class BVT24(RetinalImplant):
         applies to every electrode, a list of 35 entries gives each its own.
         May be given as unitful quantities (e.g. ``z=100 * um``); see
         :py:mod:`pulse2percept.units`.
-    eye : {'RE', 'LE'}, optional
+    eye : {'right', 'left'}, optional
         Eye in which array is implanted.
     preprocess : bool or callable, optional
         Either True/False to indicate whether to execute the implant's default
@@ -61,7 +61,7 @@ class BVT24(RetinalImplant):
     placement = 'suprachoroidal'
     _default_scene_input_frame = 'head'
 
-    def __init__(self, z=0, eye='RE', preprocess=False,
+    def __init__(self, z=0, eye='right', preprocess=False,
                  safe_mode=False):
         self.eye = eye
         self.preprocess = preprocess
@@ -98,7 +98,7 @@ class BVT24(RetinalImplant):
             z_arr = np.ones(n_elecs, dtype=float) * z
 
         # the position of the electrodes 1-20, 21a-21m, R1-R2 for left eye
-        if self.eye == 'LE':
+        if self.eye == 'left':
             x_arr = np.negative(x_arr)
 
         # the radius of all the electrodes in the implants
@@ -151,7 +151,7 @@ class BVT44(RetinalImplant):
         applies to every electrode, a list of 35 entries gives each its own.
         May be given as unitful quantities (e.g. ``z=100 * um``); see
         :py:mod:`pulse2percept.units`.
-    eye : {'RE', 'LE'}, optional
+    eye : {'right', 'left'}, optional
         Eye in which array is implanted.
     preprocess : bool or callable, optional
         Either True/False to indicate whether to execute the implant's default
@@ -166,7 +166,7 @@ class BVT44(RetinalImplant):
     placement = 'suprachoroidal'
     _default_scene_input_frame = 'head'
 
-    def __init__(self, z=0, eye='LE', preprocess=False,
+    def __init__(self, z=0, eye='left', preprocess=False,
                  safe_mode=False):
         self.eye = eye
         self.preprocess = preprocess
@@ -197,7 +197,7 @@ class BVT44(RetinalImplant):
             z_arr = np.ones(n_elecs, dtype=float) * z
 
         # the position of the electrodes 1-20, 21a-21m, R1-R2 for left eye
-        if self.eye == 'LE':
+        if self.eye == 'left':
             x_arr = np.negative(x_arr)
 
         for x, y, z, r, name in zip(x_arr, y_arr, z_arr, r_arr, names):

--- a/pulse2percept/implants/retina/imie.py
+++ b/pulse2percept/implants/retina/imie.py
@@ -30,7 +30,7 @@ class IMIE(RetinalImplant):
         applies to every electrode, a list of 35 entries gives each its own.
         May be given as unitful quantities (e.g. ``z=100 * um``); see
         :py:mod:`pulse2percept.units`.
-    eye : {'RE', 'LE'}, optional
+    eye : {'right', 'left'}, optional
         Eye in which array is implanted.
     preprocess : bool or callable, optional
         Either True/False to indicate whether to execute the implant's default
@@ -46,7 +46,7 @@ class IMIE(RetinalImplant):
     placement = 'epiretinal'
     _default_scene_input_frame = 'head'
 
-    def __init__(self, z=0, eye='RE', preprocess=True,
+    def __init__(self, z=0, eye='right', preprocess=True,
                  safe_mode=False):
         self.eye = eye
         self.preprocess = preprocess
@@ -60,7 +60,7 @@ class IMIE(RetinalImplant):
             electrode_type=DiskElectrode, radius=elec_radius)
         
         # Unfortunately, in the left eye the labeling of columns is reversed...
-        if self.eye == 'LE':
+        if self.eye == 'left':
             # TODO: Would be better to have more flexibility in the naming
             # convention. This is a quick-and-dirty fix:
             names = self.electrode_array.electrode_names

--- a/pulse2percept/implants/retina/prima.py
+++ b/pulse2percept/implants/retina/prima.py
@@ -296,7 +296,7 @@ class PRIMAPivotal(RetinalImplant):
         applies to every electrode, a list of 378 entries gives each its own.
         May be given as unitful quantities (e.g. ``z=100 * um``); see
         :py:mod:`pulse2percept.units`.
-    eye : {'RE', 'LE'}, optional
+    eye : {'right', 'left'}, optional
         Eye in which array is implanted.
     preprocess : bool or callable, optional
         Either True/False to indicate whether to execute the implant's default
@@ -336,7 +336,7 @@ class PRIMAPivotal(RetinalImplant):
     #: The device is illuminated, not driven by a current source.
     stimulus_unit = mW / mm ** 2
 
-    def __init__(self, z=0, eye='RE', preprocess=False,
+    def __init__(self, z=0, eye='right', preprocess=False,
                  safe_mode=False, encoder=_DEVICE_DEFAULT):
         self.spacing = 100  # um, nearest-neighbor center-to-center
         self.pixel_width = 100  # um, flat-to-flat
@@ -507,7 +507,7 @@ class Lorach2015Array(RetinalImplant):
         applies to every electrode, a list of 142 entries gives each its own.
         May be given as unitful quantities (e.g. ``z=100 * um``); see
         :py:mod:`pulse2percept.units`.
-    eye : {'RE', 'LE'}, optional
+    eye : {'right', 'left'}, optional
         Eye in which array is implanted.
     preprocess : bool or callable, optional
         Either True/False to indicate whether to execute the implant's default
@@ -528,7 +528,7 @@ class Lorach2015Array(RetinalImplant):
     placement = 'subretinal'
     technology = 'photovoltaic'
 
-    def __init__(self, z=0, eye='RE', preprocess=False,
+    def __init__(self, z=0, eye='right', preprocess=False,
                  safe_mode=False):
         self.spacing = 75  # um, nearest-neighbor center-to-center
         self.pixel_width = 70  # um, flat-to-flat
@@ -619,7 +619,7 @@ class Ho2019FlatArray(RetinalImplant):
         applies to every electrode, a list of them gives each its own.
         May be given as unitful quantities (e.g. ``z=100 * um``); see
         :py:mod:`pulse2percept.units`.
-    eye : {'RE', 'LE'}, optional
+    eye : {'right', 'left'}, optional
         Eye in which array is implanted.
     preprocess : bool or callable, optional
         Either True/False to indicate whether to execute the implant's default
@@ -644,7 +644,7 @@ class Ho2019FlatArray(RetinalImplant):
     placement = 'subretinal'
     technology = 'photovoltaic'
 
-    def __init__(self, pixel_size, z=0, eye='RE',
+    def __init__(self, pixel_size, z=0, eye='right',
                  preprocess=False, safe_mode=False):
         self.pixel_size = _pixel_size_um(pixel_size, _HO2019_VARIANTS,
                                          'Ho2019FlatArray')
@@ -730,7 +730,7 @@ class Huang2021Array(RetinalImplant):
         applies to every electrode, a list of them gives each its own.
         May be given as unitful quantities (e.g. ``z=100 * um``); see
         :py:mod:`pulse2percept.units`.
-    eye : {'RE', 'LE'}, optional
+    eye : {'right', 'left'}, optional
         Eye in which array is implanted.
     preprocess : bool or callable, optional
         Either True/False to indicate whether to execute the implant's default
@@ -756,7 +756,7 @@ class Huang2021Array(RetinalImplant):
     placement = 'subretinal'
     technology = 'photovoltaic'
 
-    def __init__(self, pixel_size, z=0, eye='RE',
+    def __init__(self, pixel_size, z=0, eye='right',
                  preprocess=False, safe_mode=False):
         self.pixel_size = _pixel_size_um(pixel_size, _HUANG2021_AXIAL_SPANS,
                                          'Huang2021Array')
@@ -830,7 +830,7 @@ class PRIMA55(Ho2019FlatArray):
     """
     __slots__ = ()
 
-    def __init__(self, z=0, eye='RE', preprocess=False,
+    def __init__(self, z=0, eye='right', preprocess=False,
                  safe_mode=False):
         super().__init__(55, z=z, eye=eye,
                          preprocess=preprocess, safe_mode=safe_mode)
@@ -850,7 +850,7 @@ class PRIMA40(Ho2019FlatArray):
     """
     __slots__ = ()
 
-    def __init__(self, z=0, eye='RE', preprocess=False,
+    def __init__(self, z=0, eye='right', preprocess=False,
                  safe_mode=False):
         super().__init__(40, z=z, eye=eye,
                          preprocess=preprocess, safe_mode=safe_mode)

--- a/pulse2percept/implants/retina/tests/test_alpha.py
+++ b/pulse2percept/implants/retina/tests/test_alpha.py
@@ -59,12 +59,12 @@ def test_AlphaIMS_indexing():
 
 def test_AlphaIMS_eye():
     # Right-eye implant:
-    alpha_re = AlphaIMS(eye='RE')
+    alpha_re = AlphaIMS(eye='right')
     npt.assert_equal(alpha_re['A37'].x > alpha_re['A1'].x, True)
     npt.assert_almost_equal(alpha_re['A37'].y, alpha_re['A1'].y)
 
     # Left-eye implant:
-    alpha_le = AlphaIMS(eye='LE')
+    alpha_le = AlphaIMS(eye='left')
     npt.assert_equal(alpha_le['A1'].x > alpha_le['AE37'].x, True)
     npt.assert_almost_equal(alpha_le['A37'].y, alpha_le['A1'].y)
 
@@ -126,12 +126,12 @@ def test_AlphaAMS_indexing():
 
 def test_AlphaAMS_eye():
     # Right-eye implant:
-    alpha_re = AlphaAMS(eye='RE')
+    alpha_re = AlphaAMS(eye='right')
     npt.assert_equal(alpha_re['A40'].x > alpha_re['A1'].x, True)
     npt.assert_almost_equal(alpha_re['A40'].y, alpha_re['A1'].y)
 
     # Left-eye implant:
-    alpha_le = AlphaAMS(eye='LE')
+    alpha_le = AlphaAMS(eye='left')
     npt.assert_equal(alpha_le['A1'].x > alpha_le['AE40'].x, True)
     npt.assert_almost_equal(alpha_le['A40'].y, alpha_le['A1'].y)
 

--- a/pulse2percept/implants/retina/tests/test_argus.py
+++ b/pulse2percept/implants/retina/tests/test_argus.py
@@ -56,13 +56,13 @@ def test_ArgusI(ztype):
             argus["unlikely name for an electrode"]
 
     # Right-eye implant:
-    argus_re = retina.ArgusI(eye='RE')
+    argus_re = retina.ArgusI(eye='right')
     npt.assert_equal(argus_re['D1'].x > argus_re['A1'].x, True)
     npt.assert_almost_equal(argus_re['D1'].y, argus_re['A1'].y)
 
     # need to adjust for reflection about y-axis
     # Left-eye implant:
-    argus_le = retina.ArgusI(eye='LE')
+    argus_le = retina.ArgusI(eye='left')
     npt.assert_equal(argus_le['A1'].x > argus_le['D4'].x, True)
     npt.assert_almost_equal(argus_le['D1'].y, argus_le['A1'].y)
 
@@ -127,12 +127,12 @@ def test_ArgusII(ztype):
         argus["unlikely name for an electrode"]
 
     # Right-eye implant:
-    argus_re = retina.ArgusII(eye='RE')
+    argus_re = retina.ArgusII(eye='right')
     npt.assert_equal(argus_re['A10'].x > argus_re['A1'].x, True)
     npt.assert_almost_equal(argus_re['A10'].y, argus_re['A1'].y)
 
     # Left-eye implant:
-    argus_le = retina.ArgusII(eye='LE')
+    argus_le = retina.ArgusII(eye='left')
     npt.assert_equal(argus_le['A1'].x > argus_le['A10'].x, True)
     npt.assert_almost_equal(argus_le['A10'].y, argus_le['A1'].y)
 

--- a/pulse2percept/implants/retina/tests/test_bvt.py
+++ b/pulse2percept/implants/retina/tests/test_bvt.py
@@ -5,7 +5,7 @@ from pulse2percept.implants.base import Implant
 from pulse2percept.implants.retina.bvt import BVT24, BVT44
 
 
-@pytest.mark.parametrize('eye', ('LE', 'RE'))
+@pytest.mark.parametrize('eye', ('left', 'right'))
 def test_BVT24(eye):
     # Create a BVT24 and make sure location is correct
     bva = BVT24(eye=eye)
@@ -29,12 +29,12 @@ def test_BVT24(eye):
     npt.assert_almost_equal(x_center, 0)
 
     # Right-eye implant:
-    bva_re = BVT24(eye='RE')
+    bva_re = BVT24(eye='right')
     npt.assert_equal(bva_re['C1'].x > bva_re['C6'].x, True)
     npt.assert_equal(bva_re['C1'].y, bva_re['C1'].y)
 
     # Left-eye implant:
-    bva_le = BVT24(eye='LE')
+    bva_le = BVT24(eye='left')
     npt.assert_equal(bva_le['C1'].x < bva_le['C6'].x, True)
     npt.assert_equal(bva_le['C1'].y, bva_le['C1'].y)
 
@@ -53,7 +53,7 @@ def test_BVT24_stim():
     npt.assert_almost_equal(stim.data, 1)
 
 
-@pytest.mark.parametrize('eye', ('LE', 'RE'))
+@pytest.mark.parametrize('eye', ('left', 'right'))
 def test_BVT44(eye):
     # Create a BVT44 and make sure location is correct
     bva = BVT44(eye=eye)
@@ -73,12 +73,12 @@ def test_BVT44(eye):
     npt.assert_almost_equal((bva['E4'].y + bva['C4'].y) / 2.0, 0)
 
     # Right-eye implant:
-    bva_re = BVT44(eye='RE')
+    bva_re = BVT44(eye='right')
     npt.assert_equal(bva_re['A6'].x > bva_re['A1'].x, True)
     npt.assert_equal(bva_re['A6'].y, bva_re['A1'].y)
 
     # Left-eye implant:
-    bva_le = BVT44(eye='LE')
+    bva_le = BVT44(eye='left')
     npt.assert_equal(bva_le['A6'].x < bva_le['A1'].x, True)
     npt.assert_equal(bva_le['A6'].y, bva_le['A1'].y)
 

--- a/pulse2percept/implants/retina/tests/test_imie.py
+++ b/pulse2percept/implants/retina/tests/test_imie.py
@@ -4,7 +4,7 @@ import numpy.testing as npt
 
 from pulse2percept.implants import retina
 
-@pytest.mark.parametrize('eye', ('LE', 'RE'))
+@pytest.mark.parametrize('eye', ('left', 'right'))
 def test_IMIE(eye):
     # Create an IMIE and make sure location is correct
 
@@ -43,13 +43,13 @@ def test_IMIE(eye):
         retina.IMIE(z=[1, 2, 3])
 
     # Right-eye implant:
-    imie_re = retina.IMIE(eye='RE')
+    imie_re = retina.IMIE(eye='right')
     npt.assert_equal(imie_re['A4'].x > imie_re['A3'].x, True)
     npt.assert_almost_equal(imie_re['A4'].y, imie_re['A3'].y)
 
     # need to adjust for reflection about y-axis
     # Left-eye implant:
-    imie_le = retina.IMIE(eye='LE')
+    imie_le = retina.IMIE(eye='left')
     npt.assert_equal(imie_le['A3'].x > imie_le['A4'].x, True)
     npt.assert_almost_equal(imie_le['A3'].y, imie_le['A4'].y)
 

--- a/pulse2percept/implants/retina/tests/test_prima.py
+++ b/pulse2percept/implants/retina/tests/test_prima.py
@@ -267,7 +267,7 @@ def test_PRIMA55_PRIMA40_are_deprecated(old_cls, pixel_size):
     # Still frozen, and still take the rest of the old signature:
     npt.assert_equal(hasattr(old, '__dict__'), False)
     with pytest.deprecated_call():
-        old_cls(-100, 'LE', False, False)
+        old_cls(-100, 'left', False, False)
 
 
 @pytest.mark.parametrize('old_cls, new_cls',
@@ -285,7 +285,7 @@ def test_PRIMA_PRIMA75_are_deprecated(old_cls, new_cls):
     # Still frozen, and still take the whole old signature:
     npt.assert_equal(hasattr(old, '__dict__'), False)
     with pytest.deprecated_call():
-        old_cls(-100, 'LE', False, False)
+        old_cls(-100, 'left', False, False)
 
 
 def test_implant_metadata():

--- a/pulse2percept/implants/tests/test_api.py
+++ b/pulse2percept/implants/tests/test_api.py
@@ -131,28 +131,29 @@ def test_generic_ensemble_knows_nothing_about_cortex():
 
 def test_retinal_implant_owns_the_eye():
     array = ElectrodeGrid((2, 3), 400)
-    npt.assert_equal(RetinalImplant(array).eye, 'RE')
-    npt.assert_equal(RetinalImplant(array, eye='LE').eye, 'LE')
-    # Case-insensitive, stored uppercase:
-    npt.assert_equal(RetinalImplant(array, eye='le').eye, 'LE')
-    npt.assert_equal(RetinalImplant(array, eye='re').eye, 'RE')
+    npt.assert_equal(RetinalImplant(array).eye, 'right')
+    npt.assert_equal(RetinalImplant(array, eye='left').eye, 'left')
+    # Case-insensitive, stored lowercase:
+    npt.assert_equal(RetinalImplant(array, eye='LEFT').eye, 'left')
+    npt.assert_equal(RetinalImplant(array, eye='Right').eye, 'right')
     # A retinal implant is not a hemisphere:
     npt.assert_equal(hasattr(RetinalImplant(array), 'hemisphere'), False)
-    for bad in ('both', 'LH', ''):
+    # The pre-0.11 codes are gone, not deprecated aliases:
+    for bad in ('LE', 'RE', 'both', 'left eye', ''):
         with pytest.raises(ValueError):
             RetinalImplant(array, eye=bad)
-    for bad in (None, 1, ['LE']):
+    for bad in (None, 1, ['left']):
         with pytest.raises(TypeError):
             RetinalImplant(array, eye=bad)
     # Device arguments still reach Implant:
-    implant = RetinalImplant(array, eye='LE', preprocess=True,
+    implant = RetinalImplant(array, eye='left', preprocess=True,
                              safe_mode=True, max_current=100)
     npt.assert_equal(implant.preprocess, True)
     npt.assert_equal(implant.safe_mode, True)
     npt.assert_almost_equal(implant.max_current, 100)
 
 
-@pytest.mark.parametrize('eye', ['LE', 'RE'])
+@pytest.mark.parametrize('eye', ['left', 'right'])
 @pytest.mark.parametrize('implant_type', EYE_SENSITIVE_DEVICES)
 def test_canonicalized_eye_drives_the_geometry(implant_type, eye):
     """Case is normalized before the device lays out its electrodes
@@ -160,9 +161,9 @@ def test_canonicalized_eye_drives_the_geometry(implant_type, eye):
     These devices reverse their column names in the left eye, so reading the
     raw constructor argument rather than the canonical
     :py:attr:`~pulse2percept.implants.retina.RetinalImplant.eye` would let the
-    metadata say 'LE' while the geometry stayed right-eye.
+    metadata say 'left' while the geometry stayed right-eye.
     """
-    lower, upper = implant_type(eye=eye.lower()), implant_type(eye=eye)
+    lower, upper = implant_type(eye=eye), implant_type(eye=eye.upper())
     npt.assert_equal(lower.eye, eye)
     npt.assert_equal(upper.eye, eye)
     npt.assert_equal(lower.electrode_names, upper.electrode_names)
@@ -175,8 +176,9 @@ def test_a_retinal_device_is_a_retinal_implant(implant_type):
     implant = implant_type()
     npt.assert_equal(isinstance(implant, RetinalImplant), True)
     # BVT44 is the one device published for the left eye:
-    npt.assert_equal(implant.eye, 'LE' if implant_type is BVT44 else 'RE')
-    npt.assert_equal(implant_type(eye='LE').eye, 'LE')
+    npt.assert_equal(implant.eye,
+                     'left' if implant_type is BVT44 else 'right')
+    npt.assert_equal(implant_type(eye='left').eye, 'left')
     npt.assert_equal(f"eye='{implant.eye}'" in repr(implant), True)
 
 
@@ -184,8 +186,8 @@ def test_a_retinal_device_is_a_retinal_implant(implant_type):
 def test_a_sized_retinal_device_is_a_retinal_implant(implant_type):
     """The two families whose constructor takes a pixel size first"""
     npt.assert_equal(isinstance(implant_type(55), RetinalImplant), True)
-    npt.assert_equal(implant_type(55).eye, 'RE')
-    npt.assert_equal(implant_type(55, eye='LE').eye, 'LE')
+    npt.assert_equal(implant_type(55).eye, 'right')
+    npt.assert_equal(implant_type(55, eye='left').eye, 'left')
 
 
 def test_cortical_implant_owns_the_hemisphere():
@@ -193,36 +195,38 @@ def test_cortical_implant_owns_the_hemisphere():
     # Unspecified by default: cortical coordinates and the model's
     # `implant_position` already say which side the device is on.
     npt.assert_equal(CorticalImplant(array).hemisphere, None)
-    npt.assert_equal(CorticalImplant(array, hemisphere='RH').hemisphere, 'RH')
-    npt.assert_equal(CorticalImplant(array, hemisphere='rh').hemisphere, 'RH')
-    npt.assert_equal(CorticalImplant(array, hemisphere='lh').hemisphere, 'LH')
+    npt.assert_equal(CorticalImplant(array, hemisphere='left').hemisphere,
+                     'left')
+    npt.assert_equal(CorticalImplant(array, hemisphere='RIGHT').hemisphere,
+                     'right')
     npt.assert_equal(hasattr(CorticalImplant(array), 'eye'), False)
-    for bad in ('both', 'LE', 'L', ''):
+    # The pre-0.11 codes are gone, not deprecated aliases:
+    for bad in ('LH', 'RH', 'both', 'L', ''):
         with pytest.raises(ValueError):
             CorticalImplant(array, hemisphere=bad)
-    for bad in (1, ['LH']):
+    for bad in (1, ['left']):
         with pytest.raises(TypeError):
             CorticalImplant(array, hemisphere=bad)
     # Unspecified is not printed; a recorded side is:
     npt.assert_equal('hemisphere' in repr(CorticalImplant(array)), False)
-    npt.assert_equal("hemisphere='LH'" in repr(
-        CorticalImplant(array, hemisphere='LH')), True)
+    npt.assert_equal("hemisphere='left'" in repr(
+        CorticalImplant(array, hemisphere='left')), True)
 
 
 @pytest.mark.parametrize('implant_type', CORTICAL_DEVICES)
 def test_a_cortical_device_is_a_cortical_implant(implant_type):
     npt.assert_equal(isinstance(implant_type(), CorticalImplant), True)
     npt.assert_equal(implant_type().hemisphere, None)
-    npt.assert_equal(implant_type(hemisphere='lh').hemisphere, 'LH')
+    npt.assert_equal(implant_type(hemisphere='LEFT').hemisphere, 'left')
     with pytest.raises(ValueError):
-        implant_type(hemisphere='LE')
+        implant_type(hemisphere='LH')
 
 
 @pytest.mark.parametrize('implant_type', CORTICAL_DEVICES)
 def test_hemisphere_does_not_move_a_cortical_device(implant_type):
     """Recording a side is metadata, not a placement"""
     plain = implant_type()
-    for hemisphere in ('LH', 'RH'):
+    for hemisphere in ('left', 'right'):
         sided = implant_type(hemisphere=hemisphere)
         npt.assert_equal(sided.electrode_names, plain.electrode_names)
         npt.assert_array_equal(sided.electrode_array.coordinates(),
@@ -234,12 +238,13 @@ def test_neuralink_has_the_same_hemisphere_contract():
     threads = [LinearEdgeThread(x, 0, 0) for x in (0, 1000)]
     npt.assert_equal(isinstance(Neuralink(threads), CorticalImplant), False)
     npt.assert_equal(Neuralink(threads).hemisphere, None)
-    npt.assert_equal(Neuralink(threads, hemisphere='rh').hemisphere, 'RH')
+    npt.assert_equal(Neuralink(threads, hemisphere='Right').hemisphere,
+                     'right')
     with pytest.raises(ValueError):
-        Neuralink(threads, hemisphere='RE')
+        Neuralink(threads, hemisphere='RH')
     with pytest.raises(TypeError):
         Neuralink(threads, hemisphere=1)
     # ... and it does not move the threads:
     npt.assert_array_equal(
-        Neuralink(threads, hemisphere='LH').electrode_array.coordinates(),
+        Neuralink(threads, hemisphere='left').electrode_array.coordinates(),
         Neuralink(threads).electrode_array.coordinates())

--- a/pulse2percept/implants/tests/test_base.py
+++ b/pulse2percept/implants/tests/test_base.py
@@ -786,7 +786,7 @@ def test_Implant_thresholds_at_construction():
     npt.assert_equal(sorted(implant.thresholds), ['A1', 'A2'])
     npt.assert_almost_equal(implant.thresholds['A2'], 107)
     # Threshold keys use the final left-eye electrode names:
-    implant = ArgusII(eye='LE', thresholds={'A10': 80})
+    implant = ArgusII(eye='left', thresholds={'A10': 80})
     npt.assert_equal(sorted(implant.thresholds), ['A10'])
     npt.assert_almost_equal(implant.thresholds['A10'], 80)
     stim = ArgusII(thresholds=80).prepare_stim(

--- a/pulse2percept/models/retina/beyeler2019.py
+++ b/pulse2percept/models/retina/beyeler2019.py
@@ -557,7 +557,7 @@ class AxonMapSpatial(RetinalSpatial):
                 f"laterality, which {type(self.implant).__name__} does not. "
                 f"Wrap a custom array in "
                 f"pulse2percept.implants.retina.RetinalImplant, e.g. "
-                f"RetinalImplant(ElectrodeGrid(...), eye='RE').")
+                f"RetinalImplant(ElectrodeGrid(...), eye='right').")
         return self.implant.eye
 
     @property
@@ -590,7 +590,7 @@ class AxonMapSpatial(RetinalSpatial):
         return {**super().get_param_units(), 'rho': um, 'lam': um,
                 'loc_od': dva, 'meridian_blend': dva, 'axons_range': deg}
 
-    def _jansonius2009(self, phi0, beta_sup=-1.9, beta_inf=0.5, eye='RE'):
+    def _jansonius2009(self, phi0, beta_sup=-1.9, beta_inf=0.5, eye='right'):
         """Generate one nerve fiber bundle using [Jansonius2009]_.
 
         Parameters
@@ -601,7 +601,7 @@ class AxonMapSpatial(RetinalSpatial):
             Superior-retina curvature parameter (Eq. 5 in [Jansonius2009]_).
         beta_inf : float, optional
             Inferior-retina curvature parameter (Eq. 6 in [Jansonius2009]_).
-        eye : {'RE', 'LE'}, optional
+        eye : {'right', 'left'}, optional
             Eye for which to generate the bundle.
 
         Returns
@@ -615,10 +615,10 @@ class AxonMapSpatial(RetinalSpatial):
         [Jansonius2009]_ did not include bundles with ``phi0`` in [-60, 60]
         degrees."""
         loc_od = self.loc_od
-        if eye.upper() not in ['LE', 'RE']:
-            e_s = f"Unknown eye string '{eye}': Choose from 'LE', 'RE'."
+        if eye.lower() not in ['left', 'right']:
+            e_s = f"Unknown eye string '{eye}': Choose from 'left', 'right'."
             raise ValueError(e_s)
-        if eye.upper() == 'LE':
+        if eye.lower() == 'left':
             # Jansonius is parameterized for a right eye; mirror left eyes.
             loc_od = (-loc_od[0], loc_od[1])
         if np.abs(phi0) > 180.0:
@@ -653,7 +653,7 @@ class AxonMapSpatial(RetinalSpatial):
             idx = xprime < -loc_od[0]
         ymodel[idx] = yprime[idx] + loc_od[1] * (xmodel[idx] / loc_od[0]) ** 2
         # Mirror back to the left eye:
-        if eye.upper() == 'LE':
+        if eye.lower() == 'left':
             xmodel *= -1
         return np.vstack((xmodel, ymodel)).astype(np.float32).T
 
@@ -954,7 +954,7 @@ class AxonMapSpatial(RetinalSpatial):
 
     def _correct_loc_od(self):
         """Place the optic disc on the nasal side of the implanted eye."""
-        sign = -1 if self.eye == 'LE' else 1
+        sign = -1 if self.eye == 'left' else 1
         self.loc_od = (sign * np.abs(self.loc_od[0]), self.loc_od[1])
 
     def _build(self):
@@ -1116,7 +1116,7 @@ class AxonMapSpatial(RetinalSpatial):
             od_xy = self.visual_field_map.dva_to_ret(*self.loc_od)
             od_w = 1770
             od_h = 1880
-            if self.eye == 'RE':
+            if self.eye == 'right':
                 labels = ['superior', 'inferior', 'temporal', 'nasal']
             else:
                 labels = ['superior', 'inferior', 'nasal', 'temporal']

--- a/pulse2percept/models/retina/tests/test_beyeler2019.py
+++ b/pulse2percept/models/retina/tests/test_beyeler2019.py
@@ -356,9 +356,9 @@ def test_AxonMapModel():
 
     # The eye is the implanted one, and is not settable on its own:
     npt.assert_equal(
-        AxonMapModel(implant=ArgusII(eye='LE'), step=5).spatial.eye, 'LE')
+        AxonMapModel(implant=ArgusII(eye='left'), step=5).spatial.eye, 'left')
     with pytest.raises(TypeError):
-        AxonMapModel(implant=ArgusII(), eye='LE')
+        AxonMapModel(implant=ArgusII(), eye='left')
 
     # Lambda cannot be too small:
     with pytest.raises(ValueError):
@@ -404,7 +404,7 @@ def test_deepcopy_AxonMapModel(build):
     npt.assert_equal(original.spatial != copied.spatial, True)
 
 
-@ pytest.mark.parametrize('eye', ('LE', 'RE'))
+@ pytest.mark.parametrize('eye', ('left', 'right'))
 @ pytest.mark.parametrize('loc_od', ((15.5, 1.5), (7.0, 3.0), (-2.0, -2.0)))
 @ pytest.mark.parametrize('sign', (-1.0, 1.0))
 def test_AxonMapModel__jansonius2009(eye, loc_od, sign):
@@ -1040,17 +1040,17 @@ def _user_warnings(build):
 
 def test_axon_map_eye_follows_the_implant():
     """The eye is the implanted one, and cannot drift out of step with it"""
-    implant = ArgusII(eye='RE')
+    implant = ArgusII(eye='right')
     model = AxonMapModel(implant=implant, step=2, n_axons=50,
                          n_ax_segments=30).build()
-    npt.assert_equal(model.spatial.eye, 'RE')
+    npt.assert_equal(model.spatial.eye, 'right')
     # The optic disc is on the nasal side, which is a different side per eye:
     npt.assert_equal(model.spatial.loc_od[0] > 0, True)
 
     # Turning the *bound implant* around is the one build-invalidating change
     # the parameter machinery cannot see, so the model checks it itself:
-    implant.eye = 'LE'
-    npt.assert_equal(model.spatial.eye, 'LE')
+    implant.eye = 'left'
+    npt.assert_equal(model.spatial.eye, 'left')
     npt.assert_equal(model.is_built, False)
     model.predict_percept({'A1': 20})
     npt.assert_equal(model.is_built, True)
@@ -1077,9 +1077,9 @@ def test_axon_map_needs_an_implant_with_an_eye():
         model.spatial.eye
     # Wrapping the same array in a RetinalImplant is all it takes:
     fixed = AxonMapModel(
-        implant=RetinalImplant(ElectrodeGrid((3, 3), 2000), eye='LE'),
+        implant=RetinalImplant(ElectrodeGrid((3, 3), 2000), eye='left'),
         **grid).build()
-    npt.assert_equal(fixed.spatial.eye, 'LE')
+    npt.assert_equal(fixed.spatial.eye, 'left')
     npt.assert_equal(fixed.is_built, True)
 
 

--- a/pulse2percept/models/retina/tests/test_granley2021.py
+++ b/pulse2percept/models/retina/tests/test_granley2021.py
@@ -371,10 +371,10 @@ def test_biphasicAxonMapModel():
 
     # The eye is the implanted one, and is not settable on its own:
     npt.assert_equal(
-        BiphasicAxonMapModel(implant=ArgusII(eye='LE'), step=5).spatial.eye,
-        'LE')
+        BiphasicAxonMapModel(implant=ArgusII(eye='left'), step=5).spatial.eye,
+        'left')
     with pytest.raises(TypeError):
-        BiphasicAxonMapModel(implant=ArgusII(), eye='LE')
+        BiphasicAxonMapModel(implant=ArgusII(), eye='left')
 
     # Lambda cannot be too small:
     with pytest.raises(ValueError):

--- a/pulse2percept/models/tests/test_api_equivalence.py
+++ b/pulse2percept/models/tests/test_api_equivalence.py
@@ -242,7 +242,7 @@ def test_rebinding_the_implant_invalidates_the_build():
     npt.assert_equal(model.is_built, True)
     here = model.predict_percept({'C5': 30})
 
-    model.implant = ArgusII(eye='LE')
+    model.implant = ArgusII(eye='left')
     npt.assert_equal(model.is_built, False)
     model.build()
     there = model.predict_percept({'C5': 30})

--- a/pulse2percept/plotting/argus.py
+++ b/pulse2percept/plotting/argus.py
@@ -179,7 +179,7 @@ def plot_argus_phosphenes(data, argus=None, scale=1.0, axon_map=None,
 
     # To simulate an implant in a left eye, flip the image left-right (along
     # with the electrode x-coordinates):
-    if argus.eye == 'LE':
+    if argus.eye == 'left':
         img_argus = np.fliplr(img_argus)
         px_argus[:, 0] = img_argus.shape[1] - px_argus[:, 0] - 1
 

--- a/pulse2percept/plotting/tests/test_argus.py
+++ b/pulse2percept/plotting/tests/test_argus.py
@@ -120,7 +120,8 @@ def test_argus_plot_does_not_flip_the_electrode_constants():
          'xrange': (-10, 10), 'yrange': (-10, 10)},
     ])
     _, ax = plt.subplots()
-    for implant in (ArgusI(eye='LE'), ArgusII(eye='LE'), ArgusII(eye='LE')):
+    for implant in (ArgusI(eye='left'), ArgusII(eye='left'),
+                    ArgusII(eye='left')):
         plot_argus_phosphenes(df, implant, ax=ax)
         npt.assert_array_equal(argus_mod.PX_ARGUS1, px1)
         npt.assert_array_equal(argus_mod.PX_ARGUS2, px2)
@@ -164,11 +165,11 @@ def test_the_plotted_implant_owns_the_axon_laterality(monkeypatch):
 
     monkeypatch.setattr(AxonMapSpatial, 'grow_axon_bundles', spy)
     # A model bound to the other eye, which used to be what decided:
-    axon_map = AxonMapModel(implant=ArgusII(eye='RE'), loc_od=(15.5, 1.5))
+    axon_map = AxonMapModel(implant=ArgusII(eye='right'), loc_od=(15.5, 1.5))
     _, ax = plt.subplots()
-    plot_argus_phosphenes(df, ArgusII(eye='LE'), ax=ax, axon_map=axon_map)
+    plot_argus_phosphenes(df, ArgusII(eye='left'), ax=ax, axon_map=axon_map)
     # The optic disc is nasal, so a left eye puts it at negative x:
-    npt.assert_equal(grown, [('LE', (-15.5, 1.5))])
+    npt.assert_equal(grown, [('left', (-15.5, 1.5))])
     # ... and the caller's model is left pointed where it was:
-    npt.assert_equal(axon_map.implant.eye, 'RE')
+    npt.assert_equal(axon_map.implant.eye, 'right')
     npt.assert_equal(tuple(axon_map.spatial.loc_od), (15.5, 1.5))

--- a/pulse2percept/vision/__init__.py
+++ b/pulse2percept/vision/__init__.py
@@ -3,15 +3,18 @@
 .. autosummary::
     :toctree: _api
 
+    binocular
     scene
     scotoma
 
 .. versionadded:: 0.11.0
 """
+from .binocular import BinocularScene
 from .scene import Scene
 from .scotoma import Scotoma
 
 __all__ = [
+    'BinocularScene',
     'Scene',
     'Scotoma'
 ]

--- a/pulse2percept/vision/__init__.py
+++ b/pulse2percept/vision/__init__.py
@@ -1,4 +1,4 @@
-"""Residual vision: what a person still sees, and where it is lost.
+"""Visual scenes, residual vision, and binocular views.
 
 .. autosummary::
     :toctree: _api

--- a/pulse2percept/vision/binocular.py
+++ b/pulse2percept/vision/binocular.py
@@ -1,0 +1,129 @@
+""":py:class:`~pulse2percept.vision.BinocularScene`"""
+import matplotlib.pyplot as plt
+
+from .scene import Scene
+from ..utils import PrettyPrint
+
+
+class BinocularScene(PrettyPrint):
+    """The left and right monocular views, side by side
+
+    A :py:class:`~pulse2percept.vision.Scene` is one eye's visual field.
+    ``BinocularScene`` holds two of them, and says which eye each belongs to.
+    The two sides are equal peers: neither is the implanted or the primary
+    one, and they need not share a source, FOV, shape, scotoma or aperture.
+
+    It does *not* model how the visual system combines them. There is no
+    fusion, suppression, rivalry, stereopsis or ocular dominance here: this is
+    what the left eye sees, and this is what the right eye sees. Plotting them
+    is therefore an HMD-style pair of monocular views rather than one
+    binocularly fused image.
+
+    Models remain monocular in v0.11, so a prediction names the eye it is
+    about::
+
+        percept = model.predict_percept(binocular.left)
+
+    .. versionadded:: 0.11.0
+
+    Parameters
+    ----------
+    left, right : :py:class:`~pulse2percept.vision.Scene`
+        What each eye sees. Stored as given, not copied.
+
+    Examples
+    --------
+    A unilateral implant: a scotoma in the left eye, the fellow eye intact.
+
+    >>> import numpy as np
+    >>> from pulse2percept.units import dva
+    >>> from pulse2percept.vision import BinocularScene, Scene, Scotoma
+    >>> picture = np.zeros((8, 8))
+    >>> binocular = BinocularScene(
+    ...     left=Scene(picture, fov=40 * dva, scotoma=Scotoma.circle(8 * dva)),
+    ...     right=Scene(picture, fov=40 * dva))
+    >>> binocular.left.scotoma is None, binocular.right.scotoma is None
+    (False, True)
+
+    """
+
+    def __init__(self, left, right):
+        for name, scene in (('left', left), ('right', right)):
+            if not isinstance(scene, Scene):
+                raise TypeError(f"'{name}' must be a Scene, not "
+                                f"{type(scene)}.")
+        self._left = left
+        self._right = right
+
+    def _pprint_params(self):
+        """Return a dict of class attributes to pretty-print"""
+        return {'left': self.left, 'right': self.right}
+
+    @property
+    def left(self):
+        """What the left eye sees, as a Scene"""
+        return self._left
+
+    @property
+    def right(self):
+        """What the right eye sees, as a Scene"""
+        return self._right
+
+    def plot(self, left_percept=None, right_percept=None, gaze=None, frame=0,
+             rings=False, vmax=None, vmin=0, axes=None, **kwargs):
+        """Plot the two eyes side by side
+
+        Each panel is its own :py:meth:`~pulse2percept.vision.Scene.plot`: an
+        eye given no percept shows its native or residual scene, and an eye
+        given one shows that percept in its own field. The two are drawn
+        independently and never combined.
+
+        Parameters
+        ----------
+        left_percept, right_percept : \
+:py:class:`~pulse2percept.percepts.Percept`, optional
+            A brightness percept for that eye, or None to draw its scene.
+        gaze : (x, y), optional
+            Where both eyes are pointing, in dva. Defaults to the origin.
+            One gaze is shared: vergence is not modeled.
+        frame : int, optional
+            Which frame of a video scene to draw. Ignored for still scenes.
+        rings : bool, float, or sequence, optional
+            Eccentricity rings, as in
+            :py:meth:`~pulse2percept.vision.Scene.plot`.
+        vmax : float, optional
+            The percept brightness that displays as white, shared by both
+            eyes. Required whenever either percept is given.
+        vmin : float, optional
+            The percept brightness that displays as black. Defaults to 0.
+        axes : sequence of two matplotlib.axes.Axes, optional
+            Axes to draw the left and right eye on, in that order. If None,
+            makes a new side-by-side pair.
+        **kwargs :
+            Passed on to :py:meth:`~pulse2percept.vision.Scene.plot`.
+
+        Returns
+        -------
+        axes : (ax_left, ax_right)
+            The two axes, always in left-eye, right-eye order.
+
+        """
+        if axes is None:
+            _, axes = plt.subplots(1, 2, figsize=kwargs.pop('figsize',
+                                                            (10, 5)))
+        axes = tuple(axes)
+        if len(axes) != 2:
+            raise ValueError(f"'axes' must be one axes per eye (2 of them), "
+                             f"not {len(axes)}.")
+        drawn = []
+        for ax, label, scene, percept in zip(axes, ('left', 'right'),
+                                             (self.left, self.right),
+                                             (left_percept, right_percept)):
+            # A shared display range only reaches the eye it has a percept
+            # for; `Scene.plot` refuses one it has nothing to map.
+            scale = {'vmax': vmax, 'vmin': vmin} if percept is not None else {}
+            drawn.append(scene.plot(gaze=gaze, frame=frame, ax=ax,
+                                    rings=rings, percept=percept, **scale,
+                                    **kwargs))
+            drawn[-1].set_title(f'{label} eye')
+        return tuple(drawn)

--- a/pulse2percept/vision/scene.py
+++ b/pulse2percept/vision/scene.py
@@ -340,8 +340,9 @@ class Scene(PrettyPrint):
     aperture : 'circle' or None, optional
         Shape of the rendered field. Default (None) fills the rectangular
         frame. ``'circle'`` instead renders an eye-centered disc of radius
-        ``min(fov) / 2`` and blacks out the corners around it. Rendering only:
-        the source, the pixel grid, and what a device samples are unchanged.
+        ``min(fov) / 2`` and blacks out the corners around it. It affects only
+        the rendered scene, not scene sampling, device input, stimulation, or
+        the underlying prosthetic model response.
 
     Examples
     --------
@@ -426,8 +427,8 @@ class Scene(PrettyPrint):
     def aperture(self):
         """The rendered field boundary: ``'circle'`` or None for the frame
 
-        Rendering only. The source, the pixel grid and what a device is given
-        to encode are rectangular either way.
+        Affects only the rendered scene. The source, the pixel grid, and what
+        a device is given to encode are rectangular either way.
         """
         return self._aperture
 
@@ -802,7 +803,6 @@ class Scene(PrettyPrint):
         :py:meth:`~pulse2percept.models.Model.predict_percept` returns;
         without one the percept is drawn alone on black, because superimposing
         it on intact native vision would assert an unmodeled interaction.
-        Rendering only: it does not change what any model predicts.
 
         Parameters
         ----------
@@ -838,10 +838,10 @@ class Scene(PrettyPrint):
 
         """
         if percept is None:
-            if vmax is not None:
-                raise ValueError("'vmax' maps percept brightness onto a "
-                                 "display, and there is no percept to plot. "
-                                 "Pass 'percept'.")
+            if vmax is not None or vmin != 0:
+                raise ValueError("'vmin' and 'vmax' map percept brightness "
+                                 "onto a display, and there is no percept to "
+                                 "plot. Pass 'percept'.")
             rgb = self._native_rgb(gaze=gaze)
         elif self.scotoma is None:
             rgb = self._prosthetic_rgb(percept, vmax, vmin=vmin, gaze=gaze)

--- a/pulse2percept/vision/scene.py
+++ b/pulse2percept/vision/scene.py
@@ -29,6 +29,9 @@ _RING_COLOR = '0.3'
 # The only non-numeric `scotoma_fill`; see `_inpaint_rgb` for what it does.
 _INPAINT = 'inpaint'
 
+# The only `aperture` v0.11 supports; see `Scene._aperture_mask`.
+_CIRCLE = 'circle'
+
 
 def _resolve_fov(fov, n_rows, n_cols):
     """Normalize a user-supplied ``fov`` to ``(width, height)`` in dva"""
@@ -130,6 +133,33 @@ def _resolve_background(background):
         raise ValueError(f"'background' is a display intensity and must lie "
                          f"in [0, 1], not {background!r}.")
     return bg
+
+
+def _resolve_aperture(aperture):
+    """Normalize ``aperture`` to None or ``_CIRCLE``"""
+    if aperture is None:
+        return None
+    if aperture != _CIRCLE:
+        raise ValueError(f"'aperture' is either None or {_CIRCLE!r}, not "
+                         f"{aperture!r}.")
+    return _CIRCLE
+
+
+def _check_prosthetic(prosthetic):
+    """Reject a percept that cannot be placed in a scene as brightness"""
+    if not isinstance(prosthetic, Percept):
+        raise TypeError(f"'prosthetic' must be a Percept, not "
+                        f"{type(prosthetic)}.")
+    if prosthetic.is_rgb:
+        raise ValueError("'prosthetic' must be a brightness percept: "
+                         "models produce brightness in arbitrary units, "
+                         "and composing it is what turns that into "
+                         "display intensity.")
+    if not prosthetic._has_space:
+        raise ValueError("'prosthetic' has no visual-field coordinates, "
+                         "so there is nowhere in the scene to put it. "
+                         "Predict it on a model grid, or pass 'space' "
+                         "when building it.")
 
 
 def _ring_radii(rings, fov):
@@ -307,6 +337,11 @@ class Scene(PrettyPrint):
         rasterized loss map before it is drawn, softening the boundary from
         both sides. Defaults to 2. Rendering only: the scotoma's geometry is
         unchanged.
+    aperture : 'circle' or None, optional
+        Shape of the rendered field. Default (None) fills the rectangular
+        frame. ``'circle'`` instead renders an eye-centered disc of radius
+        ``min(fov) / 2`` and blacks out the corners around it. Rendering only:
+        the source, the pixel grid, and what a device samples are unchanged.
 
     Examples
     --------
@@ -323,7 +358,7 @@ class Scene(PrettyPrint):
     """
 
     def __init__(self, source, fov, scotoma=None, scotoma_fill=0,
-                 scotoma_blend=2, background=0):
+                 scotoma_blend=2, background=0, aperture=None):
         if not isinstance(source, (ImageStimulus, VideoStimulus)):
             # A picture is the common case:
             source = ImageStimulus(source)
@@ -342,17 +377,22 @@ class Scene(PrettyPrint):
         self._scotoma = scotoma
         self._scotoma_fill = fill
         self._scotoma_blend = blend
+        self._aperture = _resolve_aperture(aperture)
         n_rows, n_cols = self._frame_shape
         self._fov = _resolve_fov(fov, n_rows, n_cols)
         self._cached_frames = None
 
     def _pprint_params(self):
         """Return a dict of class attributes to pretty-print"""
-        return {'source': type(self.source).__name__, 'fov': self.fov,
-                'shape': self.shape, 'scotoma': self.scotoma,
-                'background': self.background,
-                'scotoma_fill': self.scotoma_fill,
-                'scotoma_blend': self.scotoma_blend}
+        params = {'source': type(self.source).__name__, 'fov': self.fov,
+                  'shape': self.shape, 'scotoma': self.scotoma,
+                  'background': self.background,
+                  'scotoma_fill': self.scotoma_fill,
+                  'scotoma_blend': self.scotoma_blend}
+        # Omitted when rectangular, which is the default:
+        if self.aperture is not None:
+            params['aperture'] = self.aperture
+        return params
 
     @property
     def source(self):
@@ -381,6 +421,15 @@ class Scene(PrettyPrint):
     def scotoma_blend(self):
         """Gaussian sigma, in scene pixels, softening the drawn scotoma"""
         return self._scotoma_blend
+
+    @property
+    def aperture(self):
+        """The rendered field boundary: ``'circle'`` or None for the frame
+
+        Rendering only. The source, the pixel grid and what a device is given
+        to encode are rectangular either way.
+        """
+        return self._aperture
 
     @property
     def _frame_shape(self):
@@ -565,11 +614,50 @@ class Scene(PrettyPrint):
             return self._scotoma_fill
         return _inpaint_rgb(frame_rgb, loss > 0)
 
+    def _aperture_mask(self, gaze_xy):
+        """True at pixel centers a circular aperture hides
+
+        Eye-centered like the scotoma and the rings, so the disc sits at
+        ``gaze``. Its radius is the shorter half-axis of the FOV, the same
+        convention the outermost eccentricity ring uses. The boundary is hard.
+        """
+        gx, gy = gaze_xy
+        x_scene, y_scene = self._pixel_centers()
+        radius = min(self._fov) / 2
+        return (x_scene - gx) ** 2 + (y_scene - gy) ** 2 > radius ** 2
+
+    def _apply_aperture(self, frames, gaze=None):
+        """Black out ``(rows, cols, 3, n_frames)`` outside the aperture"""
+        if self._aperture is None:
+            return frames
+        points = _gaze_points(gaze, frames.shape[-1])
+        static = len(points) == 1
+        mask = self._aperture_mask(points[0]) if static else None
+        out = np.array(frames, dtype=np.float32)
+        for f in range(frames.shape[-1]):
+            outside = mask if static else self._aperture_mask(points[f])
+            out[outside, :, f] = 0
+        return out
+
+    def _percept_on_grid(self, sample, gaze_xy):
+        """Percept brightness read at every scene pixel center
+
+        ``sample`` is a `_percept_sampler`; the returned array is
+        ``(rows, cols, n)`` with one trailing entry per frame it carries.
+        """
+        n_rows, n_cols = self._frame_shape
+        gx, gy = gaze_xy
+        x_scene, y_scene = self._pixel_centers()
+        # The percept is eye-centered; the scene raster is not:
+        points = np.column_stack(((y_scene - gy).ravel(),
+                                  (x_scene - gx).ravel()))
+        return sample(points).reshape((n_rows, n_cols, -1))
+
     def _native_rgb(self, gaze=None):
         """What is left of native vision, as ``(rows, cols, 3, n_frames)``"""
         frames = self._rgb_frames()
         if self.scotoma is None:
-            return frames
+            return self._apply_aperture(frames, gaze=gaze)
         n_frames = frames.shape[-1]
         gaze = _gaze_points(gaze, n_frames)
         static = len(gaze) == 1
@@ -584,7 +672,7 @@ class Scene(PrettyPrint):
             fill = self._fill_rgb(frame, loss)
             alpha = loss[..., np.newaxis]
             out[..., f] = (1 - alpha) * frame + alpha * fill
-        return out
+        return self._apply_aperture(out, gaze=gaze)
 
     def _pixel_centers(self, pad=0):
         """Scene coordinates of every pixel center, as ``(x, y)`` meshes"""
@@ -600,19 +688,7 @@ class Scene(PrettyPrint):
                 f"scotoma_fill={_INPAINT!r} cannot be combined with a "
                 f"prosthetic percept because their interaction is not modeled. "
                 f"Use a numeric 'scotoma_fill' for prosthetic composition.")
-        if not isinstance(prosthetic, Percept):
-            raise TypeError(f"'prosthetic' must be a Percept, not "
-                            f"{type(prosthetic)}.")
-        if prosthetic.is_rgb:
-            raise ValueError("'prosthetic' must be a brightness percept: "
-                             "models produce brightness in arbitrary units, "
-                             "and composing it is what turns that into "
-                             "display intensity.")
-        if not prosthetic._has_space:
-            raise ValueError("'prosthetic' has no visual-field coordinates, "
-                             "so there is nowhere in the scene to put it. "
-                             "Predict it on a model grid, or pass 'space' "
-                             "when building it.")
+        _check_prosthetic(prosthetic)
         vmin, vmax = _check_range(vmin, vmax)
         scene_rgb = self._rgb_frames()
         pframes, out_time, out_unit = self._prosthetic_frames(prosthetic)
@@ -620,14 +696,10 @@ class Scene(PrettyPrint):
         gaze = _gaze_points(gaze, n_out)
         n_rows, n_cols = self._frame_shape
 
-        x_scene, y_scene = self._pixel_centers()
         static = len(gaze) == 1
         if static:
-            gx, gy = gaze[0]
-            points = np.column_stack(((y_scene - gy).ravel(),
-                                      (x_scene - gx).ravel()))
-            brightness = _percept_sampler(prosthetic, pframes)(points)
-            brightness = brightness.reshape((n_rows, n_cols, n_out))
+            brightness = self._percept_on_grid(
+                _percept_sampler(prosthetic, pframes), gaze[0])
             loss = self._rendered_loss_at(gaze[0])
 
         out = np.empty((n_rows, n_cols, 3, n_out), dtype=np.float32)
@@ -635,11 +707,8 @@ class Scene(PrettyPrint):
             if static:
                 frame = brightness[..., f]
             else:
-                gx, gy = gaze[f]
-                points = np.column_stack(((y_scene - gy).ravel(),
-                                          (x_scene - gx).ravel()))
                 sample = _percept_sampler(prosthetic, pframes[..., f:f + 1])
-                frame = sample(points).reshape((n_rows, n_cols))
+                frame = self._percept_on_grid(sample, gaze[f])[..., 0]
                 loss = self._rendered_loss_at(gaze[f])
             phosphene = np.clip((frame - vmin) / (vmax - vmin), 0, 1)
             native = scene_rgb[..., 0 if scene_rgb.shape[-1] == 1 else f]
@@ -647,8 +716,34 @@ class Scene(PrettyPrint):
             lost = np.maximum(fill, phosphene[..., np.newaxis])
             alpha = loss[..., np.newaxis]
             out[..., f] = (1 - alpha) * native + alpha * lost
-        return Percept(out, space=self._grid(), time=out_time,
-                       time_unit=out_unit)
+        return Percept(self._apply_aperture(out, gaze=gaze),
+                       space=self._grid(), time=out_time, time_unit=out_unit)
+
+    def _prosthetic_rgb(self, prosthetic, vmax, vmin=0, gaze=None):
+        """A prosthetic percept alone on black, on the scene's pixel grid
+
+        Places a percept where and at what size this field sees it. Not a
+        composition: with no scotoma there is nothing to paint the percept
+        into, and superimposing it on intact native vision would assert an
+        interaction that is not modeled.
+        """
+        _check_prosthetic(prosthetic)
+        vmin, vmax = _check_range(vmin, vmax)
+        pframes, _, _ = self._prosthetic_frames(prosthetic)
+        n_out = pframes.shape[-1]
+        gaze = _gaze_points(gaze, n_out)
+        if len(gaze) == 1:
+            brightness = self._percept_on_grid(
+                _percept_sampler(prosthetic, pframes), gaze[0])
+        else:
+            brightness = np.concatenate(
+                [self._percept_on_grid(
+                    _percept_sampler(prosthetic, pframes[..., f:f + 1]),
+                    gaze[f]) for f in range(n_out)], axis=-1)
+        scaled = np.clip((brightness - vmin) / (vmax - vmin), 0, 1)
+        rgb = np.repeat(scaled[:, :, np.newaxis, :], 3, axis=2)
+        return self._apply_aperture(np.asarray(rgb, dtype=np.float32),
+                                    gaze=gaze)
 
     def _prosthetic_frames(self, prosthetic):
         """Line a percept up with the output frames, and say when they happen"""
@@ -693,12 +788,21 @@ class Scene(PrettyPrint):
                        time=self.time, time_unit=self.time_unit)
 
     def plot(self, gaze=None, frame=0, ax=None, rings=False,
-             ring_color=_RING_COLOR, **kwargs):
+             ring_color=_RING_COLOR, percept=None, vmax=None, vmin=0,
+             **kwargs):
         """Plot what is left of native vision
 
         The scene unchanged where vision is intact, and ``scotoma_fill`` where
         it is lost. A scotoma is eye-centered, so ``gaze`` decides where in the
         scene it falls.
+
+        Passing a ``percept`` draws a prosthetic percept in this field instead,
+        so its size and place can be read against the FOV. With a scotoma that
+        is the same composition
+        :py:meth:`~pulse2percept.models.Model.predict_percept` returns;
+        without one the percept is drawn alone on black, because superimposing
+        it on intact native vision would assert an unmodeled interaction.
+        Rendering only: it does not change what any model predicts.
 
         Parameters
         ----------
@@ -718,6 +822,13 @@ class Scene(PrettyPrint):
         ring_color : color, optional
             Any Matplotlib color for those rings and their labels. Defaults to
             a mid-gray that reads on a light scene.
+        percept : :py:class:`~pulse2percept.percepts.Percept`, optional
+            A brightness percept to draw in this field, placed by ``gaze``.
+        vmax : float, optional
+            The percept brightness that displays as white. Required whenever
+            ``percept`` is given: brightness is in arbitrary units.
+        vmin : float, optional
+            The percept brightness that displays as black. Defaults to 0.
         **kwargs :
             Passed on to :py:meth:`~pulse2percept.percepts.Percept.plot`.
 
@@ -726,7 +837,16 @@ class Scene(PrettyPrint):
         ax : matplotlib.axes.Axes
 
         """
-        rgb = self._native_rgb(gaze=gaze)
+        if percept is None:
+            if vmax is not None:
+                raise ValueError("'vmax' maps percept brightness onto a "
+                                 "display, and there is no percept to plot. "
+                                 "Pass 'percept'.")
+            rgb = self._native_rgb(gaze=gaze)
+        elif self.scotoma is None:
+            rgb = self._prosthetic_rgb(percept, vmax, vmin=vmin, gaze=gaze)
+        else:
+            rgb = self._compose(percept, vmax, vmin=vmin, gaze=gaze).data
         if not 0 <= frame < rgb.shape[-1]:
             raise ValueError(f"'frame' must be in 0..{rgb.shape[-1] - 1}, not "
                              f"{frame}.")

--- a/pulse2percept/vision/scotoma.py
+++ b/pulse2percept/vision/scotoma.py
@@ -83,6 +83,46 @@ class Scotoma(PrettyPrint):
                              f"[{loss.min():g}, {loss.max():g}].")
         return loss
 
+    def mirror(self, name=None):
+        """A copy reflected across the vertical meridian
+
+        Purely geometric: ``mirrored(x, y) == original(-x, y)`` in
+        eye-centered visual-field coordinates.
+
+        .. versionadded:: 0.11.0
+
+        Parameters
+        ----------
+        name : str, optional
+            Name for the mirrored scotoma (default: original name, marked
+            as mirrored)
+
+        Returns
+        -------
+        scotoma : :py:class:`~pulse2percept.vision.Scotoma`
+            A new scotoma. The original is left unchanged.
+
+        Examples
+        --------
+        The fellow eye of a bilateral, meridian-symmetric loss:
+
+        >>> from pulse2percept.units import dva
+        >>> from pulse2percept.vision import Scotoma
+        >>> left_scotoma = Scotoma.circle(3 * dva, center=(6, 0) * dva)
+        >>> right_scotoma = left_scotoma.mirror()
+        >>> float(right_scotoma(-6, 0)), float(right_scotoma(6, 0))
+        (1.0, 0.0)
+
+        """
+        mask = self.mask
+
+        def mirrored(x, y):
+            return mask(-x, y)
+
+        if name is None and self.name is not None:
+            name = f'mirror of {self.name}'
+        return type(self)(mirrored, name=name)
+
     @classmethod
     def ellipse(cls, x_radius, y_radius, center=(0, 0), name=None):
         """An elliptical scotoma, lost inside and intact outside

--- a/pulse2percept/vision/tests/test_binocular.py
+++ b/pulse2percept/vision/tests/test_binocular.py
@@ -1,0 +1,169 @@
+"""Two independent monocular views, held side by side (#668)
+
+Scenes here are laid out one degree per pixel with an odd pixel count, as in
+`test_scene`, so pixel centers land on whole degrees.
+"""
+import numpy as np
+import numpy.testing as npt
+import pytest
+import matplotlib.pyplot as plt
+
+from pulse2percept.percepts import Percept
+from pulse2percept.stimuli import ImageStimulus, VideoStimulus
+from pulse2percept.units import dva
+from pulse2percept.vision import BinocularScene, Scene, Scotoma
+
+SCENE_PX = 21
+HALF = (SCENE_PX - 1) // 2
+
+
+def flat_scene(level=0.5, px=SCENE_PX, **kwargs):
+    """A uniform gray field, so a percept drawn on it is the only structure"""
+    data = np.full((px, px), float(level))
+    kwargs.setdefault('scotoma_blend', 0)
+    return Scene(ImageStimulus(data), fov=(px, px), **kwargs)
+
+
+def spot_percept(scene, x_dva=0.0, y_dva=0.0, brightness=10.0):
+    """A single bright grid point at an eye-centered location"""
+    data = np.zeros((SCENE_PX, SCENE_PX, 1))
+    col, row = scene.dva_to_pixel(x_dva, y_dva)
+    data[int(round(float(row))), int(round(float(col)))] = brightness
+    return Percept(data, space=scene._grid())
+
+
+def test_the_two_eyes_are_stored_as_given_and_not_swapped():
+    left, right = flat_scene(0.2), flat_scene(0.8)
+    binocular = BinocularScene(left=left, right=right)
+    npt.assert_equal(binocular.left is left, True)
+    npt.assert_equal(binocular.right is right, True)
+    # Positional order is left, right:
+    npt.assert_equal(BinocularScene(left, right).left is left, True)
+    npt.assert_equal('left' in repr(binocular), True)
+    npt.assert_equal('right' in repr(binocular), True)
+
+
+@pytest.mark.parametrize('bad', [None, 0.5, np.zeros((4, 4)),
+                                 ImageStimulus(np.zeros((4, 4)))])
+def test_only_scenes_can_be_an_eye(bad):
+    scene = flat_scene()
+    with pytest.raises(TypeError):
+        BinocularScene(left=bad, right=scene)
+    with pytest.raises(TypeError):
+        BinocularScene(left=scene, right=bad)
+
+
+def test_the_two_eyes_are_independent_channels():
+    """Different source, FOV, shape, scotoma and aperture on the two sides"""
+    left = Scene(ImageStimulus(np.full((9, 9), 0.3)), fov=(30, 30),
+                 scotoma=Scotoma.circle(6), scotoma_fill=0.0,
+                 aperture='circle')
+    right = Scene(VideoStimulus(np.zeros((15, 21, 2)), time=[0, 10]),
+                  fov=(42, 30), background=1)
+    binocular = BinocularScene(left=left, right=right)
+    npt.assert_equal(binocular.left.fov, (30.0, 30.0))
+    npt.assert_equal(binocular.right.fov, (42.0, 30.0))
+    npt.assert_equal(binocular.left.shape, (9, 9))
+    npt.assert_equal(binocular.right.shape, (15, 21))
+    npt.assert_equal(binocular.left.aperture, 'circle')
+    npt.assert_equal(binocular.right.aperture, None)
+    npt.assert_equal(binocular.right.scotoma, None)
+
+
+def test_plot_draws_the_two_eyes_in_order_on_their_own_axes():
+    binocular = BinocularScene(left=flat_scene(0.2), right=flat_scene(0.8))
+    ax_left, ax_right = binocular.plot()
+    npt.assert_equal(ax_left is not ax_right, True)
+    npt.assert_equal(ax_left.get_title(), 'left eye')
+    npt.assert_equal(ax_right.get_title(), 'right eye')
+    npt.assert_almost_equal(ax_left.images[-1].get_array()[HALF, HALF],
+                            [0.2] * 3, decimal=6)
+    npt.assert_almost_equal(ax_right.images[-1].get_array()[HALF, HALF],
+                            [0.8] * 3, decimal=6)
+    plt.close('all')
+    # Supplied axes are used, in the same order:
+    _, axes = plt.subplots(1, 2)
+    npt.assert_equal(binocular.plot(axes=axes), tuple(axes))
+    plt.close('all')
+    with pytest.raises(ValueError):
+        binocular.plot(axes=plt.subplots(1, 3)[1])
+    plt.close('all')
+
+
+def test_a_percept_can_be_shown_in_one_eye_only():
+    """The fellow eye shows its own scene, whichever side is implanted"""
+    left, right = flat_scene(0.2), flat_scene(0.8)
+    binocular = BinocularScene(left=left, right=right)
+    percept = spot_percept(left, x_dva=-4.0)
+
+    ax_left, ax_right = binocular.plot(left_percept=percept, vmax=10)
+    # The implanted eye shows the phosphene on black, the fellow eye its scene
+    npt.assert_almost_equal(ax_left.images[-1].get_array()[HALF, HALF - 4],
+                            [1.0] * 3, decimal=6)
+    npt.assert_almost_equal(ax_left.images[-1].get_array()[HALF, HALF], 0.0)
+    npt.assert_almost_equal(ax_right.images[-1].get_array()[HALF, HALF],
+                            [0.8] * 3, decimal=6)
+    plt.close('all')
+
+    ax_left, ax_right = binocular.plot(right_percept=percept, vmax=10)
+    npt.assert_almost_equal(ax_left.images[-1].get_array()[HALF, HALF],
+                            [0.2] * 3, decimal=6)
+    npt.assert_almost_equal(ax_right.images[-1].get_array()[HALF, HALF - 4],
+                            [1.0] * 3, decimal=6)
+    plt.close('all')
+
+
+def test_two_percepts_stay_two_percepts():
+    """No fusion: neither eye is averaged, maxed or otherwise combined"""
+    left, right = flat_scene(0.0), flat_scene(0.0)
+    binocular = BinocularScene(left=left, right=right)
+    on_the_left = spot_percept(left, x_dva=-6.0)
+    on_the_right = spot_percept(right, x_dva=6.0)
+    ax_left, ax_right = binocular.plot(left_percept=on_the_left,
+                                       right_percept=on_the_right, vmax=10)
+    seen_left = ax_left.images[-1].get_array()
+    seen_right = ax_right.images[-1].get_array()
+    # Each eye shows its own phosphene, and only its own:
+    npt.assert_almost_equal(seen_left[HALF, HALF - 6], [1.0] * 3, decimal=6)
+    npt.assert_almost_equal(seen_left[HALF, HALF + 6], 0.0)
+    npt.assert_almost_equal(seen_right[HALF, HALF + 6], [1.0] * 3, decimal=6)
+    npt.assert_almost_equal(seen_right[HALF, HALF - 6], 0.0)
+    # ... and each panel matches that eye's scene drawn on its own:
+    npt.assert_almost_equal(seen_left,
+                            left.plot(percept=on_the_left,
+                                      vmax=10).images[-1].get_array(),
+                            decimal=6)
+    plt.close('all')
+
+
+def test_each_eye_keeps_its_own_aperture():
+    left = flat_scene(0.6, aperture='circle')
+    right = flat_scene(0.6)
+    ax_left, ax_right = BinocularScene(left=left, right=right).plot()
+    # The corner is inside the rectangle but outside the disc:
+    npt.assert_almost_equal(ax_left.images[-1].get_array()[0, 0], 0.0)
+    npt.assert_almost_equal(ax_right.images[-1].get_array()[0, 0],
+                            [0.6] * 3, decimal=6)
+    plt.close('all')
+
+
+def test_a_shared_gaze_moves_both_eyes_together():
+    scotoma = Scotoma.circle(4)
+    left = flat_scene(0.7, scotoma=scotoma, scotoma_fill=0.0)
+    right = flat_scene(0.7, scotoma=scotoma, scotoma_fill=0.0)
+    axes = BinocularScene(left=left, right=right).plot(gaze=(6, 0) * dva)
+    for ax, scene in zip(axes, (left, right)):
+        npt.assert_almost_equal(ax.images[-1].get_array(),
+                                scene._native_rgb(gaze=(6, 0))[..., 0],
+                                decimal=6)
+    plt.close('all')
+
+
+def test_it_has_no_implant_or_model_behavior():
+    """A container for two views, not a dispatcher"""
+    binocular = BinocularScene(left=flat_scene(), right=flat_scene())
+    for absent in ('eye', 'implant', 'predict_percept', 'play', 'fuse',
+                   '_compose', '_device_input', '_sample_at'):
+        npt.assert_equal(hasattr(binocular, absent), False)
+    # A Scene is monocular; eye identity lives in the container, not the scene:
+    npt.assert_equal(hasattr(binocular.left, 'eye'), False)

--- a/pulse2percept/vision/tests/test_scene.py
+++ b/pulse2percept/vision/tests/test_scene.py
@@ -14,6 +14,7 @@ from pulse2percept.percepts import Percept
 from pulse2percept.stimuli import ImageStimulus, VideoStimulus, samples
 from pulse2percept.units import dva, ms, s
 from pulse2percept.vision import Scene, Scotoma
+from pulse2percept.vision.scene import _ring_radii
 
 SCENE_PX = 41
 HALF = (SCENE_PX - 1) // 2
@@ -716,3 +717,167 @@ def test_play_animates_a_video_scene_and_refuses_a_still_one():
     plt.close('all')
     with pytest.raises(ValueError):
         ramp_scene().play()
+
+
+def circle_scene(**kwargs):
+    """`ramp_scene` seen through a circular aperture"""
+    return ramp_scene(aperture='circle', **kwargs)
+
+
+def test_no_aperture_is_the_default_and_fills_the_frame():
+    scene = ramp_scene()
+    npt.assert_equal(scene.aperture, None)
+    npt.assert_equal('aperture' in repr(scene), False)
+    # Every pixel of the rectangle still shows the ramp, corners included:
+    native = scene._native_rgb()[..., 0]
+    npt.assert_almost_equal(native[0, 0, 0], ramp_at(-HALF), decimal=6)
+    npt.assert_almost_equal(native[0, -1, 0], ramp_at(HALF), decimal=6)
+
+
+def test_a_circular_aperture_keeps_the_center_and_blacks_out_the_corners():
+    scene = circle_scene()
+    npt.assert_equal(scene.aperture, 'circle')
+    npt.assert_equal("aperture='circle'" in repr(scene), True)
+    rect = ramp_scene()._native_rgb()[..., 0]
+    circ = scene._native_rgb()[..., 0]
+    # Inside the disc nothing changed; the four corners went black:
+    npt.assert_array_equal(circ[HALF, :, 0], rect[HALF, :, 0])
+    npt.assert_array_equal(circ[:, HALF, 0], rect[:, HALF, 0])
+    for row, col in ((0, 0), (0, -1), (-1, 0), (-1, -1)):
+        npt.assert_almost_equal(circ[row, col], 0.0)
+    # The right-hand corners are the bright end of the ramp, so they say the
+    # aperture blacked them out rather than the source being dark there:
+    npt.assert_almost_equal(rect[0, -1, 0], ramp_at(HALF), decimal=6)
+    npt.assert_almost_equal(rect[-1, -1, 0], ramp_at(HALF), decimal=6)
+
+
+@pytest.mark.parametrize('aperture', ['circular', 'CIRCLE', 'ellipse', '',
+                                      0, ['circle']])
+def test_a_bad_aperture_is_refused(aperture):
+    with pytest.raises(ValueError):
+        ramp_scene(aperture=aperture)
+
+
+def test_the_aperture_radius_is_the_shorter_half_of_the_field():
+    """A wide field is clipped by its height, matching the outermost ring"""
+    data = np.tile(np.linspace(0.2, 1, 81), (41, 1))
+    scene = Scene(ImageStimulus(data), fov=(81, 41), aperture='circle')
+    lit = scene._native_rgb()[..., 0, 0] > 0
+    radius = np.hypot(*scene._pixel_centers())
+    # 20.5 dva is min(fov) / 2, not max(fov) / 2:
+    npt.assert_equal(radius[lit].max() <= 20.5, True)
+    npt.assert_equal(radius[~lit].min() > 20.5, True)
+
+
+def test_the_aperture_is_eye_centered_and_follows_gaze():
+    data = np.tile(np.linspace(0.2, 1, SCENE_PX), (SCENE_PX, 1))
+    scene = Scene(ImageStimulus(data), fov=(SCENE_PX, SCENE_PX),
+                  aperture='circle')
+    lit = scene._native_rgb(gaze=(8, -5) * dva)[..., 0, 0] > 0
+    x, y = scene._pixel_centers()
+    # scene = eye-centered + gaze, so the disc is centered on the gaze point:
+    npt.assert_array_equal(lit, (x - 8) ** 2 + (y + 5) ** 2 <= 20.5 ** 2)
+
+
+def test_a_transparent_background_does_not_leak_outside_the_aperture():
+    """Outside the aperture is black even when the scene's ground is white"""
+    scene = Scene(rgba_source(), fov=(8, 8), background=1, aperture='circle')
+    native = scene._native_rgb()[..., 0]
+    npt.assert_almost_equal(native[0, 0], 0.0)
+    # ... while the background still shows through inside it:
+    npt.assert_almost_equal(native[0, 4], [1.0, 1.0, 1.0], decimal=6)
+
+
+def test_the_aperture_does_not_change_what_a_device_is_given():
+    """The critical invariant: a rendering boundary, not a sampling geometry"""
+    x = np.array([-19.0, -8.0, 0.0, 6.5, 18.0, 30.0])
+    y = np.array([17.0, -3.0, 0.0, 11.25, -19.0, 0.0])
+    rect, circ = ramp_scene(), circle_scene()
+    for gaze in (None, (6, -4) * dva, (-9.5, 12) * dva):
+        npt.assert_array_equal(circ._sample_at(x, y, gaze=gaze),
+                               rect._sample_at(x, y, gaze=gaze))
+        npt.assert_array_equal(circ._device_input(x, y, gaze=gaze),
+                               rect._device_input(x, y, gaze=gaze))
+    npt.assert_array_equal(circ.dva_to_pixel(x, y), rect.dva_to_pixel(x, y))
+    npt.assert_array_equal(circ.pixel_to_dva(x, y), rect.pixel_to_dva(x, y))
+    npt.assert_array_equal(circ._frames(), rect._frames())
+
+
+def test_the_aperture_leaves_the_scotoma_alone_inside_it():
+    scotoma = Scotoma.circle(6)
+    rect = ramp_scene(scotoma=scotoma, scotoma_fill=0.5)
+    circ = ramp_scene(scotoma=scotoma, scotoma_fill=0.5, aperture='circle')
+    npt.assert_array_equal(circ.scotoma(0.0, 0.0), rect.scotoma(0.0, 0.0))
+    inside = np.hypot(*circ._pixel_centers()) <= 20.5
+    npt.assert_array_equal(circ._native_rgb()[..., 0][inside],
+                           rect._native_rgb()[..., 0][inside])
+
+
+def test_the_aperture_clips_a_composed_percept_only_when_it_is_drawn():
+    scotoma = Scotoma.circle(6)
+    bright = Percept(np.ones((SCENE_PX, SCENE_PX, 1)),
+                     space=ramp_scene()._grid())
+    rect = ramp_scene(scotoma=scotoma, scotoma_fill=0.0)
+    circ = ramp_scene(scotoma=scotoma, scotoma_fill=0.0, aperture='circle')
+    seen_rect = rect._compose(bright, vmax=1).data[..., 0]
+    seen_circ = circ._compose(bright, vmax=1).data[..., 0]
+    inside = np.hypot(*circ._pixel_centers()) <= 20.5
+    npt.assert_array_equal(seen_circ[inside], seen_rect[inside])
+    npt.assert_almost_equal(seen_circ[0, -1], 0.0)
+    npt.assert_almost_equal(seen_rect[0, -1, 0], ramp_at(HALF), decimal=6)
+
+
+def test_a_percept_can_be_plotted_in_the_context_of_the_whole_field():
+    """A small phosphene, drawn on black at the scale of the ocular field"""
+    space = Scene(ImageStimulus(np.zeros((9, 9))), fov=(9, 9))._grid()
+    data = np.zeros((9, 9, 1))
+    data[4, 4] = 20.0
+    phosphene = Percept(data, space=space)
+    scene = circle_scene()
+    ax = scene.plot(percept=phosphene, vmax=20)
+    drawn = ax.images[-1].get_array()
+    # The percept lands on the fovea at its own size, not stretched to the FOV
+    npt.assert_almost_equal(drawn[HALF, HALF], [1.0, 1.0, 1.0], decimal=6)
+    npt.assert_almost_equal(drawn[HALF, HALF + 3], 0.0)
+    # ... and native vision is not underneath it, since nothing is lost here:
+    npt.assert_almost_equal(drawn[HALF, HALF + 15], 0.0)
+    npt.assert_almost_equal(drawn[0, 0], 0.0)
+    plt.close('all')
+    # Brightness is in arbitrary units, so a display range is required:
+    with pytest.raises(ValueError):
+        scene.plot(percept=phosphene)
+    with pytest.raises(ValueError):
+        scene.plot(vmax=20)
+
+
+def test_plotting_a_percept_over_a_scotoma_is_the_composed_view():
+    scene = ramp_scene(scotoma=Scotoma.circle(6), scotoma_fill=0.0)
+    bright = Percept(np.ones((SCENE_PX, SCENE_PX, 1)), space=scene._grid())
+    ax = scene.plot(percept=bright, vmax=1)
+    npt.assert_almost_equal(ax.images[-1].get_array(),
+                            scene._compose(bright, vmax=1).data[..., 0],
+                            decimal=6)
+    plt.close('all')
+
+
+def test_rings_still_land_on_the_fovea_the_aperture_is_centered_on():
+    scene = circle_scene()
+    ax = scene.plot(gaze=(7, -3) * dva, rings=[10])
+    # The ring is a circle of radius 10 about the gaze point:
+    ring = ax.lines[-1]
+    xs, ys = ring.get_xdata(), ring.get_ydata()
+    npt.assert_almost_equal([xs.min(), xs.max()], [-3.0, 17.0], decimal=6)
+    npt.assert_almost_equal([ys.min(), ys.max()], [-13.0, 7.0], decimal=6)
+    # The outermost ring `rings=True` asks for sits inside that same boundary:
+    npt.assert_almost_equal(_ring_radii(True, scene.fov).max(), 20.0)
+    plt.close('all')
+
+
+def test_the_aperture_reaches_the_frames_the_player_shows():
+    frames = np.stack([np.full((9, 9), v) for v in (0.4, 0.8)], axis=-1)
+    scene = Scene(VideoStimulus(frames, time=[0, 10]), fov=(9, 9),
+                  aperture='circle')
+    ani = scene.play()
+    npt.assert_almost_equal(ani._frame_data[0, 0, :, 0], 0.0)
+    npt.assert_almost_equal(ani._frame_data[4, 4, :, 1], 0.8, decimal=6)
+    plt.close('all')

--- a/pulse2percept/vision/tests/test_scene.py
+++ b/pulse2percept/vision/tests/test_scene.py
@@ -846,8 +846,12 @@ def test_a_percept_can_be_plotted_in_the_context_of_the_whole_field():
     # Brightness is in arbitrary units, so a display range is required:
     with pytest.raises(ValueError):
         scene.plot(percept=phosphene)
+    # ... and a display range with nothing to map onto it is not silently
+    # ignored, either way round:
     with pytest.raises(ValueError):
         scene.plot(vmax=20)
+    with pytest.raises(ValueError):
+        scene.plot(vmin=5)
 
 
 def test_plotting_a_percept_over_a_scotoma_is_the_composed_view():

--- a/pulse2percept/vision/tests/test_scotoma.py
+++ b/pulse2percept/vision/tests/test_scotoma.py
@@ -114,3 +114,44 @@ def test_Scotoma_rejects_non_finite_coordinates(coord):
         scotoma(0, coord)
     with pytest.raises(ValueError):
         scotoma(np.array([0.0, coord]), 0)
+
+
+def test_Scotoma_mirror():
+    """Reflection across the vertical meridian: mirrored(x, y) == f(-x, y)"""
+    left = Scotoma.circle(2, center=(6, -3))
+    right = left.mirror()
+    npt.assert_almost_equal(right(-6, -3), 1)
+    npt.assert_almost_equal(right(6, -3), 0)
+    # y is untouched, so a y-flip would fail here:
+    npt.assert_almost_equal(right(-6, 3), 0)
+    npt.assert_equal('mirror' in repr(right), True)
+
+
+def test_Scotoma_mirror_an_arbitrary_mask():
+    """Any callable mirrors, not just circle/ellipse"""
+    # Graded and asymmetric in both x and y:
+    def mask(x, y):
+        return np.clip((x + 10) / 20, 0, 1) * np.clip((y + 5) / 10, 0, 1)
+
+    scotoma = Scotoma(mask, name='graded')
+    mirrored = scotoma.mirror()
+    x, y = np.meshgrid(np.linspace(-9, 9, 19), np.linspace(-4, 4, 9))
+    npt.assert_almost_equal(mirrored(x, y), scotoma(-x, y))
+    npt.assert_equal(np.any(mirrored(x, y) != scotoma(x, y)), True)
+
+
+def test_Scotoma_mirror_twice_is_the_original():
+    scotoma = Scotoma(lambda x, y: np.clip((x + 10) / 20, 0, 1))
+    x, y = np.meshgrid(np.linspace(-9, 9, 19), np.linspace(-4, 4, 9))
+    npt.assert_almost_equal(scotoma.mirror().mirror()(x, y), scotoma(x, y))
+
+
+def test_Scotoma_mirror_leaves_the_original_alone():
+    left = Scotoma.circle(2, center=(6, -3), name='left')
+    mask = left.mask
+    right = left.mirror()
+    npt.assert_equal(right is left, False)
+    npt.assert_equal(left.mask is mask, True)
+    npt.assert_equal(left.name, 'left')
+    npt.assert_almost_equal(left(6, -3), 1)
+    npt.assert_almost_equal(left(-6, -3), 0)


### PR DESCRIPTION
Adds the final v0.11 scene API improvements:

- [x] add rendering-only `Scene(aperture='circle')`
- [x] allow `Scene.plot(percept=...)` to show phosphenes in full-FOV context
- [x] add `BinocularScene` for independent left/right monocular views without binocular fusion
- [x] replace `eye='LE'/'RE'` and `hemisphere='LH'/'RH'` with canonical `'left'/'right'`

Circular apertures are for rendering only and don't affect the underlying scene. Existing models remain monocular.