### PR TITLE
[FIX] Make all photovoltaic retinal arrays use optical stimulation consistently

### DIFF
--- a/doc/topics/encoders.rst
+++ b/doc/topics/encoders.rst
@@ -158,7 +158,8 @@ An implant's :py:class:`~pulse2percept.implants.Raster` determines which
 electrodes may pulse together; see :ref:`topics-rasters`. PRIMA uses no raster;
 all 378 pixels may be illuminated at once. With ``safe_mode=True``,
 :py:class:`~pulse2percept.implants.retina.PRIMAPivotal` checks the documented projector
-settings (3.5 mW/mm^2, 30 Hz, 0.7--9.8 ms ON durations, and duty cycle <= 0.294).
+settings (880 nm, 3.5 mW/mm^2, 30 Hz, 0.7--9.8 ms ON durations, and duty cycle
+<= 0.294).
 This is not a biological safety check or a demonstrated hardware maximum. That
 envelope is specific to the pivotal projector: research arrays with no
 published envelope of their own raise on ``safe_mode=True`` rather than borrow

--- a/doc/topics/encoders.rst
+++ b/doc/topics/encoders.rst
@@ -9,8 +9,8 @@ Stimulus Encoders
 A visual source contains gray levels; an implant delivers stimulation. An
 :py:class:`~pulse2percept.stimuli.Encoder` defines the mapping between the two.
 :py:class:`~pulse2percept.stimuli.StimulusEncoder` covers devices driven by a
-current source; :py:class:`~pulse2percept.stimuli.PRIMAEncoder` covers the
-photovoltaic PRIMA system, which is driven by light.
+current source; :py:class:`~pulse2percept.stimuli.PhotovoltaicEncoder` covers
+subretinal photovoltaic arrays, which are driven by light.
 
 Basic usage
 -----------
@@ -95,9 +95,10 @@ Optical encoding
 
 .. versionadded:: 0.11.0
 
-:py:class:`~pulse2percept.implants.retina.PRIMAPivotal` is illuminated by an
-880 nm projector. :py:class:`~pulse2percept.stimuli.PRIMAEncoder` maps image
-intensity to pulse duration and returns irradiance in ``mW/mm^2``:
+Photovoltaic arrays are illuminated by pulsed near-infrared light rather than
+driven by a current source.
+:py:class:`~pulse2percept.stimuli.PhotovoltaicEncoder` maps image intensity to
+ON duration at fixed peak irradiance and returns ``mW/mm^2``:
 
 .. code-block:: python
 
@@ -105,13 +106,33 @@ intensity to pulse duration and returns irradiance in ``mW/mm^2``:
     stim = implant.prepare_stim(p2p.stimuli.samples.logo_bvl())
     stim.unit  # mW/mm^2
 
-At the default settings, the projector runs at 30 Hz and 3.5 mW/mm^2. It has
-14 nonzero ON durations from 0.7 to 9.8 ms. The default linear mapping from
-image intensity to these levels is a pulse2percept convention; the clinical
-camera-to-pulse-duration transfer function is not published. Set
+The implant class describes the array; the encoder describes an optical
+stimulation protocol. Each photovoltaic implant therefore defaults to an
+encoder configured for its own experimental system (see
+:ref:`topics-implants`), and any array accepts any compatible encoder:
+
+.. code-block:: python
+
+    implant.encoder = p2p.stimuli.PhotovoltaicEncoder(
+        irradiance=4,      # mW/mm^2
+        freq=40,           # Hz
+        pulse_dur=4,       # ms
+        wavelength=915,    # nm
+    )
+
+:py:class:`~pulse2percept.stimuli.PRIMAEncoder` is the PRIMA specialization.
+Its defaults are the pivotal projector: 30 Hz, 3.5 mW/mm^2, and 14 nonzero ON
+durations from 0.7 to 9.8 ms. It quantizes duration onto that 0.7 ms grid; the
+generic encoder does not, so it can express protocols such as 4 ms at 40 Hz or
+10 ms at 2 Hz.
+
+Where a source paper does not specify a natural-image grayscale transfer
+function -- which is the case for all of these systems -- the mapping from
+gray level to ON duration is an explicit pulse2percept simulation convention
+(linear), not a reconstruction of the original camera pipeline. Set
 ``grayscale=False`` for binary encoding.
 
-The clinical system also applies ambient-light adaptation, contrast
+The clinical PRIMA system also applies ambient-light adaptation, contrast
 enhancement, zoom, and, in some tests, contrast inversion. These operations
 remain explicit preprocessing steps in pulse2percept.
 
@@ -125,7 +146,10 @@ For example:
     percept = model.predict_percept(p2p.stimuli.samples.logo_bvl())
 
 Here ``ScoreboardModel`` visualizes implant geometry and optical drive. It does
-not model photovoltaic transduction or retinal activation.
+not model photovoltaic transduction or retinal activation. Drive of 1.0 means a
+fully lit pixel at the encoder's settings; for
+:py:class:`~pulse2percept.stimuli.PRIMAEncoder` it means the projector's
+documented maximum instead, so lowering any setting lowers the drive.
 
 Device constraints
 ------------------
@@ -135,7 +159,10 @@ electrodes may pulse together; see :ref:`topics-rasters`. PRIMA uses no raster;
 all 378 pixels may be illuminated at once. With ``safe_mode=True``,
 :py:class:`~pulse2percept.implants.retina.PRIMAPivotal` checks the documented projector
 settings (3.5 mW/mm^2, 30 Hz, 0.7--9.8 ms ON durations, and duty cycle <= 0.294).
-This is not a biological safety check or a demonstrated hardware maximum.
+This is not a biological safety check or a demonstrated hardware maximum. That
+envelope is specific to the pivotal projector: research arrays with no
+published envelope of their own raise on ``safe_mode=True`` rather than borrow
+it.
 
 Encoders can also quantize timing with ``clock`` and gray levels with
 ``n_levels``. These constraints are conservative: quantization may lower a

--- a/doc/topics/implants.rst
+++ b/doc/topics/implants.rst
@@ -228,11 +228,50 @@ However, these peripheral cells covered by the common return are not
 independently stimulating and are therefore not exposed in pulse2percept.
 
 All four classes are driven by pulsed near-infrared illumination rather than
-injected current: ``prepare_stim`` returns irradiance in ``mW/mm^2``, encoded
-by :py:class:`~pulse2percept.stimuli.PRIMAEncoder` by default. Its settings
-describe the standard PRIMA projector, not the illumination protocol of each
-original study; pass a configured encoder or ``encoder=None`` instead.
-Photovoltaic conversion to tissue current is not modeled.
+injected current: ``prepare_stim`` returns irradiance in ``mW/mm^2``.
+
+An implant class describes the photovoltaic *array*; its default encoder
+describes a documented optical stimulation protocol for that experimental
+system. The two are separate, so each array gets its own encoder:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 22 48
+
+   * - Object
+     - Default encoder
+     - Optical protocol
+   * - ``PRIMAPivotal()``
+     - ``PRIMAEncoder``
+     - 880 nm, 3.5 mW/mm^2, 30 Hz, ON durations on a 0.7 ms grid up to 9.8 ms
+   * - ``Lorach2015Array()``
+     - ``PhotovoltaicEncoder``
+     - 915 nm, 4 mW/mm^2, 4 ms pulses at 40 Hz [Lorach2015]_
+   * - ``Ho2019FlatArray()``
+     - ``PhotovoltaicEncoder``
+     - 915 nm, 8 mW/mm^2, 4 ms pulses at 40 Hz [Ho2019]_
+   * - ``Huang2021Array()``
+     - ``PhotovoltaicEncoder``
+     - 880 nm, 4.7 mW/mm^2, 10 ms pulses at 2 Hz [Huang2021]_
+
+[Huang2021]_ swept irradiance from 0.002 to 4.7 mW/mm^2 while measuring VEP
+thresholds rather than running a video system, so 4.7 mW/mm^2 is its brightest
+measured condition, not a device or safety maximum.
+
+None of these papers specifies a natural-image grayscale transfer function, so
+gray level maps to ON duration by an explicit pulse2percept simulation
+convention (linear, and additionally quantized onto the 0.7 ms grid for
+``PRIMAEncoder``) rather than by a reconstruction of the original camera
+pipeline. Pass a configured encoder or ``encoder=None`` to opt out.
+
+``safe_mode=True`` checks the documented PRIMA projector envelope on
+:py:class:`~pulse2percept.implants.retina.PRIMAPivotal`. No comparable
+envelope has been published for the research arrays, so they raise rather than
+borrow PRIMA's limits. Negative or non-finite irradiance is rejected on every
+array, with or without ``safe_mode``.
+
+Photovoltaic conversion to tissue current, and retinal transduction, are not
+modeled.
 
 ``PRIMA``, ``PRIMA75``, ``PRIMA55`` and ``PRIMA40`` are deprecated aliases;
 see the v0.11 release notes for the corresponding canonical names.

--- a/doc/topics/implants.rst
+++ b/doc/topics/implants.rst
@@ -227,6 +227,13 @@ The total number of fabricated cells was therefore 526 for F55,
 However, these peripheral cells covered by the common return are not
 independently stimulating and are therefore not exposed in pulse2percept.
 
+All four classes are driven by pulsed near-infrared illumination rather than
+injected current: ``prepare_stim`` returns irradiance in ``mW/mm^2``, encoded
+by :py:class:`~pulse2percept.stimuli.PRIMAEncoder` by default. Its settings
+describe the standard PRIMA projector, not the illumination protocol of each
+original study; pass a configured encoder or ``encoder=None`` instead.
+Photovoltaic conversion to tissue current is not modeled.
+
 ``PRIMA``, ``PRIMA75``, ``PRIMA55`` and ``PRIMA40`` are deprecated aliases;
 see the v0.11 release notes for the corresponding canonical names.
 

--- a/doc/users/release_notes.rst
+++ b/doc/users/release_notes.rst
@@ -50,8 +50,7 @@ Highlights
   :py:class:`~pulse2percept.vision.BinocularScene` for the two eyes' views
   side by side (:pull:`854`, :pull:`871`, :pull:`883`, :pull:`890`).
 
-* New photovoltaic stimulation pipeline for
-  :py:class:`~pulse2percept.implants.retina.PRIMAPivotal`, from image
+* New photovoltaic stimulation pipeline for the PRIMA-style arrays, from image
   encoding to irradiance-based model input (:pull:`868`).
 
 
@@ -103,7 +102,7 @@ Generic implants carry neither.
   and new :py:class:`~pulse2percept.implants.retina.Ho2019FlatArray` and
   :py:class:`~pulse2percept.implants.retina.Huang2021Array` classes capture other
   photovoltaic designs. Device geometry and pixel dimensions were corrected
-  accordingly (:pull:`865`).
+  accordingly (:pull:`865`, :pull:`891`).
 
 * :py:class:`~pulse2percept.implants.EnsembleImplant` can now be constructed
   from physical coordinates with ``from_coords`` or from any 2D visual-field map

--- a/doc/users/release_notes.rst
+++ b/doc/users/release_notes.rst
@@ -51,7 +51,7 @@ Highlights
   side by side (:pull:`854`, :pull:`871`, :pull:`883`, :pull:`890`).
 
 * New photovoltaic stimulation pipeline for the PRIMA-style arrays, from image
-  encoding to irradiance-based model input (:pull:`868`).
+  encoding to irradiance-based model input (:pull:`868`, :pull:`891`).
 
 
 API changes and improvements
@@ -101,8 +101,11 @@ Generic implants carry neither.
   ``PRIMA75`` becomes :py:class:`~pulse2percept.implants.retina.Lorach2015Array`,
   and new :py:class:`~pulse2percept.implants.retina.Ho2019FlatArray` and
   :py:class:`~pulse2percept.implants.retina.Huang2021Array` classes capture other
-  photovoltaic designs. Device geometry and pixel dimensions were corrected
-  accordingly (:pull:`865`, :pull:`891`).
+  photovoltaic designs (:pull:`865`).
+  The new :py:class:`~pulse2percept.stimuli.PhotovoltaicEncoder` holds the
+  generic image-to-irradiance machinery, with 
+  :py:class:`~pulse2percept.stimuli.PRIMAEncoder` implementing the PRIMA
+  projector specialization (:pull:`891`).
 
 * :py:class:`~pulse2percept.implants.EnsembleImplant` can now be constructed
   from physical coordinates with ``from_coords`` or from any 2D visual-field map

--- a/pulse2percept/implants/retina/prima.py
+++ b/pulse2percept/implants/retina/prima.py
@@ -377,11 +377,11 @@ class PRIMAPivotal(_PhotovoltaicRetinalImplant):
         preprocessing method whenever a stimulus is prepared, or a custom
         function (callable).
     safe_mode : bool, optional
-        Enforces the documented projector operating envelope: irradiance
-        <= 3.5 mW/mm^2, ON durations on the 0.7 ms grid and <= 9.8 ms,
-        duty cycle <= 0.294, and frame rate <= 30 Hz. All 378 pixels may be
-        illuminated simultaneously. This is not a biological safety limit or a
-        demonstrated hardware maximum.
+        Enforces the documented projector operating envelope: 880 nm
+        illumination, irradiance <= 3.5 mW/mm^2, ON durations on the 0.7 ms
+        grid and <= 9.8 ms, duty cycle <= 0.294, and frame rate <= 30 Hz. All
+        378 pixels may be illuminated simultaneously. This is not a biological
+        safety limit or a demonstrated hardware maximum.
 
         .. versionchanged:: 0.11.0
             Checks the optical envelope instead of electrical charge balance.
@@ -472,6 +472,13 @@ class PRIMAPivotal(_PhotovoltaicRetinalImplant):
                 "Safety check: stimulus no longer carries a projector "
                 "schedule, so its duty cycle cannot be verified. Build it "
                 "with a PRIMAEncoder, or set safe_mode=False.")
+        # The projector is an 880 nm system; photovoltaic pixel response is
+        # wavelength dependent, so another wavelength is another device.
+        if abs(schedule.wavelength - PRIMAEncoder.projector_wavelength) > 1e-9:
+            raise ValueError(
+                f"Safety check: the projector illuminates at "
+                f"{PRIMAEncoder.projector_wavelength:g} nm, not "
+                f"{schedule.wavelength:g} nm.")
         irradiance, freq = schedule.irradiance, schedule.freq
         dur = np.asarray(schedule.pulse_dur, dtype=np.float64)
         step = PRIMAEncoder.pulse_step

