### PR TITLE
[FIX] Phosphene size in Dynaphos model

### DIFF
--- a/doc/users/release_notes.rst
+++ b/doc/users/release_notes.rst
@@ -208,6 +208,11 @@ Bug fixes
   `n_gray` and preserves the full stimulus in percept metadata
   (:pull:`869`).
 
+* :py:class:`~pulse2percept.models.cortex.DynaphosModel` phosphenes are half as
+  wide: the Gaussian standard deviation is a quarter of the phosphene diameter,
+  matching the reference implementation's ``radius_to_sigma = 0.5``
+  (:pull:`873`).
+
 
 v0.10.0 Encoders (2026-08-23)
 =============================

--- a/doc/users/release_notes.rst
+++ b/doc/users/release_notes.rst
@@ -211,7 +211,7 @@ Bug fixes
 * :py:class:`~pulse2percept.models.cortex.DynaphosModel` phosphenes are half as
   wide: the Gaussian standard deviation is a quarter of the phosphene diameter,
   matching the reference implementation's ``radius_to_sigma = 0.5``
-  (:pull:`873`).
+  (:pull:`894`).
 
 
 v0.10.0 Encoders (2026-08-23)

--- a/pulse2percept/models/cortex/dynaphos.py
+++ b/pulse2percept/models/cortex/dynaphos.py
@@ -50,7 +50,11 @@ class DynaphosModel(BaseModel):
     Implements the Dynaphos model. Percepts from each
     electrode are Gaussian blobs, with the size dictated by a magnification factor
     M determined by the electrode's position in the visual cortex.
-    
+
+    The blob's Gaussian standard deviation is a quarter of the phosphene
+    diameter P (dva), following the reference implementation's
+    ``radius_to_sigma = 0.5``.
+
     Parameters
     ----------
     implant : :py:class:`~pulse2percept.implants.Implant`
@@ -439,7 +443,9 @@ class DynaphosModel(BaseModel):
             D = 2 * np.sqrt(amp / K) # mm
             P = (D / M) # dva
             # calculate sigma for gaussian (only update sigma if amplitude > 0)
-            sigma = np.where(amp > 0, np.clip(P / 2, 1e-22, None), sigma) 
+            # P is a diameter, and the reference implementation uses
+            # radius_to_sigma = 0.5, i.e. sigma = 0.5 * P/2 = P/4:
+            sigma = np.where(amp > 0, np.clip(P / 4, 1e-22, None), sigma)
             # get activation (Ieff converted from uA to A)
             A = A + ((-A / tau_act_s) + Ieff * _A_PER_UA) * dt_s
             # get brightness

--- a/pulse2percept/models/cortex/tests/test_dynaphos.py
+++ b/pulse2percept/models/cortex/tests/test_dynaphos.py
@@ -18,6 +18,7 @@ from pulse2percept.stimuli import (AmplitudeEncoder,
                                    Stimulus)
 from pulse2percept.units import (DimensionMismatchError, Quantity, dva,
                                  mA, mm, ms, s, uA, um)
