### PR TITLE
[ENH] Add phosphene measurements to Percept

### DIFF
--- a/doc/_ext/github_link.py
+++ b/doc/_ext/github_link.py
@@ -42,7 +42,12 @@ def _linkcode_resolve(domain, info, package, url_fmt, revision):
         # Python 2 only
         class_name = class_name.encode('utf-8')
     module = __import__(info['module'], fromlist=[class_name])
-    obj = attrgetter(info['fullname'])(module)
+    try:
+        obj = attrgetter(info['fullname'])(module)
+    except AttributeError:
+        # Documented but not a runtime attribute, as an annotation-only
+        # dataclass field is. There is nothing to point a source link at:
+        return
 
     try:
         fn = inspect.getsourcefile(obj)

--- a/doc/topics/models.rst
+++ b/doc/topics/models.rst
@@ -145,6 +145,132 @@ predict a percept from a stimulus.
 The result of ``predict_percept`` is a
 :py:class:`~pulse2percept.percepts.Percept`.
 
+Measuring a percept
+-------------------
+
+.. versionadded:: 0.11.0
+
+Prediction stops at the percept. Measuring one is optional post-processing,
+not part of the model::
+
+    stimulus → model → Percept → optional measurement
+
+:py:meth:`~pulse2percept.percepts.Percept.measure` summarizes how bright a
+modeled percept is and what shape it has. Nothing is measured until you ask,
+and nothing is cached afterwards:
+
+.. code-block:: python
+
+    percept = model.predict_percept({'A8': 30})
+    metrics = percept.measure()
+
+    metrics.peak.diameter          # 1.72 dva
+    metrics.peak.centroid          # (5.32, 5.32) dva
+    metrics.peak.total_brightness  # 102.7 brightness units x dva^2
+
+Support
+~~~~~~~
+
+Geometry is measured on the pixels at or above 50% of a frame's own positive
+peak brightness. The threshold is *relative* and re-evaluated per frame, so
+doubling a percept's brightness leaves its measured shape where it was. Lower
+it to measure a wider skirt:
+
+.. code-block:: python
+
+    metrics = percept.measure(threshold=0.25)
+
+Negative model output never counts as brightness; each frame is clipped at
+zero first.
+
+What is measured
+~~~~~~~~~~~~~~~~
+
+Brightness comes in two flavors. ``max_brightness`` is the brightest positive
+pixel, in the model's own arbitrary units. ``total_brightness`` integrates
+positive brightness over the visual field --- a pixel sum scaled by the area
+of a pixel, in brightness units x dva^2 --- so it approximates a spatial
+integral instead of tracking how finely you sampled the field. Neither is on a
+psychophysical absolute scale.
+
+The remaining measurements describe the suprathreshold support:
+
+**area**
+    Area of the support (dva^2).
+
+**diameter**
+    Diameter (dva) of the circle with the same area. At ``threshold=0.5``
+    this approximates the FWHM of a sufficiently sampled circular Gaussian.
+
+**centroid**
+    Brightness-weighted ``(x, y)`` center, in dva.
+
+**major_axis**, **minor_axis**
+    Axes (dva) of the ellipse with the same brightness-weighted second
+    moments as the support.
+
+**elongation**
+    ``major_axis / minor_axis``; 1 for a circular phosphene.
+
+**n_components**
+    Number of disconnected suprathreshold regions.
+
+**touches_edge**
+    Whether the support reaches the simulated field boundary.
+
+A frame with no positive brightness has no phosphene: its brightness, area and
+component count are zero, and the quantities that would place or shape a
+phosphene are ``NaN`` rather than a phantom blob at the origin.
+
+Multiple components and clipping
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Model output is not always one tidy phosphene. ``n_components`` counts the
+disconnected suprathreshold regions, and every other measurement describes the
+*whole* support: pulse2percept does not quietly keep the largest blob and
+throw the rest away. An ``elongation`` of 4 can mean one stretched phosphene
+or two round ones far apart, and ``n_components`` is what tells them apart.
+
+``touches_edge`` warns that the support runs into the border of the simulated
+visual field. When it is True, area, diameter, axes, centroid and integrated
+brightness describe only the part of the percept the simulation covers. No
+extrapolation is attempted; widen the model's ``xrange``/``yrange`` if you
+need the whole thing.
+
+Temporal percepts
+~~~~~~~~~~~~~~~~~
+
+Every frame is measured independently, and each measurement is also available
+as an array over frames:
+
+.. code-block:: python
+
+    metrics = percept.measure()
+
+    metrics.total_brightness  # one value per frame
+    metrics.peak_frame        # frame with the most integrated brightness
+    metrics.peak              # that frame's measurements
+
+``peak_frame`` ranks frames by integrated positive brightness, taking the
+earliest of any tie. When each frame occurred stays where it was, in
+``percept.time``; measurement adds no time integration or duration metrics.
+
+Scope
+~~~~~
+
+These are measurements of a modeled percept *image*. They do not estimate
+visual acuity, phosphene discriminability, pairwise separability, behavioral
+resolution, or object-recognition performance --- those are psychophysical
+questions that a picture of a percept does not answer.
+
+``measure()`` applies to model-produced brightness percepts, and raises for
+the RGB percepts scene composition returns, whose values are display
+intensities rather than perceived brightness. Positions and sizes are reported
+in degrees of visual angle, so the percept must have been built on a real
+:py:class:`~pulse2percept.topography.Grid2D`; a percept carrying bare image
+pixel indices is rejected rather than measured as though pixels were degrees.
+
+
 Source, delivered stimulation, percept
 --------------------------------------
 

--- a/doc/topics/models.rst
+++ b/doc/topics/models.rst
@@ -166,7 +166,7 @@ and nothing is cached afterwards:
 
     metrics.peak.diameter          # dva
     metrics.peak.centroid          # (x, y) in dva
-    metrics.peak.total_brightness  # brightness units x dva^2
+    metrics.peak.integrated_brightness  # brightness units x dva^2
 
 Support
 ~~~~~~~
@@ -187,13 +187,16 @@ What is measured
 ~~~~~~~~~~~~~~~~
 
 Brightness comes in two flavors. ``max_brightness`` is the brightest positive
-pixel, in the model's own arbitrary units. ``total_brightness`` integrates
+pixel, in the model's own arbitrary units. ``integrated_brightness`` sums
 positive brightness over the visual field --- a pixel sum scaled by the area
 of a pixel, in brightness units x dva^2 --- so it approximates a spatial
 integral instead of tracking how finely you sampled the field. Neither is on a
 psychophysical absolute scale.
 
-The remaining measurements describe the suprathreshold support:
+The remaining measurements describe the suprathreshold support as a set of
+pixels. Brightness enters only through where the threshold falls, not as a
+weight, so the geometry stays internally consistent: a circular phosphene has
+``major_axis == minor_axis == diameter``.
 
 **area**
     Area of the support (dva^2).
@@ -203,11 +206,10 @@ The remaining measurements describe the suprathreshold support:
     this approximates the FWHM of a sufficiently sampled circular Gaussian.
 
 **centroid**
-    Brightness-weighted ``(x, y)`` center, in dva.
+    Center ``(x, y)`` of the support, in dva: the mean position of its pixels.
 
 **major_axis**, **minor_axis**
-    Axes (dva) of the ellipse with the same brightness-weighted second
-    moments as the support.
+    Axes (dva) of the ellipse with the same second moments as the support.
 
 **elongation**
     ``major_axis / minor_axis``; 1 for a circular phosphene.
@@ -247,7 +249,7 @@ as an array over frames:
 
     metrics = percept.measure()
 
-    metrics.total_brightness  # one value per frame
+    metrics.integrated_brightness  # one value per frame
     metrics.peak_frame        # frame with the most integrated brightness
     metrics.peak              # that frame's measurements
 

--- a/doc/topics/models.rst
+++ b/doc/topics/models.rst
@@ -150,69 +150,65 @@ Measuring a percept
 
 .. versionadded:: 0.11.0
 
-Prediction stops at the percept. Measuring one is optional post-processing,
-not part of the model::
+Prediction stops at the percept. Measurement is optional post-processing,
+performed on call and not part of the model::
 
     stimulus → model → Percept → optional measurement
 
-:py:meth:`~pulse2percept.percepts.Percept.measure` summarizes how bright a
-modeled percept is and what shape it has. Nothing is measured until you ask,
-and nothing is cached afterwards:
+:py:meth:`~pulse2percept.percepts.Percept.measure` reports the brightness and
+geometry of the phosphenes in each frame:
 
 .. code-block:: python
 
     percept = model.predict_percept({'A8': 30})
     metrics = percept.measure()
 
-    metrics.peak.diameter          # dva
-    metrics.peak.centroid          # (x, y) in dva
+    metrics.peak.diameter               # dva
+    metrics.peak.centroid               # (x, y) in dva
     metrics.peak.integrated_brightness  # brightness units x dva^2
 
 Support
 ~~~~~~~
 
-Geometry is measured on the pixels at or above 50% of a frame's own positive
-peak brightness. The threshold is *relative* and re-evaluated per frame, so
-doubling a percept's brightness leaves its measured shape where it was. Lower
-it to measure a wider skirt:
+Each frame is clipped at zero, so negative model output does not contribute.
+Geometry is then measured on the *support*: the pixels at or above 50% of that
+frame's own positive maximum. The threshold is relative and re-evaluated per
+frame, so scaling a percept's brightness does not change its measured shape.
+Lower it to include more of the falloff:
 
 .. code-block:: python
 
     metrics = percept.measure(threshold=0.25)
 
-Negative model output never counts as brightness; each frame is clipped at
-zero first.
-
 What is measured
 ~~~~~~~~~~~~~~~~
 
-Brightness comes in two flavors. ``max_brightness`` is the brightest positive
-pixel, in the model's own arbitrary units. ``integrated_brightness`` sums
-positive brightness over the visual field --- a pixel sum scaled by the area
-of a pixel, in brightness units x dva^2 --- so it approximates a spatial
-integral instead of tracking how finely you sampled the field. Neither is on a
-psychophysical absolute scale.
+``max_brightness`` is the largest positive pixel value, in the model's
+arbitrary units. ``integrated_brightness`` is the pixel sum scaled by pixel
+area (brightness units x dva^2), which approximates a spatial integral and is
+therefore insensitive to sampling resolution. Neither is on a psychophysical
+absolute scale.
 
-The remaining measurements describe the suprathreshold support as a set of
-pixels. Brightness enters only through where the threshold falls, not as a
-weight, so the geometry stays internally consistent: a circular phosphene has
-``major_axis == minor_axis == diameter``.
+The remaining measurements describe the support as a binary set of pixels;
+brightness enters only through where the threshold falls. For a sufficiently
+sampled circular phosphene, ``major_axis``, ``minor_axis`` and ``diameter``
+approximately agree.
 
 **area**
     Area of the support (dva^2).
 
 **diameter**
-    Diameter (dva) of the circle with the same area. At ``threshold=0.5``
-    this approximates the FWHM of a sufficiently sampled circular Gaussian.
+    Diameter (dva) of the circle of equal area. At ``threshold=0.5`` this
+    approximates the FWHM of a sufficiently sampled circular Gaussian.
 
 **centroid**
-    Center ``(x, y)`` of the support, in dva: the mean position of its pixels.
+    Mean position ``(x, y)`` of the support pixels, in dva.
 
 **major_axis**, **minor_axis**
     Axes (dva) of the ellipse with the same second moments as the support.
 
 **elongation**
-    ``major_axis / minor_axis``; 1 for a circular phosphene.
+    ``major_axis / minor_axis``; approaches 1 for a circular phosphene.
 
 **n_components**
     Number of disconnected suprathreshold regions.