--- a/pulse2percept/implants/retina/prima.py
+++ b/pulse2percept/implants/retina/prima.py
@@ -13,20 +13,37 @@ from collections.abc import Sequence
 from .base import RetinalImplant
 from ..electrodes import HexElectrode
 from ..electrode_arrays import ElectrodeGrid
-from ...stimuli import PRIMAEncoder
+from ...stimuli import PhotovoltaicEncoder, PRIMAEncoder
 from ...stimuli.base import _describe_unit
 from ...stimuli.encoders import _OpticalStimulus
 from ...units import DimensionMismatchError, as_value, mW, mm, um
 from ...utils import deprecated
 from ...utils.constants import MS_PER_S, ZORDER
 
-# Distinguish the default PRIMAEncoder from ``encoder=None``.
+# Distinguish an implant's own default encoder from ``encoder=None``.
 _DEVICE_DEFAULT = object()
 
 
-def _projector(stim):
-    """Return ``stim`` if it retains a PRIMA projector schedule."""
+def _optical(stim):
+    """Return ``stim`` if it retains a pulsed-illumination schedule."""
     return stim if isinstance(stim, _OpticalStimulus) else None
+
+
+#: Representative optical stimulation in [Lorach2015]_: 915 nm, 4 mW/mm^2,
+#: 4 ms pulses at 40 Hz (grating-acuity experiments).
+_LORACH2015_OPTICS = {'wavelength': 915, 'irradiance': 4.0, 'freq': 40,
+                      'pulse_dur': 4.0}
+
+#: Representative optical stimulation in [Ho2019]_: 915 nm, 8 mW/mm^2, 4 ms
+#: pulses at 40 Hz (grating-acuity experiments).
+_HO2019_OPTICS = {'wavelength': 915, 'irradiance': 8.0, 'freq': 40,
+                  'pulse_dur': 4.0}
+
+#: Representative optical stimulation in [Huang2021]_: 880 nm, 10 ms pulses at
+#: 2 Hz. Peak irradiance is the brightest of the 0.002-4.7 mW/mm^2 series that
+#: paper sweeps -- a measurement condition, not a device or safety maximum.
+_HUANG2021_OPTICS = {'wavelength': 880, 'irradiance': 4.7, 'freq': 2,
+                     'pulse_dur': 10.0}
 
 
 #: F55 layout reconstructed from Fig. 2(a) of [Ho2019]_.
@@ -289,9 +306,9 @@ class _PhotovoltaicRetinalImplant(RetinalImplant):
         """Reject negative or nonfinite irradiance."""
         if stim.unit.dimension != self.stimulus_unit.dimension:
             return
-        projector = _projector(stim)
-        if projector is not None:
-            values = np.array([projector.irradiance], dtype=np.float64)
+        schedule = _optical(stim)
+        if schedule is not None:
+            values = np.array([schedule.irradiance], dtype=np.float64)
         else:
             values = np.asarray(stim.data, dtype=np.float64)
         if values.size == 0:
@@ -303,66 +320,27 @@ class _PhotovoltaicRetinalImplant(RetinalImplant):
                 f"Irradiance is a power density and cannot be negative "
                 f"(got {values.min():.3f} mW/mm^2); a dark pixel is zero.")
 
-    def _require_within_optical_envelope(self, stim):
-        """Check the documented PRIMA projector operating envelope."""
-        if stim.unit.dimension != self.stimulus_unit.dimension:
-            raise DimensionMismatchError(
-                f"Safety check 'safe_mode' needs an optical stimulus, not "
-                f"{_describe_unit(stim.unit)}. Give the implant a "
-                f"PRIMAEncoder to encode image or video input into "
-                f"irradiance first.")
-        projector = _projector(stim)
-        if projector is None:
-            # Duty cycle requires the projector schedule, not waveform samples.
-            raise ValueError(
-                "Safety check: stimulus no longer carries a projector "
-                "schedule, so its duty cycle cannot be verified. Build it "
-                "with a PRIMAEncoder, or set safe_mode=False.")
-        irradiance, freq = projector.irradiance, projector.freq
-        dur = np.asarray(projector.pulse_dur, dtype=np.float64)
-        step = PRIMAEncoder.pulse_step
-        if irradiance > PRIMAEncoder.max_irradiance + 1e-9:
-            raise ValueError(
-                f"Safety check: {irradiance:.3f} mW/mm^2 exceeds the "
-                f"{PRIMAEncoder.max_irradiance} mW/mm^2 the device delivers.")
-        longest = float(dur.max(initial=0.0))
-        if longest > PRIMAEncoder.max_pulse_dur + 1e-9:
-            raise ValueError(
-                f"Safety check: {longest:.3f} ms exceeds the longest "
-                f"documented ON duration of {PRIMAEncoder.max_pulse_dur} ms.")
-        steps = dur[dur > 0] / step
-        if steps.size and np.any(np.abs(steps - np.round(steps)) > 1e-6):
-            raise ValueError(
-                f"Safety check: ON durations must be whole multiples of "
-                f"{step} ms, the step the projector modulates in.")
-        # Check duty cycle before frame rate to catch combined violations.
-        duty = freq * longest / MS_PER_S
-        if duty > PRIMAEncoder.max_duty_cycle + 1e-9:
-            raise ValueError(
-                f"Safety check: duty cycle {duty:.3f} ({freq:g} Hz x "
-                f"{longest:.3f} ms) exceeds the "
-                f"{PRIMAEncoder.max_duty_cycle:.3f} the device delivers. "
-                f"Lower 'freq' or shorten 'pulse_dur'.")
-        if freq > PRIMAEncoder.max_freq + 1e-9:
-            raise ValueError(
-                f"Safety check: stimulus runs the projector at {freq:g} Hz, "
-                f"above the documented {PRIMAEncoder.max_freq:g} Hz. Set "
-                f"safe_mode=False to explore other frame rates.")
+    def _check_optical_safe_mode(self, stim):
+        """Reject ``safe_mode`` where no optical envelope is published."""
+        raise NotImplementedError(
+            f"'safe_mode' is not available for {type(self).__name__}: no "
+            f"optical operating envelope has been published for this array, "
+            f"and the PRIMA projector limits checked by PRIMAPivotal are "
+            f"specific to that system. Set safe_mode=False.")
 
     def check_stim(self, stim):
         """Require finite, non-negative irradiance.
 
         Charge balance does not apply to light and is not checked. With
-        ``safe_mode``, the stimulus must also stay inside the standard PRIMA
-        projector envelope (see
-        :py:class:`~pulse2percept.stimuli.PRIMAEncoder`), which is not a
-        safety limit established per array.
+        ``safe_mode``, a subclass may additionally check its own documented
+        optical operating envelope; arrays without one reject ``safe_mode``
+        rather than borrow another device's limits.
 
         .. versionadded:: 0.11.0
         """
         self._require_physical_light(stim)
         if self.safe_mode:
-            self._require_within_optical_envelope(stim)
+            self._check_optical_safe_mode(stim)
         if self.max_current is not None:
             # The inherited current-limit check rejects optical units.
             self._require_within_current_limit(stim)
@@ -409,8 +387,8 @@ class PRIMAPivotal(_PhotovoltaicRetinalImplant):
             Checks the optical envelope instead of electrical charge balance.
     encoder : :py:class:`~pulse2percept.stimuli.Encoder`, optional
         Image/video encoder. Defaults to
-        :py:class:`~pulse2percept.stimuli.PRIMAEncoder`. Pass ``None`` to
-        disable automatic encoding.
+        :py:class:`~pulse2percept.stimuli.PRIMAEncoder`, which describes the
+        pivotal-trial projector. Pass ``None`` to disable automatic encoding.
 
         .. versionadded:: 0.11.0
 
@@ -421,6 +399,9 @@ class PRIMAPivotal(_PhotovoltaicRetinalImplant):
     *  :py:meth:`~pulse2percept.implants.Implant.prepare_stim`
        returns optical irradiance (``mW/mm^2``). Photovoltaic conversion is not
        modeled.
+    *  Gray levels map linearly onto the projector's 0.7 ms duration grid.
+       The clinical camera-to-pulse-duration transfer function is not
+       published, so that mapping is a pulse2percept convention.
     """
     # Frozen class: User cannot add more class attributes
     __slots__ = ('shape', 'spacing', 'pixel_width', 'gap')
@@ -476,6 +457,52 @@ class PRIMAPivotal(_PhotovoltaicRetinalImplant):
             for elec, z_elec in zip(self.electrode_array.electrode_objects, z):
                 elec.z = z_elec
 
+    def _check_optical_safe_mode(self, stim):
+        """Check the documented PRIMA projector operating envelope."""
+        if stim.unit.dimension != self.stimulus_unit.dimension:
+            raise DimensionMismatchError(
+                f"Safety check 'safe_mode' needs an optical stimulus, not "
+                f"{_describe_unit(stim.unit)}. Give the implant a "
+                f"PRIMAEncoder to encode image or video input into "
+                f"irradiance first.")
+        schedule = _optical(stim)
+        if schedule is None:
+            # Duty cycle requires the projector schedule, not waveform samples.
+            raise ValueError(
+                "Safety check: stimulus no longer carries a projector "
+                "schedule, so its duty cycle cannot be verified. Build it "
+                "with a PRIMAEncoder, or set safe_mode=False.")
+        irradiance, freq = schedule.irradiance, schedule.freq
+        dur = np.asarray(schedule.pulse_dur, dtype=np.float64)
+        step = PRIMAEncoder.pulse_step
+        if irradiance > PRIMAEncoder.max_irradiance + 1e-9:
+            raise ValueError(
+                f"Safety check: {irradiance:.3f} mW/mm^2 exceeds the "
+                f"{PRIMAEncoder.max_irradiance} mW/mm^2 the device delivers.")
+        longest = float(dur.max(initial=0.0))
+        if longest > PRIMAEncoder.max_pulse_dur + 1e-9:
+            raise ValueError(
+                f"Safety check: {longest:.3f} ms exceeds the longest "
+                f"documented ON duration of {PRIMAEncoder.max_pulse_dur} ms.")
+        steps = dur[dur > 0] / step
+        if steps.size and np.any(np.abs(steps - np.round(steps)) > 1e-6):
+            raise ValueError(
+                f"Safety check: ON durations must be whole multiples of "
+                f"{step} ms, the step the projector modulates in.")
+        # Check duty cycle before frame rate to catch combined violations.
+        duty = freq * longest / MS_PER_S
+        if duty > PRIMAEncoder.max_duty_cycle + 1e-9:
+            raise ValueError(
+                f"Safety check: duty cycle {duty:.3f} ({freq:g} Hz x "
+                f"{longest:.3f} ms) exceeds the "
+                f"{PRIMAEncoder.max_duty_cycle:.3f} the device delivers. "
+                f"Lower 'freq' or shorten 'pulse_dur'.")
+        if freq > PRIMAEncoder.max_freq + 1e-9:
+            raise ValueError(
+                f"Safety check: stimulus runs the projector at {freq:g} Hz, "
+                f"above the documented {PRIMAEncoder.max_freq:g} Hz. Set "
+                f"safe_mode=False to explore other frame rates.")
+
     def plot(self, annotate=False, autoscale=True, ax=None, stim=None,
              stim_cmap=False):
         """Plot the implant and its 2 x 2 mm substrate.
@@ -521,18 +548,18 @@ class Lorach2015Array(_PhotovoltaicRetinalImplant):
         preprocessing method whenever a stimulus is prepared, or a custom
         function (callable).
     safe_mode : bool, optional
-        Enforces the standard PRIMA projector envelope (see
-        :py:class:`~pulse2percept.stimuli.PRIMAEncoder`), not a safety limit
-        established for this array.
+        Not supported: no optical operating envelope has been published for
+        this array, and the PRIMA projector limits are specific to
+        :py:class:`~pulse2percept.implants.retina.PRIMAPivotal`. ``True``
+        raises when a stimulus is checked.
 
         .. versionchanged:: 0.11.0
-            Checks the optical envelope instead of electrical charge balance.
+            No longer applies the PRIMA projector envelope to this array.
     encoder : :py:class:`~pulse2percept.stimuli.Encoder`, optional
-        Image/video encoder. Defaults to
-        :py:class:`~pulse2percept.stimuli.PRIMAEncoder`, whose settings
-        describe the standard PRIMA projector, not the illumination protocol
-        of the paper this array comes from. Pass ``None`` to disable automatic
-        encoding.
+        Image/video encoder. Defaults to a
+        :py:class:`~pulse2percept.stimuli.PhotovoltaicEncoder` configured
+        for the illumination reported in [Lorach2015]_ (915 nm, 4 mW/mm^2,
+        4 ms pulses at 40 Hz). Pass ``None`` to disable automatic encoding.
 
         .. versionadded:: 0.11.0
     
@@ -542,6 +569,11 @@ class Lorach2015Array(_PhotovoltaicRetinalImplant):
        :py:meth:`~pulse2percept.implants.Implant.prepare_stim` returns
        irradiance (``mW/mm^2``). Photovoltaic conversion to tissue current is
        not modeled.
+    *  The default encoder reproduces the 915 nm, 4 mW/mm^2, 4 ms, 40 Hz
+       illumination of the [Lorach2015]_ grating experiments. Gray levels set
+       ON duration linearly, which is a pulse2percept simulation convention:
+       the paper does not specify a natural-image grayscale transfer
+       function.
     *  [Lorach2015]_ reports the 65 um row spacing as the "pixel pitch".
     *  Seven rim pixels extend beyond the nominal 1 mm substrate and are clipped
        when plotted.
@@ -563,8 +595,8 @@ class Lorach2015Array(_PhotovoltaicRetinalImplant):
         self.preprocess = preprocess
         self.safe_mode = safe_mode
         # Do not share mutable encoder state between implant instances.
