### PR TITLE
[OPT] Speed up scene composition and grayscale video loading

### DIFF
--- a/doc/users/release_notes.rst
+++ b/doc/users/release_notes.rst
@@ -181,7 +181,7 @@ Scene and plotting
   configurable backgrounds, inpainting, eccentricity rings, and static or
   animated visualization. Inpainting is intentionally unavailable when
   composing prosthetic vision because its interaction with prosthetic
-  brightness is not modeled (:pull:`871`, :pull:`884`, :pull:`892`).
+  brightness is not modeled (:pull:`871`, :pull:`884`, :pull:`893`).
 
 * ``Scene(aperture='circle')`` renders an eye-centered disc of radius
   ``min(fov) / 2`` instead of the full rectangle (:pull:`890`).

--- a/doc/users/release_notes.rst
+++ b/doc/users/release_notes.rst
@@ -181,7 +181,7 @@ Scene and plotting
   configurable backgrounds, inpainting, eccentricity rings, and static or
   animated visualization. Inpainting is intentionally unavailable when
   composing prosthetic vision because its interaction with prosthetic
-  brightness is not modeled (:pull:`871`, :pull:`884`).
+  brightness is not modeled (:pull:`871`, :pull:`884`, :pull:`892`).
 
 * ``Scene(aperture='circle')`` renders an eye-centered disc of radius
   ``min(fov) / 2`` instead of the full rectangle (:pull:`890`).

--- a/pulse2percept/stimuli/base.py
+++ b/pulse2percept/stimuli/base.py
@@ -2377,12 +2377,11 @@ class VideoStimulus(Stimulus):
         if vid.ndim < 3 or vid.ndim > 4:
             raise ValueError(f"Videos must have 3 or 4 dimensions, not "
                              f"{vid.ndim}.")
-        # Convert to grayscale if necessary:
+        # Narrow to float32 before `rgb2gray`:
+        vid = img_as_float32(vid)
         if as_gray:
             if vid.ndim == 4:
                 vid = rgb2gray(vid.transpose((0, 1, 3, 2)))
-        # Convert to float array in [0, 1] and call the Stimulus constructor:
-        vid = img_as_float32(vid)
         # Resize if necessary:
         if resize is not None:
             height, width = resize

--- a/pulse2percept/stimuli/tests/test_videos.py
+++ b/pulse2percept/stimuli/tests/test_videos.py
@@ -799,3 +799,24 @@ def test_VideoStimulus_accepts_a_path(tmp_path):
                      from_str.metadata['source'])
     # A Path is a filename, so the file-only arguments still apply:
     npt.assert_equal(VideoStimulus(fname, stop_time=3000).vid_shape[-1], 3)
+
+
+@pytest.mark.parametrize('resize', [None, (5, 9)])
+def test_VideoStimulus_as_gray_from_uint8_rgb(resize):
+    """Grayscale ingest narrows to float32 before mixing the channels"""
+    shape = (10, 18, 3, 4)
+    rgb = np.random.randint(0, 256, shape, dtype=np.uint8)
+    stim = VideoStimulus(rgb, as_gray=True, resize=resize,
+                         metadata={'fps': 25})
+    rows, cols = resize if resize else shape[:2]
+    npt.assert_equal(stim.vid_shape, (rows, cols, shape[-1]))
+    npt.assert_equal(stim.data.dtype, np.float32)
+    npt.assert_equal(stim.shape, (rows * cols, shape[-1]))
+    npt.assert_almost_equal(stim.time, np.arange(shape[-1]) * 1000.0 / 25)
+    # `rgb2gray` wants the channels last; the frames come along for the ride:
+    expected = rgb2gray(rgb.transpose((0, 1, 3, 2)) / 255.0)
+    if resize is not None:
+        expected = vid_resize(expected, (rows, cols, shape[-1]))
+    npt.assert_almost_equal(stim.data.reshape(stim.vid_shape), expected,
+                            decimal=6)
+    npt.assert_equal(stim.data.min() >= 0 and stim.data.max() <= 1, True)