@@ -220,57 +216,54 @@ weight, so the geometry stays internally consistent: a circular phosphene has
 **touches_edge**
     Whether the support reaches the simulated field boundary.
 
-A frame with no positive brightness has no phosphene: its brightness, area and
-component count are zero, and the quantities that would place or shape a
-phosphene are ``NaN`` rather than a phantom blob at the origin.
+A frame without positive brightness has no phosphene: brightness, area and
+component count are zero, and position and shape are ``NaN``.
 
 Multiple components and clipping
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Model output is not always one tidy phosphene. ``n_components`` counts the
-disconnected suprathreshold regions, and every other measurement describes the
-*whole* support: pulse2percept does not quietly keep the largest blob and
-throw the rest away. An ``elongation`` of 4 can mean one stretched phosphene
-or two round ones far apart, and ``n_components`` is what tells them apart.
+Model output need not form a single connected phosphene. ``n_components``
+counts the disconnected suprathreshold regions; the largest is not selected,
+and every other measurement describes the combined support. An ``elongation``
+of 4 is consistent with one elongated phosphene or with two round ones some
+distance apart, which ``n_components`` distinguishes.
 
-``touches_edge`` warns that the support runs into the border of the simulated
-visual field. When it is True, area, diameter, axes, centroid and integrated
-brightness describe only the part of the percept the simulation covers. No
-extrapolation is attempted; widen the model's ``xrange``/``yrange`` if you
-need the whole thing.
+``touches_edge`` flags support reaching the border of the simulated visual
+field. Where it is True, the measurements describe only the portion inside the
+field, and no extrapolation is performed. Widen the model's ``xrange`` and
+``yrange`` to capture the full percept.
 
 Temporal percepts
 ~~~~~~~~~~~~~~~~~
 
-Every frame is measured independently, and each measurement is also available
-as an array over frames:
+Frames are measured independently, and each measurement is also available as
+an array over frames:
 
 .. code-block:: python
 
     metrics = percept.measure()
 
     metrics.integrated_brightness  # one value per frame
-    metrics.peak_frame        # frame with the most integrated brightness
-    metrics.peak              # that frame's measurements
+    metrics.peak_frame             # index of the brightest frame
+    metrics.peak                   # that frame's measurements
 
 ``peak_frame`` ranks frames by integrated positive brightness, taking the
-earliest of any tie. When each frame occurred stays where it was, in
-``percept.time``; measurement adds no time integration or duration metrics.
+earliest on a tie. Frame timing remains in ``percept.time``; no time
+integration or duration metrics are computed.
 
 Scope
 ~~~~~
 
-These are measurements of a modeled percept *image*. They do not estimate
+These measurements describe the modeled percept *image*. They do not estimate
 visual acuity, phosphene discriminability, pairwise separability, behavioral
-resolution, or object-recognition performance --- those are psychophysical
-questions that a picture of a percept does not answer.
+resolution, or object-recognition performance.
 
-``measure()`` applies to model-produced brightness percepts, and raises for
-the RGB percepts scene composition returns, whose values are display
-intensities rather than perceived brightness. Positions and sizes are reported
-in degrees of visual angle, so the percept must have been built on a real
-:py:class:`~pulse2percept.topography.Grid2D`; a percept carrying bare image
-pixel indices is rejected rather than measured as though pixels were degrees.
+``measure()`` applies to model-produced brightness percepts and raises for the
+RGB percepts returned by scene composition, whose values are display
+intensities. Positions and sizes are in degrees of visual angle, so the percept
+must have been built on a
+:py:class:`~pulse2percept.topography.Grid2D`; a percept holding bare pixel
+indices is rejected.
 
 
 Source, delivered stimulation, percept

--- a/doc/topics/models.rst
+++ b/doc/topics/models.rst
@@ -164,9 +164,9 @@ and nothing is cached afterwards:
     percept = model.predict_percept({'A8': 30})
     metrics = percept.measure()
 
-    metrics.peak.diameter          # 1.72 dva
-    metrics.peak.centroid          # (5.32, 5.32) dva
-    metrics.peak.total_brightness  # 102.7 brightness units x dva^2
+    metrics.peak.diameter          # dva
+    metrics.peak.centroid          # (x, y) in dva
+    metrics.peak.total_brightness  # brightness units x dva^2
 
 Support
 ~~~~~~~

--- a/pulse2percept/percepts/__init__.py
+++ b/pulse2percept/percepts/__init__.py
@@ -1,9 +1,15 @@
 """Visual percepts and phosphenes.
 
+The ``metrics`` module is documented but deliberately not imported here:
+:py:meth:`~pulse2percept.percepts.Percept.measure` loads it on demand, so
+predicting a percept never pays for the measurement machinery. Import its
+classes from ``pulse2percept.percepts.metrics`` if you need them directly.
+
 .. autosummary::
     :toctree: _api
 
     base
+    metrics
 
 """
 from .base import Percept

--- a/pulse2percept/percepts/base.py
+++ b/pulse2percept/percepts/base.py
@@ -535,25 +535,21 @@ class Percept(Data):
     def measure(self, threshold=0.5):
         """Measure the brightness and geometry of the phosphenes in a percept
 
-        Measures each frame of a model-produced brightness percept: how bright
-        it is, how large and how elongated its phosphenes are, and where they
-        sit in the visual field. Nothing is measured or stored until this is
-        called, and nothing is cached afterwards, so a percept whose data have
-        changed measures anew.
+        Measures each frame of a brightness percept: its integrated and peak
+        brightness, and the position, size and shape of its suprathreshold
+        support. Results are computed on call and not cached, so a percept
+        whose data changed measures anew.
 
         See :py:func:`~pulse2percept.percepts.metrics.measure_percept` for the
-        definitions, units, and the inputs it rejects (RGB percepts and
-        percepts built without a real
-        :py:class:`~pulse2percept.topography.Grid2D`, whose coordinates are
-        pixel indices rather than degrees of visual angle).
+        definitions, units, and the inputs it rejects.
 
         .. versionadded:: 0.11.0
 
         Parameters
         ----------
         threshold : float, optional
-            Fraction of each frame's own maximum brightness at or above which
-            a pixel counts as part of a phosphene. Must lie in (0, 1].
+            Fraction of each frame's own positive maximum at or above which a
+            pixel belongs to the support. Must lie in (0, 1].
 
         Returns
         -------
@@ -562,8 +558,8 @@ class Percept(Data):
             frame, plus the framewise arrays and the brightest frame.
 
         """
-        # Imported here so that predicting a percept never pays for the
-        # measurement machinery:
+        # Local import: predicting a percept must not load the measurement
+        # module.
         from .metrics import measure_percept
         return measure_percept(self, threshold=threshold)
 

--- a/pulse2percept/percepts/base.py
+++ b/pulse2percept/percepts/base.py
@@ -532,6 +532,41 @@ class Percept(Data):
         raise ValueError(f'Unknown axis value "{axis}". Use "frames" or '
                          f'None.')
 
+    def measure(self, threshold=0.5):
+        """Measure the brightness and geometry of the phosphenes in a percept
+
+        Measures each frame of a model-produced brightness percept: how bright
+        it is, how large and how elongated its phosphenes are, and where they
+        sit in the visual field. Nothing is measured or stored until this is
+        called, and nothing is cached afterwards, so a percept whose data have
+        changed measures anew.
+
+        See :py:func:`~pulse2percept.percepts.metrics.measure_percept` for the
+        definitions, units, and the inputs it rejects (RGB percepts and
+        percepts built without a real
+        :py:class:`~pulse2percept.topography.Grid2D`, whose coordinates are
+        pixel indices rather than degrees of visual angle).
+
+        .. versionadded:: 0.11.0
+
+        Parameters
+        ----------
+        threshold : float, optional
+            Fraction of each frame's own maximum brightness at or above which
+            a pixel counts as part of a phosphene. Must lie in (0, 1].
+
+        Returns
+        -------
+        metrics : :py:class:`~pulse2percept.percepts.metrics.PerceptMetrics`
+            One :py:class:`~pulse2percept.percepts.metrics.FrameMetrics` per
+            frame, plus the framewise arrays and the brightest frame.
+
+        """
+        # Imported here so that predicting a percept never pays for the
+        # measurement machinery:
+        from .metrics import measure_percept
+        return measure_percept(self, threshold=threshold)
+
     def rewind(self):
         """Rewind the iterator"""
         self._next_frame = 0

--- a/pulse2percept/percepts/metrics.py
+++ b/pulse2percept/percepts/metrics.py
@@ -46,7 +46,9 @@ class FrameMetrics:
     total_brightness : float
         Positive brightness integrated over the visual field, in brightness
         units x dva^2. This is a pixel sum scaled by the area of a pixel, so
-        it does not change when the same percept is sampled more finely.
+        it approximates an integral rather than counting pixels: sampling the
+        same percept more finely leaves it approximately unchanged, up to
+        discretization.
     max_brightness : float
         Largest positive brightness in the frame, in arbitrary brightness
         units.
@@ -56,8 +58,10 @@ class FrameMetrics:
         Brightness-weighted center ``(x, y)`` of the support, in dva.
     diameter : float
         Diameter (dva) of the circle with the same area as the support,
-        ``2 * sqrt(area / pi)``. For a well-sampled circular Gaussian and the
-        default half-maximum threshold, this is its FWHM.
+        ``2 * sqrt(area / pi)``. For a sufficiently sampled circular Gaussian
+        and the default half-maximum threshold, this approximates its FWHM;
+        the support is a set of whole pixels, so the agreement is limited by
+        how finely the grid samples the phosphene.
     major_axis, minor_axis : float
         Axis lengths (dva) of the ellipse with the same brightness-weighted
         second moments as the support, ``4 * sqrt(eigenvalue)``.
@@ -115,12 +119,17 @@ class PerceptMetrics:
     ----------
     frames : tuple of FrameMetrics
         One measurement per frame, in the order the frames are stored.
