### PR TITLE
[ENH] Add side-by-side stereo Scene support

### DIFF
--- a/doc/topics/models.rst
+++ b/doc/topics/models.rst
@@ -494,8 +494,7 @@ monocular views:
 
     ax_left, ax_right = binocular.plot(left_percept=percept, vmax=2)
 
-Imagery already packed left-right side by side, as HMDs and stereo cameras
-deliver it, splits into the two eyes with
+Imagery already packed left-right side by side splits into the two eyes with
 :py:meth:`~pulse2percept.vision.BinocularScene.from_side_by_side`:
 
 .. code-block:: python
@@ -506,8 +505,8 @@ deliver it, splits into the two eyes with
     )
 
 The left half becomes the left eye and the right half the right eye. ``fov``
-describes one eye's half, no pixel values change, and
-no disparity or depth is inferred.
+describes one eye's half, splitting does not flip, resample, or interpolate
+either half, and no disparity or depth is inferred.
 
 A bilateral loss is often symmetric about the vertical meridian.
 :py:meth:`~pulse2percept.vision.Scene.fellow_eye` builds the homologous scene

--- a/doc/topics/models.rst
+++ b/doc/topics/models.rst
@@ -494,6 +494,21 @@ monocular views:
 
     ax_left, ax_right = binocular.plot(left_percept=percept, vmax=2)
 
+Imagery that is already packed left-right side by side, as HMD and stereo
+cameras deliver it, splits into the two eyes with
+:py:meth:`~pulse2percept.vision.BinocularScene.from_side_by_side`:
+
+.. code-block:: python
+
+    binocular = p2p.vision.BinocularScene.from_side_by_side(
+        stereo_image,
+        fov=(60, 40) * dva,
+    )
+
+The left half becomes the left eye and the right half the right eye, with
+``fov`` describing each eye's half rather than the packed frame. The split
+changes no pixel values; it neither creates disparity nor infers depth.
+
 A bilateral loss is often symmetric about the vertical meridian.
 :py:meth:`~pulse2percept.vision.Scene.fellow_eye` builds the homologous scene
 for the other eye:

--- a/doc/topics/models.rst
+++ b/doc/topics/models.rst
@@ -494,8 +494,8 @@ monocular views:
 
     ax_left, ax_right = binocular.plot(left_percept=percept, vmax=2)
 
-Imagery that is already packed left-right side by side, as HMD and stereo
-cameras deliver it, splits into the two eyes with
+Imagery already packed left-right side by side, as HMDs and stereo cameras
+deliver it, splits into the two eyes with
 :py:meth:`~pulse2percept.vision.BinocularScene.from_side_by_side`:
 
 .. code-block:: python
@@ -505,9 +505,9 @@ cameras deliver it, splits into the two eyes with
         fov=(60, 40) * dva,
     )
 
-The left half becomes the left eye and the right half the right eye, with
-``fov`` describing each eye's half rather than the packed frame. The split
-changes no pixel values; it neither creates disparity nor infers depth.
+The left half becomes the left eye and the right half the right eye. ``fov``
+describes one eye's half, no pixel values change, and
+no disparity or depth is inferred.
 
 A bilateral loss is often symmetric about the vertical meridian.
 :py:meth:`~pulse2percept.vision.Scene.fellow_eye` builds the homologous scene

--- a/doc/users/release_notes.rst
+++ b/doc/users/release_notes.rst
@@ -196,9 +196,11 @@ Scene and plotting
   :py:class:`~pulse2percept.vision.BinocularScene` place images, video,
   scotomas, and prosthetic percepts in visual-field coordinates. Scenes support
   eye-centered gaze, rectangular or elliptical apertures, residual-vision
-  rendering, and fellow-eye geometry; binocular scenes keep the two monocular
-  views independent while plotting them on a common angular scale
-  (:pull:`871`, :pull:`884`, :pull:`890`, :pull:`893`, :pull:`899`).
+  rendering, and fellow-eye geometry; binocular scenes can be built from a
+  side-by-side stereo image and keep the two monocular views independent while
+  plotting them on a common angular scale
+  (:pull:`871`, :pull:`884`, :pull:`890`, :pull:`893`, :pull:`899`,
+  :pull:`900`).
 
 * New :py:mod:`pulse2percept.plotting` module provides combined
   stimulus/percept figures and animations. :py:mod:`pulse2percept.viz` is

