### PR TITLE
[ENH] Improve Scene and binocular QoL

### DIFF
--- a/doc/topics/models.rst
+++ b/doc/topics/models.rst
@@ -461,16 +461,21 @@ The rendered field boundary
 
 .. versionadded:: 0.11.0
 
-A scene's source, pixel grid and sampling are rectangular. ``aperture='circle'``
-renders an eye-centered disc of radius ``min(fov) / 2`` instead, blacking out
-the corners around it and changing the rendered scene only:
+A scene's source, pixel grid and sampling are rectangular. ``fov`` gives the
+rendered field its outer dimensions ``(width, height)``, and ``aperture`` gives
+it its shape: the default ``'rectangle'`` uses the whole frame, while
+``'ellipse'`` inscribes an ellipse in those dimensions and blacks out the
+corners around it:
 
 .. code-block:: python
 
-    scene = p2p.vision.Scene(image, fov=40 * dva, aperture='circle')
+    disc = p2p.vision.Scene(image, fov=40 * dva, aperture='ellipse')
+    wide = p2p.vision.Scene(image, fov=(60, 40) * dva, aperture='ellipse')
 
-Like the scotoma and the eccentricity rings, the disc is
-eye-centered, so gaze moves it through the scene.
+A square ``fov`` therefore renders as a disc, and a 60 x 40 one as an ellipse
+reaching 30 degrees sideways and 20 degrees up. Like the scotoma and the
+eccentricity rings, it is eye-centered, so gaze moves it through the scene. It
+changes the rendered scene only.
 
 Both eyes
 ~~~~~~~~~
@@ -490,8 +495,20 @@ monocular views:
     ax_left, ax_right = binocular.plot(left_percept=percept, vmax=2)
 
 A bilateral loss is often symmetric about the vertical meridian.
-:py:meth:`~pulse2percept.vision.Scotoma.mirror` reflects a scotoma across it
-(``mirrored(x, y) == original(-x, y)``) and returns a new one:
+:py:meth:`~pulse2percept.vision.Scene.fellow_eye` builds the homologous scene
+for the other eye:
+
+.. code-block:: python
+
+    left = p2p.vision.Scene(image, fov=40 * dva, scotoma=scotoma)
+    binocular = p2p.vision.BinocularScene(left, left.fellow_eye())
+
+It reflects eye-specific geometry, such as a scotoma, across the vertical
+meridian. The image itself is not flipped, since both eyes look at the same
+world in the same orientation.
+
+:py:meth:`~pulse2percept.vision.Scotoma.mirror` is the same reflection on a
+scotoma alone (``mirrored(x, y) == original(-x, y)``):
 
 .. code-block:: python
 

--- a/doc/users/release_notes.rst
+++ b/doc/users/release_notes.rst
@@ -48,7 +48,8 @@ Highlights
   :py:class:`~pulse2percept.vision.Scotoma` for gaze-aware simulation of
   residual vision and retinal prostheses, and
   :py:class:`~pulse2percept.vision.BinocularScene` for the two eyes' views
-  side by side (:pull:`854`, :pull:`871`, :pull:`883`, :pull:`890`).
+  side by side (:pull:`854`, :pull:`871`, :pull:`883`, :pull:`890`,
+  :pull:`899`).
 
 * New photovoltaic stimulation pipeline for the PRIMA-style arrays, from image
   encoding to irradiance-based model input (:pull:`868`, :pull:`891`).
@@ -191,18 +192,13 @@ Topography
 Scene and plotting
 ~~~~~~~~~~~~~~~~~~
 
-* :py:class:`~pulse2percept.vision.Scene` supports softened scotoma boundaries,
-  configurable backgrounds, inpainting, eccentricity rings, and static or
-  animated visualization. Inpainting is intentionally unavailable when
-  composing prosthetic vision because its interaction with prosthetic
-  brightness is not modeled (:pull:`871`, :pull:`884`, :pull:`893`).
-
-* ``Scene(aperture='circle')`` renders an eye-centered disc of radius
-  ``min(fov) / 2`` instead of the full rectangle (:pull:`890`).
-
-* New :py:class:`~pulse2percept.vision.BinocularScene` holds a left and a
-  right :py:class:`~pulse2percept.vision.Scene` and plots them side by side
-  (:pull:`890`).
+* New :py:class:`~pulse2percept.vision.Scene` and
+  :py:class:`~pulse2percept.vision.BinocularScene` place images, video,
+  scotomas, and prosthetic percepts in visual-field coordinates. Scenes support
+  eye-centered gaze, rectangular or elliptical apertures, residual-vision
+  rendering, and fellow-eye geometry; binocular scenes keep the two monocular
+  views independent while plotting them on a common angular scale
+  (:pull:`871`, :pull:`884`, :pull:`890`, :pull:`893`, :pull:`899`).
 
 * New :py:mod:`pulse2percept.plotting` module provides combined
   stimulus/percept figures and animations. :py:mod:`pulse2percept.viz` is