-        self.encoder = (PRIMAEncoder() if encoder is _DEVICE_DEFAULT
-                        else encoder)
+        self.encoder = (PhotovoltaicEncoder(**_LORACH2015_OPTICS)
+                        if encoder is _DEVICE_DEFAULT else encoder)
 
         # Normalized here rather than in ElectrodeGrid, because a
         # per-electrode list of heights never reaches the grid at all -- it is
@@ -652,20 +684,11 @@ class Ho2019FlatArray(_PhotovoltaicRetinalImplant):
         preprocessing method whenever a stimulus is prepared, or a custom
         function (callable).
     safe_mode : bool, optional
-        Enforces the standard PRIMA projector envelope (see
-        :py:class:`~pulse2percept.stimuli.PRIMAEncoder`), not a safety limit
-        established for this array.
-
-        .. versionchanged:: 0.11.0
-            Checks the optical envelope instead of electrical charge balance.
+        Not supported: no optical operating envelope has been published for
+        this array, and the PRIMA projector limits are specific to
+        :py:class:`~pulse2percept.implants.retina.PRIMAPivotal`.
     encoder : :py:class:`~pulse2percept.stimuli.Encoder`, optional
-        Image/video encoder. Defaults to
-        :py:class:`~pulse2percept.stimuli.PRIMAEncoder`, whose settings
-        describe the standard PRIMA projector, not the illumination protocol
-        of the paper this array comes from. Pass ``None`` to disable automatic
-        encoding.
-
-        .. versionadded:: 0.11.0
+        Image/video encoder. Pass ``None`` to disable automatic encoding.
     
     Notes
     -----
@@ -673,6 +696,10 @@ class Ho2019FlatArray(_PhotovoltaicRetinalImplant):
        :py:meth:`~pulse2percept.implants.Implant.prepare_stim` returns
        irradiance (``mW/mm^2``). Photovoltaic conversion to tissue current is
        not modeled.
+    *  The default encoder reproduces the 915 nm, 8 mW/mm^2, 4 ms, 40 Hz
+       illumination of the [Ho2019]_ grating experiments. Gray levels set ON
+       duration linearly, which is a pulse2percept simulation convention: the
+       paper does not specify a natural-image grayscale transfer function.
     *  [Ho2019]_ also describes pillar arrays Pil55 and Pil40, which are not
        modeled here.
     *  The F55 layout is reconstructed from Fig. 2(a). The F40 outline is not
@@ -699,8 +726,8 @@ class Ho2019FlatArray(_PhotovoltaicRetinalImplant):
         self.preprocess = preprocess
         self.safe_mode = safe_mode
         # Do not share mutable encoder state between implant instances.
-        self.encoder = (PRIMAEncoder() if encoder is _DEVICE_DEFAULT
-                        else encoder)
+        self.encoder = (PhotovoltaicEncoder(**_HO2019_OPTICS)
+                        if encoder is _DEVICE_DEFAULT else encoder)
 
         # Normalized here rather than in ElectrodeGrid, because a
         # per-electrode list of heights never reaches the grid at all -- it is
@@ -782,18 +809,18 @@ class Huang2021Array(_PhotovoltaicRetinalImplant):
         preprocessing method whenever a stimulus is prepared, or a custom
         function (callable).
     safe_mode : bool, optional
-        Enforces the standard PRIMA projector envelope (see
-        :py:class:`~pulse2percept.stimuli.PRIMAEncoder`), not a safety limit
-        established for this array.
+        Not supported: no optical operating envelope has been published for
+        this array, and the PRIMA projector limits are specific to
+        :py:class:`~pulse2percept.implants.retina.PRIMAPivotal`. ``True``
+        raises when a stimulus is checked.
 
         .. versionchanged:: 0.11.0
-            Checks the optical envelope instead of electrical charge balance.
+            No longer applies the PRIMA projector envelope to this array.
     encoder : :py:class:`~pulse2percept.stimuli.Encoder`, optional
-        Image/video encoder. Defaults to
-        :py:class:`~pulse2percept.stimuli.PRIMAEncoder`, whose settings
-        describe the standard PRIMA projector, not the illumination protocol
-        of the paper this array comes from. Pass ``None`` to disable automatic
-        encoding.
+        Image/video encoder. Defaults to a
+        :py:class:`~pulse2percept.stimuli.PhotovoltaicEncoder` configured
+        for the illumination reported in [Huang2021]_ (880 nm, 4.7 mW/mm^2,
+        10 ms pulses at 2 Hz). Pass ``None`` to disable automatic encoding.
 
         .. versionadded:: 0.11.0
     
@@ -803,6 +830,9 @@ class Huang2021Array(_PhotovoltaicRetinalImplant):
        :py:meth:`~pulse2percept.implants.Implant.prepare_stim` returns
        irradiance (``mW/mm^2``). Photovoltaic conversion to tissue current is
        not modeled.
+    *  The default encoder reproduces the 880 nm, 10 ms, 2 Hz full-field
+       stimulation of [Huang2021]_. Gray levels set ON duration linearly
+       (a p2p convention).
     *  ``n_total_pixels`` gives the fabricated pixel count; peripheral pixels
        covered by the common return are not modeled as electrodes.
     *  Exposed-pixel layouts are reconstructed from Fig. 7 of [Huang2021]_.
@@ -833,8 +863,8 @@ class Huang2021Array(_PhotovoltaicRetinalImplant):
         self.preprocess = preprocess
         self.safe_mode = safe_mode
         # Do not share mutable encoder state between implant instances.
-        self.encoder = (PRIMAEncoder() if encoder is _DEVICE_DEFAULT
-                        else encoder)
+        self.encoder = (PhotovoltaicEncoder(**_HUANG2021_OPTICS)
+                        if encoder is _DEVICE_DEFAULT else encoder)
 
         # Normalized here rather than in ElectrodeGrid, because a
         # per-electrode list of heights never reaches the grid at all -- it is

--- a/pulse2percept/implants/retina/prima.py
+++ b/pulse2percept/implants/retina/prima.py
@@ -272,7 +272,103 @@ class PhotovoltaicPixel(HexElectrode):
         raise NotImplementedError
 
 
-class PRIMAPivotal(RetinalImplant):
+class _PhotovoltaicRetinalImplant(RetinalImplant):
+    """Subretinal photovoltaic array driven by pulsed NIR illumination.
+
+    Stimulation is irradiance (``mW/mm^2``), not injected current.
+    """
+    # Frozen class: User cannot add more class attributes
+    __slots__ = ()
+
+    technology = 'photovoltaic'
+
+    #: The device is illuminated, not driven by a current source.
+    stimulus_unit = mW / mm ** 2
+
+    def _require_physical_light(self, stim):
+        """Reject negative or nonfinite irradiance."""
+        if stim.unit.dimension != self.stimulus_unit.dimension:
+            return
+        projector = _projector(stim)
+        if projector is not None:
+            values = np.array([projector.irradiance], dtype=np.float64)
+        else:
+            values = np.asarray(stim.data, dtype=np.float64)
+        if values.size == 0:
+            return
+        if not np.all(np.isfinite(values)):
+            raise ValueError("Optical stimulus has non-finite irradiance.")
+        if values.min() < 0:
+            raise ValueError(
+                f"Irradiance is a power density and cannot be negative "
+                f"(got {values.min():.3f} mW/mm^2); a dark pixel is zero.")
+
+    def _require_within_optical_envelope(self, stim):
+        """Check the documented PRIMA projector operating envelope."""
+        if stim.unit.dimension != self.stimulus_unit.dimension:
+            raise DimensionMismatchError(
+                f"Safety check 'safe_mode' needs an optical stimulus, not "
+                f"{_describe_unit(stim.unit)}. Give the implant a "
+                f"PRIMAEncoder to encode image or video input into "
+                f"irradiance first.")
+        projector = _projector(stim)
+        if projector is None:
+            # Duty cycle requires the projector schedule, not waveform samples.
+            raise ValueError(
+                "Safety check: stimulus no longer carries a projector "
+                "schedule, so its duty cycle cannot be verified. Build it "
+                "with a PRIMAEncoder, or set safe_mode=False.")
+        irradiance, freq = projector.irradiance, projector.freq
+        dur = np.asarray(projector.pulse_dur, dtype=np.float64)
+        step = PRIMAEncoder.pulse_step
+        if irradiance > PRIMAEncoder.max_irradiance + 1e-9:
+            raise ValueError(
+                f"Safety check: {irradiance:.3f} mW/mm^2 exceeds the "
+                f"{PRIMAEncoder.max_irradiance} mW/mm^2 the device delivers.")
+        longest = float(dur.max(initial=0.0))
+        if longest > PRIMAEncoder.max_pulse_dur + 1e-9:
+            raise ValueError(
+                f"Safety check: {longest:.3f} ms exceeds the longest "
+                f"documented ON duration of {PRIMAEncoder.max_pulse_dur} ms.")
+        steps = dur[dur > 0] / step
+        if steps.size and np.any(np.abs(steps - np.round(steps)) > 1e-6):
+            raise ValueError(
+                f"Safety check: ON durations must be whole multiples of "
+                f"{step} ms, the step the projector modulates in.")
+        # Check duty cycle before frame rate to catch combined violations.
+        duty = freq * longest / MS_PER_S
+        if duty > PRIMAEncoder.max_duty_cycle + 1e-9:
+            raise ValueError(
+                f"Safety check: duty cycle {duty:.3f} ({freq:g} Hz x "
+                f"{longest:.3f} ms) exceeds the "
+                f"{PRIMAEncoder.max_duty_cycle:.3f} the device delivers. "
+                f"Lower 'freq' or shorten 'pulse_dur'.")
+        if freq > PRIMAEncoder.max_freq + 1e-9:
+            raise ValueError(
+                f"Safety check: stimulus runs the projector at {freq:g} Hz, "
+                f"above the documented {PRIMAEncoder.max_freq:g} Hz. Set "
+                f"safe_mode=False to explore other frame rates.")
+
+    def check_stim(self, stim):
+        """Require finite, non-negative irradiance.
+
+        Charge balance does not apply to light and is not checked. With
+        ``safe_mode``, the stimulus must also stay inside the standard PRIMA
+        projector envelope (see
+        :py:class:`~pulse2percept.stimuli.PRIMAEncoder`), which is not a
+        safety limit established per array.
+
+        .. versionadded:: 0.11.0
+        """
+        self._require_physical_light(stim)
+        if self.safe_mode:
+            self._require_within_optical_envelope(stim)
+        if self.max_current is not None:
+            # The inherited current-limit check rejects optical units.
+            self._require_within_current_limit(stim)
+
+
+class PRIMAPivotal(_PhotovoltaicRetinalImplant):
     """Create the PRIMA array used in the pivotal PRIMAvera trial
     
     The implant has 378 photovoltaic pixels, each 100 um wide on a 100 um
@@ -330,11 +426,7 @@ class PRIMAPivotal(RetinalImplant):
     __slots__ = ('shape', 'spacing', 'pixel_width', 'gap')
 
     placement = 'subretinal'
-    technology = 'photovoltaic'
     family = 'PRIMA'
-
-    #: The device is illuminated, not driven by a current source.
-    stimulus_unit = mW / mm ** 2
 
     def __init__(self, z=0, eye='right', preprocess=False,
                  safe_mode=False, encoder=_DEVICE_DEFAULT):
@@ -384,91 +476,6 @@ class PRIMAPivotal(RetinalImplant):
             for elec, z_elec in zip(self.electrode_array.electrode_objects, z):
                 elec.z = z_elec
 
-    def _require_physical_light(self, stim):
-        """Reject negative or nonfinite irradiance."""
-        if stim.unit.dimension != self.stimulus_unit.dimension:
-            return
-        projector = _projector(stim)
-        if projector is not None:
-            # Read peak irradiance directly from the projector schedule.
-            values = np.array([projector.irradiance], dtype=np.float64)
-        else:
-            values = np.asarray(stim.data, dtype=np.float64)
-        if values.size == 0:
-            return
-        if not np.all(np.isfinite(values)):
-            raise ValueError("Optical stimulus has non-finite irradiance.")
-        if values.min() < 0:
-            raise ValueError(
-                f"Optical stimulus asks for {values.min():.3f} mW/mm^2. "
-                f"Irradiance is a power density and cannot be negative; "
-                f"a dark pixel is zero.")
-
-    def _require_within_optical_envelope(self, stim):
-        """Check the documented PRIMA projector operating envelope."""
-        if stim.unit.dimension != self.stimulus_unit.dimension:
-            raise DimensionMismatchError(
-                f"Safety check 'safe_mode' needs an optical stimulus to "
-                f"check, and this one is measured in "
-                f"{_describe_unit(stim.unit)}. Give the implant a "
-                f"PRIMAEncoder so that image or video input is encoded into "
-                f"irradiance first.")
-        projector = _projector(stim)
-        if projector is None:
-            # Duty cycle requires the projector schedule, not waveform samples.
-            raise ValueError(
-                "Safety check: this stimulus no longer describes a projector "
-                "(irradiance, frame rate, per-pixel ON durations), so its "
-                "duty cycle cannot be verified. Build it with a PRIMAEncoder "
-                "and keep it intact, or set safe_mode=False and check the "
-                "device envelope yourself.")
-        irradiance, freq = projector.irradiance, projector.freq
-        dur = np.asarray(projector.pulse_dur, dtype=np.float64)
-        step = PRIMAEncoder.pulse_step
-        if irradiance > PRIMAEncoder.max_irradiance + 1e-9:
-            raise ValueError(
-                f"Safety check: stimulus projects {irradiance:.3f} mW/mm^2, "
-                f"which exceeds the {PRIMAEncoder.max_irradiance} mW/mm^2 the "
-                f"device delivers.")
-        longest = float(dur.max(initial=0.0))
-        if longest > PRIMAEncoder.max_pulse_dur + 1e-9:
-            raise ValueError(
-                f"Safety check: stimulus lights a pixel for {longest:.3f} ms, "
-                f"which exceeds the longest documented ON duration of "
-                f"{PRIMAEncoder.max_pulse_dur} ms.")
-        # Require 0.7 ms ON-duration steps.
-        steps = dur[dur > 0] / step
-        if steps.size and np.any(np.abs(steps - np.round(steps)) > 1e-6):
-            raise ValueError(
-                f"Safety check: ON durations must be whole multiples of "
-                f"{step} ms, the step the projector modulates in.")
-        # Check duty cycle before frame rate to catch combined violations.
-        duty = freq * longest / MS_PER_S
-        if duty > PRIMAEncoder.max_duty_cycle + 1e-9:
-            raise ValueError(
-                f"Safety check: stimulus asks for a duty cycle of "
-                f"{duty:.3f} ({freq:g} Hz x {longest:.3f} ms), which exceeds "
-                f"the {PRIMAEncoder.max_duty_cycle:.3f} the device delivers. "
-                f"Lower 'freq' or shorten 'pulse_dur'.")
-        if freq > PRIMAEncoder.max_freq + 1e-9:
-            raise ValueError(
-                f"Safety check: stimulus runs the projector at {freq:g} Hz, "
-                f"and the pivotal system is reported to run at "
-                f"{PRIMAEncoder.max_freq:g} Hz. Set safe_mode=False to "
-                f"explore other frame rates.")
-
-    def check_stim(self, stim):
-        """Validate optical stimulation and, in safe mode, projector limits.
-
-        .. versionadded:: 0.11.0
-        """
-        self._require_physical_light(stim)
-        if self.safe_mode:
-            self._require_within_optical_envelope(stim)
-        if self.max_current is not None:
-            # The inherited current-limit check rejects optical units.
-            self._require_within_current_limit(stim)
-
     def plot(self, annotate=False, autoscale=True, ax=None, stim=None,
              stim_cmap=False):
         """Plot the implant and its 2 x 2 mm substrate.