--- a/pulse2percept/stimuli/tests/test_videos.py
+++ b/pulse2percept/stimuli/tests/test_videos.py
@@ -804,19 +804,26 @@ def test_VideoStimulus_accepts_a_path(tmp_path):
 @pytest.mark.parametrize('resize', [None, (5, 9)])
 def test_VideoStimulus_as_gray_from_uint8_rgb(resize):
     """Grayscale ingest narrows to float32 before mixing the channels"""
-    shape = (10, 18, 3, 4)
-    rgb = np.random.randint(0, 256, shape, dtype=np.uint8)
+    n_rows, n_cols, n_frames = 10, 18, 4
+    # Each channel ramps along a different axis and each frame sits at its own
+    # blue level, so a swapped channel or a shuffled frame changes the gray:
+    red = np.linspace(0, 255, n_cols)[np.newaxis, :, np.newaxis]
+    green = np.linspace(255, 0, n_rows)[:, np.newaxis, np.newaxis]
+    blue = np.linspace(40, 200, n_frames)[np.newaxis, np.newaxis, :]
+    shape = (n_rows, n_cols, n_frames)
+    rgb = np.stack([np.broadcast_to(c, shape) for c in (red, green, blue)],
+                   axis=2).round().astype(np.uint8)
     stim = VideoStimulus(rgb, as_gray=True, resize=resize,
                          metadata={'fps': 25})
-    rows, cols = resize if resize else shape[:2]
-    npt.assert_equal(stim.vid_shape, (rows, cols, shape[-1]))
+    rows, cols = resize if resize else (n_rows, n_cols)
+    npt.assert_equal(stim.vid_shape, (rows, cols, n_frames))
     npt.assert_equal(stim.data.dtype, np.float32)
-    npt.assert_equal(stim.shape, (rows * cols, shape[-1]))
-    npt.assert_almost_equal(stim.time, np.arange(shape[-1]) * 1000.0 / 25)
+    npt.assert_equal(stim.shape, (rows * cols, n_frames))
+    npt.assert_almost_equal(stim.time, np.arange(n_frames) * 1000.0 / 25)
     # `rgb2gray` wants the channels last; the frames come along for the ride:
     expected = rgb2gray(rgb.transpose((0, 1, 3, 2)) / 255.0)
     if resize is not None:
-        expected = vid_resize(expected, (rows, cols, shape[-1]))
+        expected = vid_resize(expected, (rows, cols, n_frames))
     npt.assert_almost_equal(stim.data.reshape(stim.vid_shape), expected,
                             decimal=6)
     npt.assert_equal(stim.data.min() >= 0 and stim.data.max() <= 1, True)

--- a/pulse2percept/vision/scene.py
+++ b/pulse2percept/vision/scene.py
@@ -382,6 +382,8 @@ class Scene(PrettyPrint):
         n_rows, n_cols = self._frame_shape
         self._fov = _resolve_fov(fov, n_rows, n_cols)
         self._cached_frames = None
+        # `_pixel_centers` keyed by pad:
+        self._pixel_centers_cache = {}
 
     def _pprint_params(self):
         """Return a dict of class attributes to pretty-print"""
@@ -586,14 +588,16 @@ class Scene(PrettyPrint):
         return frames
 
     def _loss_at(self, gaze_xy, pad=0):
-        """Geometric loss at each scene pixel, in [0, 1]"""
+        """Geometric loss at each scene pixel, in [0, 1], as float32"""
         n_rows, n_cols = self._frame_shape
         if self.scotoma is None:
-            return np.zeros((n_rows + 2 * pad, n_cols + 2 * pad))
+            return np.zeros((n_rows + 2 * pad, n_cols + 2 * pad),
+                            dtype=np.float32)
         # scene = visual field + gaze:
         gx, gy = gaze_xy
         x_scene, y_scene = self._pixel_centers(pad=pad)
-        return self.scotoma(x_scene - gx, y_scene - gy)
+        return np.asarray(self.scotoma(x_scene - gx, y_scene - gy),
+                          dtype=np.float32)
 
     def _rendered_loss_at(self, gaze_xy):
         """The loss map as drawn: `_loss_at` softened by `scotoma_blend`"""
@@ -677,10 +681,15 @@ class Scene(PrettyPrint):
 
     def _pixel_centers(self, pad=0):
         """Scene coordinates of every pixel center, as ``(x, y)`` meshes"""