+    threshold : float
+        Fraction of each frame's own positive maximum that defined its
+        support, recorded so a result says what was measured.
 
     """
     frames: tuple[FrameMetrics, ...]
+    threshold: float
 
     def __repr__(self):
         return (f"PerceptMetrics(n_frames={len(self.frames)}, "
+                f"threshold={self.threshold:g}, "
                 f"peak_frame={self.peak_frame})")
 
     def _column(self, name, dtype=float):
@@ -253,8 +262,10 @@ def measure_percept(percept, threshold=0.5):
     threshold : float, optional
         Fraction of a frame's own positive maximum at or above which a pixel
         counts as part of the phosphene. Must lie in (0, 1]. The default of
-        0.5 makes :py:attr:`FrameMetrics.diameter` the full width at half
-        maximum of a circular Gaussian phosphene.
+        0.5 makes :py:attr:`FrameMetrics.diameter` approximately the full
+        width at half maximum of a sufficiently sampled circular Gaussian
+        phosphene. More generally, a Gaussian of standard deviation ``sigma``
+        has support diameter ``2 * sigma * sqrt(-2 * log(threshold))``.
 
     Returns
     -------
@@ -291,6 +302,6 @@ def measure_percept(percept, threshold=0.5):
     # coordinates run the other way from the stored (ascending) 'ydva':
     x, y = np.meshgrid(np.asarray(percept.xdva, dtype=np.float64),
                        np.asarray(percept.ydva, dtype=np.float64)[::-1])
-    return PerceptMetrics(frames=tuple(
-        _measure_frame(data[..., t], x, y, dx, dy, threshold)
-        for t in range(data.shape[-1])))
+    frames = tuple(_measure_frame(data[..., t], x, y, dx, dy, threshold)
+                   for t in range(data.shape[-1]))
+    return PerceptMetrics(frames=frames, threshold=threshold)

--- a/pulse2percept/percepts/metrics.py
+++ b/pulse2percept/percepts/metrics.py
@@ -1,6 +1,12 @@
-""":py:class:`~pulse2percept.percepts.FrameMetrics`,
-   :py:class:`~pulse2percept.percepts.PerceptMetrics`,
-   :py:func:`~pulse2percept.percepts.measure_percept`"""
+""":py:class:`~pulse2percept.percepts.metrics.FrameMetrics`,
+   :py:class:`~pulse2percept.percepts.metrics.PerceptMetrics`,
+   :py:func:`~pulse2percept.percepts.metrics.measure_percept`
+
+Measurements of the phosphenes in a percept. Not imported by
+:py:mod:`pulse2percept.percepts` itself, so that predicting a percept never
+loads them; :py:meth:`~pulse2percept.percepts.Percept.measure` pulls them in
+on demand.
+"""
 from dataclasses import dataclass
 
 import numpy as np

--- a/pulse2percept/percepts/metrics.py
+++ b/pulse2percept/percepts/metrics.py
@@ -40,6 +40,12 @@ class FrameMetrics:
     measurement below describes the *entire* support, even if it falls into
     several blobs.
 
+    Geometry is measured on the support as a set of pixels, not weighted by
+    the brightness inside it: brightness enters only through where the
+    threshold falls. So for a circular phosphene the support is a disk, and
+    :py:attr:`major_axis`, :py:attr:`minor_axis` and :py:attr:`diameter` all
+    agree.
+
     A frame with no positive brightness has no phosphene: its brightness,
     area, and component count are zero, and the quantities that would describe
     the position or shape of a phosphene are ``NaN`` rather than a phantom
@@ -49,7 +55,7 @@ class FrameMetrics:
 
     Attributes
     ----------
-    total_brightness : float
+    integrated_brightness : float
         Positive brightness integrated over the visual field, in brightness
         units x dva^2. This is a pixel sum scaled by the area of a pixel, so
         it approximates an integral rather than counting pixels: sampling the
@@ -61,7 +67,8 @@ class FrameMetrics:
     area : float
         Area of the support (dva^2).
     centroid : (float, float)
-        Brightness-weighted center ``(x, y)`` of the support, in dva.
+        Center ``(x, y)`` of the support, in dva: the mean position of its
+        pixels.
     diameter : float
         Diameter (dva) of the circle with the same area as the support,
         ``2 * sqrt(area / pi)``. For a sufficiently sampled circular Gaussian
@@ -69,8 +76,10 @@ class FrameMetrics:
         the support is a set of whole pixels, so the agreement is limited by
         how finely the grid samples the phosphene.
     major_axis, minor_axis : float
-        Axis lengths (dva) of the ellipse with the same brightness-weighted
-        second moments as the support, ``4 * sqrt(eigenvalue)``.
+        Axis lengths (dva) of the ellipse with the same second moments as the
+        support, ``4 * sqrt(eigenvalue)``. For a uniformly filled ellipse this
+        recovers its actual axes, so a circular support gives
+        ``major_axis == minor_axis == diameter``.
     elongation : float
         ``major_axis / minor_axis``; 1 for a circular phosphene.
     n_components : int
@@ -84,7 +93,7 @@ class FrameMetrics:
         measurements describe only the visible part of it.
 
     """
-    total_brightness: float
+    integrated_brightness: float
     max_brightness: float
     area: float
     centroid: tuple[float, float]
@@ -98,7 +107,7 @@ class FrameMetrics:
 
 # What a frame without any positive brightness measures. Shared because
 # ``FrameMetrics`` is immutable:
-_NO_PHOSPHENE = FrameMetrics(total_brightness=0.0, max_brightness=0.0,
+_NO_PHOSPHENE = FrameMetrics(integrated_brightness=0.0, max_brightness=0.0,
                              area=0.0, centroid=(np.nan, np.nan),
                              diameter=np.nan, major_axis=np.nan,
                              minor_axis=np.nan, elongation=np.nan,
@@ -144,11 +153,11 @@ class PerceptMetrics:
 
     @property
     def peak_frame(self):
-        """Index of the frame with the largest ``total_brightness``
+        """Index of the frame with the largest ``integrated_brightness``
 
         Ties go to the earliest frame, as with ``np.argmax``.
         """
-        return int(np.argmax(self.total_brightness))
+        return int(np.argmax(self.integrated_brightness))
 
     @property
     def peak(self):
@@ -156,9 +165,9 @@ class PerceptMetrics:
         return self.frames[self.peak_frame]
 
     @property
-    def total_brightness(self):
+    def integrated_brightness(self):
         """Integrated positive brightness of each frame, (T,)"""
-        return self._column('total_brightness')
+        return self._column('integrated_brightness')
 
     @property
     def max_brightness(self):
@@ -177,7 +186,7 @@ class PerceptMetrics:
 
     @property
     def centroid(self):
-        """Brightness-weighted ``(x, y)`` center (dva) of each frame, (T, 2)"""
+        """Support ``(x, y)`` center (dva) of each frame, (T, 2)"""
         return np.array([frame.centroid for frame in self.frames],
                         dtype=float).reshape((len(self.frames), 2))
 
@@ -208,8 +217,12 @@ class PerceptMetrics:
 
 
 def _measure_frame(frame, x, y, dx, dy, threshold):
-    """Measure one (Y, X) frame laid out on the coordinates ``x``/``y``"""
-    positive = np.clip(np.asarray(frame, dtype=np.float64), 0, None)
+    """Measure one (Y, X) frame on the 1D column/row coordinates ``x``/``y``"""
+    frame = np.asarray(frame, dtype=np.float64)
+    # Before clipping, which would turn a -inf into an innocent-looking 0:
+    if not np.all(np.isfinite(frame)):
+        raise ValueError("Percept data must be finite to be measured.")
+    positive = np.clip(frame, 0, None)
     peak = positive.max()
     pixel_area = dx * dy
     if peak <= 0:
@@ -217,36 +230,38 @@ def _measure_frame(frame, x, y, dx, dy, threshold):
     # The threshold is relative to this frame's own maximum, so scaling a
     # frame's brightness leaves its support -- and every shape measure -- put:
     support = positive >= threshold * peak
-    area = support.sum() * pixel_area
-    weights = positive[support]
-    total_weight = weights.sum()
-    xs, ys = x[support], y[support]
-    cx = (weights * xs).sum() / total_weight
-    cy = (weights * ys).sum() / total_weight
+    n_rows, n_cols = support.shape
+    # Only the support pixels carry coordinates, so index the 1D axes rather
+    # than building two full-field coordinate images:
+    rows, cols = np.nonzero(support)
+    xs, ys = x[cols], y[rows]
+    area = rows.size * pixel_area
+    cx, cy = xs.mean(), ys.mean()
     off_x, off_y = xs - cx, ys - cy
     # Pixels are cells, not point samples: without the variance of a uniform
     # cell added in, a support only a pixel or two across measures zero width.
-    cov_xx = (weights * off_x ** 2).sum() / total_weight + dx ** 2 / 12
-    cov_yy = (weights * off_y ** 2).sum() / total_weight + dy ** 2 / 12
-    cov_xy = (weights * off_x * off_y).sum() / total_weight
+    cov_xx = (off_x ** 2).mean() + dx ** 2 / 12
+    cov_yy = (off_y ** 2).mean() + dy ** 2 / 12
+    cov_xy = (off_x * off_y).mean()
     # `eigvalsh` returns the two eigenvalues in ascending order; clip because
     # roundoff can push a near-degenerate one slightly negative:
     eigvals = np.clip(np.linalg.eigvalsh([[cov_xx, cov_xy],
                                           [cov_xy, cov_yy]]), 0, None)
     minor_axis = 4 * np.sqrt(eigvals[0])
     major_axis = 4 * np.sqrt(eigvals[1])
-    touches_edge = bool(support[0].any() or support[-1].any() or
-                        support[:, 0].any() or support[:, -1].any())
-    return FrameMetrics(total_brightness=float(positive.sum() * pixel_area),
-                        max_brightness=float(peak),
-                        area=float(area),
-                        centroid=(float(cx), float(cy)),
-                        diameter=float(2 * np.sqrt(area / np.pi)),
-                        major_axis=float(major_axis),
-                        minor_axis=float(minor_axis),
-                        elongation=float(major_axis / minor_axis),
-                        n_components=int(label(support, connectivity=2).max()),
-                        touches_edge=touches_edge)
+    touches_edge = bool(rows.min() == 0 or rows.max() == n_rows - 1 or
+                        cols.min() == 0 or cols.max() == n_cols - 1)
+    return FrameMetrics(
+        integrated_brightness=float(positive.sum() * pixel_area),
+        max_brightness=float(peak),
+        area=float(area),
+        centroid=(float(cx), float(cy)),
+        diameter=float(2 * np.sqrt(area / np.pi)),
+        major_axis=float(major_axis),
+        minor_axis=float(minor_axis),
+        elongation=float(major_axis / minor_axis),
+        n_components=int(label(support, connectivity=2).max()),
+        touches_edge=touches_edge)
 
 
 def measure_percept(percept, threshold=0.5):
@@ -299,17 +314,15 @@ def measure_percept(percept, threshold=0.5):
         raise ValueError(f"'threshold' is a fraction of a frame's own maximum "
                          f"brightness and must lie in (0, 1], not "
                          f"{threshold}.")
-    # Left in the dtype it was stored in; `_measure_frame` promotes one frame
-    # at a time, so a long percept is never duplicated in double precision:
+    # Left in the dtype it was stored in; `_measure_frame` promotes, and
+    # checks, one frame at a time, so a long percept is never duplicated:
     data = percept.data
-    if not np.all(np.isfinite(data)):
-        raise ValueError("Percept data must be finite to be measured.")
     dx = _pixel_spacing(percept.xdva, 'xdva')
     dy = _pixel_spacing(percept.ydva, 'ydva')
     # Row 0 of a percept is drawn at the *top* of the visual field, so the row
     # coordinates run the other way from the stored (ascending) 'ydva':
-    x, y = np.meshgrid(np.asarray(percept.xdva, dtype=np.float64),
-                       np.asarray(percept.ydva, dtype=np.float64)[::-1])
+    x = np.asarray(percept.xdva, dtype=np.float64)
+    y = np.asarray(percept.ydva, dtype=np.float64)[::-1]
     frames = tuple(_measure_frame(data[..., t], x, y, dx, dy, threshold)
                    for t in range(data.shape[-1]))
     return PerceptMetrics(frames=frames, threshold=threshold)

--- a/pulse2percept/percepts/metrics.py
+++ b/pulse2percept/percepts/metrics.py
@@ -1,0 +1,296 @@
+""":py:class:`~pulse2percept.percepts.FrameMetrics`,
+   :py:class:`~pulse2percept.percepts.PerceptMetrics`,
+   :py:func:`~pulse2percept.percepts.measure_percept`"""
+from dataclasses import dataclass
+
+import numpy as np
+from skimage.measure import label
+
+
+def _pixel_spacing(coords, name):
+    """Spacing (dva) between neighboring pixel centers along one axis"""
+    coords = np.asarray(coords, dtype=np.float64).ravel()
+    if coords.size < 2:
+        raise ValueError(f"Phosphene measurements need at least two pixels "
+                         f"along '{name}' to know how much of the visual "
+                         f"field a pixel covers.")
+    # Grid2D lays its axes down with `linspace`, so the end points give the
+    # exact spacing even when the stored coordinates are float32:
+    return abs(coords[-1] - coords[0]) / (coords.size - 1)
+
+
+@dataclass(frozen=True)
+class FrameMetrics:
+    """Phosphene measurements for a single frame of a brightness percept
+
+    Produced by :py:func:`measure_percept` (usually through
+    :py:meth:`~pulse2percept.percepts.Percept.measure`); not meant to be
+    constructed directly.
+
+    All measurements consider only positive brightness: the frame is clipped
+    at zero first, so negative model output does not count as phosphene
+    brightness. "Support" means the pixels at or above ``threshold`` times the
+    frame's own positive maximum (half maximum by default), and every shape
+    measurement below describes the *entire* support, even if it falls into
+    several blobs.
+
+    A frame with no positive brightness has no phosphene: its brightness,
+    area, and component count are zero, and the quantities that would describe
+    the position or shape of a phosphene are ``NaN`` rather than a phantom
+    phosphene at the origin.
+
+    .. versionadded:: 0.11.0
+
+    Attributes
+    ----------
+    total_brightness : float
+        Positive brightness integrated over the visual field, in brightness
+        units x dva^2. This is a pixel sum scaled by the area of a pixel, so
+        it does not change when the same percept is sampled more finely.
+    max_brightness : float
+        Largest positive brightness in the frame, in arbitrary brightness
+        units.
+    area : float
+        Area of the support (dva^2).
+    centroid : (float, float)
+        Brightness-weighted center ``(x, y)`` of the support, in dva.
+    diameter : float
+        Diameter (dva) of the circle with the same area as the support,
+        ``2 * sqrt(area / pi)``. For a well-sampled circular Gaussian and the
+        default half-maximum threshold, this is its FWHM.
+    major_axis, minor_axis : float
+        Axis lengths (dva) of the ellipse with the same brightness-weighted
+        second moments as the support, ``4 * sqrt(eigenvalue)``.
+    elongation : float
+        ``major_axis / minor_axis``; 1 for a circular phosphene.
+    n_components : int
+        Number of connected components in the support, using full 2D
+        connectivity so diagonally adjacent pixels count as connected.
+        Descriptive only: the measurements above still describe the combined
+        support.
+    touches_edge : bool
+        Whether the support reaches the first or last row or column. If True,
+        the percept may extend past the simulated visual field, and the
+        measurements describe only the visible part of it.
+
+    """
+    total_brightness: float
+    max_brightness: float
+    area: float
+    centroid: tuple[float, float]
+    diameter: float
+    major_axis: float
+    minor_axis: float
+    elongation: float
+    n_components: int
+    touches_edge: bool
+
+
+# What a frame without any positive brightness measures. Shared because
+# ``FrameMetrics`` is immutable:
+_NO_PHOSPHENE = FrameMetrics(total_brightness=0.0, max_brightness=0.0,
+                             area=0.0, centroid=(np.nan, np.nan),
+                             diameter=np.nan, major_axis=np.nan,
+                             minor_axis=np.nan, elongation=np.nan,
+                             n_components=0, touches_edge=False)
+
+
+@dataclass(frozen=True)
+class PerceptMetrics:
+    """Phosphene measurements for every frame of a brightness percept
+
+    Produced by :py:func:`measure_percept` (usually through
+    :py:meth:`~pulse2percept.percepts.Percept.measure`); not meant to be
+    constructed directly. Frames are measured independently of one another;
+    :py:attr:`~pulse2percept.percepts.Percept.time` remains the source of
+    timing information.
+
+    Each measurement of :py:class:`FrameMetrics` is also available as an array
+    over frames, so ``metrics.diameter`` is the diameter of every frame and
+    ``metrics.peak.diameter`` is the diameter of the brightest one.
+
+    .. versionadded:: 0.11.0
+
+    Attributes
+    ----------
+    frames : tuple of FrameMetrics
+        One measurement per frame, in the order the frames are stored.
+
+    """
+    frames: tuple[FrameMetrics, ...]
+
+    def __repr__(self):
+        return (f"PerceptMetrics(n_frames={len(self.frames)}, "
+                f"peak_frame={self.peak_frame})")
+
+    def _column(self, name, dtype=float):
+        return np.array([getattr(frame, name) for frame in self.frames],
+                        dtype=dtype)
+
+    @property
+    def peak_frame(self):
+        """Index of the frame with the largest ``total_brightness``
+
+        Ties go to the earliest frame, as with ``np.argmax``.
+        """
+        return int(np.argmax(self.total_brightness))
+
+    @property
+    def peak(self):
+        """:py:class:`FrameMetrics` of the frame at :py:attr:`peak_frame`"""
+        return self.frames[self.peak_frame]
+
+    @property
+    def total_brightness(self):
+        """Integrated positive brightness of each frame, (T,)"""
+        return self._column('total_brightness')
+
+    @property
+    def max_brightness(self):
+        """Largest positive brightness of each frame, (T,)"""
+        return self._column('max_brightness')
+
+    @property
+    def area(self):
+        """Support area (dva^2) of each frame, (T,)"""
+        return self._column('area')
+
+    @property
+    def diameter(self):
+        """Equivalent-circle diameter (dva) of each frame, (T,)"""
+        return self._column('diameter')
+
+    @property
+    def centroid(self):
+        """Brightness-weighted ``(x, y)`` center (dva) of each frame, (T, 2)"""
+        return np.array([frame.centroid for frame in self.frames],
+                        dtype=float).reshape((len(self.frames), 2))
+
+    @property
+    def major_axis(self):
+        """Equivalent-ellipse major axis (dva) of each frame, (T,)"""
+        return self._column('major_axis')
+
+    @property
+    def minor_axis(self):
+        """Equivalent-ellipse minor axis (dva) of each frame, (T,)"""
+        return self._column('minor_axis')
+
+    @property
+    def elongation(self):
+        """Axis ratio of each frame, (T,)"""
+        return self._column('elongation')
+
+    @property
+    def n_components(self):
+        """Number of connected support components in each frame, (T,)"""
+        return self._column('n_components', dtype=int)
+
+    @property
+    def touches_edge(self):
+        """Whether each frame's support reaches the field border, (T,)"""
+        return self._column('touches_edge', dtype=bool)
+
+
+def _measure_frame(frame, x, y, dx, dy, threshold):
+    """Measure one (Y, X) frame laid out on the coordinates ``x``/``y``"""
+    positive = np.clip(np.asarray(frame, dtype=np.float64), 0, None)
+    peak = positive.max()
+    pixel_area = dx * dy
+    if peak <= 0:
+        return _NO_PHOSPHENE
+    # The threshold is relative to this frame's own maximum, so scaling a
+    # frame's brightness leaves its support -- and every shape measure -- put:
+    support = positive >= threshold * peak
+    area = support.sum() * pixel_area
+    weights = positive[support]
+    total_weight = weights.sum()
+    xs, ys = x[support], y[support]
+    cx = (weights * xs).sum() / total_weight
+    cy = (weights * ys).sum() / total_weight
+    off_x, off_y = xs - cx, ys - cy
+    # Pixels are cells, not point samples: without the variance of a uniform
+    # cell added in, a support only a pixel or two across measures zero width.
+    cov_xx = (weights * off_x ** 2).sum() / total_weight + dx ** 2 / 12
+    cov_yy = (weights * off_y ** 2).sum() / total_weight + dy ** 2 / 12
+    cov_xy = (weights * off_x * off_y).sum() / total_weight
+    # `eigvalsh` returns the two eigenvalues in ascending order; clip because
+    # roundoff can push a near-degenerate one slightly negative:
+    eigvals = np.clip(np.linalg.eigvalsh([[cov_xx, cov_xy],
+                                          [cov_xy, cov_yy]]), 0, None)
+    minor_axis = 4 * np.sqrt(eigvals[0])
+    major_axis = 4 * np.sqrt(eigvals[1])
+    touches_edge = bool(support[0].any() or support[-1].any() or
+                        support[:, 0].any() or support[:, -1].any())
+    return FrameMetrics(total_brightness=float(positive.sum() * pixel_area),
+                        max_brightness=float(peak),
+                        area=float(area),
+                        centroid=(float(cx), float(cy)),
+                        diameter=float(2 * np.sqrt(area / np.pi)),
+                        major_axis=float(major_axis),
+                        minor_axis=float(minor_axis),
+                        elongation=float(major_axis / minor_axis),
+                        n_components=int(label(support, connectivity=2).max()),
+                        touches_edge=touches_edge)
+
+
+def measure_percept(percept, threshold=0.5):
+    """Measure the phosphenes in a brightness percept
+
+    Measures every frame of ``percept`` independently and returns the results
+    as a :py:class:`PerceptMetrics`. See :py:class:`FrameMetrics` for what is
+    measured and in what units.
+
+    .. versionadded:: 0.11.0
+
+    Parameters
+    ----------
+    percept : :py:class:`~pulse2percept.percepts.Percept`
+        A (Y, X, T) percept of perceived brightness built on a real
+        :py:class:`~pulse2percept.topography.Grid2D`. Positions and sizes are
+        reported in degrees of visual angle, which a percept built without a
+        grid does not have (its coordinates are pixel indices).
+    threshold : float, optional
+        Fraction of a frame's own positive maximum at or above which a pixel
+        counts as part of the phosphene. Must lie in (0, 1]. The default of
+        0.5 makes :py:attr:`FrameMetrics.diameter` the full width at half
+        maximum of a circular Gaussian phosphene.
+
+    Returns
+    -------
+    metrics : :py:class:`PerceptMetrics`
+
+    Notes
+    -----
+    These are measurements of the model's output image. They describe how big
+    and how bright a modeled phosphene is, not how well an observer could
+    resolve or tell apart what they saw.
+
+    """
+    if getattr(percept, 'is_rgb', False):
+        raise ValueError("Phosphene measurements are defined on model-"
+                         "produced perceived brightness, not on the RGB "
+                         "display values this percept holds. Measure the "
+                         "brightness percept a model produced instead.")
+    if not getattr(percept, '_has_space', False):
+        raise ValueError("Phosphene measurements are reported in degrees of "
+                         "visual angle, but this percept was built without a "
+                         "Grid2D, so its 'xdva'/'ydva' are pixel indices. "
+                         "Pass 'space' when building the percept.")
+    threshold = float(threshold)
+    if not 0 < threshold <= 1:
+        raise ValueError(f"'threshold' is a fraction of a frame's own maximum "
+                         f"brightness and must lie in (0, 1], not "
+                         f"{threshold}.")
+    data = np.asarray(percept.data, dtype=np.float64)
+    if not np.all(np.isfinite(data)):
+        raise ValueError("Percept data must be finite to be measured.")
+    dx = _pixel_spacing(percept.xdva, 'xdva')
+    dy = _pixel_spacing(percept.ydva, 'ydva')
+    # Row 0 of a percept is drawn at the *top* of the visual field, so the row
+    # coordinates run the other way from the stored (ascending) 'ydva':
+    x, y = np.meshgrid(np.asarray(percept.xdva, dtype=np.float64),
+                       np.asarray(percept.ydva, dtype=np.float64)[::-1])
+    return PerceptMetrics(frames=tuple(
+        _measure_frame(data[..., t], x, y, dx, dy, threshold)
+        for t in range(data.shape[-1])))

--- a/pulse2percept/percepts/metrics.py
+++ b/pulse2percept/percepts/metrics.py
@@ -299,7 +299,9 @@ def measure_percept(percept, threshold=0.5):
         raise ValueError(f"'threshold' is a fraction of a frame's own maximum "
                          f"brightness and must lie in (0, 1], not "
                          f"{threshold}.")
-    data = np.asarray(percept.data, dtype=np.float64)
+    # Left in the dtype it was stored in; `_measure_frame` promotes one frame
+    # at a time, so a long percept is never duplicated in double precision:
+    data = percept.data
     if not np.all(np.isfinite(data)):
         raise ValueError("Percept data must be finite to be measured.")
     dx = _pixel_spacing(percept.xdva, 'xdva')

--- a/pulse2percept/percepts/metrics.py
+++ b/pulse2percept/percepts/metrics.py
@@ -2,10 +2,9 @@
    :py:class:`~pulse2percept.percepts.metrics.PerceptMetrics`,
    :py:func:`~pulse2percept.percepts.metrics.measure_percept`
 
-Measurements of the phosphenes in a percept. Not imported by
-:py:mod:`pulse2percept.percepts` itself, so that predicting a percept never
-loads them; :py:meth:`~pulse2percept.percepts.Percept.measure` pulls them in
-on demand.
+Phosphene measurements. Imported on demand by
+:py:meth:`~pulse2percept.percepts.Percept.measure`, not by
+:py:mod:`pulse2percept.percepts`.
 """
 from dataclasses import dataclass
 
@@ -20,8 +19,8 @@ def _pixel_spacing(coords, name):
         raise ValueError(f"Phosphene measurements need at least two pixels "
                          f"along '{name}' to know how much of the visual "
                          f"field a pixel covers.")
-    # Grid2D lays its axes down with `linspace`, so the end points give the
-    # exact spacing even when the stored coordinates are float32:
+    # Grid2D spaces its axes with `linspace`, so the end points give the exact
+    # spacing even when the stored coordinates are float32:
     return abs(coords[-1] - coords[0]) / (coords.size - 1)
 
 
@@ -29,68 +28,55 @@ def _pixel_spacing(coords, name):
 class FrameMetrics:
     """Phosphene measurements for a single frame of a brightness percept
 
-    Produced by :py:func:`measure_percept` (usually through
-    :py:meth:`~pulse2percept.percepts.Percept.measure`); not meant to be
-    constructed directly.
+    Produced by :py:func:`measure_percept`, usually through
+    :py:meth:`~pulse2percept.percepts.Percept.measure`.
 
-    All measurements consider only positive brightness: the frame is clipped
-    at zero first, so negative model output does not count as phosphene
-    brightness. "Support" means the pixels at or above ``threshold`` times the
-    frame's own positive maximum (half maximum by default), and every shape
-    measurement below describes the *entire* support, even if it falls into
-    several blobs.
+    Only positive brightness is measured: the frame is clipped at zero first.
+    The support is the set of pixels at or above ``threshold`` times the
+    frame's own positive maximum (half maximum by default). Geometry is
+    measured on that support as a binary set of pixels, unweighted by the
+    brightness within it, and describes the support in full even when it falls
+    into several components. For a sufficiently sampled circular support,
+    :py:attr:`major_axis`, :py:attr:`minor_axis` and :py:attr:`diameter`
+    converge to a common value.
 
-    Geometry is measured on the support as a set of pixels, not weighted by
-    the brightness inside it: brightness enters only through where the
-    threshold falls. So for a circular phosphene the support is a disk, and
-    :py:attr:`major_axis`, :py:attr:`minor_axis` and :py:attr:`diameter` all
-    agree.
-
-    A frame with no positive brightness has no phosphene: its brightness,
-    area, and component count are zero, and the quantities that would describe
-    the position or shape of a phosphene are ``NaN`` rather than a phantom
-    phosphene at the origin.
+    A frame without positive brightness has no phosphene: brightness, area and
+    component count are zero, and position and shape are ``NaN``.
 
     .. versionadded:: 0.11.0
 
     Attributes
     ----------
     integrated_brightness : float
-        Positive brightness integrated over the visual field, in brightness
-        units x dva^2. This is a pixel sum scaled by the area of a pixel, so
-        it approximates an integral rather than counting pixels: sampling the
-        same percept more finely leaves it approximately unchanged, up to
+        Positive brightness integrated over the visual field (brightness units
+        x dva^2): the pixel sum scaled by pixel area. Approximates a spatial
+        integral, so it is insensitive to sampling resolution up to
         discretization.
     max_brightness : float
-        Largest positive brightness in the frame, in arbitrary brightness
-        units.
+        Largest positive brightness in the frame (arbitrary units).
     area : float
         Area of the support (dva^2).
     centroid : (float, float)
-        Center ``(x, y)`` of the support, in dva: the mean position of its
-        pixels.
+        Mean position ``(x, y)`` of the support pixels (dva).
     diameter : float
-        Diameter (dva) of the circle with the same area as the support,
-        ``2 * sqrt(area / pi)``. For a sufficiently sampled circular Gaussian
-        and the default half-maximum threshold, this approximates its FWHM;
-        the support is a set of whole pixels, so the agreement is limited by
-        how finely the grid samples the phosphene.
+        Diameter (dva) of the circle of equal area, ``2 * sqrt(area / pi)``.
+        At ``threshold=0.5`` this approximates the FWHM of a sufficiently
+        sampled circular Gaussian; agreement is limited by grid resolution.
     major_axis, minor_axis : float
         Axis lengths (dva) of the ellipse with the same second moments as the
-        support, ``4 * sqrt(eigenvalue)``. For a uniformly filled ellipse this
-        recovers its actual axes, so a circular support gives
-        ``major_axis == minor_axis == diameter``.
+        support, ``4 * sqrt(eigenvalue)``. Exact for a continuous uniformly
+        filled ellipse; sampled supports approach those values as resolution
+        increases.
     elongation : float
-        ``major_axis / minor_axis``; 1 for a circular phosphene.
+        ``major_axis / minor_axis``; approaches 1 for a circular phosphene.
     n_components : int
         Number of connected components in the support, using full 2D
-        connectivity so diagonally adjacent pixels count as connected.
-        Descriptive only: the measurements above still describe the combined
-        support.
+        connectivity so diagonal neighbors count as connected. Descriptive
+        only: the other measurements still describe the combined support.
     touches_edge : bool
         Whether the support reaches the first or last row or column. If True,
-        the percept may extend past the simulated visual field, and the
-        measurements describe only the visible part of it.
+        the percept may extend beyond the simulated field and the measurements
+        describe only its visible part.
 
     """
     integrated_brightness: float
@@ -105,7 +91,7 @@ class FrameMetrics:
     touches_edge: bool
 
 
-# What a frame without any positive brightness measures. Shared because
+# What a frame without positive brightness measures. Shared because
 # ``FrameMetrics`` is immutable:
 _NO_PHOSPHENE = FrameMetrics(integrated_brightness=0.0, max_brightness=0.0,
                              area=0.0, centroid=(np.nan, np.nan),
@@ -118,15 +104,14 @@ _NO_PHOSPHENE = FrameMetrics(integrated_brightness=0.0, max_brightness=0.0,
 class PerceptMetrics:
     """Phosphene measurements for every frame of a brightness percept
 
-    Produced by :py:func:`measure_percept` (usually through
-    :py:meth:`~pulse2percept.percepts.Percept.measure`); not meant to be
-    constructed directly. Frames are measured independently of one another;
-    :py:attr:`~pulse2percept.percepts.Percept.time` remains the source of
-    timing information.
+    Produced by :py:func:`measure_percept`, usually through
+    :py:meth:`~pulse2percept.percepts.Percept.measure`. Frames are measured
+    independently; frame timing stays in
+    :py:attr:`~pulse2percept.percepts.Percept.time`.
 
-    Each measurement of :py:class:`FrameMetrics` is also available as an array
-    over frames, so ``metrics.diameter`` is the diameter of every frame and
-    ``metrics.peak.diameter`` is the diameter of the brightest one.
+    Every :py:class:`FrameMetrics` measurement is also available as an array
+    over frames: ``metrics.diameter`` is the diameter of each frame,
+    ``metrics.peak.diameter`` that of the brightest.
 
     .. versionadded:: 0.11.0
 
@@ -136,7 +121,7 @@ class PerceptMetrics:
         One measurement per frame, in the order the frames are stored.
     threshold : float
         Fraction of each frame's own positive maximum that defined its
-        support, recorded so a result says what was measured.
+        support.
 
     """
     frames: tuple[FrameMetrics, ...]
@@ -219,7 +204,7 @@ class PerceptMetrics:
 def _measure_frame(frame, x, y, dx, dy, threshold):
     """Measure one (Y, X) frame on the 1D column/row coordinates ``x``/``y``"""
     frame = np.asarray(frame, dtype=np.float64)
-    # Before clipping, which would turn a -inf into an innocent-looking 0:
+    # Before clipping, which would map -inf onto 0:
     if not np.all(np.isfinite(frame)):
         raise ValueError("Percept data must be finite to be measured.")
     positive = np.clip(frame, 0, None)
@@ -227,24 +212,23 @@ def _measure_frame(frame, x, y, dx, dy, threshold):
     pixel_area = dx * dy
     if peak <= 0:
         return _NO_PHOSPHENE
-    # The threshold is relative to this frame's own maximum, so scaling a
-    # frame's brightness leaves its support -- and every shape measure -- put:
+    # Relative to this frame's own maximum, so scaling brightness leaves the
+    # support, and every measurement derived from it, unchanged:
     support = positive >= threshold * peak
     n_rows, n_cols = support.shape
-    # Only the support pixels carry coordinates, so index the 1D axes rather
-    # than building two full-field coordinate images:
+    # Index the 1D axes rather than building two full-field coordinate images:
     rows, cols = np.nonzero(support)
     xs, ys = x[cols], y[rows]
     area = rows.size * pixel_area
     cx, cy = xs.mean(), ys.mean()
     off_x, off_y = xs - cx, ys - cy
     # Pixels are cells, not point samples: without the variance of a uniform
-    # cell added in, a support only a pixel or two across measures zero width.
+    # cell, a support a pixel or two across would measure zero width.
     cov_xx = (off_x ** 2).mean() + dx ** 2 / 12
     cov_yy = (off_y ** 2).mean() + dy ** 2 / 12
     cov_xy = (off_x * off_y).mean()
-    # `eigvalsh` returns the two eigenvalues in ascending order; clip because
-    # roundoff can push a near-degenerate one slightly negative:
+    # `eigvalsh` returns eigenvalues in ascending order; clip because roundoff
+    # can push a near-degenerate one slightly negative:
     eigvals = np.clip(np.linalg.eigvalsh([[cov_xx, cov_xy],
                                           [cov_xy, cov_yy]]), 0, None)
     minor_axis = 4 * np.sqrt(eigvals[0])
@@ -267,36 +251,39 @@ def _measure_frame(frame, x, y, dx, dy, threshold):
 def measure_percept(percept, threshold=0.5):
     """Measure the phosphenes in a brightness percept
 
-    Measures every frame of ``percept`` independently and returns the results
-    as a :py:class:`PerceptMetrics`. See :py:class:`FrameMetrics` for what is
-    measured and in what units.
+    Measures each frame independently. See :py:class:`FrameMetrics` for the
+    definitions and units.
 
     .. versionadded:: 0.11.0
 
     Parameters
     ----------
     percept : :py:class:`~pulse2percept.percepts.Percept`
-        A (Y, X, T) percept of perceived brightness built on a real
-        :py:class:`~pulse2percept.topography.Grid2D`. Positions and sizes are
-        reported in degrees of visual angle, which a percept built without a
-        grid does not have (its coordinates are pixel indices).
+        A (Y, X, T) brightness percept built on a
+        :py:class:`~pulse2percept.topography.Grid2D`. The grid is required
+        because positions and sizes are reported in degrees of visual angle;
+        without one a percept carries pixel indices instead.
     threshold : float, optional
         Fraction of a frame's own positive maximum at or above which a pixel
-        counts as part of the phosphene. Must lie in (0, 1]. The default of
-        0.5 makes :py:attr:`FrameMetrics.diameter` approximately the full
-        width at half maximum of a sufficiently sampled circular Gaussian
-        phosphene. More generally, a Gaussian of standard deviation ``sigma``
-        has support diameter ``2 * sigma * sqrt(-2 * log(threshold))``.
+        belongs to the support. Must lie in (0, 1]. A Gaussian of standard
+        deviation ``sigma`` has support diameter
+        ``2 * sigma * sqrt(-2 * log(threshold))``, so the default of 0.5 gives
+        approximately its FWHM.
 
     Returns
     -------
     metrics : :py:class:`PerceptMetrics`
 
+    Raises
+    ------
+    ValueError
+        For an RGB percept, a percept without visual-field coordinates, a
+        threshold outside (0, 1], or non-finite data.
+
     Notes
     -----
-    These are measurements of the model's output image. They describe how big
-    and how bright a modeled phosphene is, not how well an observer could
-    resolve or tell apart what they saw.
+    These measurements describe the modeled percept image, not behavioral
+    performance such as acuity or discriminability.
 
     """
     if getattr(percept, 'is_rgb', False):
@@ -314,8 +301,8 @@ def measure_percept(percept, threshold=0.5):
         raise ValueError(f"'threshold' is a fraction of a frame's own maximum "
                          f"brightness and must lie in (0, 1], not "
                          f"{threshold}.")
-    # Left in the dtype it was stored in; `_measure_frame` promotes, and
-    # checks, one frame at a time, so a long percept is never duplicated:
+    # Left in its stored dtype; `_measure_frame` promotes and checks one frame
+    # at a time, so a long percept is never duplicated:
     data = percept.data
     dx = _pixel_spacing(percept.xdva, 'xdva')
     dy = _pixel_spacing(percept.ydva, 'ydva')

--- a/pulse2percept/percepts/tests/test_metrics.py
+++ b/pulse2percept/percepts/tests/test_metrics.py
@@ -1,6 +1,3 @@
-import subprocess
-import sys
-
 import numpy as np
 import numpy.testing as npt
 import pytest
@@ -14,11 +11,19 @@ from pulse2percept.topography import Grid2D
 FWHM = 2 * np.sqrt(2 * np.log(2))
 
 
-def gaussian(grid, x0=0, y0=0, sigma_x=1, sigma_y=None, amplitude=1):
-    """A Gaussian blob sampled on ``grid``, as a one-frame (Y, X, 1) array"""
+def gaussian(grid, x0=0, y0=0, sigma_x=1, sigma_y=None, amplitude=1,
+             angle=0):
+    """A Gaussian blob sampled on ``grid``, as a one-frame (Y, X, 1) array
+
+    ``angle`` rotates the blob counterclockwise (radians) about ``(x0, y0)``.
+    """
     sigma_y = sigma_x if sigma_y is None else sigma_y
-    frame = amplitude * np.exp(-0.5 * (((grid.x - x0) / sigma_x) ** 2 +
-                                       ((grid.y - y0) / sigma_y) ** 2))
+    dx, dy = grid.x - x0, grid.y - y0
+    # Rotate the sampling coordinates into the blob's own frame:
+    u = dx * np.cos(angle) + dy * np.sin(angle)
+    v = -dx * np.sin(angle) + dy * np.cos(angle)
+    frame = amplitude * np.exp(-0.5 * ((u / sigma_x) ** 2 +
+                                       (v / sigma_y) ** 2))
     return frame[..., np.newaxis]
 
 
@@ -44,6 +49,12 @@ def test_measure_percept_circular_gaussian():
                         rtol=0.03)
     npt.assert_allclose(metrics.peak.elongation, 1, rtol=0.02)
     npt.assert_allclose(metrics.peak.major_axis, metrics.peak.minor_axis,
+                        rtol=0.02)
+    # Geometry is measured on the support alone, so the second-moment axes of
+    # a disk agree with its equivalent-circle diameter:
+    npt.assert_allclose(metrics.peak.major_axis, metrics.peak.diameter,
+                        rtol=0.02)
+    npt.assert_allclose(metrics.peak.minor_axis, metrics.peak.diameter,
                         rtol=0.02)
     npt.assert_equal(metrics.peak.n_components, 1)
     npt.assert_equal(metrics.peak.touches_edge, False)
@@ -93,7 +104,7 @@ def test_measure_percept_anisotropic_pixels():
     npt.assert_almost_equal(metrics.minor_axis, 4 * np.sqrt(dy ** 2 / 12))
     npt.assert_almost_equal(metrics.elongation, dx / dy)
     npt.assert_almost_equal(metrics.centroid, (grid.x[3, 2], grid.y[3, 2]))
-    npt.assert_almost_equal(metrics.total_brightness, dx * dy)
+    npt.assert_almost_equal(metrics.integrated_brightness, dx * dy)
 
 
 def test_measure_percept_anisotropic_gaussian():
@@ -109,6 +120,33 @@ def test_measure_percept_anisotropic_gaussian():
     npt.assert_allclose(tall.minor_axis, wide.minor_axis, rtol=1e-6)
 
 
+def test_measure_percept_rotated_gaussian():
+    # A blob at 90 deg leaves the off-diagonal moment zero; these angles do
+    # not, so they are what actually exercises `cov_xy`:
+    grid = Grid2D((-6, 6), (-6, 6), step=0.05)
+    kwargs = dict(sigma_x=1.5, sigma_y=0.5)
+    upright = measure_percept(Percept(gaussian(grid, **kwargs),
+                                      space=grid)).peak
+    for angle in (np.pi / 6, np.pi / 4, np.pi / 3):
+        turned = measure_percept(Percept(gaussian(grid, angle=angle,
+                                                  **kwargs), space=grid)).peak
+        # Axis lengths and elongation are rotation invariant; only the
+        # orientation of the ellipse changed:
+        npt.assert_allclose(turned.major_axis, upright.major_axis, rtol=0.02)
+        npt.assert_allclose(turned.minor_axis, upright.minor_axis, rtol=0.02)
+        npt.assert_allclose(turned.elongation, upright.elongation, rtol=0.02)
+        npt.assert_allclose(turned.area, upright.area, rtol=0.02)
+        npt.assert_almost_equal(turned.centroid, (0, 0), decimal=2)
+    # A 45 deg blob really is diagonal: its support spans x and y equally,
+    # which a measurement that ignored `cov_xy` would report as circular.
+    diagonal = measure_percept(Percept(gaussian(grid, angle=np.pi / 4,
+                                                **kwargs), space=grid)).peak
+    rows, cols = np.nonzero(gaussian(grid, angle=np.pi / 4,
+                                     **kwargs)[..., 0] >= 0.5)
+    npt.assert_allclose(np.ptp(cols), np.ptp(rows), rtol=0.05)
+    npt.assert_allclose(diagonal.elongation, 3, rtol=0.03)
+
+
 def test_measure_percept_amplitude_scaling():
     grid = Grid2D((-5, 5), (-5, 5), step=0.1)
     base = measure_percept(Percept(gaussian(grid), space=grid)).peak
@@ -117,7 +155,8 @@ def test_measure_percept_amplitude_scaling():
     # Brightness scales, but the threshold is relative to each frame's own
     # maximum, so the support and everything derived from it is untouched:
     npt.assert_allclose(scaled.max_brightness, 7.5 * base.max_brightness)
-    npt.assert_allclose(scaled.total_brightness, 7.5 * base.total_brightness)
+    npt.assert_allclose(scaled.integrated_brightness,
+                        7.5 * base.integrated_brightness)
     npt.assert_allclose(scaled.area, base.area)
     npt.assert_allclose(scaled.diameter, base.diameter)
     npt.assert_allclose(scaled.elongation, base.elongation)
@@ -133,8 +172,8 @@ def test_measure_percept_resolution_invariance():
                                              space=coarse)).peak
     fine_metrics = measure_percept(Percept(gaussian(fine, **args),
                                            space=fine)).peak
-    npt.assert_allclose(fine_metrics.total_brightness,
-                        coarse_metrics.total_brightness, rtol=0.01)
+    npt.assert_allclose(fine_metrics.integrated_brightness,
+                        coarse_metrics.integrated_brightness, rtol=0.01)
     npt.assert_allclose(fine_metrics.area, coarse_metrics.area, rtol=0.02)
     npt.assert_allclose(fine_metrics.diameter, coarse_metrics.diameter,
                         rtol=0.01)
@@ -157,7 +196,7 @@ def test_measure_percept_empty():
     for frame in (np.zeros(grid.shape), -np.ones(grid.shape)):
         metrics = measure_percept(Percept(frame[..., np.newaxis], space=grid))
         npt.assert_equal(metrics.peak_frame, 0)
-        npt.assert_equal(metrics.peak.total_brightness, 0)
+        npt.assert_equal(metrics.peak.integrated_brightness, 0)
         npt.assert_equal(metrics.peak.max_brightness, 0)
         npt.assert_equal(metrics.peak.area, 0)
         npt.assert_equal(metrics.peak.n_components, 0)
@@ -202,8 +241,8 @@ def test_measure_percept_temporal():
     npt.assert_equal(isinstance(metrics.frames[0], FrameMetrics), True)
     npt.assert_equal(isinstance(metrics, PerceptMetrics), True)
     npt.assert_allclose(metrics.max_brightness, amplitudes)
-    npt.assert_allclose(metrics.total_brightness / metrics.total_brightness[2],
-                        amplitudes)
+    integrated = metrics.integrated_brightness
+    npt.assert_allclose(integrated / integrated[2], amplitudes)
     npt.assert_equal(metrics.peak_frame, 1)
     npt.assert_equal(metrics.peak, metrics.frames[1])
     # The relative threshold makes every frame the same size:
@@ -246,7 +285,7 @@ def test_measure_percept_invalid():
         with pytest.raises(ValueError):
             measure_percept(Percept(gaussian(grid), space=grid),
                             threshold=threshold)
-    for bad in (np.nan, np.inf):
+    for bad in (np.nan, np.inf, -np.inf):
         frame = gaussian(grid)
         frame[0, 0, 0] = bad
         with pytest.raises(ValueError):
@@ -286,8 +325,8 @@ def test_Percept_measure_not_cached():
     percept.data[:] *= 2
     second = percept.measure()
     npt.assert_equal(second is first, False)
-    npt.assert_allclose(second.total_brightness,
-                        2 * first.total_brightness)
+    npt.assert_allclose(second.integrated_brightness,
+                        2 * first.integrated_brightness)
     npt.assert_allclose(second.max_brightness, 2 * first.max_brightness)
     # The threshold is relative, so the geometry is where it was:
     npt.assert_allclose(second.area, first.area)
@@ -301,24 +340,3 @@ def test_Percept_measure_rejects_rgb():
     grid = Grid2D((-2, 2), (-2, 2), step=0.5)
     with pytest.raises(ValueError):
         Percept(np.zeros(grid.shape + (3, 1)), space=grid).measure()
-
-
-def test_Percept_measure_not_imported_eagerly():
-    # Ordinary percept use must not pull in the measurement module; only
-    # `Percept.measure` imports it. This has to run in a subprocess, because
-    # by the time this test executes the module has long been imported.
-    code = ("import sys;"
-            "import numpy as np;"
-            "import pulse2percept as p2p;"
-            "from pulse2percept.percepts import Percept;"
-            "from pulse2percept.topography import Grid2D;"
-            "grid = Grid2D((-2, 2), (-2, 2), step=0.5);"
-            "percept = Percept(np.ones(grid.shape + (1,)), space=grid);"
-            "name = 'pulse2percept.percepts.metrics';"
-            "print('BEFORE', name in sys.modules);"
-            "percept.measure();"
-            "print('AFTER', name in sys.modules)")
-    out = subprocess.run([sys.executable, '-c', code], capture_output=True,
-                         text=True, check=True)
-    npt.assert_equal(out.stdout.strip().splitlines()[-2:],
-                     ['BEFORE False', 'AFTER True'])

--- a/pulse2percept/percepts/tests/test_metrics.py
+++ b/pulse2percept/percepts/tests/test_metrics.py
@@ -1,3 +1,6 @@
+import subprocess
+import sys
+
 import numpy as np
 import numpy.testing as npt
 import pytest
@@ -298,3 +301,24 @@ def test_Percept_measure_rejects_rgb():
     grid = Grid2D((-2, 2), (-2, 2), step=0.5)
     with pytest.raises(ValueError):
         Percept(np.zeros(grid.shape + (3, 1)), space=grid).measure()
+
+
+def test_Percept_measure_not_imported_eagerly():
+    # Ordinary percept use must not pull in the measurement module; only
+    # `Percept.measure` imports it. This has to run in a subprocess, because
+    # by the time this test executes the module has long been imported.
+    code = ("import sys;"
+            "import numpy as np;"
+            "import pulse2percept as p2p;"
+            "from pulse2percept.percepts import Percept;"
+            "from pulse2percept.topography import Grid2D;"
+            "grid = Grid2D((-2, 2), (-2, 2), step=0.5);"
+            "percept = Percept(np.ones(grid.shape + (1,)), space=grid);"
+            "name = 'pulse2percept.percepts.metrics';"
+            "print('BEFORE', name in sys.modules);"
+            "percept.measure();"
+            "print('AFTER', name in sys.modules)")
+    out = subprocess.run([sys.executable, '-c', code], capture_output=True,
+                         text=True, check=True)
+    npt.assert_equal(out.stdout.strip().splitlines()[-2:],
+                     ['BEFORE False', 'AFTER True'])

--- a/pulse2percept/percepts/tests/test_metrics.py
+++ b/pulse2percept/percepts/tests/test_metrics.py
@@ -252,3 +252,49 @@ def test_measure_percept_invalid():
     with pytest.raises(ValueError):
         measure_percept(Percept(np.ones((5, 1, 1)),
                                 space=Grid2D((0, 0), (-2, 2), step=1)))
+
+
+def test_Percept_measure():
+    grid = Grid2D((-5, 5), (-5, 5), step=0.1)
+    percept = Percept(gaussian(grid, x0=1, y0=-2, sigma_x=1.3), space=grid)
+    metrics = percept.measure()
+    npt.assert_equal(isinstance(metrics, PerceptMetrics), True)
+    npt.assert_equal(metrics.threshold, 0.5)
+    # The method is a thin delegation, so it must agree with the function:
+    npt.assert_equal(metrics, measure_percept(percept))
+    npt.assert_equal(metrics is measure_percept(percept), False)
+
+
+def test_Percept_measure_threshold():
+    grid = Grid2D((-5, 5), (-5, 5), step=0.1)
+    percept = Percept(gaussian(grid, sigma_x=1.3), space=grid)
+    strict = percept.measure(threshold=0.25)
+    npt.assert_equal(strict.threshold, 0.25)
+    npt.assert_equal(strict, measure_percept(percept, threshold=0.25))
+    # A lower threshold keeps more of the frame than the default does:
+    npt.assert_equal(strict.peak.area > percept.measure().peak.area, True)
+
+
+def test_Percept_measure_not_cached():
+    grid = Grid2D((-5, 5), (-5, 5), step=0.1)
+    percept = Percept(gaussian(grid, sigma_x=1.3), space=grid)
+    first = percept.measure()
+    # Brighten the percept in place; a cached result would not notice:
+    percept.data[:] *= 2
+    second = percept.measure()
+    npt.assert_equal(second is first, False)
+    npt.assert_allclose(second.total_brightness,
+                        2 * first.total_brightness)
+    npt.assert_allclose(second.max_brightness, 2 * first.max_brightness)
+    # The threshold is relative, so the geometry is where it was:
+    npt.assert_allclose(second.area, first.area)
+    npt.assert_allclose(second.diameter, first.diameter)
+    npt.assert_allclose(second.centroid, first.centroid)
+
+
+def test_Percept_measure_rejects_rgb():
+    # One smoke check that validation is reached through the method; the full
+    # matrix is tested against `measure_percept` itself:
+    grid = Grid2D((-2, 2), (-2, 2), step=0.5)
+    with pytest.raises(ValueError):
+        Percept(np.zeros(grid.shape + (3, 1)), space=grid).measure()

--- a/pulse2percept/percepts/tests/test_metrics.py
+++ b/pulse2percept/percepts/tests/test_metrics.py
@@ -47,6 +47,52 @@ def test_measure_percept_circular_gaussian():
     npt.assert_almost_equal(metrics.peak.max_brightness, 1)
 
 
+def test_measure_percept_threshold():
+    grid = Grid2D((-5, 5), (-5, 5), step=0.05)
+    sigma = 1.2
+    percept = Percept(gaussian(grid, sigma_x=sigma), space=grid)
+    # A Gaussian falls to `threshold` of its peak at a radius of
+    # sigma * sqrt(-2 * log(threshold)):
+    for threshold in (np.exp(-0.5), 0.25, 0.8):
+        metrics = measure_percept(percept, threshold=threshold)
+        npt.assert_equal(metrics.threshold, threshold)
+        npt.assert_allclose(metrics.peak.diameter,
+                            2 * sigma * np.sqrt(-2 * np.log(threshold)),
+                            rtol=0.02)
+    # exp(-0.5) puts the support edge exactly one standard deviation out:
+    at_sigma = measure_percept(percept, threshold=np.exp(-0.5)).peak
+    npt.assert_allclose(at_sigma.diameter, 2 * sigma, rtol=0.02)
+    # A stricter threshold keeps strictly less of the same frame:
+    half = measure_percept(percept, threshold=0.5).peak
+    npt.assert_equal(at_sigma.area < half.area, True)
+    npt.assert_equal(measure_percept(percept).threshold, 0.5)
+
+
+def test_measure_percept_anisotropic_pixels():
+    # Deliberately unequal x/y spacing, so a pixel is twice as wide as it is
+    # tall. Anything that collapses (dx, dy) to a single step size, or drops
+    # the within-cell variance, gets this wrong:
+    grid = Grid2D((-1, 1), (-1, 1), step=(0.5, 0.25))
+    dx, dy = 0.5, 0.25
+    npt.assert_almost_equal(np.diff(grid.x[0, :]), dx)
+    npt.assert_almost_equal(np.abs(np.diff(grid.y[:, 0])), dy)
+    # A support of exactly one pixel: the pixel is all the extent there is.
+    frame = np.zeros(grid.shape)
+    frame[3, 2] = 1.0
+    metrics = measure_percept(Percept(frame[..., np.newaxis], space=grid)).peak
+    npt.assert_almost_equal(metrics.area, dx * dy)
+    npt.assert_almost_equal(metrics.diameter, 2 * np.sqrt(dx * dy / np.pi))
+    npt.assert_equal(np.isfinite([metrics.major_axis, metrics.minor_axis]),
+                     [True, True])
+    npt.assert_equal(min(metrics.major_axis, metrics.minor_axis) > 0, True)
+    # A uniform cell has variance (side ** 2) / 12 along each side:
+    npt.assert_almost_equal(metrics.major_axis, 4 * np.sqrt(dx ** 2 / 12))
+    npt.assert_almost_equal(metrics.minor_axis, 4 * np.sqrt(dy ** 2 / 12))
+    npt.assert_almost_equal(metrics.elongation, dx / dy)
+    npt.assert_almost_equal(metrics.centroid, (grid.x[3, 2], grid.y[3, 2]))
+    npt.assert_almost_equal(metrics.total_brightness, dx * dy)
+
+
 def test_measure_percept_anisotropic_gaussian():
     grid = Grid2D((-6, 6), (-6, 6), step=0.05)
     wide = measure_percept(Percept(gaussian(grid, sigma_x=1.5, sigma_y=0.5),

--- a/pulse2percept/percepts/tests/test_metrics.py
+++ b/pulse2percept/percepts/tests/test_metrics.py
@@ -43,7 +43,7 @@ def test_measure_percept_circular_gaussian():
     sigma = 1.2
     percept = Percept(gaussian(grid, sigma_x=sigma), space=grid)
     metrics = measure_percept(percept, threshold=0.5)
-    # At half maximum, the equivalent-circle diameter is the FWHM:
+    # At half maximum, the equivalent-circle diameter approximates the FWHM:
     npt.assert_allclose(metrics.peak.diameter, FWHM * sigma, rtol=0.02)
     npt.assert_allclose(metrics.peak.area, np.pi * (FWHM * sigma / 2) ** 2,
                         rtol=0.03)
@@ -51,7 +51,7 @@ def test_measure_percept_circular_gaussian():
     npt.assert_allclose(metrics.peak.major_axis, metrics.peak.minor_axis,
                         rtol=0.02)
     # Geometry is measured on the support alone, so the second-moment axes of
-    # a disk agree with its equivalent-circle diameter:
+    # a sampled disk approach its equivalent-circle diameter:
     npt.assert_allclose(metrics.peak.major_axis, metrics.peak.diameter,
                         rtol=0.02)
     npt.assert_allclose(metrics.peak.minor_axis, metrics.peak.diameter,
@@ -83,14 +83,13 @@ def test_measure_percept_threshold():
 
 
 def test_measure_percept_anisotropic_pixels():
-    # Deliberately unequal x/y spacing, so a pixel is twice as wide as it is
-    # tall. Anything that collapses (dx, dy) to a single step size, or drops
-    # the within-cell variance, gets this wrong:
+    # Pixels twice as wide as they are tall: this fails if (dx, dy) collapses
+    # to a single step size, or if the within-cell variance is dropped.
     grid = Grid2D((-1, 1), (-1, 1), step=(0.5, 0.25))
     dx, dy = 0.5, 0.25
     npt.assert_almost_equal(np.diff(grid.x[0, :]), dx)
     npt.assert_almost_equal(np.abs(np.diff(grid.y[:, 0])), dy)
-    # A support of exactly one pixel: the pixel is all the extent there is.
+    # A support of exactly one pixel, whose cell is its entire extent:
     frame = np.zeros(grid.shape)
     frame[3, 2] = 1.0
     metrics = measure_percept(Percept(frame[..., np.newaxis], space=grid)).peak
@@ -321,14 +320,14 @@ def test_Percept_measure_not_cached():
     grid = Grid2D((-5, 5), (-5, 5), step=0.1)
     percept = Percept(gaussian(grid, sigma_x=1.3), space=grid)
     first = percept.measure()
-    # Brighten the percept in place; a cached result would not notice:
+    # Brighten in place; a cached result would not reflect this:
     percept.data[:] *= 2
     second = percept.measure()
     npt.assert_equal(second is first, False)
     npt.assert_allclose(second.integrated_brightness,
                         2 * first.integrated_brightness)
     npt.assert_allclose(second.max_brightness, 2 * first.max_brightness)
-    # The threshold is relative, so the geometry is where it was:
+    # The threshold is relative, so the geometry is unchanged:
     npt.assert_allclose(second.area, first.area)
     npt.assert_allclose(second.diameter, first.diameter)
     npt.assert_allclose(second.centroid, first.centroid)

--- a/pulse2percept/percepts/tests/test_metrics.py
+++ b/pulse2percept/percepts/tests/test_metrics.py
@@ -1,0 +1,208 @@
+import numpy as np
+import numpy.testing as npt
+import pytest
+
+from pulse2percept.percepts import Percept
+from pulse2percept.percepts.metrics import (FrameMetrics, PerceptMetrics,
+                                            measure_percept)
+from pulse2percept.topography import Grid2D
+
+# Full width at half maximum of a Gaussian with unit standard deviation:
+FWHM = 2 * np.sqrt(2 * np.log(2))
+
+
+def gaussian(grid, x0=0, y0=0, sigma_x=1, sigma_y=None, amplitude=1):
+    """A Gaussian blob sampled on ``grid``, as a one-frame (Y, X, 1) array"""
+    sigma_y = sigma_x if sigma_y is None else sigma_y
+    frame = amplitude * np.exp(-0.5 * (((grid.x - x0) / sigma_x) ** 2 +
+                                       ((grid.y - y0) / sigma_y) ** 2))
+    return frame[..., np.newaxis]
+
+
+def test_measure_percept_centroid():
+    # A blob away from the origin in both x and y, on a field whose x and y
+    # ranges differ, so a transposed or flipped axis cannot go unnoticed:
+    grid = Grid2D((-8, 8), (-4, 4), step=0.05)
+    percept = Percept(gaussian(grid, x0=2.5, y0=-1.5, sigma_x=0.6), space=grid)
+    metrics = measure_percept(percept)
+    npt.assert_almost_equal(metrics.peak.centroid, (2.5, -1.5), decimal=2)
+    npt.assert_equal(metrics.centroid.shape, (1, 2))
+    npt.assert_almost_equal(metrics.centroid[0], (2.5, -1.5), decimal=2)
+
+
+def test_measure_percept_circular_gaussian():
+    grid = Grid2D((-5, 5), (-5, 5), step=0.05)
+    sigma = 1.2
+    percept = Percept(gaussian(grid, sigma_x=sigma), space=grid)
+    metrics = measure_percept(percept, threshold=0.5)
+    # At half maximum, the equivalent-circle diameter is the FWHM:
+    npt.assert_allclose(metrics.peak.diameter, FWHM * sigma, rtol=0.02)
+    npt.assert_allclose(metrics.peak.area, np.pi * (FWHM * sigma / 2) ** 2,
+                        rtol=0.03)
+    npt.assert_allclose(metrics.peak.elongation, 1, rtol=0.02)
+    npt.assert_allclose(metrics.peak.major_axis, metrics.peak.minor_axis,
+                        rtol=0.02)
+    npt.assert_equal(metrics.peak.n_components, 1)
+    npt.assert_equal(metrics.peak.touches_edge, False)
+    npt.assert_almost_equal(metrics.peak.max_brightness, 1)
+
+
+def test_measure_percept_anisotropic_gaussian():
+    grid = Grid2D((-6, 6), (-6, 6), step=0.05)
+    wide = measure_percept(Percept(gaussian(grid, sigma_x=1.5, sigma_y=0.5),
+                                   space=grid)).peak
+    tall = measure_percept(Percept(gaussian(grid, sigma_x=0.5, sigma_y=1.5),
+                                   space=grid)).peak
+    npt.assert_equal(wide.major_axis > wide.minor_axis, True)
+    npt.assert_allclose(wide.elongation, 3, rtol=0.03)
+    # Rotating the blob by 90 deg must not change its axis lengths:
+    npt.assert_allclose(tall.major_axis, wide.major_axis, rtol=1e-6)
+    npt.assert_allclose(tall.minor_axis, wide.minor_axis, rtol=1e-6)
+
+
+def test_measure_percept_amplitude_scaling():
+    grid = Grid2D((-5, 5), (-5, 5), step=0.1)
+    base = measure_percept(Percept(gaussian(grid), space=grid)).peak
+    scaled = measure_percept(Percept(gaussian(grid, amplitude=7.5),
+                                     space=grid)).peak
+    # Brightness scales, but the threshold is relative to each frame's own
+    # maximum, so the support and everything derived from it is untouched:
+    npt.assert_allclose(scaled.max_brightness, 7.5 * base.max_brightness)
+    npt.assert_allclose(scaled.total_brightness, 7.5 * base.total_brightness)
+    npt.assert_allclose(scaled.area, base.area)
+    npt.assert_allclose(scaled.diameter, base.diameter)
+    npt.assert_allclose(scaled.elongation, base.elongation)
+    npt.assert_allclose(scaled.centroid, base.centroid)
+
+
+def test_measure_percept_resolution_invariance():
+    # The same continuous Gaussian, sampled twice as finely:
+    coarse = Grid2D((-5, 5), (-5, 5), step=0.1)
+    fine = Grid2D((-5, 5), (-5, 5), step=0.05)
+    args = dict(x0=1.0, y0=-0.75, sigma_x=1.1)
+    coarse_metrics = measure_percept(Percept(gaussian(coarse, **args),
+                                             space=coarse)).peak
+    fine_metrics = measure_percept(Percept(gaussian(fine, **args),
+                                           space=fine)).peak
+    npt.assert_allclose(fine_metrics.total_brightness,
+                        coarse_metrics.total_brightness, rtol=0.01)
+    npt.assert_allclose(fine_metrics.area, coarse_metrics.area, rtol=0.02)
+    npt.assert_allclose(fine_metrics.diameter, coarse_metrics.diameter,
+                        rtol=0.01)
+    npt.assert_allclose(fine_metrics.centroid, coarse_metrics.centroid,
+                        atol=0.01)
+
+
+def test_measure_percept_nonsquare_field():
+    grid = Grid2D((-10, 2), (-1, 5), step=0.05)
+    percept = Percept(gaussian(grid, x0=-4, y0=3, sigma_x=1.2, sigma_y=0.4),
+                      space=grid)
+    metrics = measure_percept(percept).peak
+    npt.assert_almost_equal(metrics.centroid, (-4, 3), decimal=2)
+    npt.assert_allclose(metrics.elongation, 3, rtol=0.03)
+    npt.assert_allclose(metrics.diameter, FWHM * np.sqrt(1.2 * 0.4), rtol=0.02)
+
+
+def test_measure_percept_empty():
+    grid = Grid2D((-2, 2), (-2, 2), step=0.1)
+    for frame in (np.zeros(grid.shape), -np.ones(grid.shape)):
+        metrics = measure_percept(Percept(frame[..., np.newaxis], space=grid))
+        npt.assert_equal(metrics.peak_frame, 0)
+        npt.assert_equal(metrics.peak.total_brightness, 0)
+        npt.assert_equal(metrics.peak.max_brightness, 0)
+        npt.assert_equal(metrics.peak.area, 0)
+        npt.assert_equal(metrics.peak.n_components, 0)
+        npt.assert_equal(metrics.peak.touches_edge, False)
+        # No phosphene means no place and no shape, not one at the origin:
+        npt.assert_equal(np.isnan(metrics.peak.centroid), (True, True))
+        for name in ('diameter', 'major_axis', 'minor_axis', 'elongation'):
+            npt.assert_equal(np.isnan(getattr(metrics.peak, name)), True)
+
+
+def test_measure_percept_touches_edge():
+    grid = Grid2D((-5, 5), (-5, 5), step=0.1)
+    centered = Percept(gaussian(grid, sigma_x=1), space=grid)
+    npt.assert_equal(measure_percept(centered).peak.touches_edge, False)
+    # Pushed far enough that the half-maximum support runs off the field:
+    clipped = Percept(gaussian(grid, x0=4.8, sigma_x=1), space=grid)
+    npt.assert_equal(measure_percept(clipped).peak.touches_edge, True)
+
+
+def test_measure_percept_multiple_components():
+    grid = Grid2D((-8, 8), (-8, 8), step=0.05)
+    blob = gaussian(grid, x0=-4, sigma_x=0.5) + gaussian(grid, x0=4,
+                                                         sigma_x=0.5)
+    metrics = measure_percept(Percept(blob, space=grid)).peak
+    npt.assert_equal(metrics.n_components, 2)
+    # Both blobs are measured, not just the first one found:
+    one = measure_percept(Percept(gaussian(grid, x0=-4, sigma_x=0.5),
+                                  space=grid)).peak
+    npt.assert_allclose(metrics.area, 2 * one.area, rtol=0.02)
+    # The two are symmetric about x=0, so their combined centroid sits there:
+    npt.assert_almost_equal(metrics.centroid[0], 0, decimal=6)
+    npt.assert_equal(metrics.major_axis > one.major_axis, True)
+
+
+def test_measure_percept_temporal():
+    grid = Grid2D((-4, 4), (-4, 4), step=0.1)
+    amplitudes = [0.5, 2.0, 1.0]
+    frames = np.concatenate([gaussian(grid, amplitude=amp)
+                             for amp in amplitudes], axis=-1)
+    metrics = measure_percept(Percept(frames, space=grid, time=[0, 1, 2]))
+    npt.assert_equal(len(metrics.frames), 3)
+    npt.assert_equal(isinstance(metrics.frames[0], FrameMetrics), True)
+    npt.assert_equal(isinstance(metrics, PerceptMetrics), True)
+    npt.assert_allclose(metrics.max_brightness, amplitudes)
+    npt.assert_allclose(metrics.total_brightness / metrics.total_brightness[2],
+                        amplitudes)
+    npt.assert_equal(metrics.peak_frame, 1)
+    npt.assert_equal(metrics.peak, metrics.frames[1])
+    # The relative threshold makes every frame the same size:
+    npt.assert_allclose(metrics.diameter, [metrics.diameter[0]] * 3)
+    for name, shape in [('area', (3,)), ('elongation', (3,)),
+                        ('major_axis', (3,)), ('minor_axis', (3,)),
+                        ('n_components', (3,)), ('touches_edge', (3,)),
+                        ('centroid', (3, 2))]:
+        npt.assert_equal(getattr(metrics, name).shape, shape)
+    npt.assert_equal(metrics.n_components.dtype, np.dtype(int))
+    npt.assert_equal(metrics.touches_edge.dtype, np.dtype(bool))
+
+
+def test_measure_percept_peak_frame_ties():
+    grid = Grid2D((-4, 4), (-4, 4), step=0.2)
+    frames = np.concatenate([gaussian(grid)] * 3, axis=-1)
+    npt.assert_equal(measure_percept(Percept(frames, space=grid)).peak_frame,
+                     0)
+
+
+def test_measure_percept_immutable():
+    grid = Grid2D((-4, 4), (-4, 4), step=0.2)
+    metrics = measure_percept(Percept(gaussian(grid), space=grid))
+    with pytest.raises(Exception):
+        metrics.frames[0].area = 1
+    with pytest.raises(Exception):
+        metrics.frames = ()
+
+
+def test_measure_percept_invalid():
+    grid = Grid2D((-4, 4), (-4, 4), step=0.2)
+    # RGB percepts are display values, not perceived brightness:
+    rgb = Percept(np.zeros(grid.shape + (3, 1)), space=grid)
+    with pytest.raises(ValueError):
+        measure_percept(rgb)
+    # Without a Grid2D, 'xdva'/'ydva' are pixel indices, not dva:
+    with pytest.raises(ValueError):
+        measure_percept(Percept(np.zeros((10, 10, 1))))
+    for threshold in (0, -0.5, 1.5, np.nan):
+        with pytest.raises(ValueError):
+            measure_percept(Percept(gaussian(grid), space=grid),
+                            threshold=threshold)
+    for bad in (np.nan, np.inf):
+        frame = gaussian(grid)
+        frame[0, 0, 0] = bad
+        with pytest.raises(ValueError):
+            measure_percept(Percept(frame, space=grid))
+    # A single-pixel axis says nothing about how much field a pixel covers:
+    with pytest.raises(ValueError):
+        measure_percept(Percept(np.ones((5, 1, 1)),
+                                space=Grid2D((0, 0), (-2, 2), step=1)))


### PR DESCRIPTION
Adds opt-in phosphene quantification on top of `Percept` via:

```python
metrics = percept.measure()
```

The new measurement layer reports per-frame brightness and geometry, including integrated brightness, peak brightness, support area, equivalent diameter, centroid, major/minor axes, elongation, connected components, and edge clipping.

Key points:

* no added work in `predict_percept`
* measurements are computed only when requested and are not cached
* spatial quantities use the percept’s actual dva sampling
* analytical tests cover Gaussian size/centroid/elongation, threshold behavior, sampling invariance, anisotropic pixels, temporal percepts, clipping, and multi-component output

Closes #295.