@@ -489,7 +496,7 @@ class PRIMAPivotal(RetinalImplant):
         return self.spacing * np.sqrt(3) / 2
 
 
-class Lorach2015Array(RetinalImplant):
+class Lorach2015Array(_PhotovoltaicRetinalImplant):
     """Create the 70 um photovoltaic array of [Lorach2015]_
     
     The array has 142 pixels, each 70 um wide on a 75 um hexagonal grid, with a
@@ -514,10 +521,27 @@ class Lorach2015Array(RetinalImplant):
         preprocessing method whenever a stimulus is prepared, or a custom
         function (callable).
     safe_mode : bool, optional
-        If safe mode is enabled, only charge-balanced stimuli are allowed.
+        Enforces the standard PRIMA projector envelope (see
+        :py:class:`~pulse2percept.stimuli.PRIMAEncoder`), not a safety limit
+        established for this array.
+
+        .. versionchanged:: 0.11.0
+            Checks the optical envelope instead of electrical charge balance.
+    encoder : :py:class:`~pulse2percept.stimuli.Encoder`, optional
+        Image/video encoder. Defaults to
+        :py:class:`~pulse2percept.stimuli.PRIMAEncoder`, whose settings
+        describe the standard PRIMA projector, not the illumination protocol
+        of the paper this array comes from. Pass ``None`` to disable automatic
+        encoding.
+
+        .. versionadded:: 0.11.0
     
     Notes
     -----
+    *  Driven by pulsed near-infrared illumination:
+       :py:meth:`~pulse2percept.implants.Implant.prepare_stim` returns
+       irradiance (``mW/mm^2``). Photovoltaic conversion to tissue current is
+       not modeled.
     *  [Lorach2015]_ reports the 65 um row spacing as the "pixel pitch".
     *  Seven rim pixels extend beyond the nominal 1 mm substrate and are clipped
        when plotted.
@@ -526,10 +550,9 @@ class Lorach2015Array(RetinalImplant):
     __slots__ = ('shape', 'spacing', 'pixel_width', 'gap')
 
     placement = 'subretinal'
-    technology = 'photovoltaic'
 
     def __init__(self, z=0, eye='right', preprocess=False,
-                 safe_mode=False):
+                 safe_mode=False, encoder=_DEVICE_DEFAULT):
         self.spacing = 75  # um, nearest-neighbor center-to-center
         self.pixel_width = 70  # um, flat-to-flat
         self.gap = self.spacing - self.pixel_width  # um, open inter-pixel gap
@@ -539,6 +562,9 @@ class Lorach2015Array(RetinalImplant):
         self.eye = eye
         self.preprocess = preprocess
         self.safe_mode = safe_mode
+        # Do not share mutable encoder state between implant instances.
+        self.encoder = (PRIMAEncoder() if encoder is _DEVICE_DEFAULT
+                        else encoder)
 
         # Normalized here rather than in ElectrodeGrid, because a
         # per-electrode list of heights never reaches the grid at all -- it is
@@ -596,7 +622,7 @@ class Lorach2015Array(RetinalImplant):
         return self.spacing * np.sqrt(3) / 2
 
 
-class Ho2019FlatArray(RetinalImplant):
+class Ho2019FlatArray(_PhotovoltaicRetinalImplant):
     """Create a flat photovoltaic array of [Ho2019]_
     
     Supports the F55 and F40 arrays on a 1 mm substrate:
@@ -626,10 +652,27 @@ class Ho2019FlatArray(RetinalImplant):
         preprocessing method whenever a stimulus is prepared, or a custom
         function (callable).
     safe_mode : bool, optional
-        If safe mode is enabled, only charge-balanced stimuli are allowed.
+        Enforces the standard PRIMA projector envelope (see
+        :py:class:`~pulse2percept.stimuli.PRIMAEncoder`), not a safety limit
+        established for this array.
+
+        .. versionchanged:: 0.11.0
+            Checks the optical envelope instead of electrical charge balance.
+    encoder : :py:class:`~pulse2percept.stimuli.Encoder`, optional
+        Image/video encoder. Defaults to
+        :py:class:`~pulse2percept.stimuli.PRIMAEncoder`, whose settings
+        describe the standard PRIMA projector, not the illumination protocol
+        of the paper this array comes from. Pass ``None`` to disable automatic
+        encoding.
+
+        .. versionadded:: 0.11.0
     
     Notes
     -----
+    *  Driven by pulsed near-infrared illumination:
+       :py:meth:`~pulse2percept.implants.Implant.prepare_stim` returns
+       irradiance (``mW/mm^2``). Photovoltaic conversion to tissue current is
+       not modeled.
     *  [Ho2019]_ also describes pillar arrays Pil55 and Pil40, which are not
        modeled here.
     *  The F55 layout is reconstructed from Fig. 2(a). The F40 outline is not
@@ -642,10 +685,9 @@ class Ho2019FlatArray(RetinalImplant):
     __slots__ = ('pixel_size', 'shape', 'spacing', 'pixel_width', 'gap')
 
     placement = 'subretinal'
-    technology = 'photovoltaic'
 
     def __init__(self, pixel_size, z=0, eye='right',
-                 preprocess=False, safe_mode=False):
+                 preprocess=False, safe_mode=False, encoder=_DEVICE_DEFAULT):
         self.pixel_size = _pixel_size_um(pixel_size, _HO2019_VARIANTS,
                                          'Ho2019FlatArray')
         spec = _HO2019_VARIANTS[self.pixel_size]
@@ -656,6 +698,9 @@ class Ho2019FlatArray(RetinalImplant):
         self.eye = eye
         self.preprocess = preprocess
         self.safe_mode = safe_mode
+        # Do not share mutable encoder state between implant instances.
+        self.encoder = (PRIMAEncoder() if encoder is _DEVICE_DEFAULT
+                        else encoder)
 
         # Normalized here rather than in ElectrodeGrid, because a
         # per-electrode list of heights never reaches the grid at all -- it is
@@ -704,7 +749,7 @@ class Ho2019FlatArray(RetinalImplant):
         return self.spacing * np.sqrt(3) / 2
 
 
