### PR TITLE
[ENH] Decouple Scene prediction, plotting, and render resolution

### DIFF
--- a/doc/topics/models.rst
+++ b/doc/topics/models.rst
@@ -259,7 +259,8 @@ visual acuity, phosphene discriminability, pairwise separability, behavioral
 resolution, or object-recognition performance.
 
 ``measure()`` applies to model-produced brightness percepts and raises for the
-RGB percepts returned by scene composition, whose values are display
+RGB percepts :py:meth:`~pulse2percept.vision.Scene.render` returns, whose values
+are display
 intensities. Positions and sizes are in degrees of visual angle, so the percept
 must have been built on a
 :py:class:`~pulse2percept.topography.Grid2D`; a percept holding bare pixel
@@ -435,10 +436,11 @@ without an ``encoder``, raises ``ValueError``.
 Residual vision
 ~~~~~~~~~~~~~~~
 
-If the scene also carries a :py:class:`~pulse2percept.vision.Scotoma`, the
-result is what the person actually sees -- intact native vision outside the
-lost region, and the prosthetic percept inside it -- as a single RGB
-:py:class:`~pulse2percept.percepts.Percept` on the scene's own pixel grid:
+``predict_percept`` always returns perceived brightness on the model grid,
+with or without a :py:class:`~pulse2percept.vision.Scotoma`. A scotoma
+describes residual *native* vision, so it does not enter the model response,
+and prosthetic encoding samples the unmasked scene including locations inside
+it. Drawing the two together is a separate step:
 
 .. code-block:: python
 
@@ -446,26 +448,51 @@ lost region, and the prosthetic percept inside it -- as a single RGB
                              scotoma=p2p.vision.Scotoma.circle(8 * dva))
     model = p2p.models.retina.ScoreboardModel(implant=implant, rho=200)
 
-    percept = model.predict_percept(scene, gaze=(0, 0) * dva, vmax=50)
+    percept = model.predict_percept(scene, gaze=(0, 0) * dva)
+    scene.plot(percept=percept, gaze=(0, 0) * dva, vmax=50)
 
-``vmax`` is required here and is not inferred: model brightness is in
-arbitrary units, so which brightness counts as white is a claim about the
-display, not about the model. Holding it fixed across calls is what keeps two
-gazes comparable.
+Inside the loss the two compose as
+``(1 - loss) * native + loss * max(scotoma_fill, phosphene)``. With no
+scotoma the percept is drawn alone on black, because superimposing it on
+intact native vision would assert an unmodeled interaction.
 
-The scotoma affects *native* vision only. Prosthetic encoding samples the
-unmasked scene, including locations inside the scotoma.
+``vmax`` is required: model brightness is in arbitrary units, so which
+brightness counts as white is a display choice. Hold it fixed to keep
+separate calls comparable.
 
-The rendered field boundary
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Source and percept need not share a resolution. ``plot`` draws the source at
+its own raster and the percept as a local patch on the model grid, so a fine
+simulation in a wide field costs the model grid's pixels rather than the whole
+field at the model's step.
+
+:py:meth:`~pulse2percept.vision.Scene.render` is the explicit dense
+composition, for when one RGB raster is needed (saving, downstream image
+processing):
+
+.. code-block:: python
+
+    rgb = scene.render(percept=percept, gaze=(0, 0) * dva, vmax=50)
+    fine = scene.render(percept=percept, vmax=50, step=0.02 * dva)
+
+The raster defaults to the source's own, which resamples nothing. ``step``
+(dva per pixel, rounded up so pixels are never coarser than asked) or
+``shape`` chooses another; the two are mutually exclusive. A fine step over a
+wide field is expensive by construction.
+
+.. versionchanged:: 0.11.0
+    Scene prediction returns the model percept rather than an RGB
+    composition. ``vmin`` and ``vmax`` moved to ``Scene.plot`` and the new
+    ``Scene.render``.
+
+The field boundary
+~~~~~~~~~~~~~~~~~~
 
 .. versionadded:: 0.11.0
 
 A scene's source, pixel grid and sampling are rectangular. ``fov`` gives the
-rendered field its outer dimensions ``(width, height)``, and ``aperture`` gives
-it its shape: the default ``'rectangle'`` uses the whole frame, while
-``'ellipse'`` inscribes an ellipse in those dimensions and blacks out the
-corners around it:
+field its outer dimensions ``(width, height)``, and ``aperture`` gives it its
+shape: the default ``'rectangle'`` uses the whole frame, while ``'ellipse'``
+inscribes an ellipse in those dimensions:
 
 .. code-block:: python
 
@@ -474,8 +501,12 @@ corners around it:
 
 A square ``fov`` therefore renders as a disc, and a 60 x 40 one as an ellipse
 reaching 30 degrees sideways and 20 degrees up. Like the scotoma and the
-eccentricity rings, it is eye-centered, so gaze moves it through the scene. It
-changes the rendered scene only.
+eccentricity rings, it is eye-centered, so gaze moves it through the scene.
+
+The aperture is support, not scene content: ``plot`` clips its artists to it,
+``render`` writes black outside it, and the source arrays are never modified.
+Scene sampling, device input and stimulation are untouched either way -- a
+camera does not go blind at the edge of an eye-shaped display aperture.
 
 Both eyes
 ~~~~~~~~~
@@ -545,9 +576,9 @@ time as the last axis in both::
     (Y, X, T)     perceived brightness in arbitrary units
     (Y, X, 3, T)  RGB intensities in [0, 1]
 
-Prosthesis models produce brightness percepts. When a
-:py:class:`~pulse2percept.vision.Scene` has a scotoma, scene-driven prediction
-composes that model output with residual vision and returns an RGB percept:
+Prosthesis models produce brightness percepts.
+:py:meth:`~pulse2percept.vision.Scene.render` composes one with residual
+vision and returns an RGB percept:
 
 .. code-block:: python
 

--- a/doc/users/release_notes.rst
+++ b/doc/users/release_notes.rst
@@ -48,8 +48,9 @@ Highlights
   :py:class:`~pulse2percept.vision.Scotoma` for gaze-aware simulation of
   residual vision and retinal prostheses, and
   :py:class:`~pulse2percept.vision.BinocularScene` for the two eyes' views
-  side by side (:pull:`854`, :pull:`871`, :pull:`883`, :pull:`890`,
-  :pull:`899`).
+  side by side. Image, simulation and display resolution are independent
+  (:pull:`854`, :pull:`871`, :pull:`883`, :pull:`890`, :pull:`899`,
+  :pull:`901`).
 
 * New photovoltaic stimulation pipeline for the PRIMA-style arrays, from image
   encoding to irradiance-based model input (:pull:`868`, :pull:`891`).
@@ -139,6 +140,8 @@ Models
   be specified in dva for single-region 2D maps (:pull:`862`, :pull:`879`,
   :pull:`884`). ``implant.plot()`` therefore shows device geometry, whereas
   ``model.plot(show_implant=True)`` shows the placed implant.
+  ``predict_percept`` always returns perceived brightness on the model grid,
+  a :py:class:`~pulse2percept.vision.Scene` included (:pull:`901`).
   
 * New :py:class:`~pulse2percept.models.retina.BiphasicScoreboardModel` and
   :py:class:`~pulse2percept.models.retina.BiphasicScoreboardSpatial` apply the
@@ -200,7 +203,7 @@ Scene and plotting
   side-by-side stereo image and keep the two monocular views independent while
   plotting them on a common angular scale
   (:pull:`871`, :pull:`884`, :pull:`890`, :pull:`893`, :pull:`899`,
-  :pull:`900`).
+  :pull:`900`, :pull:`901`).
 
 * New :py:mod:`pulse2percept.plotting` module provides combined
   stimulus/percept figures and animations. :py:mod:`pulse2percept.viz` is

--- a/examples/plot_getting_started.py
+++ b/examples/plot_getting_started.py
@@ -229,12 +229,18 @@ model = p2p.models.retina.ScoreboardModel(
     step=0.1,
 )
 
-percept = model.predict_percept(scene, gaze=(0, 0) * dva, vmax=2)
-percept.plot()
+###############################################################################
+# The model predicts on its own grid; drawing it back into the scene is a
+# separate step that keeps each layer at its own resolution:
+
+percept = model.predict_percept(scene, gaze=(0, 0) * dva)
+scene.plot(percept=percept, gaze=(0, 0) * dva, vmax=2)
 plt.title('Residual vision with a PRIMA percept in the scotoma')
 plt.show()
 
 ###############################################################################
+# ``scene.render(...)`` gives the same view as one dense RGB percept.
+#
 # A :class:`~pulse2percept.vision.Scene` can also represent gaze, videos,
 # backgrounds, and other residual-vision conditions.
 # The :ref:`example gallery <sphx_glr_examples>` contains complete simulations.

--- a/examples/vision/plot_amd_prima.py
+++ b/examples/vision/plot_amd_prima.py
@@ -83,31 +83,36 @@ model = ScoreboardModel(implant=implant, implant_position=center, rho=50,
                         xrange=(0, 12), yrange=(-8, 4), step=0.05)
 
 ###############################################################################
-# The scene is trial input, like any other stimulus:
+# The scene is trial input, like any other stimulus. The prediction is the
+# prosthetic percept on the model's own 0.05-degree grid; drawing it back into
+# the field is a separate step, and the source keeps its own 240 x 300 pixels.
 
-percept = model.predict_percept(scene, gaze=(0, 0) * dva, vmax=2)
+percept = model.predict_percept(scene, gaze=(0, 0) * dva)
 
-percept.plot()
+scene.plot(percept=percept, gaze=(0, 0) * dva, vmax=2)
 plt.title('Native vision with a PRIMA percept in the scotoma')
 
 ###############################################################################
 # The lesion is eye-centered and the implant is on the retina, so both travel
 # together when the eye moves:
 
-percept = model.predict_percept(scene, gaze=(8, -4) * dva, vmax=2)
+percept = model.predict_percept(scene, gaze=(8, -4) * dva)
 
-percept.plot()
+scene.plot(percept=percept, gaze=(8, -4) * dva, vmax=2)
 plt.title('Looking 8 degrees right and 4 degrees down')
 
 ###############################################################################
+# ``scene.render(percept=percept, gaze=(8, -4) * dva, vmax=2, step=0.05*dva)``
+# rasterizes both layers onto one RGB grid, here 800 x 800 pixels. Ask for it
+# when a single image is needed; plotting does not pay that cost.
 
 implant.preprocess = lambda stim: stim.filter('sobel')
 
 # Edges drive far fewer pixels, so white sits much lower:
 
-percept = model.predict_percept(scene, gaze=(0, 0) * dva, vmax=0.3)
+percept = model.predict_percept(scene, gaze=(0, 0) * dva)
 
-percept.plot()
+scene.plot(percept=percept, gaze=(0, 0) * dva, vmax=0.3)
 plt.title('Edge-filtered device input, intact vision around it')
 
 ###############################################################################

--- a/pulse2percept/models/base.py
+++ b/pulse2percept/models/base.py
@@ -1732,8 +1732,7 @@ class Model(Frozen, PrettyPrint):
         if self.has_time and not self.temporal.is_built:
             self.temporal.build()
 
-    def predict_percept(self, source, t_percept=None, gaze=None, vmax=None,
-                        vmin=0):
+    def predict_percept(self, source, t_percept=None, gaze=None):
         """Predict a percept.
 
         Parameters
@@ -1747,47 +1746,38 @@ class Model(Frozen, PrettyPrint):
         gaze : (x, y) or (n_frames, 2), optional
             Scene location falling on the fovea, in degrees of visual angle,
             so that ``scene = eye-centered visual field + gaze``. Requires
-            ``source`` to be a scene. Gaze always moves the percept across
-            the scene; it moves the scene across the electrodes too unless the
-            implant's
+            ``source`` to be a scene. Gaze decides which part of the scene
+            reaches the electrodes unless the implant's
             :py:attr:`~pulse2percept.implants.Implant.scene_input_frame` is
-            ``'head'``.
-        vmax : float, optional
-            Percept brightness mapped to white when composing a scene with a
-            scotoma. Required for scotoma composition.
-        vmin : float, optional
-            Percept brightness mapped to black for scotoma composition.
+            ``'head'``; the percept itself stays on the model's eye-centered
+            grid either way.
 
         Returns
         -------
         percept : :py:class:`~pulse2percept.percepts.Percept` or None
-            Brightness percept for ordinary prediction. For a scene with a scotoma,
-            returns an RGB percept on the scene pixel grid.
+            Perceived brightness on the model's spatial grid, for a scene as
+            for any other source. A scene's scotoma describes residual
+            *native* vision and does not enter the model response; draw the
+            two together with :py:meth:`~pulse2percept.vision.Scene.plot` or
+            :py:meth:`~pulse2percept.vision.Scene.render`.
 
         .. versionchanged:: 0.11.0
-            ``source`` is now the presented stimulus or scene rather than an implant
-            carrying a stimulus.
+            ``source`` is now the presented stimulus or scene rather than an
+            implant carrying a stimulus. Scene prediction returns the model
+            percept; ``vmin`` and ``vmax`` moved to ``Scene.plot`` and
+            ``Scene.render``.
         """
         # Scene sampling depends on the current spatial build:
         self._build_stale()
         if not isinstance(source, Scene):
-            for name, value in (('gaze', gaze), ('vmax', vmax)):
-                if value is not None:
-                    raise ValueError(
-                        f"'{name}' says where an implanted eye is looking in "
-                        f"a scene, and this prediction is not about one. Pass "
-                        f"a Scene to place one.")
-            if vmin != 0:
-                raise ValueError("'vmin' maps a percept onto a display, which "
-                                 "only happens for a scene with a scotoma.")
+            if gaze is not None:
+                raise ValueError(
+                    "'gaze' says where an implanted eye is looking in a "
+                    "scene, and this prediction is not about one. Pass a "
+                    "Scene to place one.")
             return self._predict_percept(self._prepared(source), t_percept)