--- a/pulse2percept/vision/binocular.py
+++ b/pulse2percept/vision/binocular.py
@@ -67,8 +67,7 @@ class BinocularScene(PrettyPrint):
     >>> float(binocular.right.scotoma(-6, 0))
     1.0
 
-    Imagery that is already packed left-right side by side, split into the
-    two eyes by
+    Imagery already packed left-right side by side, split with
     :py:meth:`~pulse2percept.vision.BinocularScene.from_side_by_side`:
 
     >>> stereo = np.zeros((10, 40))
@@ -91,42 +90,38 @@ class BinocularScene(PrettyPrint):
 
     @classmethod
     def from_side_by_side(cls, source, fov, **scene_kwargs):
-        """Split one side-by-side stereo image into the two eyes
+        """Build a binocular scene from a side-by-side stereo image.
 
-        A side-by-side stereo image packs both views into one frame, the left
-        eye's in its left half and the right eye's in its right half. This
-        splits that frame exactly halfway along its width and hands each half
-        to a :py:class:`~pulse2percept.vision.Scene`.
+        The left half of the image becomes the left-eye scene and the right
+        half becomes the right-eye scene. The split is exact: neither view is
+        flipped, resampled, or interpolated.
 
-        Nothing is flipped, resampled, cropped or interpolated: the two halves
-        keep their pixel values and their grayscale/RGB/RGBA channels. This
-        loads existing stereo imagery; it neither creates disparity nor infers
-        depth, and the result remains two independent monocular views.
+        This method unpacks existing stereo imagery; it does not create
+        disparity or infer depth.
 
         .. versionadded:: 0.11.0
 
         Parameters
         ----------
         source : ImageStimulus or image
-            The packed stereo frame. Anything that is not already an
-            :py:class:`~pulse2percept.stimuli.ImageStimulus`, such as a file
-            name or a NumPy array, is handed to ``ImageStimulus``. Stereo
-            video is not supported.
+            Side-by-side stereo image. Filenames, NumPy arrays, and other
+            inputs accepted by
+            :py:class:`~pulse2percept.stimuli.ImageStimulus` are converted to
+            one first. Metadata is preserved in both eye images.
+            Stereo video is not supported.
         fov : float or (width, height)
-            How much of the visual field *one eye's* half covers, in degrees
-            of visual angle. The packed frame's width has no visual-field
-            meaning, so a scalar (horizontal) FOV gets its vertical extent
-            from the aspect ratio of a half, not of the packed frame.
+            Per-eye field of view in degrees of visual angle. For a scalar FOV,
+            the vertical extent is inferred from the aspect ratio of one half
+            of the image, not the packed stereo frame.
         **scene_kwargs :
-            Passed unchanged to both
-            :py:class:`~pulse2percept.vision.Scene` constructors, so the two
-            eyes get identical scotoma, background, aperture and blend
-            settings. Eye-specific geometry is neither inferred nor mirrored
-            here; build the two scenes yourself if they should differ.
+            Additional arguments passed unchanged to both
+            :py:class:`~pulse2percept.vision.Scene` constructors. Use separate
+            scenes when the two eyes need different scotomas or other settings.
 
         Returns
         -------
         binocular : :py:class:`~pulse2percept.vision.BinocularScene`
+            The left and right monocular scenes.
 
         Examples
         --------
@@ -134,11 +129,10 @@ class BinocularScene(PrettyPrint):
         >>> from pulse2percept.units import dva
         >>> from pulse2percept.vision import BinocularScene
         >>> stereo = np.zeros((10, 40))
-        >>> binocular = BinocularScene.from_side_by_side(stereo,
-        ...                                              fov=(60, 40) * dva)
+        >>> binocular = BinocularScene.from_side_by_side(
+        ...     stereo, fov=(60, 40) * dva)
         >>> binocular.left.shape, binocular.left.fov
         ((10, 20), (60.0, 40.0))