-class Huang2021Array(RetinalImplant):
+class Huang2021Array(_PhotovoltaicRetinalImplant):
     """Create a vertical-junction photovoltaic array of [Huang2021]_
     
     Supports four arrays on a 1.5 mm substrate. Only exposed pixels are modeled
@@ -737,10 +782,27 @@ class Huang2021Array(RetinalImplant):
         preprocessing method whenever a stimulus is prepared, or a custom
         function (callable).
     safe_mode : bool, optional
-        If safe mode is enabled, only charge-balanced stimuli are allowed.
+        Enforces the standard PRIMA projector envelope (see
+        :py:class:`~pulse2percept.stimuli.PRIMAEncoder`), not a safety limit
+        established for this array.
+
+        .. versionchanged:: 0.11.0
+            Checks the optical envelope instead of electrical charge balance.
+    encoder : :py:class:`~pulse2percept.stimuli.Encoder`, optional
+        Image/video encoder. Defaults to
+        :py:class:`~pulse2percept.stimuli.PRIMAEncoder`, whose settings
+        describe the standard PRIMA projector, not the illumination protocol
+        of the paper this array comes from. Pass ``None`` to disable automatic
+        encoding.
+
+        .. versionadded:: 0.11.0
     
     Notes
     -----
+    *  Driven by pulsed near-infrared illumination:
+       :py:meth:`~pulse2percept.implants.Implant.prepare_stim` returns
+       irradiance (``mW/mm^2``). Photovoltaic conversion to tissue current is
+       not modeled.
     *  ``n_total_pixels`` gives the fabricated pixel count; peripheral pixels
        covered by the common return are not modeled as electrodes.
     *  Exposed-pixel layouts are reconstructed from Fig. 7 of [Huang2021]_.
@@ -754,10 +816,9 @@ class Huang2021Array(RetinalImplant):
                  'pixel_width', 'gap')
 
     placement = 'subretinal'
-    technology = 'photovoltaic'
 
     def __init__(self, pixel_size, z=0, eye='right',
-                 preprocess=False, safe_mode=False):
+                 preprocess=False, safe_mode=False, encoder=_DEVICE_DEFAULT):
         self.pixel_size = _pixel_size_um(pixel_size, _HUANG2021_AXIAL_SPANS,
                                          'Huang2021Array')
         spans = _HUANG2021_AXIAL_SPANS[self.pixel_size]
@@ -771,6 +832,9 @@ class Huang2021Array(RetinalImplant):
         self.eye = eye
         self.preprocess = preprocess
         self.safe_mode = safe_mode
+        # Do not share mutable encoder state between implant instances.
+        self.encoder = (PRIMAEncoder() if encoder is _DEVICE_DEFAULT
+                        else encoder)
 
         # Normalized here rather than in ElectrodeGrid, because a
         # per-electrode list of heights never reaches the grid at all -- it is

--- a/pulse2percept/implants/retina/tests/test_prima.py
+++ b/pulse2percept/implants/retina/tests/test_prima.py
@@ -787,6 +787,33 @@ def test_PRIMAPivotal_safe_mode_accepts_the_full_device():
         implant.prepare_stim(samples.logo_bvl())
 
 
+def test_PRIMAPivotal_safe_mode_checks_the_wavelength():
+    """The envelope is validated on the schedule, not the encoder class.
+
+    A PhotovoltaicEncoder can now put pivotal settings on a different
+    wavelength; photovoltaic response is wavelength dependent, so that is a
+    different operating point, not the PRIMA projector.
+    """
+    # Binary mode keeps ON durations on the projector's own 0.7 ms grid, so
+    # wavelength is the only thing left to fault.
+    off_color = PhotovoltaicEncoder(wavelength=915, irradiance=3.5, freq=30,
+                                    pulse_dur=9.8, grayscale=False)
+    with pytest.raises(ValueError) as excinfo:
+        PRIMAPivotal(safe_mode=True,
+                     encoder=off_color).prepare_stim(samples.logo_bvl())
+    npt.assert_equal('880 nm, not 915 nm' in str(excinfo.value), True)
+    # The same settings at 880 nm pass, so only wavelength was at fault:
+    on_color = PhotovoltaicEncoder(wavelength=880, irradiance=3.5, freq=30,
+                                   pulse_dur=9.8, grayscale=False)
+    npt.assert_equal(
+        PRIMAPivotal(safe_mode=True, encoder=on_color).prepare_stim(
+            samples.logo_bvl()).unit, mW / mm ** 2)
+    # Without safe_mode the wavelength check is skipped:
+    npt.assert_equal(
+        PRIMAPivotal(encoder=off_color).prepare_stim(
+            samples.logo_bvl()).unit, mW / mm ** 2)
+
+
 @pytest.mark.parametrize('encoder, msg', [
     (LooseEncoder(irradiance=5.0), 'exceeds the 3.5 mW/mm^2'),
     (LooseEncoder(pulse_dur=14.0), 'longest documented ON duration'),

--- a/pulse2percept/implants/retina/tests/test_prima.py
+++ b/pulse2percept/implants/retina/tests/test_prima.py
@@ -16,8 +16,8 @@ from pulse2percept.implants.retina import (ArgusII, PhotovoltaicPixel,
                                            Ho2019FlatArray, Huang2021Array,
                                            PRIMA, PRIMA75, PRIMA55, PRIMA40)
 from pulse2percept.stimuli import (BiphasicPulse, BiphasicPulseTrain,
-                                   ImageStimulus, PRIMAEncoder, samples,
-                                   Stimulus)
+                                   ImageStimulus, PhotovoltaicEncoder,
+                                   PRIMAEncoder, samples, Stimulus)
 from pulse2percept.units import DimensionMismatchError, deg, mW, mm, um, xTh
 from pulse2percept.utils.constants import ZORDER
 from pulse2percept.models.retina import ScoreboardModel
@@ -629,9 +629,39 @@ def test_photovoltaic_arrays_are_stimulated_optically(implant_type):
     implant = implant_type()
     npt.assert_equal(implant.technology, 'photovoltaic')
     npt.assert_equal(implant.stimulus_unit, mW / mm ** 2)
-    npt.assert_equal(isinstance(implant.encoder, PRIMAEncoder), True)
+    npt.assert_equal(isinstance(implant.encoder, PhotovoltaicEncoder), True)
+    # Only the pivotal device is driven by the PRIMA projector:
+    npt.assert_equal(isinstance(implant.encoder, PRIMAEncoder),
+                     isinstance(implant, PRIMAPivotal))
     # All photovoltaic pixels may be illuminated simultaneously.
     npt.assert_equal(implant.raster, None)
+
+
+# optical protocol that each implant's default encoder represents:
+OPTICAL_PROTOCOLS = [
+    # Pivotal PRIMA projector [Holz2026]_:
+    (PRIMAPivotal, (880, 3.5, 30, 9.8)),
+    # Grating experiments of [Lorach2015]_:
+    (Lorach2015Array, (915, 4.0, 40, 4.0)),
+    # Grating experiments of [Ho2019]_:
+    (partial(Ho2019FlatArray, 55), (915, 8.0, 40, 4.0)),
+    (partial(Ho2019FlatArray, 40), (915, 8.0, 40, 4.0)),
+    # Brightest full-field condition of [Huang2021]_:
+    (partial(Huang2021Array, 55), (880, 4.7, 2, 10.0)),
+    (partial(Huang2021Array, 20), (880, 4.7, 2, 10.0)),
+]
+
+
+@pytest.mark.parametrize('implant_type, protocol', OPTICAL_PROTOCOLS)
+def test_photovoltaic_default_protocol(implant_type, protocol):
+    """Each array defaults to its own published stimulation conditions."""
+    encoder = implant_type().encoder
+    wavelength, irradiance, freq, pulse_dur = protocol
+    npt.assert_almost_equal(encoder.wavelength, wavelength)
+    npt.assert_almost_equal(encoder.irradiance, irradiance)
+    npt.assert_almost_equal(encoder.freq, freq)
+    npt.assert_almost_equal(encoder.pulse_dur, pulse_dur)
+    npt.assert_equal(encoder.grayscale, True)
 
 
 @pytest.mark.parametrize('implant_type', PHOTOVOLTAIC)
@@ -664,8 +694,10 @@ def test_photovoltaic_arrays_encode_images(implant_type):
     npt.assert_equal(stim.unit, mW / mm ** 2)
     npt.assert_equal(list(stim.electrodes),
                      list(implant.electrode_array.electrodes))
-    npt.assert_almost_equal(stim.data.max(), 3.5)
+    # A lit pixel sits at the encoder's own peak irradiance:
+    npt.assert_almost_equal(stim.data.max(), implant.encoder.irradiance)
     npt.assert_equal(stim.data.min() >= 0, True)
+    npt.assert_almost_equal(stim._spatial_view().data.max(), 1, decimal=5)
 
 
 @pytest.mark.parametrize('implant_type', PHOTOVOLTAIC)
@@ -699,24 +731,40 @@ def test_photovoltaic_arrays_refuse_light_that_is_not_light(implant_type,
     npt.assert_equal('cannot be negative' in str(excinfo.value), True)
 
 
-@pytest.mark.parametrize('implant_type', PHOTOVOLTAIC)
-def test_photovoltaic_arrays_safe_mode(implant_type):
+def test_PRIMAPivotal_safe_mode_checks_the_projector():
     """safe_mode checks the PRIMA projector envelope, not charge balance."""
     # Light is never charge-balanced, so the electrical check must not run:
-    implant = implant_type(safe_mode=True)
+    implant = PRIMAPivotal(safe_mode=True)
     npt.assert_equal(implant.prepare_stim(samples.logo_bvl()).unit,
                      mW / mm ** 2)
-    # The same envelope applies to every array; no per-array limits:
     for encoder, msg in [(PRIMAEncoder(freq=60), 'duty cycle'),
                          (LooseEncoder(irradiance=5.0), 'exceeds the 3.5')]:
         with pytest.raises(ValueError) as excinfo:
-            implant_type(safe_mode=True,
+            PRIMAPivotal(safe_mode=True,
                          encoder=encoder).prepare_stim(samples.logo_bvl())
         npt.assert_equal(msg in str(excinfo.value), True)
         # Without safe_mode the envelope check is skipped:
         npt.assert_equal(
-            implant_type(encoder=encoder).prepare_stim(
+            PRIMAPivotal(encoder=encoder).prepare_stim(
                 samples.logo_bvl()).unit, mW / mm ** 2)
+
+
+@pytest.mark.parametrize('implant_type', PHOTOVOLTAIC[1:])
+def test_photovoltaic_arrays_have_no_borrowed_safe_mode(implant_type):
+    """Arrays without a published envelope refuse safe_mode.
+
+    The PRIMA projector limits belong to the pivotal system. Applying them to
+    a research array would silently misrepresent that array's own protocol,
+    which is brighter than PRIMA in the Ho and Huang cases.
+    """
+    implant = implant_type(safe_mode=True)
+    with pytest.raises(NotImplementedError) as excinfo:
+        implant.prepare_stim(samples.logo_bvl())
+    npt.assert_equal('safe_mode' in str(excinfo.value), True)
+    npt.assert_equal('PRIMAPivotal' in str(excinfo.value), True)
+    # Its own default protocol is fine without safe_mode:
+    npt.assert_equal(implant_type().prepare_stim(samples.logo_bvl()).unit,
+                     mW / mm ** 2)
 
 
 def test_PRIMA_deprecated_alias_keeps_the_encoder():

--- a/pulse2percept/implants/retina/tests/test_prima.py
+++ b/pulse2percept/implants/retina/tests/test_prima.py
@@ -613,12 +613,110 @@ def test_PRIMAPivotal_rejects_threshold_relative_stimuli():
     npt.assert_equal(ArgusII(encoder=None).prepare_stim(train).unit, xTh)
 
 
-@pytest.mark.parametrize('implant_type', [Lorach2015Array,
-                                          partial(Ho2019FlatArray, 55),
-                                          partial(Huang2021Array, 55)])
-def test_other_photovoltaic_arrays_have_no_encoder(implant_type):
-    # Other photovoltaic arrays do not assume the pivotal PRIMA protocol.
-    npt.assert_equal(implant_type().encoder, None)
+# Constructor variants must not change the optical input pipeline:
+PHOTOVOLTAIC = [PRIMAPivotal,
+                Lorach2015Array,
+                partial(Ho2019FlatArray, 55),
+                partial(Ho2019FlatArray, 40),
+                partial(Huang2021Array, 55),
+                partial(Huang2021Array, 40),
+                partial(Huang2021Array, 30),
+                partial(Huang2021Array, 20)]
+
+
+@pytest.mark.parametrize('implant_type', PHOTOVOLTAIC)
+def test_photovoltaic_arrays_are_stimulated_optically(implant_type):
+    implant = implant_type()
+    npt.assert_equal(implant.technology, 'photovoltaic')
+    npt.assert_equal(implant.stimulus_unit, mW / mm ** 2)
+    npt.assert_equal(isinstance(implant.encoder, PRIMAEncoder), True)
+    # All photovoltaic pixels may be illuminated simultaneously.
+    npt.assert_equal(implant.raster, None)
+
+
+@pytest.mark.parametrize('implant_type', PHOTOVOLTAIC)
+def test_photovoltaic_encoder_is_per_instance(implant_type):
+    a, b = implant_type(), implant_type()
+    npt.assert_equal(a.encoder is b.encoder, False)
+    a.encoder.threshold = 0.9
+    npt.assert_almost_equal(b.encoder.threshold, 0.5)
+
+
+@pytest.mark.parametrize('implant_type', PHOTOVOLTAIC)
+def test_photovoltaic_encoder_opt_out(implant_type):
+    implant = implant_type(encoder=None)
+    npt.assert_equal(implant.encoder, None)
+    # A picture is dimensionless, so nothing turns it into irradiance:
+    with pytest.raises(DimensionMismatchError):
+        implant.prepare_stim(samples.logo_bvl())
+    with pytest.raises(TypeError):
+        implant_type(encoder='binary')
+    # A custom encoder reaches the implant through the usual machinery:
+    implant.encoder = PRIMAEncoder(irradiance=2.0)
+    npt.assert_almost_equal(
+        implant.prepare_stim(samples.logo_bvl()).data.max(), 2.0)
+
+
+@pytest.mark.parametrize('implant_type', PHOTOVOLTAIC)
+def test_photovoltaic_arrays_encode_images(implant_type):
+    implant = implant_type()
+    stim = implant.prepare_stim(samples.logo_bvl())
+    npt.assert_equal(stim.unit, mW / mm ** 2)
+    npt.assert_equal(list(stim.electrodes),
+                     list(implant.electrode_array.electrodes))
+    npt.assert_almost_equal(stim.data.max(), 3.5)
+    npt.assert_equal(stim.data.min() >= 0, True)
+
+
+@pytest.mark.parametrize('implant_type', PHOTOVOLTAIC)
+def test_photovoltaic_arrays_reject_current(implant_type):
+    implant = implant_type()
+    elec = implant.electrode_names[0]
+    with pytest.raises(DimensionMismatchError):
+        implant.prepare_stim({elec: BiphasicPulseTrain(20, 20, 0.45)})
+    with pytest.raises(DimensionMismatchError):
+        implant.prepare_stim({elec: BiphasicPulse(10, 0.45)})
+
+
+@pytest.mark.parametrize('implant_type', PHOTOVOLTAIC)
+@pytest.mark.parametrize('safe_mode', (False, True))
+def test_photovoltaic_arrays_refuse_light_that_is_not_light(implant_type,
+                                                            safe_mode):
+    # Negative or nonfinite irradiance is invalid regardless of safe_mode.
+    implant = implant_type(safe_mode=safe_mode)
+    stim = implant_type().prepare_stim(samples.logo_bvl())
+    for factor in (np.nan, np.inf):
+        with pytest.raises(ValueError) as excinfo:
+            implant.check_stim(stim * factor)
+        npt.assert_equal('non-finite irradiance' in str(excinfo.value), True)
+    negative = Stimulus(stim)
+    negative.metadata = {'user': None}
+    negative._stim = {'data': -np.abs(negative.data),
+                      'electrodes': negative.electrodes,
+                      'time': negative.time}
+    with pytest.raises(ValueError) as excinfo:
+        implant.check_stim(negative)
+    npt.assert_equal('cannot be negative' in str(excinfo.value), True)
+
+
+@pytest.mark.parametrize('implant_type', PHOTOVOLTAIC)
+def test_photovoltaic_arrays_safe_mode(implant_type):
+    """safe_mode checks the PRIMA projector envelope, not charge balance."""
+    # Light is never charge-balanced, so the electrical check must not run:
+    implant = implant_type(safe_mode=True)
+    npt.assert_equal(implant.prepare_stim(samples.logo_bvl()).unit,
+                     mW / mm ** 2)
+    # The same envelope applies to every array; no per-array limits:
+    for encoder, msg in [(PRIMAEncoder(freq=60), 'duty cycle'),
+                         (LooseEncoder(irradiance=5.0), 'exceeds the 3.5')]:
+        with pytest.raises(ValueError) as excinfo:
+            implant_type(safe_mode=True,
+                         encoder=encoder).prepare_stim(samples.logo_bvl())
+        npt.assert_equal(msg in str(excinfo.value), True)
+        # Without safe_mode the envelope check is skipped:
+        npt.assert_equal(
+            implant_type(encoder=encoder).prepare_stim(
+                samples.logo_bvl()).unit, mW / mm ** 2)
 
 
 def test_PRIMA_deprecated_alias_keeps_the_encoder():

--- a/pulse2percept/models/base.py
+++ b/pulse2percept/models/base.py
@@ -256,7 +256,7 @@ def _device_scene(scene, implant):
     if device.shape != scene.shape:
         refuse('shape', scene.shape, device.shape)
     if scene.time is not None:
-        # Same instants, told in whichever unit preprocessing handed back:
+        # Same instants:
         mine = np.asarray(scene.time)
         theirs = np.asarray(as_value(Quantity(np.asarray(device.time),
                                               device.time_unit),
@@ -272,40 +272,37 @@ def _device_scene(scene, implant):
 def _scene_stim(model, scene, gaze):
     """Prepare electrode stimulation sampled from a scene."""
     if not model.has_space:
-        raise ValueError("Registering a scene against an implant needs a "
-                         "spatial model. This model has only a temporal one.")
+        raise ValueError("Scene registration requires a spatial model.")
+
     implant = model.implant
     spatial = model.spatial
-    # Up here rather than next to its use below: a model that cannot register
-    # a scene at all is refused before the scene is preprocessed.
     x_vf, y_vf = spatial._scene_sampling_points()
+
     if implant.encoder is None:
         raise ValueError(
-            "A scene is a picture, and there is no principled default for "
-            "turning a gray level into stimulation. Give the implant an "
-            "'encoder' (e.g. an AmplitudeEncoder, or a PRIMAEncoder for a "
-            "photovoltaic device) to say how.")
+            "Scene input requires an implant encoder.")
+
     device_scene = _device_scene(scene, implant)
     frame = implant.scene_input_frame
     if frame not in ('eye', 'head'):
-        # Validate class defaults as well as instance overrides:
-        raise ValueError(f"This implant's 'scene_input_frame' is {frame!r}, "
-                         f"which says nothing about how gaze registers the "
-                         f"scene onto it; expected 'eye' or 'head'.")
-    # Head-fixed input ignores gaze when sampling, but gaze is still validated:
+        raise ValueError(
+            f"'scene_input_frame' must be 'eye' or 'head', not {frame!r}.")
+
     _gaze_points(gaze, device_scene.n_frames)
     input_gaze = gaze if frame == 'eye' else None
     gray = device_scene._device_input(x_vf, y_vf, gaze=input_gaze)
+
     if device_scene.time is None:
-        # A still scene is sampled as a one-frame movie; a `Stimulus` with no
-        # time axis wants that frame axis gone, or it reads the frame as a
-        # time point:
         gray = gray[:, 0]
-    seen = Stimulus(gray, electrodes=implant.electrode_names,
-                    time=device_scene.time,
-                    metadata=device_scene.source.metadata)
-    # Preprocessing already ran on the scene source. Use a shallow copy with
-    # preprocessing disabled for the remaining preparation steps:
+
+    seen = Stimulus(
+        gray,
+        electrodes=implant.electrode_names,
+        time=device_scene.time,
+        metadata=device_scene.source.metadata,
+    )
+
+    # Scene preprocessing has already been applied.
     device = copy(implant)
     device.preprocess = False
     return device.prepare_stim(seen._inherit_units(device_scene.source))

--- a/pulse2percept/models/retina/beyeler2019.py
+++ b/pulse2percept/models/retina/beyeler2019.py
@@ -90,9 +90,6 @@ class ScoreboardSpatial(RetinalSpatial):
     :math:`\rho` produce broader phosphenes.
 
     For current-driven implants, :math:`a_e` is current amplitude.
-    :py:class:`~pulse2percept.stimuli.PRIMAEncoder` instead provides normalized
-    optical drive. In that case, Scoreboard visualizes the stimulation pattern;
-    it does not model the retinal response.
 
     .. warning::
 
@@ -177,7 +174,8 @@ class ScoreboardSpatial(RetinalSpatial):
     n_jobs : int or None, optional
         Alias for ``n_threads``. ``None`` and -1 use all available CPU cores."""
 