--- a/examples/vision/plot_amd_prima.py
+++ b/examples/vision/plot_amd_prima.py
@@ -119,24 +119,27 @@ plt.title('Edge-filtered device input, intact vision around it')
 # The two are held together by a
 # :py:class:`~pulse2percept.vision.BinocularScene`.
 #
-# ``aperture='circle'`` renders each field as an eye-centered disc rather than
-# a rectangle, which reads as an ocular field. It changes the rendering only;
-# the implant is given the same scene values either way.
+# ``aperture='ellipse'`` inscribes an eye-centered ellipse in ``fov`` rather
+# than using the whole rectangle. This changes the rendering only.
+#
+# Differences in residual acuity are not modeled.
+#
+# Vision loss need not be identical in both eyes:
 
 implant.preprocess = False
 
 worse_eye = Scene(logo, fov=40 * dva, scotoma=scotoma, scotoma_fill=0,
-                  background=1, aperture='circle')
-fellow_eye = Scene(logo, fov=40 * dva, background=1, aperture='circle',
+                  background=1, aperture='ellipse')
+fellow_eye = Scene(logo, fov=40 * dva, background=1, aperture='ellipse',
                    scotoma=Scotoma.circle(3 * dva, center=center),
                    scotoma_fill=0.4)
 
 binocular = BinocularScene(left=worse_eye, right=fellow_eye)
 
 ###############################################################################
-# Differences in residual acuity or contrast sensitivity between the two eyes
-# are not currently modeled; the scenes differ only through explicitly
-# specified visual-field loss and source content.
+# For vision loss that is symmetric about the vertical meridian,
+# :py:meth:`~pulse2percept.vision.Scene.fellow_eye` builds the homologous
+# scene for the fellow eye.
 #
 # By default, models are monocular:
 

--- a/pulse2percept/vision/binocular.py
+++ b/pulse2percept/vision/binocular.py
@@ -1,8 +1,27 @@
 """:py:class:`~pulse2percept.vision.BinocularScene`"""
+import numpy as np
 import matplotlib.pyplot as plt
 
 from .scene import Scene
 from ..utils import PrettyPrint
+
+
+def _share_visual_field(axes):
+    """Put both axes on the same degrees-per-inch scale
+
+    Each `Scene.plot` scales its axes to its own FOV, which would draw a
+    30-degree and a 50-degree field at the same size on screen. Widening both
+    to the union of the two ranges keeps one degree the same length in either
+    panel. Presentation only: each image keeps its own extent.
+    """
+    for axis in ('x', 'y'):
+        limits = [getattr(ax, f'get_{axis}lim')() for ax in axes]
+        lo = min(min(lim) for lim in limits)
+        hi = max(max(lim) for lim in limits)
+        for ax in axes:
+            getattr(ax, f'set_{axis}lim')(lo, hi)
+            # `Percept._label_axes` fixes five ticks across its own range:
+            getattr(ax, f'set_{axis}ticks')(np.linspace(lo, hi, num=5))
 
 
 class BinocularScene(PrettyPrint):
@@ -44,6 +63,15 @@ class BinocularScene(PrettyPrint):
     ...     right=Scene(picture, fov=40 * dva))
     >>> binocular.left.scotoma is None, binocular.right.scotoma is None
     (False, True)
+
+    A bilateral loss that is symmetric about the vertical meridian, built with
+    :py:meth:`~pulse2percept.vision.Scene.fellow_eye`:
+
+    >>> left = Scene(picture, fov=40 * dva,
+    ...              scotoma=Scotoma.circle(3 * dva, center=(6, 0) * dva))
+    >>> binocular = BinocularScene(left, left.fellow_eye())
+    >>> float(binocular.right.scotoma(-6, 0))
+    1.0
 
     """
 
@@ -108,9 +136,10 @@ class BinocularScene(PrettyPrint):
             The two axes, always in left-eye, right-eye order.
 
         """
+        fig = None
         if axes is None:
-            _, axes = plt.subplots(1, 2, figsize=kwargs.pop('figsize',
-                                                            (10, 5)))
+            fig, axes = plt.subplots(1, 2, figsize=kwargs.pop('figsize',
+                                                              (10, 5)))
         axes = tuple(axes)
         if len(axes) != 2:
             raise ValueError(f"'axes' must be one axes per eye (2 of them), "
@@ -126,4 +155,7 @@ class BinocularScene(PrettyPrint):
                                     rings=rings, percept=percept, **scale,
                                     **kwargs))
             drawn[-1].set_title(f'{label} eye')
+        _share_visual_field(drawn)
+        if fig is not None:
+            fig.tight_layout()
         return tuple(drawn)

--- a/pulse2percept/vision/binocular.py
+++ b/pulse2percept/vision/binocular.py
@@ -6,22 +6,15 @@ from .scene import Scene
 from ..utils import PrettyPrint
 
 