-        resp = self._predict_percept(_scene_stim(self, source, gaze),
+        return self._predict_percept(_scene_stim(self, source, gaze),
                                      t_percept)
-        if source.scotoma is None or resp is None:
-            # Nothing is lost, so there is nothing to compose the percept
-            # into: what the implant produces is the whole answer.
-            return resp
-        return source._compose(resp, vmax, vmin=vmin, gaze=gaze)
 
     def _prepared(self, source):
         """Prepare a source for the bound implant.

--- a/pulse2percept/models/tests/test_api_equivalence.py
+++ b/pulse2percept/models/tests/test_api_equivalence.py
@@ -195,12 +195,14 @@ def test_scene_with_gaze_prediction_is_unchanged():
     assert_matches_reference('scene_gaze', percept)
 
 
-def test_scene_with_scotoma_prediction_is_unchanged():
+def test_scene_with_scotoma_composition_is_unchanged():
+    """The dense composition now lives in `Scene.render`, at the same numbers"""
     model = ScoreboardModel(implant=encoding_grid(), rho=200, **GRID).build()
     scene = scene_of(scotoma=Scotoma.circle(6), scotoma_fill=0.0,
                      scotoma_blend=0)
+    percept = model.predict_percept(scene)
     assert_matches_reference('scene_scotoma',
-                             model.predict_percept(scene, vmax=50))
+                             scene.render(percept=percept, vmax=50))
 
 
 @pytest.mark.parametrize('ModelClass', [ScoreboardModel, AxonMapModel])

--- a/pulse2percept/models/tests/test_scene.py
+++ b/pulse2percept/models/tests/test_scene.py
@@ -89,6 +89,16 @@ def model_for(implant, **kwargs):
     return ScoreboardModel(implant=implant, **params).build()
 
 
+def composed(model, scene, vmax, gaze=None, **kwargs):
+    """What the field shows: the model percept rendered into the scene
+
+    Prediction stops at the model grid, so putting the percept back in the
+    scene is a separate, explicit step.
+    """
+    percept = model.predict_percept(scene, gaze=gaze)
+    return scene.render(percept=percept, gaze=gaze, vmax=vmax, **kwargs).data
+
+
 def seen_by(model, scene, gaze=None):
     """The gray level each electrode was handed, in electrode order
 
@@ -180,15 +190,19 @@ def test_a_camera_driven_phosphene_still_travels_with_the_eye():
     model = model_for(implant_at(*Curcio1990Map().dva_to_ret(2.0, 0.0),
                                  input_frame='head'),
                       rho=100, xrange=(-4, 4), yrange=(-4, 4), step=0.5)
-    fixating = model.predict_percept(scene, vmax=2).data[..., 0]
-    shifted = model.predict_percept(scene, gaze=(5, 0) * dva,
-                                    vmax=2).data[..., 0]
+    fixating = composed(model, scene, vmax=2)[..., 0]
+    shifted = composed(model, scene, vmax=2, gaze=(5, 0) * dva)[..., 0]
     # Unchanged input, so the phosphene is the same one, five degrees right:
     npt.assert_almost_equal(shifted[HALF, HALF + 5 + 2],
                             fixating[HALF, HALF + 2], decimal=5)
-    npt.assert_almost_equal(model.predict_percept(scene, gaze=(0, 0),
-                                                  vmax=2).data[..., 0],
+    npt.assert_almost_equal(composed(model, scene, vmax=2, gaze=(0, 0))[...,
+                                                                       0],
                             fixating, decimal=6)
+    # The model response itself never moved: a head-fixed camera hands the
+    # electrodes the same input whatever the eye does.
+    npt.assert_array_equal(
+        model.predict_percept(scene, gaze=(5, 0) * dva).data,
+        model.predict_percept(scene).data)
 
 
 def test_y_orientation_survives_the_map():
@@ -277,13 +291,13 @@ def test_preprocessing_does_not_reach_native_vision():
     # look somewhere the inversion actually shows:
     npt.assert_almost_equal(seen_by(model, scene, gaze=(8, 0)),
                             [[1 - ramp_at(8.0)]], decimal=3)
-    percept = model.predict_percept(scene, gaze=(8, 0) * dva, vmax=100)
+    seen = composed(model, scene, vmax=100, gaze=(8, 0) * dva)
     # Outside the scotoma: the original scene, bit for bit and uninverted.
     original = np.repeat(source.data.reshape((SCENE_PX, SCENE_PX, 1)), 3,
                          axis=-1)
     x, y = scene._pixel_centers()
     intact = scene.scotoma(x - 8, y) == 0
-    npt.assert_array_equal(percept.data[..., 0][intact], original[intact])
+    npt.assert_array_equal(seen[..., 0][intact], original[intact])
     # ... and the caller's scene was not rewritten on the way through:
     npt.assert_array_equal(scene.source.data, source.data)
 
@@ -469,56 +483,83 @@ def test_without_a_scene_nothing_changes():
     percept = plain.predict_percept(BiphasicPulse(20, 0.45))
     npt.assert_equal(percept.is_rgb, False)
     npt.assert_equal(percept.data.ndim, 3)
-    for kwargs in ({'gaze': (1, 0)}, {'vmax': 20}, {'vmin': 3}):
-        with pytest.raises(ValueError):
+    with pytest.raises(ValueError):
+        plain.predict_percept(BiphasicPulse(20, 0.45), gaze=(1, 0))
+    # A display range is not a prediction argument at all any more:
+    for kwargs in ({'vmax': 20}, {'vmin': 3}):
+        with pytest.raises(TypeError):
             plain.predict_percept(BiphasicPulse(20, 0.45), **kwargs)
     # No stimulus at all still says nothing rather than raising:
     npt.assert_equal(plain.predict_percept(None), None)
 
 
-def test_a_scene_without_a_scotoma_returns_the_prosthetic_percept():
-    """Nothing is lost, so there is nothing to compose into"""
+def test_scene_prediction_returns_the_model_percept():
+    """A scene changes where the input comes from, not what is predicted"""
     model = model_for(implant_at(0, 0))
-    percept = model.predict_percept(scene_of())
-    npt.assert_equal(percept.is_rgb, False)
-    npt.assert_equal(percept.data.ndim, 3)
-    # On the model's grid, not the scene's:
-    npt.assert_equal(percept.shape[:2], model.spatial.grid.shape)
-    # `vmax` is meaningless here and is simply unused:
-    npt.assert_array_equal(
-        model.predict_percept(scene_of(), vmax=20).data, percept.data)
+    for scene in (scene_of(),
+                  scene_of(scotoma=Scotoma.circle(6), scotoma_fill=0.0)):
+        percept = model.predict_percept(scene)
+        npt.assert_equal(percept.is_rgb, False)
+        npt.assert_equal(percept.data.ndim, 3)
+        # On the model's grid, not the scene's:
+        npt.assert_equal(percept.shape[:2], model.spatial.grid.shape)
+        npt.assert_equal(percept.shape[:2] == (SCENE_PX, SCENE_PX), False)
+        npt.assert_almost_equal(percept.xdva, model.spatial.grid.x[0])
 
 
-def test_a_scene_with_a_scotoma_returns_a_composed_rgb_percept():
+def test_a_scotoma_does_not_touch_the_prosthetic_percept():
+    """The scotoma describes native vision, not the implant's response"""
+    model = model_for(implant_at(0, 0))
+    seeing = model.predict_percept(scene_of(), gaze=(3, -1) * dva)
+    for fill in (0.0, 0.6, 'inpaint'):
+        blind = scene_of(scotoma=Scotoma.circle(6), scotoma_fill=fill,
+                         scotoma_blend=1.5)
+        npt.assert_array_equal(
+            model.predict_percept(blind, gaze=(3, -1) * dva).data,
+            seeing.data)
+    # The premise: the rendered field really does differ.
+    npt.assert_equal(np.allclose(
+        composed(model, scene_of(scotoma=Scotoma.circle(6), scotoma_fill=0.0),
+                 vmax=20), scene_of().render().data), False)
+
+
+def test_display_range_is_not_a_prediction_argument():
+    """`vmin` and `vmax` belong to `Scene.plot` and `Scene.render`"""
+    scene = scene_of(scotoma=Scotoma.circle(6))
+    model = model_for(implant_at(0, 0))
+    for kwargs in ({'vmax': 20}, {'vmin': 3}):
+        with pytest.raises(TypeError):
+            model.predict_percept(scene, **kwargs)
+    # ... and rendering does require one, since brightness is arbitrary:
+    percept = model.predict_percept(scene)
+    with pytest.raises(ValueError) as excinfo:
+        scene.render(percept=percept)
+    npt.assert_equal('vmax' in str(excinfo.value), True)
+
+
+def test_rendering_a_scene_with_a_scotoma_gives_a_composed_rgb_percept():
     scene = scene_of(scotoma=Scotoma.circle(6), scotoma_fill=0.0)
-    percept = model_for(implant_at(0, 0)).predict_percept(scene, vmax=20)
-    npt.assert_equal(percept.is_rgb, True)
-    npt.assert_equal(percept.shape, (SCENE_PX, SCENE_PX, 3, 1))
-    npt.assert_equal(percept.data.min() >= 0, True)
-    npt.assert_equal(percept.data.max() <= 1, True)
-    # Reported on the scene's grid, in scene coordinates:
-    npt.assert_almost_equal(percept.xdva, np.arange(-HALF, HALF + 1),
+    model = model_for(implant_at(0, 0))
+    rendered = scene.render(percept=model.predict_percept(scene), vmax=20)
+    npt.assert_equal(rendered.is_rgb, True)
+    npt.assert_equal(rendered.shape, (SCENE_PX, SCENE_PX, 3, 1))
+    npt.assert_equal(rendered.data.min() >= 0, True)
+    npt.assert_equal(rendered.data.max() <= 1, True)
+    # Reported on the render grid, in scene coordinates:
+    npt.assert_almost_equal(rendered.xdva, np.arange(-HALF, HALF + 1),
                             decimal=4)
 
 
 def test_an_inpainted_scotoma_cannot_hold_a_prosthetic_percept():
     """Filling-in would floor the phosphene; a numeric fill still works"""
     model = model_for(implant_at(0, 0))
+    filled = scene_of(scotoma=Scotoma.circle(6), scotoma_fill='inpaint')
     with pytest.raises(ValueError):
-        model.predict_percept(scene_of(scotoma=Scotoma.circle(6),
-                                       scotoma_fill='inpaint'), vmax=20)
+        filled.render(percept=model.predict_percept(filled), vmax=20)
+    numeric = scene_of(scotoma=Scotoma.circle(6), scotoma_fill=0.0)
     npt.assert_equal(
-        model.predict_percept(scene_of(scotoma=Scotoma.circle(6),
-                                       scotoma_fill=0.0), vmax=20).is_rgb,
-        True)
-
-
-def test_vmax_is_required_for_a_composed_percept():
-    scene = scene_of(scotoma=Scotoma.circle(6))
-    model = model_for(implant_at(0, 0))
-    with pytest.raises(ValueError) as excinfo:
-        model.predict_percept(scene)
-    npt.assert_equal('vmax' in str(excinfo.value), True)
+        numeric.render(percept=model.predict_percept(numeric),
+                       vmax=20).is_rgb, True)
 
 
 def test_the_intact_periphery_is_the_scene_exactly():
@@ -526,11 +567,11 @@ def test_the_intact_periphery_is_the_scene_exactly():
     rng = np.random.default_rng(0)
     rgb = ImageStimulus(rng.random((SCENE_PX, SCENE_PX, 3)))
     scene = scene_of(rgb, scotoma=Scotoma.circle(6))
-    percept = model_for(implant_at(0, 0)).predict_percept(scene, vmax=20)
+    seen = composed(model_for(implant_at(0, 0)), scene, vmax=20)
     source = rgb.data.reshape((SCENE_PX, SCENE_PX, 3))
     x, y = scene._pixel_centers()
     intact = scene.scotoma(x, y) == 0
-    npt.assert_array_equal(percept.data[..., 0][intact], source[intact])
+    npt.assert_array_equal(seen[..., 0][intact], source[intact])
 
 
 def test_the_phosphene_lands_where_the_electrode_looks():
@@ -541,7 +582,7 @@ def test_the_phosphene_lands_where_the_electrode_looks():
         implant = implant_at(*visual_field_map.dva_to_ret(x_dva, y_dva))
         model = model_for(implant, rho=80, xrange=(-8, 8), yrange=(-8, 8),
                           step=0.5)
-        frame = model.predict_percept(scene, vmax=2).data[..., 0]
+        frame = composed(model, scene, vmax=2)[..., 0]
         row, col = int(round(HALF - y_dva)), int(round(x_dva + HALF))
         # Brightest where the electrode looks, dark on the opposite side:
         npt.assert_equal(frame[row, col].mean() > 0.5, True)
@@ -553,9 +594,8 @@ def test_gaze_moves_the_scotoma_and_the_phosphene_together():
     scene = scene_of(scotoma=Scotoma.circle(4), scotoma_fill=0.3)
     model = model_for(implant_at(0, 0), rho=100, xrange=(-2, 2),
                       yrange=(-2, 2), step=0.5)
-    fixating = model.predict_percept(scene, vmax=2).data[..., 0]
-    shifted = model.predict_percept(scene, gaze=(5, 0) * dva,
-                                    vmax=2).data[..., 0]
+    fixating = composed(model, scene, vmax=2)[..., 0]
+    shifted = composed(model, scene, vmax=2, gaze=(5, 0) * dva)[..., 0]
     # The whole eye-centered pair travelled 5 degrees right across the scene:
     npt.assert_almost_equal(shifted[HALF, HALF + 5], fixating[HALF, HALF],
                             decimal=5)
@@ -578,9 +618,8 @@ def test_a_fixed_vmax_does_not_renormalize_when_gaze_changes():
         ``gaze_x``. That pixel is pure phosphene; the intact periphery would
         otherwise dominate any whole-frame maximum.
         """
-        percept = model.predict_percept(scene, gaze=(gaze_x, 0) * dva,
-                                        **kwargs)
-        return float(percept.data[HALF, HALF + gaze_x, 0, 0])
+        seen = composed(model, scene, gaze=(gaze_x, 0) * dva, **kwargs)
+        return float(seen[HALF, HALF + gaze_x, 0, 0])
 
     dim, bright = phosphene(-16, vmax=200), phosphene(16, vmax=200)
     npt.assert_equal(0 < dim < bright < 1, True)
@@ -600,7 +639,7 @@ def test_a_video_scene_keeps_its_own_timing():
                      scotoma=Scotoma.circle(6), scotoma_fill=0.0)
     model = model_for(implant_at(0, 0), rho=150, xrange=(-4, 4),
                       yrange=(-4, 4), step=0.5)
-    percept = model.predict_percept(scene, vmax=200)
+    percept = scene.render(percept=model.predict_percept(scene), vmax=200)
     npt.assert_equal(percept.shape, (SCENE_PX, SCENE_PX, 3, 3))
     npt.assert_almost_equal(percept.time, [0, 100, 200])
     # Brighter frames make brighter phosphenes, in the right order. Read at
@@ -633,7 +672,8 @@ def test_a_spatiotemporal_model_composes_against_a_video_scene():
     npt.assert_almost_equal(raw.time, [100, 200, 300])
     npt.assert_almost_equal(scene.time, [0, 100, 200])
 
-    percept = spatiotemporal().predict_percept(scene, vmax=5)
+    percept = scene.render(
+        percept=spatiotemporal().predict_percept(scene), vmax=5)
     npt.assert_equal(percept.shape, (SCENE_PX, SCENE_PX, 3, 3))
     # The percept's clock describes the output, not the video's onsets:
     npt.assert_almost_equal(percept.time, [100, 200, 300])
@@ -662,15 +702,15 @@ def test_a_single_timed_percept_is_not_broadcast_over_a_video():
                            yrange=(-2, 2), step=1).build().spatial.grid
     at_10 = Percept(np.full((5, 5, 1), 20.0), space=grid, time=[10])
     with pytest.raises(ValueError) as excinfo:
-        scene._compose(at_10, vmax=20)
+        scene.render(percept=at_10, vmax=20)
     npt.assert_equal('never simulated' in str(excinfo.value), True)
     # A percept with no clock at all did not happen at any instant, so it does
     # stand behind every frame:
     timeless = Percept(np.full((5, 5, 1), 20.0), space=grid)
     npt.assert_equal(timeless.time, None)
-    composed = scene._compose(timeless, vmax=20)
-    npt.assert_equal(composed.shape[-1], 3)
-    npt.assert_almost_equal(composed.time, [0, 10, 20])
+    seen = scene.render(percept=timeless, vmax=20)
+    npt.assert_equal(seen.shape[-1], 3)
+    npt.assert_almost_equal(seen.time, [0, 10, 20])
 
 
 def test_a_temporal_percept_must_cover_the_video():
@@ -682,14 +722,14 @@ def test_a_temporal_percept_must_cover_the_video():
                            yrange=(-2, 2), step=1).build().spatial.grid
     short = Percept(values, space=grid, time=[5, 15])
     with pytest.raises(ValueError) as excinfo:
-        scene._compose(short, vmax=20)
+        scene.render(percept=short, vmax=20)
     npt.assert_equal('never simulated' in str(excinfo.value), True)
     # A percept that does cover it composes, endpoints included:
     covering = Percept(values, space=grid, time=[0, 20])
-    npt.assert_equal(scene._compose(covering, vmax=20).shape[-1], 3)
+    npt.assert_equal(scene.render(percept=covering, vmax=20).shape[-1], 3)
     # ... and so does a still percept, which has no interval to run off:
     still = Percept(values[..., :1], space=grid)
-    npt.assert_equal(scene._compose(still, vmax=20).shape[-1], 3)
+    npt.assert_equal(scene.render(percept=still, vmax=20).shape[-1], 3)
 
 
 def test_the_time_range_check_crosses_units():
@@ -701,12 +741,12 @@ def test_the_time_range_check_crosses_units():
     values = np.stack([np.full((5, 5), b) for b in (0.0, 20.0)], axis=-1)
     # 0-20 ms is exactly 0-0.02 s:
     covering = Percept(values, space=grid, time=[0, 0.02], time_unit=s)
-    composed = scene._compose(covering, vmax=20)
-    npt.assert_equal(composed.time_unit, ms)
-    npt.assert_almost_equal(composed.time, [0, 10, 20])
+    seen = scene.render(percept=covering, vmax=20)
+    npt.assert_equal(seen.time_unit, ms)
+    npt.assert_almost_equal(seen.time, [0, 10, 20])
     short = Percept(values, space=grid, time=[0, 0.01], time_unit=s)
     with pytest.raises(ValueError):
-        scene._compose(short, vmax=20)
+        scene.render(percept=short, vmax=20)
 
 
 def test_per_frame_gaze_moves_the_eye_between_video_frames():
@@ -859,8 +899,8 @@ def test_implant_position_moves_scene_sampling_and_the_percept_alike():
                             seen_by(fovea, scene_of(), gaze=(4, -3) * dva),
                             decimal=4)
     # ... and the phosphene is drawn there too. Row is -y, column is +x:
-    here = fovea.predict_percept(scene, vmax=2).data[..., 0]
-    there = placed.predict_percept(scene, vmax=2).data[..., 0]
+    here = composed(fovea, scene, vmax=2)[..., 0]
+    there = composed(placed, scene, vmax=2)[..., 0]
     npt.assert_almost_equal(there[HALF + 3, HALF + 4], here[HALF, HALF],
                             decimal=4)
 

--- a/pulse2percept/vision/scene.py
+++ b/pulse2percept/vision/scene.py
@@ -2,6 +2,7 @@
 import numpy as np
 from matplotlib.backends.backend_agg import FigureCanvasAgg
 from matplotlib.figure import Figure
+from matplotlib.patches import Ellipse, Rectangle
 from scipy.interpolate import RegularGridInterpolator
 from scipy.ndimage import gaussian_filter
 
@@ -18,6 +19,11 @@ from ..utils import PrettyPrint
 # How many sigmas of the blur kernel are kept; also how far off-frame the loss
 # map is rasterized, so the cropped result is free of edge effects:
 _TRUNCATE = 4.0
+
+# Roughly how many raster nodes are interpolated at once. The interpolator
+# works in float64, so a fine raster sampled in one go costs several times the
+# float32 result it is written into.
+_SAMPLE_BLOCK = 1 << 20
 
 # Eccentricity spacing, in dva, that `rings=True` asks for
 _RING_STEP = 5.0
@@ -51,6 +57,58 @@ def _resolve_fov(fov, n_rows, n_cols):
             raise ValueError(f"'fov' {name} must be a finite positive number "
                              f"of degrees, not {f}.")
     return (width, height)
+
+
+def _raster_axes(fov, shape):
+    """Pixel-center coordinates of a raster spanning ``fov``
+
+    ``fov`` is the raster's *outer* extent, so the outermost centers sit half
+    an angular pixel inside it. ``xs`` ascends left to right and ``ys``
+    descends, so ``ys[0]`` is row 0 at the top of the field.
+    """
+    n_rows, n_cols = shape
+    width, height = fov
+    dx, dy = width / n_cols, height / n_rows
+    xs = (np.arange(n_cols, dtype=float) + 0.5) * dx - width / 2
+    ys = height / 2 - (np.arange(n_rows, dtype=float) + 0.5) * dy
+    return xs, ys
+
+
+def _raster_step(xs, ys):
+    """Angular pixel pitch ``(dx, dy)`` of a raster, as positive numbers"""
+    def pitch(axis):
+        # A single row or column has no spacing to read off:
+        return abs(float(axis[1] - axis[0])) if axis.size > 1 else 1.0
+    return pitch(xs), pitch(ys)
+
+
+def _raster_extent(xs, ys):
+    """Outer edges ``(left, right, bottom, top)`` of a raster, for ``imshow``"""
+    dx, dy = _raster_step(xs, ys)
+    return (float(xs[0]) - dx / 2, float(xs[-1]) + dx / 2,
+            float(ys[-1]) - dy / 2, float(ys[0]) + dy / 2)
+
+
+def _raster_grid(xs, ys):
+    """A Grid2D on the nodes of a raster, ``ys`` descending"""
+    return Grid2D((float(xs[0]), float(xs[-1])),
+                  (float(ys[-1]), float(ys[0])), step=_raster_step(xs, ys))
+
+
+def _pad_axis(axis, step, pad):
+    """Extend a regular axis by ``pad`` samples of signed ``step`` at both ends"""
+    if pad == 0:
+        return axis
+    lead = axis[0] + step * np.arange(-pad, 0)
+    tail = axis[-1] + step * np.arange(1, pad + 1)
+    return np.concatenate((lead, axis, tail))
+
+
+def _pixel_count(extent, step):
+    """How many pixels of at most ``step`` degrees it takes to cover ``extent``"""
+    n = extent / step
+    # A ratio that is only integral up to rounding must not buy a pixel:
+    return max(int(np.ceil(n - 1e-9 * max(n, 1.0))), 1)
 
 
 def _gaze_points(gaze, n_frames):
@@ -92,19 +150,41 @@ def _drop_gray_axis(values):
     return values[:, 0] if values.shape[1] == 1 else values
 
 
-def _percept_sampler(prosthetic, frames):
-    """Read a percept at arbitrary eye-centered ``(y, x)`` coordinates in dva"""
+def _as_rgb(frame):
+    """One ``(rows, cols, channels)`` frame as RGB, without copying gray"""
+    if frame.shape[2] == 3:
+        return frame
+    return np.broadcast_to(frame, frame.shape[:2] + (3,))
+
+
+def _percept_axes(prosthetic):
+    """The percept's eye-centered ``(xs, ys)`` axes in dva, both ascending"""
     ys = np.asarray(prosthetic.ydva, dtype=float)
     xs = np.asarray(prosthetic.xdva, dtype=float)
     if ys.size < 2 or xs.size < 2:
         raise ValueError(f"A percept needs extent in both directions to be "
                          f"placed in a scene, but this one's grid is "
                          f"{ys.size} x {xs.size}.")
+    return xs, ys
+
+
+def _percept_on(prosthetic, frames, xs, ys, gaze_xy):
+    """Percept brightness at every node of a scene-coordinate raster
+
+    Returns ``(rows, cols, n)``, one trailing entry per frame carried.
+    """
+    pxs, pys = _percept_axes(prosthetic)
     # `Grid2D` meshes its y axis reversed, so row 0 of the data holds the
     # largest y while `ydva` ascends. Flipping the rows puts the two back in
     # the same order, which is also the ascending one the interpolator wants.
-    return RegularGridInterpolator((ys, xs), frames[::-1], method='linear',
-                                   bounds_error=False, fill_value=0)
+    sample = RegularGridInterpolator((pys, pxs), frames[::-1],
+                                     method='linear', bounds_error=False,
+                                     fill_value=0)
+    # The percept is eye-centered; the raster is in scene coordinates:
+    gx, gy = gaze_xy
+    x, y = np.meshgrid(xs - gx, ys - gy)
+    points = np.column_stack((y.ravel(), x.ravel()))
+    return sample(points).reshape((ys.size, xs.size, -1))
 
 
 def _resolve_fill(scotoma_fill):
@@ -334,18 +414,25 @@ class Scene(PrettyPrint):
         Gray level or RGB value to use for transparent pixels. Defaults to
         black.
     scotoma_blend : float, optional
-        Standard deviation, in scene pixels, of a Gaussian blur applied to the
-        rasterized loss map before it is drawn, softening the boundary from
-        both sides. Defaults to 2. Rendering only: the scotoma's geometry is
-        unchanged.
+        Standard deviation, in degrees of visual angle, of a Gaussian blur
+        applied to the rasterized loss map before it is drawn, softening the
+        boundary from both sides. Defaults to 0.5 dva; 0 leaves it as sharp as
+        the scotoma itself. Converted to pixels against whichever raster is
+        being drawn, so the angular softness does not depend on resolution.
+        Rendering only: the scotoma's geometry is unchanged.
+
+        .. versionchanged:: 0.11.0
+            Measured in degrees of visual angle rather than in scene pixels.
     aperture : {'rectangle', 'ellipse'}, optional
-        Shape of the rendered field. ``fov`` gives the aperture its dimensions
-        and this gives it its shape: the default ``'rectangle'`` fills the
-        whole frame, while ``'ellipse'`` inscribes an eye-centered ellipse of
-        semi-axes ``fov / 2`` in it and blacks out the corners around it. A
-        square ``fov`` therefore renders as a disc. Affects only the rendered
-        scene, not scene sampling, device input, stimulation, or the underlying
-        prosthetic model response.
+        Shape of the field's support. ``fov`` gives the aperture its
+        dimensions and this gives it its shape: the default ``'rectangle'``
+        fills the whole frame, while ``'ellipse'`` inscribes an eye-centered
+        ellipse of semi-axes ``fov / 2`` in it, so a square ``fov`` renders as
+        a disc. Support is a display boundary:
+        :py:meth:`~pulse2percept.vision.Scene.plot` clips its artists to it and
+        :py:meth:`~pulse2percept.vision.Scene.render` writes black outside it,
+        while scene sampling, device input, stimulation and the prosthetic
+        model response are untouched.
 
     Examples
     --------
@@ -362,7 +449,7 @@ class Scene(PrettyPrint):
     """
 
     def __init__(self, source, fov, scotoma=None, scotoma_fill=0,
-                 scotoma_blend=2, background=0, aperture=_RECTANGLE):
+                 scotoma_blend=0.5, background=0, aperture=_RECTANGLE):
         if not isinstance(source, (ImageStimulus, VideoStimulus)):
             # A picture is the common case:
             source = ImageStimulus(source)
@@ -370,12 +457,11 @@ class Scene(PrettyPrint):
             raise TypeError(f"'scotoma' must be a Scotoma object, not "
                             f"{type(scotoma)}.")
         fill = _resolve_fill(scotoma_fill)
-        blend = float(as_value(scotoma_blend, dimensionless,
-                               'scotoma_blend'))
+        blend = float(as_value(scotoma_blend, dva, 'scotoma_blend'))
         if not np.isfinite(blend) or blend < 0:
-            raise ValueError(f"'scotoma_blend' is a Gaussian sigma in scene "
-                             f"pixels and must be finite and non-negative, "
-                             f"not {scotoma_blend}.")
+            raise ValueError(f"'scotoma_blend' is a Gaussian sigma in degrees "
+                             f"of visual angle and must be finite and "
+                             f"non-negative, not {scotoma_blend}.")
         self._source = source
         self._background = _resolve_background(background)
         self._scotoma = scotoma
@@ -385,8 +471,8 @@ class Scene(PrettyPrint):
         n_rows, n_cols = self._frame_shape
         self._fov = _resolve_fov(fov, n_rows, n_cols)
         self._cached_frames = None
-        # `_pixel_centers` keyed by pad:
-        self._pixel_centers_cache = {}
+        self._axes_cache = None
+        self._pixel_centers_cache = None
 
     def _pprint_params(self):
         """Return a dict of class attributes to pretty-print"""
@@ -425,12 +511,12 @@ class Scene(PrettyPrint):
 
     @property
     def scotoma_blend(self):
-        """Gaussian sigma, in scene pixels, softening the drawn scotoma"""
+        """Gaussian sigma, in dva, softening the drawn scotoma boundary"""
         return self._scotoma_blend
 
     @property
     def aperture(self):
-        """Shape of the rendered field: ``'rectangle'`` or ``'ellipse'``"""
+        """Shape of the field's support: ``'rectangle'`` or ``'ellipse'``"""
         return self._aperture
 
     @property
@@ -614,38 +700,80 @@ class Scene(PrettyPrint):
         # `rgb2gray` wants the channels last:
         return rgb2gray(values.transpose((0, 2, 1)))
 
-    def _rgb_frames(self):
-        """The source as ``(rows, cols, 3, n_frames)``, scotoma not applied"""
-        frames = self._frames()
-        if frames.shape[2] == 1:
-            frames = np.repeat(frames, 3, axis=2)
-        return frames
+    @property
+    def _axes(self):
+        """Pixel-center axes ``(xs, ys)`` of the source raster, in scene dva"""
+        if self._axes_cache is None:
+            self._axes_cache = _raster_axes(self._fov, self._frame_shape)
+        return self._axes_cache
 
-    def _loss_at(self, gaze_xy, pad=0):
-        """Geometric loss at each scene pixel, in [0, 1], as float32"""
-        n_rows, n_cols = self._frame_shape
+    def _pixel_centers(self):
+        """Scene coordinates of every pixel center, as ``(x, y)`` meshes"""
+        if self._pixel_centers_cache is None:
+            centers = np.meshgrid(*self._axes)
+            for mesh in centers:
+                mesh.flags.writeable = False
+            self._pixel_centers_cache = centers
+        return self._pixel_centers_cache
+
+    def _source_on(self, xs, ys):
+        """The source at every node of a scene-coordinate raster
+
+        ``(rows, cols, channels, n_frames)`` with 1 or 3 channels, as
+        `_frames`. The source lives in scene coordinates, so this does not
+        depend on gaze.
+        """
+        if np.array_equal(xs, self._axes[0]) and                 np.array_equal(ys, self._axes[1]):
+            # The raster the source already sits on, so nothing is resampled
+            # and the intact periphery comes through bit for bit:
+            return self._frames()
+        n_rows, n_cols = ys.size, xs.size
+        # Interpolated in row blocks: the interpolator works in float64, so a
+        # fine raster done in one go costs several times the float32 result.
+        block = max(1, _SAMPLE_BLOCK // max(n_cols, 1))
+        out = None
+        for lo in range(0, n_rows, block):
+            hi = min(lo + block, n_rows)
+            x, y = np.meshgrid(xs, ys[lo:hi])
+            values = self._sample_at(x, y)
+            if values.ndim == 2:
+                # Grayscale: give it the channel axis `_frames` has
+                values = values[:, np.newaxis, :]
+            if out is None:
+                out = np.empty((n_rows, n_cols) + values.shape[1:],
+                               dtype=np.float32)
+            out[lo:hi] = values.reshape((hi - lo, n_cols) + values.shape[1:])
+        return out
+
+    def _loss_on(self, xs, ys, gaze_xy):
+        """Geometric loss at every node of a raster, in [0, 1], as float32"""
         if self.scotoma is None:
-            return np.zeros((n_rows + 2 * pad, n_cols + 2 * pad),
-                            dtype=np.float32)
+            return np.zeros((ys.size, xs.size), dtype=np.float32)
         # scene = visual field + gaze:
         gx, gy = gaze_xy
-        x_scene, y_scene = self._pixel_centers(pad=pad)
-        return np.asarray(self.scotoma(x_scene - gx, y_scene - gy),
-                          dtype=np.float32)
+        x, y = np.meshgrid(xs - gx, ys - gy)
+        return np.asarray(self.scotoma(x, y), dtype=np.float32)
 
-    def _rendered_loss_at(self, gaze_xy):
-        """The loss map as drawn: `_loss_at` softened by `scotoma_blend`"""
+    def _rendered_loss_on(self, xs, ys, gaze_xy):
+        """The loss map as drawn: `_loss_on` softened by `scotoma_blend`
+
+        The sigma is angular, so it is converted against this raster's own
+        pixel pitch; anisotropic pixels get separate row and column sigmas.
+        """
         sigma = self._scotoma_blend
         # An inpainted fill ignores the hard boundary:
         hard = self.scotoma is None or self._scotoma_fill == _INPAINT
         if hard or sigma == 0:
-            return self._loss_at(gaze_xy)
-        # Blur the loss field, not a frame-sized crop of it:
-        pad = int(np.ceil(_TRUNCATE * sigma)) + 1
-        loss = self._loss_at(gaze_xy, pad=pad)
-        blurred = gaussian_filter(loss, sigma, mode='nearest',
+            return self._loss_on(xs, ys, gaze_xy)
+        dx, dy = _raster_step(xs, ys)
+        sigmas = (sigma / dy, sigma / dx)
+        pads = tuple(int(np.ceil(_TRUNCATE * s)) + 1 for s in sigmas)
+        # Blur the loss field, not a raster-sized crop of it:
+        loss = self._loss_on(_pad_axis(xs, dx, pads[1]),
+                             _pad_axis(ys, -dy, pads[0]), gaze_xy)
+        blurred = gaussian_filter(loss, sigmas, mode='nearest',
                                   truncate=_TRUNCATE)
-        return np.clip(blurred[pad:-pad, pad:-pad], 0, 1)
+        return np.clip(blurred[pads[0]:-pads[0], pads[1]:-pads[1]], 0, 1)
 
     def _fill_rgb(self, frame_rgb, loss):
         """What complete loss shows for one ``(rows, cols, 3)`` frame"""
@@ -653,79 +781,94 @@ class Scene(PrettyPrint):
             return self._scotoma_fill
         return _inpaint_rgb(frame_rgb, loss > 0)
 
-    def _aperture_mask(self, gaze_xy):
-        """Return a mask for pixels outside the eye-centered aperture.
+    def _aperture_mask(self, xs, ys, gaze_xy):
+        """Raster nodes outside the eye-centered aperture
 
         The ellipse spans the full Scene FOV, with semi-axes `fov / 2`.
         `gaze_xy` sets its center in scene coordinates.
         """
         gx, gy = gaze_xy
-        x_scene, y_scene = self._pixel_centers()
         a, b = self._fov[0] / 2, self._fov[1] / 2
-        return ((x_scene - gx) / a) ** 2 + ((y_scene - gy) / b) ** 2 > 1
+        across = ((xs - gx) / a) ** 2
+        down = (((ys - gy) / b) ** 2)[:, np.newaxis]
+        return across + down > 1
 
-    def _apply_aperture(self, frames, gaze=None):
-        """Black out ``(rows, cols, 3, n_frames)`` outside the aperture"""
+    def _apply_aperture(self, frames, xs, ys, gaze=None):
+        """Black out ``(rows, cols, 3, n_frames)`` outside the aperture
+
+        A display decision taken at the boundary of a finished raster: outside
+        the aperture is undefined visual-field support, not black content.
+        """
         if self._aperture == _RECTANGLE:
             return frames
         points = _gaze_points(gaze, frames.shape[-1])
         static = len(points) == 1
-        mask = self._aperture_mask(points[0]) if static else None
+        mask = self._aperture_mask(xs, ys, points[0]) if static else None
         out = np.array(frames, dtype=np.float32)
         for f in range(frames.shape[-1]):
-            outside = mask if static else self._aperture_mask(points[f])
+            outside = mask if static else self._aperture_mask(xs, ys,
+                                                              points[f])
             out[outside, :, f] = 0
         return out
 
-    def _percept_on_grid(self, sample, gaze_xy):
-        """Percept brightness read at every scene pixel center
+    def _support_patch(self, gaze_xy, transform):
+        """The field's support as a patch, for clipping drawn artists"""
+        width, height = self._fov
+        if self._aperture == _ELLIPSE:
+            # Eye-centered, so it sits wherever gaze points:
+            return Ellipse(tuple(gaze_xy), width, height, transform=transform)
+        # A rectangular aperture is the frame itself, which does not move:
+        return Rectangle((-width / 2, -height / 2), width, height,
+                         transform=transform)
 
-        ``sample`` is a `_percept_sampler`; the returned array is
-        ``(rows, cols, n)`` with one trailing entry per frame it carries.
+    def _clip_to_support(self, artists, gaze_xy, transform):
+        """Clip drawn artists to the field's support
+
+        Outside the aperture is undefined visual-field support, so the
+        boundary belongs to the artists rather than to their arrays. The
+        source layer already covers exactly the rectangle, so only a local
+        patch, which may reach past the field, needs clipping to that.
         """
-        n_rows, n_cols = self._frame_shape
-        gx, gy = gaze_xy
-        x_scene, y_scene = self._pixel_centers()
-        # The percept is eye-centered; the scene raster is not:
-        points = np.column_stack(((y_scene - gy).ravel(),
-                                  (x_scene - gx).ravel()))
-        return sample(points).reshape((n_rows, n_cols, -1))
+        if self._aperture == _RECTANGLE:
+            artists = artists[1:]
+        if not artists:
+            return
+        clip = self._support_patch(gaze_xy, transform)
+        for artist in artists:
+            artist.set_clip_path(clip)
 
-    def _native_rgb(self, gaze=None):
-        """What is left of native vision, as ``(rows, cols, 3, n_frames)``"""
-        frames = self._rgb_frames()
+    def _native_on(self, xs, ys, gaze=None):
+        """Residual native vision on a raster, ``(rows, cols, 3, n_frames)``"""
+        frames = self._source_on(xs, ys)
         if self.scotoma is None:
-            return self._apply_aperture(frames, gaze=gaze)
+            return (frames if frames.shape[2] == 3
+                    else np.repeat(frames, 3, axis=2))
         n_frames = frames.shape[-1]
-        gaze = _gaze_points(gaze, n_frames)
-        static = len(gaze) == 1
+        points = _gaze_points(gaze, n_frames)
+        static = len(points) == 1
         if static:
-            loss = self._rendered_loss_at(gaze[0])
-        out = np.empty(frames.shape, dtype=np.float32)
+            loss = self._rendered_loss_on(xs, ys, points[0])
+        out = np.empty((ys.size, xs.size, 3, n_frames), dtype=np.float32)
         for f in range(n_frames):
             if not static:
-                loss = self._rendered_loss_at(gaze[f])
-            frame = frames[..., f]
+                loss = self._rendered_loss_on(xs, ys, points[f])
+            frame = _as_rgb(frames[..., f])
             # An inpainted fill reads this frame, so it is per-frame work:
             fill = self._fill_rgb(frame, loss)
             alpha = loss[..., np.newaxis]
             out[..., f] = (1 - alpha) * frame + alpha * fill
-        return self._apply_aperture(out, gaze=gaze)
+        return out
 
-    def _pixel_centers(self, pad=0):
-        """Scene coordinates of every pixel center, as ``(x, y)`` meshes"""
-        if pad not in self._pixel_centers_cache:
-            n_rows, n_cols = self._frame_shape
-            cols, rows = np.meshgrid(np.arange(-pad, n_cols + pad),
-                                     np.arange(-pad, n_rows + pad))
-            centers = self.pixel_to_dva(cols, rows)
-            for mesh in centers:
-                mesh.flags.writeable = False
-            self._pixel_centers_cache[pad] = centers
-        return self._pixel_centers_cache[pad]
+    def _native_rgb(self, gaze=None):
+        """Residual native vision on the source raster, aperture not applied"""
+        return self._native_on(*self._axes, gaze=gaze)
 
-    def _compose(self, prosthetic, vmax, vmin=0, gaze=None):
-        """Native vision with a prosthetic percept painted into the loss"""
+    def _composed_on(self, xs, ys, prosthetic, vmax, vmin=0, gaze=None):
+        """Native vision on a raster with a prosthetic percept in the loss
+
+        ``out = (1 - loss) * native + loss * max(fill, phosphene)``. Returns
+        ``(frames, time, time_unit)``.
+        """
         if self._scotoma_fill == _INPAINT:
             raise ValueError(
                 f"scotoma_fill={_INPAINT!r} cannot be combined with a "
@@ -733,21 +876,19 @@ class Scene(PrettyPrint):
                 f"Use a numeric 'scotoma_fill' for prosthetic composition.")
         _check_prosthetic(prosthetic)
         vmin, vmax = _check_range(vmin, vmax)
-        # Not `_rgb_frames`: a grayscale source is broadcast to RGB below
-        # rather than copied into a second full-size array.
-        scene_frames = self._frames()
         pframes, out_time, out_unit = self._prosthetic_frames(prosthetic)
         n_out = pframes.shape[-1]
-        gaze = _gaze_points(gaze, n_out)
-        n_rows, n_cols = self._frame_shape
+        points = _gaze_points(gaze, n_out)
+        # Not `_native_on`: a grayscale source is broadcast to RGB per frame
+        # below rather than copied into a second full-size array.
+        source = self._source_on(xs, ys)
+        n_scene = source.shape[-1]
+        n_rows, n_cols = ys.size, xs.size
 
-        static = len(gaze) == 1
+        static = len(points) == 1
         if static:
-            brightness = self._percept_on_grid(
-                _percept_sampler(prosthetic, pframes), gaze[0])
-            loss = self._rendered_loss_at(gaze[0])
-
-        n_scene = scene_frames.shape[-1]
+            brightness = _percept_on(prosthetic, pframes, xs, ys, points[0])
+            loss = self._rendered_loss_on(xs, ys, points[0])
         # Frame-major while composing: writing a whole frame at a time is
         # contiguous here:
         out = np.empty((n_out, n_rows, n_cols, 3), dtype=np.float32)
@@ -755,24 +896,20 @@ class Scene(PrettyPrint):
             if static:
                 frame = brightness[..., f]
             else:
-                sample = _percept_sampler(prosthetic, pframes[..., f:f + 1])
-                frame = self._percept_on_grid(sample, gaze[f])[..., 0]
-                loss = self._rendered_loss_at(gaze[f])
+                frame = _percept_on(prosthetic, pframes[..., f:f + 1],
+                                    xs, ys, points[f])[..., 0]
+                loss = self._rendered_loss_on(xs, ys, points[f])
             phosphene = np.clip((frame - vmin) / (vmax - vmin), 0, 1)
-            native = scene_frames[..., 0 if n_scene == 1 else f]
-            if native.shape[2] == 1:
-                # Grayscale = three identical copies
-                native = np.broadcast_to(native, (n_rows, n_cols, 3))
+            native = _as_rgb(source[..., 0 if n_scene == 1 else f])
             fill = self._fill_rgb(native, loss)
             lost = np.maximum(fill, phosphene[..., np.newaxis])
             alpha = loss[..., np.newaxis]
             out[f] = (1 - alpha) * native + alpha * lost
-        out = np.ascontiguousarray(np.moveaxis(out, 0, -1))
-        return Percept(self._apply_aperture(out, gaze=gaze),
-                       space=self._grid(), time=out_time, time_unit=out_unit)
+        return (np.ascontiguousarray(np.moveaxis(out, 0, -1)), out_time,
+                out_unit)
 
-    def _prosthetic_rgb(self, prosthetic, vmax, vmin=0, gaze=None):
-        """A prosthetic percept alone on black, on the scene's pixel grid
+    def _prosthetic_on(self, xs, ys, prosthetic, vmax, vmin=0, gaze=None):
+        """A prosthetic percept alone on black, on a scene-coordinate raster
 
         Places a percept where and at what size this field sees it. Not a
         composition: with no scotoma there is nothing to paint the percept
@@ -781,21 +918,47 @@ class Scene(PrettyPrint):
         """
         _check_prosthetic(prosthetic)
         vmin, vmax = _check_range(vmin, vmax)
-        pframes, _, _ = self._prosthetic_frames(prosthetic)
+        pframes, out_time, out_unit = self._prosthetic_frames(prosthetic)
         n_out = pframes.shape[-1]
-        gaze = _gaze_points(gaze, n_out)
-        if len(gaze) == 1:
-            brightness = self._percept_on_grid(
-                _percept_sampler(prosthetic, pframes), gaze[0])
+        points = _gaze_points(gaze, n_out)
+        if len(points) == 1:
+            brightness = _percept_on(prosthetic, pframes, xs, ys, points[0])
         else:
             brightness = np.concatenate(
-                [self._percept_on_grid(
-                    _percept_sampler(prosthetic, pframes[..., f:f + 1]),
-                    gaze[f]) for f in range(n_out)], axis=-1)
+                [_percept_on(prosthetic, pframes[..., f:f + 1], xs, ys,
+                             points[f]) for f in range(n_out)], axis=-1)
         scaled = np.clip((brightness - vmin) / (vmax - vmin), 0, 1)
         rgb = np.repeat(scaled[:, :, np.newaxis, :], 3, axis=2)
-        return self._apply_aperture(np.asarray(rgb, dtype=np.float32),
-                                    gaze=gaze)
+        return np.asarray(rgb, dtype=np.float32), out_time, out_unit
+
+    def _display_on(self, xs, ys, percept=None, vmax=None, vmin=0, gaze=None):
+        """Display-ready RGB on a scene-coordinate raster, and its clock
+
+        Residual native vision, or that with a prosthetic percept composed
+        into the loss. The aperture is left to whatever draws the result.
+        Returns ``(frames, time, time_unit)``.
+        """
+        if percept is None:
+            if vmax is not None or vmin != 0:
+                raise ValueError("'vmin' and 'vmax' map percept brightness "
+                                 "onto a display, and there is no percept "
+                                 "here. Pass 'percept'.")
+            return (self._native_on(xs, ys, gaze=gaze), self.time,
+                    self.time_unit)
+        if self.scotoma is None:
+            return self._prosthetic_on(xs, ys, percept, vmax, vmin=vmin,
+                                       gaze=gaze)
+        return self._composed_on(xs, ys, percept, vmax, vmin=vmin, gaze=gaze)
+
+    def _n_display_frames(self, percept):
+        """How many frames a drawn or rendered result has
+
+        A video scene sets the clock, so a percept is read at its frame times;
+        a still scene has whatever frames the percept brought.
+        """
+        if percept is None or self.time is not None:
+            return self.n_frames
+        return percept.data.shape[-1]
 
     def _prosthetic_frames(self, prosthetic):
         """Line a percept up with the output frames, and say when they happen"""
@@ -826,18 +989,97 @@ class Scene(PrettyPrint):
 
     def _grid(self):
         """A Grid2D on the scene's pixel centers, in scene coordinates"""
-        n_rows, n_cols = self._frame_shape
-        x_left, y_top = self.pixel_to_dva(0, 0)
-        x_right, y_bottom = self.pixel_to_dva(n_cols - 1, n_rows - 1)
-        step = (float(x_right - x_left) / (n_cols - 1) if n_cols > 1 else 1.0,
-                float(y_top - y_bottom) / (n_rows - 1) if n_rows > 1 else 1.0)
-        return Grid2D((float(x_left), float(x_right)),
-                      (float(y_bottom), float(y_top)), step=step)
+        return _raster_grid(*self._axes)
 
-    def _native_percept(self, gaze=None):
-        """Residual native vision as an ordinary RGB percept"""
-        return Percept(self._native_rgb(gaze=gaze), space=self._grid(),
-                       time=self.time, time_unit=self.time_unit)
+    def _render_shape(self, step, shape):
+        """The ``(rows, cols)`` a requested render raster comes out at"""
+        if step is not None and shape is not None:
+            raise ValueError("'step' and 'shape' both choose the render "
+                             "raster; pass one or the other.")
+        if shape is not None:
+            shape = np.asarray(shape)
+            if shape.shape != (2,) or shape.dtype.kind not in 'iu' or                     shape.min() < 1:
+                raise ValueError(f"'shape' must be a (rows, cols) pair of "
+                                 f"positive integers, not {np.ravel(shape)}.")
+            return (int(shape[0]), int(shape[1]))
+        if step is None:
+            # The source's own raster, so rendering resamples nothing unless
+            # it is asked to:
+            return self._frame_shape
+        step = np.asarray(as_value(step, dva, 'step'), dtype=float)
+        if step.ndim == 0:
+            step = np.repeat(step, 2)
+        if step.shape != (2,) or not np.all(np.isfinite(step)) or                 step.min() <= 0:
+            raise ValueError(f"'step' is an angular sampling in degrees and "
+                             f"must be a positive number or a (dx, dy) pair, "
+                             f"not {np.ravel(step)}.")
+        # Rounded up, so the rendered pixels are never coarser than asked:
+        return (_pixel_count(self._fov[1], step[1]),
+                _pixel_count(self._fov[0], step[0]))
+
+    def render(self, percept=None, gaze=None, vmax=None, vmin=0, step=None,
+               shape=None):
+        """Rasterize this field onto one dense RGB percept
+
+        Residual native vision, with a prosthetic ``percept`` composed into the
+        loss where there is a scotoma, on one common raster. Use it when a
+        single RGB image is needed, for saving or for downstream image
+        processing; :py:meth:`~pulse2percept.vision.Scene.plot` draws the same
+        content without forcing a shared resolution.
+
+        The raster defaults to the source's own, which resamples nothing.
+        ``step`` or ``shape`` chooses another; a fine ``step`` over a wide
+        field is expensive by construction.
+
+        .. versionadded:: 0.11.0
+
+        Parameters
+        ----------
+        percept : :py:class:`~pulse2percept.percepts.Percept`, optional
+            A brightness percept to place in this field, positioned by
+            ``gaze``. With a scotoma it is composed into the loss as
+            ``(1 - loss) * native + loss * max(scotoma_fill, phosphene)``;
+            with none it is rendered alone on black, because superimposing it
+            on intact native vision would assert an unmodeled interaction.
+            ``scotoma_fill='inpaint'`` cannot be composed with one.
+        gaze : (x, y) or (n_frames, 2), optional
+            Where the eye is pointing: the scene location that falls on the
+            fovea, in dva. Defaults to the origin.
+        vmax : float, optional
+            The percept brightness that displays as white. Required whenever
+            ``percept`` is given: brightness is in arbitrary units.
+        vmin : float, optional
+            The percept brightness that displays as black. Defaults to 0.
+        step : float or (dx, dy), optional
+            Angular sampling of the render raster, in dva. Rounded up, so the
+            rendered pixels are never coarser than this. Mutually exclusive
+            with ``shape``.
+        shape : (rows, cols), optional
+            The render raster itself. Mutually exclusive with ``step``.
+
+        Returns
+        -------
+        percept : :py:class:`~pulse2percept.percepts.Percept`
+            An RGB percept in ``[0, 1]`` on the render raster, black outside
+            the aperture. The source is left unchanged.
+
+        Examples
+        --------
+        >>> import numpy as np
+        >>> from pulse2percept.units import dva
+        >>> from pulse2percept.vision import Scene
+        >>> scene = Scene(np.zeros((60, 80)), fov=40 * dva)
+        >>> scene.render().shape
+        (60, 80, 3, 1)
+        >>> scene.render(step=0.25 * dva).shape
+        (120, 160, 3, 1)
+
+        """
+        xs, ys = _raster_axes(self._fov, self._render_shape(step, shape))
+        frames, time, unit = self._display_on(xs, ys, percept=percept,
+                                              vmax=vmax, vmin=vmin, gaze=gaze)
+        return Percept(self._apply_aperture(frames, xs, ys, gaze=gaze),
+                       space=_raster_grid(xs, ys), time=time, time_unit=unit)
 
     def plot(self, gaze=None, frame=0, ax=None, rings=False,
              ring_color=_RING_COLOR, percept=None, vmax=None, vmin=0,
@@ -848,12 +1090,18 @@ class Scene(PrettyPrint):
         it is lost. A scotoma is eye-centered, so ``gaze`` decides where in the
         scene it falls.
 
-        Passing a ``percept`` draws a prosthetic percept in this field instead,
-        so its size and place can be read against the FOV. With a scotoma that
-        is the same composition
-        :py:meth:`~pulse2percept.models.Model.predict_percept` returns;
-        without one the percept is drawn alone on black, because superimposing
-        it on intact native vision would assert an unmodeled interaction.
+        Passing a ``percept`` draws it in this field as well, so its size and
+        place can be read against the FOV. Each layer keeps its own
+        resolution: the source on the source raster, the percept as a local
+        patch on its own visual-field grid. Neither is resampled onto a common
+        raster; see :py:meth:`~pulse2percept.vision.Scene.render` for that.
+
+        Inside the patch the layers compose as
+        ``(1 - loss) * native + loss * max(scotoma_fill, phosphene)``, so
+        where the percept is dark the patch is ordinary residual vision and
+        its boundary does not show. With no scotoma the percept is drawn alone
+        on black, because superimposing it on intact native vision would
+        assert an unmodeled interaction.
 
         Parameters
         ----------
@@ -874,7 +1122,8 @@ class Scene(PrettyPrint):
             Any Matplotlib color for those rings and their labels. Defaults to
             a mid-gray that reads on a light scene.
         percept : :py:class:`~pulse2percept.percepts.Percept`, optional
-            A brightness percept to draw in this field, placed by ``gaze``.
+            A brightness percept to draw in this field, placed by ``gaze`` and
+            drawn at its own resolution over the source.
         vmax : float, optional
             The percept brightness that displays as white. Required whenever
             ``percept`` is given: brightness is in arbitrary units.
@@ -888,27 +1137,54 @@ class Scene(PrettyPrint):
         ax : matplotlib.axes.Axes
 
         """
-        if percept is None:
-            if vmax is not None or vmin != 0:
-                raise ValueError("'vmin' and 'vmax' map percept brightness "
-                                 "onto a display, and there is no percept to "
-                                 "plot. Pass 'percept'.")
-            rgb = self._native_rgb(gaze=gaze)
-        elif self.scotoma is None:
-            rgb = self._prosthetic_rgb(percept, vmax, vmin=vmin, gaze=gaze)
-        else:
-            rgb = self._compose(percept, vmax, vmin=vmin, gaze=gaze).data
-        if not 0 <= frame < rgb.shape[-1]:
-            raise ValueError(f"'frame' must be in 0..{rgb.shape[-1] - 1}, not "
+        if percept is not None:
+            _check_prosthetic(percept)
+        n_out = self._n_display_frames(percept)
+        if not 0 <= frame < n_out:
+            raise ValueError(f"'frame' must be in 0..{n_out - 1}, not "
                              f"{frame}.")
-        still = Percept(rgb[..., frame:frame + 1], space=self._grid())
-        radii = _ring_radii(rings, self.fov)
+        points = _gaze_points(gaze, n_out)
+        gaze_xy = points[0] if len(points) == 1 else points[frame]
+        xs, ys = self._axes
+        # The source layer has its own frame count; one drawn frame of it
+        # needs only the one gaze:
+        src_frame = 0 if self.n_frames == 1 else frame
+        patch = None
+        if percept is None:
+            # `_display_on` rejects a display range with nothing to map:
+            wide = self._display_on(xs, ys, vmax=vmax, vmin=vmin,
+                                    gaze=gaze_xy)[0][..., src_frame]
+        else:
+            pxs, pys = _percept_axes(percept)
+            # Eye-centered percept coordinates, moved into the scene; `pys`
+            # descends so that row 0 of the patch is its top, as drawn:
+            pxs = pxs + gaze_xy[0]
+            pys = pys[::-1] + gaze_xy[1]
+            patch = self._display_on(pxs, pys, percept=percept, vmax=vmax,
+                                     vmin=vmin, gaze=gaze)[0][..., frame]
+            if self.scotoma is None:
+                # Nothing is lost, so there is no residual vision to draw the
+                # percept into; only the field's extent is left to show.
+                wide = np.zeros((ys.size, xs.size, 3), dtype=np.float32)
+            else:
+                wide = self._native_on(xs, ys, gaze=gaze_xy)[..., src_frame]
+        still = Percept(wide[..., np.newaxis], space=self._grid())
         ax = still.plot(ax=ax, **kwargs)
+        artists = [ax.images[-1]]
+        if patch is not None:
+            # `imshow` must not renegotiate the limits the wide layer set:
+            xlim, ylim = ax.get_xlim(), ax.get_ylim()
+            artists.append(ax.imshow(patch, origin='upper',
+                                     extent=_raster_extent(pxs, pys),
+                                     zorder=artists[0].get_zorder() + 1))
+            ax.set_xlim(xlim)
+            ax.set_ylim(ylim)
+        self._clip_to_support(artists, gaze_xy, ax.transData)
+        radii = _ring_radii(rings, self.fov)
         if radii.size:
             # The fovea sits wherever gaze points, which is where the scotoma
             # is drawn too; at the default gaze that is the scene's center.
-            _draw_rings(ax, radii, _gaze_points(gaze, rgb.shape[-1])[0],
-                        color=ring_color)
+            _draw_rings(ax, radii, gaze_xy, color=ring_color)
         return ax
 
     def play(self, gaze=None, rings=False, ring_color=_RING_COLOR, ax=None,
@@ -940,8 +1216,10 @@ class Scene(PrettyPrint):
         if self.time is None:
             raise ValueError("A still scene has nothing to play. Use plot().")
         radii = _ring_radii(rings, self.fov)
+        # The player rasterizes its own frames, so this is display output:
+        native = self.render(gaze=gaze)
         if not radii.size:
-            return self._native_percept(gaze=gaze).play(ax=ax, **kwargs)
+            return native.play(ax=ax, **kwargs)
         points = _gaze_points(gaze, self.n_frames)
         if len(points) > 1:
             raise ValueError(
@@ -951,9 +1229,8 @@ class Scene(PrettyPrint):
                 "rings=False.")
         # Painted into the displayed frames rather than left as an artist
         # behind the player's canvas, which would hide them:
-        frames = self._native_rgb(gaze=gaze)
         overlay = _rings_overlay(self._frame_shape, radii, points[0],
                                  self.dva_to_pixel, color=ring_color)
-        decorated = Percept(_over(frames, overlay), space=self._grid(),
+        decorated = Percept(_over(native.data, overlay), space=self._grid(),
                             time=self.time, time_unit=self.time_unit)
         return decorated.play(ax=ax, **kwargs)

--- a/pulse2percept/vision/scene.py
+++ b/pulse2percept/vision/scene.py
@@ -83,7 +83,7 @@ def _raster_step(xs, ys):
 
 
 def _raster_extent(xs, ys):
-    """Outer edges ``(left, right, bottom, top)`` of a raster, for ``imshow``"""
+    """Outer edges ``(left, right, bottom, top)`` of a raster, for `imshow`"""
     dx, dy = _raster_step(xs, ys)
     return (float(xs[0]) - dx / 2, float(xs[-1]) + dx / 2,
             float(ys[-1]) - dy / 2, float(ys[0]) + dy / 2)
@@ -96,7 +96,7 @@ def _raster_grid(xs, ys):
 
 
 def _pad_axis(axis, step, pad):
-    """Extend a regular axis by ``pad`` samples of signed ``step`` at both ends"""
+    """Extend a regular axis by ``pad`` samples of signed ``step`` each end"""
     if pad == 0:
         return axis
     lead = axis[0] + step * np.arange(-pad, 0)
@@ -105,7 +105,7 @@ def _pad_axis(axis, step, pad):
 
 
 def _pixel_count(extent, step):
-    """How many pixels of at most ``step`` degrees it takes to cover ``extent``"""
+    """How many pixels of at most ``step`` degrees ``extent`` takes"""
     n = extent / step
     # A ratio that is only integral up to rounding must not buy a pixel:
     return max(int(np.ceil(n - 1e-9 * max(n, 1.0))), 1)
@@ -155,6 +155,18 @@ def _as_rgb(frame):
     if frame.shape[2] == 3:
         return frame
     return np.broadcast_to(frame, frame.shape[:2] + (3,))
+
+
+def _take_frame(frames, frame):
+    """One frame of a stack, kept as a stack; ``None`` keeps all of them"""
+    return frames if frame is None else frames[..., frame:frame + 1]
+
+
+def _take_time(time, frame):
+    """The matching slice of a frame clock, which may be absent"""
+    if frame is None or time is None:
+        return time
+    return np.asarray(time)[frame:frame + 1]
 
 
 def _percept_axes(prosthetic):
@@ -671,7 +683,10 @@ class Scene(PrettyPrint):
 
     def _sample_at(self, x, y, gaze=None):
         """What the scene shows at eye-centered visual-field positions"""
-        frames = self._frames()
+        return self._sample_frames(self._frames(), x, y, gaze=gaze)
+
+    def _sample_frames(self, frames, x, y, gaze=None):
+        """`_sample_at` against a chosen stack of the source's frames"""
         gaze = _gaze_points(gaze, frames.shape[-1])
         x = np.asarray(x, dtype=float).ravel()
         y = np.asarray(y, dtype=float).ravel()
@@ -716,17 +731,27 @@ class Scene(PrettyPrint):
             self._pixel_centers_cache = centers
         return self._pixel_centers_cache
 
-    def _source_on(self, xs, ys):
+    def _source_frame(self, frame):
+        """Which source frame an output frame reads; None means all of them"""
+        if frame is None:
+            return None
+        # A still source stands behind every output frame:
+        return frame if self.n_frames > 1 else 0
+
+    def _source_on(self, xs, ys, frame=None):
         """The source at every node of a scene-coordinate raster
 
         ``(rows, cols, channels, n_frames)`` with 1 or 3 channels, as
         `_frames`. The source lives in scene coordinates, so this does not
-        depend on gaze.
+        depend on gaze. ``frame`` restricts both the work and the result to
+        that one source frame.
         """
-        if np.array_equal(xs, self._axes[0]) and                 np.array_equal(ys, self._axes[1]):
+        frames = _take_frame(self._frames(), frame)
+        same_x = np.array_equal(xs, self._axes[0])
+        if same_x and np.array_equal(ys, self._axes[1]):
             # The raster the source already sits on, so nothing is resampled
             # and the intact periphery comes through bit for bit:
-            return self._frames()
+            return frames
         n_rows, n_cols = ys.size, xs.size
         # Interpolated in row blocks: the interpolator works in float64, so a
         # fine raster done in one go costs several times the float32 result.
@@ -735,7 +760,7 @@ class Scene(PrettyPrint):
         for lo in range(0, n_rows, block):
             hi = min(lo + block, n_rows)
             x, y = np.meshgrid(xs, ys[lo:hi])
-            values = self._sample_at(x, y)
+            values = self._sample_frames(frames, x, y)
             if values.ndim == 2:
                 # Grayscale: give it the channel axis `_frames` has
                 values = values[:, np.newaxis, :]
@@ -837,9 +862,13 @@ class Scene(PrettyPrint):
         for artist in artists:
             artist.set_clip_path(clip)
 
-    def _native_on(self, xs, ys, gaze=None):
-        """Residual native vision on a raster, ``(rows, cols, 3, n_frames)``"""
-        frames = self._source_on(xs, ys)
+    def _native_on(self, xs, ys, gaze=None, frame=None):
+        """Residual native vision on a raster, ``(rows, cols, 3, n_frames)``
+
+        ``frame`` restricts the work to that one source frame, in which case
+        ``gaze`` is the single pair that frame is seen with.
+        """
+        frames = self._source_on(xs, ys, frame=frame)
         if self.scotoma is None:
             return (frames if frames.shape[2] == 3
                     else np.repeat(frames, 3, axis=2))
@@ -863,25 +892,28 @@ class Scene(PrettyPrint):
         """Residual native vision on the source raster, aperture not applied"""
         return self._native_on(*self._axes, gaze=gaze)
 
-    def _composed_on(self, xs, ys, prosthetic, vmax, vmin=0, gaze=None):
+    def _composed_on(self, xs, ys, prosthetic, vmax, vmin=0, gaze=None,
+                     frame=None):
         """Native vision on a raster with a prosthetic percept in the loss
 
         ``out = (1 - loss) * native + loss * max(fill, phosphene)``. Returns
-        ``(frames, time, time_unit)``.
+        ``(frames, time, time_unit)``. ``frame`` restricts the work to that
+        one output frame, in which case ``gaze`` is the single pair for it.
         """
         if self._scotoma_fill == _INPAINT:
             raise ValueError(
                 f"scotoma_fill={_INPAINT!r} cannot be combined with a "
-                f"prosthetic percept because their interaction is not modeled. "
-                f"Use a numeric 'scotoma_fill' for prosthetic composition.")
+                f"prosthetic percept because their interaction is not "
+                f"modeled. Use a numeric 'scotoma_fill' to compose one.")
         _check_prosthetic(prosthetic)
         vmin, vmax = _check_range(vmin, vmax)
-        pframes, out_time, out_unit = self._prosthetic_frames(prosthetic)
+        pframes, out_time, out_unit = self._prosthetic_frames(prosthetic,
+                                                              frame=frame)
         n_out = pframes.shape[-1]
         points = _gaze_points(gaze, n_out)
         # Not `_native_on`: a grayscale source is broadcast to RGB per frame
         # below rather than copied into a second full-size array.
-        source = self._source_on(xs, ys)
+        source = self._source_on(xs, ys, frame=self._source_frame(frame))
         n_scene = source.shape[-1]
         n_rows, n_cols = ys.size, xs.size
 
@@ -908,17 +940,20 @@ class Scene(PrettyPrint):
         return (np.ascontiguousarray(np.moveaxis(out, 0, -1)), out_time,
                 out_unit)
 
-    def _prosthetic_on(self, xs, ys, prosthetic, vmax, vmin=0, gaze=None):
+    def _prosthetic_on(self, xs, ys, prosthetic, vmax, vmin=0, gaze=None,
+                       frame=None):
         """A prosthetic percept alone on black, on a scene-coordinate raster
 
         Places a percept where and at what size this field sees it. Not a
         composition: with no scotoma there is nothing to paint the percept
         into, and superimposing it on intact native vision would assert an
-        interaction that is not modeled.
+        interaction that is not modeled. ``frame`` restricts the work to that
+        one output frame, in which case ``gaze`` is the single pair for it.
         """
         _check_prosthetic(prosthetic)
         vmin, vmax = _check_range(vmin, vmax)
-        pframes, out_time, out_unit = self._prosthetic_frames(prosthetic)
+        pframes, out_time, out_unit = self._prosthetic_frames(prosthetic,
+                                                              frame=frame)
         n_out = pframes.shape[-1]
         points = _gaze_points(gaze, n_out)
         if len(points) == 1:
@@ -931,24 +966,29 @@ class Scene(PrettyPrint):
         rgb = np.repeat(scaled[:, :, np.newaxis, :], 3, axis=2)
         return np.asarray(rgb, dtype=np.float32), out_time, out_unit
 
-    def _display_on(self, xs, ys, percept=None, vmax=None, vmin=0, gaze=None):
+    def _display_on(self, xs, ys, percept=None, vmax=None, vmin=0, gaze=None,
+                    frame=None):
         """Display-ready RGB on a scene-coordinate raster, and its clock
 
         Residual native vision, or that with a prosthetic percept composed
         into the loss. The aperture is left to whatever draws the result.
-        Returns ``(frames, time, time_unit)``.
+        Returns ``(frames, time, time_unit)``. ``frame`` restricts the work to
+        that one output frame, in which case ``gaze`` is the single pair for
+        it.
         """
         if percept is None:
             if vmax is not None or vmin != 0:
                 raise ValueError("'vmin' and 'vmax' map percept brightness "
                                  "onto a display, and there is no percept "
                                  "here. Pass 'percept'.")
-            return (self._native_on(xs, ys, gaze=gaze), self.time,
-                    self.time_unit)
+            # Without a percept the output frames are the source's own:
+            return (self._native_on(xs, ys, gaze=gaze, frame=frame),
+                    _take_time(self.time, frame), self.time_unit)
         if self.scotoma is None:
             return self._prosthetic_on(xs, ys, percept, vmax, vmin=vmin,
-                                       gaze=gaze)
-        return self._composed_on(xs, ys, percept, vmax, vmin=vmin, gaze=gaze)
+                                       gaze=gaze, frame=frame)
+        return self._composed_on(xs, ys, percept, vmax, vmin=vmin, gaze=gaze,
+                                 frame=frame)
 
     def _n_display_frames(self, percept):
         """How many frames a drawn or rendered result has
@@ -960,18 +1000,29 @@ class Scene(PrettyPrint):
             return self.n_frames
         return percept.data.shape[-1]
 
-    def _prosthetic_frames(self, prosthetic):
-        """Line a percept up with the output frames, and say when they happen"""
+    def _prosthetic_frames(self, prosthetic, frame=None):
+        """Line a percept up with the output frames, and say when they happen
+
+        ``frame`` narrows the result to that one output frame and aligns it
+        alone; the timing checks are made against the whole video either way.
+        """
         if self.time is None:
-            return prosthetic.data, prosthetic.time, prosthetic.time_unit
+            # A still scene has no clock of its own, so the percept's frames
+            # are the output frames:
+            return (_take_frame(prosthetic.data, frame),
+                    _take_time(prosthetic.time, frame), prosthetic.time_unit)
         n_out = self.n_frames
         n_pros = prosthetic.data.shape[-1]
+        out_time = _take_time(self.time, frame)
         if n_pros == 1 and prosthetic.time is None:
-            return (np.repeat(prosthetic.data, n_out, axis=-1), self.time,
-                    self.time_unit)
+            # An untimed still percept stands behind every frame:
+            return (np.repeat(prosthetic.data, 1 if frame is not None
+                              else n_out, axis=-1), out_time, self.time_unit)
         if n_pros == n_out:
-            return prosthetic.data, prosthetic.time, prosthetic.time_unit
+            return (_take_frame(prosthetic.data, frame),
+                    _take_time(prosthetic.time, frame), prosthetic.time_unit)
         unit = prosthetic.time_unit
+        # Checked against the whole video, not just the frame being drawn:
         asked = np.asarray(self.source.times(unit), dtype=float)
         lo, hi = float(prosthetic.time[0]), float(prosthetic.time[-1])
         slack = 1e-9 * max(abs(lo), abs(hi), 1.0)
@@ -983,9 +1034,16 @@ class Scene(PrettyPrint):
                 f"frame there would show a phosphene that was never "
                 f"simulated. Predict the percept over the whole video, or "
                 f"trim the video to the percept.")
-        frames = prosthetic[..., Quantity(np.asarray(self.time),
-                                          self.time_unit)]
-        return frames, self.time, self.time_unit
+        asked_time = np.asarray(out_time, dtype=float)
+        if frame is None:
+            frames = prosthetic[..., Quantity(asked_time, self.time_unit)]
+        else:
+            # A scalar time index drops the frame axis, which is what a
+            # one-element array index is read as too; put the axis back:
+            frames = prosthetic[..., Quantity(float(asked_time[0]),
+                                              self.time_unit)]
+            frames = frames[..., np.newaxis]
+        return frames, out_time, self.time_unit
 
     def _grid(self):
         """A Grid2D on the scene's pixel centers, in scene coordinates"""
@@ -998,7 +1056,8 @@ class Scene(PrettyPrint):
                              "raster; pass one or the other.")
         if shape is not None:
             shape = np.asarray(shape)
-            if shape.shape != (2,) or shape.dtype.kind not in 'iu' or                     shape.min() < 1:
+            bad = shape.shape != (2,) or shape.dtype.kind not in 'iu'
+            if bad or shape.min() < 1:
                 raise ValueError(f"'shape' must be a (rows, cols) pair of "
                                  f"positive integers, not {np.ravel(shape)}.")
             return (int(shape[0]), int(shape[1]))
@@ -1009,7 +1068,8 @@ class Scene(PrettyPrint):
         step = np.asarray(as_value(step, dva, 'step'), dtype=float)
         if step.ndim == 0:
             step = np.repeat(step, 2)
-        if step.shape != (2,) or not np.all(np.isfinite(step)) or                 step.min() <= 0:
+        bad = step.shape != (2,) or not np.all(np.isfinite(step))
+        if bad or step.min() <= 0:
             raise ValueError(f"'step' is an angular sampling in degrees and "
                              f"must be a positive number or a (dx, dy) pair, "
                              f"not {np.ravel(step)}.")
@@ -1144,16 +1204,16 @@ class Scene(PrettyPrint):
             raise ValueError(f"'frame' must be in 0..{n_out - 1}, not "
                              f"{frame}.")
         points = _gaze_points(gaze, n_out)
+        # One frame is drawn, so one gaze and one frame of each layer is all
+        # the work there is; the others are never evaluated.
         gaze_xy = points[0] if len(points) == 1 else points[frame]
         xs, ys = self._axes
-        # The source layer has its own frame count; one drawn frame of it
-        # needs only the one gaze:
-        src_frame = 0 if self.n_frames == 1 else frame
+        src_frame = self._source_frame(frame)
         patch = None
         if percept is None:
             # `_display_on` rejects a display range with nothing to map:
             wide = self._display_on(xs, ys, vmax=vmax, vmin=vmin,
-                                    gaze=gaze_xy)[0][..., src_frame]
+                                    gaze=gaze_xy, frame=frame)[0][..., 0]
         else:
             pxs, pys = _percept_axes(percept)
             # Eye-centered percept coordinates, moved into the scene; `pys`
@@ -1161,13 +1221,15 @@ class Scene(PrettyPrint):
             pxs = pxs + gaze_xy[0]
             pys = pys[::-1] + gaze_xy[1]
             patch = self._display_on(pxs, pys, percept=percept, vmax=vmax,
-                                     vmin=vmin, gaze=gaze)[0][..., frame]
+                                     vmin=vmin, gaze=gaze_xy,
+                                     frame=frame)[0][..., 0]
             if self.scotoma is None:
                 # Nothing is lost, so there is no residual vision to draw the
                 # percept into; only the field's extent is left to show.
                 wide = np.zeros((ys.size, xs.size, 3), dtype=np.float32)
             else:
-                wide = self._native_on(xs, ys, gaze=gaze_xy)[..., src_frame]
+                wide = self._native_on(xs, ys, gaze=gaze_xy,
+                                       frame=src_frame)[..., 0]
         still = Percept(wide[..., np.newaxis], space=self._grid())
         ax = still.plot(ax=ax, **kwargs)
         artists = [ax.images[-1]]

--- a/pulse2percept/vision/tests/test_binocular.py
+++ b/pulse2percept/vision/tests/test_binocular.py
@@ -32,6 +32,15 @@ def spot_percept(scene, x_dva=0.0, y_dva=0.0, brightness=10.0):
     return Percept(data, space=scene._grid())
 
 
+def clipped_away(ax, point_dva):
+    """Whether the drawn image's support leaves out a visual-field location"""
+    clip = ax.images[-1].get_clip_path()
+    if clip is None:
+        return False
+    return not clip.get_fully_transformed_path().contains_point(
+        ax.transData.transform(point_dva))
+
+
 def test_the_two_eyes_are_stored_as_given_and_not_swapped():
     left, right = flat_scene(0.2), flat_scene(0.8)
     binocular = BinocularScene(left=left, right=right)
@@ -137,13 +146,21 @@ def test_two_percepts_stay_two_percepts():
 
 
 def test_each_eye_keeps_its_own_aperture():