-    #: Also accepts encoded normalized optical drive from PRIMAEncoder.
+    #: Also accepts encoded normalized optical drive from a
+    #: PhotovoltaicEncoder.
     extra_stimulus_units = (dimensionless,)
 
     def __init__(self, implant, *, rho=100, xrange=(-15, 15),
@@ -253,9 +251,6 @@ class ScoreboardModel(Model):
         :math:`\rho` produce broader phosphenes.
 
         For current-driven implants, :math:`a_e` is current amplitude.
-        :py:class:`~pulse2percept.stimuli.PRIMAEncoder` instead provides
-        normalized optical drive. In that case, Scoreboard visualizes the
-        stimulation pattern; it does not model the retinal response.
 
     .. warning::
 

--- a/pulse2percept/models/retina/beyeler2019.py
+++ b/pulse2percept/models/retina/beyeler2019.py
@@ -89,7 +89,11 @@ class ScoreboardSpatial(RetinalSpatial):
     controls the spatial spread of activation. Larger values of
     :math:`\rho` produce broader phosphenes.
 
-    For current-driven implants, :math:`a_e` is current amplitude.
+    For current-driven implants, :math:`a_e` is current amplitude. For
+    photovoltaic implants,
+    :py:class:`~pulse2percept.stimuli.PhotovoltaicEncoder` instead provides
+    normalized optical drive. Scoreboard visualizes the stimulation pattern;
+    it does not model photovoltaic conversion or the retinal response.
 
     .. warning::
 
@@ -250,7 +254,12 @@ class ScoreboardModel(Model):
         controls the spatial spread of activation. Larger values of
         :math:`\rho` produce broader phosphenes.
 
-        For current-driven implants, :math:`a_e` is current amplitude.
+        For current-driven implants, :math:`a_e` is current amplitude. For
+        photovoltaic implants,
+        :py:class:`~pulse2percept.stimuli.PhotovoltaicEncoder` instead
+        provides normalized optical drive. Scoreboard visualizes the
+        stimulation pattern; it does not model photovoltaic conversion or the
+        retinal response.
 
     .. warning::
 

--- a/pulse2percept/stimuli/__init__.py
+++ b/pulse2percept/stimuli/__init__.py
@@ -40,6 +40,7 @@ Convert visual stimuli to electrical stimulation.
     StimulusEncoder
     AmplitudeEncoder
     FrequencyEncoder
+    PhotovoltaicEncoder
     PRIMAEncoder
 
 Psychophysics
@@ -98,7 +99,8 @@ from .pulses import AsymmetricBiphasicPulse, BiphasicPulse, MonophasicPulse
 from .pulse_trains import (PulseTrain, BiphasicPulseTrain,
                            BiphasicTripletTrain, AsymmetricBiphasicPulseTrain)
 from .encoders import (Encoder, StimulusEncoder, AmplitudeEncoder,
-                       FrequencyEncoder, PRIMAEncoder)
+                       FrequencyEncoder, PhotovoltaicEncoder,
+                       PRIMAEncoder)
 from .psychophysics import BarStimulus, GratingStimulus
 from .samples import LogoBVL, LogoUCSB
 from . import psychophysics, samples
@@ -118,6 +120,7 @@ __all__ = [
     'LogoBVL',
     'LogoUCSB',
     'MonophasicPulse',
+    'PhotovoltaicEncoder',
     'PRIMAEncoder',
     'psychophysics',
     'PulseTrain',

--- a/pulse2percept/stimuli/encoders.py
+++ b/pulse2percept/stimuli/encoders.py
@@ -1221,10 +1221,10 @@ class _OpticalStimulus(Stimulus):
         if not math.isfinite(irradiance) or irradiance < 0:
             raise ValueError(f"'irradiance' must be a finite, nonnegative "
                              f"power density, not {irradiance}.")
-        # ON duration (ms) per pixel and projector frame:
+        # ON duration (ms) per pixel and pulse period:
         self._dur = self._own(dur, np.float64)
         self._ticks = self._own(ticks, np.int64)
-        # Onset (ticks) of every projector frame:
+        # Onset (ticks) of every pulse period:
         self._onsets = self._own(onsets, np.int64)
         self._irradiance = irradiance
         self._freq = float(freq)
@@ -1348,7 +1348,7 @@ class _OpticalStimulus(Stimulus):
             lo, hi = bounds[j], bounds[j + 1]
             if hi <= lo:
                 continue
-            # Time since the current projector-frame onset.
+            # Time since the current pulse-period onset.
             since = ticks[lo:hi] - self._onsets[j]
             # Match the one-DT rise/fall convention used by other stimuli.
             np.copyto(data[:, lo:hi], irradiance,

--- a/pulse2percept/stimuli/encoders.py
+++ b/pulse2percept/stimuli/encoders.py
@@ -1387,8 +1387,9 @@ class PhotovoltaicEncoder(Encoder):
         Pulse repetition rate (Hz).
     pulse_dur : float or Quantity
         ON duration (ms) of a fully lit pixel. Must fit into ``1000 / freq``.
-    wavelength : float or Quantity, optional
-        Wavelength (nm) of the illumination.
+    wavelength : float or Quantity
+        Wavelength (nm) of the illumination. Photovoltaic pixel response is
+        wavelength dependent, so there is no generic default.
     grayscale : bool, optional
         If True (default), map gray levels to ON duration. If False, use
         binary off/on encoding.
@@ -1423,7 +1424,7 @@ class PhotovoltaicEncoder(Encoder):
     __slots__ = ('irradiance', 'freq', 'pulse_dur', 'wavelength', 'grayscale',
                  'threshold')
 
-    def __init__(self, irradiance, freq, pulse_dur, wavelength=880 * nm,
+    def __init__(self, irradiance, freq, pulse_dur, wavelength,
                  grayscale=True, threshold=0.5):
         irradiance = as_value(irradiance, _IRRADIANCE, 'irradiance')
         freq = as_value(freq, Hz, 'freq')
@@ -1644,6 +1645,9 @@ class PRIMAEncoder(PhotovoltaicEncoder):
     #: Longest documented ON duration (ms), i.e. 14 steps
     max_pulse_dur = 9.8
 
+    #: Wavelength (nm) the projector illuminates at
+    projector_wavelength = 880.0
+
     #: Peak irradiance (mW/mm^2) of the pivotal-trial projector
     max_irradiance = 3.5
 
@@ -1664,7 +1668,8 @@ class PRIMAEncoder(PhotovoltaicEncoder):
                  pulse_dur=9.8 * ms, grayscale=True, threshold=0.5):
         # Wavelength is a property of the projector, not a setting.
         super().__init__(irradiance=irradiance, freq=freq,
-                         pulse_dur=pulse_dur, wavelength=880 * nm,
+                         pulse_dur=pulse_dur,
+                         wavelength=self.projector_wavelength * nm,
                          grayscale=grayscale, threshold=threshold)
 
     def _pprint_params(self):

--- a/pulse2percept/stimuli/encoders.py
+++ b/pulse2percept/stimuli/encoders.py
@@ -2,6 +2,7 @@
    :py:class:`~pulse2percept.stimuli.StimulusEncoder`,
    :py:class:`~pulse2percept.stimuli.AmplitudeEncoder`,
    :py:class:`~pulse2percept.stimuli.FrequencyEncoder`,
+   :py:class:`~pulse2percept.stimuli.PhotovoltaicEncoder`,
    :py:class:`~pulse2percept.stimuli.PRIMAEncoder`"""
 from abc import ABCMeta, abstractmethod
 import math
@@ -11,7 +12,7 @@ from copy import deepcopy
 from .base import ImageStimulus, Stimulus, VideoStimulus, _adoptable
 from .pulses import BiphasicPulse
 from ..units import (DimensionMismatchError, Hz, as_value, dimensionless, mW,
-                     mm, ms, uA, xTh)
+                     mm, ms, nm, uA, xTh)
 from ..utils import PrettyPrint, frame_interval
 # Point encoder warnings at the caller.
 from ..utils.deprecation import _warn_external
@@ -1197,10 +1198,10 @@ class _NormalizedStimulus(Stimulus):
 
 
 class _OpticalStimulus(Stimulus):
-    """Lazy PRIMA projector schedule.
+    """Lazy pulsed-illumination schedule.
 
-    Stores per-pixel ON duration for each projector frame, peak irradiance, and
-    frame rate. Waveform samples are generated on demand.
+    Stores per-pixel ON duration for each pulse period, peak irradiance, and
+    repetition rate. Waveform samples are generated on demand.
     """
     #: described by its schedule rather than by its samples
     _is_parametric = True
@@ -1255,17 +1256,17 @@ class _OpticalStimulus(Stimulus):
 
     @property
     def freq(self):
-        """Projector frame rate (Hz)"""
+        """Pulse repetition rate (Hz)"""
         return self._freq
 
     @property
     def pulse_dur(self):
-        """ON duration (ms) of every pixel, one column per projector frame"""
+        """ON duration (ms) of every pixel, one column per pulse period"""
         return self._dur
 
     @property
     def duty_cycle(self):
-        """Fraction of each projector period every pixel spends on"""
+        """Fraction of each pulse period every pixel spends on"""
         return self._dur * self._freq / MS_PER_S
 
     @property
@@ -1292,7 +1293,7 @@ class _OpticalStimulus(Stimulus):
         drive = (self._irradiance * self.duty_cycle / self._ref_drive).astype(
             np.float32)
         if self._static:
-            # Collapse repeated projector periods for a static source.
+            # Collapse repeated pulse periods for a static source.
             stim = _NormalizedStimulus(drive[:, 0].ravel(),
                                        electrodes=self.electrodes)
         else:
@@ -1318,9 +1319,9 @@ class _OpticalStimulus(Stimulus):
         factor = float(factor)
         if not math.isfinite(factor) or factor < 0:
             raise ValueError(f"Scaling an optical stimulus by {factor} would "
-                             f"ask the projector for a negative or undefined "
-                             f"irradiance. Only nonnegative, finite factors "
-                             f"describe light.")
+                             f"ask for a negative or undefined irradiance. "
+                             f"Only nonnegative, finite factors describe "
+                             f"light.")
         return self._rebuilt(self.electrodes, self._dur,
                              self._irradiance * factor)
 
@@ -1334,13 +1335,13 @@ class _OpticalStimulus(Stimulus):
         """Expand the schedule into rectangular pulses."""
         ticks = np.asarray(self._ticks)
         n_frames = self._onsets.size
-        # Map stored time points to projector frames.
+        # Map stored time points to pulse periods.
         at = np.searchsorted(self._onsets, ticks, side='right') - 1
         np.clip(at, 0, n_frames - 1, out=at)
         # Keep durations per frame to avoid an n_electrodes x n_time int64 array.
         dur = np.round(self._dur / DT).astype(np.int64)
         data = np.zeros((dur.shape[0], ticks.size), dtype=np.float32)
-        # Each projector frame occupies a contiguous time span.
+        # Each pulse period occupies a contiguous time span.
         bounds = np.searchsorted(at, np.arange(n_frames + 1))
         irradiance = np.float32(self._irradiance)
         for j in range(n_frames):
@@ -1367,79 +1368,67 @@ class _OpticalStimulus(Stimulus):
                 'metadata': self.metadata}
 
 
-class PRIMAEncoder(Encoder):
-    """Encode image/video gray levels for the PRIMA projector.
+class PhotovoltaicEncoder(Encoder):
+    """Encode image/video gray levels as pulsed optical stimulation
 
-    PRIMA uses 880 nm illumination rather than injected current. The projector
-    uses fixed peak irradiance and pulse-width modulation [Palanker2020]_,
-    [Holz2026]_. This encoder returns irradiance in ``mW/mm^2``.
+    Photovoltaic subretinal arrays are driven by pulsed near-infrared light.
+    This encoder samples an image or video at the implant's pixel locations
+    and returns irradiance in ``mW/mm^2``.
+    Peak irradiance is fixed; gray level sets the ON duration within each
+    pulse period.
 
     .. versionadded:: 0.11.0
 
     Parameters
     ----------
-    irradiance : float or Quantity, optional
+    irradiance : float or Quantity
         Peak irradiance (mW/mm^2) while a pixel is on.
-    freq : float or Quantity, optional
-        Projector frame rate (Hz).
-    pulse_dur : float or Quantity, optional
-        Maximum ON duration (ms). Must lie on the ``pulse_step`` grid and not
-        exceed ``max_pulse_dur``.
+    freq : float or Quantity
+        Pulse repetition rate (Hz).
+    pulse_dur : float or Quantity
+        ON duration (ms) of a fully lit pixel. Must fit into ``1000 / freq``.
+    wavelength : float or Quantity, optional
+        Wavelength (nm) of the illumination.
     grayscale : bool, optional
-        If True (default), map gray levels to pulse duration. If False, use
+        If True (default), map gray levels to ON duration. If False, use
         binary off/on encoding.
     threshold : float, optional
         Binary-mode threshold. The default 0.5 is a pulse2percept convention.
 
     Notes
     -----
-    *  Pivotal-system defaults are 3.5 mW/mm^2, 30 Hz, and 14 nonzero ON
-       durations from 0.7 to 9.8 ms.
-    *  Grayscale mode maps normalized intensity linearly to these duration
-       levels. The clinical camera-to-pulse-duration transfer function is not
-       published.
-    *  Videos are sampled at the projector clock using zero-order hold.
-    *  ``_spatial_view`` returns normalized time-averaged optical drive for
-       spatial models. It is neither retinal current nor perceptual brightness.
-    *  Clinical image preprocessing is outside this encoder.
+    *  Grayscale mode scales ON duration linearly, ``gray * pulse_dur``. The
+       studies these arrays come from report fixed-duration pulses and do not
+       specify a natural-image grayscale transfer function, so this mapping is
+       a pulse2percept simulation convention, not the experimental encoding
+       protocol. Because durations are continuous, an image with many gray
+       levels produces more distinct time points than a device that quantizes
+       duration (see :py:class:`~pulse2percept.stimuli.PRIMAEncoder`).
+    *  Videos are sampled at the pulse rate using zero-order hold.
+    *  ``_spatial_view`` returns normalized time-averaged optical drive, where
+       1.0 is a fully lit pixel at these settings (``ref_drive``). It is
+       neither retinal current nor perceptual brightness.
+    *  Photovoltaic conversion to retinal current is not modeled.
 
     Examples
     --------