-def _share_visual_field(axes):
-    """Put both axes on the same degrees-per-inch scale
-
-    Each `Scene.plot` scales its axes to its own FOV, which would draw a
-    30-degree and a 50-degree field at the same size on screen. Widening both
-    to the union of the two ranges keeps one degree the same length in either
-    panel. Presentation only: each image keeps its own extent.
-    """
-    for axis in ('x', 'y'):
-        limits = [getattr(ax, f'get_{axis}lim')() for ax in axes]
-        lo = min(min(lim) for lim in limits)
-        hi = max(max(lim) for lim in limits)
+def _share_visual_field(axes, scenes):
+    """Put both axes on the same degrees-per-inch scale"""
+    half = [max(scene.fov[i] for scene in scenes) / 2 for i in (0, 1)]
+    for axis, extent in zip(('x', 'y'), half):
         for ax in axes:
-            getattr(ax, f'set_{axis}lim')(lo, hi)
+            getattr(ax, f'set_{axis}lim')(-extent, extent)
             # `Percept._label_axes` fixes five ticks across its own range:
-            getattr(ax, f'set_{axis}ticks')(np.linspace(lo, hi, num=5))
+            getattr(ax, f'set_{axis}ticks')(np.linspace(-extent, extent,
+                                                        num=5))
 
 
 class BinocularScene(PrettyPrint):
@@ -155,7 +148,7 @@ class BinocularScene(PrettyPrint):
                                     rings=rings, percept=percept, **scale,
                                     **kwargs))
             drawn[-1].set_title(f'{label} eye')
-        _share_visual_field(drawn)
+        _share_visual_field(drawn, (self.left, self.right))
         if fig is not None:
             fig.tight_layout()
         return tuple(drawn)

--- a/pulse2percept/vision/binocular.py
+++ b/pulse2percept/vision/binocular.py
@@ -7,7 +7,7 @@ from ..utils import PrettyPrint
 
 
 def _share_visual_field(axes, scenes):
-    """Put both axes on the same degrees-per-inch scale"""
+    """Draw both eyes over the same angular extent."""
     half = [max(scene.fov[i] for scene in scenes) / 2 for i in (0, 1)]
     for axis, extent in zip(('x', 'y'), half):
         for ax in axes:

--- a/pulse2percept/vision/scene.py
+++ b/pulse2percept/vision/scene.py
@@ -545,11 +545,11 @@ class Scene(PrettyPrint):
 
         """
         scotoma = None if self.scotoma is None else self.scotoma.mirror()
-        return type(self)(self.source, self.fov, scotoma=scotoma,
-                          scotoma_fill=self.scotoma_fill,
-                          scotoma_blend=self.scotoma_blend,
-                          background=self.background,
-                          aperture=self.aperture)
+        return Scene(self.source, self.fov, scotoma=scotoma,
+                     scotoma_fill=self.scotoma_fill,
+                     scotoma_blend=self.scotoma_blend,
+                     background=self.background,
+                     aperture=self.aperture)
 
     def _frames(self):
         """The source as a dense ``(rows, cols, channels, n_frames)`` array"""

--- a/pulse2percept/vision/scene.py
+++ b/pulse2percept/vision/scene.py
@@ -29,8 +29,10 @@ _RING_COLOR = '0.3'
 # The only non-numeric `scotoma_fill`; see `_inpaint_rgb` for what it does.
 _INPAINT = 'inpaint'
 
-# The only `aperture` v0.11 supports; see `Scene._aperture_mask`.
-_CIRCLE = 'circle'
+# The two `aperture` shapes; see `Scene._aperture_mask`. Both take their
+# dimensions from `fov`, so the shape is all that is named here.
+_RECTANGLE = 'rectangle'
+_ELLIPSE = 'ellipse'
 
 
 def _resolve_fov(fov, n_rows, n_cols):
@@ -136,13 +138,12 @@ def _resolve_background(background):
 
 
 def _resolve_aperture(aperture):
-    """Normalize ``aperture`` to None or ``_CIRCLE``"""
-    if aperture is None:
-        return None
-    if aperture != _CIRCLE:
-        raise ValueError(f"'aperture' is either None or {_CIRCLE!r}, not "
-                         f"{aperture!r}.")
-    return _CIRCLE
+    """Normalize ``aperture`` to ``_RECTANGLE`` or ``_ELLIPSE``"""
+    for shape in (_RECTANGLE, _ELLIPSE):
+        if aperture == shape:
+            return shape
+    raise ValueError(f"'aperture' is either {_RECTANGLE!r} or {_ELLIPSE!r}, "
+                     f"not {aperture!r}.")
 
 
 def _check_prosthetic(prosthetic):
@@ -337,12 +338,14 @@ class Scene(PrettyPrint):
         rasterized loss map before it is drawn, softening the boundary from
         both sides. Defaults to 2. Rendering only: the scotoma's geometry is
         unchanged.
-    aperture : 'circle' or None, optional
-        Shape of the rendered field. Default (None) fills the rectangular
-        frame. ``'circle'`` instead renders an eye-centered disc of radius
-        ``min(fov) / 2`` and blacks out the corners around it. It affects only
-        the rendered scene, not scene sampling, device input, stimulation, or
-        the underlying prosthetic model response.
+    aperture : {'rectangle', 'ellipse'}, optional
+        Shape of the rendered field. ``fov`` gives the aperture its dimensions
+        and this gives it its shape: the default ``'rectangle'`` fills the
+        whole frame, while ``'ellipse'`` inscribes an eye-centered ellipse of
+        semi-axes ``fov / 2`` in it and blacks out the corners around it. A
+        square ``fov`` therefore renders as a disc. Affects only the rendered
+        scene, not scene sampling, device input, stimulation, or the underlying
+        prosthetic model response.
 
     Examples
     --------
@@ -359,7 +362,7 @@ class Scene(PrettyPrint):
     """
 
     def __init__(self, source, fov, scotoma=None, scotoma_fill=0,
-                 scotoma_blend=2, background=0, aperture=None):
+                 scotoma_blend=2, background=0, aperture=_RECTANGLE):
         if not isinstance(source, (ImageStimulus, VideoStimulus)):
             # A picture is the common case:
             source = ImageStimulus(source)