+    """Support is geometry, so each panel is clipped to its own shape"""
     left = flat_scene(0.6, aperture='ellipse')
     right = flat_scene(0.6)
     ax_left, ax_right = BinocularScene(left=left, right=right).plot()
-    # The corner is inside the rectangle but outside the ellipse:
-    npt.assert_almost_equal(ax_left.images[-1].get_array()[0, 0], 0.0)
-    npt.assert_almost_equal(ax_right.images[-1].get_array()[0, 0],
-                            [0.6] * 3, decimal=6)
+    # The corner is inside the rectangle but outside the ellipse, so it is
+    # clipped away rather than written black:
+    npt.assert_equal([clipped_away(ax, (-HALF, HALF))
+                      for ax in (ax_left, ax_right)], [True, False])
+    for ax in (ax_left, ax_right):
+        npt.assert_almost_equal(ax.images[-1].get_array()[0, 0], [0.6] * 3,
+                                decimal=6)
+    # ... and rendering the same two eyes does black it out:
+    npt.assert_almost_equal(left.render().data[0, 0, :, 0], 0.0)
+    npt.assert_almost_equal(right.render().data[0, 0, :, 0], [0.6] * 3,
+                            decimal=6)
     plt.close('all')
 
 

--- a/pulse2percept/vision/tests/test_scene.py
+++ b/pulse2percept/vision/tests/test_scene.py
@@ -12,9 +12,11 @@ import matplotlib.pyplot as plt
 
 from pulse2percept.percepts import Percept
 from pulse2percept.stimuli import ImageStimulus, VideoStimulus, samples