-    >>> from pulse2percept.implants.retina import PRIMAPivotal
-    >>> from pulse2percept.stimuli import PRIMAEncoder, samples
-    >>> PRIMAEncoder().encode(samples.logo_bvl(), implant=PRIMAPivotal()).unit
+    >>> from pulse2percept.implants.retina import Lorach2015Array
+    >>> from pulse2percept.stimuli import PhotovoltaicEncoder, samples
+    >>> encoder = PhotovoltaicEncoder(irradiance=4, freq=40, pulse_dur=4,
+    ...                               wavelength=915)
+    >>> encoder.encode(samples.logo_bvl(), implant=Lorach2015Array()).unit
     mW/mm^2
 
     """
-    #: Wavelength (nm) of the projected near-infrared light
-    wavelength = 880.0
+    __slots__ = ('irradiance', 'freq', 'pulse_dur', 'wavelength', 'grayscale',
+                 'threshold')
 
-    #: Smallest nonzero ON duration (ms) the projector can produce; every other
-    #: duration is a whole multiple of it
-    pulse_step = 0.7
-
-    #: Longest documented ON duration (ms), i.e. 14 steps
-    max_pulse_dur = 9.8
-
-    #: Peak irradiance (mW/mm^2) of the pivotal-trial projector
-    max_irradiance = 3.5
-
-    #: Frame rate (Hz) of the pivotal-trial projector
-    max_freq = 30.0
-
-    #: Largest documented duty cycle, ``max_freq * max_pulse_dur``
-    max_duty_cycle = max_freq * max_pulse_dur / MS_PER_S
-
-    #: Time-averaged irradiance (mW/mm^2) the normalized spatial view calls 1.0
-    ref_drive = max_irradiance * max_duty_cycle
-
-    __slots__ = ('irradiance', 'freq', 'pulse_dur', 'grayscale', 'threshold')
-
-    def __init__(self, irradiance=3.5 * mW / mm ** 2, freq=30 * Hz,
-                 pulse_dur=9.8 * ms, grayscale=True, threshold=0.5):
+    def __init__(self, irradiance, freq, pulse_dur, wavelength=880 * nm,
+                 grayscale=True, threshold=0.5):
         irradiance = as_value(irradiance, _IRRADIANCE, 'irradiance')
         freq = as_value(freq, Hz, 'freq')
         pulse_dur = as_value(pulse_dur, ms, 'pulse_dur')
+        wavelength = as_value(wavelength, nm, 'wavelength')
         threshold = as_value(threshold, dimensionless, 'threshold')
         _finite('irradiance', irradiance)
         if irradiance <= 0:
@@ -1447,27 +1436,14 @@ class PRIMAEncoder(Encoder):
         _finite('freq', freq)
         if freq <= 0:
             raise ValueError("'freq' must be positive.")
+        _finite('wavelength', wavelength)
+        if wavelength <= 0:
+            raise ValueError("'wavelength' must be positive.")
         _finite('pulse_dur', pulse_dur)
         if pulse_dur < 0:
             raise ValueError("'pulse_dur' cannot be negative.")
         if pulse_dur > 0:
-            # Require exact hardware-grid durations; do not round silently.
-            steps = pulse_dur / self.pulse_step
-            if abs(steps - round(steps)) > 1e-9:
-                raise ValueError(
-                    f"'pulse_dur' must be a whole multiple of "
-                    f"{self.pulse_step} ms, the step the projector modulates "
-                    f"in, not {pulse_dur:g} ms.")
-            if pulse_dur > self.max_pulse_dur + 1e-9:
-                raise ValueError(
-                    f"'pulse_dur' cannot exceed {self.max_pulse_dur} ms, the "
-                    f"longest documented ON duration, not {pulse_dur:g} ms.")
-            period = MS_PER_S / freq
-            if pulse_dur >= period:
-                raise ValueError(
-                    f"A {pulse_dur:g} ms pulse does not fit into the "
-                    f"{period:.3f} ms period of a {freq:g} Hz projector. "
-                    f"Shorten 'pulse_dur' or lower 'freq'.")
+            self._check_pulse_dur(pulse_dur, freq)
         _finite('threshold', threshold)
         if not 0 <= threshold <= 1:
             raise ValueError(f"'threshold' must be a gray level in [0, 1], "
@@ -1475,37 +1451,53 @@ class PRIMAEncoder(Encoder):
         self.irradiance = irradiance
         self.freq = freq
         self.pulse_dur = pulse_dur
+        self.wavelength = wavelength
         self.grayscale = bool(grayscale)
         self.threshold = threshold
 
     def _pprint_params(self):
         """Return a dict of class arguments to pretty-print"""
         return {'irradiance': self.irradiance, 'freq': self.freq,
-                'pulse_dur': self.pulse_dur, 'grayscale': self.grayscale,
-                'threshold': self.threshold}
+                'pulse_dur': self.pulse_dur, 'wavelength': self.wavelength,
+                'grayscale': self.grayscale, 'threshold': self.threshold}
+
+    def _check_pulse_dur(self, pulse_dur, freq):
+        """Reject a pulse (ms) that does not fit into one period"""
+        period = MS_PER_S / freq
+        if pulse_dur >= period:
+            raise ValueError(
+                f"A {pulse_dur:g} ms pulse does not fit into the "
+                f"{period:.3f} ms period of a {freq:g} Hz pulse train. "
+                f"Shorten 'pulse_dur' or lower 'freq'.")
 
     @property
     def period(self):
-        """Projector period (ms)"""
+        """Pulse period (ms)"""
         return MS_PER_S / self.freq
 
     @property
-    def n_levels(self):
-        """Number of nonzero ON durations available up to ``pulse_dur``"""
-        return int(round(self.pulse_dur / self.pulse_step))
+    def ref_drive(self):
+        """Time-averaged irradiance (mW/mm^2) the normalized view calls 1.0
+
+        A fully lit pixel at these settings. Devices with a documented
+        projector maximum normalize against that maximum instead.
+        """
+        drive = self.irradiance * self.pulse_dur * self.freq / MS_PER_S
+        # A dark schedule has nothing to normalize by; its drive is 0 anyway.
+        return drive if drive > 0 else 1.0
 
     def _durations(self, gray):
         """Map gray levels in [0, 1] to ON durations (ms)
 
         Binary mode lights a pixel for the full ``pulse_dur``; grayscale mode
-        pulse-width modulates onto the projector's own duration grid.
+        scales it linearly, which is a pulse2percept convention.
         """
-        # Use float64 so durations land exactly on the hardware grid.
+        # Use float64 so durations survive rounding onto the DT time grid.
         gray = np.asarray(gray, dtype=np.float64)
         if not self.grayscale:
             return np.where(gray >= self.threshold, self.pulse_dur, 0.0)
         # Gray levels are already clipped to [0, 1].
-        return np.round(gray * self.n_levels) * self.pulse_step
+        return gray * self.pulse_dur
 
     def encode(self, source, implant=None):
         """Encode an image or a video as near-infrared irradiance
@@ -1546,12 +1538,12 @@ class PRIMAEncoder(Encoder):
         total = float(frame_time[-1] + frame_dur)
         n_periods = max(1, int(np.ceil((total - start) / period - 1e-9)))
         onset_ms = start + np.arange(n_periods, dtype=np.float64) * period
-        # Sample source frames at projector onsets using zero-order hold.
+        # Sample source frames at pulse onsets using zero-order hold.
         at = np.searchsorted(frame_time, onset_ms, side='right') - 1
         np.clip(at, 0, frame_time.size - 1, out=at)
         dur = self._durations(gray[:, at])
 
-        # Round absolute onsets to DT to avoid accumulated 30 Hz period error.
+        # Round absolute onsets to DT to avoid accumulated period error.
         onsets = np.round(onset_ms / DT).astype(np.int64)
         end = int(np.round(total / DT))
         dur_ticks = np.round(dur / DT).astype(np.int64)
@@ -1577,18 +1569,139 @@ class PRIMAEncoder(Encoder):
             _warn_external(
                 f"This stimulus has {n_time} time points, which every model "
                 f"downstream will pay for. A lower 'freq' or a shorter source "
-                f"is the lever that helps most; in grayscale mode, so is a "
-                f"shorter 'pulse_dur', which offers fewer distinct durations.",
-                category=UserWarning)
+                f"is the lever that helps most; so is a source with fewer "
+                f"distinct gray levels, since each one needs its own ON "
+                f"duration.", category=UserWarning)
         if n_el * n_time > _BIG_STIM and implant is None:
             _warn_external(
                 f"Encoding {n_el} pixels x {n_time} time points will allocate "
                 f"{n_el * n_time * 4 / 1e9:.1f} GB. Pass 'implant' to encode "
                 f"at pixel resolution instead.", category=UserWarning)
 
-        # Keep the projector schedule lazy; render waveform samples on demand.
+        # Keep the pulse schedule lazy; render waveform samples on demand.
         return _OpticalStimulus(
             electrodes, dur, ticks, onsets, self.irradiance, self.freq,
             self.wavelength, self.grayscale, total, static,
             np.zeros(1) if static else onset_ms,
             total if static else period, self.ref_drive)
+
+
+class PRIMAEncoder(PhotovoltaicEncoder):
+    """Encode image/video gray levels for the PRIMA projector.
+
+    PRIMA uses 880 nm illumination rather than injected current. The projector
+    uses fixed peak irradiance and pulse-width modulation [Palanker2020]_,
+    [Holz2026]_. This encoder returns irradiance in ``mW/mm^2``.
+
+    Unlike the generic
+    :py:class:`~pulse2percept.stimuli.PhotovoltaicEncoder`, ON durations are
+    quantized onto the projector's own 0.7 ms duration grid, and normalized
+    drive is referenced to the projector maximum rather than to these
+    settings.
+
+    .. versionadded:: 0.11.0
+
+    Parameters
+    ----------
+    irradiance : float or Quantity, optional
+        Peak irradiance (mW/mm^2) while a pixel is on.
+    freq : float or Quantity, optional
+        Projector frame rate (Hz).
+    pulse_dur : float or Quantity, optional
+        Maximum ON duration (ms). Must lie on the ``pulse_step`` grid and not
+        exceed ``max_pulse_dur``.
+    grayscale : bool, optional
+        If True (default), map gray levels to pulse duration. If False, use
+        binary off/on encoding.
+    threshold : float, optional
+        Binary-mode threshold. The default 0.5 is a pulse2percept convention.
+
+    Notes
+    -----
+    *  Pivotal-system defaults are 3.5 mW/mm^2, 30 Hz, and 14 nonzero ON
+       durations from 0.7 to 9.8 ms.
+    *  Grayscale mode maps normalized intensity linearly to these duration
+       levels. The clinical camera-to-pulse-duration transfer function is not
+       published.
+    *  Videos are sampled at the projector clock using zero-order hold.
+    *  ``_spatial_view`` returns normalized time-averaged optical drive for
+       spatial models. It is neither retinal current nor perceptual
+       brightness.
+    *  Clinical image preprocessing is outside this encoder.
+
+    Examples
+    --------
+    >>> from pulse2percept.implants.retina import PRIMAPivotal
+    >>> from pulse2percept.stimuli import PRIMAEncoder, samples
+    >>> PRIMAEncoder().encode(samples.logo_bvl(), implant=PRIMAPivotal()).unit
+    mW/mm^2
+
+    """
+    #: Smallest nonzero ON duration (ms) the projector can produce; every other
+    #: duration is a whole multiple of it
+    pulse_step = 0.7
+
+    #: Longest documented ON duration (ms), i.e. 14 steps
+    max_pulse_dur = 9.8
+
+    #: Peak irradiance (mW/mm^2) of the pivotal-trial projector
+    max_irradiance = 3.5
+
+    #: Frame rate (Hz) of the pivotal-trial projector
+    max_freq = 30.0
+
+    #: Largest documented duty cycle, ``max_freq * max_pulse_dur``
+    max_duty_cycle = max_freq * max_pulse_dur / MS_PER_S
+
+    #: Time-averaged irradiance (mW/mm^2) the normalized spatial view calls
+    #: 1.0. Fixed at the projector maximum, so lowering any setting lowers the
+    #: normalized drive.
+    ref_drive = max_irradiance * max_duty_cycle
+
+    __slots__ = ()
+
+    def __init__(self, irradiance=3.5 * mW / mm ** 2, freq=30 * Hz,
+                 pulse_dur=9.8 * ms, grayscale=True, threshold=0.5):
+        # Wavelength is a property of the projector, not a setting.
+        super().__init__(irradiance=irradiance, freq=freq,
+                         pulse_dur=pulse_dur, wavelength=880 * nm,
+                         grayscale=grayscale, threshold=threshold)
+
+    def _pprint_params(self):
+        """Return a dict of class arguments to pretty-print"""
+        return {'irradiance': self.irradiance, 'freq': self.freq,
+                'pulse_dur': self.pulse_dur, 'grayscale': self.grayscale,
+                'threshold': self.threshold}
+
+    def _check_pulse_dur(self, pulse_dur, freq):
+        """Also require an exact duration from the projector's own grid"""
+        # Require exact hardware-grid durations; do not round silently.
+        steps = pulse_dur / self.pulse_step
+        if abs(steps - round(steps)) > 1e-9:
+            raise ValueError(
+                f"'pulse_dur' must be a whole multiple of "
+                f"{self.pulse_step} ms, the step the projector modulates "
+                f"in, not {pulse_dur:g} ms.")
+        if pulse_dur > self.max_pulse_dur + 1e-9:
+            raise ValueError(
+                f"'pulse_dur' cannot exceed {self.max_pulse_dur} ms, the "
+                f"longest documented ON duration, not {pulse_dur:g} ms.")
+        super()._check_pulse_dur(pulse_dur, freq)
+
+    @property
+    def n_levels(self):
+        """Number of nonzero ON durations available up to ``pulse_dur``"""
+        return int(round(self.pulse_dur / self.pulse_step))
+
+    def _durations(self, gray):
+        """Map gray levels in [0, 1] to ON durations (ms)
+
+        Binary mode lights a pixel for the full ``pulse_dur``; grayscale mode
+        pulse-width modulates onto the projector's own duration grid.
+        """
+        # Use float64 so durations land exactly on the hardware grid.
+        gray = np.asarray(gray, dtype=np.float64)
+        if not self.grayscale:
+            return np.where(gray >= self.threshold, self.pulse_dur, 0.0)
+        # Gray levels are already clipped to [0, 1].
+        return np.round(gray * self.n_levels) * self.pulse_step