@@ -393,7 +396,7 @@ class Scene(PrettyPrint):
                   'scotoma_fill': self.scotoma_fill,
                   'scotoma_blend': self.scotoma_blend}
         # Omitted when rectangular, which is the default:
-        if self.aperture is not None:
+        if self.aperture != _RECTANGLE:
             params['aperture'] = self.aperture
         return params
 
@@ -427,11 +430,7 @@ class Scene(PrettyPrint):
 
     @property
     def aperture(self):
-        """The rendered field boundary: ``'circle'`` or None for the frame
-
-        Affects only the rendered scene. The source, the pixel grid, and what
-        a device is given to encode are rectangular either way.
-        """
+        """Shape of the rendered field: ``'rectangle'`` or ``'ellipse'``"""
         return self._aperture
 
     @property
@@ -516,6 +515,41 @@ class Scene(PrettyPrint):
         col = (x + self._fov[0] / 2) / dx - 0.5
         row = (self._fov[1] / 2 - y) / dy - 0.5
         return col, row
+
+    def fellow_eye(self):
+        """The homologous scene for the other eye
+
+        Reflects eye-specific geometry (e.g., scotoma) across the vertical
+        meridian. The scene image is not flipped.
+
+        .. versionadded:: 0.11.0
+
+        Returns
+        -------
+        scene : :py:class:`~pulse2percept.vision.Scene`
+            A new scene. The original is left unchanged.
+
+        Examples
+        --------
+        A loss 6 degrees into one eye's right hemifield sits 6 degrees into
+        the other eye's left hemifield:
+
+        >>> import numpy as np
+        >>> from pulse2percept.units import dva
+        >>> from pulse2percept.vision import Scene, Scotoma
+        >>> left = Scene(np.zeros((8, 8)), fov=40 * dva,
+        ...              scotoma=Scotoma.circle(3 * dva, center=(6, 0) * dva))
+        >>> right = left.fellow_eye()
+        >>> float(right.scotoma(-6, 0)), float(right.scotoma(6, 0))
+        (1.0, 0.0)
+
+        """
+        scotoma = None if self.scotoma is None else self.scotoma.mirror()
+        return type(self)(self.source, self.fov, scotoma=scotoma,
+                          scotoma_fill=self.scotoma_fill,
+                          scotoma_blend=self.scotoma_blend,
+                          background=self.background,
+                          aperture=self.aperture)
 
     def _frames(self):
         """The source as a dense ``(rows, cols, channels, n_frames)`` array"""
@@ -620,20 +654,19 @@ class Scene(PrettyPrint):
         return _inpaint_rgb(frame_rgb, loss > 0)
 
     def _aperture_mask(self, gaze_xy):
-        """True at pixel centers a circular aperture hides
+        """Return a mask for pixels outside the eye-centered aperture.
 