+from pulse2percept.topography import Grid2D
 from pulse2percept.units import dva, ms, s
 from pulse2percept.vision import Scene, Scotoma
-from pulse2percept.vision.scene import _ring_radii
+from pulse2percept.vision.scene import (_raster_axes, _raster_step,
+                                        _ring_radii)
 
 SCENE_PX = 41
 HALF = (SCENE_PX - 1) // 2
@@ -42,6 +44,16 @@ def rgba_source():
 def ramp_at(x_dva):
     """What `ramp_scene` shows at a scene x"""
     return (x_dva + HALF) / (2 * HALF)
+
+
+def rendered_loss(scene, gaze=(0, 0)):
+    """The drawn loss map, on the scene's own raster"""
+    return scene._rendered_loss_on(*scene._axes, gaze)
+
+
+def rendered(scene, **kwargs):
+    """`Scene.render` on the source raster, as a bare RGB array"""
+    return scene.render(**kwargs).data
 
 
 def seen_at(scene, x_dva, y_dva=0.0):
@@ -374,7 +386,7 @@ def test_inpainting_a_constant_surround_gives_back_the_constant():
 def test_the_inpainted_fill_knows_nothing_of_what_it_covers():
     """Only the visible surround may reach the filled region"""
     scotoma = Scotoma.circle(6)