-
         """
         if isinstance(source, VideoStimulus):
             raise TypeError("'source' must be a still stereo image, not a "
@@ -151,7 +145,11 @@ class BinocularScene(PrettyPrint):
                              f"into a left and a right half, so its width "
                              f"must be even, not {n_cols}.")
         halves = np.split(source.data.reshape(source.img_shape), 2, axis=1)
-        return cls(*[Scene(ImageStimulus(half), fov=fov, **scene_kwargs)
+        # Each half is derived from the packed frame, so it inherits its
+        # metadata (including a `source_shape` of the packed frame), as
+        # `ImageStimulus.crop` does:
+        return cls(*[Scene(ImageStimulus(half, metadata=source.metadata),
+                           fov=fov, **scene_kwargs)
                      for half in halves])
 
     def _pprint_params(self):

--- a/pulse2percept/vision/binocular.py
+++ b/pulse2percept/vision/binocular.py
@@ -3,6 +3,7 @@ import numpy as np
 import matplotlib.pyplot as plt
 
 from .scene import Scene
+from ..stimuli import ImageStimulus, VideoStimulus
 from ..utils import PrettyPrint
 
 
@@ -66,6 +67,18 @@ class BinocularScene(PrettyPrint):
     >>> float(binocular.right.scotoma(-6, 0))
     1.0
 
+    Imagery that is already packed left-right side by side, split into the
+    two eyes by
+    :py:meth:`~pulse2percept.vision.BinocularScene.from_side_by_side`:
+
+    >>> stereo = np.zeros((10, 40))
+    >>> stereo[:, 20:] = 1.0
+    >>> binocular = BinocularScene.from_side_by_side(stereo, fov=40 * dva)
+    >>> binocular.left.shape, binocular.right.shape
+    ((10, 20), (10, 20))
+    >>> float(binocular.left.source.data.max())
+    0.0
+
     """
 
     def __init__(self, left, right):
@@ -75,6 +88,71 @@ class BinocularScene(PrettyPrint):
                                 f"{type(scene)}.")
         self._left = left
         self._right = right
+
+    @classmethod
+    def from_side_by_side(cls, source, fov, **scene_kwargs):
+        """Split one side-by-side stereo image into the two eyes
+
+        A side-by-side stereo image packs both views into one frame, the left
+        eye's in its left half and the right eye's in its right half. This
+        splits that frame exactly halfway along its width and hands each half
+        to a :py:class:`~pulse2percept.vision.Scene`.
+
+        Nothing is flipped, resampled, cropped or interpolated: the two halves
+        keep their pixel values and their grayscale/RGB/RGBA channels. This
+        loads existing stereo imagery; it neither creates disparity nor infers
+        depth, and the result remains two independent monocular views.
+
+        .. versionadded:: 0.11.0
+
+        Parameters
+        ----------
+        source : ImageStimulus or image
+            The packed stereo frame. Anything that is not already an
+            :py:class:`~pulse2percept.stimuli.ImageStimulus`, such as a file
+            name or a NumPy array, is handed to ``ImageStimulus``. Stereo
+            video is not supported.
+        fov : float or (width, height)
+            How much of the visual field *one eye's* half covers, in degrees
+            of visual angle. The packed frame's width has no visual-field
+            meaning, so a scalar (horizontal) FOV gets its vertical extent
+            from the aspect ratio of a half, not of the packed frame.
+        **scene_kwargs :
+            Passed unchanged to both
+            :py:class:`~pulse2percept.vision.Scene` constructors, so the two
+            eyes get identical scotoma, background, aperture and blend
+            settings. Eye-specific geometry is neither inferred nor mirrored
+            here; build the two scenes yourself if they should differ.
+
+        Returns
+        -------
+        binocular : :py:class:`~pulse2percept.vision.BinocularScene`
+
+        Examples
+        --------
+        >>> import numpy as np
+        >>> from pulse2percept.units import dva
+        >>> from pulse2percept.vision import BinocularScene
+        >>> stereo = np.zeros((10, 40))
+        >>> binocular = BinocularScene.from_side_by_side(stereo,
+        ...                                              fov=(60, 40) * dva)
+        >>> binocular.left.shape, binocular.left.fov
+        ((10, 20), (60.0, 40.0))
+
+        """
+        if isinstance(source, VideoStimulus):
+            raise TypeError("'source' must be a still stereo image, not a "
+                            "VideoStimulus: stereo video is not supported.")
+        if not isinstance(source, ImageStimulus):
+            source = ImageStimulus(source)
+        n_cols = source.img_shape[1]
+        if n_cols % 2:
+            raise ValueError(f"A side-by-side stereo image must split evenly "
+                             f"into a left and a right half, so its width "
+                             f"must be even, not {n_cols}.")
+        halves = np.split(source.data.reshape(source.img_shape), 2, axis=1)
+        return cls(*[Scene(ImageStimulus(half), fov=fov, **scene_kwargs)
+                     for half in halves])
 
     def _pprint_params(self):
         """Return a dict of class attributes to pretty-print"""