+from pulse2percept.utils import cart2pol
 
 def test_DynaphosModel():
     model = DynaphosModel(implant=Cortivis(), implant_position=(20, -5) * mm,
@@ -79,6 +80,34 @@ def test_predict_spatial_unsplit_map():
     npt.assert_equal(np.any(percept[:, half + 1:] > 0), True)
 
 
+def test_phosphene_size_matches_the_model_equations():
+    # sigma = P/4, where P = D/M is the phosphene diameter (dva) and
+    # D = 2*sqrt(amp/K) the diameter of activated cortex (mm).
+    x_el, amp = -61385.0, 200.0
+    implant = Implant(ElectrodeArray([DiskElectrode(x_el, 0, 0, 100)]))
+    # Window is +-5 sigma wide at a step of ~sigma/6, so the second moment
+    # recovers sigma to well under 1%:
+    model = DynaphosModel(implant=implant, xrange=(7.25, 8.75),
+                          yrange=(-0.75, 0.75), step=0.025, dt=20).build()
+    vfm = model.visual_field_map
+    x0, y0 = vfm.to_dva()['v1'](np.array([x_el]), np.array([0.0]))
+    _, r = cart2pol(np.asarray(x0), np.asarray(y0))
+    M = vfm.k * (vfm.b - vfm.a) / ((r + vfm.a) * (r + vfm.b))
+    expected = 2 * np.sqrt(amp / model.excitability) / M / 4
+
+    source = {0: BiphasicPulseTrain(freq=300, amp=amp, phase_dur=0.17,
+                                    stim_dur=100)}
+    percept = model.predict_percept(source, t_percept=[100.])
+    frame = np.asarray(percept.data[..., 0], dtype=np.float64)
+    total = frame.sum()
+    xg, yg = model.grid['dva'].x, model.grid['dva'].y
+    mean_x = (frame * xg).sum() / total
+    mean_y = (frame * yg).sum() / total
+    sigma_x = np.sqrt((frame * (xg - mean_x) ** 2).sum() / total)
+    sigma_y = np.sqrt((frame * (yg - mean_y) ** 2).sum() / total)
+    npt.assert_allclose([sigma_x, sigma_y], [expected[0]] * 2, rtol=0.01)
+
+
 def test_temporal_predict():
     model = DynaphosModel(implant=Cortivis(), step=0.1).build()
     # User can set params
@@ -114,17 +143,6 @@ def test_temporal_predict():
     bright_amp_ref = np.array([0.0, 0.0, 0.4636, 0.7247, 0.8891])
     npt.assert_almost_equal(bright_amp, bright_amp_ref, decimal=3)
     npt.assert_equal(np.all(np.diff(bright_amp) >= 0), True)
-
-    # Test that default models give expected values
-    orion = DynaphosModel(implant=Orion(), implant_position=(15, 0) * mm,
-                          step=0.1, dt=20).build()
-    percept = orion.predict_percept(
-        {'55': BiphasicPulseTrain(freq=300, amp=100, phase_dur=0.17)})
-    npt.assert_equal(np.sum(percept.data > 0.0122), 147)
-    npt.assert_equal(np.sum(percept.data > 0.0375), 96)
-    npt.assert_equal(np.sum(percept.data > 0.3305), 49)
-    npt.assert_equal(np.sum(percept.data > 0.8451), 39)
-    npt.assert_equal(np.sum(percept.data > 0.8883), 9)
 
 def test_deepcopy_Dynaphos():
     original = DynaphosModel(implant=Cortivis())
@@ -391,7 +409,7 @@ def test_location_noise():
                                             phase_dur=0.17)}
     kwargs = dict(implant_position=(20, -5) * mm,
                   xrange=(-4, 4), yrange=(-4, 4),
-                  step=0.05)
+                  step=0.025)
     plain = DynaphosModel(implant=implant, **kwargs).build()
     expected = plain.predict_percept(source).data
 
@@ -411,7 +429,9 @@ def test_location_noise():
                         _brightest_dva(plain.predict_percept(source),
                                        plain.grid),
                         offset, atol=0.06)
-    npt.assert_allclose(got.max(), expected.max(), rtol=0.05)
+    # Compare totals, not peaks: the blob is ~0.013 dva wide here, so the
+    # sampled peak depends on where the grid happens to cut it.
+    npt.assert_allclose(got.sum(), expected.sum(), rtol=0.05)
     npt.assert_array_equal(moved.build().predict_percept(source).data, got)
 
     with pytest.raises(ValueError):
@@ -424,7 +444,7 @@ def test_location_noise_crosses_meridian():
     # Choose an electrode/offset pair that crosses the vertical meridian.
     implant = Implant(ElectrodeArray([DiskElectrode(-25000, 2000, 0, 100)]))
     source = {0: BiphasicPulseTrain(freq=300, amp=200, phase_dur=0.17)}
-    kwargs = dict(xrange=(-4, 4), yrange=(-4, 4), step=0.05)
+    kwargs = dict(xrange=(-4, 4), yrange=(-4, 4), step=0.025)
     plain = DynaphosModel(implant=implant, **kwargs).build()
     canonical = plain.predict_percept(source)
     npt.assert_array_less(0, _brightest_dva(canonical, plain.grid)[0])

--- a/pulse2percept/models/cortex/tests/test_dynaphos.py
+++ b/pulse2percept/models/cortex/tests/test_dynaphos.py
@@ -18,7 +18,6 @@ from pulse2percept.stimuli import (AmplitudeEncoder,
                                    Stimulus)
 from pulse2percept.units import (DimensionMismatchError, Quantity, dva,
                                  mA, mm, ms, s, uA, um)
