### PR TITLE
[FIX] Left/right retina laterality in Watson2014DisplaceMap

### DIFF
--- a/doc/users/release_notes.rst
+++ b/doc/users/release_notes.rst
@@ -127,7 +127,9 @@ Models
   retina-specific behavior formerly embedded in the generic
   :py:class:`~pulse2percept.models.SpatialModel`, including the default retinal
   map, physical retinal extents, and scene registration. ``SpatialModel`` is now
-  anatomy-neutral.
+  anatomy-neutral. Retinal models derive a read-only ``eye`` from their implant
+  and reject an eye-dependent ``visual_field_map`` that disagrees with it
+  (:pull:`895`).
 
 * Model construction and placement were simplified. Models bind their implant,
   expose supported constructor parameters explicitly, build on demand, and take
@@ -172,6 +174,12 @@ Topography
       # v0.11
       p2p.topography.retina.Watson2014Map()
       p2p.topography.cortex.Polimeni2006Map()
+
+* :py:class:`~pulse2percept.topography.retina.Watson2014DisplaceMap` now takes
+  ``eye='left'`` or ``eye='right'`` (default ``'right'``, which reproduces
+  previous behavior). Watson's nasal and temporal ganglion-cell displacement
+  fits are now applied to the correct half-retina in a left eye, which was
+  previously mirrored (:pull:`895`).
 
 
 Scene and plotting

--- a/doc/users/release_notes.rst
+++ b/doc/users/release_notes.rst
@@ -127,9 +127,8 @@ Models
   retina-specific behavior formerly embedded in the generic
   :py:class:`~pulse2percept.models.SpatialModel`, including the default retinal
   map, physical retinal extents, and scene registration. ``SpatialModel`` is now
-  anatomy-neutral. Retinal models derive a read-only ``eye`` from their implant
-  and reject an eye-dependent ``visual_field_map`` that disagrees with it
-  (:pull:`895`).
+  anatomy-neutral. Retinal models reject an eye-dependent ``visual_field_map``
+  whose eye disagrees with the bound implant (:pull:`895`).
 
 * Model construction and placement were simplified. Models bind their implant,
   expose supported constructor parameters explicitly, build on demand, and take

--- a/pulse2percept/models/retina/base.py
+++ b/pulse2percept/models/retina/base.py
@@ -107,8 +107,8 @@ class RetinalSpatial(SpatialModel):
         if map_eye is None:
             return built
         implant_eye = getattr(self.implant, 'eye', None)
-        return (built and self._built_map_eye == map_eye
-                and implant_eye == map_eye)
+        return (built and self._built_map_eye == map_eye and
+                implant_eye == map_eye)
 
     def build(self, **build_params):
         """Build the model

--- a/pulse2percept/models/retina/base.py
+++ b/pulse2percept/models/retina/base.py
@@ -78,21 +78,13 @@ class RetinalSpatial(SpatialModel):
         # Laterality the grid was last built for; see `is_built`.
         self._built_map_eye = None
 
-    @property
-    def eye(self):
-        """Eye being modeled (``None`` for a generic implant)
-
-        .. versionadded:: 0.11.0
-        """
-        return getattr(self.implant, 'eye', None)
-
     def _validate_map_eye(self):
         """Require an eye-dependent visual_field_map to match the implant"""
         map_eye = getattr(self.visual_field_map, 'eye', None)
         if map_eye is None:
             return
-        eye = self.eye
-        if eye is None:
+        implant_eye = getattr(self.implant, 'eye', None)
+        if implant_eye is None:
             raise TypeError(
                 f"{type(self.visual_field_map).__name__} depends on retinal "
                 f"laterality, but {type(self.implant).__name__} does not "
@@ -100,12 +92,12 @@ class RetinalSpatial(SpatialModel):
                 f"pulse2percept.implants.retina.RetinalImplant, e.g. "
                 f"RetinalImplant(ElectrodeGrid(...), eye='{map_eye}'), or "
                 f"use an eye-independent visual_field_map.")
-        if eye != map_eye:
+        if implant_eye != map_eye:
             raise ValueError(
-                f"The implant sits in the {eye} eye, but "
+                f"The implant sits in the {implant_eye} eye, but "
                 f"{type(self.visual_field_map).__name__}(eye='{map_eye}') "
-                f"maps the {map_eye} eye. Set the map's 'eye' to '{eye}' or "
-                f"implant the {map_eye} eye.")
+                f"maps the {map_eye} eye. Use a map with "
+                f"eye='{implant_eye}', or an implant with eye='{map_eye}'.")
 
     @property
     def is_built(self):
@@ -114,7 +106,9 @@ class RetinalSpatial(SpatialModel):
         map_eye = getattr(self.visual_field_map, 'eye', None)
         if map_eye is None:
             return built
-        return built and self._built_map_eye == map_eye and self.eye == map_eye
+        implant_eye = getattr(self.implant, 'eye', None)
+        return (built and self._built_map_eye == map_eye
+                and implant_eye == map_eye)
 
     def build(self, **build_params):
         """Build the model