-        Eye-centered like the scotoma and the rings, so the disc sits at
-        ``gaze``. Its radius is the shorter half-axis of the FOV, the same
-        convention the outermost eccentricity ring uses. The boundary is hard.
+        The ellipse spans the full Scene FOV, with semi-axes `fov / 2`.
+        `gaze_xy` sets its center in scene coordinates.
         """
         gx, gy = gaze_xy
         x_scene, y_scene = self._pixel_centers()
-        radius = min(self._fov) / 2
-        return (x_scene - gx) ** 2 + (y_scene - gy) ** 2 > radius ** 2
+        a, b = self._fov[0] / 2, self._fov[1] / 2
+        return ((x_scene - gx) / a) ** 2 + ((y_scene - gy) / b) ** 2 > 1
 
     def _apply_aperture(self, frames, gaze=None):
         """Black out ``(rows, cols, 3, n_frames)`` outside the aperture"""
-        if self._aperture is None:
+        if self._aperture == _RECTANGLE:
             return frames
         points = _gaze_points(gaze, frames.shape[-1])
         static = len(points) == 1

--- a/pulse2percept/vision/tests/test_binocular.py
+++ b/pulse2percept/vision/tests/test_binocular.py
@@ -57,7 +57,7 @@ def test_the_two_eyes_are_independent_channels():
     """Different source, FOV, shape, scotoma and aperture on the two sides"""
     left = Scene(ImageStimulus(np.full((9, 9), 0.3)), fov=(30, 30),
                  scotoma=Scotoma.circle(6), scotoma_fill=0.0,
-                 aperture='circle')
+                 aperture='ellipse')
     right = Scene(VideoStimulus(np.zeros((15, 21, 2)), time=[0, 10]),
                   fov=(42, 30), background=1)
     binocular = BinocularScene(left=left, right=right)
@@ -65,8 +65,8 @@ def test_the_two_eyes_are_independent_channels():
     npt.assert_equal(binocular.right.fov, (42.0, 30.0))
     npt.assert_equal(binocular.left.shape, (9, 9))
     npt.assert_equal(binocular.right.shape, (15, 21))
-    npt.assert_equal(binocular.left.aperture, 'circle')
-    npt.assert_equal(binocular.right.aperture, None)
+    npt.assert_equal(binocular.left.aperture, 'ellipse')
+    npt.assert_equal(binocular.right.aperture, 'rectangle')
     npt.assert_equal(binocular.right.scotoma, None)
 
 
@@ -137,13 +137,44 @@ def test_two_percepts_stay_two_percepts():
 
 
 def test_each_eye_keeps_its_own_aperture():
-    left = flat_scene(0.6, aperture='circle')
+    left = flat_scene(0.6, aperture='ellipse')
     right = flat_scene(0.6)
     ax_left, ax_right = BinocularScene(left=left, right=right).plot()
-    # The corner is inside the rectangle but outside the disc:
+    # The corner is inside the rectangle but outside the ellipse:
     npt.assert_almost_equal(ax_left.images[-1].get_array()[0, 0], 0.0)
     npt.assert_almost_equal(ax_right.images[-1].get_array()[0, 0],
                             [0.6] * 3, decimal=6)
+    plt.close('all')
+
+
+def test_two_fovs_are_drawn_on_one_angular_scale():
+    """A 30-degree field must not be stretched to look like a 50-degree one"""
+    left, right = flat_scene(0.4, px=31), flat_scene(0.4, px=51)
+    npt.assert_equal(left.fov != right.fov, True)
+    ax_left, ax_right = BinocularScene(left=left, right=right).plot()
+    npt.assert_almost_equal(ax_left.get_xlim(), ax_right.get_xlim())
+    npt.assert_almost_equal(ax_left.get_ylim(), ax_right.get_ylim())
+    # Both axes span the wider field, and the images keep their own extents:
+    npt.assert_almost_equal(ax_right.get_xlim(), (-25.0, 25.0))
+    npt.assert_almost_equal(ax_left.images[-1].get_extent(),
+                            (-15.5, 15.5, -15.5, 15.5))
+    npt.assert_almost_equal(ax_right.images[-1].get_extent(),
+                            (-25.5, 25.5, -25.5, 25.5))
+    plt.close('all')
+
+
+def test_plot_lays_out_only_the_figure_it_made(monkeypatch):
+    binocular = BinocularScene(left=flat_scene(), right=flat_scene())
+    laid_out = []
+    monkeypatch.setattr(plt.Figure, 'tight_layout',
+                        lambda self, *a, **kw: laid_out.append(self))
+    binocular.plot()
+    npt.assert_equal(len(laid_out), 1)
+    plt.close('all')
+    # A caller's figure is left as the caller arranged it:
+    _, axes = plt.subplots(1, 2)
+    binocular.plot(axes=axes)
+    npt.assert_equal(len(laid_out), 1)
     plt.close('all')
 
 

--- a/pulse2percept/vision/tests/test_binocular.py
+++ b/pulse2percept/vision/tests/test_binocular.py
@@ -154,8 +154,9 @@ def test_two_fovs_are_drawn_on_one_angular_scale():
     ax_left, ax_right = BinocularScene(left=left, right=right).plot()
     npt.assert_almost_equal(ax_left.get_xlim(), ax_right.get_xlim())
     npt.assert_almost_equal(ax_left.get_ylim(), ax_right.get_ylim())
-    # Both axes span the wider field, and the images keep their own extents:
-    npt.assert_almost_equal(ax_right.get_xlim(), (-25.0, 25.0))
+    # Both axes span the wider field's stated outer extent, not the outermost
+    # pixel centers, and the images keep their own extents:
+    npt.assert_almost_equal(ax_right.get_xlim(), (-25.5, 25.5))
     npt.assert_almost_equal(ax_left.images[-1].get_extent(),
                             (-15.5, 15.5, -15.5, 15.5))
     npt.assert_almost_equal(ax_right.images[-1].get_extent(),

--- a/pulse2percept/vision/tests/test_scene.py
+++ b/pulse2percept/vision/tests/test_scene.py
@@ -719,14 +719,44 @@ def test_play_animates_a_video_scene_and_refuses_a_still_one():
         ramp_scene().play()
 
 
-def circle_scene(**kwargs):
-    """`ramp_scene` seen through a circular aperture"""
-    return ramp_scene(aperture='circle', **kwargs)
+def test_the_fellow_eye_mirrors_an_asymmetric_scotoma():
+    """Eye-centered anatomy is reflected; the world it looks at is not"""
+    scotoma = Scotoma.circle(3, center=(6, 0))
+    scene = ramp_scene(scotoma=scotoma, aperture='ellipse', background=0.25,
+                       scotoma_fill=0.4, scotoma_blend=1.5)
+    fellow = scene.fellow_eye()
+    npt.assert_equal(fellow is scene, False)
+    npt.assert_equal(isinstance(fellow, Scene), True)
+    # The loss is 6 degrees into the other hemifield now:
+    npt.assert_almost_equal(float(fellow.scotoma(-6, 0)), 1.0)
+    npt.assert_almost_equal(float(fellow.scotoma(6, 0)), 0.0)
+    # ... and the original is untouched:
+    npt.assert_equal(scene.scotoma is scotoma, True)
+    npt.assert_almost_equal(float(scene.scotoma(6, 0)), 1.0)
+    # Everything that is not eye-specific carries over, source object included:
+    npt.assert_equal(fellow.source is scene.source, True)
+    npt.assert_equal(fellow.fov, scene.fov)
+    npt.assert_equal(fellow.aperture, scene.aperture)
+    npt.assert_almost_equal(fellow.background, scene.background)
+    npt.assert_equal(fellow.scotoma_fill, scene.scotoma_fill)
+    npt.assert_equal(fellow.scotoma_blend, scene.scotoma_blend)
 
 
-def test_no_aperture_is_the_default_and_fills_the_frame():
+def test_the_fellow_eye_of_an_intact_field_is_intact_too():
+    fellow = ramp_scene().fellow_eye()
+    npt.assert_equal(fellow.scotoma, None)
+    # The picture itself is not flipped: both eyes see the same world:
+    npt.assert_array_equal(fellow._native_rgb(), ramp_scene()._native_rgb())
+
+
+def ellipse_scene(**kwargs):
+    """`ramp_scene` seen through an elliptical aperture (here, a disc)"""
+    return ramp_scene(aperture='ellipse', **kwargs)
+
+
+def test_a_rectangular_aperture_is_the_default_and_fills_the_frame():
     scene = ramp_scene()
-    npt.assert_equal(scene.aperture, None)
+    npt.assert_equal(scene.aperture, 'rectangle')
     npt.assert_equal('aperture' in repr(scene), False)
     # Every pixel of the rectangle still shows the ramp, corners included:
     native = scene._native_rgb()[..., 0]
@@ -734,10 +764,10 @@ def test_no_aperture_is_the_default_and_fills_the_frame():
     npt.assert_almost_equal(native[0, -1, 0], ramp_at(HALF), decimal=6)
 
 
-def test_a_circular_aperture_keeps_the_center_and_blacks_out_the_corners():
-    scene = circle_scene()
-    npt.assert_equal(scene.aperture, 'circle')
-    npt.assert_equal("aperture='circle'" in repr(scene), True)
+def test_a_square_fov_ellipse_keeps_the_center_and_blacks_out_the_corners():
+    scene = ellipse_scene()
+    npt.assert_equal(scene.aperture, 'ellipse')
+    npt.assert_equal("aperture='ellipse'" in repr(scene), True)
     rect = ramp_scene()._native_rgb()[..., 0]
     circ = scene._native_rgb()[..., 0]
     # Inside the disc nothing changed; the four corners went black:
@@ -751,28 +781,36 @@ def test_a_circular_aperture_keeps_the_center_and_blacks_out_the_corners():
     npt.assert_almost_equal(rect[-1, -1, 0], ramp_at(HALF), decimal=6)
 
 
-@pytest.mark.parametrize('aperture', ['circular', 'CIRCLE', 'ellipse', '',
-                                      0, ['circle']])
+@pytest.mark.parametrize('aperture', ['circle', 'circular', 'ELLIPSE', '',
+                                      None, 0, ['ellipse']])
 def test_a_bad_aperture_is_refused(aperture):
     with pytest.raises(ValueError):
         ramp_scene(aperture=aperture)
 
 
-def test_the_aperture_radius_is_the_shorter_half_of_the_field():
-    """A wide field is clipped by its height, matching the outermost ring"""
-    data = np.tile(np.linspace(0.2, 1, 81), (41, 1))
-    scene = Scene(ImageStimulus(data), fov=(81, 41), aperture='circle')
+def test_an_ellipse_takes_a_semiaxis_from_each_side_of_the_field():
+    """A 61 x 41 field is apertured by both dimensions, not by the shorter"""
+    data = np.tile(np.linspace(0.2, 1, 61), (41, 1))
+    scene = Scene(ImageStimulus(data), fov=(61, 41), aperture='ellipse')
     lit = scene._native_rgb()[..., 0, 0] > 0
-    radius = np.hypot(*scene._pixel_centers())
-    # 20.5 dva is min(fov) / 2, not max(fov) / 2:
-    npt.assert_equal(radius[lit].max() <= 20.5, True)
-    npt.assert_equal(radius[~lit].min() > 20.5, True)
+    x, y = scene._pixel_centers()
+    npt.assert_array_equal(lit, (x / 30.5) ** 2 + (y / 20.5) ** 2 <= 1)
+    # The aperture reaches much farther sideways than up: 25 dva out along
+    # the horizontal is kept, though a disc of radius min(fov) / 2 would have
+    # cut it, while the same x lifted 15 dva is outside:
+    npt.assert_equal(lit[20, 55], True)          # (25, 0) dva
+    npt.assert_equal(lit[5, 55], False)          # (25, 15) dva
+    # ... and the semiaxes themselves are in, while the corners are not:
+    for row, col in ((20, 0), (20, -1), (0, 30), (-1, 30)):
+        npt.assert_equal(lit[row, col], True)
+    for row, col in ((0, 0), (0, -1), (-1, 0), (-1, -1)):
+        npt.assert_equal(lit[row, col], False)
 
 
 def test_the_aperture_is_eye_centered_and_follows_gaze():
     data = np.tile(np.linspace(0.2, 1, SCENE_PX), (SCENE_PX, 1))
     scene = Scene(ImageStimulus(data), fov=(SCENE_PX, SCENE_PX),
-                  aperture='circle')
+                  aperture='ellipse')
     lit = scene._native_rgb(gaze=(8, -5) * dva)[..., 0, 0] > 0
     x, y = scene._pixel_centers()
     # scene = eye-centered + gaze, so the disc is centered on the gaze point:
@@ -781,7 +819,7 @@ def test_the_aperture_is_eye_centered_and_follows_gaze():
 
 def test_a_transparent_background_does_not_leak_outside_the_aperture():
     """Outside the aperture is black even when the scene's ground is white"""