-from pulse2percept.utils import cart2pol
 
 def test_DynaphosModel():
     model = DynaphosModel(implant=Cortivis(), implant_position=(20, -5) * mm,
@@ -83,16 +82,15 @@ def test_predict_spatial_unsplit_map():
 def test_phosphene_size_matches_the_model_equations():
     # sigma = P/4, where P = D/M is the phosphene diameter (dva) and
     # D = 2*sqrt(amp/K) the diameter of activated cortex (mm).
-    x_el, amp = -61385.0, 200.0
-    implant = Implant(ElectrodeArray([DiskElectrode(x_el, 0, 0, 100)]))
+    ecc, amp = 8.0, 200.0
+    implant = Implant(ElectrodeArray([DiskElectrode(0, 0, 0, 100)]))
     # Window is +-5 sigma wide at a step of ~sigma/6, so the second moment
     # recovers sigma to well under 1%:
-    model = DynaphosModel(implant=implant, xrange=(7.25, 8.75),
+    model = DynaphosModel(implant=implant, implant_position=(ecc, 0) * dva,
+                          xrange=(ecc - 0.75, ecc + 0.75),
                           yrange=(-0.75, 0.75), step=0.025, dt=20).build()
     vfm = model.visual_field_map
-    x0, y0 = vfm.to_dva()['v1'](np.array([x_el]), np.array([0.0]))
-    _, r = cart2pol(np.asarray(x0), np.asarray(y0))
-    M = vfm.k * (vfm.b - vfm.a) / ((r + vfm.a) * (r + vfm.b))
+    M = vfm.k * (vfm.b - vfm.a) / ((ecc + vfm.a) * (ecc + vfm.b))
     expected = 2 * np.sqrt(amp / model.excitability) / M / 4
 
     source = {0: BiphasicPulseTrain(freq=300, amp=amp, phase_dur=0.17,
@@ -105,7 +103,7 @@ def test_phosphene_size_matches_the_model_equations():
     mean_y = (frame * yg).sum() / total
     sigma_x = np.sqrt((frame * (xg - mean_x) ** 2).sum() / total)
     sigma_y = np.sqrt((frame * (yg - mean_y) ** 2).sum() / total)
-    npt.assert_allclose([sigma_x, sigma_y], [expected[0]] * 2, rtol=0.01)
+    npt.assert_allclose([sigma_x, sigma_y], [expected] * 2, rtol=0.01)
 
 
 def test_temporal_predict():

--- a/pulse2percept/models/tests/test_api_equivalence.py
+++ b/pulse2percept/models/tests/test_api_equivalence.py
@@ -17,14 +17,12 @@ import pytest
 
 from pulse2percept.implants import GridImplant
 from pulse2percept.implants.retina import ArgusII
-from pulse2percept.implants.cortex import Cortivis
 from pulse2percept.models import FadingTemporal, Model
 from pulse2percept.models.retina import (AxonMapModel, BiphasicAxonMapModel,
                                          ScoreboardModel, ScoreboardSpatial)
-from pulse2percept.models.cortex import DynaphosModel
 from pulse2percept.stimuli import (AmplitudeEncoder, BiphasicPulseTrain,
                                    ImageStimulus, VideoStimulus)
-from pulse2percept.units import dva, mm, xTh
+from pulse2percept.units import dva, xTh
 from pulse2percept.vision import Scene, Scotoma
 
 GRID = dict(xrange=(-8, 8), yrange=(-6, 6), step=1)
@@ -66,10 +64,6 @@ REFERENCE = {
                  3.807037961360792, 0.5194367010755934, 1.0132546632537747,
                  (5.0853018679140565, 27.047305434768763,
                   6.941999430159145, 49.25247073610444)),
-    'dynaphos': ((7, 7, 6), (0.0, 100.0),
-                 3.864256768792984e-06, 1.0946714610327035e-06,
-                 3.800738015684018e-12,
-                 (2.0, 4.0, 1.0, 1.0)),
     'scene_gaze': ((13, 17, 1), None,
                    1663.1452019751928, 36.72337341308594, 43973.7099062507,
                    (6.000000013081055, 40.855445551864825,
@@ -193,15 +187,6 @@ def test_biphasic_axon_map_prediction_is_unchanged():
     percept = model.predict_percept(
         {'C5': BiphasicPulseTrain(20, 2 * xTh, 0.45, stim_dur=100)})
     assert_matches_reference('biphasic', percept)
-
-
-def test_dynaphos_prediction_is_unchanged():
-    model = DynaphosModel(implant=Cortivis(), implant_position=(20, -5) * mm,
-                          xrange=(-3, 3), yrange=(-3, 3),
-                          step=1, dt=20).build()
-    percept = model.predict_percept(
-        {'11': BiphasicPulseTrain(300, 100, 0.17, stim_dur=100)})
-    assert_matches_reference('dynaphos', percept)
 
 
 def test_scene_with_gaze_prediction_is_unchanged():


### PR DESCRIPTION
This PR fixes the Dynaphos phosphene-size bug (sigma = P/4, per the reference implementation's `radius_to_sigma = 0.5`), replaces the obsolete raster assertions with one analytical regression, and drops Dynaphos from the historical API-equivalence references.

Closes #872. Supercedes #873.