-        n_rows, n_cols = self._frame_shape
-        cols, rows = np.meshgrid(np.arange(-pad, n_cols + pad),
-                                 np.arange(-pad, n_rows + pad))
-        return self.pixel_to_dva(cols, rows)
+        if pad not in self._pixel_centers_cache:
+            n_rows, n_cols = self._frame_shape
+            cols, rows = np.meshgrid(np.arange(-pad, n_cols + pad),
+                                     np.arange(-pad, n_rows + pad))
+            centers = self.pixel_to_dva(cols, rows)
+            for mesh in centers:
+                mesh.flags.writeable = False
+            self._pixel_centers_cache[pad] = centers
+        return self._pixel_centers_cache[pad]
 
     def _compose(self, prosthetic, vmax, vmin=0, gaze=None):
         """Native vision with a prosthetic percept painted into the loss"""
@@ -691,7 +700,9 @@ class Scene(PrettyPrint):
                 f"Use a numeric 'scotoma_fill' for prosthetic composition.")
         _check_prosthetic(prosthetic)
         vmin, vmax = _check_range(vmin, vmax)
-        scene_rgb = self._rgb_frames()
+        # Not `_rgb_frames`: a grayscale source is broadcast to RGB below
+        # rather than copied into a second full-size array.
+        scene_frames = self._frames()
         pframes, out_time, out_unit = self._prosthetic_frames(prosthetic)
         n_out = pframes.shape[-1]
         gaze = _gaze_points(gaze, n_out)
@@ -703,7 +714,10 @@ class Scene(PrettyPrint):
                 _percept_sampler(prosthetic, pframes), gaze[0])
             loss = self._rendered_loss_at(gaze[0])
 
-        out = np.empty((n_rows, n_cols, 3, n_out), dtype=np.float32)
+        n_scene = scene_frames.shape[-1]
+        # Frame-major while composing: writing a whole frame at a time is
+        # contiguous here:
+        out = np.empty((n_out, n_rows, n_cols, 3), dtype=np.float32)
         for f in range(n_out):
             if static:
                 frame = brightness[..., f]
@@ -712,11 +726,15 @@ class Scene(PrettyPrint):
                 frame = self._percept_on_grid(sample, gaze[f])[..., 0]
                 loss = self._rendered_loss_at(gaze[f])
             phosphene = np.clip((frame - vmin) / (vmax - vmin), 0, 1)
-            native = scene_rgb[..., 0 if scene_rgb.shape[-1] == 1 else f]
+            native = scene_frames[..., 0 if n_scene == 1 else f]
+            if native.shape[2] == 1:
+                # Grayscale = three identical copies
+                native = np.broadcast_to(native, (n_rows, n_cols, 3))
             fill = self._fill_rgb(native, loss)
             lost = np.maximum(fill, phosphene[..., np.newaxis])
             alpha = loss[..., np.newaxis]
-            out[..., f] = (1 - alpha) * native + alpha * lost
+            out[f] = (1 - alpha) * native + alpha * lost
+        out = np.ascontiguousarray(np.moveaxis(out, 0, -1))
         return Percept(self._apply_aperture(out, gaze=gaze),
                        space=self._grid(), time=out_time, time_unit=out_unit)
 

--- a/pulse2percept/vision/tests/test_scene.py
+++ b/pulse2percept/vision/tests/test_scene.py
@@ -885,3 +885,155 @@ def test_the_aperture_reaches_the_frames_the_player_shows():
     npt.assert_almost_equal(ani._frame_data[0, 0, :, 0], 0.0)
     npt.assert_almost_equal(ani._frame_data[4, 4, :, 1], 0.8, decimal=6)
     plt.close('all')
