### PR TITLE
[ENH] Add blank visual-field scenes

### DIFF
--- a/doc/topics/models.rst
+++ b/doc/topics/models.rst
@@ -479,6 +479,18 @@ The raster defaults to the source's own, which resamples nothing. ``step``
 ``shape`` chooses another; the two are mutually exclusive. A fine step over a
 wide field is expensive by construction.
 
+:py:meth:`~pulse2percept.vision.Scene.blank` provides a black visual-field
+canvas when no image is needed:
+
+.. code-block:: python
+
+    scene = p2p.vision.Scene.blank(fov=45 * dva)
+
+Its backing raster (512 x 512 by default) is only the default render raster;
+prediction still happens on the model grid. Black is scene content, not
+blindness; use a :py:class:`~pulse2percept.vision.Scotoma` for vision that is
+lost.
+
 .. versionchanged:: 0.11.0
     Scene prediction returns the model percept rather than an RGB
     composition. ``vmin`` and ``vmax`` moved to ``Scene.plot`` and the new

--- a/doc/topics/models.rst
+++ b/doc/topics/models.rst
@@ -486,10 +486,10 @@ canvas when no image is needed:
 
     scene = p2p.vision.Scene.blank(fov=45 * dva)
 
-Its backing raster (512 x 512 by default) is only the default render raster;
-prediction still happens on the model grid. Black is scene content, not
-blindness; use a :py:class:`~pulse2percept.vision.Scotoma` for vision that is
-lost.
+Its fixed 512 x 512 backing raster is only the raster ``render`` falls back
+to; ask ``render`` for another, and prediction still happens on the model grid
+regardless. Black is scene content, not blindness; use a
+:py:class:`~pulse2percept.vision.Scotoma` for vision that is lost.
 
 .. versionchanged:: 0.11.0
     Scene prediction returns the model percept rather than an RGB

--- a/doc/users/release_notes.rst
+++ b/doc/users/release_notes.rst
@@ -199,11 +199,12 @@ Scene and plotting
   :py:class:`~pulse2percept.vision.BinocularScene` place images, video,
   scotomas, and prosthetic percepts in visual-field coordinates. Scenes support
   eye-centered gaze, rectangular or elliptical apertures, residual-vision
-  rendering, and fellow-eye geometry; binocular scenes can be built from a
-  side-by-side stereo image and keep the two monocular views independent while
-  plotting them on a common angular scale
+  rendering, and fellow-eye geometry; ``Scene.blank`` gives a black
+  visual-field canvas when no image is needed; binocular scenes can be built
+  from a side-by-side stereo image and keep the two monocular views
+  independent while plotting them on a common angular scale
   (:pull:`871`, :pull:`884`, :pull:`890`, :pull:`893`, :pull:`899`,
-  :pull:`900`, :pull:`901`).
+  :pull:`900`, :pull:`901`, :pull:`902`).
 
 * New :py:mod:`pulse2percept.plotting` module provides combined
   stimulus/percept figures and animations. :py:mod:`pulse2percept.viz` is

--- a/pulse2percept/vision/scene.py
+++ b/pulse2percept/vision/scene.py
@@ -59,6 +59,16 @@ def _resolve_fov(fov, n_rows, n_cols):
     return (width, height)
 
 