--- a/pulse2percept/vision/tests/test_binocular.py
+++ b/pulse2percept/vision/tests/test_binocular.py
@@ -206,3 +206,84 @@ def test_it_has_no_implant_or_model_behavior():
         npt.assert_equal(hasattr(binocular, absent), False)
     # A Scene is monocular; eye identity lives in the container, not the scene:
     npt.assert_equal(hasattr(binocular.left, 'eye'), False)
+
+
+def packed_stereo(rows=10, half_cols=20, channels=None):
+    """A side-by-side frame whose halves are unmistakably different"""
+    shape = (rows, 2 * half_cols) + (() if channels is None else (channels,))
+    stereo = np.zeros(shape, dtype=np.float32)
+    stereo[:, half_cols:] = 1.0
+    return stereo
+
+
+def test_side_by_side_splits_left_from_right():
+    stereo = packed_stereo()
+    binocular = BinocularScene.from_side_by_side(stereo, fov=(40, 20) * dva)
+    for eye, level in ((binocular.left, 0.0), (binocular.right, 1.0)):
+        npt.assert_equal(eye.shape, (10, 20))
+        npt.assert_almost_equal(eye.source.data.reshape(eye.shape),
+                                np.full((10, 20), level))
+    # The halves are drawn as given, neither swapped nor flipped:
+    npt.assert_almost_equal(binocular.left._native_rgb().max(), 0.0)
+    npt.assert_almost_equal(binocular.right._native_rgb().min(), 1.0)
+
+
+def test_side_by_side_splits_columns_not_channels():
+    stereo = packed_stereo(rows=6, half_cols=4, channels=3)
+    stereo[:, 4:, 1:] = 0.25
+    binocular = BinocularScene.from_side_by_side(stereo, fov=(40, 20) * dva)
+    for eye in (binocular.left, binocular.right):
+        npt.assert_equal(eye.source.img_shape, (6, 4, 3))
+        npt.assert_equal(eye.shape, (6, 4))
+    right = binocular.right.source.data.reshape(6, 4, 3)
+    npt.assert_almost_equal(right[..., 0], 1.0)
+    npt.assert_almost_equal(right[..., 1:], 0.25)
+
+
+@pytest.mark.parametrize('n_cols', [21, 7])
+def test_an_odd_width_has_no_seam(n_cols):
+    stereo = np.zeros((10, n_cols))
+    with pytest.raises(ValueError) as excinfo:
+        BinocularScene.from_side_by_side(stereo, fov=40 * dva)
+    npt.assert_equal('even' in str(excinfo.value), True)
+
+
+def test_a_scalar_fov_describes_one_eye_not_the_packed_frame():
+    """The packing geometry has no visual-field meaning"""
+    binocular = BinocularScene.from_side_by_side(packed_stereo(), fov=40)
+    for eye in (binocular.left, binocular.right):
+        npt.assert_equal(eye.shape, (10, 20))
+        # 40 degrees across 20 columns, so 20 degrees down 10 rows:
+        npt.assert_almost_equal(eye.fov, (40.0, 20.0))
+
+
+def test_an_explicit_fov_pair_goes_to_both_eyes():
+    binocular = BinocularScene.from_side_by_side(packed_stereo(),
+                                                 fov=(60, 40) * dva)
+    npt.assert_almost_equal(binocular.left.fov, (60.0, 40.0))
+    npt.assert_almost_equal(binocular.right.fov, (60.0, 40.0))
+
+
+def test_scene_kwargs_reach_both_eyes():
+    binocular = BinocularScene.from_side_by_side(packed_stereo(), fov=40 * dva,
+                                                 aperture='ellipse',
+                                                 background=0.5,
+                                                 scotoma=Scotoma.circle(8))
+    for eye in (binocular.left, binocular.right):
+        npt.assert_equal(eye.aperture, 'ellipse')
+        npt.assert_almost_equal(eye.background, (0.5, 0.5, 0.5))
+        npt.assert_equal(eye.scotoma is not None, True)
+
+
+def test_an_image_stimulus_is_a_stereo_source():
+    stereo = ImageStimulus(packed_stereo())
+    binocular = BinocularScene.from_side_by_side(stereo, fov=40 * dva)
+    npt.assert_equal(binocular.left.shape, (10, 20))
+    npt.assert_almost_equal(binocular.left.source.data.max(), 0.0)
+    npt.assert_almost_equal(binocular.right.source.data.min(), 1.0)
+
+
+def test_stereo_video_is_out_of_scope():
+    video = VideoStimulus(np.zeros((10, 40, 3)), time=[0, 1, 2])
+    with pytest.raises(TypeError):
+        BinocularScene.from_side_by_side(video, fov=40 * dva)