-    lost = ramp_scene(scotoma=scotoma)._loss_at((0, 0)) > 0
+    lost = rendered_loss(ramp_scene(scotoma=scotoma)) > 0
     base = np.tile(np.linspace(0, 1, SCENE_PX), (SCENE_PX, 1))
     rng = np.random.default_rng(0)
     sources = [np.where(lost, hidden, base)
@@ -407,13 +419,15 @@ def test_an_inpainted_scene_refuses_to_compose_a_prosthetic_percept():
     scene = Scene(ImageStimulus(rgb), fov=(31, 31), scotoma=Scotoma.circle(4),
                   scotoma_fill='inpaint')
     dark = Percept(np.zeros((31, 31, 1)), space=scene._grid())
-    with pytest.raises(ValueError):
-        scene._compose(dark, vmax=1)
+    for draw in (scene.render, lambda **kw: scene.plot(**kw)):
+        with pytest.raises(ValueError):
+            draw(percept=dark, vmax=1)
+    plt.close('all')
     # The same scene with a numeric fill composes, and native vision is
     # unaffected either way:
     numeric = Scene(ImageStimulus(rgb), fov=(31, 31),
                     scotoma=Scotoma.circle(4), scotoma_fill=0.0)
-    npt.assert_equal(numeric._compose(dark, vmax=1).data.shape,
+    npt.assert_equal(rendered(numeric, percept=dark, vmax=1).shape,
                      (31, 31, 3, 1))
     npt.assert_equal(np.all(np.isfinite(scene._native_rgb())), True)
 
@@ -615,17 +629,19 @@ def test_scotoma_and_fill_are_validated():
 
 def test_no_blend_leaves_the_boundary_as_sharp_as_the_scotoma_is():
     source = ImageStimulus(np.zeros((8, 8)))
-    npt.assert_equal(Scene(source, fov=8).scotoma_blend, 2.0)
+    npt.assert_equal(Scene(source, fov=8).scotoma_blend, 0.5)
+    npt.assert_equal(Scene(source, fov=8, scotoma_blend=1.5 * dva)
+                     .scotoma_blend, 1.5)
     sharp = ramp_scene(scotoma=Scotoma.circle(6), scotoma_fill=0.3,
                        scotoma_blend=0)
-    npt.assert_array_equal(np.unique(sharp._rendered_loss_at((0, 0))),
+    npt.assert_array_equal(np.unique(rendered_loss(sharp)),
                            [0.0, 1.0])
 
 
 def test_blending_softens_the_boundary_and_only_the_boundary():
-    """One degree per pixel here, so a sigma of 2 px is 2 dva"""
+    """One degree per pixel here, so a sigma of 2 dva is 2 px"""
     scene = ramp_scene(scotoma=Scotoma.circle(6), scotoma_blend=2)
-    loss = scene._rendered_loss_at((0, 0))
+    loss = rendered_loss(scene)
     # 3 sigmas: inside the lost field, 4 sigmas: outside it
     npt.assert_equal(loss[HALF, HALF] > 0.98, True)
     npt.assert_almost_equal(loss[HALF, HALF + 15], 0.0, decimal=12)
@@ -663,7 +679,7 @@ def test_a_softened_boundary_shows_in_the_composed_percept():
     scene = ramp_scene(scotoma=Scotoma.circle(6), scotoma_fill=0.0,
                        scotoma_blend=2)
     bright = Percept(np.ones((SCENE_PX, SCENE_PX, 1)), space=scene._grid())
-    seen = scene._compose(bright, vmax=1).data[..., 0]
+    seen = rendered(scene, percept=bright, vmax=1)[..., 0]
     npt.assert_equal(seen[HALF, HALF, 0] > 0.98, True)
     npt.assert_almost_equal(seen[HALF, HALF + 15, 0], ramp_at(15), decimal=6)
     npt.assert_equal(ramp_at(6) < seen[HALF, HALF + 6, 0] < 1.0, True)
@@ -680,6 +696,197 @@ def test_blending_is_rendering_only():
     npt.assert_array_equal(soft.scotoma(x, y), sharp.scotoma(x, y))
     npt.assert_equal(np.allclose(soft._native_rgb(), sharp._native_rgb()),
                      False)
+
+
+def test_the_blended_boundary_is_angular_not_pixel_sized():
+    """The same softness in degrees on two very different rasters"""
+    scene = ramp_scene(scotoma=Scotoma.circle(6), scotoma_blend=2)
+    xs = np.linspace(-12, 12, 25)
+    profiles = []
+    for shape in ((SCENE_PX, SCENE_PX), (5 * SCENE_PX, 5 * SCENE_PX)):
+        axes = _raster_axes(scene.fov, shape)
+        loss = scene._rendered_loss_on(*axes, (0, 0))
+        # The horizontal meridian, where the circle's edge is at x = +/-6:
+        row = int(np.argmin(np.abs(axes[1])))
+        profiles.append(np.interp(xs, axes[0], loss[row]))
+    npt.assert_allclose(*profiles, atol=0.02)
+    # The premise: the transition is gradual over several degrees, so a
+    # pixel-valued sigma would have blurred five times as far on the fine one.
+    npt.assert_equal(0.05 < profiles[0][xs.tolist().index(6.0)] < 0.95, True)
+
+
+def test_anisotropic_pixels_get_their_own_blur_sigma():
+    """0.5 x 0.2 degree pixels: 2 degrees is 4 columns but 10 rows
+
+    One sigma for both axes would blur 2.5 times as far across as down, which
+    is what makes the two directions comparable here at all.
+    """
+    scene = Scene(ImageStimulus(np.ones((5 * SCENE_PX, 2 * SCENE_PX))),
+                  fov=(SCENE_PX, SCENE_PX), scotoma=Scotoma.circle(6),
+                  scotoma_blend=2)
+    xs, ys = scene._axes
+    npt.assert_almost_equal(_raster_step(xs, ys), (0.5, 0.2))
+    loss = scene._rendered_loss_on(xs, ys, (0, 0))
+    out = np.linspace(0, 12, 61)
+    row, col = int(np.argmin(np.abs(ys))), int(np.argmin(np.abs(xs)))
+    # A circular scotoma softened by an angular sigma reads the same going
+    # right as going up:
+    along_x = np.interp(out, xs[col:], loss[row, col:])
+    along_y = np.interp(out, ys[row::-1], loss[row::-1, col])
+    npt.assert_allclose(along_x, along_y, atol=0.03)
+
+
+def test_render_defaults_to_the_source_raster():
+    """Asking to render resamples nothing unless a grid is named"""
+    scene = ramp_scene(scotoma=Scotoma.circle(6), scotoma_fill=0.3)
+    npt.assert_equal(scene.render().shape, (SCENE_PX, SCENE_PX, 3, 1))
+    npt.assert_array_equal(scene.render().data, scene._native_rgb())
+
+
+def test_render_takes_a_shape_or_a_step_but_not_both():
+    scene = ramp_scene()
+    npt.assert_equal(scene.render(shape=(7, 13)).shape, (7, 13, 3, 1))
+    with pytest.raises(ValueError):
+        scene.render(step=1, shape=(7, 13))
+    for shape in ((0, 4), (4,), (4.5, 4), (4, 4, 4)):
+        with pytest.raises(ValueError):
+            scene.render(shape=shape)
+    for step in (0, -1, np.nan, (1, 0), (1, 2, 3)):
+        with pytest.raises(ValueError):
+            scene.render(step=step)
+
+
+def test_render_samples_no_coarser_than_the_step_asked_for():
+    """`fov` still bounds the outer pixel edges, so the FOV is preserved"""
+    scene = ramp_scene()
+    for step in (0.5, 0.3, 4.0, (1.0, 0.25)):
+        drawn = scene.render(step=step)
+        dx, dy = np.asarray(step, dtype=float) * np.ones(2)
+        n_rows, n_cols = drawn.shape[:2]
+        npt.assert_equal(SCENE_PX / n_cols <= dx + 1e-12, True)
+        npt.assert_equal(SCENE_PX / n_rows <= dy + 1e-12, True)
+        # One pixel coarser would have been too coarse:
+        npt.assert_equal(SCENE_PX / max(n_cols - 1, 1) > dx, True)
+        # The outer edges are the FOV, not the outermost centers:
+        npt.assert_almost_equal(
+            (drawn.xdva[-1] - drawn.xdva[0]) * n_cols / max(n_cols - 1, 1),
+            SCENE_PX, decimal=6)
+    # A step that divides the field exactly does not buy a spare pixel:
+    npt.assert_equal(scene.render(step=SCENE_PX / 41).shape[:2], (41, 41))
+    # ... and a unitful step says the same thing:
+    npt.assert_equal(scene.render(step=0.5 * dva).shape,
+                     scene.render(step=0.5).shape)
+
+
+def test_render_leaves_the_source_alone():
+    scene = ramp_scene(scotoma=Scotoma.circle(6), scotoma_fill=0.0,
+                       aperture='ellipse')
+    before = scene.source.data.copy()
+    bright = Percept(np.ones((SCENE_PX, SCENE_PX, 1)), space=scene._grid())
+    scene.render(percept=bright, vmax=1, step=0.5)
+    scene.render(step=0.5)
+    npt.assert_array_equal(scene.source.data, before)
+    npt.assert_equal(np.any(before > 0), True)
+
+
+def test_render_composes_by_the_documented_equation():
+    """(1 - loss) * native + loss * max(fill, phosphene), analytically"""
+    native, fill, half = 0.8, 0.2, 0.5
+    scene = Scene(ImageStimulus(np.full((9, 9), native)), fov=(9, 9),
+                  scotoma=Scotoma(lambda x, y: np.full(np.shape(x), half)),
+                  scotoma_fill=fill, scotoma_blend=0)
+    for brightness, vmax in ((1.0, 4.0), (3.0, 4.0)):
+        percept = Percept(np.full((9, 9, 1), brightness),
+                          space=scene._grid())
+        phosphene = brightness / vmax
+        npt.assert_almost_equal(
+            scene.render(percept=percept, vmax=vmax).data[4, 4, :, 0],
+            (1 - half) * native + half * max(fill, phosphene), decimal=6)
+    # Renders at a different resolution agree, the composition being pointwise:
+    percept = Percept(np.full((9, 9, 1), 3.0), space=scene._grid())
+    npt.assert_almost_equal(
+        scene.render(percept=percept, vmax=4, shape=(45, 45)).data[22, 22, 0,
+                                                                  0],
+        scene.render(percept=percept, vmax=4).data[4, 4, 0, 0], decimal=6)
+
+
+def test_the_aperture_is_support_and_not_scene_data():
+    """Black is valid data; outside the ellipse is undefined support"""
+    # A black square in the middle of a white field, so a blacked-out pixel
+    # and a black source pixel cannot be confused:
+    data = np.ones((21, 21))
+    data[9:12, 9:12] = 0.0
+    scene = Scene(ImageStimulus(data), fov=(21, 21), aperture='ellipse')
+    before = scene.source.data.copy()
+    drawn = scene.render().data[..., 0]
+    npt.assert_array_equal(scene.source.data, before)
+    # The black square inside the ellipse is ordinary black scene content:
+    npt.assert_almost_equal(drawn[10, 10], 0.0)
+    npt.assert_almost_equal(drawn[10, 14], [1.0] * 3, decimal=6)
+    # The corners are outside the support and go black as a display result:
+    npt.assert_almost_equal(drawn[0, 0], 0.0)
+    # Plotting instead keeps the array and clips the artist, and the black
+    # square is still black in it:
+    ax = scene.plot()
+    npt.assert_almost_equal(ax.images[-1].get_array()[0, 0], [1.0] * 3,
+                            decimal=6)
+    npt.assert_almost_equal(ax.images[-1].get_array()[10, 10], 0.0)
+    npt.assert_equal(ax.images[-1].get_clip_path() is not None, True)
+    plt.close('all')
+    # ... and the device samples the source either way, aperture or not:
+    x, y = np.array([-10.0, 0.0, 10.0]), np.array([10.0, 0.0, -10.0])
+    plain = Scene(ImageStimulus(data), fov=(21, 21))
+    npt.assert_array_equal(scene._device_input(x, y),
+                           plain._device_input(x, y))
+
+
+def test_plotting_keeps_each_layer_at_its_own_resolution():
+    """A 60 x 80 source and a 301 x 301 percept stay two artists"""
+    rng = np.random.default_rng(0)
+    scene = Scene(ImageStimulus(rng.random((60, 80))), fov=45 * dva,
+                  scotoma=Scotoma.circle(8), scotoma_fill=0.0,
+                  scotoma_blend=0.5)
+    # A checkerboard at the percept's own step, dimmer in its top half: both
+    # would be gone if the patch were first resampled onto the source raster.
+    data = np.zeros((301, 301, 1))
+    data[::2, ::2, 0] = 8.0
+    data[:150] *= 0.25
+    percept = Percept(data, space=Grid2D((-3, 3), (-3, 3), step=6 / 300))
+    ax = scene.plot(percept=percept, vmax=8)
+    wide, patch = (image.get_array() for image in ax.images)
+    npt.assert_equal(wide.shape, (60, 80, 3))
+    npt.assert_equal(patch.shape, (301, 301, 3))
+    # The patch covers the percept's own extent, not the whole field:
+    npt.assert_almost_equal(ax.images[1].get_extent(),
+                            (-3.01, 3.01, -3.01, 3.01), decimal=6)
+    npt.assert_almost_equal(ax.images[0].get_extent(),
+                            (-22.5, 22.5, -16.875, 16.875), decimal=6)
+    # Pixel-for-pixel checkerboard, and the dim half is at the top:
+    npt.assert_equal(patch[150, ::2, 0].min() > patch[150, 1::2, 0].max(),
+                     True)
+    npt.assert_equal(patch[0, 0, 0] < patch[-1, 0, 0], True)
+    # Nothing was resampled onto a common raster: the whole field at the
+    # percept's step would be far bigger than the two artists together.
+    common = scene._render_shape(6 / 300, None)
+    npt.assert_equal(np.prod(common) > 20 * (60 * 80 + 301 ** 2), True)
+    plt.close('all')
+
+
+def test_a_dark_percept_patch_is_ordinary_residual_vision():
+    """No artificial border where the local patch ends"""
+    scene = Scene(ImageStimulus(np.full((41, 41), 0.7)), fov=(41, 41),
+                  scotoma=Scotoma.circle(14), scotoma_fill=0.25,
+                  scotoma_blend=2)
+    dark = Percept(np.zeros((21, 21, 1)),
+                   space=Grid2D((-10, 10), (-10, 10), step=1))
+    ax = scene.plot(percept=dark, vmax=5)
+    wide, patch = (image.get_array() for image in ax.images)
+    # The patch reduces to the residual view the wide layer shows, so the two
+    # agree where they overlap:
+    npt.assert_almost_equal(patch[0, :], wide[HALF - 10, HALF - 10:HALF + 11],
+                            decimal=6)
+    npt.assert_almost_equal(patch[10, 10], wide[HALF, HALF], decimal=6)
+    plt.close('all')
 
 
 def test_plot_draws_native_vision_where_the_eye_is_pointing():
@@ -768,11 +975,12 @@ def test_a_rectangular_aperture_is_the_default_and_fills_the_frame():
 
 
 def test_a_square_fov_ellipse_keeps_the_center_and_blacks_out_the_corners():
+    """Blacking out is `render`'s doing: a display result, not scene data"""
     scene = ellipse_scene()
     npt.assert_equal(scene.aperture, 'ellipse')
     npt.assert_equal("aperture='ellipse'" in repr(scene), True)
-    rect = ramp_scene()._native_rgb()[..., 0]
-    circ = scene._native_rgb()[..., 0]
+    rect = rendered(ramp_scene())[..., 0]
+    circ = rendered(scene)[..., 0]
     # Inside the disc nothing changed; the four corners went black:
     npt.assert_array_equal(circ[HALF, :, 0], rect[HALF, :, 0])
     npt.assert_array_equal(circ[:, HALF, 0], rect[:, HALF, 0])
@@ -782,6 +990,8 @@ def test_a_square_fov_ellipse_keeps_the_center_and_blacks_out_the_corners():
     # aperture blacked them out rather than the source being dark there:
     npt.assert_almost_equal(rect[0, -1, 0], ramp_at(HALF), decimal=6)
     npt.assert_almost_equal(rect[-1, -1, 0], ramp_at(HALF), decimal=6)
+    # ... and the underlying residual view is untouched by the aperture:
+    npt.assert_array_equal(scene._native_rgb(), ramp_scene()._native_rgb())
 
 
 @pytest.mark.parametrize('aperture', ['circle', 'circular', 'ELLIPSE', '',
@@ -795,7 +1005,7 @@ def test_an_ellipse_takes_a_semiaxis_from_each_side_of_the_field():
     """A 61 x 41 field is apertured by both dimensions, not by the shorter"""
     data = np.tile(np.linspace(0.2, 1, 61), (41, 1))
     scene = Scene(ImageStimulus(data), fov=(61, 41), aperture='ellipse')
-    lit = scene._native_rgb()[..., 0, 0] > 0
+    lit = rendered(scene)[..., 0, 0] > 0
     x, y = scene._pixel_centers()
     npt.assert_array_equal(lit, (x / 30.5) ** 2 + (y / 20.5) ** 2 <= 1)
     # The aperture reaches much farther sideways than up: 25 dva out along
@@ -814,7 +1024,7 @@ def test_the_aperture_is_eye_centered_and_follows_gaze():
     data = np.tile(np.linspace(0.2, 1, SCENE_PX), (SCENE_PX, 1))
     scene = Scene(ImageStimulus(data), fov=(SCENE_PX, SCENE_PX),
                   aperture='ellipse')
-    lit = scene._native_rgb(gaze=(8, -5) * dva)[..., 0, 0] > 0
+    lit = rendered(scene, gaze=(8, -5) * dva)[..., 0, 0] > 0
     x, y = scene._pixel_centers()
     # scene = eye-centered + gaze, so the disc is centered on the gaze point:
     npt.assert_array_equal(lit, (x - 8) ** 2 + (y + 5) ** 2 <= 20.5 ** 2)
@@ -823,7 +1033,7 @@ def test_the_aperture_is_eye_centered_and_follows_gaze():
 def test_a_transparent_background_does_not_leak_outside_the_aperture():
     """Outside the aperture is black even when the scene's ground is white"""
     scene = Scene(rgba_source(), fov=(8, 8), background=1, aperture='ellipse')
-    native = scene._native_rgb()[..., 0]
+    native = rendered(scene)[..., 0]
     npt.assert_almost_equal(native[0, 0], 0.0)
     # ... while the background still shows through inside it:
     npt.assert_almost_equal(native[0, 4], [1.0, 1.0, 1.0], decimal=6)
@@ -860,12 +1070,19 @@ def test_the_aperture_clips_a_composed_percept_only_when_it_is_drawn():
                      space=ramp_scene()._grid())
     rect = ramp_scene(scotoma=scotoma, scotoma_fill=0.0)
     ellip = ramp_scene(scotoma=scotoma, scotoma_fill=0.0, aperture='ellipse')
-    seen_rect = rect._compose(bright, vmax=1).data[..., 0]
-    seen_ellip = ellip._compose(bright, vmax=1).data[..., 0]
+    seen_rect = rendered(rect, percept=bright, vmax=1)[..., 0]
+    seen_ellip = rendered(ellip, percept=bright, vmax=1)[..., 0]
     inside = np.hypot(*ellip._pixel_centers()) <= 20.5
     npt.assert_array_equal(seen_ellip[inside], seen_rect[inside])
     npt.assert_almost_equal(seen_ellip[0, -1], 0.0)
     npt.assert_almost_equal(seen_rect[0, -1, 0], ramp_at(HALF), decimal=6)
+    # Plotting clips instead: the same elliptical support, applied to the
+    # artist rather than written into its array.
+    ax = ellip.plot(percept=bright, vmax=1)
+    npt.assert_array_equal(ax.images[0].get_array(),
+                           rect._native_rgb()[..., 0])
+    npt.assert_equal(ax.images[0].get_clip_path() is not None, True)
+    plt.close('all')
 
 
 def test_a_percept_can_be_plotted_in_the_context_of_the_whole_field():
@@ -876,13 +1093,17 @@ def test_a_percept_can_be_plotted_in_the_context_of_the_whole_field():
     phosphene = Percept(data, space=space)
     scene = ellipse_scene()
     ax = scene.plot(percept=phosphene, vmax=20)
-    drawn = ax.images[-1].get_array()
+    wide, patch = (image.get_array() for image in ax.images)
+    # Each layer keeps its own resolution:
+    npt.assert_equal(wide.shape, (SCENE_PX, SCENE_PX, 3))
+    npt.assert_equal(patch.shape, (9, 9, 3))
     # The percept lands on the fovea at its own size, not stretched to the FOV
-    npt.assert_almost_equal(drawn[HALF, HALF], [1.0, 1.0, 1.0], decimal=6)
-    npt.assert_almost_equal(drawn[HALF, HALF + 3], 0.0)
+    npt.assert_almost_equal(ax.images[1].get_extent(),
+                            (-4.5, 4.5, -4.5, 4.5), decimal=6)
+    npt.assert_almost_equal(patch[4, 4], [1.0, 1.0, 1.0], decimal=6)
+    npt.assert_almost_equal(patch[4, 7], 0.0)
     # ... and native vision is not underneath it, since nothing is lost here:
-    npt.assert_almost_equal(drawn[HALF, HALF + 15], 0.0)
-    npt.assert_almost_equal(drawn[0, 0], 0.0)
+    npt.assert_almost_equal(wide, 0.0)
     plt.close('all')
     # Brightness is in arbitrary units, so a display range is required:
     with pytest.raises(ValueError):
@@ -896,12 +1117,16 @@ def test_a_percept_can_be_plotted_in_the_context_of_the_whole_field():
 
 
 def test_plotting_a_percept_over_a_scotoma_is_the_composed_view():
+    """On a shared raster the drawn layers are the dense composition"""
     scene = ramp_scene(scotoma=Scotoma.circle(6), scotoma_fill=0.0)
     bright = Percept(np.ones((SCENE_PX, SCENE_PX, 1)), space=scene._grid())
     ax = scene.plot(percept=bright, vmax=1)
-    npt.assert_almost_equal(ax.images[-1].get_array(),
-                            scene._compose(bright, vmax=1).data[..., 0],
+    npt.assert_almost_equal(ax.images[1].get_array(),
+                            rendered(scene, percept=bright, vmax=1)[..., 0],
                             decimal=6)
+    # The wide layer underneath it is residual native vision:
+    npt.assert_almost_equal(ax.images[0].get_array(),
+                            scene._native_rgb()[..., 0], decimal=6)
     plt.close('all')
 
 
@@ -972,7 +1197,7 @@ def test_composing_a_grayscale_video_keeps_the_canonical_rgb_layout():
     """A gray source is composed as RGB without ever differing by channel"""
     n = 3
     scene = gray_video_scene(n, scotoma=Scotoma.circle(6), scotoma_fill=0.0)
-    seen = scene._compose(ramped_percept(scene, n), vmax=1).data
+    seen = rendered(scene, percept=ramped_percept(scene, n), vmax=1)
     npt.assert_equal(seen.shape, (SCENE_PX, SCENE_PX, 3, n))
     npt.assert_equal(np.asarray(seen).dtype, np.float32)
     npt.assert_array_equal(seen[:, :, 0, :], seen[:, :, 1, :])
@@ -988,7 +1213,7 @@ def test_composing_a_grayscale_video_keeps_the_canonical_rgb_layout():
 def test_composing_an_rgb_video_keeps_every_channel_where_it_was():
     n = 3
     scene = rgb_video_scene(n, scotoma=Scotoma.circle(6), scotoma_fill=0.2)
-    seen = scene._compose(ramped_percept(scene, n), vmax=1).data
+    seen = rendered(scene, percept=ramped_percept(scene, n), vmax=1)
     npt.assert_equal(seen.shape, (SCENE_PX, SCENE_PX, 3, n))
     source = scene.source.data.reshape(scene.source.vid_shape)
     x, y = scene._pixel_centers()
@@ -1010,15 +1235,16 @@ def test_composition_follows_a_gaze_that_moves_between_frames(blend):
                              scotoma_blend=blend)
     gaze = np.array([[-7.0, 2.0], [0.0, 0.0], [8.0, -3.0]])
     percept = ramped_percept(scene, n)
-    moving = scene._compose(percept, vmax=1, gaze=gaze).data
+    moving = rendered(scene, percept=percept, vmax=1, gaze=gaze)
     for f in range(n):
         still = frame_scene(scene, f)
-        alone = still._compose(
-            Percept(percept.data[..., f:f + 1], space=still._grid()),
-            vmax=1, gaze=gaze[f]).data
+        alone = rendered(
+            still, percept=Percept(percept.data[..., f:f + 1],
+                                   space=still._grid()),
+            vmax=1, gaze=gaze[f])
         npt.assert_almost_equal(moving[..., f], alone[..., 0], decimal=6)
     # Reusing the pixel raster must not freeze the geometry:
-    static = scene._compose(percept, vmax=1, gaze=gaze[1]).data
+    static = rendered(scene, percept=percept, vmax=1, gaze=gaze[1])
     npt.assert_equal(np.allclose(moving, static), False)
 
 
@@ -1027,13 +1253,14 @@ def test_a_static_gaze_composes_every_frame_of_a_video():
     scene = gray_video_scene(n, scotoma=Scotoma.circle(5), scotoma_fill=0.1,
                              scotoma_blend=2)
     percept = ramped_percept(scene, n)
-    seen = scene._compose(percept, vmax=1, gaze=(4.0, -1.0)).data
+    seen = rendered(scene, percept=percept, vmax=1, gaze=(4.0, -1.0))
     npt.assert_equal(seen.shape, (SCENE_PX, SCENE_PX, 3, n))
     for f in range(n):
         still = frame_scene(scene, f)
-        alone = still._compose(
-            Percept(percept.data[..., f:f + 1], space=still._grid()),
-            vmax=1, gaze=(4.0, -1.0)).data
+        alone = rendered(
+            still, percept=Percept(percept.data[..., f:f + 1],
+                                   space=still._grid()),
+            vmax=1, gaze=(4.0, -1.0))
         npt.assert_almost_equal(seen[..., f], alone[..., 0], decimal=6)
     # The frames are not copies of one another:
     npt.assert_equal(np.allclose(seen[..., 0], seen[..., -1]), False)
@@ -1044,16 +1271,16 @@ def test_an_elliptical_aperture_survives_composing_a_video():
     scene = gray_video_scene(n, scotoma=Scotoma.circle(6), scotoma_fill=0.0,
                              aperture='ellipse')
     percept = ramped_percept(scene, n)
-    seen = scene._compose(percept, vmax=1).data
+    seen = rendered(scene, percept=percept, vmax=1)
     npt.assert_equal(seen.shape, (SCENE_PX, SCENE_PX, 3, n))
     npt.assert_equal(np.asarray(seen).dtype, np.float32)
     npt.assert_array_equal(seen[0, 0], 0)
     npt.assert_array_equal(seen[-1, -1], 0)
     # Inside the disc the aperture changes nothing:
     rect = gray_video_scene(n, scotoma=Scotoma.circle(6), scotoma_fill=0.0)
-    inside = ~scene._aperture_mask((0, 0))
+    inside = ~scene._aperture_mask(*scene._axes, (0, 0))
     npt.assert_array_equal(seen[inside],
-                           rect._compose(percept, vmax=1).data[inside])
+                           rendered(rect, percept=percept, vmax=1)[inside])
 
 
 @pytest.mark.parametrize('blend', [0, 2])
@@ -1061,20 +1288,17 @@ def test_the_loss_composition_renders_is_float32(blend):
     """A float64 loss map would upcast the whole float32 blend"""
     scene = ramp_scene(scotoma=Scotoma.circle(6), scotoma_fill=0.0,
                        scotoma_blend=blend)
-    npt.assert_equal(scene._rendered_loss_at((0, 0)).dtype, np.float32)
-    npt.assert_equal(ramp_scene()._rendered_loss_at((0, 0)).dtype, np.float32)
+    npt.assert_equal(rendered_loss(scene).dtype, np.float32)
+    npt.assert_equal(rendered_loss(ramp_scene()).dtype, np.float32)
 
 
-@pytest.mark.parametrize('pad', [0, 9])
-def test_repeated_pixel_center_queries_read_the_same_raster(pad):
+def test_repeated_pixel_center_queries_read_the_same_raster():
     scene = ramp_scene(scotoma=Scotoma.circle(6), scotoma_blend=2)
-    x, y = scene._pixel_centers(pad=pad)
-    npt.assert_equal(x.shape, (SCENE_PX + 2 * pad,) * 2)
-    again = scene._pixel_centers(pad=pad)
+    x, y = scene._pixel_centers()
+    npt.assert_equal(x.shape, (SCENE_PX,) * 2)
+    again = scene._pixel_centers()
     npt.assert_array_equal(again[0], x)
     npt.assert_array_equal(again[1], y)
-    # A padded raster is the unpadded one plus a margin, not a rescaled grid:
-    if pad:
-        x0, y0 = scene._pixel_centers()
-        npt.assert_array_equal(x[pad:-pad, pad:-pad], x0)
-        npt.assert_array_equal(y[pad:-pad, pad:-pad], y0)
+    # The pixel centers are the source raster's own axes:
+    npt.assert_array_equal(x[0], scene._axes[0])
+    npt.assert_array_equal(y[:, 0], scene._axes[1])

--- a/pulse2percept/vision/tests/test_scene.py
+++ b/pulse2percept/vision/tests/test_scene.py
@@ -15,6 +15,7 @@ from pulse2percept.stimuli import ImageStimulus, VideoStimulus, samples
 from pulse2percept.topography import Grid2D
 from pulse2percept.units import dva, ms, s
 from pulse2percept.vision import Scene, Scotoma
+from pulse2percept.vision import scene as scene_module
 from pulse2percept.vision.scene import (_raster_axes, _raster_step,
                                         _ring_radii)
 
@@ -804,10 +805,10 @@ def test_render_composes_by_the_documented_equation():
             (1 - half) * native + half * max(fill, phosphene), decimal=6)
     # Renders at a different resolution agree, the composition being pointwise:
     percept = Percept(np.full((9, 9, 1), 3.0), space=scene._grid())
-    npt.assert_almost_equal(
-        scene.render(percept=percept, vmax=4, shape=(45, 45)).data[22, 22, 0,
-                                                                  0],
-        scene.render(percept=percept, vmax=4).data[4, 4, 0, 0], decimal=6)
+    fine = scene.render(percept=percept, vmax=4, shape=(45, 45))
+    npt.assert_almost_equal(fine.data[22, 22, 0, 0],
+                            scene.render(percept=percept,
+                                         vmax=4).data[4, 4, 0, 0], decimal=6)
 
 
 def test_the_aperture_is_support_and_not_scene_data():
@@ -1281,6 +1282,109 @@ def test_an_elliptical_aperture_survives_composing_a_video():
     inside = ~scene._aperture_mask(*scene._axes, (0, 0))
     npt.assert_array_equal(seen[inside],
                            rendered(rect, percept=percept, vmax=1)[inside])
+
+
+def frames_evaluated(monkeypatch):
+    """Record how many frames each stage of the drawing path evaluates"""
+    counts = {'source': [], 'percept': []}
+    source_on, percept_on = Scene._source_on, scene_module._percept_on
+
+    def counted_source(self, xs, ys, frame=None):
+        out = source_on(self, xs, ys, frame=frame)
+        counts['source'].append(out.shape[-1])
+        return out
+
+    def counted_percept(prosthetic, frames, xs, ys, gaze_xy):
+        counts['percept'].append(frames.shape[-1])
+        return percept_on(prosthetic, frames, xs, ys, gaze_xy)
+
+    monkeypatch.setattr(Scene, '_source_on', counted_source)
+    monkeypatch.setattr(scene_module, '_percept_on', counted_percept)
+    return counts
+
+
+def test_plotting_one_frame_evaluates_only_that_frame(monkeypatch):
+    """Drawing frame k must not compose, sample or align the other frames"""
+    n = 6
+    scene = gray_video_scene(n, scotoma=Scotoma.circle(6), scotoma_fill=0.0,
+                             scotoma_blend=2)
+    percept = ramped_percept(scene, n)
+    counts = frames_evaluated(monkeypatch)
+    ax = scene.plot(percept=percept, vmax=1, frame=4, ax=plt.subplots()[1])
+    # One source frame for the patch, one for the wide layer, one percept
+    # frame, whatever the length of the video:
+    npt.assert_equal(counts['source'], [1, 1])
+    npt.assert_equal(counts['percept'], [1])
+    # ... and it is frame 4, drawn exactly as the dense composition has it:
+    dense = rendered(scene, percept=percept, vmax=1)
+    npt.assert_almost_equal(ax.images[1].get_array(), dense[..., 4],
+                            decimal=6)
+    npt.assert_almost_equal(ax.images[0].get_array(),
+                            scene._native_rgb()[..., 4], decimal=6)
+    plt.close('all')
+
+
+def test_a_still_scene_narrows_to_the_requested_percept_frame(monkeypatch):
+    """One source frame stands behind whichever percept frame is drawn"""
+    n = 5
+    scene = ramp_scene(scotoma=Scotoma.circle(6), scotoma_fill=0.0)
+    percept = ramped_percept(scene, n)
+    counts = frames_evaluated(monkeypatch)
+    ax = scene.plot(percept=percept, vmax=1, frame=3, ax=plt.subplots()[1])
+    npt.assert_equal(counts['percept'], [1])
+    npt.assert_equal(counts['source'], [1, 1])
+    npt.assert_almost_equal(ax.images[1].get_array(),
+                            rendered(scene, percept=percept,
+                                     vmax=1)[..., 3], decimal=6)
+    plt.close('all')
+
+
+def test_plotting_a_video_frame_without_a_percept_reads_one_frame(monkeypatch):
+    n = 6
+    scene = gray_video_scene(n, scotoma=Scotoma.circle(6), scotoma_fill=0.2)
+    counts = frames_evaluated(monkeypatch)
+    ax = scene.plot(frame=2, ax=plt.subplots()[1])
+    npt.assert_equal(counts['source'], [1])
+    npt.assert_almost_equal(ax.images[0].get_array(),
+                            scene._native_rgb()[..., 2], decimal=6)
+    plt.close('all')
+
+
+def test_render_still_rasterizes_the_whole_video(monkeypatch):
+    """Narrowing is `plot`'s business; `render` is the full temporal result"""
+    n = 6
+    scene = gray_video_scene(n, scotoma=Scotoma.circle(6), scotoma_fill=0.0)
+    percept = ramped_percept(scene, n)
+    counts = frames_evaluated(monkeypatch)
+    npt.assert_equal(scene.render(percept=percept, vmax=1).shape[-1], n)
+    npt.assert_equal(counts['source'], [n])
+    npt.assert_equal(counts['percept'], [n])
+
+
+def test_narrowing_aligns_the_percept_at_that_scene_time_alone():
+    """A resampled percept is read at frame k's instant, and at no other"""
+    n = 4
+    ramp = np.tile(np.linspace(0, 1, SCENE_PX), (SCENE_PX, 1))
+    frames = np.stack([ramp * w for w in np.linspace(0.4, 1.0, n)], axis=-1)
+    scene = Scene(VideoStimulus(frames, time=[0.0, 10.0, 20.0, 30.0]),
+                  fov=(SCENE_PX, SCENE_PX))
+    # A clock of its own, so the percept is resampled rather than taken:
+    percept = Percept(np.stack([ramp * b for b in (0.0, 3.0)], axis=-1),
+                      space=scene._grid(), time=[-5.0, 35.0])
+    full, full_time, unit = scene._prosthetic_frames(percept)
+    npt.assert_equal(full.shape[-1], n)
+    for f in range(n):
+        one, one_time, one_unit = scene._prosthetic_frames(percept, frame=f)
+        npt.assert_equal(one.shape[-1], 1)
+        npt.assert_array_equal(one[..., 0], full[..., f])
+        npt.assert_almost_equal(one_time, np.asarray(full_time)[f:f + 1])
+        npt.assert_equal(one_unit, unit)
+    # A percept that does not cover the video is refused whichever frame is
+    # asked for, since the check is made against the whole video:
+    short = Percept(percept.data, space=scene._grid(), time=[0.0, 20.0])
+    for frame in (None, 0):
+        with pytest.raises(ValueError):
+            scene._prosthetic_frames(short, frame=frame)
 
 
 @pytest.mark.parametrize('blend', [0, 2])


### PR DESCRIPTION
This PR separates the three spatial grids involved in scene-based prosthetic simulation:

* the source image/video raster,
* the model grid used to predict the prosthetic percept,
* the optional dense raster used for final RGB rendering.

The motivating case is wide-field simulation with a small, finely sampled prosthetic region such as PRIMA: fine phosphene rendering no longer requires resampling the entire visual field at the model step.

`Model.predict_percept(Scene)` now returns the model-grid brightness percept without composing it into the scene. `Scene.plot(...)` draws the wide-field source and local prosthetic percept at their own resolutions, avoiding unnecessary full-field upsampling. The new `Scene.render(...)` explicitly rasterizes everything onto one RGB grid when a dense image or video is actually needed.

The refactor also treats the aperture as display support (rather than "black" scene data), makes `scotoma_blend` resolution-independent, and `Scene.plot(frame=...)` actually evaluates only the requested frame.