--- a/pulse2percept/models/retina/base.py
+++ b/pulse2percept/models/retina/base.py
@@ -75,15 +75,68 @@ class RetinalSpatial(SpatialModel):
         # extent, which is resolved through the map as it is assigned. See
         # `_visual_field_map_first`.
         super().__init__(implant, **_visual_field_map_first(params))
+        # Laterality the grid was last built for; see `is_built`.
+        self._built_map_eye = None
+
+    @property
+    def eye(self):
+        """Eye being modeled (``None`` for a generic implant)
+
+        .. versionadded:: 0.11.0
+        """
+        return getattr(self.implant, 'eye', None)
+
+    def _validate_map_eye(self):
+        """Require an eye-dependent visual_field_map to match the implant"""
+        map_eye = getattr(self.visual_field_map, 'eye', None)
+        if map_eye is None:
+            return
+        eye = self.eye
+        if eye is None:
+            raise TypeError(
+                f"{type(self.visual_field_map).__name__} depends on retinal "
+                f"laterality, but {type(self.implant).__name__} does not "
+                f"carry an eye. Wrap a custom array in "
+                f"pulse2percept.implants.retina.RetinalImplant, e.g. "
+                f"RetinalImplant(ElectrodeGrid(...), eye='{map_eye}'), or "
+                f"use an eye-independent visual_field_map.")
+        if eye != map_eye:
+            raise ValueError(
+                f"The implant sits in the {eye} eye, but "
+                f"{type(self.visual_field_map).__name__}(eye='{map_eye}') "
+                f"maps the {map_eye} eye. Set the map's 'eye' to '{eye}' or "
+                f"implant the {map_eye} eye.")
+
+    @property
+    def is_built(self):
+        """Return whether the grid matches the current retinal laterality"""
+        built = super().is_built
+        map_eye = getattr(self.visual_field_map, 'eye', None)
+        if map_eye is None:
+            return built
+        return built and self._built_map_eye == map_eye and self.eye == map_eye
+
+    def build(self, **build_params):
+        """Build the model
+
+        Parameters
+        ----------
+        **build_params : keyword arguments
+            Declared model parameters to set before building.
+
+        Returns
+        -------
+        self
+        """
+        self.set_params(**build_params)
+        # Before the grid is laid out, so a mismatch cannot be baked into it:
+        self._validate_map_eye()
+        super().build()
+        self._built_map_eye = getattr(self.visual_field_map, 'eye', None)
+        return self
 
     def set_params(self, **params):
-        """Set the parameters of this model
-
-        ``visual_field_map`` is applied before the other parameters, so that a
-        retinal extent given for ``xrange``/``yrange`` in the same call is
-        resolved through the map the caller asked for. See
-        ``_visual_field_map_first``.
-        """
+        """Set the parameters of this model"""
         super().set_params(**_visual_field_map_first(params))
 
     def get_default_params(self):
@@ -92,10 +145,7 @@ class RetinalSpatial(SpatialModel):
                 'visual_field_map': Curcio1990Map()}
 
     def _scene_sampling_points(self):
-        """Return placed electrode positions in dva, through retinotopy.
-
-        See :py:meth:`~pulse2percept.models.SpatialModel`.
-        """
+        """Return placed electrode positions in dva, through retinotopy."""
         visual_field_map = self.visual_field_map
         if not isinstance(visual_field_map, RetinalMap):
             raise ValueError(

--- a/pulse2percept/models/retina/tests/test_base.py
+++ b/pulse2percept/models/retina/tests/test_base.py
@@ -19,20 +19,6 @@ def model(implant, **params):
                              verbose=False, **params)
 
 