+def _check_shape(shape):
+    """Normalize a ``(rows, cols)`` raster shape to a pair of ints"""
+    shape = np.asarray(shape)
+    bad = shape.shape != (2,) or shape.dtype.kind not in 'iu'
+    if bad or shape.min() < 1:
+        raise ValueError(f"'shape' must be a (rows, cols) pair of positive "
+                         f"integers, not {np.ravel(shape)}.")
+    return (int(shape[0]), int(shape[1]))
+
+
 def _raster_axes(fov, shape):
     """Pixel-center coordinates of a raster spanning ``fov``
 
@@ -458,6 +468,12 @@ class Scene(PrettyPrint):
     >>> scene.fov
     (40.0, 32.0)
 
+    :py:meth:`~pulse2percept.vision.Scene.blank` gives a black field instead
+    of a picture -- darkness, not blindness:
+
+    >>> blank = Scene.blank()
+    >>> blank.plot()                                    # doctest: +SKIP
+
     """
 
     def __init__(self, source, fov, scotoma=None, scotoma_fill=0,
@@ -485,6 +501,45 @@ class Scene(PrettyPrint):
         self._cached_frames = None
         self._axes_cache = None
         self._pixel_centers_cache = None
+
+    @classmethod
+    def blank(cls, fov=45, shape=(512, 512), **kwargs):
+        """A uniformly black visual field
+
+        Black is scene content -- a dark world -- not blindness: a device
+        sampling it is given black. Use a
+        :py:class:`~pulse2percept.vision.Scotoma` for vision that is lost.
+
+        .. versionadded:: 0.11.0
+
+        Parameters
+        ----------
+        fov : float or (width, height), optional
+            Angular extent of the field, in dva. With the square default
+            ``shape``, the default 45 dva is a 45 x 45 dva disc.
+        shape : (rows, cols), optional
+            Backing raster of the black source, and the raster
+            :py:meth:`~pulse2percept.vision.Scene.render` defaults to. Display
+            resolution only: it does not set the grid a prosthetic model
+            predicts on.
+        **kwargs :
+            Any other :py:class:`~pulse2percept.vision.Scene` argument.
+            ``aperture`` defaults to ``'ellipse'`` rather than
+            ``'rectangle'``.
+
+        Examples
+        --------
+        >>> from pulse2percept.units import dva
+        >>> from pulse2percept.vision import Scene
+        >>> blank = Scene.blank(fov=60 * dva)
+        >>> blank.fov
+        (60.0, 60.0)
+
+        """
+        n_rows, n_cols = _check_shape(shape)
+        kwargs.setdefault('aperture', _ELLIPSE)
+        return cls(np.zeros((n_rows, n_cols), dtype=np.float32), fov=fov,
+                   **kwargs)
 
     def _pprint_params(self):
         """Return a dict of class attributes to pretty-print"""
@@ -1055,12 +1110,7 @@ class Scene(PrettyPrint):
             raise ValueError("'step' and 'shape' both choose the render "
                              "raster; pass one or the other.")
         if shape is not None:
-            shape = np.asarray(shape)
-            bad = shape.shape != (2,) or shape.dtype.kind not in 'iu'
-            if bad or shape.min() < 1:
-                raise ValueError(f"'shape' must be a (rows, cols) pair of "
-                                 f"positive integers, not {np.ravel(shape)}.")
-            return (int(shape[0]), int(shape[1]))
+            return _check_shape(shape)
         if step is None:
             # The source's own raster, so rendering resamples nothing unless
             # it is asked to:

--- a/pulse2percept/vision/scene.py
+++ b/pulse2percept/vision/scene.py
@@ -40,6 +40,11 @@ _INPAINT = 'inpaint'
 _RECTANGLE = 'rectangle'
 _ELLIPSE = 'ellipse'
 
+# Backing raster of a blank scene. Fixed: it is a display raster only, and
+# making it configurable would let it set the aspect ratio a scalar `fov`
+# resolves against. `Scene.render` chooses a render raster of its own.
+_BLANK_SHAPE = (512, 512)
+
 
 def _resolve_fov(fov, n_rows, n_cols):
     """Normalize a user-supplied ``fov`` to ``(width, height)`` in dva"""
@@ -57,16 +62,6 @@ def _resolve_fov(fov, n_rows, n_cols):
             raise ValueError(f"'fov' {name} must be a finite positive number "
                              f"of degrees, not {f}.")
     return (width, height)
-
-
-def _check_shape(shape):
-    """Normalize a ``(rows, cols)`` raster shape to a pair of ints"""
-    shape = np.asarray(shape)
-    bad = shape.shape != (2,) or shape.dtype.kind not in 'iu'
-    if bad or shape.min() < 1:
-        raise ValueError(f"'shape' must be a (rows, cols) pair of positive "
-                         f"integers, not {np.ravel(shape)}.")
-    return (int(shape[0]), int(shape[1]))
 
 
 def _raster_axes(fov, shape):
@@ -503,25 +498,25 @@ class Scene(PrettyPrint):
         self._pixel_centers_cache = None
 
     @classmethod
-    def blank(cls, fov=45, shape=(512, 512), **kwargs):
+    def blank(cls, fov=45, **kwargs):
         """A uniformly black visual field
 
         Black is scene content -- a dark world -- not blindness: a device
         sampling it is given black. Use a
         :py:class:`~pulse2percept.vision.Scotoma` for vision that is lost.
 
+        The black source sits on a fixed 512 x 512 raster, which is what
+        :py:meth:`~pulse2percept.vision.Scene.render` falls back to; ask
+        ``render`` for ``step`` or ``shape`` to get another output
+        resolution. Neither sets the grid a prosthetic model predicts on.
+
         .. versionadded:: 0.11.0
 
         Parameters
         ----------
         fov : float or (width, height), optional
-            Angular extent of the field, in dva. With the square default
-            ``shape``, the default 45 dva is a 45 x 45 dva disc.
-        shape : (rows, cols), optional
-            Backing raster of the black source, and the raster
-            :py:meth:`~pulse2percept.vision.Scene.render` defaults to. Display
-            resolution only: it does not set the grid a prosthetic model
-            predicts on.
+            Angular extent of the field, in dva. The backing raster is square,
+            so the default 45 dva is a 45 x 45 dva disc.
         **kwargs :
             Any other :py:class:`~pulse2percept.vision.Scene` argument.
             ``aperture`` defaults to ``'ellipse'`` rather than
@@ -536,9 +531,8 @@ class Scene(PrettyPrint):
         (60.0, 60.0)
 
         """
-        n_rows, n_cols = _check_shape(shape)
         kwargs.setdefault('aperture', _ELLIPSE)
-        return cls(np.zeros((n_rows, n_cols), dtype=np.float32), fov=fov,
+        return cls(np.zeros(_BLANK_SHAPE, dtype=np.float32), fov=fov,
                    **kwargs)
 
     def _pprint_params(self):
@@ -1110,7 +1104,12 @@ class Scene(PrettyPrint):
             raise ValueError("'step' and 'shape' both choose the render "
                              "raster; pass one or the other.")
         if shape is not None:
-            return _check_shape(shape)
+            shape = np.asarray(shape)
+            bad = shape.shape != (2,) or shape.dtype.kind not in 'iu'
+            if bad or shape.min() < 1:
+                raise ValueError(f"'shape' must be a (rows, cols) pair of "
+                                 f"positive integers, not {np.ravel(shape)}.")
+            return (int(shape[0]), int(shape[1]))
         if step is None:
             # The source's own raster, so rendering resamples nothing unless
             # it is asked to:

--- a/pulse2percept/vision/tests/test_scene.py
+++ b/pulse2percept/vision/tests/test_scene.py
@@ -1420,8 +1420,8 @@ def test_a_blank_scene_is_a_black_elliptical_field_by_default():
 
 def test_a_blank_scene_is_an_ordinary_black_scene():
     """`blank` is convenience only, not a second Scene implementation"""
-    blank = Scene.blank(fov=45, shape=(32, 48), aperture='rectangle')
-    plain = Scene(np.zeros((32, 48)), fov=45, aperture='rectangle')
+    blank = Scene.blank(fov=45, aperture='rectangle')
+    plain = Scene(np.zeros(blank.shape), fov=45, aperture='rectangle')
     npt.assert_equal(blank.fov, plain.fov)
     npt.assert_equal(blank.shape, plain.shape)
     for x, y in [(0, 0), (-10, 4), (12, -8)]:
@@ -1431,16 +1431,21 @@ def test_a_blank_scene_is_an_ordinary_black_scene():
     npt.assert_almost_equal(rendered(blank), rendered(plain))
 
 
-def test_a_blank_scene_keeps_the_fov_and_shape_it_is_given():
-    scene = Scene.blank(fov=(60, 40) * dva, shape=(30, 50))
-    npt.assert_equal(scene.fov, (60.0, 40.0))
-    npt.assert_equal(scene.shape, (30, 50))
+def test_a_blank_scene_keeps_the_fov_it_is_given():
+    npt.assert_equal(Scene.blank(fov=(60, 40) * dva).fov, (60.0, 40.0))
+    # The backing raster is square, so a scalar fov stays square:
+    npt.assert_equal(Scene.blank(fov=60).fov, (60.0, 60.0))
 
 
-@pytest.mark.parametrize('shape', [(0, 4), (4, -1), (4, 4, 4), 4, (4.0, 4.0)])
-def test_a_blank_scene_needs_a_real_raster(shape):
-    with pytest.raises(ValueError):
-        Scene.blank(shape=shape)
+def test_the_blank_raster_is_not_the_callers_business():
+    """A display raster that could be set would set the aspect ratio too"""
+    with pytest.raises(TypeError):
+        Scene.blank(shape=(32, 48))
+    # Output resolution is `render`'s to choose, and it leaves the field
+    # geometry alone:
+    scene = Scene.blank(fov=45)
+    npt.assert_equal(scene.render(shape=(1080, 1920)).shape[:2], (1080, 1920))
+    npt.assert_equal(scene.fov, (45.0, 45.0))
 
 
 def test_an_explicit_aperture_overrides_the_blank_default():

--- a/pulse2percept/vision/tests/test_scene.py
+++ b/pulse2percept/vision/tests/test_scene.py
@@ -1406,3 +1406,66 @@ def test_repeated_pixel_center_queries_read_the_same_raster():
     # The pixel centers are the source raster's own axes:
     npt.assert_array_equal(x[0], scene._axes[0])
     npt.assert_array_equal(y[:, 0], scene._axes[1])
+
+
+def test_a_blank_scene_is_a_black_elliptical_field_by_default():
+    scene = Scene.blank()
+    npt.assert_equal(scene.fov, (45.0, 45.0))
+    npt.assert_equal(scene.shape, (512, 512))
+    npt.assert_equal(scene.aperture, 'ellipse')
+    data = scene.source.data
+    npt.assert_equal(np.all(np.isfinite(data)), True)
+    npt.assert_array_equal(data, 0.0)
+
+
+def test_a_blank_scene_is_an_ordinary_black_scene():
+    """`blank` is convenience only, not a second Scene implementation"""
+    blank = Scene.blank(fov=45, shape=(32, 48), aperture='rectangle')
+    plain = Scene(np.zeros((32, 48)), fov=45, aperture='rectangle')
+    npt.assert_equal(blank.fov, plain.fov)
+    npt.assert_equal(blank.shape, plain.shape)
+    for x, y in [(0, 0), (-10, 4), (12, -8)]:
+        npt.assert_almost_equal(blank._sample_at(x, y), plain._sample_at(x, y))
+        npt.assert_almost_equal(blank._device_input(x, y),
+                                plain._device_input(x, y))
+    npt.assert_almost_equal(rendered(blank), rendered(plain))
+
+
+def test_a_blank_scene_keeps_the_fov_and_shape_it_is_given():
+    scene = Scene.blank(fov=(60, 40) * dva, shape=(30, 50))
+    npt.assert_equal(scene.fov, (60.0, 40.0))
+    npt.assert_equal(scene.shape, (30, 50))
+
+
+@pytest.mark.parametrize('shape', [(0, 4), (4, -1), (4, 4, 4), 4, (4.0, 4.0)])
+def test_a_blank_scene_needs_a_real_raster(shape):
+    with pytest.raises(ValueError):
+        Scene.blank(shape=shape)
+
+
+def test_an_explicit_aperture_overrides_the_blank_default():
+    npt.assert_equal(Scene.blank(aperture='rectangle').aperture, 'rectangle')
+    npt.assert_equal(Scene.blank().aperture, 'ellipse')
+
+
+def test_a_blank_scene_does_not_resample_a_finer_percept():
+    """The backing raster is a display default, not the model's grid"""
+    scene = Scene.blank(fov=45 * dva)
+    # Deliberately finer than the 45 / 512 dva backing raster:
+    space = Grid2D((-2, 2), (-2, 2), step=0.02)
+    data = np.zeros(space.x.shape + (1,))
+    data[100, 100] = 5.0
+    ax = scene.plot(percept=Percept(data, space=space), vmax=5)
+    wide, patch = (image.get_array() for image in ax.images)
+    npt.assert_equal(wide.shape, (512, 512, 3))
+    npt.assert_equal(patch.shape, (201, 201, 3))
+    npt.assert_almost_equal(ax.images[1].get_extent(),
+                            (-2.01, 2.01, -2.01, 2.01), decimal=6)
+    npt.assert_almost_equal(patch[100, 100], [1.0, 1.0, 1.0], decimal=6)
+    plt.close('all')
+
+
+def test_a_blank_scene_gives_a_device_black():
+    scene = Scene.blank(fov=45 * dva)
+    for x, y in [(0, 0), (-20, 0), (0, 20), (10, -10), (22, 22)]:
+        npt.assert_almost_equal(seen_at(scene, x, y), 0.0)


### PR DESCRIPTION
`Scene.blank()` provides a black wide-field canvas with an elliptical aperture by default. It is an ordinary source-backed `Scene`; its backing raster only determines the default display/render resolution and does not affect prosthetic model resolution. Black represents darkness, not blindness; visual loss remains represented by `Scotoma`.