--- a/pulse2percept/stimuli/tests/test_encoders.py
+++ b/pulse2percept/stimuli/tests/test_encoders.py
@@ -12,14 +12,15 @@ from pulse2percept.implants.retina import ArgusII, PRIMAPivotal
 from pulse2percept.stimuli import (AmplitudeEncoder, BiphasicPulse,
                                    BiphasicPulseTrain, Encoder,
                                    FrequencyEncoder, ImageStimulus,
-                                   MonophasicPulse, PRIMAEncoder, Stimulus,
-                                   StimulusEncoder, VideoStimulus)
+                                   MonophasicPulse, PhotovoltaicEncoder,
+                                   PRIMAEncoder, Stimulus, StimulusEncoder,
+                                   VideoStimulus)
 from pulse2percept.stimuli import encoders
 from pulse2percept.utils.constants import DT
 from pulse2percept.utils.testing import assert_warns_msg
 from pulse2percept.units import (DimensionMismatchError, Hz, Quantity, W,
-                                 dimensionless, kHz, m, mA, mW, mm, ms, uA,
-                                 us, xTh)
+                                 dimensionless, kHz, m, mA, mW, mm, ms, nm,
+                                 uA, us, xTh)
 from pulse2percept.units import s as sec
 
 
@@ -1368,6 +1369,104 @@ def test_encoded_stimulus_survives_preparation_unrendered():
     stim = ArgusII(encoder=AmplitudeEncoder()).prepare_stim(img)
     npt.assert_equal(_rendered(stim), False)
     npt.assert_equal(stim.data.shape[0], 60)
+
+
+# -----------------------------------------------------------------------------
+# PhotovoltaicEncoder
+# -----------------------------------------------------------------------------
+
+def test_PhotovoltaicEncoder():
+    encoder = PhotovoltaicEncoder(irradiance=4, freq=40, pulse_dur=4,
+                                  wavelength=915)
+    npt.assert_almost_equal(encoder.irradiance, 4)
+    npt.assert_almost_equal(encoder.freq, 40)
+    npt.assert_almost_equal(encoder.pulse_dur, 4)
+    npt.assert_almost_equal(encoder.wavelength, 915)
+    npt.assert_almost_equal(encoder.period, 25)
+    # Normalized drive is referenced to a fully lit pixel at these settings.
+    npt.assert_almost_equal(encoder.ref_drive, 4 * 4 * 40 / 1000)
+    npt.assert_equal(encoder.grayscale, True)
+    npt.assert_equal(isinstance(encoder, Encoder), True)
+    npt.assert_equal(isinstance(encoder, StimulusEncoder), False)
+    npt.assert_equal('PhotovoltaicEncoder' in str(encoder), True)
+    npt.assert_equal('wavelength' in str(encoder), True)
+
+    # Unitful and bare parameters are equivalent.
+    unitful = PhotovoltaicEncoder(irradiance=4000 * W / m ** 2,
+                                  freq=0.04 * kHz, pulse_dur=4000 * us,
+                                  wavelength=915 * nm)
+    npt.assert_almost_equal(unitful.irradiance, 4)
+    npt.assert_almost_equal(unitful.freq, 40)
+    npt.assert_almost_equal(unitful.pulse_dur, 4)
+    npt.assert_almost_equal(unitful.wavelength, 915)
+
+
+@pytest.mark.parametrize('kwargs', [
+    {'irradiance': 0}, {'irradiance': -1}, {'irradiance': np.inf},
+    {'freq': 0}, {'freq': -40}, {'freq': np.nan},
+    {'pulse_dur': -4}, {'pulse_dur': np.inf},
+    {'pulse_dur': 30},        # does not fit into a 25 ms period
+    {'wavelength': 0}, {'wavelength': -915},
+    {'threshold': -0.1}, {'threshold': 1.5},
+])
+def test_PhotovoltaicEncoder_rejects(kwargs):
+    settings = {'irradiance': 4, 'freq': 40, 'pulse_dur': 4}
+    settings.update(kwargs)
+    with pytest.raises(ValueError):
+        PhotovoltaicEncoder(**settings)
+
+
+@pytest.mark.parametrize('pulse_dur, freq', [(4, 40), (10, 2)])
+def test_PhotovoltaicEncoder_is_not_bound_to_the_PRIMA_grid(pulse_dur, freq):
+    """Durations off the 0.7 ms PRIMA grid are ordinary optical protocols."""
+    with pytest.raises(ValueError):
+        PRIMAEncoder(pulse_dur=pulse_dur, freq=freq)
+    encoder = PhotovoltaicEncoder(irradiance=4, freq=freq,
+                                  pulse_dur=pulse_dur)
+    stim = encoder.encode(ImageStimulus(np.ones((16, 16))),
+                          implant=PRIMAPivotal())
+    npt.assert_almost_equal(stim.pulse_dur.max(), pulse_dur)
+    npt.assert_almost_equal(on_intervals(stim)[0], pulse_dur, decimal=6)
+
+
+def test_PhotovoltaicEncoder_grayscale_is_continuous():
+    """Gray levels scale ON duration linearly, without quantization."""
+    implant = PRIMAPivotal()
+    ramp = np.tile(np.linspace(0, 1, 64), (64, 1))
+    encoder = PhotovoltaicEncoder(irradiance=4, freq=40, pulse_dur=4)
+    stim = encoder.encode(ImageStimulus(ramp), implant=implant)
+    gray = implant.reshape_stim(ImageStimulus(ramp)).data
+    npt.assert_almost_equal(stim.pulse_dur[:, :1], gray * 4, decimal=6)
+    # More distinct durations than PRIMA's 14 duration levels allow:
+    npt.assert_equal(np.unique(np.round(stim.pulse_dur, 6)).size > 14, True)
+    # Gray level changes duration, not peak irradiance.
+    lit = stim.data[stim.data > 0]
+    npt.assert_almost_equal(np.unique(np.round(lit, 6)), np.array([4.0]))
+
+    # Binary mode lights a pixel for the full duration or not at all.
+    binary = PhotovoltaicEncoder(irradiance=4, freq=40, pulse_dur=4,
+                                 grayscale=False, threshold=0.5)
+    dur = binary.encode(ImageStimulus(ramp), implant=implant).pulse_dur
+    npt.assert_almost_equal(np.unique(np.round(dur, 6)), np.array([0.0, 4.0]))
+
+
+def test_PhotovoltaicEncoder_spatial_view():
+    implant = PRIMAPivotal()
+    ramp = np.tile(np.linspace(0, 1, 64), (64, 1))
+    encoder = PhotovoltaicEncoder(irradiance=4, freq=40, pulse_dur=4)
+    view = encoder.encode(ImageStimulus(ramp),
+                          implant=implant)._spatial_view()
+    npt.assert_equal(view.unit, dimensionless)
+    npt.assert_almost_equal(view.data.min(), 0)
+    npt.assert_almost_equal(view.data.max(), 1, decimal=6)
+    # 1.0 is a fully lit pixel at these settings, so halving the gray level
+    # halves the drive, but halving the irradiance does not change the scale.
+    half = encoder.encode(ImageStimulus(np.full((8, 8), 0.5)),
+                          implant=implant)._spatial_view()
+    npt.assert_almost_equal(half.data.max(), 0.5, decimal=6)
+    dim = PhotovoltaicEncoder(irradiance=2, freq=40, pulse_dur=4).encode(
+        ImageStimulus(np.ones((8, 8))), implant=implant)._spatial_view()
+    npt.assert_almost_equal(dim.data.max(), 1, decimal=6)
 
 
 # -----------------------------------------------------------------------------

--- a/pulse2percept/stimuli/tests/test_encoders.py
+++ b/pulse2percept/stimuli/tests/test_encoders.py
@@ -1410,10 +1410,17 @@ def test_PhotovoltaicEncoder():
     {'threshold': -0.1}, {'threshold': 1.5},
 ])
 def test_PhotovoltaicEncoder_rejects(kwargs):
-    settings = {'irradiance': 4, 'freq': 40, 'pulse_dur': 4}
+    settings = {'irradiance': 4, 'freq': 40, 'pulse_dur': 4,
+                'wavelength': 915}
     settings.update(kwargs)
     with pytest.raises(ValueError):
         PhotovoltaicEncoder(**settings)
+
+
+def test_PhotovoltaicEncoder_needs_a_wavelength():
+    """There is no generic default; each device names its own."""
+    with pytest.raises(TypeError):
+        PhotovoltaicEncoder(irradiance=4, freq=40, pulse_dur=4)
 
 
 @pytest.mark.parametrize('pulse_dur, freq', [(4, 40), (10, 2)])
@@ -1422,7 +1429,7 @@ def test_PhotovoltaicEncoder_is_not_bound_to_the_PRIMA_grid(pulse_dur, freq):
     with pytest.raises(ValueError):
         PRIMAEncoder(pulse_dur=pulse_dur, freq=freq)
     encoder = PhotovoltaicEncoder(irradiance=4, freq=freq,
-                                  pulse_dur=pulse_dur)
+                                  pulse_dur=pulse_dur, wavelength=915)
     stim = encoder.encode(ImageStimulus(np.ones((16, 16))),
                           implant=PRIMAPivotal())
     npt.assert_almost_equal(stim.pulse_dur.max(), pulse_dur)
@@ -1433,7 +1440,8 @@ def test_PhotovoltaicEncoder_grayscale_is_continuous():
     """Gray levels scale ON duration linearly, without quantization."""
     implant = PRIMAPivotal()
     ramp = np.tile(np.linspace(0, 1, 64), (64, 1))
-    encoder = PhotovoltaicEncoder(irradiance=4, freq=40, pulse_dur=4)
+    encoder = PhotovoltaicEncoder(irradiance=4, freq=40, pulse_dur=4,
+                                  wavelength=915)
     stim = encoder.encode(ImageStimulus(ramp), implant=implant)
     gray = implant.reshape_stim(ImageStimulus(ramp)).data
     npt.assert_almost_equal(stim.pulse_dur[:, :1], gray * 4, decimal=6)
@@ -1445,7 +1453,8 @@ def test_PhotovoltaicEncoder_grayscale_is_continuous():
 
     # Binary mode lights a pixel for the full duration or not at all.
     binary = PhotovoltaicEncoder(irradiance=4, freq=40, pulse_dur=4,
-                                 grayscale=False, threshold=0.5)
+                                 wavelength=915, grayscale=False,
+                                 threshold=0.5)
     dur = binary.encode(ImageStimulus(ramp), implant=implant).pulse_dur
     npt.assert_almost_equal(np.unique(np.round(dur, 6)), np.array([0.0, 4.0]))
 
@@ -1453,7 +1462,8 @@ def test_PhotovoltaicEncoder_grayscale_is_continuous():
 def test_PhotovoltaicEncoder_spatial_view():
     implant = PRIMAPivotal()
     ramp = np.tile(np.linspace(0, 1, 64), (64, 1))
-    encoder = PhotovoltaicEncoder(irradiance=4, freq=40, pulse_dur=4)
+    encoder = PhotovoltaicEncoder(irradiance=4, freq=40, pulse_dur=4,
+                                  wavelength=915)
     view = encoder.encode(ImageStimulus(ramp),
                           implant=implant)._spatial_view()
     npt.assert_equal(view.unit, dimensionless)
@@ -1464,7 +1474,8 @@ def test_PhotovoltaicEncoder_spatial_view():
     half = encoder.encode(ImageStimulus(np.full((8, 8), 0.5)),
                           implant=implant)._spatial_view()
     npt.assert_almost_equal(half.data.max(), 0.5, decimal=6)
-    dim = PhotovoltaicEncoder(irradiance=2, freq=40, pulse_dur=4).encode(
+    dim = PhotovoltaicEncoder(irradiance=2, freq=40, pulse_dur=4,
+                              wavelength=915).encode(
         ImageStimulus(np.ones((8, 8))), implant=implant)._spatial_view()
     npt.assert_almost_equal(dim.data.max(), 1, decimal=6)
 
@@ -1492,6 +1503,7 @@ def test_PRIMAEncoder():
     npt.assert_equal(encoder.grayscale, True)
     npt.assert_almost_equal(encoder.threshold, 0.5)
     npt.assert_almost_equal(encoder.period, 1000 / 30)
+    npt.assert_almost_equal(encoder.wavelength, 880)
     npt.assert_equal(encoder.n_levels, 14)
     npt.assert_equal(isinstance(encoder, Encoder), True)
     # PRIMAEncoder is not an electrical StimulusEncoder.


### PR DESCRIPTION
This PR adds a generic `PhotovoltaicEncoder` for pulsed NIR stimulation and keeps `PRIMAEncoder` as the pivotal PRIMA projector specialization.

`Lorach2015Array`, `Ho2019FlatArray`, and `Huang2021Array` now:

* use irradiance in `mW/mm²` rather than electrical current
* default to `PhotovoltaicEncoder` settings based on their published stimulation protocols
* preserve `encoder=None` for manual optical stimulation
* reject negative/non-finite irradiance and electrical pulse stimuli

`PRIMAPivotal` continues to default to `PRIMAEncoder`, including its 880 nm, 0.7 ms duration grid, and documented projector envelope under `safe_mode`.

The generic encoder uses continuous linear PWM for grayscale input as an explicit pulse2percept simulation convention where the source papers do not specify a natural-image transfer function.