--- a/pulse2percept/vision/tests/test_binocular.py
+++ b/pulse2percept/vision/tests/test_binocular.py
@@ -216,28 +216,37 @@ def packed_stereo(rows=10, half_cols=20, channels=None):
     return stereo
 
 
+def packed_ramp(rows=10, half_cols=20):
+    """A side-by-side ramp in which no two pixels share a value"""
+    n_px = rows * 2 * half_cols
+    return (np.arange(n_px, dtype=np.float32) / n_px).reshape(rows, -1)
+
+
 def test_side_by_side_splits_left_from_right():
-    stereo = packed_stereo()
+    stereo = packed_ramp()
     binocular = BinocularScene.from_side_by_side(stereo, fov=(40, 20) * dva)
-    for eye, level in ((binocular.left, 0.0), (binocular.right, 1.0)):
+    for eye, half in ((binocular.left, stereo[:, :20]),
+                      (binocular.right, stereo[:, 20:])):
         npt.assert_equal(eye.shape, (10, 20))
-        npt.assert_almost_equal(eye.source.data.reshape(eye.shape),
-                                np.full((10, 20), level))
-    # The halves are drawn as given, neither swapped nor flipped:
-    npt.assert_almost_equal(binocular.left._native_rgb().max(), 0.0)
-    npt.assert_almost_equal(binocular.right._native_rgb().min(), 1.0)
+        # Exact, so a flip along either axis or any resampling fails here:
+        npt.assert_array_equal(eye.source.data.reshape(eye.shape), half)
 
 
-def test_side_by_side_splits_columns_not_channels():
-    stereo = packed_stereo(rows=6, half_cols=4, channels=3)
+@pytest.mark.parametrize('channels', [3, 4])
+def test_side_by_side_splits_columns_not_channels(channels):
+    stereo = packed_stereo(rows=6, half_cols=4, channels=channels)
     stereo[:, 4:, 1:] = 0.25
     binocular = BinocularScene.from_side_by_side(stereo, fov=(40, 20) * dva)
     for eye in (binocular.left, binocular.right):
-        npt.assert_equal(eye.source.img_shape, (6, 4, 3))
+        npt.assert_equal(eye.source.img_shape, (6, 4, channels))
         npt.assert_equal(eye.shape, (6, 4))
-    right = binocular.right.source.data.reshape(6, 4, 3)
-    npt.assert_almost_equal(right[..., 0], 1.0)
-    npt.assert_almost_equal(right[..., 1:], 0.25)
+    # All channels survive, alpha included; nothing is dropped to RGB:
+    right = binocular.right.source.data.reshape(6, 4, channels)
+    npt.assert_array_equal(right[..., 0], np.ones((6, 4), dtype=np.float32))
+    npt.assert_array_equal(right[..., 1:], np.full((6, 4, channels - 1), 0.25,
+                                                   dtype=np.float32))
+    npt.assert_array_equal(binocular.left.source.data.reshape(6, 4, channels),
+                           np.zeros((6, 4, channels), dtype=np.float32))
 
 
 @pytest.mark.parametrize('n_cols', [21, 7])

--- a/pulse2percept/vision/tests/test_binocular.py
+++ b/pulse2percept/vision/tests/test_binocular.py
@@ -283,6 +283,13 @@ def test_an_image_stimulus_is_a_stereo_source():
     npt.assert_almost_equal(binocular.right.source.data.min(), 1.0)
 
 
+def test_both_halves_inherit_the_packed_frame_metadata():
+    stereo = ImageStimulus(packed_stereo(), metadata={'foo': 'bar'})
+    binocular = BinocularScene.from_side_by_side(stereo, fov=40 * dva)
+    for eye in (binocular.left, binocular.right):
+        npt.assert_equal(eye.source.metadata['foo'], 'bar')
+
+
 def test_stereo_video_is_out_of_scope():
     video = VideoStimulus(np.zeros((10, 40, 3)), time=[0, 1, 2])
     with pytest.raises(TypeError):


### PR DESCRIPTION
Adds `BinocularScene.from_side_by_side()` for constructing binocular scenes from existing left-right stereo imagery. The function splits the packed image exactly into left and right eye views, treating `fov` as the per-eye field of view and preserving image values, channels, and metadata without resampling.

This only unpacks existing stereo images; it does not synthesize disparity or infer depth.