-def test_RetinalSpatial_eye():
-    imp = implant(eye='right')
-    spatial = model(imp)
-    npt.assert_equal(spatial.eye, 'right')
-    npt.assert_equal(spatial.eye, spatial.implant.eye)
-    # Derived, not stored:
-    imp.eye = 'left'
-    npt.assert_equal(spatial.eye, 'left')
-    with pytest.raises(AttributeError):
-        spatial.eye = 'right'
-    # A generic implant does not say which eye it sits in:
-    npt.assert_equal(model(implant(generic=True)).eye, None)
-
-
 @pytest.mark.parametrize('eye', ('left', 'right'))
 def test_RetinalSpatial_matching_map(eye):
     spatial = model(implant(eye=eye),
@@ -82,4 +68,3 @@ def test_RetinalSpatial_eye_mutation_after_build():
     # Rebuilding the now-matching left/left configuration works:
     spatial.build()
     npt.assert_equal(spatial.is_built, True)
-    npt.assert_equal(spatial.eye, 'left')

--- a/pulse2percept/models/retina/tests/test_base.py
+++ b/pulse2percept/models/retina/tests/test_base.py
@@ -1,0 +1,85 @@
+import numpy.testing as npt
+import pytest
+
+from pulse2percept.implants import ElectrodeGrid, Implant
+from pulse2percept.implants.retina import RetinalImplant
+from pulse2percept.models.retina import ScoreboardSpatial
+from pulse2percept.topography.retina import (Curcio1990Map, Watson2014Map,
+                                             Watson2014DisplaceMap)
+
+
+def implant(eye='right', generic=False):
+    array = ElectrodeGrid((2, 2), 400)
+    return Implant(array) if generic else RetinalImplant(array, eye=eye)
+
+
+def model(implant, **params):
+    # Tiny grid: these tests are about laterality, not about the percept.
+    return ScoreboardSpatial(implant, xrange=(-1, 1), yrange=(-1, 1), step=1,
+                             verbose=False, **params)
+
+
+def test_RetinalSpatial_eye():
+    imp = implant(eye='right')
+    spatial = model(imp)
+    npt.assert_equal(spatial.eye, 'right')
+    npt.assert_equal(spatial.eye, spatial.implant.eye)
+    # Derived, not stored:
+    imp.eye = 'left'
+    npt.assert_equal(spatial.eye, 'left')
+    with pytest.raises(AttributeError):
+        spatial.eye = 'right'
+    # A generic implant does not say which eye it sits in:
+    npt.assert_equal(model(implant(generic=True)).eye, None)
+
+
+@pytest.mark.parametrize('eye', ('left', 'right'))
+def test_RetinalSpatial_matching_map(eye):
+    spatial = model(implant(eye=eye),
+                    visual_field_map=Watson2014DisplaceMap(eye=eye))
+    spatial.build()
+    npt.assert_equal(spatial.is_built, True)
+
+
+def test_RetinalSpatial_map_eye_mismatch():
+    spatial = model(implant(eye='left'),
+                    visual_field_map=Watson2014DisplaceMap(eye='right'))
+    with pytest.raises(ValueError):
+        spatial.build()
+
+
+def test_RetinalSpatial_map_eye_missing():
+    spatial = model(implant(generic=True),
+                    visual_field_map=Watson2014DisplaceMap(eye='right'))
+    with pytest.raises(TypeError):
+        spatial.build()
+
+
+@pytest.mark.parametrize('eye', ('left', 'right'))
+@pytest.mark.parametrize('vfmap', (Curcio1990Map, Watson2014Map))
+def test_RetinalSpatial_eye_agnostic_map(eye, vfmap):
+    spatial = model(implant(eye=eye), visual_field_map=vfmap())
+    spatial.build()
+    npt.assert_equal(spatial.is_built, True)
+    # An eye-agnostic grid does not depend on laterality:
+    spatial.implant.eye = 'left' if eye == 'right' else 'right'
+    npt.assert_equal(spatial.is_built, True)
+
+
+def test_RetinalSpatial_eye_mutation_after_build():
+    # Mutating `implant.eye` or the bound map's `eye` bypasses parameter
+    # assignment, so `is_built` has to catch it.
+    for mutate in ['implant', 'map', 'both']:
+        spatial = model(implant(eye='right'),
+                        visual_field_map=Watson2014DisplaceMap(eye='right'))
+        spatial.build()
+        npt.assert_equal(spatial.is_built, True)
+        if mutate in ('implant', 'both'):
+            spatial.implant.eye = 'left'
+        if mutate in ('map', 'both'):
+            spatial.visual_field_map.eye = 'left'
+        npt.assert_equal(spatial.is_built, False)
+    # Rebuilding the now-matching left/left configuration works:
+    spatial.build()
+    npt.assert_equal(spatial.is_built, True)
+    npt.assert_equal(spatial.eye, 'left')

--- a/pulse2percept/models/tests/test_base.py
+++ b/pulse2percept/models/tests/test_base.py
@@ -2063,6 +2063,8 @@ def test_location_noise_resets_on_a_new_implant():
 
 def test_location_noise_needs_an_invertible_map():
     model = _one_electrode_model(location_noise=1.0, seed=7)
+    # Watson displacement is eye-dependent, so it needs a lateralized implant:
+    model.implant = _implant_at([(560, 0)], cls=RetinalImplant)
     model.visual_field_map = Watson2014DisplaceMap()
     model.build()
     with pytest.raises(NotImplementedError):

--- a/pulse2percept/topography/retina/tests/test_watson2014.py
+++ b/pulse2percept/topography/retina/tests/test_watson2014.py
@@ -74,3 +74,55 @@ def test_Watson2014DisplaceMap():
     npt.assert_almost_equal(radii[np.argmax(all_displace)], 2.1212121)
     # Smoke test
     trafo.dva_to_ret(0, 0)
+
+
+def test_Watson2014DisplaceMap_eye():
+    npt.assert_equal(Watson2014DisplaceMap().eye, 'right')
+    npt.assert_equal(Watson2014DisplaceMap(eye='LEFT').eye, 'left')
+    npt.assert_equal(Watson2014DisplaceMap(eye='Right').eye, 'right')
+    with pytest.raises(TypeError):
+        Watson2014DisplaceMap(eye=0)
+    with pytest.raises(ValueError):
+        Watson2014DisplaceMap(eye='both')
+    # `eye` is a regular parameter:
+    npt.assert_equal('right' in repr(Watson2014DisplaceMap()), True)
+    npt.assert_equal(Watson2014DisplaceMap() == Watson2014DisplaceMap(), True)
+    npt.assert_equal(Watson2014DisplaceMap() ==
+                     Watson2014DisplaceMap(eye='left'), False)
+
+
+@pytest.mark.parametrize('eye', ('right', 'left'))
+def test_Watson2014DisplaceMap_meridian(eye):
+    trafo = Watson2014DisplaceMap(eye=eye)
+    # An eccentricity where the two fits differ clearly:
+    rho = 2.0
+    expect = {m: rho + trafo.watson_displacement(rho, meridian=m)
+              for m in ('nasal', 'temporal')}
+    npt.assert_equal(np.isclose(expect['nasal'], expect['temporal']), False)
+    # Nasal is on the right of a right eye and on the left of a left eye:
+    nasal_sign = -1 if eye == 'left' else 1
+    for sign, meridian in [(nasal_sign, 'nasal'), (-nasal_sign, 'temporal')]:
+        ref = Watson2014Map().dva_to_ret(sign * expect[meridian], 0)
+        npt.assert_almost_equal(trafo.dva_to_ret(sign * rho, 0), ref)
+
+
+def test_Watson2014DisplaceMap_mirror():
+    right = Watson2014DisplaceMap(eye='right')
+    left = Watson2014DisplaceMap(eye='left')
+    x = np.array([-8.0, -2.5, -0.5, 0.5, 2.5, 8.0])
+    y = np.array([-6.0, 3.0, -1.5, 0.0, 4.5, -2.0])
+    x_right, y_right = right.dva_to_ret(x, y)
+    x_left, y_left = left.dva_to_ret(-x, y)
+    npt.assert_almost_equal(x_left, -x_right)
+    npt.assert_almost_equal(y_left, y_right)
+
+
+@pytest.mark.parametrize('eye', ('right', 'left'))
+def test_Watson2014DisplaceMap_vertical_meridian(eye):
+    # Legacy tie-break: x == 0 takes the nasal fit for either eye.
+    trafo = Watson2014DisplaceMap(eye=eye)
+    for ydva in [-5.0, -1.0, 1.0, 5.0]:
+        rho = np.abs(ydva) + trafo.watson_displacement(np.abs(ydva),
+                                                       meridian='nasal')
+        ref = Watson2014Map().dva_to_ret(0, np.sign(ydva) * rho)
+        npt.assert_almost_equal(trafo.dva_to_ret(0, ydva), ref)

--- a/pulse2percept/topography/retina/watson2014.py
+++ b/pulse2percept/topography/retina/watson2014.py
@@ -103,7 +103,8 @@ class Watson2014DisplaceMap(Watson2014Map):
     [Watson2014]_ fits Eq. 5 separately for the nasal and temporal meridian.
     Specify ``eye`` as either ``'left'`` or ``'right'`` for the proper
     assignment (one is the horizontal mirror of the other).
-    Points on the vertical meridian (``x == 0``) use the nasal fit.
+    Points on the vertical meridian (``x == 0``) use the nasal fit, which is a
+    backward-compatible tie-break rather than an anatomical claim.
 
     Parameters
     ----------

--- a/pulse2percept/topography/retina/watson2014.py
+++ b/pulse2percept/topography/retina/watson2014.py
@@ -100,7 +100,39 @@ class Watson2014DisplaceMap(Watson2014Map):
     receptive field. The displacement function is described in Eq. 5 of
     [Watson2014]_.
 
+    [Watson2014]_ fits Eq. 5 separately for the nasal and temporal meridian.
+    Specify ``eye`` as either ``'left'`` or ``'right'`` for the proper
+    assignment (one is the horizontal mirror of the other).
+    Points on the vertical meridian (``x == 0``) use the nasal fit.
+
+    Parameters
+    ----------
+    eye : {'right', 'left'}, optional
+        Eye whose nasal/temporal displacement functions are used.
+        Case-insensitive on input; stored lowercase. Defaults to ``'right'``.
+
+        .. versionadded:: 0.11.0
+
     """
+
+    @property
+    def eye(self):
+        """Eye whose nasal and temporal displacement functions are used"""
+        return self._eye
+
+    @eye.setter
+    def eye(self, eye):
+        """Eye setter (called upon `self.eye = eye`)"""
+        if not isinstance(eye, str):
+            raise TypeError(f"'eye' must be a string, not {type(eye)}.")
+        eye = eye.lower()
+        if eye not in ('left', 'right'):
+            raise ValueError(f"'eye' must be either 'left' or 'right', not "
+                             f"{eye}.")
+        self._eye = eye
+
+    def get_default_params(self):
+        return {**super().get_default_params(), 'eye': 'right'}
 
     def watson_displacement(self, r, meridian='temporal'):
         """Ganglion cell displacement function
@@ -113,6 +145,9 @@ class Watson2014DisplaceMap(Watson2014Map):
         r : double|array-like
             Eccentricity in degrees of visual angle (dva)
         meridian : 'temporal' or 'nasal'
+            Meridian whose fit to apply, elementwise if array-like. Which
+            meridian a visual-field location falls on depends on the eye, but
+            this function does not: it only evaluates the requested fit.
 
         Returns
         -------
@@ -152,8 +187,14 @@ class Watson2014DisplaceMap(Watson2014Map):
         """
         # Convert x, y (dva) into polar coordinates:
         theta, rho_dva = cart2pol(xdva, ydva)
-        # Add RGC displacement:
-        meridian = np.where(xdva < 0, 'temporal', 'nasal')
+        # Add RGC displacement. The nasal retina lies on the right of a right
+        # eye and on the left of a left eye; x == 0 takes the nasal fit either
+        # way:
+        if self.eye == 'left':
+            is_temporal = np.greater(xdva, 0)
+        else:
+            is_temporal = np.less(xdva, 0)
+        meridian = np.where(is_temporal, 'temporal', 'nasal')
         rho_dva += self.watson_displacement(rho_dva, meridian=meridian)
         # Convert back to x, y (dva):
         x, y = pol2cart(theta, rho_dva)


### PR DESCRIPTION
This PR adds an `eye` parameter for `Watson2014DisplaceMap`, so it works as expected with the new implant architecture. A map with `eye` != an implant's `eye` will raise a `ValueError`.