-    scene = Scene(rgba_source(), fov=(8, 8), background=1, aperture='circle')
+    scene = Scene(rgba_source(), fov=(8, 8), background=1, aperture='ellipse')
     native = scene._native_rgb()[..., 0]
     npt.assert_almost_equal(native[0, 0], 0.0)
     # ... while the background still shows through inside it:
@@ -792,24 +830,24 @@ def test_the_aperture_does_not_change_what_a_device_is_given():
     """The critical invariant: a rendering boundary, not a sampling geometry"""
     x = np.array([-19.0, -8.0, 0.0, 6.5, 18.0, 30.0])
     y = np.array([17.0, -3.0, 0.0, 11.25, -19.0, 0.0])
-    rect, circ = ramp_scene(), circle_scene()
+    rect, ellip = ramp_scene(), ellipse_scene()
     for gaze in (None, (6, -4) * dva, (-9.5, 12) * dva):
-        npt.assert_array_equal(circ._sample_at(x, y, gaze=gaze),
+        npt.assert_array_equal(ellip._sample_at(x, y, gaze=gaze),
                                rect._sample_at(x, y, gaze=gaze))
-        npt.assert_array_equal(circ._device_input(x, y, gaze=gaze),
+        npt.assert_array_equal(ellip._device_input(x, y, gaze=gaze),
                                rect._device_input(x, y, gaze=gaze))
-    npt.assert_array_equal(circ.dva_to_pixel(x, y), rect.dva_to_pixel(x, y))
-    npt.assert_array_equal(circ.pixel_to_dva(x, y), rect.pixel_to_dva(x, y))
-    npt.assert_array_equal(circ._frames(), rect._frames())
+    npt.assert_array_equal(ellip.dva_to_pixel(x, y), rect.dva_to_pixel(x, y))
+    npt.assert_array_equal(ellip.pixel_to_dva(x, y), rect.pixel_to_dva(x, y))
+    npt.assert_array_equal(ellip._frames(), rect._frames())
 
 
 def test_the_aperture_leaves_the_scotoma_alone_inside_it():
     scotoma = Scotoma.circle(6)
     rect = ramp_scene(scotoma=scotoma, scotoma_fill=0.5)
-    circ = ramp_scene(scotoma=scotoma, scotoma_fill=0.5, aperture='circle')
-    npt.assert_array_equal(circ.scotoma(0.0, 0.0), rect.scotoma(0.0, 0.0))
-    inside = np.hypot(*circ._pixel_centers()) <= 20.5
-    npt.assert_array_equal(circ._native_rgb()[..., 0][inside],
+    ellip = ramp_scene(scotoma=scotoma, scotoma_fill=0.5, aperture='ellipse')
+    npt.assert_array_equal(ellip.scotoma(0.0, 0.0), rect.scotoma(0.0, 0.0))
+    inside = np.hypot(*ellip._pixel_centers()) <= 20.5
+    npt.assert_array_equal(ellip._native_rgb()[..., 0][inside],
                            rect._native_rgb()[..., 0][inside])
 
 
@@ -818,12 +856,12 @@ def test_the_aperture_clips_a_composed_percept_only_when_it_is_drawn():
     bright = Percept(np.ones((SCENE_PX, SCENE_PX, 1)),
                      space=ramp_scene()._grid())
     rect = ramp_scene(scotoma=scotoma, scotoma_fill=0.0)
-    circ = ramp_scene(scotoma=scotoma, scotoma_fill=0.0, aperture='circle')
+    ellip = ramp_scene(scotoma=scotoma, scotoma_fill=0.0, aperture='ellipse')
     seen_rect = rect._compose(bright, vmax=1).data[..., 0]
-    seen_circ = circ._compose(bright, vmax=1).data[..., 0]
-    inside = np.hypot(*circ._pixel_centers()) <= 20.5
-    npt.assert_array_equal(seen_circ[inside], seen_rect[inside])
-    npt.assert_almost_equal(seen_circ[0, -1], 0.0)
+    seen_ellip = ellip._compose(bright, vmax=1).data[..., 0]
+    inside = np.hypot(*ellip._pixel_centers()) <= 20.5
+    npt.assert_array_equal(seen_ellip[inside], seen_rect[inside])
+    npt.assert_almost_equal(seen_ellip[0, -1], 0.0)
     npt.assert_almost_equal(seen_rect[0, -1, 0], ramp_at(HALF), decimal=6)
 
 
@@ -833,7 +871,7 @@ def test_a_percept_can_be_plotted_in_the_context_of_the_whole_field():
     data = np.zeros((9, 9, 1))
     data[4, 4] = 20.0
     phosphene = Percept(data, space=space)
-    scene = circle_scene()
+    scene = ellipse_scene()
     ax = scene.plot(percept=phosphene, vmax=20)
     drawn = ax.images[-1].get_array()
     # The percept lands on the fovea at its own size, not stretched to the FOV
@@ -865,7 +903,7 @@ def test_plotting_a_percept_over_a_scotoma_is_the_composed_view():
 
 
 def test_rings_still_land_on_the_fovea_the_aperture_is_centered_on():
-    scene = circle_scene()
+    scene = ellipse_scene()
     ax = scene.plot(gaze=(7, -3) * dva, rings=[10])
     # The ring is a circle of radius 10 about the gaze point:
     ring = ax.lines[-1]
@@ -880,7 +918,7 @@ def test_rings_still_land_on_the_fovea_the_aperture_is_centered_on():
 def test_the_aperture_reaches_the_frames_the_player_shows():
     frames = np.stack([np.full((9, 9), v) for v in (0.4, 0.8)], axis=-1)
     scene = Scene(VideoStimulus(frames, time=[0, 10]), fov=(9, 9),
-                  aperture='circle')
+                  aperture='ellipse')
     ani = scene.play()
     npt.assert_almost_equal(ani._frame_data[0, 0, :, 0], 0.0)
     npt.assert_almost_equal(ani._frame_data[4, 4, :, 1], 0.8, decimal=6)
@@ -998,10 +1036,10 @@ def test_a_static_gaze_composes_every_frame_of_a_video():
     npt.assert_equal(np.allclose(seen[..., 0], seen[..., -1]), False)
 
 
-def test_a_circular_aperture_survives_composing_a_video():
+def test_an_elliptical_aperture_survives_composing_a_video():
     n = 3
     scene = gray_video_scene(n, scotoma=Scotoma.circle(6), scotoma_fill=0.0,
-                             aperture='circle')
+                             aperture='ellipse')
     percept = ramped_percept(scene, n)
     seen = scene._compose(percept, vmax=1).data
     npt.assert_equal(seen.shape, (SCENE_PX, SCENE_PX, 3, n))


### PR DESCRIPTION
Cleans up several usability rough edges in the new v0.11 vision API:

- [x] replaces `aperture=None` / `'circle'` with explicit `'rectangle'` / `'ellipse'`
- [x] makes elliptical apertures follow the full `(width, height)` FOV
- [x] adds `Scene.fellow_eye()` for mirrored eye-specific geometry without flipping the scene image
- [x] plots both eyes on a common angular extent when their FOVs differ
- [x] applies `tight_layout()` only to figures created by `BinocularScene.plot()`
- [x] updates tests, docs, and examples