+
+
+def gray_video_scene(n_frames=3, **kwargs):
+    """A ramp scene dimmed by a different factor in every frame"""
+    ramp = np.tile(np.linspace(0, 1, SCENE_PX), (SCENE_PX, 1))
+    frames = np.stack([ramp * w for w in np.linspace(0.4, 1.0, n_frames)],
+                      axis=-1)
+    kwargs.setdefault('scotoma_blend', 0)
+    return Scene(VideoStimulus(frames, time=np.arange(n_frames) * 10.0),
+                 fov=(SCENE_PX, SCENE_PX), **kwargs)
+
+
+def rgb_video_scene(n_frames=3, **kwargs):
+    """Three channels that never agree, so a channel mix-up shows up"""
+    rgb = np.stack([np.tile(np.linspace(0, 1, SCENE_PX), (SCENE_PX, 1)),
+                    np.tile(np.linspace(1, 0, SCENE_PX), (SCENE_PX, 1)),
+                    np.full((SCENE_PX, SCENE_PX), 0.5)], axis=-1)
+    frames = np.stack([rgb * w for w in np.linspace(0.4, 1.0, n_frames)],
+                      axis=-1)
+    kwargs.setdefault('scotoma_blend', 0)
+    return Scene(VideoStimulus(frames, time=np.arange(n_frames) * 10.0),
+                 fov=(SCENE_PX, SCENE_PX), **kwargs)
+
+
+def ramped_percept(scene, n_frames):
+    """A percept on the scene's own grid, brighter with every frame"""
+    frame = np.tile(np.linspace(0, 1, SCENE_PX), (SCENE_PX, 1))
+    data = np.stack([frame * w for w in np.linspace(0.3, 1.0, n_frames)],
+                    axis=-1)
+    return Percept(data, space=scene._grid(),
+                   time=np.arange(n_frames) * 10.0)
+
+
+def frame_scene(scene, f, **kwargs):
+    """A still scene of frame ``f``, built exactly like the video one"""
+    frames = scene.source.data.reshape(scene.source.vid_shape)
+    return Scene(ImageStimulus(frames[..., f]), fov=scene.fov,
+                 scotoma=scene.scotoma, scotoma_fill=scene.scotoma_fill,
+                 scotoma_blend=scene.scotoma_blend,
+                 aperture=scene.aperture, **kwargs)
+
+
+def test_composing_a_grayscale_video_keeps_the_canonical_rgb_layout():
+    """A gray source is composed as RGB without ever differing by channel"""
+    n = 3
+    scene = gray_video_scene(n, scotoma=Scotoma.circle(6), scotoma_fill=0.0)
+    seen = scene._compose(ramped_percept(scene, n), vmax=1).data
+    npt.assert_equal(seen.shape, (SCENE_PX, SCENE_PX, 3, n))
+    npt.assert_equal(np.asarray(seen).dtype, np.float32)
+    npt.assert_array_equal(seen[:, :, 0, :], seen[:, :, 1, :])
+    npt.assert_array_equal(seen[:, :, 0, :], seen[:, :, 2, :])
+    # Where nothing is lost, native vision passes through untouched:
+    source = scene.source.data.reshape(scene.source.vid_shape)
+    x, y = scene._pixel_centers()
+    intact = scene.scotoma(x, y) == 0
+    for f in range(n):
+        npt.assert_array_equal(seen[intact, 0, f], source[intact, f])
+
+
+def test_composing_an_rgb_video_keeps_every_channel_where_it_was():
+    n = 3
+    scene = rgb_video_scene(n, scotoma=Scotoma.circle(6), scotoma_fill=0.2)
+    seen = scene._compose(ramped_percept(scene, n), vmax=1).data
+    npt.assert_equal(seen.shape, (SCENE_PX, SCENE_PX, 3, n))
+    source = scene.source.data.reshape(scene.source.vid_shape)
+    x, y = scene._pixel_centers()
+    intact = scene.scotoma(x, y) == 0
+    npt.assert_array_equal(seen[intact], source[intact])
+    # Inside complete loss the fill and the phosphene are all that is left,
+    # whichever is brighter (dim phosphene in frame 0, bright one in frame -1):
+    for f in (0, n - 1):
+        phosphene = float(ramped_percept(scene, n).data[HALF, HALF, f])
+        npt.assert_almost_equal(seen[HALF, HALF, :, f],
+                                [max(0.2, phosphene)] * 3, decimal=6)
+
+
+@pytest.mark.parametrize('blend', [0, 2])
+def test_composition_follows_a_gaze_that_moves_between_frames(blend):
+    """Frame f of a moving-gaze composition is frame f composed on its own"""
+    n = 3
+    scene = gray_video_scene(n, scotoma=Scotoma.circle(6), scotoma_fill=0.0,
+                             scotoma_blend=blend)
+    gaze = np.array([[-7.0, 2.0], [0.0, 0.0], [8.0, -3.0]])
+    percept = ramped_percept(scene, n)
+    moving = scene._compose(percept, vmax=1, gaze=gaze).data
+    for f in range(n):
+        still = frame_scene(scene, f)
+        alone = still._compose(
+            Percept(percept.data[..., f:f + 1], space=still._grid()),
+            vmax=1, gaze=gaze[f]).data
+        npt.assert_almost_equal(moving[..., f], alone[..., 0], decimal=6)
+    # Reusing the pixel raster must not freeze the geometry:
+    static = scene._compose(percept, vmax=1, gaze=gaze[1]).data
+    npt.assert_equal(np.allclose(moving, static), False)
+
+
+def test_a_static_gaze_composes_every_frame_of_a_video():
+    n = 4
+    scene = gray_video_scene(n, scotoma=Scotoma.circle(5), scotoma_fill=0.1,
+                             scotoma_blend=2)
+    percept = ramped_percept(scene, n)
+    seen = scene._compose(percept, vmax=1, gaze=(4.0, -1.0)).data
+    npt.assert_equal(seen.shape, (SCENE_PX, SCENE_PX, 3, n))
+    for f in range(n):
+        still = frame_scene(scene, f)
+        alone = still._compose(
+            Percept(percept.data[..., f:f + 1], space=still._grid()),
+            vmax=1, gaze=(4.0, -1.0)).data
+        npt.assert_almost_equal(seen[..., f], alone[..., 0], decimal=6)
+    # The frames are not copies of one another:
+    npt.assert_equal(np.allclose(seen[..., 0], seen[..., -1]), False)
+
+
+def test_a_circular_aperture_survives_composing_a_video():
+    n = 3
+    scene = gray_video_scene(n, scotoma=Scotoma.circle(6), scotoma_fill=0.0,
+                             aperture='circle')
+    percept = ramped_percept(scene, n)
+    seen = scene._compose(percept, vmax=1).data
+    npt.assert_equal(seen.shape, (SCENE_PX, SCENE_PX, 3, n))
+    npt.assert_equal(np.asarray(seen).dtype, np.float32)
+    npt.assert_array_equal(seen[0, 0], 0)
+    npt.assert_array_equal(seen[-1, -1], 0)
+    # Inside the disc the aperture changes nothing:
+    rect = gray_video_scene(n, scotoma=Scotoma.circle(6), scotoma_fill=0.0)
+    inside = ~scene._aperture_mask((0, 0))
+    npt.assert_array_equal(seen[inside],
+                           rect._compose(percept, vmax=1).data[inside])
+
+
+@pytest.mark.parametrize('blend', [0, 2])
+def test_the_loss_composition_renders_is_float32(blend):
+    """A float64 loss map would upcast the whole float32 blend"""
+    scene = ramp_scene(scotoma=Scotoma.circle(6), scotoma_fill=0.0,
+                       scotoma_blend=blend)
+    npt.assert_equal(scene._rendered_loss_at((0, 0)).dtype, np.float32)
+    npt.assert_equal(ramp_scene()._rendered_loss_at((0, 0)).dtype, np.float32)
+
+
+@pytest.mark.parametrize('pad', [0, 9])
+def test_repeated_pixel_center_queries_read_the_same_raster(pad):
+    scene = ramp_scene(scotoma=Scotoma.circle(6), scotoma_blend=2)
+    x, y = scene._pixel_centers(pad=pad)
+    npt.assert_equal(x.shape, (SCENE_PX + 2 * pad,) * 2)
+    again = scene._pixel_centers(pad=pad)
+    npt.assert_array_equal(again[0], x)
+    npt.assert_array_equal(again[1], y)
+    # A padded raster is the unpadded one plus a margin, not a rescaled grid:
+    if pad:
+        x0, y0 = scene._pixel_centers()
+        npt.assert_array_equal(x[pad:-pad, pad:-pad], x0)
+        npt.assert_array_equal(y[pad:-pad, pad:-pad], y0)


### PR DESCRIPTION
Reduce allocation and memory overhead in `Scene._compose` by:
- caching scene pixel geometry
- keeping loss/blend math in float32
- broadcasting grayscale frames instead of materializing RGB copies
- composing through a frame-major scratch buffer while preserving the existing `Percept` layout
